### PR TITLE
feat(rest-api) update swagger docs with 415 status api response

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/accessibility/ACheckerResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/accessibility/ACheckerResource.java
@@ -21,6 +21,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -114,6 +115,7 @@ public class ACheckerResource {
     @JSONP
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+    @Consumes({MediaType.APPLICATION_JSON})
     @Operation(
             operationId = "postValidateContent",
             summary = "Validates content",
@@ -215,6 +217,7 @@ public class ACheckerResource {
                             )
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad Request"),
+                    @ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
                     @ApiResponse(responseCode = "500", description = "Internal Server Error")
             }
     )

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/ContentAnalyticsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/ContentAnalyticsResource.java
@@ -137,6 +137,7 @@ public class ContentAnalyticsResource {
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad Request"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
                     @ApiResponse(responseCode = "500", description = "Internal Server Error")
             }
     )
@@ -196,6 +197,7 @@ public class ContentAnalyticsResource {
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad Request"),
                     @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                    @ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
                     @ApiResponse(responseCode = "500", description = "Internal Server Error")
             }
     )
@@ -266,6 +268,7 @@ public class ContentAnalyticsResource {
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad Request"),
                     @ApiResponse(responseCode = "401", description = "Unauthorized"),
+                    @ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
                     @ApiResponse(responseCode = "500", description = "Internal Server Error")
             }
     )
@@ -319,6 +322,7 @@ public class ContentAnalyticsResource {
                     ),
                     @ApiResponse(responseCode = "400", description = "Bad Request"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
                     @ApiResponse(responseCode = "500", description = "Internal Server Error")
             }
     )

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
@@ -410,6 +410,7 @@ public class ApiTokenResource implements Serializable {
                     @ApiResponse(responseCode = "400", description = "Bad request"),
                     @ApiResponse(responseCode = "401", description = "Invalid user"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
             }
     )
@@ -575,6 +576,7 @@ public class ApiTokenResource implements Serializable {
                     @ApiResponse(responseCode = "400", description = "Bad request"),
                     @ApiResponse(responseCode = "401", description = "Invalid user"),
                     @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
                     @ApiResponse(responseCode = "500", description = "Unexpected server error")
             }
     )

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/AuthenticationResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/AuthenticationResource.java
@@ -121,6 +121,7 @@ public class AuthenticationResource implements Serializable {
                             schema = @Schema(implementation = ResponseEntityUserMapView.class))),
                     @ApiResponse(responseCode = "401", description = "User not authenticated"),
                     @ApiResponse(responseCode = "403", description = "Forbidden request"),
+                    @ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
                     @ApiResponse(responseCode = "500", description = "Unexpected error")
                 }
             )

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResource.java
@@ -210,6 +210,7 @@ public class ContentTypeResource implements Serializable {
 					),
 					@ApiResponse(responseCode = "400", description = "Bad Request"),
 					@ApiResponse(responseCode = "403", description = "Forbidden"),
+					@ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
 					@ApiResponse(responseCode = "500", description = "Internal Server Error")
 			}
 	)
@@ -446,6 +447,7 @@ public class ContentTypeResource implements Serializable {
 					),
 					@ApiResponse(responseCode = "400", description = "Bad Request"),
 					@ApiResponse(responseCode = "403", description = "Forbidden"),
+					@ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
 					@ApiResponse(responseCode = "500", description = "Internal Server Error")
 			}
 	)
@@ -644,6 +646,7 @@ public class ContentTypeResource implements Serializable {
 					@ApiResponse(responseCode = "400", description = "Bad Request"),
 					@ApiResponse(responseCode = "403", description = "Forbidden"),
 					@ApiResponse(responseCode = "404", description = "Not Found"),
+					@ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
 					@ApiResponse(responseCode = "500", description = "Internal Server Error")
 			}
 	)
@@ -1236,6 +1239,7 @@ public class ContentTypeResource implements Serializable {
 					),
 					@ApiResponse(responseCode = "400", description = "Bad Request"),
 					@ApiResponse(responseCode = "403", description = "Forbidden"),
+					@ApiResponse(responseCode = "415", description = "Unsupported Media Type"),
 					@ApiResponse(responseCode = "500", description = "Internal Server Error")
 			}
 	)

--- a/dotcms-postman/src/main/resources/postman/Accessibility_Checker_Tests.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Accessibility_Checker_Tests.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "cb25dbbd-2dfc-4105-9c09-a0a55c58927f",
+		"_postman_id": "e01f8671-adc7-4d6e-a33c-096d1f2686be",
 		"name": "Accessibility Checker Tests",
 		"description": "This Postman Collection verifies that the Accessibility Checker -- a.k.a. AChecker -- is working as expected after being migrated from a DWR class to a REST Endpoint. Basically, this new endpoint exposes two methods:\n\n1. Retrieving the list of Accessiblity Guidelines that Content Authors can use to validate content.\n    \n2. Send the validation request to the specific service, and receive the list of errors/suggestions that must be followed in order to make the content comply with the selected Accessibility Guideline(s).",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5403727"
