### PR TITLE
#25818: Renaming 'Next Release' to release label at release time

### DIFF
--- a/.github/workflows/issue_comp_release-labeling.yml
+++ b/.github/workflows/issue_comp_release-labeling.yml
@@ -1,0 +1,119 @@
+name: 'Release Labeling'
+on:
+  workflow_call:
+    secrets:
+      CI_MACHINE_TOKEN:
+        description: 'CI machine token'
+        required: true
+    inputs:
+      rename_label:
+        description: 'Rename label'
+        type: string
+        required: false
+        default: 'Next Release'
+      new_label:
+        description: 'New label'
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      rename_label:
+        description: 'Rename label'
+        type: string
+        required: false
+        default: 'Next Release'
+      new_label:
+        description: 'New label'
+        type: string
+        required: true
+
+jobs:
+  release-labeling:
+    runs-on: ubuntu-20.04
+    env:
+      REPO: core
+    steps:
+      - run: echo 'GitHub context'
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: Rename label
+        if: success()
+        id: validate-inputs
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          retries: 3
+          retry-exempt-status-codes: 400,401
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            async function getLabel(name) {
+              console.log(`Getting label [${name}]`);
+              try {
+                const response = await github.rest.issues.getLabel({
+                  owner: '${{ github.repository_owner }}',
+                  repo: '${{ env.REPO }}',
+                  name,
+                });
+                return response.data;
+              } catch(error) {
+                console.log(`Error getting label: ${error}`);
+                return undefined;
+              }
+            }
+            
+            const renameLabel = await getLabel('${{ inputs.rename_label }}');
+            if (!renameLabel) {
+              console.log(`Label [${{ inputs.rename_label }}] not found, skipping rename`);
+              return;
+            }
+            
+            const newLabel = await getLabel('${{ inputs.new_label }}');
+            if (newLabel) {
+              console.log(`Label [${newLabel.name}] already exists, skipping rename`);
+              return;
+            }
+            
+            console.log(`Renaming label [${renameLabel.name}] for owner [${{ github.repository_owner }}] repo [${{ env.REPO }}] with new label [${{ inputs.new_label }}]`);
+            await github.rest.issues.updateLabel({
+              owner: '${{ github.repository_owner }}',
+              repo: '${{ env.REPO }}',
+              name: renameLabel.name,
+              new_name: '${{ inputs.new_label }}'
+            });
+            
+      - name: Re-Create New Label
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          result-encoding: string
+          retries: 3
+          retry-exempt-status-codes: 400,401
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            async function getLabel(name) {
+              console.log(`Getting label [${name}]`);
+              try {
+                const response = await github.rest.issues.getLabel({
+                  owner: '${{ github.repository_owner }}',
+                  repo: '${{ env.REPO }}',
+                  name,
+                });
+                return response.data;
+              } catch(error) {
+                console.log(`Error getting label: ${error}`);
+                return undefined;
+              }
+            }
+            
+            const renameLabel = await getLabel('${{ inputs.rename_label }}');
+            if (renameLabel) {
+              console.log(`Label [${renameLabel.name}] already exists, skipping re-creation`);
+              return;
+            }
+            
+            console.log(`Recreating label [${{ inputs.rename_label }}] for owner [${{ github.repository_owner }}] repo [${{ env.REPO }}]`);
+            await github.rest.issues.createLabel({
+              owner: '${{ github.repository_owner }}',
+              repo: '${{ env.REPO }}',
+              name: '${{ inputs.rename_label }}'
+            });

--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -395,32 +395,13 @@ jobs:
 
       - uses: ./.github/actions/core-cicd/cleanup-runner
 
-      #      - name: Fetch `Next Release` issues
-      #        id: fetch-next-release-issues
-      #        uses: ./.github/actions/issues/issue-fetcher
-      #        with:
-      #          fetch_operation: 'WITH_LABELS'
-      #          fetch_value: ${{ env.FETCH_VALUE }}
-      #          github_token: ${{ secrets.GITHUB_TOKEN }}
-      #        if: github.event.inputs.update_github_labels == 'true'
-      #
-      #      - name: Clear next release issues
-      #        uses: ./.github/actions/issues/issue-labeler
-      #        with:
-      #          issues_json: ${{ steps.fetch-next-release-issues.outputs.issues }}
-      #          labels: ${{ env.FETCH_VALUE }}
-      #          operation: 'REMOVE'
-      #          github_token: ${{ secrets.GITHUB_TOKEN }}
-      #        if: github.event.inputs.update_github_labels == 'true'
-      #
-      #      - name: Label current release issues
-      #        uses: ./.github/actions/issues/issue-labeler
-      #        with:
-      #          issues_json: ${{ steps.fetch-next-release-issues.outputs.issues }}
-      #          labels: 'Release ${{ needs.prepare-release.outputs.release_version }}'
-      #          operation: 'ADD'
-      #          github_token: ${{ secrets.GITHUB_TOKEN }}
-      #        if: github.event.inputs.update_github_labels == 'true'
+      - name: Release Labeling
+        if: success() && github.event.inputs.update_github_labels == 'true'
+        uses: ./.github/workflows/issue_comp_release-labeling.yml
+        with:
+          new_label: 'Release ${{ github.event.inputs.release_version }}''
+        secrets:
+          CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
 
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@v2


### PR DESCRIPTION
According to @bryanboza 's requirements at release time the `Next Release` label should be renamed to the release version one and a new `Next Release` label should be created.

This PR fixes: #25818