### PR TITLE
feat(content analytics) fixes #30521 : Allow users to pass down simple Strings to query for Content Analytics data

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/content/ContentAnalyticsQuery.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/content/ContentAnalyticsQuery.java
@@ -10,29 +10,43 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.liferay.util.StringPool.COLON;
 import static com.liferay.util.StringPool.COMMA;
+import static com.liferay.util.StringPool.PERIOD;
 
 /**
  * This class represents the parameters of a Content Analytics Query abstracting the complexity
  * of the underlying JSON format. The simplified REST Endpoint and the Content Analytics ViewTool
  * use this class so that parameters can be entered in a more user-friendly way. Here's an example
- * of what this simple JSON data looks like:
+ * of what this simple JSON data looks like for the default {@code request} schema:
  * <pre>
  *     {@code
  *     {
- *       "measures": "request.count,request.totalSessions",
- *       "dimensions": "request.host,request.whatAmI,request.url",
- *       "timeDimensions": "request.createdAt,day:Last month",
- *       "filters": "request.totalRequest gt 0,request.whatAmI contains PAGE||FILE",
- *       "order": "request.count asc,request.createdAt asc",
+ *       "measures": "count,totalSessions",
+ *       "dimensions": "host,whatAmI,url",
+ *       "timeDimensions": "createdAt,day:Last month",
+ *       "filters": "totalRequest gt 0,whatAmI contains PAGE||FILE",
+ *       "order": "count asc,createdAt asc",
  *       "limit": 5,
  *       "offset": 0
  *     }
  *     }
  * </pre>
- * Notice how there are four separator characters:
+ * Under the covers, this builder will prefix the appropriate terms with the specified or default
+ * schema. If you want to provide a specific one, just add it to the JSON body:
+ * <pre>
+ *     {@code
+ *     {
+ *         "scheme": "YOUR-SCHEME-NAME-HERE",
+ *         ...
+ *         ...
+ *     }
+ *     }
+ * </pre>
+ * Notice how there are four separator characters for different parameters. They must be used
+ * correctly for the data to be parsed correctly:
  * <ul>
  *     <li>Blank space.</li>
  *     <li>Comma.</li>
@@ -46,6 +60,7 @@ import static com.liferay.util.StringPool.COMMA;
 @JsonDeserialize(builder = ContentAnalyticsQuery.Builder.class)
 public class ContentAnalyticsQuery implements Serializable {
 
+    public static final String SCHEME_ATTR = "scheme";
     public static final String MEASURES_ATTR = "measures";
     public static final String DIMENSIONS_ATTR = "dimensions";
     public static final String TIME_DIMENSIONS_ATTR = "timeDimensions";
@@ -60,6 +75,7 @@ public class ContentAnalyticsQuery implements Serializable {
     public static final String OPERATOR_ATTR = "operator";
     public static final String VALUES_ATTR = "values";
 
+    private final String scheme;
     @JsonProperty()
     private final Set<String> measures;
     @JsonProperty()
@@ -75,13 +91,13 @@ public class ContentAnalyticsQuery implements Serializable {
     @JsonProperty()
     private final int offset;
 
-    private static final String SEPARATOR_1 = "\\s+";
-    private static final String SEPARATOR_2 = COLON;
-    private static final String SEPARATOR_3 = COMMA;
-    private static final String SEPARATOR_4 = "\\|\\|";
+    private static final String SPACE = "\\s+";
+    private static final String DOUBLE_PIPE = "\\|\\|";
     private static final String DEFAULT_DATE_RANGE = "Last week";
+    private static final String DEFAULT_SCHEME = "request";
 
     private ContentAnalyticsQuery(final Builder builder) {
+        this.scheme = builder.scheme;
         this.measures = builder.measures;
         this.dimensions = builder.dimensions;
         this.timeDimensions = builder.timeDimensions;
@@ -89,6 +105,10 @@ public class ContentAnalyticsQuery implements Serializable {
         this.order = builder.order;
         this.limit = builder.limit;
         this.offset = builder.offset;
+    }
+
+    public String scheme() {
+        return this.scheme;
     }
 
     public Set<String> measures() {
@@ -126,13 +146,14 @@ public class ContentAnalyticsQuery implements Serializable {
     @Override
     public String toString() {
         return "ContentAnalyticsQuery{" +
-                "measures='" + measures + '\'' +
-                ", dimensions='" + dimensions + '\'' +
-                ", timeDimensions='" + timeDimensions + '\'' +
-                ", filters='" + filters + '\'' +
-                ", order='" + order + '\'' +
-                ", limit='" + limit + '\'' +
-                ", offset='" + offset + '\'' +
+                "scheme='" + scheme + '\'' +
+                ", measures=" + measures +
+                ", dimensions=" + dimensions +
+                ", timeDimensions=" + timeDimensions +
+                ", filters=" + filters +
+                ", order=" + order +
+                ", limit=" + limit +
+                ", offset=" + offset +
                 '}';
     }
 
@@ -142,6 +163,7 @@ public class ContentAnalyticsQuery implements Serializable {
      */
     public static class Builder {
 
+        private String scheme = DEFAULT_SCHEME;
         private Set<String> measures;
         private Set<String> dimensions;
         private final List<Map<String, String>> timeDimensions = new ArrayList<>();
@@ -151,15 +173,28 @@ public class ContentAnalyticsQuery implements Serializable {
         private int offset = 0;
 
         /**
+         * Sets the default scheme for the parameters sent to the Content Analytics service.
+         *
+         * @param scheme The default scheme for the parameters.
+         *
+         * @return The builder instance.
+         */
+        public Builder scheme(final String scheme) {
+            this.scheme = scheme;
+            return this;
+        }
+
+        /**
          * The measures parameter contains a set of measures and each measure is an aggregation over
          * a certain column in your ClickHouse database table.
          *
-         * @param measures A string with the measures separated by {@link #SEPARATOR_3}.
+         * @param measures A string with the measures separated by
+         *                 {@link com.liferay.util.StringPool#COMMA}.
          *
          * @return The builder instance.
          */
         public Builder measures(final String measures) {
-            this.measures = Set.of(measures.split(SEPARATOR_3));
+            this.measures = addScheme(Set.of(measures.split(COMMA)));
             return this;
         }
 
@@ -168,12 +203,13 @@ public class ContentAnalyticsQuery implements Serializable {
          * an attribute related to a measure, e.g. the measure user_count can have dimensions like
          * country, age, occupation, etc.
          *
-         * @param dimensions A string with the dimensions separated by {@link #SEPARATOR_3}.
+         * @param dimensions A string with the dimensions separated by
+         *                   {@link com.liferay.util.StringPool#COMMA}.
          *
          * @return The builder instance.
          */
         public Builder dimensions(final String dimensions) {
-            this.dimensions = Set.of(dimensions.split(SEPARATOR_3));
+            this.dimensions = addScheme(Set.of(dimensions.split(COMMA)));
             return this;
         }
 
@@ -183,7 +219,7 @@ public class ContentAnalyticsQuery implements Serializable {
          * value will be "Last week".
          *
          * @param timeDimensions A string with the time dimensions separated by
-         *                       {@link #SEPARATOR_3}.
+         *                       {@link com.liferay.util.StringPool#COMMA}.
          *
          * @return The builder instance.
          */
@@ -191,11 +227,11 @@ public class ContentAnalyticsQuery implements Serializable {
             if (UtilMethods.isNotSet(timeDimensions)) {
                 return this;
             }
-            final String[] timeParams = timeDimensions.split(SEPARATOR_3);
+            final String[] timeParams = timeDimensions.split(COMMA);
             final Map<String, String> timeDimensionsData = new HashMap<>();
-            timeDimensionsData.put(TIME_DIMENSIONS_DIMENSION_ATTR, timeParams[0]);
+            timeDimensionsData.put(TIME_DIMENSIONS_DIMENSION_ATTR, addScheme(timeParams[0]));
             if (timeParams.length > 1) {
-                final String[] granularityAndRange = timeParams[1].split(SEPARATOR_2);
+                final String[] granularityAndRange = timeParams[1].split(COLON);
                 if (granularityAndRange.length > 1) {
                     timeDimensionsData.put(GRANULARITY_ATTR, granularityAndRange[0]);
                     timeDimensionsData.put(DATE_RANGE_ATTR, granularityAndRange[1]);
@@ -215,7 +251,8 @@ public class ContentAnalyticsQuery implements Serializable {
          * filter on a measure, you are restricting the results after the measure has been
          * calculated. They are composed of 3 parts: member, operator, and values.
          *
-         * @param filters A string with the filters separated by {@link #SEPARATOR_3}.
+         * @param filters A string with the filters separated by
+         *                {@link com.liferay.util.StringPool#COMMA}.
          *
          * @return The builder instance.
          */
@@ -223,13 +260,13 @@ public class ContentAnalyticsQuery implements Serializable {
             if (UtilMethods.isNotSet(filters)) {
                 return this;
             }
-            final String[] filterArr = filters.split(SEPARATOR_3);
+            final String[] filterArr = filters.split(COMMA);
             for (final String filter : filterArr) {
-                final String[] filterParams = filter.split(SEPARATOR_1);
+                final String[] filterParams = filter.split(SPACE);
                 final Map<String, Object> filterDataMap = new HashMap<>();
-                filterDataMap.put(MEMBER_ATTR, filterParams[0]);
+                filterDataMap.put(MEMBER_ATTR, addScheme(filterParams[0]));
                 filterDataMap.put(OPERATOR_ATTR, filterParams[1]);
-                final String[] filterValues = filterParams[2].split(SEPARATOR_4);
+                final String[] filterValues = filterParams[2].split(DOUBLE_PIPE);
                 filterDataMap.put(VALUES_ATTR, filterValues);
                 this.filters.add(filterDataMap);
             }
@@ -242,7 +279,8 @@ public class ContentAnalyticsQuery implements Serializable {
          * on the order of the keys in the object. If not provided, default ordering is applied. If
          * an empty object ([]) is provided, no ordering is applied.
          *
-         * @param order A string with the order separated by {@link #SEPARATOR_3}.
+         * @param order A string with the order separated by
+         *              {@link com.liferay.util.StringPool#COMMA}.
          *
          * @return The builder instance.
          */
@@ -250,10 +288,14 @@ public class ContentAnalyticsQuery implements Serializable {
             if (UtilMethods.isNotSet(order)) {
                 return this;
             }
-            final Set<String> orderCriteria = Set.of(order.split(SEPARATOR_3));
+            final Set<String> orderCriteria = Set.of(order.split(COMMA));
             for (final String orderCriterion : orderCriteria) {
-                final String[] orderParams = orderCriterion.split(SEPARATOR_1);
-                this.order.add(orderParams);
+                final String[] orderParams = orderCriterion.split(SPACE);
+                if (orderParams.length > 1) {
+                    this.order.add(new String[]{addScheme(orderParams[0]), orderParams[1]});
+                } else {
+                    this.order.add(orderParams);
+                }
             }
             return this;
         }
@@ -282,7 +324,6 @@ public class ContentAnalyticsQuery implements Serializable {
             return this;
         }
 
-
         /**
          * This method builds the ContentAnalyticsQuery object based on all the specified
          * parameters for the query.
@@ -297,19 +338,44 @@ public class ContentAnalyticsQuery implements Serializable {
          * This method builds the ContentAnalyticsQuery object based on all the specified
          * parameters in the provided map.
          *
-         * @param form A {@link Map} containing the query data.
+         * @param parameters A {@link Map} containing the query data.
          *
          * @return The {@link ContentAnalyticsQuery} object.
          */
-        public ContentAnalyticsQuery build(final Map<String, Object> form) {
-            this.measures((String) form.get(MEASURES_ATTR));
-            this.dimensions((String) form.get(DIMENSIONS_ATTR));
-            this.timeDimensions((String) form.get(TIME_DIMENSIONS_ATTR));
-            this.filters((String) form.get(FILTERS_ATTR));
-            this.order((String) form.get(ORDER_ATTR));
-            this.limit((Integer) form.get(LIMIT_ATTR));
-            this.offset((Integer) form.get(OFFSET_ATTR));
+        public ContentAnalyticsQuery build(final Map<String, Object> parameters) {
+            this.scheme((String) parameters.getOrDefault(SCHEME_ATTR, DEFAULT_SCHEME));
+            this.measures((String) parameters.get(MEASURES_ATTR));
+            this.dimensions((String) parameters.get(DIMENSIONS_ATTR));
+            this.timeDimensions((String) parameters.get(TIME_DIMENSIONS_ATTR));
+            this.filters((String) parameters.get(FILTERS_ATTR));
+            this.order((String) parameters.get(ORDER_ATTR));
+            this.limit((Integer) parameters.get(LIMIT_ATTR));
+            this.offset((Integer) parameters.get(OFFSET_ATTR));
             return new ContentAnalyticsQuery(this);
+        }
+
+        /**
+         * This method adds the default scheme to the terms if they don't contain it.
+         *
+         * @param terms The terms to check.
+         *
+         * @return The terms with the default scheme added if they don't contain it.
+         */
+        private Set<String> addScheme(final Set<String> terms) {
+            return terms.stream()
+                    .map(this::addScheme)
+                    .collect(Collectors.toSet());
+        }
+
+        /**
+         * This method adds the default scheme to the term if it doesn't contain it.
+         *
+         * @param term The term to check.
+         *
+         * @return The term with the default scheme added if it doesn't contain it.
+         */
+        private String addScheme(final String term) {
+            return term.contains(PERIOD) ? term : scheme + PERIOD + term;
         }
 
     }

--- a/dotCMS/src/test/java/com/dotcms/analytics/content/ContentAnalyticsQueryTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/content/ContentAnalyticsQueryTest.java
@@ -1,0 +1,155 @@
+package com.dotcms.analytics.content;
+
+import com.dotcms.util.JsonUtil;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.DATE_RANGE_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.DIMENSIONS_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.FILTERS_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.GRANULARITY_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.MEASURES_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.MEMBER_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.OPERATOR_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.ORDER_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.TIME_DIMENSIONS_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.TIME_DIMENSIONS_DIMENSION_ATTR;
+import static com.dotcms.analytics.content.ContentAnalyticsQuery.VALUES_ATTR;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that the {@link ContentAnalyticsQuery} class is working as expected.
+ *
+ * @author Jose Castro
+ * @since Dec 5th, 2024
+ */
+public class ContentAnalyticsQueryTest {
+
+    /**
+     * <ul>
+     *     <li><b>Method to test: </b>{@link ContentAnalyticsQuery.Builder#build(Map)}</li>
+     *     </li>
+     *     <li><b>Given Scenario: </b>Transform the parameters of a CubeJS query as simple Strings
+     *     into an actual CubeJS query.</li>
+     *     <li><b>Expected Result: </b>The generated CubeJS JSON query must contain the exact same
+     *     parameters as the original ones, even if their formatting is different.</li>
+     * </ul>
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void getCubeJSQueryFromSimpleString() throws IOException {
+        // ╔════════════════════════╗
+        // ║  Generating Test Data  ║
+        // ╚════════════════════════╝
+        final String testQueryParams = "{\n" +
+                "    \"measures\": \"request.count,request.totalSessions\",\n" +
+                "    \"dimensions\": \"request.host,request.whatAmI,request.url\",\n" +
+                "    \"timeDimensions\": \"request.createdAt,day:Last month\",\n" +
+                "    \"filters\": \"request.totalRequest gt 0,request.whatAmI contains PAGE||FILE\",\n" +
+                "    \"order\": \"request.count asc,request.createdAt asc\",\n" +
+                "    \"limit\": 5,\n" +
+                "    \"offset\": 0\n" +
+                "}";
+        final Map<String, Object> queryParamsMap = JsonUtil.getJsonFromString(testQueryParams);
+
+        // ╔══════════════════╗
+        // ║  Initialization  ║
+        // ╚══════════════════╝
+        final ContentAnalyticsQuery contentAnalyticsQuery =
+                new ContentAnalyticsQuery.Builder().build(queryParamsMap);
+        final String cubeJsQuery = JsonUtil.getJsonStringFromObject(contentAnalyticsQuery);
+        final Map<String, Object> mapFromGeneratedQuery = JsonUtil.getJsonFromString(cubeJsQuery);
+
+        // ╔══════════════╗
+        // ║  Assertions  ║
+        // ╚══════════════╝
+        // Checking measures
+        boolean expectedMeasures = false;
+        for (final String measure : contentAnalyticsQuery.measures()) {
+            expectedMeasures = ((List<String>) mapFromGeneratedQuery.get(MEASURES_ATTR)).contains(measure);
+            if (!expectedMeasures) {
+                break;
+            }
+        }
+        assertTrue(expectedMeasures, "Generated measures don't match the expected ones");
+
+        // Checking dimensions
+        boolean expectedDimensions = false;
+        for (final String dimension : contentAnalyticsQuery.dimensions()) {
+            expectedDimensions = ((List<String>) mapFromGeneratedQuery.get(DIMENSIONS_ATTR)).contains(dimension);
+            if (!expectedDimensions) {
+                break;
+            }
+        }
+        assertTrue(expectedDimensions, "Generated dimensions don't match the expected ones");
+
+        // Checking time dimensions
+        boolean expectedTimeDimensions = false;
+        for (final Map<String, String> timeDimension : contentAnalyticsQuery.timeDimensions()) {
+            final Map<String, String> generatedTimeDimension =
+                    ((List<Map<String, String>>) mapFromGeneratedQuery.get(TIME_DIMENSIONS_ATTR)).get(0);
+            expectedTimeDimensions =
+                    generatedTimeDimension.containsKey(TIME_DIMENSIONS_DIMENSION_ATTR)
+                    && generatedTimeDimension.containsKey(GRANULARITY_ATTR)
+                    && generatedTimeDimension.containsKey(DATE_RANGE_ATTR)
+                    && generatedTimeDimension.get(TIME_DIMENSIONS_DIMENSION_ATTR).equals(timeDimension.get(TIME_DIMENSIONS_DIMENSION_ATTR))
+                    && generatedTimeDimension.get(GRANULARITY_ATTR).equals(timeDimension.get(GRANULARITY_ATTR))
+                    && generatedTimeDimension.get(DATE_RANGE_ATTR).equals(timeDimension.get(DATE_RANGE_ATTR));
+            if (!expectedTimeDimensions) {
+                break;
+            }
+        }
+        assertTrue(expectedTimeDimensions, "Generated time dimensions don't match the expected ones");
+
+        // Checking filters and values for each filter
+        boolean expectedFilters = false;
+        for (final Map<String, Object> filter : contentAnalyticsQuery.filters()) {
+            for (final Map<String, Object> generatedFilter : (List<Map<String, Object>>) mapFromGeneratedQuery.get(FILTERS_ATTR)) {
+                if (generatedFilter.get(MEMBER_ATTR).equals(filter.get(MEMBER_ATTR))) {
+                    final String generatedValues = generatedFilter.get(VALUES_ATTR).toString();
+                    final String expectedValues =
+                            Arrays.asList((String[]) filter.get(VALUES_ATTR)).toString();
+                    expectedFilters = generatedFilter.containsKey(MEMBER_ATTR)
+                            && generatedFilter.containsKey(OPERATOR_ATTR)
+                            && generatedFilter.containsKey(VALUES_ATTR)
+                            && generatedFilter.get(MEMBER_ATTR).equals(filter.get(MEMBER_ATTR))
+                            && generatedFilter.get(OPERATOR_ATTR).equals(filter.get(OPERATOR_ATTR))
+                            && generatedValues.equals(expectedValues);
+                    if (expectedFilters) {
+                        continue;
+                    }
+                    break;
+                }
+            }
+        }
+        assertTrue(expectedFilters, "Generated filters don't match the expected ones");
+
+        // Checking order
+        boolean expectedOrder = false;
+        for (final String[] order : contentAnalyticsQuery.order()) {
+            final String key = order[0];
+            for (final List<String> generatedOrder : (List<List<String>>)mapFromGeneratedQuery.get(ORDER_ATTR)) {
+                expectedOrder = generatedOrder.get(0).equals(key) && generatedOrder.get(1).equals(order[1]);
+                if (expectedOrder) {
+                    break;
+                }
+            }
+            if (!expectedOrder) {
+                break;
+            }
+        }
+        assertTrue(expectedOrder, "Generated order values don't match the expected ones");
+
+        // Checking limit
+        assertEquals(contentAnalyticsQuery.limit(), Integer.parseInt(mapFromGeneratedQuery.get("limit").toString()), "Generated limit value doesn't match the expected one");
+
+        // Checking offset
+        assertEquals(contentAnalyticsQuery.offset(), Integer.parseInt(mapFromGeneratedQuery.get("offset").toString()), "Generated offset value doesn't match the expected one");
+    }
+
+}

--- a/dotCMS/src/test/java/com/dotcms/analytics/content/ContentAnalyticsQueryTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/content/ContentAnalyticsQueryTest.java
@@ -47,11 +47,11 @@ public class ContentAnalyticsQueryTest {
         // ║  Generating Test Data  ║
         // ╚════════════════════════╝
         final String testQueryParams = "{\n" +
-                "    \"measures\": \"request.count,request.totalSessions\",\n" +
-                "    \"dimensions\": \"request.host,request.whatAmI,request.url\",\n" +
-                "    \"timeDimensions\": \"request.createdAt,day:Last month\",\n" +
-                "    \"filters\": \"request.totalRequest gt 0,request.whatAmI contains PAGE||FILE\",\n" +
-                "    \"order\": \"request.count asc,request.createdAt asc\",\n" +
+                "    \"measures\": \"count,totalSessions\",\n" +
+                "    \"dimensions\": \"host,whatAmI,url\",\n" +
+                "    \"timeDimensions\": \"createdAt,day:Last month\",\n" +
+                "    \"filters\": \"totalRequest gt 0,whatAmI contains PAGE||FILE\",\n" +
+                "    \"order\": \"count asc,createdAt asc\",\n" +
                 "    \"limit\": 5,\n" +
                 "    \"offset\": 0\n" +
                 "}";

--- a/dotcms-postman/src/main/resources/postman/ContentTypeResourceTests.json
+++ b/dotcms-postman/src/main/resources/postman/ContentTypeResourceTests.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "9f75619d-685f-4bdb-b16d-4baa2f6d62d6",
+		"_postman_id": "9aa702a3-2811-429a-a33c-480b75530b23",
 		"name": "ContentType Resource",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5403727",
-		"_collection_link": "https://cloudy-robot-285072.postman.co/workspace/JCastro-Workspace~5bfa586e-54db-429b-b7d5-c4ff997e3a0d/collection/5403727-9f75619d-685f-4bdb-b16d-4baa2f6d62d6?action=share&source=collection_link&creator=5403727"
+		"_exporter_id": "5403727"
 	},
 	"item": [
 		{

--- a/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
@@ -38,7 +38,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"measures\": \"request.count,request.totalSessions\",\n    \"dimensions\": \"request.host,request.whatAmI,request.url\",\n    \"timeDimensions\": \"request.createdAt,day:Last month\",\n    \"filters\": \"request.totalRequest gt 0,request.whatAmI contains PAGE||FILE\",\n    \"order\": \"request.count asc,request.createdAt asc\",\n    \"limit\": 5,\n    \"offset\": 0\n}",
+									"raw": "{\n    \"measures\": \"count,totalSessions\",\n    \"dimensions\": \"host,whatAmI,url\",\n    \"timeDimensions\": \"createdAt,day:Last month\",\n    \"filters\": \"totalRequest gt 0,whatAmI contains PAGE||FILE\",\n    \"order\": \"count asc,createdAt asc\",\n    \"limit\": 5,\n    \"offset\": 0\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -120,7 +120,7 @@
 							"response": []
 						}
 					],
-					"description": "This test group verifies that the Endpoint that receives simple String parameters for the Content Analytics query works as expected. This endpoint takes a JSON body with parameters such as the following:\n\n`{`\n\n`\"measures\": \"request.count request.totalSessions\",`\n\n`\"dimensions\": \"request.host request.whatAmI request.url\",`\n\n`\"timeDimensions\": \"request.createdAt:day:Last month\",`\n\n`\"filters\": \"request.totalRequest gt 0:request.whatAmI contains PAGE,FILE\",`\n\n`\"order\": \"request.count asc:request.createdAt asc\",`\n\n`\"limit\": 5,`\n\n`\"offset\": 0`\n\n`}`"
+					"description": "This test group verifies that the Endpoint that receives simple String parameters for the Content Analytics query works as expected. This endpoint takes a JSON body with parameters such as the following:\n\n`{`\n\n`\"measures\": \"count,totalSessions\",`\n\n`\"dimensions\": \"host,whatAmI,url\",`\n\n`\"timeDimensions\": \"createdAt,day:Last month\",`\n\n`\"filters\": \"totalRequest gt 0,whatAmI contains PAGE,FILE\",`\n\n`\"order\": \"count asc,createdAt asc\",`\n\n`\"limit\": 5,`\n\n`\"offset\": 0`\n\n`}`\n\nThe schema prefix for the appropriate terms is appended automatically by the service."
 				},
 				{
 					"name": "Using the JSON query",

--- a/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
@@ -38,7 +38,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"measures\": \"request.count request.totalSessions\",\n    \"dimensions\": \"request.host request.whatAmI request.url\",\n    \"timeDimensions\": \"request.createdAt:day:Last month\",\n    \"filters\": \"request.totalRequest gt 0:request.whatAmI contains PAGE,FILE\",\n    \"order\": \"request.count asc:request.createdAt asc\",\n    \"limit\": 5,\n    \"offset\": 0\n}",
+									"raw": "{\n    \"measures\": \"request.count,request.totalSessions\",\n    \"dimensions\": \"request.host,request.whatAmI,request.url\",\n    \"timeDimensions\": \"request.createdAt,day:Last month\",\n    \"filters\": \"request.totalRequest gt 0,request.whatAmI contains PAGE||FILE\",\n    \"order\": \"request.count asc,request.createdAt asc\",\n    \"limit\": 5,\n    \"offset\": 0\n}",
 									"options": {
 										"raw": {
 											"language": "json"


### PR DESCRIPTION
### Proposed Changes
* After discussion with the team, here's the new data format for the simple String query. By default, the `request` scheme is prepended to the appropriate terms so users won't have to repeat so many times:
```json
{
    "measures": "count,totalSessions",
    "dimensions": "host,whatAmI,url",
    "timeDimensions": "createdAt,day:Last month",
    "filters": "totalRequest gt 0,whatAmI contains PAGE||FILE",
    "order": "count asc,createdAt asc",
    "limit": 50,
    "offset": 0
}
```
If you want to set a specific scheme, just pass it down in the JSON body like this:
```json
{
    "scheme": "YOUR-SCHEME-NAME-HERE",
     ...
     ...
}
```
The following must be taken into account when putting a query together:
  * Measures: Values are separated by commas: `count,totalSessions`
  * Dimensions: Values are separated by commas: `host,whatAmI,url`
  * Time Dimensions: Values are separated by a comma: `createdAt,day:Last month` . The second parameter 'day' -- the "granularity" parameter -- is optional, and separated from the date range by a colon.
  * Filters: Values are separated by commas: `totalRequest gt 0,whatAmI contains PAGE||FILE` . In the `contains` clause, values are separated by `||`.
  * Order: Values are separated by comma: `count asc,createdAt asc`
  * Limit: Value is provided as is: `50`
  * Offset: Value is provided as is: `0`

This PR fixes: #30521

This PR fixes: #30521