### PR TITLE
chore(edit-content): fix error with load content 

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-select-existing-file/dot-select-existing-file.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-select-existing-file/dot-select-existing-file.component.ts
@@ -76,6 +76,7 @@ export class DotSelectExistingFileComponent implements OnInit {
         const data = this.#dialogConfig?.data as DialogData;
         const inputType = data?.inputType === INPUT_TYPES.Image ? ['image'] : [];
         this.store.setMimeTypes(inputType);
+        this.store.loadContent();
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-select-existing-file/store/select-existing-file.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-select-existing-file/store/select-existing-file.store.ts
@@ -207,7 +207,6 @@ export const SelectExisingFileStore = signalStore(
     withHooks((store) => ({
         onInit: () => {
             store.loadFolders();
-            store.loadContent();
         }
     }))
 );


### PR DESCRIPTION
### Parent Isssue

https://github.com/dotCMS/core/issues/30060

### Proposed Changes

This pull request includes changes to the `dot-select-existing-file` component and its associated store to improve the initialization process. The most important changes involve modifying the loading behavior of content data.

Initialization process improvements:

* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-select-existing-file/dot-select-existing-file.component.ts`](diffhunk://#diff-18bf6e06cc08560259db33d84f324194172c43e47220f07b1de0990cf71077acR79): Added a call to `this.store.loadContent()` to ensure content is loaded during the component's initialization.
* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-select-existing-file/store/select-existing-file.store.ts`](diffhunk://#diff-4e8a1b332dae5fb8ead291b76bf6099437aaf4aa6fd0a759ffe71c3074ffe7f0L210): Removed the call to `store.loadContent()` from the `onInit` hook to prevent redundant loading of content.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)


This PR fixes: #30060