### PR TITLE
ci: Update legacy release workflow to use core cicd setup java (#30762)

### DIFF
--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -34,8 +34,6 @@ on:
         default: true
         required: false
 env:
-  JAVA_VERSION: 11
-  JAVA_DISTRO: temurin
   JVM_TEST_MAVEN_OPTS: '-e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
   DOCKER_BUILD_CONTEXT: /home/runner/work/_temp/core-build
 jobs:
@@ -126,10 +124,8 @@ jobs:
           echo "release_commit=${release_commit}" >> $GITHUB_OUTPUT
 
       - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRO }}
+        id: setup-java
+        uses: ./.github/actions/core-cicd/setup-java
 
       - name: Build Core
         run: |
@@ -265,10 +261,8 @@ jobs:
           key: npm-${{ hashFiles('core-web/package-lock.json') }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.JAVA_DISTRO }}
+        id: setup-java
+        uses: ./.github/actions/core-cicd/setup-java
 
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v20

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -92,7 +92,7 @@
         <jandex-maven-plugin.version>1.2.3</jandex-maven-plugin.version>
 
         <javadoc.additional.params>-Xdoclint:none --allow-script-in-comments</javadoc.additional.params>
-        <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
+        <jdk.min.version>21</jdk.min.version>
         <maven.compiler.argument.source>${maven.compiler.source}</maven.compiler.argument.source>
         <maven.compiler.argument.target>${maven.compiler.target}</maven.compiler.argument.target>
         <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
@@ -1049,8 +1049,7 @@
                                 </bannedRepositories>
                                 <requireJavaVersion>
                                     <version>${jdk.min.version}</version>
-                                    <message>To build this project JDK ${jdk.min.version} (or greater) is required.
-                                        Please install it.</message>
+                                    <message>Building this project requires JDK version ${jdk.min.version} or higher. It is recommended to use SDKMAN to manage JDK versions. Run "sdk env install" to install and activate the correct JDK version specified in the .sdkmanrc file.</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
### Proposed Changes
* Refactor legacy release workflow to use new core-cicd/setup-java action to consistently use the same java version accross workflows
* Updated maven enforcer plugin to error if not using Java 21 minimum to build/compile

This PR fixes: #30762