### PR TITLE
fix(cache) missed setting stat collection, adding back

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/cache/DynamicTTLCache.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/DynamicTTLCache.java
@@ -47,6 +47,7 @@ public class DynamicTTLCache<K, V>  {
                     return currentDuration;
                 }
             })
+            .recordStats()
             .maximumSize(maxCapacity)
             .build();
     }


### PR DESCRIPTION
#30670
The DynamicTTL does not call the stats collector when it instantiates the Caffeine Cache.  This adds the stats collector to the DynamicTTL cache

![image](https://github.com/user-attachments/assets/832240c7-33b1-4af2-b4ba-e4ed9f3160bb)

This PR fixes: #30670