+		"_exporter_id": "36604690"
 	},
 	"item": [
 		{
@@ -595,6 +595,80 @@
 							}
 						}
 					]
+				},
+				{
+					"name": "Unsupported Media Type",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Validate the response status is 415",
+									"pm.test(\"Response status is 415\", function () {",
+									"    pm.response.to.have.status(415);",
+									"});",
+									"",
+									"// Validate that the response body contains the 'message' property and it is not empty",
+									"pm.test(\"Response should have an error message\", function () {",
+									"    const responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+									"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						},
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"content-type": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"lang\": \"en\",\n    \"content\": \"Adventure travel done right\\n\\nWherever you want to go, whatever you want to get into, we’ve got a trip that’ll make your dream vacation come true. Visit like a local, explore at your own pace, and eat like a king (or a vegan king, if that’s more your thing).\",\n    \"guidelines\": \"{{guidelines_abbr}}\",\n    \"fragment\": \"true\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/achecker/_validate",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"achecker",
+								"_validate"
+							]
+						},
+						"description": "The `guidelines` attribute is required. This request will fail."
+					},
+					"response": []
 				}
 			]
 		}

--- a/dotcms-postman/src/main/resources/postman/ApiToken_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/ApiToken_Resource.postman_collection.json
@@ -1,10 +1,10 @@
 {
   "info": {
-    "_postman_id": "f445f00a-010c-4560-b726-aacf92908f74",
+    "_postman_id": "ea297de7-1ffd-423f-9cfe-c9d697c42e8b",
     "name": "ApiToken Resource",
     "description": "Tests for the api token",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "5403727"
+    "_exporter_id": "36604690"
   },
   "item": [
     {
@@ -41,8 +41,14 @@
             },
             "url": {
               "raw": "{{serverURL}}/api/v1/configuration",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "configuration"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configuration"
+              ]
             }
           },
           "response": []
@@ -83,9 +89,8 @@
             "header": [
               {
                 "key": "Content-Type",
-                "name": "Content-Type",
-                "type": "text",
-                "value": "application/json"
+                "value": "application/json",
+                "type": "text"
               }
             ],
             "body": {
@@ -99,8 +104,15 @@
             },
             "url": {
               "raw": "{{serverURL}}/api/v1/apitoken/remote",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "apitoken", "remote"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apitoken",
+                "remote"
+              ]
             },
             "description": "Create a new remote token should response 403 when ENABLE_PROXY_TOKEN_REQUESTS is set to false"
           },
@@ -137,8 +149,14 @@
             },
             "url": {
               "raw": "{{serverURL}}/api/v1/configuration",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "configuration"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "configuration"
+              ]
             }
           },
           "response": []
@@ -186,9 +204,8 @@
             "header": [
               {
                 "key": "Content-Type",
-                "name": "Content-Type",
-                "type": "text",
-                "value": "application/json"
+                "value": "application/json",
+                "type": "text"
               }
             ],
             "body": {
@@ -202,8 +219,15 @@
             },
             "url": {
               "raw": "{{serverURL}}/api/v1/apitoken/remote",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "apitoken", "remote"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apitoken",
+                "remote"
+              ]
             },
             "description": "Create a new remote token"
           },
@@ -229,8 +253,14 @@
             "header": [],
             "url": {
               "raw": "{{serverURL}}/api/v1/logout",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "logout"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "logout"
+              ]
             },
             "description": "Logout before try with invalid user"
           },
@@ -272,9 +302,8 @@
             "header": [
               {
                 "key": "Content-Type",
-                "name": "Content-Type",
-                "type": "text",
-                "value": "application/json"
+                "value": "application/json",
+                "type": "text"
               }
             ],
             "body": {
@@ -288,8 +317,15 @@
             },
             "url": {
               "raw": "{{serverURL}}/api/v1/apitoken/remote",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "apitoken", "remote"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apitoken",
+                "remote"
+              ]
             },
             "description": "Try to create a new remote token with a invalid local user, it mean send a invalid_user in the auth header"
           },
@@ -331,9 +367,8 @@
             "header": [
               {
                 "key": "Content-Type",
-                "name": "Content-Type",
-                "type": "text",
-                "value": "application/json"
+                "value": "application/json",
+                "type": "text"
               }
             ],
             "body": {
@@ -347,8 +382,15 @@
             },
             "url": {
               "raw": "{{serverURL}}/api/v1/apitoken/remote",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "apitoken", "remote"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apitoken",
+                "remote"
+              ]
             },
             "description": "Try to create a new remote token with a invalid local user, it mean send a invalid_user in the auth header"
           },
