### PR TITLE
fix: ( dot-binary-field-editor ): #30982 Files without an extension cannot be edited / saved 

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-editor/dot-binary-field-editor.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-editor/dot-binary-field-editor.component.spec.ts
@@ -290,6 +290,23 @@ describe('DotBinaryFieldEditorComponent', () => {
             expect(component.form.valid).toBe(false);
         }));
 
+        it('should set form as valid when there is no extension', fakeAsync(() => {
+            dotBinaryFieldValidatorService.setAccept([]);
+            spectator.detectChanges();
+
+            const spy = jest.spyOn(component.name, 'setErrors');
+
+            component.form.setValue({
+                name: 'testNoExtension',
+                content: 'test'
+            });
+
+            tick(1000);
+
+            expect(spy).not.toHaveBeenCalled();
+            expect(component.form.valid).toBe(true);
+        }));
+
         afterEach(() => {
             jest.restoreAllMocks();
         });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-editor/dot-binary-field-editor.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-editor/dot-binary-field-editor.component.ts
@@ -68,7 +68,7 @@ export class DotBinaryFieldEditorComponent implements OnInit, OnChanges {
     @Output() readonly cancel = new EventEmitter<void>();
     @ViewChild('editorRef', { static: true }) editorRef!: MonacoEditorComponent;
     readonly form = new FormGroup({
-        name: new FormControl('', [Validators.required, Validators.pattern(/^[^.]+\.[^.]+$/)]),
+        name: new FormControl('', [Validators.required]),
         content: new FormControl('')
     });
     mimeType = '';
@@ -189,7 +189,7 @@ export class DotBinaryFieldEditorComponent implements OnInit, OnChanges {
             this.updateLanguageForFileExtension(fileExtension);
         }
 
-        this.validateFileType(fileExtension);
+        this.validateFileType();
         this.cd.detectChanges();
     }
 
@@ -210,13 +210,12 @@ export class DotBinaryFieldEditorComponent implements OnInit, OnChanges {
         this.updateEditorLanguage(id);
     }
 
-    private validateFileType(fileExtension: string) {
+    private validateFileType() {
         const isValidType = this.dotBinaryFieldValidatorService.isValidType({
             extension: this.extension,
             mimeType: this.mimeType
         });
-
-        if (fileExtension && !isValidType) {
+        if (!isValidType) {
             this.name.setErrors({ invalidExtension: this.invalidFileMessage });
         }
     }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/store/file-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/store/file-field.store.ts
@@ -99,7 +99,9 @@ export const FileFieldStore = signalStore(
                 });
             },
             /**
-             * setAcceptedFiles is used to set accepted files
+             * Sets the maximum file size allowed for uploads.
+             *
+             * @param {number} maxFileSize - The maximum file size.
              */
             setMaxSizeFile: (maxFileSize: number) => {
                 patchState(store, {


### PR DESCRIPTION
### Proposed Changes
* Support for the safe without an extension, as there is no constraint on the field. If the field is restricted to a specific extension via properties, the constraint should be respected, such as in this case: text/plain.
* 
<img width="752" alt="image" src="https://github.com/user-attachments/assets/09bd4044-1397-460f-8bd6-872f4c4cfb1e" />


### Screenshots


This PR fixes: #30982