### PR TITLE
#30673: Making dotAI and analytics app properties reloadable

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/app/AIModels.java
@@ -39,9 +39,7 @@ public class AIModels {
 
     private static final String SUPPORTED_MODELS_KEY = "supportedModels";
     private static final String AI_MODELS_FETCH_ATTEMPTS_KEY = "ai.models.fetch.attempts";
-    private static final int AI_MODELS_FETCH_ATTEMPTS = Config.getIntProperty(AI_MODELS_FETCH_ATTEMPTS_KEY, 3);
     private static final String AI_MODELS_FETCH_TIMEOUT_KEY = "ai.models.fetch.timeout";
-    private static final int AI_MODELS_FETCH_TIMEOUT = Config.getIntProperty(AI_MODELS_FETCH_TIMEOUT_KEY, 4000);
     private static final String AI_MODELS_API_URL_KEY = "AI_MODELS_API_URL";
     private static final String AI_MODELS_API_URL_DEFAULT = "https://api.openai.com/v1/models";
     private static final String AI_MODELS_API_URL = Config.getStringProperty(
@@ -60,11 +58,12 @@ public class AIModels {
     }
 
     private static CircuitBreakerUrl.Response<OpenAIModels> fetchOpenAIModels(final AppConfig appConfig) {
+        final String aiModelsApiUrl = Config.getStringProperty(AI_MODELS_API_URL_KEY, AI_MODELS_API_URL_DEFAULT);
         final CircuitBreakerUrl.Response<OpenAIModels> response = CircuitBreakerUrl.builder()
                 .setMethod(CircuitBreakerUrl.Method.GET)
-                .setUrl(AI_MODELS_API_URL)
-                .setTimeout(AI_MODELS_FETCH_TIMEOUT)
-                .setTryAgainAttempts(AI_MODELS_FETCH_ATTEMPTS)
+                .setUrl(aiModelsApiUrl)
+                .setTimeout(Config.getIntProperty(AI_MODELS_FETCH_TIMEOUT_KEY, 4000))
+                .setTryAgainAttempts(Config.getIntProperty(AI_MODELS_FETCH_ATTEMPTS_KEY, 3))
                 .setHeaders(CircuitBreakerUrl.authHeaders("Bearer " + appConfig.getApiKey()))
                 .setThrowWhenNot2xx(true)
                 .build()
@@ -75,7 +74,7 @@ public class AIModels {
                     AIModels.class,
                     () -> String.format(
                             "Error fetching OpenAI supported models from [%s] (status code: [%d])",
-                            AI_MODELS_API_URL,
+                            aiModelsApiUrl,
                             response.getStatusCode()));
             throw new DotRuntimeException("Error fetching OpenAI supported models");
         }

--- a/dotCMS/src/main/java/com/dotcms/ai/db/PgVectorDataSource.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/db/PgVectorDataSource.java
@@ -14,10 +14,18 @@ import javax.sql.DataSource;
  */
 class PgVectorDataSource {
 
+    private static final String AI_DB_BASE_URL_KEY = "AI_DB_BASE_URL";
+    private static final String AI_DB_USERNAME_KEY = "AI_DB_USERNAME";
+    private static final String AI_DB_PASSWORD_KEY = "AI_DB_PASSWORD";
+    private static final String AI_DB_MAX_TOTAL_KEY = "AI_DB_MAX_TOTAL";
+
     /**
      * returns the configured datasource
      */
     public static final Lazy<DataSource> datasource = Lazy.of(PgVectorDataSource::resolveDataSource);
+
+    private PgVectorDataSource() {
+    }
 
     /**
      * Checks if a specific AI datasource is provided, if not, returns the standard dotCMS datasource
@@ -25,7 +33,7 @@ class PgVectorDataSource {
      * @return
      */
     private static DataSource resolveDataSource() {
-        if (UtilMethods.isEmpty(Config.getStringProperty("AI_DB_BASE_URL", null))) {
+        if (UtilMethods.isEmpty(Config.getStringProperty(AI_DB_BASE_URL_KEY, null))) {
             return DbConnectionFactory.getDataSource();
         }
 
@@ -38,10 +46,10 @@ class PgVectorDataSource {
      * @return
      */
     private static DataSource internalDatasource() {
-        final String userName = Config.getStringProperty("AI_DB_USERNAME");
-        final String password = Config.getStringProperty("AI_DB_PASSWORD");
-        final String dbUrl = Config.getStringProperty("AI_DB_BASE_URL");
-        final int maxConnections = Config.getIntProperty("AI_DB_MAX_TOTAL", 50);
+        final String userName = Config.getStringProperty(AI_DB_USERNAME_KEY, null);
+        final String password = Config.getStringProperty(AI_DB_PASSWORD_KEY, null);
+        final String dbUrl = Config.getStringProperty(AI_DB_BASE_URL_KEY, null);
+        final int maxConnections = Config.getIntProperty(AI_DB_MAX_TOTAL_KEY, 50);
 
         final HikariConfig config = new HikariConfig();
         config.setUsername(userName);

--- a/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPI.java
@@ -7,10 +7,8 @@ import com.dotcms.analytics.model.AccessTokenStatus;
 import com.dotcms.analytics.model.TokenStatus;
 import com.dotcms.exception.AnalyticsException;
 import com.dotmarketing.beans.Host;
-import com.dotmarketing.util.Config;
 
 import java.time.Instant;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Analytics functionality interface.
@@ -19,30 +17,15 @@ import java.util.concurrent.TimeUnit;
  */
 public interface AnalyticsAPI {
 
-    String ANALYTICS_USE_DUMMY_TOKEN_KEY = "analytics.use.dummy.token";
     String ANALYTICS_IDP_URL_KEY = "analytics.idp.url";
+    String ANALYTICS_USE_DUMMY_TOKEN_KEY = "analytics.use.dummy.token";
     String ANALYTICS_ACCESS_TOKEN_KEY_PREFIX = "ANALYTICS_ACCESS_TOKEN";
-
     String ANALYTICS_ACCESS_TOKEN_TTL_KEY = "analytics.accesstoken.ttl";
-    int ANALYTICS_ACCESS_TOKEN_TTL = Config.getIntProperty(
-        ANALYTICS_ACCESS_TOKEN_TTL_KEY,
-        (int) TimeUnit.HOURS.toSeconds(1));
-
     String ANALYTICS_ACCESS_TOKEN_TTL_WINDOW_KEY = "analytics.accesstoken.ttlwindow";
-    int ANALYTICS_ACCESS_TOKEN_TTL_WINDOW = Config.getIntProperty(
-        ANALYTICS_ACCESS_TOKEN_TTL_WINDOW_KEY,
-        (int) TimeUnit.MINUTES.toSeconds(1));
-
     String ANALYTICS_ACCESS_TOKEN_RENEW_ATTEMPTS_KEY = "analytics.accesstoken.renewattempts";
-    int ANALYTICS_ACCESS_TOKEN_RENEW_ATTEMPTS = Config.getIntProperty(ANALYTICS_ACCESS_TOKEN_RENEW_ATTEMPTS_KEY, 3);
     String ANALYTICS_ACCESS_TOKEN_RENEW_TIMEOUT_KEY = "analytics.accesstoken.renewtimeout";
-    int ANALYTICS_ACCESS_TOKEN_RENEW_TIMEOUT = Config.getIntProperty(ANALYTICS_ACCESS_TOKEN_RENEW_TIMEOUT_KEY, 4000);
-
     String ANALYTICS_KEY_RENEW_ATTEMPTS_KEY = "analytics.key.renewattempts";
-    int ANALYTICS_KEY_RENEW_ATTEMPTS = Config.getIntProperty(ANALYTICS_KEY_RENEW_ATTEMPTS_KEY, 3);
     String ANALYTICS_KEY_RENEW_TIMEOUT_KEY = "analytics.key.renewtimeout";
-    int ANALYTICS_KEY_RENEW_TIMEOUT = Config.getIntProperty(ANALYTICS_KEY_RENEW_TIMEOUT_KEY, 4000);
-
     String ANALYTICS_ACCESS_TOKEN_THREAD_NAME = "access-token-renew";
 
     AccessToken DUMMY_TOKEN = AccessToken.builder()

--- a/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/bayesian/BayesianAPIImpl.java
@@ -8,7 +8,6 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.vavr.Lazy;
 import org.apache.commons.math3.distribution.BetaDistribution;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
 
@@ -26,9 +25,6 @@ import java.util.stream.Stream;
  * @author vico
  */
 public class BayesianAPIImpl implements BayesianAPI {
-
-    private final Lazy<Integer> betaDistSamples =
-            Lazy.of(() -> Config.getIntProperty("BETA_DISTRIBUTION_SAMPLE_SIZE", 1000));
 
     /**
      * {@inheritDoc}
@@ -705,7 +701,7 @@ public class BayesianAPIImpl implements BayesianAPI {
      * @return sample size
      */
     private int resolveSampleSize() {
-        return betaDistSamples.get();
+        return Config.getIntProperty("BETA_DISTRIBUTION_SAMPLE_SIZE", 1000);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptor.java
@@ -59,7 +59,7 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
                         .addBlackPatterns(CollectionsUtils.concat(Config.getStringArrayProperty(  // except this
                                 "ANALYTICS_BLACKLISTED_KEYS", new String[]{}), DEFAULT_BLACKLISTED_PROPS)).build(),
                 new AtomicBoolean(Config.getBooleanProperty(ANALYTICS_TURNED_ON_KEY, true)),
-                ()->APILocator.systemUser(),
+                APILocator::systemUser,
                 new PagesAndUrlMapsRequestMatcher(),
                 new FilesRequestMatcher(),
                 //       new RulesRedirectsRequestMatcher(),

--- a/dotCMS/src/test/java/com/dotcms/analytics/helper/AnalyticsHelperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/helper/AnalyticsHelperTest.java
@@ -20,8 +20,8 @@ import org.junit.Test;
 import javax.ws.rs.core.Response;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.concurrent.TimeUnit;
 
-import static com.dotcms.analytics.AnalyticsAPI.ANALYTICS_ACCESS_TOKEN_TTL;
 import static com.dotcms.auth.providers.jwt.JsonWebTokenAuthCredentialProcessor.BEARER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -113,7 +113,7 @@ public class AnalyticsHelperTest extends UnitTestBase {
         AccessToken accessToken = createFreshAccessToken();
         assertFalse(AnalyticsHelper.get().hasTokenExpired(accessToken));
 
-        accessToken = accessToken.withIssueDate(Instant.now().minusSeconds(ANALYTICS_ACCESS_TOKEN_TTL));
+        accessToken = accessToken.withIssueDate(Instant.now().minusSeconds(TimeUnit.HOURS.toSeconds(1)));
         assertTrue(AnalyticsHelper.get().hasTokenExpired(accessToken));
     }
 
@@ -169,7 +169,7 @@ public class AnalyticsHelperTest extends UnitTestBase {
         assertSame(TokenStatus.BLOCKED, AnalyticsHelper.get().resolveTokenStatus(accessToken));
 
         accessToken = createAccessToken()
-            .withIssueDate(Instant.now().minusSeconds(ANALYTICS_ACCESS_TOKEN_TTL));
+            .withIssueDate(Instant.now().minusSeconds(TimeUnit.HOURS.toSeconds(1)));
         assertSame(TokenStatus.EXPIRED, AnalyticsHelper.get().resolveTokenStatus(accessToken));
     }
 
@@ -200,7 +200,7 @@ public class AnalyticsHelperTest extends UnitTestBase {
      */
     @Test(expected = AnalyticsException.class)
     public void test_checkExpiredAccessToken() throws AnalyticsException {
-        checkStatusThrowing(createAccessToken().withIssueDate(Instant.now().minusSeconds(ANALYTICS_ACCESS_TOKEN_TTL)));
+        checkStatusThrowing(createAccessToken().withIssueDate(Instant.now().minusSeconds(TimeUnit.HOURS.toSeconds(1))));
     }
 
     /**
@@ -412,7 +412,7 @@ public class AnalyticsHelperTest extends UnitTestBase {
                 "some-token-type",
                 tokenStatus,
                 null)
-            .withExpiresIn(ANALYTICS_ACCESS_TOKEN_TTL);
+            .withExpiresIn((int) TimeUnit.HOURS.toSeconds(1));
     }
 
     private AccessToken createAccessToken() {

--- a/dotcms-integration/src/test/java/com/dotcms/analytics/AnalyticsAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/analytics/AnalyticsAPIImplTest.java
@@ -105,7 +105,8 @@ public class AnalyticsAPIImplTest extends IntegrationTestBase {
     @Test(expected = AnalyticsException.class)
     public void test_getAccessToken_fail() throws Exception {
         AccessTokens.get().removeAccessToken(analyticsApp.getAnalyticsProperties().clientId(), null);
-        new AnalyticsAPIImpl("http://some-host:9999")
+        Config.initializeConfig();
+        new AnalyticsAPIImpl()
             .getAccessToken(analyticsApp, AccessTokenFetchMode.FORCE_RENEW);
     }
 
@@ -143,7 +144,7 @@ public class AnalyticsAPIImplTest extends IntegrationTestBase {
         AccessToken accessToken = analyticsAPI.getCachedAccessToken(analyticsApp);
         assertNull(accessToken);
 
-        new AnalyticsAPIImpl("http://some-host:9999").refreshAccessToken(analyticsApp);
+        new AnalyticsAPIImpl().refreshAccessToken(analyticsApp);
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/AccessTokenRenewJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/AccessTokenRenewJobTest.java
@@ -30,8 +30,8 @@ import org.quartz.JobExecutionContext;
 import org.quartz.SchedulerException;
 
 import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 
-import static com.dotcms.analytics.AnalyticsAPI.ANALYTICS_ACCESS_TOKEN_TTL;
 import static com.dotmarketing.quartz.job.AccessTokenRenewJob.ANALYTICS_ACCESS_TOKEN_RENEW_JOB;
 import static com.dotmarketing.quartz.job.AccessTokenRenewJob.ANALYTICS_ACCESS_TOKEN_RENEW_JOB_CRON_DEFAULT;
 import static com.dotmarketing.quartz.job.AccessTokenRenewJob.ANALYTICS_ACCESS_TOKEN_RENEW_JOB_CRON_KEY;
@@ -52,6 +52,7 @@ import static org.junit.Assert.assertTrue;
 public class AccessTokenRenewJobTest extends IntegrationTestBase {
 
     private static AnalyticsAPI analyticsAPI;
+    private static int accessTokenTtl;
     private AccessTokenRenewJob accessTokenRenewJob;
     private Host host;
     private AnalyticsApp analyticsApp;
@@ -67,6 +68,10 @@ public class AccessTokenRenewJobTest extends IntegrationTestBase {
 
         deleteJob();
         DotInitScheduler.start();
+
+        accessTokenTtl = Config.getIntProperty(
+                AnalyticsAPI.ANALYTICS_ACCESS_TOKEN_TTL_KEY,
+                (int) TimeUnit.HOURS.toSeconds(1));
     }
 
     @AfterClass
@@ -119,7 +124,7 @@ public class AccessTokenRenewJobTest extends IntegrationTestBase {
     public void test_accessTokenRenew_expired() throws Exception {
         analyticsAPI.resetAccessToken(analyticsApp);
 
-        final Instant issueDate = Instant.now().minusSeconds(ANALYTICS_ACCESS_TOKEN_TTL);
+        final Instant issueDate = Instant.now().minusSeconds(accessTokenTtl);
         AccessToken accessToken = analyticsAPI
             .getAccessToken(
                 analyticsApp,
@@ -144,7 +149,7 @@ public class AccessTokenRenewJobTest extends IntegrationTestBase {
     public void test_accessTokenRenew_inWindow() throws Exception {
         analyticsAPI.resetAccessToken(analyticsApp);
 
-        final Instant issueDate = Instant.now().minusSeconds(ANALYTICS_ACCESS_TOKEN_TTL).plusSeconds(30);
+        final Instant issueDate = Instant.now().minusSeconds(accessTokenTtl).plusSeconds(30);
         AccessToken accessToken = analyticsAPI
             .getAccessToken(
                 analyticsApp,

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/StartEndScheduledExperimentsJobTest.java
@@ -1,51 +1,27 @@
 package com.dotmarketing.quartz.job;
 
-import static com.dotcms.analytics.AnalyticsAPI.ANALYTICS_ACCESS_TOKEN_TTL;
-import static com.dotmarketing.quartz.job.AccessTokenRenewJob.ANALYTICS_ACCESS_TOKEN_RENEW_JOB;
-import static com.dotmarketing.quartz.job.AccessTokenRenewJob.ANALYTICS_ACCESS_TOKEN_RENEW_JOB_CRON_KEY;
-import static com.dotmarketing.quartz.job.AccessTokenRenewJob.ANALYTICS_ACCESS_TOKEN_RENEW_TRIGGER;
-import static com.dotmarketing.quartz.job.AccessTokenRenewJob.ANALYTICS_ACCESS_TOKEN_RENEW_TRIGGER_GROUP;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-
 import com.dotcms.IntegrationTestBase;
-import com.dotcms.LicenseTestUtil;
-import com.dotcms.analytics.AnalyticsTestUtils;
-import com.dotcms.analytics.app.AnalyticsApp;
-import com.dotcms.analytics.helper.AnalyticsHelper;
-import com.dotcms.analytics.model.AccessToken;
-import com.dotcms.analytics.model.TokenStatus;
 import com.dotcms.datagen.ExperimentDataGen;
-import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.experiments.business.ExperimentsAPI;
-import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.experiments.model.Scheduling;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.CacheLocator;
-import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.init.DotInitScheduler;
-import com.dotmarketing.quartz.QuartzUtils;
-import com.dotmarketing.util.Config;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.quartz.JobDataMap;
-import org.quartz.JobDetail;
-import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.SchedulerException;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 
 /**

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -376,6 +376,10 @@
                                         <file.encoding>UTF-8</file.encoding>
                                         <DOT_ES_ENDPOINTS>http://es:9200</DOT_ES_ENDPOINTS>
                                         <DOT_DATASOURCE_PROVIDER_STRATEGY_CLASS>com.dotmarketing.db.SystemEnvDataSourceStrategy</DOT_DATASOURCE_PROVIDER_STRATEGY_CLASS>
+                                        <DOT_ANALYTICS_IDP_URL>http://host.docker.internal:61111/realms/dotcms/protocol/openid-connect/token</DOT_ANALYTICS_IDP_URL>
+                                        <DOT_ALLOW_ACCESS_TO_PRIVATE_SUBNETS>true</DOT_ALLOW_ACCESS_TO_PRIVATE_SUBNETS>
+                                        <DOT_FEATURE_FLAG_EXPERIMENTS>true</DOT_FEATURE_FLAG_EXPERIMENTS>
+                                        <DOT_ENABLE_EXPERIMENTS_AUTO_JS_INJECTION>true</DOT_ENABLE_EXPERIMENTS_AUTO_JS_INJECTION>
                                     </env>
                                     <volumes>
                                         <bind combine.children="append">


### PR DESCRIPTION
With the `System Tables` it's a good practice not to cache Config properties in final classes (instance or static) variables so they can be reloadable through such.

This PR fixes: #30673