@@ -390,9 +432,8 @@
             "header": [
               {
                 "key": "Content-Type",
-                "name": "Content-Type",
-                "type": "text",
-                "value": "application/json"
+                "value": "application/json",
+                "type": "text"
               }
             ],
             "body": {
@@ -406,8 +447,15 @@
             },
             "url": {
               "raw": "{{serverURL}}/api/v1/apitoken/remote",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "apitoken", "remote"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apitoken",
+                "remote"
+              ]
             },
             "description": "Try to create a new remote token with a invalid local user, it mean send a invalid_user in the auth header"
           },
@@ -448,9 +496,8 @@
             "header": [
               {
                 "key": "Content-Type",
-                "name": "Content-Type",
-                "type": "text",
-                "value": "application/json"
+                "value": "application/json",
+                "type": "text"
               }
             ],
             "body": {
@@ -464,8 +511,15 @@
             },
             "url": {
               "raw": "{{serverURL}}/api/v1/apitoken/remote",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "apitoken", "remote"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apitoken",
+                "remote"
+              ]
             },
             "description": "Try to create a new remote token with a remote user, it mean send a inavlid user in the body request auth section"
           },
@@ -507,9 +561,8 @@
             "header": [
               {
                 "key": "Content-Type",
-                "name": "Content-Type",
-                "type": "text",
-                "value": "application/json"
+                "value": "application/json",
+                "type": "text"
               }
             ],
             "body": {
@@ -523,8 +576,89 @@
             },
             "url": {
               "raw": "{{serverURL}}/api/v1/apitoken/remote",
-              "host": ["{{serverURL}}"],
-              "path": ["api", "v1", "apitoken", "remote"]
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apitoken",
+                "remote"
+              ]
+            },
+            "description": "Create a new remote token should response 403 when ENABLE_PROXY_TOKEN_REQUESTS is set to false"
+          },
+          "response": []
+        },
+        {
+          "name": "createToken remote Unsupported Media Type",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Validate the response status is 415",
+                  "pm.test(\"Response status is 415\", function () {",
+                  "    pm.response.to.have.status(415);",
+                  "});",
+                  "",
+                  "// Validate that the response body contains the 'message' property and it is not empty",
+                  "pm.test(\"Response should have an error message\", function () {",
+                  "    const responseBody = pm.response.json();",
+                  "    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+                  "    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+                  "});",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "basic",
+              "basic": [
+                {
+                  "key": "username",
+                  "value": "admin@dotcms.com",
+                  "type": "string"
+                },
+                {
+                  "key": "password",
+                  "value": "admin",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/javascript",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"auth\": {\n        \"login\": \"admin@dotcms.com\", \n        \"password\": \"YWRtaW4=\"\n    },\n    \"remote\": {\n        \"host\": \"{{remoteTokenHost}}\", \n        \"port\": \"{{remoteTokenPort}}\", \n        \"protocol\": \"http\"\n    },\n    \"token\": {\n        \"expirationSeconds\": 94575023, \n        \"network\": \"0.0.0.0/0\", \n        \"userId\": \"dotcms.org.1\",\n        \"claims\": {\n            \"label\": \"Push Publish\"            \n        }\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{serverURL}}/api/v1/apitoken/remote",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "apitoken",
+                "remote"
+              ]
             },
             "description": "Create a new remote token should response 403 when ENABLE_PROXY_TOKEN_REQUESTS is set to false"
           },
@@ -567,7 +701,9 @@
           "listen": "test",
           "script": {
             "type": "text/javascript",
-            "exec": [""]
+            "exec": [
+              ""
+            ]
           }
         }
       ]
@@ -592,42 +728,42 @@
               "pm.collectionVariables.set(\"tokenid\", jsonData.entity.token.id);",
               "",
               "pm.test(\"Token should expire after certain duration\", function () {",
