### PR TITLE
Issue 28919 Rules tab should not be visible to user with restricted access to Rules

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
@@ -152,6 +152,7 @@ export const MOCK_RESPONSE_HEADLESS: DotPageApiResponse = {
         inode: '123-i',
         canEdit: true,
         canRead: true,
+        canSeeRules: true,
         contentType: 'htmlpageasset',
         canLock: true,
         locked: false,
@@ -212,6 +213,7 @@ export const MOCK_RESPONSE_VTL: DotPageApiResponse = {
         inode: '123-i',
         canEdit: true,
         canRead: true,
+        canSeeRules: true,
         rendered: '<html><body><h1>Hello, World!</h1></body></html>',
         contentType: 'htmlpageasset',
         canLock: true,
@@ -427,6 +429,7 @@ export const PAGE_RESPONSE_BY_LANGUAGE_ID = {
             inode: '123',
             canEdit: true,
             canRead: true,
+            canSeeRules: true,
             pageURI: 'index',
             liveInode: '1234',
             stInode: '12345',
@@ -455,6 +458,7 @@ export const PAGE_RESPONSE_BY_LANGUAGE_ID = {
             inode: '123',
             canEdit: true,
             canRead: true,
+            canSeeRules: true,
             pageURI: 'index',
             liveInode: '1234',
             stInode: '12345',
@@ -483,6 +487,7 @@ export const PAGE_RESPONSE_BY_LANGUAGE_ID = {
             inode: '123',
             canEdit: true,
             canRead: true,
+            canSeeRules: true,
             pageURI: 'index',
             liveInode: '1234',
             stInode: '12345',
@@ -757,6 +762,7 @@ export const UVE_PAGE_RESPONSE_MAP = {
             identifier: '123',
             canEdit: true,
             canRead: true,
+            canSeeRules: true,
             pageURI: 'page-one',
             canLock: false,
             isLocked: true,
@@ -785,6 +791,7 @@ export const UVE_PAGE_RESPONSE_MAP = {
             identifier: '123',
             canEdit: true,
             canRead: true,
+            canSeeRules: true,
             pageURI: 'page-one',
             canLock: true,
             locked: true,
@@ -811,6 +818,7 @@ export const UVE_PAGE_RESPONSE_MAP = {
             inode: PAGE_INODE_MOCK,
             identifier: '123',
             canRead: true,
+            canSeeRules: true,
             pageURI: 'page-one',
             canEdit: false
         },
@@ -836,6 +844,7 @@ export const UVE_PAGE_RESPONSE_MAP = {
             inode: PAGE_INODE_MOCK,
             identifier: 'i-have-a-running-experiment',
             canRead: true,
+            canSeeRules: true,
             pageURI: 'page-one',
             rendered: '<div>New Content - Hello World</div>',
             canEdit: true
@@ -862,6 +871,7 @@ export const UVE_PAGE_RESPONSE_MAP = {
             inode: PAGE_INODE_MOCK,
             identifier: '123',
             canRead: true,
+            canSeeRules: true,
             pageURI: 'page-one',
             rendered: '<div>New Content - Hello World</div>',
             canEdit: true
@@ -888,6 +898,7 @@ export const UVE_PAGE_RESPONSE_MAP = {
             inode: PAGE_INODE_MOCK,
             identifier: '123',
             canRead: true,
+            canSeeRules: true,
             pageURI: 'page-one',
             rendered: '<div>hello world</div>',
             canEdit: true
@@ -914,6 +925,7 @@ export const UVE_PAGE_RESPONSE_MAP = {
             inode: PAGE_INODE_MOCK,
             identifier: '123',
             canRead: true,
+            canSeeRules: true,
             pageURI: 'page-one',
             canEdit: true
         },
@@ -939,6 +951,7 @@ export const UVE_PAGE_RESPONSE_MAP = {
             identifier: '123',
             canEdit: true,
             canRead: true,
+            canSeeRules: true,
             pageURI: 'page-one'
         },
         site: {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
@@ -170,6 +170,7 @@ export interface DotPage {
     inode: string;
     canEdit: boolean;
     canRead: boolean;
+    canSeeRules: boolean;
     canLock?: boolean;
     locked?: boolean;
     lockedBy?: string;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
@@ -98,7 +98,8 @@ export const UVEStore = signalStore(
                                 label: 'editema.editor.navbar.rules',
                                 id: 'rules',
                                 href: `rules/${page?.identifier}`,
-                                isDisabled: !page?.canSeeRules || !page?.canEdit || !isEnterpriseLicense
+                                isDisabled:
+                                    !page?.canSeeRules || !page?.canEdit || !isEnterpriseLicense
                             },
                             {
                                 iconURL: 'experiments',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
@@ -98,7 +98,7 @@ export const UVEStore = signalStore(
                                 label: 'editema.editor.navbar.rules',
                                 id: 'rules',
                                 href: `rules/${page?.identifier}`,
-                                isDisabled: !page?.canEdit || !isEnterpriseLicense
+                                isDisabled: !page?.canSeeRules || !page?.canEdit || !isEnterpriseLicense
                             },
                             {
                                 iconURL: 'experiments',

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/PageViewStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/PageViewStrategy.java
@@ -99,6 +99,8 @@ public class PageViewStrategy extends WebAssetStrategy<HTMLPageAsset> {
         map.put("canEdit", toolBox.permissionAPI.doesUserHavePermission(page, PermissionLevel.EDIT.getType(), user, false));
         map.put("canRead", toolBox.permissionAPI.doesUserHavePermission(page, PermissionLevel.READ.getType(), user, false));
         map.put("canLock", canLock(page, user));
+        map.put("canSeeRules", toolBox.permissionAPI.doesUserHavePermissions(page, "RULES: " + PermissionLevel.READ.getType(), user, false));
+
 
         if(info.isPresent() && info.get().getLockedBy()!=null) {
             map.put("lockedOn", info.get().getLockedOn());


### PR DESCRIPTION
A new property _**canSeeRules**_ was added to page so now if the user doesn't have read permissions of rules then it will see the rules tab disabled. 

<img width="418" alt="Screenshot 11122024" src="https://github.com/user-attachments/assets/e5aa9661-b3b2-46d6-a75c-db8d6ed0fc34" />

This PR fixes: #28919