### PR TITLE
fix(uve): show the ReorderButton only inside UVE

### DIFF
--- a/examples/nextjs/src/components/layout/header/header.js
+++ b/examples/nextjs/src/components/layout/header/header.js
@@ -1,11 +1,12 @@
 'use client';
 import Link from 'next/link';
 import { isInsideEditor } from '@dotcms/client';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import ReorderButton from './components/reorderMenu';
 
 function Header({ children }) {
     const [insideEditor, setInsideEditor] = useState(false);
+    
 
     useEffect(() => {
         setInsideEditor(isInsideEditor());

--- a/examples/nextjs/src/components/layout/header/header.js
+++ b/examples/nextjs/src/components/layout/header/header.js
@@ -1,17 +1,30 @@
+'use client';
 import Link from 'next/link';
+import { isInsideEditor } from '@dotcms/client';
+import { useEffect, useMemo, useState } from 'react';
 import ReorderButton from './components/reorderMenu';
 
 function Header({ children }) {
+    const [insideEditor, setInsideEditor] = useState(false);
+
+    useEffect(() => {
+        setInsideEditor(isInsideEditor());
+    }, [])
+
     return (
-        <header className="flex items-center justify-between p-4 bg-purple-500">
+        <div className="flex items-center justify-between p-4 bg-purple-500">
             <div className="flex items-center">
                 <h2 className="text-3xl font-bold text-white">
                     <Link href="/">TravelLux in NextJS</Link>
                 </h2>
+
+                {insideEditor && (
+                    <ReorderButton />
+                )}
             </div>
-            <ReorderButton />
+            
             {children}
-        </header>
+        </div>
     );
 }
 


### PR DESCRIPTION
This pull request includes changes to the `examples/nextjs/src/components/layout/header/header.js` file to enhance functionality and improve user experience within the editor. The most important changes include adding new imports, introducing state and effect hooks, and modifying the header structure.

Enhancements to functionality:

* Added new imports for `isInsideEditor`, `useEffect`, `useMemo`, and `useState` to manage editor state and side effects.
* Introduced a new state variable `insideEditor` and an effect hook to set its value based on whether the user is inside the editor.

Improvements to user experience:

* Modified the header structure to conditionally render the `ReorderButton` component if the user is inside the editor.

This PR fixes: #30445