-							"    const currentTimestamp = Math.floor(Date.now() / 1000);",
-							"    const expirationTime = jsonData.entity.token.expiresDate;",
-							"    pm.expect(expirationTime).to.be.above(currentTimestamp);",
-							"});",
-							"",
-							"pm.test(\"Token ID should be unique\", function () {",
-							"    const tokenID = jsonData.entity.token.id;",
-							"    pm.collectionVariables.get(\"tokenIDs\") || pm.collectionVariables.set(\"tokenIDs\", []);",
-							"    const tokenIDs = pm.collectionVariables.get(\"tokenIDs\");",
-							"    pm.expect(tokenIDs).to.not.include(tokenID);",
-							"    tokenIDs.push(tokenID);",
-							"    pm.collectionVariables.set(\"tokenIDs\", tokenIDs);",
-							"});",
-							"",
-							"pm.test(\"Token should be securely generated\", function () {",
-							"    const jwtToken = jsonData.entity.jwt;",
-							"    // Add your custom logic to check the security of the JWT token",
-							"    pm.expect(jwtToken.length).to.be.above(50);  // Example: Check for a minimum length",
-							"    pm.expect(jwtToken).to.match(/^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_.+/=]+$/);  // Example: Check for a typical JWT format",
-							"});",
-							"",
-							"pm.test(\"Rate-limit shouldn't exceed\", function () {",
-							"    // Adjust the expected status code and message based on your API's rate limiting response",
-							"    const expectedRateLimitStatusCode = 429; // HTTP status code for Too Many Requests",
-							"    const expectedRateLimitMessage = \"Rate Limit Exceeded\"; // Message indicating rate limit exceeded",
-							"",
-							"    if (pm.response.code === expectedRateLimitStatusCode) {",
-							"        // Rate limit exceeded, which is expected behavior",
-							"        pm.expect(pm.response.text()).to.include(expectedRateLimitMessage);",
-							"    } else {",
-							"        ",
-							"        pm.expect(pm.response.code).to.eql(200);",
-							"    }",
-							"});",
-							"",
-							""
+              "    const currentTimestamp = Math.floor(Date.now() / 1000);",
+              "    const expirationTime = jsonData.entity.token.expiresDate;",
+              "    pm.expect(expirationTime).to.be.above(currentTimestamp);",
+              "});",
+              "",
+              "pm.test(\"Token ID should be unique\", function () {",
+              "    const tokenID = jsonData.entity.token.id;",
+              "    pm.collectionVariables.get(\"tokenIDs\") || pm.collectionVariables.set(\"tokenIDs\", []);",
+              "    const tokenIDs = pm.collectionVariables.get(\"tokenIDs\");",
+              "    pm.expect(tokenIDs).to.not.include(tokenID);",
+              "    tokenIDs.push(tokenID);",
+              "    pm.collectionVariables.set(\"tokenIDs\", tokenIDs);",
+              "});",
+              "",
+              "pm.test(\"Token should be securely generated\", function () {",
+              "    const jwtToken = jsonData.entity.jwt;",
+              "    // Add your custom logic to check the security of the JWT token",
+              "    pm.expect(jwtToken.length).to.be.above(50);  // Example: Check for a minimum length",
+              "    pm.expect(jwtToken).to.match(/^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_.+/=]+$/);  // Example: Check for a typical JWT format",
+              "});",
+              "",
+              "pm.test(\"Rate-limit shouldn't exceed\", function () {",
+              "    // Adjust the expected status code and message based on your API's rate limiting response",
+              "    const expectedRateLimitStatusCode = 429; // HTTP status code for Too Many Requests",
+              "    const expectedRateLimitMessage = \"Rate Limit Exceeded\"; // Message indicating rate limit exceeded",
+              "",
+              "    if (pm.response.code === expectedRateLimitStatusCode) {",
+              "        // Rate limit exceeded, which is expected behavior",
+              "        pm.expect(pm.response.text()).to.include(expectedRateLimitMessage);",
+              "    } else {",
+              "        ",
+              "        pm.expect(pm.response.code).to.eql(200);",
+              "    }",
+              "});",
+              "",
+              ""
             ],
             "type": "text/javascript"
           }
@@ -653,7 +789,6 @@
         "header": [
           {
             "key": "Content-Type",
-            "name": "Content-Type",
             "value": "application/json",
             "type": "text"
           }
@@ -669,8 +804,14 @@
         },
         "url": {
           "raw": "{{serverURL}}/api/v1/apitoken",
-          "host": ["{{serverURL}}"],
-          "path": ["api", "v1", "apitoken"]
+          "host": [
+            "{{serverURL}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "apitoken"
+          ]
         }
       },
       "response": []
@@ -695,26 +836,26 @@
               "pm.collectionVariables.set(\"tokenid\", jsonData.entity.token.id);",
               "",
               "pm.test(\"Token should expire\", function () {",
