### PR TITLE
POC:  SDK Enhance Error Handling in Angular and React (DONT MERGE)

### DIFF
--- a/core-web/libs/sdk/angular/src/lib/components/dot-error-boundary/dot-error-boundary.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dot-error-boundary/dot-error-boundary.component.ts
@@ -1,0 +1,38 @@
+import { Component, inject } from '@angular/core';
+
+import { DotErrorHandler } from './dot-error-handler.service';
+
+@Component({
+    selector: 'dot-error-boundary',
+    styles: [
+        `
+            :host {
+                display: contents;
+            }
+
+            /* Error message styling */
+            .error-message {
+                padding: 10px;
+                border: 1px solid red;
+                background-color: rgba(255, 0, 0, 0.1);
+                color: red;
+            }
+        `
+    ],
+    template: `
+        @if ($error(); as error) {
+            <div class="error-message">
+                {{ error.message }}
+            </div>
+        } @else {
+            <ng-content></ng-content>
+        }
+    `,
+    providers: [DotErrorHandler],
+    standalone: true
+})
+export class DotErrorBoundaryComponent {
+    errorHandler = inject(DotErrorHandler);
+
+    $error = this.errorHandler.errorSignal;
+}

--- a/core-web/libs/sdk/angular/src/lib/components/dot-error-boundary/dot-error-handler.service.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dot-error-boundary/dot-error-handler.service.ts
@@ -1,0 +1,57 @@
+import { ErrorHandler, signal } from '@angular/core';
+
+export type DotErrorContext = {
+    title?: string;
+    contentType?: string;
+    identifier?: string;
+    inode?: string;
+    uuid?: string;
+    row?: number;
+    column?: number;
+};
+
+export enum DotErrorCodes {
+    ROW001 = 'ROW001',
+    COL001 = 'COL001',
+    CON001 = 'CON001',
+    CON002 = 'CON002'
+}
+
+export const ERROR_MAP: Record<DotErrorCodes, (context: DotErrorContext) => string> = {
+    [DotErrorCodes.ROW001]: ({ row }) =>
+        `Error found on Row\nRow Index: ${row}\nCheck more on dotcms.docs.com/errors/row001`, // We can add more info
+    [DotErrorCodes.COL001]: ({ row, column }) =>
+        `Error found on Column\nRow Index: ${row}\nColumn Index: ${column}\nCheck more on dotcms.docs.com/errors/col001`,
+    [DotErrorCodes.CON001]: ({ row, column, identifier, uuid }) =>
+        `Error found on Container\nRow Index: ${row}\nColumn Index: ${column}\nContainer Identifier: ${identifier}\nContainer UUID: ${uuid}\nCheck more on dotcms.docs.com/errors/con001`,
+    [DotErrorCodes.CON002]: ({ row, column, uuid, identifier, contentType, title }) =>
+        `Error found on Contentlet\nRow Index: ${row}\nColumn Index: ${column}\nContainer UUID: ${uuid}\nContentlet Identifier: ${identifier}\nContentlet ContentType: ${contentType}\nContentlet Title: ${title}\nCheck more on dotcms.docs.com/errors/con002`
+};
+
+export class DotError extends Error {
+    context: DotErrorContext;
+
+    constructor(message: DotErrorCodes, context: DotErrorContext) {
+        super(ERROR_MAP[message](context));
+        this.name = 'DotError';
+
+        this.context = context;
+    }
+}
+
+export class DotErrorHandler implements ErrorHandler {
+    errorSignal = signal<DotError | null>(null);
+
+    handleError(error: unknown): void {
+        if (error instanceof DotError) {
+            this.errorSignal.set(error); // Set the error signal
+            console.error('DotError:\n', error.message);
+        } else {
+            console.error('Unexpected error:', error);
+        }
+    }
+
+    clearError(): void {
+        this.errorSignal.set(null); // Reset the error signal
+    }
+}

