### PR TITLE
test: Test and configure Jmeter against sandbox environm (#30890)

### DIFF
--- a/test-jmeter/README.md
+++ b/test-jmeter/README.md
@@ -90,6 +90,15 @@ The tests run under the `jmeter-standalone` profile, which is active by default.
 - Results validation
 - Report generation
 
+
+# env password
+When connecting to an external instance, to prevent the need to add the password to the command line, the password can be added to the environment variable JMETER_ADMIN_PASSWORD.  
+To prevent unexpected use of this you must add the property -Djmeter.env.password=true  or set the profile -Pjmeter.env.password
+```bash
+export JMETER_ADMIN_PASSWORD=mysecretpassword
+./mvnw verify -Djmeter.test.skip=false -pl :dotcms-test-jmeter -Djmeter.host=myhost -Djmeter.env.password=true
+```
+
 ## Troubleshooting
 
 We have not yet validated the memory requirements.  Eventually we should probably be explicit about the JVM memory settings.  These can be added into the configuration block 

--- a/test-jmeter/pom.xml
+++ b/test-jmeter/pom.xml
@@ -26,6 +26,7 @@
         <jmeter.startup.delay>5</jmeter.startup.delay>
         <jmeter.test.duration>60</jmeter.test.duration>
         <jmeter.thread.number>2</jmeter.thread.number>
+        <jmeter.admin.password>admin</jmeter.admin.password>
     </properties>
 
     <dependencies>
@@ -41,7 +42,10 @@
         <profile>
         <id>jmeter-standalone</id>
         <activation>
-            <activeByDefault>true</activeByDefault>
+            <property>
+                <name>jmeter.test.skip</name>
+                <value>false</value>
+            </property>
         </activation>
         <build>
             <plugins>
@@ -112,6 +116,7 @@
                             <host>${jmeter.host}</host>
                             <port>${jmeter.port}</port>
                             <rampup>${jmeter.rampup}</rampup>
+                            <admin.password>${jmeter.admin.password}</admin.password>
                             <startup.delay>${jmeter.startup.delay}</startup.delay>
                             <test.duration>${jmeter.test.duration}</test.duration>
                             <thread.number>${jmeter.thread.number}</thread.number>
@@ -128,5 +133,19 @@
             </plugins>
         </build>
         </profile>
+        <profile>
+            <id>jmeter.env.password</id>
+            <activation>
+                <property>
+                    <name>jmeter.env.password</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <jmeter.admin.password>${env.JMETER_ADMIN_PASSWORD}</jmeter.admin.password>
+            </properties>
+        </profile>
     </profiles>
+
+
 </project>

--- a/test-jmeter/src/test/jmeter/sessions.jmx
+++ b/test-jmeter/src/test/jmeter/sessions.jmx
@@ -57,6 +57,11 @@
               <stringProp name="Argument.value">${__P(test.duration,60)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
           </elementProp>
+          <elementProp name="host" elementType="Argument">
+                  <stringProp name="Argument.name">admin.password</stringProp>
+                  <stringProp name="Argument.value">${__P(admin.password,admin)}</stringProp>
+                  <stringProp name="Argument.metadata">=</stringProp>
+          </elementProp>
         </collectionProp>
       </Arguments>
       <hashTree/>
@@ -227,7 +232,7 @@
               <collectionProp name="Arguments.arguments">
                 <elementProp name="" elementType="HTTPArgument">
                   <boolProp name="HTTPArgument.always_encode">false</boolProp>
-                  <stringProp name="Argument.value">{&quot;userId&quot;:&quot;admin@dotcms.com&quot;,&quot;password&quot;:&quot;admin&quot;,&quot;rememberMe&quot;:false,&quot;language&quot;:&quot;en&quot;,&quot;country&quot;:&quot;US&quot;,&quot;backEndLogin&quot;:true}</stringProp>
+                  <stringProp name="Argument.value">{&quot;userId&quot;:&quot;admin@dotcms.com&quot;,&quot;password&quot;:&quot;${admin.password}&quot;,&quot;rememberMe&quot;:false,&quot;language&quot;:&quot;en&quot;,&quot;country&quot;:&quot;US&quot;,&quot;backEndLogin&quot;:true}</stringProp>
                   <stringProp name="Argument.metadata">=</stringProp>
                 </elementProp>
               </collectionProp>


### PR DESCRIPTION
### Proposed Changes
* Update jmeter to be able to pass a non default password for testing against remote instances


When connecting to an external instance, to prevent the need to add the password to the command line, the password can be added to the environment variable JMETER_ADMIN_PASSWORD.  
To prevent unexpected use of this you must add the property -Djmeter.env.password=true  or set the profile -Pjmeter.env.password
```bash
export JMETER_ADMIN_PASSWORD=mysecretpassword
./mvnw verify -Djmeter.test.skip=false -pl :dotcms-test-jmeter -Djmeter.host=myhost -Djmeter.env.password=true
```

This PR fixes: #30890