-							"    const currentTimestamp = Math.floor(Date.now() / 1000);",
-							"    const expirationTime = jsonData.entity.token.expiresDate;",
-							"    pm.expect(expirationTime).to.be.above(currentTimestamp);",
-							"});",
-							"",
-							"pm.test(\"Token ID should be unique\", function () {",
-							"    const tokenID = jsonData.entity.token.id;",
-							"    pm.collectionVariables.get(\"tokenIDs\") || pm.collectionVariables.set(\"tokenIDs\", []);",
-							"    const tokenIDs = pm.collectionVariables.get(\"tokenIDs\");",
-							"    pm.expect(tokenIDs).to.not.include(tokenID);",
-							"    tokenIDs.push(tokenID);",
-							"    pm.collectionVariables.set(\"tokenIDs\", tokenIDs);",
-							"});",
-							"",
-							"pm.test(\"Token should be securely generated\", function () {",
-							"    const jwtToken = jsonData.entity.jwt;",
-							"    // Add your custom logic to check the security of the JWT token",
-							"    pm.expect(jwtToken.length).to.be.above(50);  // Example: Check for a minimum length",
-							"    pm.expect(jwtToken).to.match(/^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_.+/=]+$/);  // Example: Check for a typical JWT format",
-							"});"
+              "    const currentTimestamp = Math.floor(Date.now() / 1000);",
+              "    const expirationTime = jsonData.entity.token.expiresDate;",
+              "    pm.expect(expirationTime).to.be.above(currentTimestamp);",
+              "});",
+              "",
+              "pm.test(\"Token ID should be unique\", function () {",
+              "    const tokenID = jsonData.entity.token.id;",
+              "    pm.collectionVariables.get(\"tokenIDs\") || pm.collectionVariables.set(\"tokenIDs\", []);",
+              "    const tokenIDs = pm.collectionVariables.get(\"tokenIDs\");",
+              "    pm.expect(tokenIDs).to.not.include(tokenID);",
+              "    tokenIDs.push(tokenID);",
+              "    pm.collectionVariables.set(\"tokenIDs\", tokenIDs);",
+              "});",
+              "",
+              "pm.test(\"Token should be securely generated\", function () {",
+              "    const jwtToken = jsonData.entity.jwt;",
+              "    // Add your custom logic to check the security of the JWT token",
+              "    pm.expect(jwtToken.length).to.be.above(50);  // Example: Check for a minimum length",
+              "    pm.expect(jwtToken).to.match(/^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_.+/=]+$/);  // Example: Check for a typical JWT format",
+              "});"
             ],
             "type": "text/javascript"
           }
@@ -740,9 +881,8 @@
         "header": [
           {
             "key": "Content-Type",
-            "name": "Content-Type",
-            "type": "text",
-            "value": "application/json"
+            "value": "application/json",
+            "type": "text"
           }
         ],
         "body": {
@@ -756,8 +896,14 @@
         },
         "url": {
           "raw": "{{serverURL}}/api/v1/apitoken",
-          "host": ["{{serverURL}}"],
-          "path": ["api", "v1", "apitoken"]
+          "host": [
+            "{{serverURL}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "apitoken"
+          ]
         }
       },
       "response": []
@@ -803,8 +949,16 @@
         "header": [],
         "url": {
           "raw": "{{serverURL}}/api/v1/apitoken/dotcms.org.1/tokens",
-          "host": ["{{serverURL}}"],
-          "path": ["api", "v1", "apitoken", "dotcms.org.1", "tokens"]
+          "host": [
+            "{{serverURL}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "apitoken",
+            "dotcms.org.1",
+            "tokens"
+          ]
         },
         "description": "Get tokens of admin user"
       },
@@ -822,9 +976,8 @@
               "});",
               "",
               "pm.test(\"Response has a valid JWT\", function () {",
-							"    pm.expect(pm.response.json().entity.jwt).to.match(/^[A-Za-z0-9-_]+\\.[A-Za-z0-9-_]+\\.[A-Za-z0-9-_.+/=]*$/);",
-							"});"
-							
+              "    pm.expect(pm.response.json().entity.jwt).to.match(/^[A-Za-z0-9-_]+\\.[A-Za-z0-9-_]+\\.[A-Za-z0-9-_.+/=]*$/);",
+              "});"
             ],
             "type": "text/javascript"
           }
@@ -850,8 +1003,16 @@
         "header": [],
         "url": {
           "raw": "{{serverURL}}/api/v1/apitoken/{{tokenid}}/jwt",
-          "host": ["{{serverURL}}"],
-          "path": ["api", "v1", "apitoken", "{{tokenid}}", "jwt"]
+          "host": [
+            "{{serverURL}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "apitoken",
+            "{{tokenid}}",
+            "jwt"
+          ]
         }
       },
       "response": []
@@ -891,8 +1052,16 @@
         "header": [],
         "url": {
           "raw": "{{serverURL}}/api/v1/apitoken/{{tokenid}}/revoke",
-          "host": ["{{serverURL}}"],
-          "path": ["api", "v1", "apitoken", "{{tokenid}}", "revoke"]
+          "host": [
+            "{{serverURL}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "apitoken",
+            "{{tokenid}}",
+            "revoke"
+          ]
         }
       },
       "response": []
@@ -932,8 +1101,15 @@
         "header": [],
         "url": {
           "raw": "{{serverURL}}/api/v1/apitoken/{{tokenid}}",
-          "host": ["{{serverURL}}"],
-          "path": ["api", "v1", "apitoken", "{{tokenid}}"]
+          "host": [
+            "{{serverURL}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "apitoken",
+            "{{tokenid}}"
+          ]
         }
       },
       "response": []
