### PR TITLE
fix(db)  allow db dump functionality to work even if the password val…

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/util/DataSourceAttributes.java
+++ b/dotCMS/src/main/java/com/dotcms/util/DataSourceAttributes.java
@@ -1,6 +1,10 @@
 
 package com.dotcms.util;
 
+import io.vavr.control.Try;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 /**
  * This class holds information fof the datasource connection to be used when exporting the DB as a postgres dump.
  *
@@ -13,8 +17,8 @@ public class DataSourceAttributes {
 
     public DataSourceAttributes(final String username, final String password, final String url) {
         super();
-        this.username = username;
-        this.password = password.toCharArray();
+        this.username = Try.of(()-> URLEncoder.encode(username, StandardCharsets.UTF_8.toString())).getOrNull();
+        this.password = Try.of(()->URLEncoder.encode(password, StandardCharsets.UTF_8.toString()).toCharArray()).getOrElse(new char[]{});
         this.url = url;
     }
 

--- a/dotCMS/src/test/java/com/dotcms/util/DataSourceAttributesTest.java
+++ b/dotCMS/src/test/java/com/dotcms/util/DataSourceAttributesTest.java
@@ -1,0 +1,33 @@
+package com.dotcms.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+class DataSourceAttributesTest {
+
+
+
+    String badPassword = "pass:/+%&word";
+    String userName = "testing:/+%&user";
+    String url = "jdbc:postgresql://localhost:5432/dotcms";
+
+
+    @Test
+    void testing_url_encoding() throws MalformedURLException {
+        DataSourceAttributes dataSourceAttributes = new DataSourceAttributes(userName, badPassword, url);
+        assertEquals("jdbc:postgresql://localhost:5432/dotcms", dataSourceAttributes.url);
+        assertEquals("testing%3A%2F%2B%25%26user", dataSourceAttributes.username);
+
+
+        assertEquals(
+                "postgresql://testing%3A%2F%2B%25%26user:pass%3A%2F%2B%25%26word@localhost:5432/dotcms",
+                dataSourceAttributes.getDbUrl()
+        );
+
+
+
+    }
+}


### PR DESCRIPTION
This pull request includes updates to the `DataSourceAttributes` class in the `dotCMS` project to improve the handling of username and password encoding. The most important changes are:

Improvements to encoding:

* [`dotCMS/src/main/java/com/dotcms/util/DataSourceAttributes.java`](diffhunk://#diff-09f7a1123aaff454ae6e8a9fef7c27f993745035d90252c8de24ba25f6b1c912R4-R7): Imported `Try` from `io.vavr.control`, `URLEncoder`, and `StandardCharsets` to handle encoding.
* [`dotCMS/src/main/java/com/dotcms/util/DataSourceAttributes.java`](diffhunk://#diff-09f7a1123aaff454ae6e8a9fef7c27f993745035d90252c8de24ba25f6b1c912L16-R21): Updated the constructor to encode the `username` and `password` using `URLEncoder` and `StandardCharsets.UTF_8`, and handle potential encoding exceptions using `Try`.

This PR fixes: #30743