### PR TITLE
Issue 31023 lts designation

### DIFF
--- a/.github/actions/core-cicd/maven-job/action.yml
+++ b/.github/actions/core-cicd/maven-job/action.yml
@@ -241,7 +241,7 @@ runs:
       name: Save Docker Image to Tar File
       if: ${{ inputs.generate-docker == 'true' }}
       shell: bash
-      run: docker save dotcms/dotcms-test:1.0.0-SNAPSHOT > /tmp/image.tar
+      run: docker save dotcms/dotcms-test:${{ inputs.version }} > /tmp/image.tar
 
     - id: upload-docker-image
       name: Upload Docker Image as Artifact

--- a/.github/workflows/cicd_5-lts.yml
+++ b/.github/workflows/cicd_5-lts.yml
@@ -1,0 +1,71 @@
+#
+# GitHub Actions Workflow for LTS Auto-run Tests
+# This file is a GitHub Actions workflow configuration for running automated tests on long-term support (LTS) branches.
+# It defines a series of jobs that are triggered on pushes to branches matching the pattern release-*. The workflow includes the following jobs:
+# Initialize: Sets up the environment and performs initial validation.
+# Build: Compiles the project if no artifacts were found during initialization.
+# Test: Runs various tests (unit, integration, frontend, etc.) based on the outputs from the initialization step.
+# Finalize: Aggregates and finalizes the results from the previous jobs.
+# The workflow uses concurrency control to manage multiple runs and cancels in-progress runs for the same branch or pull request to prevent delays.
+#
+
+name: 'LTS Auto-run Tests'
+
+on:
+  push:
+    branches:
+      - release-*
+
+# Concurrency group to manage multiple runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  # Cancel any in-progress runs for the same branch/PR to prevent delays from changes during build
+  cancel-in-progress: true
+
+jobs:
+  # Initialize the PR check process
+  initialize:
+    name: Initialize
+    uses: ./.github/workflows/cicd_comp_initialize-phase.yml
+    with:
+      validation-level: 'full'
+
+  # Build job - only runs if no artifacts were found during initialization
+  build:
+    name: PR Build
+    needs: [ initialize ]
+    if: needs.initialize.outputs.build == 'true' && needs.initialize.outputs.found_artifacts == 'false'
+    uses: ./.github/workflows/cicd_comp_build-phase.yml
+    with:
+      core-build: true
+      run-pr-checks: false
+      version: '24.12.27'
+    permissions:
+      contents: read
+      packages: write
+
+  # Test job - runs various tests based on initialization outputs
+  test:
+    name: PR Test
+    needs: [ initialize,build ]
+    if: always() && !failure() && !cancelled()
+    uses: ./.github/workflows/cicd_comp_test-phase.yml
+    with:
+      jvm_unit_test: ${{ needs.initialize.outputs.jvm_unit_test == 'true' }}
+      integration: ${{ needs.initialize.outputs.backend == 'true' }}
+      postman: ${{ needs.initialize.outputs.backend == 'true' }}
+      karate: ${{ needs.initialize.outputs.backend == 'true' }}
+      frontend: ${{ needs.initialize.outputs.frontend == 'true' }}
+      cli: ${{ needs.initialize.outputs.cli == 'true' }}
+      e2e: ${{ needs.initialize.outputs.build == 'true' }}
+    secrets:
+      DOTCMS_LICENSE: ${{ secrets.DOTCMS_LICENSE }}
+
+  # Finalize job - aggregates results from previous jobs
+  finalize:
+    name: Finalize
+    if: always()
+    needs: [ test ]
+    uses: ./.github/workflows/cicd_comp_finalize-phase.yml
+    with:
+      needsData: ${{ toJson(needs) }}

--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Validate Inputs
         run: |
-          if [[ ! ${{ github.event.inputs.release_version }} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}(_lts_v[0-9]{2})?$ ]]; then
+          if [[ ! ${{ github.event.inputs.release_version }} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}(_lts_v[0-9]{1,2})?$ ]]; then
             echo 'Release version must be in the format yy.mm.dd or yy.mm.dd_lts_v##'
             exit 1
           fi
@@ -79,7 +79,7 @@ jobs:
           fi
           release_hash=${release_commit::7}
           is_lts=false
-          [[ ${release_version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}_lts_v[0-9]{2}$ ]] && is_lts=true
+          [[ ${release_version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}_lts_v[0-9]{1,2}$ ]] && is_lts=true
 
           echo "release_version=${release_version}" >> $GITHUB_OUTPUT
           echo "release_branch=${release_branch}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request includes updates to GitHub Actions workflows and action configurations to enhance the automation processes for building, testing, and releasing the project. The most important changes include modifying the Docker image version handling, adding a new workflow for LTS auto-run tests, and updating the release version validation.

### Workflow and Action Configuration Updates:

* [`.github/actions/core-cicd/maven-job/action.yml`](diffhunk://#diff-55f17c9986a482bcfb132dc7b03fa4d1f89e17866d0dfa74cc6f41737c51f4adL244-R244): Updated the Docker image version handling to use the `inputs.version` parameter instead of a hardcoded version.

* [`.github/workflows/cicd_5-lts.yml`](diffhunk://#diff-53c794c7312739238cb8a5e653444bbfb167a03cc4b3a90605130e208ed65f2cR1-R71): Added a new GitHub Actions workflow configuration for running automated tests on long-term support (LTS) branches. This workflow includes jobs for initialization, building, testing, and finalizing with concurrency control.

### Release Version Validation Updates:

* [`.github/workflows/legacy-release_maven-release-process.yml`](diffhunk://#diff-9b645ac0f2192e1b22981f4186fbdc7fa0080f097f1ad0545f27f9250ed4410eL50-R50): Updated the release version validation regex to allow for one or two digits in the LTS version suffix. This change affects the validation of inputs and the determination of whether a release is an LTS version. [[1]](diffhunk://#diff-9b645ac0f2192e1b22981f4186fbdc7fa0080f097f1ad0545f27f9250ed4410eL50-R50) [[2]](diffhunk://#diff-9b645ac0f2192e1b22981f4186fbdc7fa0080f097f1ad0545f27f9250ed4410eL82-R82)

This PR fixes: #31023