@@ -973,8 +1149,17 @@
         "header": [],
         "url": {
           "raw": "{{serverURL}}/api/v1/apitoken/users/dotcms.org.1/revoke",
-          "host": ["{{serverURL}}"],
-          "path": ["api", "v1", "apitoken", "users", "dotcms.org.1", "revoke"]
+          "host": [
+            "{{serverURL}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "apitoken",
+            "users",
+            "dotcms.org.1",
+            "revoke"
+          ]
         }
       },
       "response": []
@@ -1014,8 +1199,88 @@
         "header": [],
         "url": {
           "raw": "{{serverURL}}/api/v1/apitoken/users/revoke",
-          "host": ["{{serverURL}}"],
-          "path": ["api", "v1", "apitoken", "users", "revoke"]
+          "host": [
+            "{{serverURL}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "apitoken",
+            "users",
+            "revoke"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "createToken Unsupported Media Type",
+      "event": [
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "// Validate the response status is 415",
+              "pm.test(\"Response status is 415\", function () {",
+              "    pm.response.to.have.status(415);",
+              "});",
+              "",
+              "// Validate that the response body contains the 'message' property and it is not empty",
+              "pm.test(\"Response should have an error message\", function () {",
+              "    const responseBody = pm.response.json();",
+              "    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+              "    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+              "});",
+              ""
+            ],
+            "type": "text/javascript",
+            "packages": {}
+          }
+        }
+      ],
+      "request": {
+        "auth": {
+          "type": "basic",
+          "basic": [
+            {
+              "key": "username",
+              "value": "admin@dotcms.com",
+              "type": "string"
+            },
+            {
+              "key": "password",
+              "value": "admin",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/javascript",
+            "type": "text"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n\t\"userId\":\"dotcms.org.1\",\n\t\"tokenId\":\"123\",\n\t\"expirationSeconds\":\"100000\"\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{serverURL}}/api/v1/apitoken",
+          "host": [
+            "{{serverURL}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "apitoken"
+          ]
         }
       },
       "response": []

--- a/dotcms-postman/src/main/resources/postman/ContentTypeResourceTests.json
+++ b/dotcms-postman/src/main/resources/postman/ContentTypeResourceTests.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "9aa702a3-2811-429a-a33c-480b75530b23",
+		"_postman_id": "173bf579-93b9-497b-baee-8f9c48e58b71",
 		"name": "ContentType Resource",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5403727"
+		"_exporter_id": "36604690"
 	},
 	"item": [
 		{
@@ -1205,6 +1205,248 @@
 							]
 						},
 						"description": "Given a content type ID.\nExpect that code is 200.\nExpect content type is deleted successfully."
+					},
+					"response": []
+				},
+				{
+					"name": "Create ContentType Unsupported Media Type",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Validate the response status is 415",
+									"pm.test(\"Response status is 415\", function () {",
+									"    pm.response.to.have.status(415);",
+									"});",
+									"",
+									"// Validate that the response body contains the 'message' property and it is not empty",
+									"pm.test(\"Response should have an error message\", function () {",
+									"    const responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+									"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/javascript"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"clazz\": \"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\", \n    \"defaultType\": false, \n    \"name\": \"Test Content Type\", \n    \"description\": \"THE DESCRIPTION\", \n    \"host\": \"SYSTEM_HOST\", \n    \"owner\": \"dotcms.org.1\", \n    \"fixed\": false, \n    \"system\": false, \n    \"folder\": \"SYSTEM_FOLDER\",\n    \"fields\": [\n            {\n                \"dataType\": \"SYSTEM\",\n                \"dbColumn\": \"system_field1\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1308941714000,\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableHostFolderField\",\n                \"indexed\": true,\n                \"listed\": false,\n                \"modDate\": 1478557845000,\n                \"name\": \"Host/Folder\",\n                \"readOnly\": false,\n                \"required\": true,\n                \"searchable\": true,\n                \"sortOrder\": 1,\n                \"unique\": false,\n                \"variable\": \"hostfolder\"\n            },\n            {\n                \"dataType\": \"LONG_TEXT\",\n                \"dbColumn\": \"text_area2\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1453474468000,\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTagField\",\n                \"indexed\": true,\n                \"listed\": false,\n                \"modDate\": 1478557845000,\n                \"name\": \"Tags\",\n                \"readOnly\": false,\n                \"required\": false,\n                \"searchable\": true,\n                \"sortOrder\": 3,\n                \"unique\": false,\n                \"variable\": \"tags\"\n            }],\n            \"workflow\": [\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"]\n}\n"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a POST.\nExpect that code is 200.\nExpect content type is created with the provided fields.\nExpect that new properties of content types are set (icon and sortOrder)."
+					},
+					"response": []
+				},
+				{
+					"name": "Filter ContentType Unsupported Media Type",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Validate the response status is 415",
+									"pm.test(\"Response status is 415\", function () {",
+									"    pm.response.to.have.status(415);",
+									"});",
+									"",
+									"// Validate that the response body contains the 'message' property and it is not empty",
+									"pm.test(\"Response should have an error message\", function () {",
+									"    const responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+									"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/javascript"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"clazz\": \"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\", \n    \"defaultType\": false, \n    \"name\": \"Test Content Type\", \n    \"description\": \"THE DESCRIPTION\", \n    \"host\": \"SYSTEM_HOST\", \n    \"owner\": \"dotcms.org.1\", \n    \"fixed\": false, \n    \"system\": false, \n    \"folder\": \"SYSTEM_FOLDER\",\n    \"fields\": [\n            {\n                \"dataType\": \"SYSTEM\",\n                \"dbColumn\": \"system_field1\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1308941714000,\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableHostFolderField\",\n                \"indexed\": true,\n                \"listed\": false,\n                \"modDate\": 1478557845000,\n                \"name\": \"Host/Folder\",\n                \"readOnly\": false,\n                \"required\": true,\n                \"searchable\": true,\n                \"sortOrder\": 1,\n                \"unique\": false,\n                \"variable\": \"hostfolder\"\n            },\n            {\n                \"dataType\": \"LONG_TEXT\",\n                \"dbColumn\": \"text_area2\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1453474468000,\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTagField\",\n                \"indexed\": true,\n                \"listed\": false,\n                \"modDate\": 1478557845000,\n                \"name\": \"Tags\",\n                \"readOnly\": false,\n                \"required\": false,\n                \"searchable\": true,\n                \"sortOrder\": 3,\n                \"unique\": false,\n                \"variable\": \"tags\"\n            }],\n            \"workflow\": [\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"]\n}\n"
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/_filter",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"_filter"
+							]
+						},
+						"description": "Given a content type payload containing field variables.\nWhen sending a POST.\nExpect that code is 200.\nExpect content type is created with the provided fields.\nExpect that new properties of content types are set (icon and sortOrder)."
+					},
+					"response": []
+				},
+				{
+					"name": "Update Content Type Unsupported Media Type",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Validate the response status is 415",
+									"pm.test(\"Response status is 415\", function () {",
+									"    pm.response.to.have.status(415);",
+									"});",
+									"",
+									"// Validate that the response body contains the 'message' property and it is not empty",
+									"pm.test(\"Response should have an error message\", function () {",
+									"    const responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+									"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"content-type": true
+						}
+					},
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/javascript",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"clazz\": \"com.dotcms.contenttype.model.type.SimpleContentType\",\n\t\"description\": \"THE DESCRIPTION\",\n        \"fields\": [\n            {\n                \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableHostFolderField\",\n                \"contentTypeId\": \"{{contentTypeID}}\",\n                \"dataType\": \"SYSTEM\",\n                \"fieldType\": \"Host-Folder\",\n                \"fieldTypeLabel\": \"Site or Folder\",\n                \"fieldVariables\": [],\n                \"fixed\": false,\n                \"iDate\": 1308941714000,\n                \"id\": \"{{contentTypeFieldID}}\",\n                \"indexed\": true,\n                \"listed\": false,\n                \"modDate\": 1632506750000,\n                \"name\": \"Host/Folder CHANGED\",\n                \"readOnly\": false,\n                \"required\": true,\n                \"searchable\": true,\n                \"sortOrder\": 1,\n                \"unique\": false,\n                \"variable\": \"hostfolder\"\n            }\n        ],\n\t\"defaultType\": false,\n\t\"system\": false,\n\t\"folder\": \"SYSTEM_FOLDER\",\n\t\"host\": \"SYSTEM_HOST\",\n    \"name\": \"Test Content Type\",\n\t\"fixed\": false,\n    \"id\": \"{{contentTypeID}}\",\n    \"workflow\":[\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"],\n    \"icon\": \"icon2\",\n    \"sortOrder\": 2\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/id/{{contentTypeID}}",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"id",
+								"{{contentTypeID}}"
+							]
+						},
+						"description": "Given a content type ID and a payload containing content type properties.\nExpect that code is 200.\nExpect content type is updated without issues.\nExpect that the new properties (icon and sortOrder) are updated with the new values."
 					},
 					"response": []
 				}
