### PR TITLE
fix(uve): Fixed blank page on experiments tab when dont have analytics config

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-analytic-app-misconfiguration/dot-experiments-analytic-app-misconfiguration.component.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-analytic-app-misconfiguration/dot-experiments-analytic-app-misconfiguration.component.ts
@@ -34,9 +34,17 @@ export class DotExperimentsAnalyticAppMisconfigurationComponent implements OnIni
     ) {}
 
     ngOnInit(): void {
-        const { healthStatus } = this.location.getState() as {
+        const location = this.location.getState() as {
             healthStatus: HealthStatusTypes;
         };
+
+        /**
+         * With the new UVE changes, probably we enter to this component without the location state
+         * so we need to check if the location state is not present and set the default configuration
+         *
+         * Probably needs a recheck later. This is a hotfix for realease
+         */
+        const healthStatus = location?.healthStatus || HealthStatusTypes.NOT_CONFIGURED;
 
         if (healthStatus === HealthStatusTypes.NOT_CONFIGURED) {
             this.setConfiguration(


### PR DESCRIPTION
### Showcase


https://github.com/user-attachments/assets/eab9443e-271b-43cf-b340-ebe2572025d5



This pull request includes a critical fix to handle cases where the location state may not be present in the `DotExperimentsAnalyticAppMisconfigurationComponent`. The most important change involves modifying the initialization logic to ensure the component sets a default configuration if the location state is missing.

Error handling improvement:

* [`core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-analytic-app-misconfiguration/dot-experiments-analytic-app-misconfiguration.component.ts`](diffhunk://#diff-426971551b406a995ae27b64c10448dcd7cff0ce08682c95f00cf8f38b6d65efL37-R48): Updated the `ngOnInit` method to check for the presence of the location state and set a default `healthStatus` if it is not present. This change is a hotfix for the release and may need a recheck later.

This PR fixes: #30594