### PR TITLE
fix(uve): Experiments and UVE start a loop trying to resolve queryParams

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-shell/dot-experiments-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-shell/dot-experiments-shell.component.spec.ts
@@ -15,7 +15,12 @@ const ActivatedRouteMock = {
         params: {
             pageId: routerParamsPageId
         },
-        parent: { parent: { data: { content: { page: { title: 'Experiment page title' } } } } }
+        parent: { parent: { data: { content: { page: { title: 'Experiment page title' } } } } },
+        queryParams: {
+            mode: 'edit',
+            variantName: 'variantName',
+            experimentId: 'experimentId'
+        }
     }
 };
 
@@ -25,8 +30,27 @@ class RouterMock {
     }
 }
 
+/**
+ * Override the snapshot of the activated route
+ * To simulate the queryParams change
+ *
+ * Note: Be sure run this before your first `spectator.detectChanges()`
+ *
+ * @param {*} activatedRoute
+ * @param {*} mock
+ */
+const overrideRouteSnashot = (activatedRoute, mock) => {
+    Object.defineProperty(activatedRoute, 'snapshot', {
+        value: mock,
+        writable: true // Allows mocking changes
+    });
+};
+
 describe('DotExperimentsShellComponent', () => {
     let spectator: Spectator<DotExperimentsShellComponent>;
+    let activatedRoute: ActivatedRoute;
+    let router: Router;
+    let routerSpy: jest.SpyInstance;
 
     const createComponent = createComponentFactory({
         component: DotExperimentsShellComponent,
@@ -48,9 +72,45 @@ describe('DotExperimentsShellComponent', () => {
 
     beforeEach(() => {
         spectator = createComponent();
+        activatedRoute = spectator.inject(ActivatedRoute, true);
+        router = spectator.inject(Router, true);
+
+        routerSpy = jest.spyOn(router, 'navigate');
     });
 
     it('should has Toast component', () => {
         expect(spectator.query(Toast)).toExist();
+    });
+
+    describe('remove queryParams', () => {
+        it('should remove queryParams when variantName, mode and experimentId is present', () => {
+            spectator.component.ngOnInit(); // At this point it was called but we didn't have the spy yet, so we need to call it again
+
+            expect(routerSpy).toHaveBeenCalledWith([], {
+                queryParams: {
+                    mode: null,
+                    variantName: null,
+                    experimentId: null
+                },
+                queryParamsHandling: 'merge',
+                replaceUrl: true
+            });
+        });
+
+        it('should not remove queryParams when variantName, mode and experimentId is not present', () => {
+            overrideRouteSnashot(activatedRoute, {
+                params: {
+                    pageId: routerParamsPageId
+                },
+                parent: {
+                    parent: { data: { content: { page: { title: 'Experiment page title' } } } }
+                },
+                queryParams: {} // No queryParams should not trigger the navigation
+            });
+
+            spectator.detectChanges();
+
+            expect(routerSpy).not.toHaveBeenCalled();
+        });
     });
 });

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-shell/dot-experiments-shell.component.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-shell/dot-experiments-shell.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject, OnInit } from '@angular/core';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
@@ -8,34 +8,36 @@ import { DotExperimentsService } from '@dotcms/data-access';
 
 import { DotExperimentsStore } from './store/dot-experiments.store';
 
-import { DotExperimentsUiHeaderComponent } from '../shared/ui/dot-experiments-header/dot-experiments-ui-header.component';
-
 @Component({
     standalone: true,
     selector: 'dot-experiments-shell',
-    imports: [RouterModule, DotExperimentsUiHeaderComponent, ToastModule],
+    imports: [RouterModule, ToastModule],
     providers: [MessageService, DotExperimentsStore, DotExperimentsService],
     templateUrl: 'dot-experiments-shell.component.html',
     styleUrls: ['./dot-experiments-shell.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotExperimentsShellComponent implements OnInit {
-    private store = inject(DotExperimentsStore);
     private router = inject(Router);
+    private activatedRoute = inject(ActivatedRoute);
 
     ngOnInit() {
         this.removeVariantQueryParams();
     }
 
     private removeVariantQueryParams() {
-        this.router.navigate([], {
-            queryParams: {
-                mode: null,
-                variantName: null,
-                experimentId: null
-            },
-            queryParamsHandling: 'merge',
-            replaceUrl: true
-        });
+        const { mode, variantName, experimentId } = this.activatedRoute.snapshot.queryParams;
+
+        if (mode || variantName || experimentId) {
+            this.router.navigate([], {
+                queryParams: {
+                    mode: null,
+                    variantName: null,
+                    experimentId: null
+                },
+                queryParamsHandling: 'merge',
+                replaceUrl: true
+            });
+        }
     }
 }


### PR DESCRIPTION
This pull request includes changes to the `dot-experiments-shell` component and its corresponding tests to handle query parameters and improve test coverage. The most important changes include adding the `ActivatedRoute` dependency, updating the component to remove specific query parameters, and enhancing the test suite to simulate and verify these changes.

Enhancements to query parameter handling:

* [`core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-shell/dot-experiments-shell.component.ts`](diffhunk://#diff-ff8a6883a47be6d7ea576fb1ca835633f6ac5c922a83d5ec39a9af39cdcff264L2-R2): Added `ActivatedRoute` dependency and updated the `removeVariantQueryParams` method to remove `mode`, `variantName`, and `experimentId` query parameters if they are present. [[1]](diffhunk://#diff-ff8a6883a47be6d7ea576fb1ca835633f6ac5c922a83d5ec39a9af39cdcff264L2-R2) [[2]](diffhunk://#diff-ff8a6883a47be6d7ea576fb1ca835633f6ac5c922a83d5ec39a9af39cdcff264L11-R31) [[3]](diffhunk://#diff-ff8a6883a47be6d7ea576fb1ca835633f6ac5c922a83d5ec39a9af39cdcff264R43)

Improvements to test coverage:

* [`core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-shell/dot-experiments-shell.component.spec.ts`](diffhunk://#diff-76e44c7376ea0d0331e161dc38be1e049e1e464f28d040dbee385382192f6a87L18-R23): Added `queryParams` to the `ActivatedRouteMock` and created the `overrideRouteSnashot` function to simulate query parameter changes. Enhanced the test suite to verify the removal of specific query parameters and ensure no navigation occurs when they are not present. [[1]](diffhunk://#diff-76e44c7376ea0d0331e161dc38be1e049e1e464f28d040dbee385382192f6a87L18-R23) [[2]](diffhunk://#diff-76e44c7376ea0d0331e161dc38be1e049e1e464f28d040dbee385382192f6a87R33-R53) [[3]](diffhunk://#diff-76e44c7376ea0d0331e161dc38be1e049e1e464f28d040dbee385382192f6a87R75-R115)


### Screenshot

https://github.com/user-attachments/assets/cdb80d90-e22a-4cdf-a8ed-4748475d40a2



This PR fixes: #30594