### PR TITLE
Fix (Core): Improving error handling on job processors discovery

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/jobs/business/api/JobProcessorDiscovery.java
+++ b/dotCMS/src/main/java/com/dotcms/jobs/business/api/JobProcessorDiscovery.java
@@ -49,11 +49,8 @@ public class JobProcessorDiscovery {
             for (Bean<?> bean : beans) {
                 Class<?> beanClass = bean.getBeanClass();
 
-                if (JobProcessor.class.isAssignableFrom(beanClass)) {
-
-                    // Validate that the bean is in the correct scope
-                    validateScope(bean);
-
+                if (JobProcessor.class.isAssignableFrom(beanClass)
+                        && isValidateScope(bean)) {
                     processors.add((Class<? extends JobProcessor>) beanClass);
                     Logger.debug(this, "Discovered JobProcessor: " + beanClass.getName());
                 }
@@ -75,14 +72,20 @@ public class JobProcessorDiscovery {
      * Validates that the scope of the bean is correct for a JobProcessor.
      *
      * @param bean The bean to validate.
+     * @return True if the scope is valid, false otherwise.
      */
-    private void validateScope(Bean<?> bean) {
+    private boolean isValidateScope(Bean<?> bean) {
+
         Class<?> scope = bean.getScope();
         if (scope != Dependent.class) {
-            throw new DotRuntimeException(
-                    "JobProcessor " + bean.getBeanClass().getName() +
-                            " must use @Dependent scope, found: " + scope.getName());
+            final String errorMessage = "JobProcessor " + bean.getBeanClass().getName() +
+                    " must use @Dependent scope, found: " + scope.getName() + " scope. "
+                    + "Won't be registered.";
+            Logger.error(this, errorMessage);
+            return false;
         }
+
+        return true;
     }
 
 }

--- a/dotcms-integration/src/test/java/com/dotcms/Junit5Suite1.java
+++ b/dotcms-integration/src/test/java/com/dotcms/Junit5Suite1.java
@@ -1,5 +1,6 @@
 package com.dotcms;
 
+import com.dotcms.jobs.business.api.JobProcessorDiscoveryTest;
 import com.dotcms.jobs.business.api.JobQueueManagerAPICDITest;
 import com.dotcms.jobs.business.api.JobQueueManagerAPIIntegrationTest;
 import com.dotcms.jobs.business.processor.impl.ImportContentletsProcessorIntegrationTest;
@@ -16,7 +17,8 @@ import org.junit.platform.suite.api.Suite;
         JobQueueManagerAPIIntegrationTest.class,
         JobQueueHelperIntegrationTest.class,
         ImportContentletsProcessorIntegrationTest.class,
-        ContentImportResourceIntegrationTest.class
+        ContentImportResourceIntegrationTest.class,
+        JobProcessorDiscoveryTest.class
 })
 public class Junit5Suite1 {
 

--- a/dotcms-integration/src/test/java/com/dotcms/jobs/business/api/JobProcessorDiscoveryTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/jobs/business/api/JobProcessorDiscoveryTest.java
@@ -1,0 +1,170 @@
+package com.dotcms.jobs.business.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.dotcms.jobs.business.job.Job;
+import com.dotcms.jobs.business.processor.JobProcessor;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test class for verifying the CDI-based job processor discovery functionality in
+ * JobProcessorDiscovery.
+ * <p>
+ * This class tests the automatic discovery of JobProcessor implementations through CDI, ensuring:
+ * <ul>
+ *   <li>Only JobProcessor implementations with @Dependent scope are discovered</li>
+ *   <li>Invalid scope processors (non-@Dependent) are filtered out</li>
+ *   <li>Non-JobProcessor classes are ignored</li>
+ *   <li>Empty results are handled correctly</li>
+ * </ul>
+ */
+public class JobProcessorDiscoveryTest {
+
+    private BeanManager beanManager;
+    private JobProcessorDiscovery discovery;
+
+    @BeforeEach
+    void setUp() {
+        beanManager = mock(BeanManager.class);
+        discovery = new JobProcessorDiscovery(beanManager);
+    }
+
+    /**
+     * Method to test: discoverJobProcessors
+     * Given Scenario: Multiple classes are available, including valid JobProcessors,
+     * invalid scope processors, and non-processor classes
+     * ExpectedResult: Only valid JobProcessor implementations with @Dependent scope are discovered
+     */
+    @Test
+    void test_discover_valid_job_processors() {
+
+        // Create mock beans
+        Bean<?> validBean1 = createMockBean(ValidJobProcessor1.class, Dependent.class);
+        Bean<?> validBean2 = createMockBean(ValidJobProcessor2.class, Dependent.class);
+        Bean<?> invalidScopeBean = createMockBean(
+                InvalidScopeProcessor.class, ApplicationScoped.class);
+        Bean<?> nonProcessorBean = createMockBean(NonProcessor.class, Dependent.class);
+
+        // Set up bean manager to return our mock beans
+        Set<Bean<?>> beans = new HashSet<>();
+        beans.add(validBean1);
+        beans.add(validBean2);
+        beans.add(invalidScopeBean);
+        beans.add(nonProcessorBean);
+        when(beanManager.getBeans(JobProcessor.class, Any.Literal.INSTANCE)).thenReturn(beans);
+
+        // Test discovery
+        List<Class<? extends JobProcessor>> discovered = discovery.discoverJobProcessors();
+
+        // Verify results
+        assertEquals(2, discovered.size(),
+                "Should discover only valid JobProcessor implementations");
+        assertTrue(discovered.contains(ValidJobProcessor1.class),
+                "Should discover ValidJobProcessor1");
+        assertTrue(discovered.contains(ValidJobProcessor2.class),
+                "Should discover ValidJobProcessor2");
+    }
+
+    /**
+     * Method to test: discoverJobProcessors
+     * Given Scenario: No JobProcessor implementations are available
+     * ExpectedResult: An empty list is returned
+     */
+    @Test
+    void test_discover_no_processors() {
+
+        // Set up bean manager to return empty set
+        when(beanManager.getBeans(JobProcessor.class, Any.Literal.INSTANCE))
+                .thenReturn(new HashSet<>());
+
+        // Test discovery
+        List<Class<? extends JobProcessor>> discovered = discovery.discoverJobProcessors();
+
+        // Verify results
+        assertTrue(discovered.isEmpty(), "Should return empty list when no processors found");
+    }
+
+    /**
+     * Helper method to create mock beans for testing.
+     *
+     * @param beanClass The class of the bean to mock
+     * @param scope     The scope annotation class to apply to the bean
+     * @return A mock Bean instance
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private Bean<?> createMockBean(Class<?> beanClass, Class<?> scope) {
+        Bean bean = mock(Bean.class);
+        when(bean.getBeanClass()).thenReturn(beanClass);
+        when(bean.getScope()).thenReturn(scope);
+        return bean;
+    }
+
+    /**
+     * Valid test JobProcessor implementation with correct @Dependent scope.
+     */
+    @Dependent
+    static class ValidJobProcessor1 implements JobProcessor {
+
+        @Override
+        public void process(Job job) {
+        }
+
+        @Override
+        public Map<String, Object> getResultMetadata(Job job) {
+            return null;
+        }
+    }
+
+    /**
+     * Second valid test JobProcessor implementation with correct @Dependent scope.
+     */
+    @Dependent
+    static class ValidJobProcessor2 implements JobProcessor {
+
+        @Override
+        public void process(Job job) {
+        }
+
+        @Override
+        public Map<String, Object> getResultMetadata(Job job) {
+            return null;
+        }
+    }
+
+    /**
+     * Invalid test JobProcessor implementation with incorrect @ApplicationScoped scope.
+     */
+    @ApplicationScoped
+    static class InvalidScopeProcessor implements JobProcessor {
+
+        @Override
+        public void process(Job job) {
+        }
+
+        @Override
+        public Map<String, Object> getResultMetadata(Job job) {
+            return null;
+        }
+    }
+
+    /**
+     * Test class that doesn't implement JobProcessor interface.
+     */
+    @Dependent
+    static class NonProcessor {
+        // Not a JobProcessor implementation
+    }
+}


### PR DESCRIPTION
This pull request includes changes to improve the job processor discovery mechanism in the `dotCMS` project. The most important changes involve refactoring the scope validation logic and adding comprehensive tests for the job processor discovery functionality.

Refactoring and improvements:

* [`dotCMS/src/main/java/com/dotcms/jobs/business/api/JobProcessorDiscovery.java`](diffhunk://#diff-796e7503dcb4b03e85602c13708c084a19b3b5555bb5bbc46667ebabca1dc9dfL52-R53): Refactored the `discoverJobProcessors` method to use the new `isValidateScope` method for scope validation instead of `validateScope`. This change improves readability and error handling by logging invalid scope errors instead of throwing exceptions. [[1]](diffhunk://#diff-796e7503dcb4b03e85602c13708c084a19b3b5555bb5bbc46667ebabca1dc9dfL52-R53) [[2]](diffhunk://#diff-796e7503dcb4b03e85602c13708c084a19b3b5555bb5bbc46667ebabca1dc9dfR75-R88)

Testing enhancements:

* [`dotcms-integration/src/test/java/com/dotcms/Junit5Suite1.java`](diffhunk://#diff-4b36fa8f2a871dca49e798d2b65b4f8a0c7ad264fd2fbb25f8bb435ff6dae160R3): Added `JobProcessorDiscoveryTest` to the JUnit test suite to ensure the new job processor discovery functionality is tested. [[1]](diffhunk://#diff-4b36fa8f2a871dca49e798d2b65b4f8a0c7ad264fd2fbb25f8bb435ff6dae160R3) [[2]](diffhunk://#diff-4b36fa8f2a871dca49e798d2b65b4f8a0c7ad264fd2fbb25f8bb435ff6dae160L19-R21)
* [`dotcms-integration/src/test/java/com/dotcms/jobs/business/api/JobProcessorDiscoveryTest.java`](diffhunk://#diff-b9c6f725701a5ba5108e37e1b740bee7ce75b2dc30b5e4b39f7d242f64559a5eR1-R170): Created a new test class to verify the CDI-based job processor discovery functionality. This class includes tests for discovering valid job processors, handling invalid scope processors, ignoring non-processor classes, and managing empty results.

This PR fixes: #30545