--- a/core-web/libs/sdk/angular/src/lib/layout/container/container.component.html
+++ b/core-web/libs/sdk/angular/src/lib/layout/container/container.component.html
@@ -1,16 +1,20 @@
 @if ($isInsideEditor()) {
     @if ($contentlets().length) {
         @for (contentlet of $contentlets(); track $index) {
-            <dotcms-contentlet-wrapper
-                [contentlet]="contentlet"
-                [container]="$dotContainerAsString()">
-                <ng-container
-                    *ngComponentOutlet="
-                        (componentsMap[contentlet.contentType] || componentsMap['CustomNoComponent']
-                            | async) || NoComponent;
-                        inputs: { contentlet }
-                    " />
-            </dotcms-contentlet-wrapper>
+            <dot-error-boundary>
+                <dotcms-contentlet-wrapper
+                    [contentlet]="contentlet"
+                    [container]="$dotContainerAsString()"
+                    [row]="row"
+                    [col]="col">
+                    <ng-container
+                        *ngComponentOutlet="
+                            (componentsMap[contentlet.contentType] ||
+                                componentsMap['CustomNoComponent'] | async) || NoComponent;
+                            inputs: { contentlet }
+                        " />
+                </dotcms-contentlet-wrapper>
+            </dot-error-boundary>
         }
     } @else {
         This container is empty.

--- a/core-web/libs/sdk/angular/src/lib/layout/contentlet/contentlet.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/layout/contentlet/contentlet.component.ts
@@ -1,5 +1,17 @@
-import { ChangeDetectionStrategy, Component, HostBinding, Input, OnChanges } from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    HostBinding,
+    inject,
+    Input,
+    OnChanges
+} from '@angular/core';
 
+import {
+    DotError,
+    DotErrorCodes,
+    DotErrorHandler
+} from '../../components/dot-error-boundary/dot-error-handler.service';
 import { DotCMSContentlet } from '../../models';
 
 /**
@@ -30,6 +42,9 @@ export class ContentletComponent implements OnChanges {
      * @memberof ContentletComponent
      */
     @Input() container!: string;
+
+    @Input() row!: number;
+    @Input() col!: number;
 
     /**
      * The identifier of contentlet component.
@@ -88,6 +103,7 @@ export class ContentletComponent implements OnChanges {
      */
     @HostBinding('attr.data-dot-object') dotContent: string | null = null;
 
+    errorHandler = inject(DotErrorHandler);
     ngOnChanges() {
         this.identifier = this.contentlet.identifier;
         this.baseType = this.contentlet.baseType;
@@ -97,5 +113,22 @@ export class ContentletComponent implements OnChanges {
         this.dotContainer = this.container;
         this.numberOfPages = this.contentlet['onNumberOfPages'];
         this.dotContent = 'contentlet';
+
+        const container = JSON.parse(this.container);
+
+        try {
+            // RANDOMLY THROWING ERRORS BUT WE CAN MAKE INTEGRITY CHECKS OF THE CONTENTLETS
+            if (Math.random() > 0.4)
+                throw new DotError(DotErrorCodes.CON002, {
+                    identifier: this.contentlet.identifier,
+                    inode: this.contentlet.inode,
+                    uuid: container.uuid,
+                    row: this.row,
+                    column: this.col,
+                    contentType: this.contentlet.contentType
+                });
+        } catch (error) {
+            this.errorHandler.handleError(error);
+        }
     }
 }

--- a/core-web/libs/sdk/angular/src/lib/layout/dotcms-layout/dotcms-layout.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/layout/dotcms-layout/dotcms-layout.component.ts
@@ -20,6 +20,7 @@ import {
     updateNavigation
 } from '@dotcms/client';
 
+import { DotErrorBoundaryComponent } from '../../components/dot-error-boundary/dot-error-boundary.component';
 import { DotCMSPageComponent } from '../../models';
 import { DotCMSPageAsset } from '../../models/dotcms.model';
 import { PageContextService } from '../../services/dotcms-context/page-context.service';
@@ -35,11 +36,13 @@ import { RowComponent } from '../row/row.component';
 @Component({
     selector: 'dotcms-layout',
     standalone: true,
-    imports: [RowComponent, AsyncPipe],
+    imports: [RowComponent, AsyncPipe, DotErrorBoundaryComponent],
     template: `
         @if (pageAsset$ | async; as page) {
             @for (row of page?.layout?.body?.rows; track $index) {
-                <dotcms-row [row]="row" />
+                <dot-error-boundary>
+                    <dotcms-row [row]="row" [index]="$index" />
+                </dot-error-boundary>
             }
         }
     `,

--- a/core-web/libs/sdk/angular/src/lib/layout/row/row.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/layout/row/row.component.ts
@@ -1,5 +1,11 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnInit } from '@angular/core';
 
+import { DotErrorBoundaryComponent } from '../../components/dot-error-boundary/dot-error-boundary.component';
+import {
+    DotError,
+    DotErrorCodes,
+    DotErrorHandler
+} from '../../components/dot-error-boundary/dot-error-handler.service';
 import { DotPageAssetLayoutRow } from '../../models';
 import { ColumnComponent } from '../column/column.component';
 
@@ -12,16 +18,18 @@ import { ColumnComponent } from '../column/column.component';
 @Component({
     selector: 'dotcms-row',
     standalone: true,
-    imports: [ColumnComponent],
+    imports: [ColumnComponent, DotErrorBoundaryComponent],
     template: `
         @for (column of row.columns; track $index) {
-            <dotcms-column [column]="column" />
+            <dot-error-boundary>
+                <dotcms-column [column]="column" [rowIndex]="index" [colIndex]="$index" />
+            </dot-error-boundary>
         }
     `,
     styleUrl: './row.component.css',
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class RowComponent {
+export class RowComponent implements OnInit {
     /**
      * The row object containing the columns.
      *
@@ -29,4 +37,18 @@ export class RowComponent {
      * @memberof RowComponent
      */
     @Input({ required: true }) row!: DotPageAssetLayoutRow;
+    @Input() index!: number;
+    errorHandler = inject(DotErrorHandler);
+
+    ngOnInit() {
+        // RANDOMLY THROW AN ERROR BUT WE CAN MAKE INTEGRITY CHECKS OF THE ROWS
+        try {
+            if (Math.random() > 0.8)
+                throw new DotError(DotErrorCodes.ROW001, {
+                    row: this.index
+                });
+        } catch (error) {
+            this.errorHandler.handleError(error);
+        }
+    }
 }

--- a/core-web/libs/sdk/react/src/lib/components/Column/Column.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Column/Column.tsx
@@ -6,6 +6,8 @@ import { PageContext } from '../../contexts/PageContext';
 import { DotCMSPageContext } from '../../models';
 import { combineClasses, getPositionStyleClasses } from '../../utils/utils';
 import { Container } from '../Container/Container';
+import { DotError, DotErrorCodes } from '../DotErrorBoundary/DotError';
+import DotErrorBoundary from '../DotErrorBoundary/DotErrorBoundary';
 
 /**
  * Props for Column component to render a column with its containers.
@@ -15,6 +17,8 @@ import { Container } from '../Container/Container';
  */
 export interface ColumnProps {
     readonly column: DotCMSPageContext['pageAsset']['layout']['body']['rows'][0]['columns'][0];
+    colIndex: number;
+    rowIndex: number;
 }
 
 /**
@@ -25,7 +29,7 @@ export interface ColumnProps {
  * @param {ColumnProps} { column }
  * @return {JSX.Element} Rendered column with containers
  */
-export function Column({ column }: ColumnProps) {
+export function Column({ column, rowIndex, colIndex }: ColumnProps) {
     const { isInsideEditor } = useContext(PageContext) as DotCMSPageContext;
 
     const { startClass, endClass } = getPositionStyleClasses(
@@ -42,14 +46,20 @@ export function Column({ column }: ColumnProps) {
           }
         : {};
 
+    // RANDOMLY THROW AN ERROR BUT WE CAN MAKE INTEGRITY CHECKS OF THE COLUMNS
+    if (Math.random() > 0.7)
+        throw new DotError(DotErrorCodes.COL001, {
+            row: rowIndex,
+            column: colIndex
+        });
+
     return (
         <div {...columnProps} className={combinedClasses}>
             <div className={column.styleClass}>
                 {column.containers.map((container) => (
-                    <Container
-                        key={`${container.identifier}-${container.uuid}`}
-                        containerRef={container}
-                    />
+                    <DotErrorBoundary key={`${container.identifier}-${container.uuid}`}>
+                        <Container containerRef={container} col={colIndex} row={rowIndex} />
+                    </DotErrorBoundary>
                 ))}
             </div>
         </div>

--- a/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotError.ts
+++ b/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotError.ts
@@ -30,7 +30,7 @@ export class DotError extends Error {
     context: DotErrorContext;
 
     constructor(message: DotErrorCodes, context: DotErrorContext) {
-        super(message);
+        super(ERROR_MAP[message](context));
         this.name = 'DotError';
 
         this.context = context;

--- a/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotError.ts
+++ b/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotError.ts
@@ -1,0 +1,38 @@
+export type DotErrorContext = {
+    title?: string;
+    contentType?: string;
+    identifier?: string;
+    inode?: string;
+    uuid?: string;
+    row?: number;
+    column?: number;
+};
+
+export enum DotErrorCodes {
+    ROW001 = 'ROW001',
+    COL001 = 'COL001',
+    CON001 = 'CON001',
+    CON002 = 'CON002'
+}
+
+export const ERROR_MAP: Record<DotErrorCodes, (context: DotErrorContext) => string> = {
+    [DotErrorCodes.ROW001]: ({ row }) =>
+        `Error found on Row\nRow Index: ${row}\nCheck more on dotcms.docs.com/errors/row001`, // We can add more info
+    [DotErrorCodes.COL001]: ({ row, column }) =>
+        `Error found on Column\nRow Index: ${row}\nColumn Index: ${column}\nCheck more on dotcms.docs.com/errors/col001`,
+    [DotErrorCodes.CON001]: ({ row, column, identifier, uuid }) =>
+        `Error found on Container\nRow Index: ${row}\nColumn Index: ${column}\nContainer Identifier: ${identifier}\nContainer UUID: ${uuid}\nCheck more on dotcms.docs.com/errors/con001`,
+    [DotErrorCodes.CON002]: ({ row, column, uuid, identifier, contentType, title }) =>
+        `Error found on Contentlet\nRow Index: ${row}\nColumn Index: ${column}\nContainer UUID: ${uuid}\nContentlet Identifier: ${identifier}\nContentlet ContentType: ${contentType}\nContentlet Title: ${title}\nCheck more on dotcms.docs.com/errors/con002`
+};
+
+export class DotError extends Error {
+    context: DotErrorContext;
+
+    constructor(message: DotErrorCodes, context: DotErrorContext) {
+        super(message);
+        this.name = 'DotError';
+
+        this.context = context;
+    }
+}

--- a/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotErrorBoundary.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, ReactNode } from 'react';
 
-import { DotError, DotErrorCodes, ERROR_MAP } from './DotError';
+import { DotError } from './DotError';
 
 interface Props {
     children?: ReactNode;
@@ -18,14 +18,6 @@ class DotErrorBoundary extends Component<Props, State> {
         return { error };
     }
 
-    componentDidCatch(error: DotError) {
-        // COLXXX: Column error
-        // ROWXXX: Row error
-        // CONXXX: Container error
-
-        console.error(ERROR_MAP[error.message as DotErrorCodes](error.context));
-    }
-
     render() {
         if (this.state.error) {
             return (
@@ -37,9 +29,7 @@ class DotErrorBoundary extends Component<Props, State> {
                         color: 'red'
                     }}>
                     {
-                        ERROR_MAP[this.state.error.message as DotErrorCodes](
-                            this.state.error.context
-                        ) // Probably will not show anything Im just testing
+                        this.state.error.message // Probably will not show anything Im just testing
                     }
                 </div>
             );

--- a/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotErrorBoundary.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotErrorBoundary.tsx
@@ -1,43 +1,48 @@
-import { Component, ErrorInfo, ReactNode } from 'react';
+import { Component, ReactNode } from 'react';
+
+import { DotError, DotErrorCodes, ERROR_MAP } from './DotError';
 
 interface Props {
     children?: ReactNode;
 }
 
 interface State {
-    hasError: boolean;
+    error?: DotError;
 }
 
 class DotErrorBoundary extends Component<Props, State> {
-    state: State = {
-        hasError: false
-    };
+    state: State = {};
 
-    constructor(props: object) {
-        super(props);
-        this.state = { hasError: false };
-    }
-
-    static getDerivedStateFromError(_: Error) {
+    static getDerivedStateFromError(error: DotError) {
         // Update state so the next render will show the fallback UI.
-        return { hasError: true };
+        return { error };
     }
 
-    componentDidCatch(error: Error, info: ErrorInfo) {
-        // Here i should get a code as:
+    componentDidCatch(error: DotError) {
         // COLXXX: Column error
         // ROWXXX: Row error
         // CONXXX: Container error
 
-        // Then consult a map with common errors and show a message that is more user friendly
-        // The map could return a function that takes the error and builds the message
-
-        console.error('ErrorBoundary', error, info);
+        console.error(ERROR_MAP[error.message as DotErrorCodes](error.context));
     }
 
     render() {
-        if (this.state.hasError) {
-            return null; // Don't show anything
+        if (this.state.error) {
+            return (
+                <div
+                    style={{
+                        padding: '10px',
+                        border: '1px solid red',
+                        backgroundColor: 'rgba(255, 0, 0, 0.1)',
+                        color: 'red'
+                    }}>
+                    {
+                        ERROR_MAP[this.state.error.message as DotErrorCodes](
+                            this.state.error.context
+                        ) // Probably will not show anything Im just testing
+                    }
+                </div>
+            );
         }
 
         return this.props.children;

--- a/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotErrorBoundary.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+    children?: ReactNode;
+}
+
+interface State {
+    hasError: boolean;
+}
+
+class DotErrorBoundary extends Component<Props, State> {
+    state: State = {
+        hasError: false
+    };
+
+    constructor(props: object) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(_: Error) {
+        // Update state so the next render will show the fallback UI.
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo) {
+        // Here i should get a code as:
+        // COLXXX: Column error
+        // ROWXXX: Row error
+        // CONXXX: Container error
+
+        // Then consult a map with common errors and show a message that is more user friendly
+        // The map could return a function that takes the error and builds the message
+
+        console.error('ErrorBoundary', error, info);
+    }
+
+    render() {
+        if (this.state.hasError) {
+            return null; // Don't show anything
+        }
+
+        return this.props.children;
+    }
+}
+
+export default DotErrorBoundary;

--- a/core-web/libs/sdk/react/src/lib/components/DotcmsLayout/DotcmsLayout.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/DotcmsLayout/DotcmsLayout.tsx
@@ -2,6 +2,7 @@ import { DotCMSPageEditorConfig } from '@dotcms/client';
 
 import { useDotcmsEditor } from '../../hooks/useDotcmsEditor';
 import { DotCMSPageContext } from '../../models';
+import DotErrorBoundary from '../DotErrorBoundary/DotErrorBoundary';
 import { PageProvider } from '../PageProvider/PageProvider';
 import { Row } from '../Row/Row';
 
@@ -43,7 +44,9 @@ export function DotcmsLayout(dotPageProps: DotcmsPageProps): JSX.Element {
     return (
         <PageProvider pageContext={pageContext}>
             {pageContext.pageAsset?.layout?.body.rows.map((row, index) => (
-                <Row key={index} row={row} />
+                <DotErrorBoundary key={index}>
+                    <Row row={row} index={index} />
+                </DotErrorBoundary>
             ))}
         </PageProvider>
     );

--- a/core-web/libs/sdk/react/src/lib/components/Row/Row.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/Row/Row.tsx
@@ -5,6 +5,8 @@ import styles from './Row.module.css';
 import { PageContext } from '../../contexts/PageContext';
 import { DotCMSPageContext } from '../../models';
 import { Column } from '../Column/Column';
+import { DotError, DotErrorCodes } from '../DotErrorBoundary/DotError';
+import DotErrorBoundary from '../DotErrorBoundary/DotErrorBoundary';
 
 /**
  * Props for the row component
@@ -20,6 +22,7 @@ export interface RowProps {
      * @memberof RowProps
      */
     row: DotCMSPageContext['pageAsset']['layout']['body']['rows'][0];
+    index: number;
 }
 
 /**
@@ -30,6 +33,8 @@ export interface RowProps {
  * @param {React.ForwardedRef<HTMLDivElement, RowProps>} ref
  * @return {JSX.Element} Rendered rows with columns
  */
+
+// Not sure why we have a forwardRef here
 export const Row = forwardRef<HTMLDivElement, RowProps>((props: RowProps, ref) => {
     const { isInsideEditor } = useContext<DotCMSPageContext | null>(
         PageContext
@@ -39,12 +44,20 @@ export const Row = forwardRef<HTMLDivElement, RowProps>((props: RowProps, ref) =
 
     const rowProps = isInsideEditor ? { 'data-dot': 'row', 'data-testid': 'row', ref } : {};
 
+    // RANDOMLY THROW AN ERROR BUT WE CAN MAKE INTEGRITY CHECKS OF THE ROWS
+    if (Math.random() > 0.8)
+        throw new DotError(DotErrorCodes.ROW001, {
+            row: props.index
+        });
+
     return (
         <div className={row.styleClass}>
             <div className="container">
                 <div {...rowProps} className={styles.row}>
                     {row.columns.map((column, index) => (
-                        <Column key={index} column={column} />
+                        <DotErrorBoundary key={index}>
+                            <Column column={column} colIndex={index} rowIndex={props.index} />
+                        </DotErrorBoundary>
                     ))}
                 </div>
             </div>

--- a/examples/angular/src/environments/environment.development.ts
+++ b/examples/angular/src/environments/environment.development.ts
@@ -5,6 +5,6 @@ export const environment = {
    * for security purposes, make sure is read-only.
    * More info: https://www.dotcms.com/docs/latest/permissions
    */
-  authToken: 'YOUR_AUTH_TOKEN',
+  authToken:"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhcGlkNmI2NmViNS0xNTRlLTRiZDctODAwZi1mZDcwNzExMjJhYjkiLCJ4bW9kIjoxNzMyNTU0NjQ3MDAwLCJuYmYiOjE3MzI1NTQ2NDcsImlzcyI6ImNkOTRiM2QzNmQiLCJsYWJlbCI6InRuMGtzIiwiZXhwIjoxNzM1MTQ2NjQ3LCJpYXQiOjE3MzI1NTQ2NDcsImp0aSI6IjlmMDFiNTFkLTQ3MzQtNDllYS1hNDkxLTFmY2FkNGU2MWNlNiJ9.jTzlRH8c60BgJ_1PbIsQKtkqPQNUQEF8AJRu9cCycsI",
   siteId: 'true',
 };

--- a/examples/angular/tsconfig.json
+++ b/examples/angular/tsconfig.json
@@ -1,30 +1,34 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
-  "compileOnSave": false,
-  "compilerOptions": {
-    "outDir": "./dist/out-tsc",
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "sourceMap": true,
-    "declaration": false,
-    "experimentalDecorators": true,
-    "moduleResolution": "node",
-    "importHelpers": true,
-    "target": "ES2022",
-    "module": "ES2022",
-    "useDefineForClassFields": false,
-    "lib": ["ES2022", "dom"]
-  },
-  "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": true,
-    "strictInputAccessModifiers": true,
-    "strictTemplates": true
-  }
+    "compileOnSave": false,
+    "compilerOptions": {
+        "outDir": "./dist/out-tsc",
+        "forceConsistentCasingInFileNames": true,
+        "strict": true,
+        "noImplicitOverride": true,
+        "noPropertyAccessFromIndexSignature": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "skipLibCheck": true,
+        "esModuleInterop": true,
+        "sourceMap": true,
+        "declaration": false,
+        "experimentalDecorators": true,
+        "moduleResolution": "node",
+        "importHelpers": true,
+        "target": "ES2022",
+        "module": "ES2022",
+        "useDefineForClassFields": false,
+        "lib": ["ES2022", "dom"],
+        "paths": {
+            "@dotcms/angular": ["../../core-web/dist/libs/sdk/angular"],
+            "@dotcms/client": ["../../core-web/dist/libs/sdk/client"]
+        }
+    },
+    "angularCompilerOptions": {
+        "enableI18nLegacyMessageIdFormat": false,
+        "strictInjectionParameters": true,
+        "strictInputAccessModifiers": true,
+        "strictTemplates": true
+    }
 }


### PR DESCRIPTION
## Summary 

`ErrorBoundaries` are a good option to manage dotCMS common errors in the template, we can provide context of where and which content is failing and how to solve it.

We can establish the most common errors and label them with codes.

In this POC I used this ones:
- ROW001 
- COL001
- CON001
- CON002

Where `ROW` is for Row errors, `COL` for Columns and `CON` for Containers/Content and the number as postfix is just an ascending value.

The UI error is just for debugging/POC purposes, we could explore that possibility in the near future, in this ticket we just want to provide more context to the developer when an error occurs and also don't crash the whole app when this happens.

I created a custom error that you can check in this [file](https://github.com/dotCMS/core/blob/2000c8801409e22c196fb5a939e2f424bc5250c9/core-web/libs/sdk/react/src/lib/components/DotErrorBoundary/DotError.ts)

The only difference between the `Angular` and `React` implementation are that in `Angular` when a component crashes it does not propagate the error to the Custom `ErrorHandler` as we expected, so we need to write `try/catch` blocks and in case it fails, we need to call manually the `DotErrorHandler`.

### Conclusion

This POC proves that we need to use a combination of ErrorBoundary to scope the Errors and get an accurate context with `try/catch` blocks to ensure that the `Error` passes through our custom `ErrorHandler`.

### Angular Demo

https://github.com/user-attachments/assets/7c8a09de-5580-499f-84fd-42368f9d2b2b

### React Demo


https://github.com/user-attachments/assets/d34d257a-d98d-4a0a-a50e-d851819d0fe2

