### PR TITLE
feat(TimeMachine) include FTM content as rendered html Refs: #30937

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
@@ -269,7 +269,6 @@ public class ContainerLoader implements DotLoader {
               velocityCodeBuilder.append("#set($_show_working_=false)");
 
             //Time-machine block begin
-             /*
               velocityCodeBuilder.append("#if($UtilMethods.isSet($request.getSession(false)) && $request.session.getAttribute(\"tm_date\"))");
 
                   velocityCodeBuilder.append("#set($_tmdate=$date.toDate($webapi.parseLong($request.session.getAttribute(\"tm_date\"))))");
@@ -293,7 +292,6 @@ public class ContainerLoader implements DotLoader {
                   .append("#end");
               //end of time-machine block
               velocityCodeBuilder.append("#end");
-             */
 
                 velocityCodeBuilder.append("#set($CONTENT_INODE = '')");
                 velocityCodeBuilder.append("#set($CONTENT_BASE_TYPE = '')");

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
@@ -269,6 +269,7 @@ public class ContainerLoader implements DotLoader {
               velocityCodeBuilder.append("#set($_show_working_=false)");
 
             //Time-machine block begin
+             /*
               velocityCodeBuilder.append("#if($UtilMethods.isSet($request.getSession(false)) && $request.session.getAttribute(\"tm_date\"))");
 
                   velocityCodeBuilder.append("#set($_tmdate=$date.toDate($webapi.parseLong($request.session.getAttribute(\"tm_date\"))))");
@@ -290,9 +291,9 @@ public class ContainerLoader implements DotLoader {
                   velocityCodeBuilder.append("#if(!$UtilMethods.isSet($user)) ")
                     .append("#set($user = $cmsuser.getLoggedInUser($request)) ")
                   .append("#end");
-
-            //end of time-machine block
+              //end of time-machine block
               velocityCodeBuilder.append("#end");
+             */
 
                 velocityCodeBuilder.append("#set($CONTENT_INODE = '')");
                 velocityCodeBuilder.append("#set($CONTENT_BASE_TYPE = '')");
@@ -408,8 +409,9 @@ public class ContainerLoader implements DotLoader {
         }
 
 
-
-        return writeOutVelocity(filePath, velocityCodeBuilder.toString());
+        final String containerCode = velocityCodeBuilder.toString();
+        Logger.debug(this, "DotResourceLoader:\tWriting out container code = " + containerCode);
+        return writeOutVelocity(filePath, containerCode);
     }
 
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -125,21 +125,8 @@ public class ContentUtils {
 
                 // time-machine
                 if (tmDate != null) {
-                    // timemachine future dates
+                    // This should take care of the rendering bits for the time machine
                     final Date ffdate = new Date(Long.parseLong(tmDate));
-                    //final Identifier ident = APILocator.getIdentifierAPI().find(inodeOrIdentifier);
-                    //if (ident == null || !UtilMethods.isSet(ident.getId())) {
-                    //    return null;
-                    //}
-
-                    // timemachine content has expired. return nothing
-                    //if (UtilMethods.isSet(ident.getSysExpireDate()) && ffdate.after(ident.getSysExpireDate())) {
-                    //    return null;
-                    //}
-                    
-                    // timemachine content to be published in the future, return the working version
-                    //if (UtilMethods.isSet(ident.getSysPublishDate()) && ffdate.after(ident.getSysPublishDate())) {
-                        //return conAPI.findContentletByIdentifierOrFallback(inodeOrIdentifier, false, sessionLang, user, true).orElse(null);
 					final PageMode pageMode = PageMode.get();
 					final Optional<Contentlet> futureContent = conAPI.findContentletByIdentifierOrFallback(
 								inodeOrIdentifier, sessionLang, VariantAPI.DEFAULT_VARIANT.name(),
@@ -147,7 +134,8 @@ public class ContentUtils {
 						if (futureContent.isPresent()) {
 							return futureContent.get();
 						}
-					//}
+						// If the content is not found or has expired
+					    // No need to return null we continue to the next step to try to find the content in the live or working version
                 }
 
 				final ContentletVersionInfo contentletVersionInfoByFallback = WebAPILocator.getVariantWebAPI()

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -8,6 +8,7 @@ import com.dotcms.rest.ContentResource;
 import com.dotcms.rest.api.v1.DotObjectMapperProvider;
 import com.dotcms.util.ConversionUtils;
 import com.dotcms.util.TimeMachineUtil;
+import com.dotcms.variant.VariantAPI;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.web.WebAPILocator;
@@ -36,6 +37,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
@@ -80,7 +82,8 @@ public class ContentUtils {
 	 * @return The requested {@link Contentlet} object.
 	 */
 		public static Contentlet find(final String inodeOrIdentifier, final User user, final boolean EDIT_OR_PREVIEW_MODE, final long sessionLang){
-			return find(inodeOrIdentifier,user,null,EDIT_OR_PREVIEW_MODE, sessionLang);
+			final Optional<String> timeMachineDate = TimeMachineUtil.getTimeMachineDate();
+			return find(inodeOrIdentifier,user,timeMachineDate.orElse(null),EDIT_OR_PREVIEW_MODE, sessionLang);
 		}
 
 	    private static Contentlet fixRecurringDates(Contentlet contentlet, String[] recDates) {
@@ -120,25 +123,31 @@ public class ContentUtils {
                     return fixRecurringDates(contentlet, recDates);
                 }
 
-                // timemachine
+                // time-machine
                 if (tmDate != null) {
                     // timemachine future dates
                     final Date ffdate = new Date(Long.parseLong(tmDate));
-                    final Identifier ident = APILocator.getIdentifierAPI().find(inodeOrIdentifier);
-                    if (ident == null || !UtilMethods.isSet(ident.getId())) {
-                        return null;
-                    }
+                    //final Identifier ident = APILocator.getIdentifierAPI().find(inodeOrIdentifier);
+                    //if (ident == null || !UtilMethods.isSet(ident.getId())) {
+                    //    return null;
+                    //}
 
                     // timemachine content has expired. return nothing
-                    if (UtilMethods.isSet(ident.getSysExpireDate()) && ffdate.after(ident.getSysExpireDate())) {
-                        return null;
-                    }
+                    //if (UtilMethods.isSet(ident.getSysExpireDate()) && ffdate.after(ident.getSysExpireDate())) {
+                    //    return null;
+                    //}
                     
                     // timemachine content to be published in the future, return the working version
-                    if (UtilMethods.isSet(ident.getSysPublishDate()) && ffdate.after(ident.getSysPublishDate())) {
-                        return conAPI.findContentletByIdentifierOrFallback(inodeOrIdentifier, false, sessionLang, user, true)
-                                        .orElse(null);
-                    }
+                    //if (UtilMethods.isSet(ident.getSysPublishDate()) && ffdate.after(ident.getSysPublishDate())) {
+                        //return conAPI.findContentletByIdentifierOrFallback(inodeOrIdentifier, false, sessionLang, user, true).orElse(null);
+					final PageMode pageMode = PageMode.get();
+					final Optional<Contentlet> futureContent = conAPI.findContentletByIdentifierOrFallback(
+								inodeOrIdentifier, sessionLang, VariantAPI.DEFAULT_VARIANT.name(),
+								ffdate, user, pageMode.respectAnonPerms);
+						if (futureContent.isPresent()) {
+							return futureContent.get();
+						}
+					//}
                 }
 
 				final ContentletVersionInfo contentletVersionInfoByFallback = WebAPILocator.getVariantWebAPI()

--- a/test-karate/src/test/java/graphql/ftm/newContainer.feature
+++ b/test-karate/src/test/java/graphql/ftm/newContainer.feature
@@ -15,7 +15,7 @@ Feature: Create a Container
         "containerStructures":[
           {
             "structureId":"#(contentTypeId)",
-            "code":"$!{dotContentMap.title}"
+            "code":"<div class=\"contentlet-title\">$!{dotContentMap.title}</div>"
           }
         ]
       }

--- a/test-karate/src/test/java/tests/graphql/ftm/CheckingTimeMachine.feature
+++ b/test-karate/src/test/java/tests/graphql/ftm/CheckingTimeMachine.feature
@@ -1,6 +1,11 @@
 Feature: Test Time Machine functionality
 
   Background:
+
+    * def CONTENTLET_ONE_V1 = 'test 1'
+    * def CONTENTLET_ONE_V2 = 'test 1 v2 (This ver will be publshed in the future)'
+    * def CONTENTLET_TWO_V2 = 'test 2 v2'
+
     * callonce read('classpath:graphql/ftm/setup.feature')
 
   @smoke @positive
@@ -10,15 +15,11 @@ Feature: Test Time Machine functionality
     When method GET
     Then status 200
     * def pageContents = extractContentlets (response)
-
-    * def contentPieceOne = getContentletByUUID(contentPieceOne, contentPieceOneId)
-    * def contentPieceTwo = getContentletByUUID(contentPieceTwo, contentPieceTwoId)
-
     * def titles = pageContents.map(x => x.title)
     # This is the first version of the content, test 1 v2 as the title says it will be published in the future
-    * match titles contains 'test 1'
+    * match titles contains CONTENTLET_ONE_V1
     # This is the second version of the content, Thisone is already published therefore it should be displayed
-    * match titles contains 'test 2 v2'
+    * match titles contains CONTENTLET_TWO_V2
 
   @positive
   Scenario: Test Time Machine functionality when a publish date is provided expect the future content to be displayed
@@ -27,13 +28,11 @@ Feature: Test Time Machine functionality
     And headers commonHeaders
     When method GET
     Then status 200
+    * def rendered = response.entity.page.rendered
+    * match rendered contains CONTENTLET_ONE_V2
     * def pageContents = extractContentlets (response)
-
-    * def contentPieceOne = getContentletByUUID(contentPieceOne, contentPieceOneId)
-    * def contentPieceTwo = getContentletByUUID(contentPieceTwo, contentPieceTwoId)
-
     * def titles = pageContents.map(x => x.title)
-    * match titles contains 'test 1 v2 (This ver will be publshed in the future)'
+    * match titles contains CONTENTLET_TWO_V2
 
   @smoke @positive
   Scenario: Send GraphQL query to fetch page details no publish date is sent
@@ -46,8 +45,8 @@ Feature: Test Time Machine functionality
     Then status 200
     * def contentlets = contentletsFromGraphQlResponse(response)
     * karate.log('contentlets:', contentlets)
-    * match contentlets contains 'test 1'
-    * match contentlets contains 'test 2 v2'
+    * match contentlets contains CONTENTLET_ONE_V1
+    * match contentlets contains CONTENTLET_TWO_V2
 
   @smoke @positive
   Scenario: Send GraphQL query to fetch page details, publish date is sent expect the future content to be displayed
@@ -60,4 +59,4 @@ Feature: Test Time Machine functionality
     Then status 200
     * def contentlets = contentletsFromGraphQlResponse(response)
     * karate.log('contentlets:', contentlets)
-    * match contentlets contains 'test 1 v2 (This ver will be publshed in the future)'
+    * match contentlets contains CONTENTLET_ONE_V2


### PR DESCRIPTION
### Proposed Changes
This update resolves an issue where changes related to TimeMachineDate were not reflected in the Rendered field, which generates the HTML output. Previously, the Contentlets field responded to these changes, but the same functionality was not applied to the Rendered field.

The update introduces two key improvements:

The TimeMachineDate is now passed to the same function used to process Contentlets, ensuring that changes also affect the Rendered field.

This function handles validation of contentlets, checking if they are scheduled for future publication or if their validity has expired. This ensures consistent behavior across fields.

The VTL layer contained logic for handling TimeMachine, which is now obsolete. All necessary validation is centralized within the updated function.

This PR fixes: #30937