### PR TITLE
fix(shortyservlet) remove noise in logs #30709

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
@@ -539,10 +539,17 @@ public class ShortyServlet extends HttpServlet {
 
             if (contentletVersionInfo.isPresent()) {
                 Logger.debug(this, "Contentlet version found for identifier: " + relatedImageId);
-                final Contentlet imageContentlet = getImageContentlet(contentletVersionInfo.get(), live);
-                validateContentlet(imageContentlet, live, imageContentlet.getInode());
-                final String fieldVar = imageContentlet.isDotAsset() ? DotAssetContentType.ASSET_FIELD_VAR : FILE_ASSET_DEFAULT;
-                return buildFieldPath(imageContentlet, fieldVar);
+                final String inode = live
+                        ? contentletVersionInfo.get().getLiveInode()
+                        : contentletVersionInfo.get().getWorkingInode();
+                try{
+                    final Contentlet imageContentlet = APILocator.getContentletAPI().find(inode, APILocator.systemUser(), false);
+                    validateContentlet(imageContentlet, live, inode);
+                    final String fieldVar = imageContentlet.isDotAsset() ? DotAssetContentType.ASSET_FIELD_VAR : FILE_ASSET_DEFAULT;
+                    return buildFieldPath(imageContentlet, fieldVar);
+                }catch (DotDataException e){
+                    Logger.debug(this.getClass(), e.getMessage());
+                }
             }
             Logger.debug(this, "No contentlet version found for identifier: " + relatedImageId + ", returning path based on original contentlet inode: " + contentlet.getInode());
         }
@@ -560,22 +567,6 @@ public class ShortyServlet extends HttpServlet {
     private boolean shouldFallbackToDefaultLanguage(final Contentlet contentlet) {
         return APILocator.getLanguageAPI().canDefaultFileToDefaultLanguage() &&
                 APILocator.getLanguageAPI().getDefaultLanguage().getId() != contentlet.getLanguageId();
-    }
-
-    /**
-     * Retrieves the appropriate contentlet version (live or working) for an image
-     * based on the provided version info.
-     *
-     * @param versionInfo The version information for the contentlet
-     * @param live Whether to retrieve the live version (true) or working version (false)
-     * @return The requested version of the contentlet
-     * @throws DotDataException If there's an error accessing the data
-     * @throws DotSecurityException If there's a security violation
-     */
-    private Contentlet getImageContentlet(final ContentletVersionInfo versionInfo, final boolean live) 
-            throws DotDataException, DotSecurityException {
-        final String inode = live ? versionInfo.getLiveInode() : versionInfo.getWorkingInode();
-        return APILocator.getContentletAPI().find(inode, APILocator.systemUser(), false);
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes
* Added a `try-catch` block to handle `DotDataException` when fetching the `Contentlet` in `ShortyServlet`.
* Removed the unused `getImageContentlet` method to reduce redundancy.
* Updated logging to reduce verbosity when an image does not exist, replacing it with a concise debug log.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
The changes address a NullPointerException occurring when a requested image by shorty does not exist. This was causing excessive error logging, making it difficult to identify the actual issue. By catching `DotDataException` and logging a debug message, we now ensure that logs remain clean and the system handles missing images gracefully.  
The removed method `getImageContentlet` was no longer necessary as its functionality was integrated directly into the updated code.  

This PR fixes: #30709