### PR TITLE
fix(NextJS example): blog page imports

### DIFF
--- a/examples/nextjs/src/app/blog/post/[[...slug]]/page.js
+++ b/examples/nextjs/src/app/blog/post/[[...slug]]/page.js
@@ -14,9 +14,9 @@ import { MyBlogPage } from "@/components/my-blog-page";
  * @return {*}
  */
 export async function generateMetadata({ params, searchParams }) {
-    const path = params?.slug?.join("/") || "/";
+    const path = params?.slug?.join("/");
     const pageRequestParams = getPageRequestParams({
-        path,
+        path: `blog/post/${path}`,
         params: searchParams,
     });
 
@@ -37,9 +37,10 @@ export async function generateMetadata({ params, searchParams }) {
 
 export default async function Home({ searchParams, params }) {
     const getPageData = async () => {
-        const path = params?.slug?.join("/") || "/";
+        const path = params?.slug?.join("/");
+        console.log(path)
         const pageParams = getPageRequestParams({
-            path,
+            path: `blog/post/${path}`,
             params: searchParams,
         });
 

--- a/examples/nextjs/src/components/my-blog-page.js
+++ b/examples/nextjs/src/components/my-blog-page.js
@@ -3,7 +3,7 @@
 import NotFound from "@/app/not-found";
 import Blog from "@/components/content-types/blog";
 import Footer from "@/components/layout/footer/footer";
-import Header from "@/components/layout/header";
+import Header from "@/components/layout/header/header";
 import Navigation from "@/components/layout/navigation";
 
 import { usePageAsset } from "@/hooks/usePageAsset";


### PR DESCRIPTION
This pull request includes changes to the `examples/nextjs` project, specifically focusing on improving the handling of blog post paths and fixing an import statement. The most important changes include updating the path generation for blog posts and correcting the import path for the `Header` component.

Path handling improvements:

* `examples/nextjs/src/app/blog/post/[[...slug]]/page.js`: Updated the `generateMetadata` and `Home` functions to use a more specific path format for blog posts. This change removes the default fallback path and ensures that the path is always correctly prefixed with `blog/post/`. ([examples/nextjs/src/app/blog/post/[[...slug]]/page.jsL17-R19](diffhunk://#diff-b407330cf92641b72b66d15e4c134e93224b6b10a9ededc2771705c259dab081L17-R19), [examples/nextjs/src/app/blog/post/[[...slug]]/page.jsL40-R43](diffhunk://#diff-b407330cf92641b72b66d15e4c134e93224b6b10a9ededc2771705c259dab081L40-R43))

Import path correction:

* [`examples/nextjs/src/components/my-blog-page.js`](diffhunk://#diff-d257d7e5642615ea385685e2cec807d0aea2551017a0517996815b419fd23b68L6-R6): Fixed the import path for the `Header` component to ensure it correctly points to `header/header`.

This PR fixes: #30607