### PR TITLE
fix(push publishing) fixes #30998 : Filter option relationships is not being respected

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
@@ -61,6 +61,7 @@ import com.dotcms.publisher.pusher.PushPublisherConfig;
 import com.dotcms.publisher.pusher.wrapper.ContentWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
 import com.dotcms.publishing.DotPublishingException;
+import com.dotcms.publishing.FilterDescriptor;
 import com.dotcms.publishing.PublisherConfig;
 import com.dotcms.publishing.PublisherFilter;
 import com.dotcms.rendering.velocity.services.PageLoader;
@@ -141,6 +142,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.dotcms.contenttype.model.type.PageContentType.PAGE_FRIENDLY_NAME_FIELD_VAR;
+import static com.dotcms.publishing.FilterDescriptor.RELATIONSHIPS_KEY;
 import static com.liferay.util.StringPool.BLANK;
 
 /**
@@ -825,9 +827,12 @@ public class ContentHandler implements IHandler {
         content = this.contentletAPI.checkin(content, userToUse, !RESPECT_FRONTEND_ROLES);
 
 		final String filterKey = this.getFilterKeyFromBundle();
-        if (!Objects.equals(PublisherFilter.SHALLOW_PUSH_KEY, filterKey)) {
+		final FilterDescriptor filterDescriptor = APILocator.getPublisherAPI().getFilterDescriptorByKey(filterKey);
+		boolean isRelationshipsFilter = filterDescriptor.getFilters().containsKey(RELATIONSHIPS_KEY) ? Boolean.class.cast(filterDescriptor.getFilters()
+				.get(FilterDescriptor.RELATIONSHIPS_KEY)) : false;
+        if (isRelationshipsFilter) {
 			// Depending on the selected Push Publishing Filter, we need to remove the "old" trees
-			// in order to add the new ones
+			// in order to add the new ones, if the relationships filter is set to false, we shouldn't remove the trees
 			this.cleanTrees(content);
 			this.regenerateTree(wrapper, remoteLocalLanguages.getLeft());
 		}

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
@@ -55,6 +55,7 @@ import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.ContentBundler;
 import com.dotcms.enterprise.publishing.remote.bundler.HostBundler;
 import com.dotcms.enterprise.publishing.remote.handler.HandlerUtil.HandlerType;
+import com.dotcms.publisher.bundle.bean.Bundle;
 import com.dotcms.publisher.bundle.business.BundleAPI;
 import com.dotcms.publisher.pusher.PushPublisherConfig;
 import com.dotcms.publisher.pusher.wrapper.ContentWrapper;
@@ -140,6 +141,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.dotcms.contenttype.model.type.PageContentType.PAGE_FRIENDLY_NAME_FIELD_VAR;
+import static com.liferay.util.StringPool.BLANK;
 
 /**
  * This handler deals with Contentlet-related information inside a bundle and
@@ -822,8 +824,7 @@ public class ContentHandler implements IHandler {
         }
         content = this.contentletAPI.checkin(content, userToUse, !RESPECT_FRONTEND_ROLES);
 
-		final String filterKey =
-				this.bundleAPI.get().getBundleById(com.dotmarketing.util.FileUtil.removeExtension(this.config.getId())).getFilterKey();
+		final String filterKey = this.getFilterKeyFromBundle();
         if (!Objects.equals(PublisherFilter.SHALLOW_PUSH_KEY, filterKey)) {
 			// Depending on the selected Push Publishing Filter, we need to remove the "old" trees
 			// in order to add the new ones
@@ -884,6 +885,20 @@ public class ContentHandler implements IHandler {
 				isHost ? PushPublishHandler.HOST : PushPublishHandler.CONTENT,
 				PushPublishAction.PUBLISH, content.getIdentifier(), content.getInode(), content.getName(), config.getId());
     }
+
+	/**
+	 * Retrieves the Push Publishing Filter that was selected to generate the current Bundle.
+	 *
+	 * @return The Push Publishing Filter key. But, if the bundle doesn't exist, returns an empty
+	 * String.
+	 *
+	 * @throws DotDataException An error occurred when interacting with the data source.
+	 */
+	private String getFilterKeyFromBundle() throws DotDataException {
+		final Bundle bundle =
+				this.bundleAPI.get().getBundleById(com.dotmarketing.util.FileUtil.removeExtension(this.config.getId()));
+		return null != bundle ? bundle.getFilterKey() : BLANK;
+	}
 
 	/**
 	 * Invalidates the respective MultiTree cache entry when the pushed Contentlet is the child of an existing record

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
@@ -827,9 +827,11 @@ public class ContentHandler implements IHandler {
         content = this.contentletAPI.checkin(content, userToUse, !RESPECT_FRONTEND_ROLES);
 
 		final String filterKey = this.getFilterKeyFromBundle();
+		Logger.debug(this, () -> "Filter Key: " + filterKey);
 		final FilterDescriptor filterDescriptor = APILocator.getPublisherAPI().getFilterDescriptorByKey(filterKey);
 		boolean isRelationshipsFilter = filterDescriptor.getFilters().containsKey(RELATIONSHIPS_KEY) ? Boolean.class.cast(filterDescriptor.getFilters()
-				.get(FilterDescriptor.RELATIONSHIPS_KEY)) : false;
+				.get(FilterDescriptor.RELATIONSHIPS_KEY)) : true;
+		Logger.debug(this, () -> "Relationships Filter: " + isRelationshipsFilter);
         if (isRelationshipsFilter) {
 			// Depending on the selected Push Publishing Filter, we need to remove the "old" trees
 			// in order to add the new ones, if the relationships filter is set to false, we shouldn't remove the trees

--- a/dotCMS/src/main/java/com/dotcms/publisher/pusher/PushPublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/pusher/PushPublisher.java
@@ -147,9 +147,11 @@ public class PushPublisher extends Publisher {
 	 *             An error occurred which caused the publishing process to
 	 *             stop.
 	 */
