### PR TITLE
fix ( Block Editor ): #30327 Image properties cannot be edited in Block Editor (Firefox) 

### DIFF
--- a/core-web/libs/block-editor/src/lib/extensions/bubble-form/plugins/bubble-form.plugin.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-form/plugins/bubble-form.plugin.ts
@@ -148,7 +148,11 @@ export class BubbleFormView extends BubbleMenuView {
             content: this.element,
             onShow: () => {
                 requestAnimationFrame(() => {
-                    this.component.instance.inputs.first.nativeElement.focus();
+                    // firefox validation because of https://github.com/dotCMS/core/issues/30327
+                    const isFirefox = /firefox/i.test(navigator.userAgent);
+                    if (!isFirefox) {
+                        this.component.instance.inputs.first.nativeElement.focus();
+                    }
                 });
             }
         });


### PR DESCRIPTION
### Proposed Changes
* When we execute the `focus()` event in Firefox, it blocks all the inputs in the form, preventing the user from editing any of the properties. With this approach, we will exclude Firefox from focusing on the first element to achieve the expected behavior.


### Screenshots


https://github.com/user-attachments/assets/dc581ec5-d259-43ae-a76c-122900d3b697


This PR fixes: #30327