### PR TITLE
fix(content-import-job) fix key fields

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/jobs/business/processor/impl/ImportContentletsProcessor.java
+++ b/dotCMS/src/main/java/com/dotcms/jobs/business/processor/impl/ImportContentletsProcessor.java
@@ -223,15 +223,15 @@ public class ImportContentletsProcessor implements JobProcessor, Validator, Canc
      * {@link JobValidationException} is thrown.</p>
      *
      * @param parameters The job parameters containing the fields to validate
-     * @param contentTypeFound The content type to validate the fields against
+     * @param contentType The content type to validate the fields against
      * @throws JobValidationException if any field specified in the parameters is not found in the content type
      */
-    private void validateFields(final Map<String, Object> parameters, final ContentType contentTypeFound) {
-        var fields = contentTypeFound.fields();
-        for (String field : getFields(parameters)) {
-            if (fields.stream().noneMatch(f -> Objects.equals(f.id(), field))) {
+    private void validateFields(final Map<String, Object> parameters, final ContentType contentType) {
+        var contentTypeFields = contentType.fields();
+        for (String providedField : getFields(parameters)) {
+            if (contentTypeFields.stream().noneMatch(field -> Objects.equals(field.id(), providedField))) {
                 final var errorMessage = String.format(
-                        "Field [%s] not found in Content Type [%s].", field, contentTypeFound.variable()
+                        "Field [%s] not found in Content Type [%s].", providedField, contentType.variable()
                 );
                 Logger.error(this, errorMessage);
                 throw new JobValidationException(errorMessage);

--- a/dotCMS/src/main/java/com/dotcms/jobs/business/processor/impl/ImportContentletsProcessor.java
+++ b/dotCMS/src/main/java/com/dotcms/jobs/business/processor/impl/ImportContentletsProcessor.java
@@ -229,7 +229,7 @@ public class ImportContentletsProcessor implements JobProcessor, Validator, Canc
     private void validateFields(final Map<String, Object> parameters, final ContentType contentTypeFound) {
         var fields = contentTypeFound.fields();
         for (String field : getFields(parameters)) {
-            if (fields.stream().noneMatch(f -> Objects.equals(f.variable(), field))) {
+            if (fields.stream().noneMatch(f -> Objects.equals(f.id(), field))) {
                 final var errorMessage = String.format(
                         "Field [%s] not found in Content Type [%s].", field, contentTypeFound.variable()
                 );

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/dotimport/ContentImportParamsSchema.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/dotimport/ContentImportParamsSchema.java
@@ -28,7 +28,7 @@ public class ContentImportParamsSchema {
                     "  \"contentType\": \"activity\",\n" +
                     "  \"language\": \"en-US\",\n" +
                     "  \"workflowActionId\": \"1234\",\n" +
-                    "  \"fields\": [\"title\"]\n" +
+                    "  \"fields\": [\"e1f99107-fd0e-49d4-a099-1cc10aa284d8\"]\n" +
                     "}"
     )
     private String form;

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/dotimport/ContentImportResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/dotimport/ContentImportResourceIntegrationTest.java
@@ -57,6 +57,7 @@ public class ContentImportResourceIntegrationTest extends Junit5WeldBaseTest {
 
     private static File csvFile;
     private static ContentType contentType;
+    private static String fieldId;
 
     @Inject
     ContentImportHelper contentImportHelper;
@@ -73,6 +74,8 @@ public class ContentImportResourceIntegrationTest extends Junit5WeldBaseTest {
 
         defaultLanguage = APILocator.getLanguageAPI().getDefaultLanguage();
         contentType = TestDataUtils.getRichTextLikeContentType();
+        fieldId = contentType.fields().get(0).id();
+        assert fieldId != null;
         csvFile = createTestCsvFile();
     }
 
@@ -101,11 +104,11 @@ public class ContentImportResourceIntegrationTest extends Junit5WeldBaseTest {
      */
     @Test
     public void test_import_content_with_valid_params() throws IOException, DotDataException {
-        ContentImportForm form = createContentImportForm(contentType.name(), String.valueOf(defaultLanguage.getId()), WORKFLOW_PUBLISH_ACTION_ID, List.of("title"));
+        ContentImportForm form = createContentImportForm(contentType.name(), String.valueOf(defaultLanguage.getId()), WORKFLOW_PUBLISH_ACTION_ID, List.of(fieldId));
         ContentImportParams params = createContentImportParams(csvFile, form);
 
         Response importContentResponse = importResource.importContent(request, response, params);
-        validateSuccessfulResponse(importContentResponse, contentType.name(), String.valueOf(defaultLanguage.getId()), List.of("title"), WORKFLOW_PUBLISH_ACTION_ID, CMD_PUBLISH);
+        validateSuccessfulResponse(importContentResponse, contentType.name(), String.valueOf(defaultLanguage.getId()), List.of(fieldId), WORKFLOW_PUBLISH_ACTION_ID, CMD_PUBLISH);
     }
 
 
@@ -119,11 +122,11 @@ public class ContentImportResourceIntegrationTest extends Junit5WeldBaseTest {
      */
     @Test
     public void test_import_content_validate_with_valid_params() throws IOException, DotDataException {
-        ContentImportForm form = createContentImportForm(contentType.name(), String.valueOf(defaultLanguage.getId()), WORKFLOW_PUBLISH_ACTION_ID, List.of("title"));
+        ContentImportForm form = createContentImportForm(contentType.name(), String.valueOf(defaultLanguage.getId()), WORKFLOW_PUBLISH_ACTION_ID, List.of(fieldId));
         ContentImportParams params = createContentImportParams(csvFile, form);
 
         Response importContentResponse = importResource.validateContentImport(request, response, params);
-        validateSuccessfulResponse(importContentResponse, contentType.name(), String.valueOf(defaultLanguage.getId()), List.of("title"), WORKFLOW_PUBLISH_ACTION_ID, CMD_PREVIEW);
+        validateSuccessfulResponse(importContentResponse, contentType.name(), String.valueOf(defaultLanguage.getId()), List.of(fieldId), WORKFLOW_PUBLISH_ACTION_ID, CMD_PREVIEW);
     }
 
     /**
@@ -136,11 +139,11 @@ public class ContentImportResourceIntegrationTest extends Junit5WeldBaseTest {
      */
     @Test
     public void test_import_content_with_language_iso_code() throws IOException, DotDataException {
-        ContentImportForm form = createContentImportForm(contentType.name(), defaultLanguage.getIsoCode(), WORKFLOW_PUBLISH_ACTION_ID, List.of("title"));
+        ContentImportForm form = createContentImportForm(contentType.name(), defaultLanguage.getIsoCode(), WORKFLOW_PUBLISH_ACTION_ID, List.of(fieldId));
         ContentImportParams params = createContentImportParams(csvFile, form);
 
         Response importContentResponse = importResource.importContent(request, response, params);
-        validateSuccessfulResponse(importContentResponse, contentType.name(), defaultLanguage.getIsoCode(), List.of("title"), WORKFLOW_PUBLISH_ACTION_ID, CMD_PUBLISH);
+        validateSuccessfulResponse(importContentResponse, contentType.name(), defaultLanguage.getIsoCode(), List.of(fieldId), WORKFLOW_PUBLISH_ACTION_ID, CMD_PUBLISH);
     }
 
 
@@ -154,11 +157,11 @@ public class ContentImportResourceIntegrationTest extends Junit5WeldBaseTest {
      */
     @Test
     public void test_import_content__validate_with_language_iso_code() throws IOException, DotDataException {
-        ContentImportForm form = createContentImportForm(contentType.name(), defaultLanguage.getIsoCode(), WORKFLOW_PUBLISH_ACTION_ID, List.of("title"));
+        ContentImportForm form = createContentImportForm(contentType.name(), defaultLanguage.getIsoCode(), WORKFLOW_PUBLISH_ACTION_ID, List.of(fieldId));
         ContentImportParams params = createContentImportParams(csvFile, form);
 
         Response importContentResponse = importResource.validateContentImport(request, response, params);
-        validateSuccessfulResponse(importContentResponse, contentType.name(), defaultLanguage.getIsoCode(), List.of("title"), WORKFLOW_PUBLISH_ACTION_ID, CMD_PREVIEW);
+        validateSuccessfulResponse(importContentResponse, contentType.name(), defaultLanguage.getIsoCode(), List.of(fieldId), WORKFLOW_PUBLISH_ACTION_ID, CMD_PREVIEW);
     }
 
     /**

--- a/dotcms-postman/src/main/resources/postman/ContentImportResource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/ContentImportResource.postman_collection.json
@@ -11,7 +11,30 @@
 			"name": "pre-execution-scripts",
 			"item": [
 				{
-					"name": "Create ContentType Copy",
+					"name": "Create ContentType",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonData = pm.response.json();",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"fields check\", function () {",
+									"    pm.expect(jsonData.entity[0].fields.length).to.eql(8);",
+									"    pm.expect(jsonData.entity[0].fields[3].variable).to.eql('title');",
+									"    pm.collectionVariables.set(\"fields\", JSON.stringify([jsonData.entity[0].fields[3].id]))",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
 					"request": {
 						"method": "POST",
 						"header": [],
@@ -1913,7 +1936,7 @@
 		},
 		{
 			"key": "fields",
-			"value": "[\"title\"]",
+			"value": "",
 			"type": "string"
 		}
 	]


### PR DESCRIPTION
This pull request focuses on updating the content import functionality to use field IDs instead of field names. 

Key changes include:

### Validation and Schema Updates:
* [`dotCMS/src/main/java/com/dotcms/jobs/business/processor/impl/ImportContentletsProcessor.java`](diffhunk://#diff-f5dc237cd813ef4bac45f0d238379d561192b07c9c1dd7e03619cde2ee3566adL232-R232): Updated the field validation logic to use `field.id()` instead of `field.variable()`.
* [`dotCMS/src/main/java/com/dotcms/rest/api/v1/content/dotimport/ContentImportParamsSchema.java`](diffhunk://#diff-ac814b1da2510effe84f7fbd1a316ce69ca5146951885d5d4a325fbfef2ab8e4L31-R31): Modified the example JSON to use a field ID instead of a field name.

### Test Case Adjustments:
* `dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/dotimport/ContentImportResourceIntegrationTest.java`: 
  * Added `fieldId` to store the ID of the first field in the content type. [[1]](diffhunk://#diff-038e819a6c662a05544ffc5a4c261de236b8dad56f380b9c4623d35c7a89e99bR60) [[2]](diffhunk://#diff-038e819a6c662a05544ffc5a4c261de236b8dad56f380b9c4623d35c7a89e99bR77-R78)
  * Updated test cases to use `fieldId` instead of the field name "title". [[1]](diffhunk://#diff-038e819a6c662a05544ffc5a4c261de236b8dad56f380b9c4623d35c7a89e99bL104-R111) [[2]](diffhunk://#diff-038e819a6c662a05544ffc5a4c261de236b8dad56f380b9c4623d35c7a89e99bL122-R129) [[3]](diffhunk://#diff-038e819a6c662a05544ffc5a4c261de236b8dad56f380b9c4623d35c7a89e99bL139-R146) [[4]](diffhunk://#diff-038e819a6c662a05544ffc5a4c261de236b8dad56f380b9c4623d35c7a89e99bL157-R164)

### Postman Collection Update:
* `dotcms-postman/src/main/resources/postman/ContentImportResource.postman_collection.json`: 
  * Added a script to set the field ID in the collection variables after creating the content type.
  * Updated the `fields` variable to be empty initially, to be populated by the script.

This PR fixes: #30669