### PR TITLE
minor(memoryReport) make the free memory report what is left available to the jvm

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/cachestats_guava.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/cachestats_guava.jsp
@@ -22,32 +22,44 @@
     </a>
 </div>
 <%}%>
+
+<%
+
+    long maxMemory = Runtime.getRuntime().maxMemory();
+    long totalMemoryInUse = Runtime.getRuntime().totalMemory();
+    long freeMemory = Runtime.getRuntime().freeMemory();
+    long usedMemory = totalMemoryInUse - freeMemory;
+    long availableMemory = maxMemory - usedMemory;
+
+%>
+
+
 <link rel="stylesheet" href="/html/js/sortable-0.8.0/css/sortable-theme-minimal.css" />
 <script src="/html/js/sortable-0.8.0/js/sortable.min.js"></script>
 <div style="padding-bottom:30px;">
     <table class="listingTable shadowBox" style="width:400px">
         <tr>
-            <th><%= LanguageUtil.get(pageContext, "Total-Memory-Available") %>
+            <th><%= LanguageUtil.get( pageContext, "Total-Memory-Available" ) %> / Xmx
             </th>
-            <td align="right"><%=UtilMethods.prettyByteify(Runtime.getRuntime().maxMemory())%>
+            <td align="right"><%=UtilMethods.prettyByteify( maxMemory )%>
             </td>
         </tr>
         <tr>
-            <th><%= LanguageUtil.get(pageContext, "Memory-Allocated") %>
+            <th><%= LanguageUtil.get( pageContext, "Memory-Allocated" ) %>
             </th>
-            <td align="right"><%= UtilMethods.prettyByteify(Runtime.getRuntime().totalMemory())%>
+            <td align="right"><%= UtilMethods.prettyByteify( totalMemoryInUse )%>
             </td>
         </tr>
         <tr>
-            <th><%= LanguageUtil.get(pageContext, "Filled-Memory") %>
+            <th><%= LanguageUtil.get( pageContext, "Filled-Memory" ) %>
             </th>
-            <td align="right"><%= UtilMethods.prettyByteify(Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory())%>
+            <td align="right"><%= UtilMethods.prettyByteify( usedMemory )%>
             </td>
         </tr>
         <tr>
-            <th><%= LanguageUtil.get(pageContext, "Free-Memory") %>
+            <th><%= LanguageUtil.get( pageContext, "Free-Memory" ) %>
             </th>
-            <td align="right"><%= UtilMethods.prettyByteify(Runtime.getRuntime().freeMemory())%>
+            <td align="right"><%= UtilMethods.prettyByteify( availableMemory )%>
             </td>
         </tr>
     </table>

--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/view_cms_maintenance.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/view_cms_maintenance.jsp
@@ -1295,31 +1295,40 @@ dd.leftdl {
                         <div id="cacheStatsCp" dojoType="dojox.layout.ContentPane" parseOnLoad="true" style="text-align: center;min-height: 100px;">
 
 
+                            <%
+
+                                long maxMemory = Runtime.getRuntime().maxMemory();
+                                long totalMemoryInUse = Runtime.getRuntime().totalMemory();
+                                long freeMemory = Runtime.getRuntime().freeMemory();
+                                long usedMemory = totalMemoryInUse - freeMemory;
+                                long availableMemory = maxMemory - usedMemory;
+
+                            %>
                             <div style="padding-bottom:30px;">
 
                                 <table class="listingTable shadowBox" style="width:400px">
                                     <tr>
-                                        <th><%= LanguageUtil.get( pageContext, "Total-Memory-Available" ) %>
+                                        <th><%= LanguageUtil.get( pageContext, "Total-Memory-Available" ) %> / Xmx
                                         </th>
-                                        <td align="right"><%=UtilMethods.prettyByteify( Runtime.getRuntime().maxMemory() )%>
+                                        <td align="right"><%=UtilMethods.prettyByteify( maxMemory )%>
                                         </td>
                                     </tr>
                                     <tr>
                                         <th><%= LanguageUtil.get( pageContext, "Memory-Allocated" ) %>
                                         </th>
-                                        <td align="right"><%= UtilMethods.prettyByteify( Runtime.getRuntime().totalMemory() )%>
+                                        <td align="right"><%= UtilMethods.prettyByteify( totalMemoryInUse )%>
                                         </td>
                                     </tr>
                                     <tr>
                                         <th><%= LanguageUtil.get( pageContext, "Filled-Memory" ) %>
                                         </th>
-                                        <td align="right"><%= UtilMethods.prettyByteify( Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() )%>
+                                        <td align="right"><%= UtilMethods.prettyByteify( usedMemory )%>
                                         </td>
                                     </tr>
                                     <tr>
                                         <th><%= LanguageUtil.get( pageContext, "Free-Memory" ) %>
                                         </th>
-                                        <td align="right"><%= UtilMethods.prettyByteify( Runtime.getRuntime().freeMemory() )%>
+                                        <td align="right"><%= UtilMethods.prettyByteify( availableMemory )%>
                                         </td>
                                     </tr>
                                 </table>


### PR DESCRIPTION
ref: #30947


This now looks right, where `Free Memory = Total Memory - Filled Memory`
![Screenshot 2024-12-13 at 9 45 03 PM](https://github.com/user-attachments/assets/cba314d9-8ffb-4097-9e27-b6d5e7e90b67)


This PR fixes: #30947