### PR TITLE
fix(uve): Maintain URL when property is changed and is a URLContentMap

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1082,6 +1082,39 @@ describe('DotEmaShellComponent', () => {
                     queryParamsHandling: 'merge'
                 });
             });
+
+            it('should mantain the current URL as queryParam when the URL property is changed and is a URLContentMap', () => {
+                jest.spyOn(store, 'pageAPIResponse').mockReturnValue(PAGE_RESPONSE_URL_CONTENT_MAP);
+
+                const navigate = jest.spyOn(router, 'navigate');
+
+                spectator.detectChanges();
+
+                spectator.triggerEventHandler(DotEmaDialogComponent, 'action', {
+                    event: new CustomEvent('ng-event', {
+                        detail: {
+                            name: NG_CUSTOM_EVENTS.URL_IS_CHANGED,
+                            payload: {
+                                htmlPageReferer: '/a-new-url'
+                            }
+                        }
+                    }),
+                    actionPayload: PAYLOAD_MOCK,
+                    form: {
+                        status: FormStatus.SAVED,
+                        isTranslation: false
+                    },
+                    clientAction: CLIENT_ACTIONS.NOOP
+                });
+                spectator.detectChanges();
+
+                expect(navigate).toHaveBeenCalledWith([], {
+                    queryParams: {
+                        url: '/test-url'
+                    },
+                    queryParamsHandling: 'merge'
+                });
+            });
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -189,23 +189,13 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
 
         if (this.shouldNavigate(url.pathname)) {
             // Navigate to the new URL if it's different from the current one
-            this.navigate({ url: url.pathname });
+            this.navigate({ url: this.getTargetUrl(url.pathname) });
 
             return;
         }
 
         this.uveStore.reload();
     }
-    /**
-     * Extracts the htmlPageReferer url from the event payload.
-     *
-     * @param {CustomEvent} event - The event object containing the payload with the URL.
-     * @return {string | undefined} - The extracted URL or undefined if not found.
-     */
-    private extractPageRefererUrl(event: CustomEvent): string | undefined {
-        return event.detail.payload?.htmlPageReferer;
-    }
-
     /**
      * Determines the target URL for navigation.
      *


### PR DESCRIPTION


https://github.com/user-attachments/assets/21efb269-b350-4e2a-893c-b99e0c135d02



This pull request includes several changes to the `DotEmaShellComponent` in the `core-web` library, focusing on improving URL handling and removing redundant code.

### Enhancements to URL handling:

* Added a new test case to ensure the current URL is maintained as a query parameter when the URL property is changed and is a `URLContentMap` in `dot-ema-shell.component.spec.ts`.

### Code simplification:

* Modified the `navigate` method to use `getTargetUrl` for determining the target URL in `dot-ema-shell.component.ts`.
* Removed the `extractPageRefererUrl` method, which was no longer necessary.

This PR fixes: #30030