### PR TITLE
Issue 30724 Task url redirecting only language_id=1 

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlet_popup_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlet_popup_inc.jsp
@@ -241,7 +241,7 @@ if(!hasPermissions) {
                <td>
                    <%if(structure.getStructureType()==Structure.STRUCTURE_TYPE_HTMLPAGE || isUrlMap  ){ %>
                        <%session.setAttribute(com.dotmarketing.util.WebKeys.CMS_SELECTED_HOST_ID, content.getHost()); %>
-                       <div style="padding:3px;"><a style="color:#0E80CB;" target="workflowWindow" text-decoration: underline;" href="/dotAdmin/#/edit-page/content?url=<%= editPath%>"><%= editPath%></a></div>
+                       <div style="padding:3px;"><a style="color:#0E80CB;" target="workflowWindow" text-decoration: underline;" href="/dotAdmin/#/edit-page/content?url=<%= editPath+ "&language_id=" + lang.getId()%>"><%= editPath%></a></div>
                    <%}else  if(structure.getStructureType()==Structure.STRUCTURE_TYPE_FILEASSET ){ %>
                        <div style="padding:3px;"><a style="color:#0E80CB; text-decoration: underline;" href="#" onclick="dotPreviewFile('/dA/<%=shorty.shortify(content.getInode()) %>/fileAsset/<%=id.getAssetName() %>?mode=PREVIEW_MODE')" >/dA/<%=shorty.shortify(content.getInode()) %>/fileAsset/<%=id.getAssetName() %>?mode=PREVIEW_MODE</a></div>
                    <%} %>


### PR DESCRIPTION
The path was only sending the url of the page, lang id was not being sent so it was setting the default one (1). 
To fix it, the proper language id was set to the url when rendering the task detail tab so now when clicking to the page url it is going to send to the correct language version

This PR fixes: #30724