### PR TITLE
fix(render) fixes issues when a parameter map with a null value is passed into the render, causing a 404/500 error

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/mock/request/MockParameterRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/mock/request/MockParameterRequest.java
@@ -28,7 +28,6 @@ public class MockParameterRequest extends HttpServletRequestWrapper implements M
     public MockParameterRequest(HttpServletRequest request, Map<String, String> setMe) {
         super(request);
         HashMap<String, String> mutable = new HashMap<>();
-        String queryString = request.getQueryString();
         List<NameValuePair> additional = URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
         for(NameValuePair nvp : additional) {
             mutable.put(nvp.getName(),nvp.getValue());

--- a/dotCMS/src/main/java/com/dotcms/mock/request/MockParameterRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/mock/request/MockParameterRequest.java
@@ -1,17 +1,18 @@
 package com.dotcms.mock.request;
 
-import java.nio.charset.Charset;
+import com.google.common.collect.ImmutableMap;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Vector;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
-import com.dotcms.repackage.com.google.common.collect.ImmutableMap;
 
 /**
  * Mock Request Parameter using a Request Wrapper. Part of the work to be
@@ -27,8 +28,8 @@ public class MockParameterRequest extends HttpServletRequestWrapper implements M
     public MockParameterRequest(HttpServletRequest request, Map<String, String> setMe) {
         super(request);
         HashMap<String, String> mutable = new HashMap<>();
-        
-        List<NameValuePair> additional = URLEncodedUtils.parse(request.getQueryString(), Charset.forName("UTF-8"));
+        String queryString = request.getQueryString();
+        List<NameValuePair> additional = URLEncodedUtils.parse(request.getQueryString(), StandardCharsets.UTF_8);
         for(NameValuePair nvp : additional) {
             mutable.put(nvp.getName(),nvp.getValue());
         }
@@ -40,7 +41,7 @@ public class MockParameterRequest extends HttpServletRequestWrapper implements M
             mutable.put(key, request.getParameter(key));
         }
         mutable.putAll(setMe);
-
+        mutable.values().removeIf(Objects::isNull);
         params = ImmutableMap.copyOf(mutable);
     }
 

--- a/src/test/java/com/dotcms/mock/request/MockParameterRequestTest.java
+++ b/src/test/java/com/dotcms/mock/request/MockParameterRequestTest.java
@@ -1,0 +1,103 @@
+package com.dotcms.mock.request;
+
+import java.util.HashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class MockParameterRequestTest {
+
+
+
+    HttpServletRequest getMockRequest() {
+        return Mockito.mock(HttpServletRequest.class);
+    }
+    @Test
+    void getParameter_returnsCorrectValue() {
+
+        HttpServletRequest mockRequest = getMockRequest();
+
+        Mockito.when(mockRequest.getQueryString()).thenReturn("param2=value2");
+
+        MockParameterRequest mockParameterRequest = new MockParameterRequest(mockRequest);
+
+        assertEquals("value2", mockParameterRequest.getParameter("param2"));
+    }
+
+    @Test
+    void getParameter_returnsNullForNonExistentParameter() {
+        HttpServletRequest mockRequest = getMockRequest();
+        Mockito.when(mockRequest.getQueryString()).thenReturn("");
+
+        MockParameterRequest mockParameterRequest = new MockParameterRequest(mockRequest);
+
+        assertNull(mockParameterRequest.getParameter("nonExistentParam"));
+    }
+
+    @Test
+    void getParameterNames_returnsAllParameterNames() {
+        HttpServletRequest mockRequest = getMockRequest();
+
+        Mockito.when(mockRequest.getQueryString()).thenReturn("param1=value1");
+
+        MockParameterRequest mockParameterRequest = new MockParameterRequest(mockRequest);
+
+        Enumeration<String> parameterNames = mockParameterRequest.getParameterNames();
+        assertEquals(true, parameterNames.hasMoreElements());
+        assertEquals("param1", parameterNames.nextElement());
+        assertEquals(false, parameterNames.hasMoreElements());
+    }
+
+    @Test
+    void getParameterMap_returnsCorrectParameterMap() {
+        HttpServletRequest mockRequest = getMockRequest();
+        Mockito.when(mockRequest.getParameterNames()).thenReturn(Collections.enumeration(Collections.singleton("param1")));
+        Mockito.when(mockRequest.getParameter("param1")).thenReturn("value1");
+        Mockito.when(mockRequest.getQueryString()).thenReturn("param1=value1");
+
+        MockParameterRequest mockParameterRequest = new MockParameterRequest(mockRequest);
+
+        Map<String, String[]> parameterMap = mockParameterRequest.getParameterMap();
+        assertEquals(1, parameterMap.size());
+        assertEquals("value1", parameterMap.get("param1")[0]);
+    }
+
+    @Test
+    void getParameterMap_handlesEmptyQueryString() {
+        HttpServletRequest mockRequest = getMockRequest();
+        Mockito.when(mockRequest.getQueryString()).thenReturn("");
+
+        MockParameterRequest mockParameterRequest = new MockParameterRequest(mockRequest);
+
+        Map<String, String[]> parameterMap = mockParameterRequest.getParameterMap();
+        assertEquals(0, parameterMap.size());
+    }
+
+
+
+    @Test
+    void test_when_null_paramter_is_passed_in() {
+
+        HttpServletRequest mockRequest = getMockRequest();
+
+        Mockito.when(mockRequest.getQueryString()).thenReturn("param2=value2");
+        Map<String,String> badMap = new HashMap<>();
+
+        badMap.put("badParam", null);
+        MockParameterRequest mockParameterRequest = new MockParameterRequest(mockRequest, badMap);
+
+        assertEquals("value2", mockParameterRequest.getParameter("param2"));
+        assertNull(mockParameterRequest.getParameter("badParam"));
+    }
+
+
+
+}


### PR DESCRIPTION
ref: #30942

This PR fixes: #30942