-	@EnterpriseFeature(licenseLevel = LicenseLevel.PROFESSIONAL)
 	@Override
 	public PublisherConfig process ( final PublishStatus status ) throws DotPublishingException {
+		if(LicenseUtil.getLevel() < LicenseLevel.PROFESSIONAL.level) {
+			throw new RuntimeException("An Enterprise Pro License is required to run this publisher.");
+		}
 		PublishAuditHistory currentStatusHistory = null;
 
 		Client client = getRestClient();

--- a/dotCMS/src/main/java/com/dotcms/publishing/PublisherAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/PublisherAPIImpl.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -308,13 +307,14 @@ public class PublisherAPIImpl implements PublisherAPI, DotInitializer {
                 this.filterList.stream().filter(filter -> filterKey.equalsIgnoreCase(filter.getKey())).findFirst().orElse(defaultFilter);
     }
 
+    @SuppressWarnings("unchecked")
     @CloseDBIfOpened
     @Override
     public PublisherFilter createPublisherFilter(final String bundleId) throws DotDataException, DotSecurityException {
 
         final String filterKey = APILocator.getBundleAPI().getBundleById(bundleId).getFilterKey();
         final FilterDescriptor filterDescriptor = this.getFilterDescriptorByKey(filterKey);
-        final PublisherFilterImpl publisherFilter = new PublisherFilterImpl((Boolean)filterDescriptor.getFilters().getOrDefault(FilterDescriptor.DEPENDENCIES_KEY,true),
+        final PublisherFilterImpl publisherFilter = new PublisherFilterImpl(filterKey, (Boolean)filterDescriptor.getFilters().getOrDefault(FilterDescriptor.DEPENDENCIES_KEY,true),
                 (Boolean)filterDescriptor.getFilters().getOrDefault(FilterDescriptor.RELATIONSHIPS_KEY,true));
 
         if(filterDescriptor.getFilters().containsKey(FilterDescriptor.EXCLUDE_CLASSES_KEY)){

--- a/dotCMS/src/main/java/com/dotcms/publishing/PublisherFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/PublisherFilter.java
@@ -8,6 +8,19 @@ package com.dotcms.publishing;
  */
 public interface PublisherFilter {
 
+    String CONTENT_ONLY_KEY = "ContentOnly.yml";
+    String FORCE_PUSH_KEY = "ForcePush.yml";
+    String INTELLIGENT__KEY = "Intelligent.yml";
+    String SHALLOW_PUSH_KEY = "ShallowPush.yml";
+    String WEB_CONTENT_KEY = "WebContentOnly.yml";
+
+    /**
+     * Returns the key of the specified Push Publishing Filter.
+     *
+     * @return The Push Publishing Filter key.
+     */
+    String key();
+
     /**
      * Check if the asset needs to be excluded from the bundle.
      * This because the excludeClasses contains the type of the asset.

--- a/dotCMS/src/main/java/com/dotcms/publishing/PublisherFilterImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/PublisherFilterImpl.java
@@ -1,5 +1,6 @@
 package com.dotcms.publishing;
 
+import com.liferay.util.StringPool;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -12,16 +13,27 @@ import java.util.Set;
  */
 public class PublisherFilterImpl implements PublisherFilter{
 
+    private final String key;
     private final Set<String> excludeClassesSet = new HashSet<>();
-    private final Set<String>excludeDependencyClassesSet = new HashSet<>();
-    private final Set<String>excludeQueryAssetIdSet = new HashSet<>();
-    private final Set<String>excludeDependencyQueryAssetIdSet = new HashSet<>();
+    private final Set<String> excludeDependencyClassesSet = new HashSet<>();
+    private final Set<String> excludeQueryAssetIdSet = new HashSet<>();
+    private final Set<String> excludeDependencyQueryAssetIdSet = new HashSet<>();
     private final boolean dependencies;
     private final boolean relationships;
 
     public PublisherFilterImpl(final boolean dependencies, final boolean relationships) {
+        this(StringPool.BLANK, dependencies, relationships);
+    }
+
+    public PublisherFilterImpl(final String key, final boolean dependencies, final boolean relationships) {
+        this.key = key;
         this.dependencies = dependencies;
         this.relationships = relationships;
+    }
+
+    @Override
+    public String key() {
+        return this.key;
     }
 
     @Override
@@ -70,16 +82,17 @@ public class PublisherFilterImpl implements PublisherFilter{
         return this.excludeDependencyClassesSet.contains(pusheableAssetType.toLowerCase());
     }
 
-    public String toString(){
-        return "PublisherFilter {" +
-                " excludeClassesSet = " + this.excludeClassesSet.toString() +
-                " , excludeDependencyClassesSet = " + this.excludeDependencyClassesSet.toString() +
-                " , excludeQueryIds = " + this.excludeQueryAssetIdSet.toString() +
-                " , excludeDependencyQueryIds = " + this.excludeDependencyQueryAssetIdSet.toString() +
-                " , relationships = " + this.relationships +
-                " , dependencies = " + this.dependencies +
-                "}";
-
-
+    @Override
+    public String toString() {
+        return "PublisherFilterImpl{" +
+                "key='" + key + '\'' +
+                ", excludeClassesSet=" + excludeClassesSet +
+                ", excludeDependencyClassesSet=" + excludeDependencyClassesSet +
+                ", excludeQueryAssetIdSet=" + excludeQueryAssetIdSet +
+                ", excludeDependencyQueryAssetIdSet=" + excludeDependencyQueryAssetIdSet +
+                ", dependencies=" + dependencies +
+                ", relationships=" + relationships +
+                '}';
     }
+
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/BundlePublisherResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/BundlePublisherResource.java
@@ -2,6 +2,7 @@ package com.dotcms.rest;
 
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.enterprise.license.LicenseLevel;
+import com.dotcms.enterprise.license.LicenseManager;
 import com.dotcms.publisher.bundle.bean.Bundle;
 import com.dotcms.publisher.business.PublishAuditAPI;
 import com.dotcms.publisher.business.PublishAuditStatus;
@@ -11,6 +12,7 @@ import com.dotcms.publisher.pusher.AuthCredentialPushPublishUtil;
 import com.dotcms.repackage.org.apache.commons.httpclient.HttpStatus;
 import com.dotcms.util.EnterpriseFeature;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.InvalidLicenseException;
 import com.dotmarketing.util.ConfigUtils;
 import com.dotmarketing.util.FileUtil;
 import com.dotmarketing.util.Logger;
@@ -61,7 +63,6 @@ public class BundlePublisherResource {
 	 *
 	 * @see PushPublisherJob
 	 */
-	@EnterpriseFeature(licenseLevel = LicenseLevel.PROFESSIONAL)
 	@POST
 	@Path("/publish")
 	@Consumes(MediaType.APPLICATION_OCTET_STREAM)
@@ -73,6 +74,9 @@ public class BundlePublisherResource {
 			@QueryParam("filterkey")   final String filterKey,
 			@Context final HttpServletRequest  request,
 			@Context final HttpServletResponse response) throws Exception {
+		if (LicenseManager.getInstance().isCommunity()) {
+			throw new InvalidLicenseException("License required");
+		}
 		Logger.debug(this, String.format("Publishing bundle with type: [ %s ], callback: [ %s ], forcePush: [ %s ], filterKey: [ %s ]",
 				type, callback, forcePush, filterKey));
 		final Map<String, String> paramsMap = new HashMap<>();

--- a/dotCMS/src/main/java/com/dotcms/rest/BundlePublisherResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/BundlePublisherResource.java
@@ -1,8 +1,7 @@
 package com.dotcms.rest;
 
-
 import com.dotcms.business.WrapInTransaction;
-import com.dotcms.enterprise.license.LicenseManager;
+import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.publisher.bundle.bean.Bundle;
 import com.dotcms.publisher.business.PublishAuditAPI;
 import com.dotcms.publisher.business.PublishAuditStatus;
@@ -10,20 +9,13 @@ import com.dotcms.publisher.business.PublishAuditStatus.Status;
 import com.dotcms.publisher.business.PublisherQueueJob;
 import com.dotcms.publisher.pusher.AuthCredentialPushPublishUtil;
 import com.dotcms.repackage.org.apache.commons.httpclient.HttpStatus;
-import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.EnterpriseFeature;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.exception.InvalidLicenseException;
 import com.dotmarketing.util.ConfigUtils;
 import com.dotmarketing.util.FileUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
-import com.liferay.portal.model.User;
-import java.io.File;
-import java.io.InputStream;
-import java.util.Calendar;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.Consumes;
@@ -34,6 +26,14 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.File;
+import java.io.InputStream;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.liferay.util.StringPool.BLANK;
 
 @Path("/bundlePublisher")
 public class BundlePublisherResource {
@@ -41,19 +41,27 @@ public class BundlePublisherResource {
 	public static String MY_TEMP = "";
 
 	/**
-	 * Method that receives from a server a bundle with the intention of publish it.<br/>
-	 * When a Bundle file is received on this end point is required to validate if the sending server is an allowed<br/>
-	 * server on this end point and if the security tokens match. If all the validations are correct the bundle will be add it<br/>
-	 * to the {@link PushPublisherJob Publish Thread}.
+	 * Receives a Bundle from another sending dotCMS instance with the intention of publishing it.
+	 * <p>When a Bundle file is received on this endpoint, it's necessary to check whether the
+	 * sending server is allowed to send data to this server, and if the security tokens match. If
+	 * all the validations are correct, the bundle will be added to the {@link PushPublisherJob
+	 * Publish Thread}.
 	 *
-	 * @param type			  response type
-	 * @param callback 		  response callback
-	 * @param forcePush 	  true/false to Force the push
-	 * @param request         {@link HttpServletRequest}
-	 * @param response        {@link HttpServletResponse}
-	 * @return Returns a {@link Response} object with a 200 status code if success or a 500 error code if anything fails on the Publish process
+	 * @param type      response type
+	 * @param callback  response callback
+	 * @param forcePush If the {@code Force Push Everything} filter is selected, this parameter
+	 *                  will be {@code true}.
+	 * @param filterKey The ID of the Push Publishing Filter that was selected to generate the
+	 *                  Bundle.
+	 * @param request   The current instance of the {@link HttpServletRequest}.
+	 * @param response  The current instance of the {@link HttpServletResponse}.
+	 *
+	 * @return Returns a {@link Response} object with a 200 status code if success or a 500 error
+	 * code if anything fails on the Publish process
+	 *
 	 * @see PushPublisherJob
 	 */
+	@EnterpriseFeature(licenseLevel = LicenseLevel.PROFESSIONAL)
 	@POST
 	@Path("/publish")
 	@Consumes(MediaType.APPLICATION_OCTET_STREAM)
@@ -62,23 +70,21 @@ public class BundlePublisherResource {
 			@QueryParam("type")        final String type,
 			@QueryParam("callback")    final String callback,
 			@QueryParam("FORCE_PUSH")  final boolean forcePush,
+			@QueryParam("filterkey")   final String filterKey,
 			@Context final HttpServletRequest  request,
-			@Context final HttpServletResponse response
-	) throws Exception {
-
-		if (LicenseManager.getInstance().isCommunity()) {
-			throw new InvalidLicenseException("License required");
-		}
-
+			@Context final HttpServletResponse response) throws Exception {
+		Logger.debug(this, String.format("Publishing bundle with type: [ %s ], callback: [ %s ], forcePush: [ %s ], filterKey: [ %s ]",
+				type, callback, forcePush, filterKey));
 		final Map<String, String> paramsMap = new HashMap<>();
 		paramsMap.put("type", type);
 		paramsMap.put("callback", callback);
+		paramsMap.put("filterKey", UtilMethods.isSet(filterKey) ? filterKey : BLANK);
 		final ResourceResponse responseResource = new ResourceResponse(paramsMap);
 		final String remoteIP = UtilMethods.isSet(request.getRemoteHost())?
 				request.getRemoteHost() : request.getRemoteAddr();
 
 		if (request.getInputStream().isFinished()) {
-			Logger.error(this.getClass(), "Push Publishing failed from " + remoteIP + " bundle expected");
+			Logger.error(this.getClass(), "Push Publishing failed from " + remoteIP + ": Bundle expected");
 			return responseResource.responseError(HttpStatus.SC_BAD_REQUEST);
 		}
 
@@ -90,14 +96,28 @@ public class BundlePublisherResource {
 		if (failResponse.isPresent()) {
 			return failResponse.get();
 		}
-
-		final Bundle bundle = this.publishBundle(forcePush, request, remoteIP);
-
+		final Bundle bundle = this.publishBundle(forcePush, filterKey, request, remoteIP);
 		return Response.ok(bundle).build();
 	}
 
+	/**
+	 * Retrieves the Bundle from the {@link HttpServletRequest} object and saves it to the file
+	 * system. Then, it calls the {@link PushPublisherJob} to start importing its contents.
+	 *
+	 * @param forcePush If the {@code Force Push Everything} filter is selected, this parameter
+	 *                  will be {@code true}.
+	 * @param filterKey The ID of the Push Publishing Filter that was selected to generate the
+	 *                  Bundle.
+	 * @param request   The current instance of the {@link HttpServletRequest}.
+	 * @param remoteIP  The IP address of the sending server.
+	 *
+	 * @return Returns the {@link Bundle} object that was saved.
+	 *
+	 * @throws Exception An error occurred when trying to save and process the Bundle.
+	 */
 	@WrapInTransaction
 	private Bundle publishBundle(final boolean forcePush,
+								 final String filterKey,
 								 final HttpServletRequest request,
 								 final String remoteIP) throws Exception {
 
@@ -109,7 +129,7 @@ public class BundlePublisherResource {
 
 		Logger.debug(BundlePublisherResource.class, "Bundle file name: " + fileName);
 
-		Bundle bundle = null;
+		Bundle bundle;
 
 		try (InputStream bundleStream = request.getInputStream()) {
 
@@ -129,6 +149,7 @@ public class BundlePublisherResource {
 				bundle.setPublishDate(Calendar.getInstance().getTime());
 				bundle.setOwner(APILocator.getUserAPI().getSystemUser().getUserId());
 				bundle.setForcePush(forcePush);
+				bundle.setFilterKey(filterKey);
 				APILocator.getBundleAPI().saveBundle(bundle);
 				Logger.debug(BundlePublisherResource.class, "Bundle saved: " + bundleFolder);
 			}
@@ -171,8 +192,4 @@ public class BundlePublisherResource {
 		return String.format("bundle_%d.tar.gz", System.currentTimeMillis());
 	}
 
-	private boolean isAdmin(final User user) {
-
-		return null != user && user.isBackendUser() && user.isAdmin();
-	}
 }

--- a/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/StartupTasksExecutor.java
@@ -276,7 +276,9 @@ public class StartupTasksExecutor {
             } catch (Exception e) {
                 taskFailure(e);
             } finally {
-                HibernateUtil.closeAndCommitTransaction();
+                if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
+                    HibernateUtil.closeAndCommitTransaction();
+                }
             }
 
         }
@@ -344,7 +346,9 @@ public class StartupTasksExecutor {
             } catch (Exception e) {
                 taskFailure(e);
             } finally {
-                HibernateUtil.closeAndCommitTransaction();
+                if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
+                    HibernateUtil.closeAndCommitTransaction();
+                }
             }
 
         }
@@ -367,7 +371,9 @@ public class StartupTasksExecutor {
 
 
             for (Class<?> c : TaskLocatorUtil.getBackportedUpgradeTaskClasses()) {
-                HibernateUtil.startTransaction();
+                if(!TaskLocatorUtil.getTaskClassesNoTransaction().contains(c)){
+                    HibernateUtil.startTransaction();
+                }
                 name = c.getCanonicalName();
                 name = name.substring(name.lastIndexOf(".") + 1);
 		String id = getTaskId(name);

--- a/dotCMS/src/main/java/com/dotmarketing/util/FileUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/FileUtil.java
@@ -9,6 +9,10 @@ import com.liferay.util.HashBuilder;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.mozilla.universalchardet.UniversalDetector;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -35,9 +39,6 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.mozilla.universalchardet.UniversalDetector;
 
 /**
  * Provide utility methods to work with binary files in dotCMS.
@@ -536,6 +537,25 @@ public class FileUtil {
 		}
 
 		return totalCount;
+	}
+
+	/**
+	 * Removes the extension from a filename. This method will remove all characters starting from
+	 * the first occurrence of the period character.
+	 *
+	 * @param filename The filename to remove the extension from.
+	 *
+	 * @return The filename without the extension.
+	 */
+	public static String removeExtension(final String filename) {
+		if (filename == null) {
+			return null;
+		}
+		final int pos = filename.indexOf(StringPool.PERIOD);
+		if (pos == -1) {
+			return filename;
+		}
+		return filename.substring(0, pos);
 	}
 
 }

--- a/dotcms-integration/src/test/java/com/dotcms/rest/BundlePublisherResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/BundlePublisherResourceIntegrationTest.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-
 import static org.mockito.Mockito.mock;
 
 public class BundlePublisherResourceIntegrationTest extends IntegrationTestBase {
@@ -30,7 +29,7 @@ public class BundlePublisherResourceIntegrationTest extends IntegrationTestBase 
             final BundlePublisherResource bundlePublisherResource = new BundlePublisherResource();
 
             try {
-                bundlePublisherResource.publish(null, null, true, request, response);
+                bundlePublisherResource.publish(null, null, true, "", request, response);
                 throw new AssertionError();
             } catch(InvalidLicenseException e) {
                 //expected

--- a/dotcms-integration/src/test/java/com/dotcms/rest/BundleResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/BundleResourceTest.java
@@ -19,6 +19,7 @@ import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.DotCacheException;
+import com.dotmarketing.business.RoleAPI;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.util.UUIDGenerator;
@@ -64,6 +65,10 @@ public class BundleResourceTest {
         IntegrationTestInitService.getInstance().init();
         bundleResource = new BundleResource();
         adminUser = APILocator.systemUser();
+        final RoleAPI roleAPI = APILocator.getRoleAPI();
+        if (!roleAPI.doesUserHaveRole(adminUser, roleAPI.loadBackEndUserRole())) {
+            roleAPI.addRoleToUser(roleAPI.loadBackEndUserRole(), adminUser);
+        }
         response = new MockHttpResponse();
     }
 


### PR DESCRIPTION
### Proposed Changes
* Passing down the Push Publishing Filter that was used when generating the bundle that is being sent to the receiving endpoints.
* When a filter with `relationships: false` is used, DO NOT re-generate the `tree` table as this may also clear relationships of the specified content with parents that we don't have records of at that point.

This PR fixes: #30998