### PR TITLE
fix (block editor):  #28741 Does Not Allow Users to Add Images Or Videos On First Click

### DIFF
--- a/core-web/libs/block-editor/src/lib/extensions/asset-form/asset-form.extension.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/asset-form/asset-form.extension.ts
@@ -143,7 +143,11 @@ export const BubbleAssetFormExtension = (viewContainerRef: ViewContainerRef) => 
                     ({ chain }) => {
                         return chain()
                             .command(({ tr }) => {
+                                preventClose = true;
                                 tr.setMeta(BUBBLE_ASSET_FORM_PLUGIN_KEY, { open: true, type });
+                                setTimeout(() => {
+                                    preventClose = false;
+                                }, 0);
 
                                 return true;
                             })


### PR DESCRIPTION
### Proposed Changes
* When the suggestion get open directly from the "+" icon and select Image or Video, it close everting after the initial focus event in the editor. 

This PR fixes: #28741