### PR TITLE
chore(uve): FTM - Implement "CopyURL" button on UVE Toolbar

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
@@ -12,6 +12,8 @@
             <p-button
                 icon="pi pi-external-link"
                 styleClass="p-button-text"
+                (cdkCopyToClipboardCopied)="triggerCopyToast()"
+                [cdkCopyToClipboard]="$toolbar().editor.copyUrl"
                 data-testId="uve-toolbar-copy-url" />
 
             <p-button

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -1,7 +1,11 @@
+import { ClipboardModule } from '@angular/cdk/clipboard';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 
+import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ToolbarModule } from 'primeng/toolbar';
+
+import { DotMessageService } from '@dotcms/data-access';
 
 import { UVEStore } from '../../../store/dot-uve.store';
 import { DotEmaBookmarksComponent } from '../dot-ema-bookmarks/dot-ema-bookmarks.component';
@@ -10,17 +14,33 @@ import { DotEmaInfoDisplayComponent } from '../dot-ema-info-display/dot-ema-info
 @Component({
     selector: 'dot-uve-toolbar',
     standalone: true,
-    imports: [ButtonModule, ToolbarModule, DotEmaBookmarksComponent, DotEmaInfoDisplayComponent],
+    imports: [
+        ButtonModule,
+        ToolbarModule,
+        DotEmaBookmarksComponent,
+        DotEmaInfoDisplayComponent,
+        ClipboardModule
+    ],
     templateUrl: './dot-uve-toolbar.component.html',
     styleUrl: './dot-uve-toolbar.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotUveToolbarComponent {
     #store = inject(UVEStore);
+    readonly #messageService = inject(MessageService);
+    readonly #dotMessageService = inject(DotMessageService);
 
     readonly $toolbar = this.#store.$uveToolbar;
 
     togglePreviewMode(preview: boolean) {
         this.#store.togglePreviewMode(preview);
+    }
+
+    triggerCopyToast() {
+        this.#messageService.add({
+            severity: 'success',
+            summary: this.#dotMessageService.get('Copied'),
+            life: 3000
+        });
     }
 }


### PR DESCRIPTION
This pull request includes several changes to the `DotUveToolbarComponent` to enhance its functionality and improve the testing setup. The most important changes include adding a copy-to-clipboard feature, updating the test suite to cover new functionality, and importing necessary modules and services.

Enhancements to `DotUveToolbarComponent`:

* Added a copy-to-clipboard feature with a success message toast. (`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html`, `core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts`) [[1]](diffhunk://#diff-9937556e73b051b878ba22ad1ce971a70019a617d7979b3e0bcc814801ad350bR15-R16) [[2]](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30R1-R45)

Updates to test suite:

* Imported `DebugElement`, `By`, and `MessageService` for testing purposes. (`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts`)
* Added `MessageService` to the test providers and injected it into the test suite. (`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts`) [[1]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1R40-R41) [[2]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1R71-R76) [[3]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1R130-R131)
* Added tests to verify the attributes of the copy URL button and the functionality of the `MessageService` when the copy-to-clipboard event is triggered. (`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts`)

This PR fixes: #30732