@@ -3463,6 +3705,85 @@
 						},
 						"method": "POST",
 						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/contenttype/fileAsset/_copy",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"contenttype",
+								"fileAsset",
+								"_copy"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Copy FileAsset Unsupported Media Type",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Validate the response status is 415",
+									"pm.test(\"Response status is 415\", function () {",
+									"    pm.response.to.have.status(415);",
+									"});",
+									"",
+									"// Validate that the response body contains the 'message' property and it is not empty",
+									"pm.test(\"Response should have an error message\", function () {",
+									"    const responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+									"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"content-type": true
+						}
+					},
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "username",
+									"value": "admin@dotcms.com",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/javascript",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"name\": \"File Asset Copy\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
 							"raw": "{{serverURL}}/api/v1/contenttype/fileAsset/_copy",
 							"host": [

--- a/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "630e7fe8-7824-4ab6-a56c-2f7c4056c596",
+		"_postman_id": "2bcae4b8-bb49-4fa7-911d-5ca9e7f6ddd5",
 		"name": "Content Analytics",
 		"description": "Performs simple data validation for the Content Analytics REST Endpoint. It's very important to notice that, for the time being, the CICD instance does not start up any of the additional third-party tools required to actually run the Content Analytics feature.\n\nThis means that these test do not deal with retrieveing or saving data at all. It verifies that important/required information is present.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "5403727"
+		"_exporter_id": "36604690"
 	},
 	"item": [
 		{
@@ -118,6 +118,69 @@
 								"description": "As the error message states, the CubeJS Query should contain either measures, dimensions or timeDimensions with granularities in order to be valid."
 							},
 							"response": []
+						},
+						{
+							"name": "Unsupported Media Type",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"// Validate the response status is 415",
+											"pm.test(\"Response status is 415\", function () {",
+											"    pm.response.to.have.status(415);",
+											"});",
+											"",
+											"// Validate that the response body contains the 'message' property and it is not empty",
+											"pm.test(\"Response should have an error message\", function () {",
+											"    const responseBody = pm.response.json();",
+											"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+											"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disabledSystemHeaders": {
+									"content-type": true
+								}
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"query\": {}\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content"
+									]
+								}
+							},
+							"response": []
 						}
 					],
 					"description": "This test group verifies that the Endpoint that receives simple String parameters for the Content Analytics query works as expected. This endpoint takes a JSON body with parameters such as the following:\n\n`{`\n\n`\"measures\": \"count,totalSessions\",`\n\n`\"dimensions\": \"host,whatAmI,url\",`\n\n`\"timeDimensions\": \"createdAt,day:Last month\",`\n\n`\"filters\": \"totalRequest gt 0,whatAmI contains PAGE,FILE\",`\n\n`\"order\": \"count asc,createdAt asc\",`\n\n`\"limit\": 5,`\n\n`\"offset\": 0`\n\n`}`\n\nThe schema prefix for the appropriate terms is appended automatically by the service."
