### PR TITLE
fix(uve): Fixing infinite loading when re-enter to uve editor in traditional pages

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -184,6 +184,12 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
             this.setIframeContent(code);
 
             requestAnimationFrame(() => {
+                /**
+                 * The status of isClientReady is changed outside of editor
+                 * so we need to set it to true here to avoid the editor to be in a loading state
+                 * This is only for traditional pages. For Headless, the isClientReady is set from the client application
+                 */
+                this.uveStore.setIsClientReady(true);
                 const win = this.contentWindow;
                 if (enableInlineEdit) {
                     this.inlineEditingService.injectInlineEdit(this.iframe);


### PR DESCRIPTION
This pull request includes an update to the `EditEmaEditorComponent` class to ensure the editor does not remain in a loading state for traditional pages. The most important change is the addition of a block of code that sets the `isClientReady` status to true.

Key change:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts`](diffhunk://#diff-24dc496db1eb6feb3e10a031baa4b4b63c20f1cd02ade574065f6b967f11c365R187-R192): Added code to set `isClientReady` to true within `requestAnimationFrame` to prevent the editor from being in a loading state for traditional pages.

This PR fixes: #30030