### PR TITLE
fix(uve) variant retrieval in contentSelector #30727

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
@@ -39,6 +39,8 @@
  *
  * title: non-required - Title of the dialog.
  *
+ * variantName: non-required - this is used to search content of particular variant.
+ * 
  * onFileSelected: non-required - JS script or JS function callback to be executed when the user selects a content from the results,
  *
  * the content object is passed to the function.
@@ -104,6 +106,7 @@ dojo.declare(
         selectButtonLabel: 'Select',
         useRelateContentOnSelect: false,
         selectedInodesSet: new Set(),
+        variantName: 'DEFAULT',
 
         setSelectedInode: function (selectBtn) {
             if (selectBtn.checked) {
@@ -1097,7 +1100,6 @@ dojo.declare(
                     });
             }
 
-            const variantName = window.sessionStorage.getItem('variantName') || 'DEFAULT';
             ContentletAjax.searchContentlets(
                 searchFor,
                 fieldsValues,
@@ -1111,7 +1113,7 @@ dojo.declare(
                 this.currentSortBy,
                 null,
                 null,
-                variantName,
+                this.variantName,
                 dojo.hitch(this, this._fillResults)
             );
 

--- a/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
+++ b/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
@@ -258,6 +258,7 @@
      languageId="<%=language_id%>"
      onContentSelected="contentSelected"
      selectButtonLabel='<%= LanguageUtil.get(pageContext, "content.search.select") %>'
+     variantName='<%=variantName%>'
      dojoType="dotcms.dijit.form.ContentSelector">
 
 </div>


### PR DESCRIPTION
### Proposed Changes
- Added a new `variantName` property to `ContentSelector.js` to handle variant-specific content searches.
- Updated `ng-contentlet-selector.jsp` to pass the `variantName` parameter to `ContentSelector`.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
**Problem Statement:**  
When users create content for a specific variant in dotCMS, it does not appear in the list when attempting to add a new piece of content to the same variant. This issue was introduced in [PR #30556](https://github.com/dotCMS/core/pull/30556), where `window.sessionStorage` was no longer used to store the `variantName`. The `ContentSelector.js` was still relying on this outdated sessionStorage item, causing it to always default to `'DEFAULT'` for the `variantName`.

### Video
https://github.com/user-attachments/assets/f527e92c-78f5-455b-9a3f-a02b7b4fe053

This PR fixes: #30727