@@ -205,6 +268,135 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "Unsupported Media Type _Query",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"// Validate the response status is 415",
+											"pm.test(\"Response status is 415\", function () {",
+											"    pm.response.to.have.status(415);",
+											"});",
+											"",
+											"// Validate that the response body contains the 'message' property and it is not empty",
+											"pm.test(\"Response should have an error message\", function () {",
+											"    const responseBody = pm.response.json();",
+											"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+											"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disabledSystemHeaders": {
+									"content-type": true
+								}
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"query\": {}\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/_query",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"_query"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Unsupported Media Type _Query Cube",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"// Validate the response status is 415",
+											"pm.test(\"Response status is 415\", function () {",
+											"    pm.response.to.have.status(415);",
+											"});",
+											"",
+											"// Validate that the response body contains the 'message' property and it is not empty",
+											"pm.test(\"Response should have an error message\", function () {",
+											"    const responseBody = pm.response.json();",
+											"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+											"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disabledSystemHeaders": {
+									"content-type": true
+								}
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"query\": {}\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/_query/cube",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"_query",
+										"cube"
+									]
+								}
+							},
+							"response": []
 						}
 					]
 				}
@@ -246,6 +438,70 @@
 						"body": {
 							"mode": "raw",
 							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/analytics/content/event",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"analytics",
+								"content",
+								"event"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Unsupported Media Type Event",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"// Validate the response status is 415",
+									"pm.test(\"Response status is 415\", function () {",
+									"    pm.response.to.have.status(415);",
+									"});",
+									"",
+									"// Validate that the response body contains the 'message' property and it is not empty",
+									"pm.test(\"Response should have an error message\", function () {",
+									"    const responseBody = pm.response.json();",
+									"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+									"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {
+							"content-type": true
+						}
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/x-www-form-urlencoded",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"query\": {}\n}\n",
 							"options": {
 								"raw": {
 									"language": "json"


### PR DESCRIPTION
### Proposed Changes
* Added `@ApiResponse(responseCode = "415", description = "Unsupported Media Type")` to Swagger documentation for already documented resources where a 415 error can be thrown.
* Created Postman tests to cover scenarios that may result in a 415 error.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
This update ensures that the 415 (Unsupported Media Type) response is properly documented in the following resources:  
- `ACheckerResource`  
- `ContentAnalyticsResource`  
- `ApiTokenResource`  
- `AuthenticationResource`  
- `ContentTypeResource`  

`WorkflowResource` is covered in this pr: #30986

This PR fixes: #30828