### PR TITLE
feat(edit-content) fix multiselect saved format

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from '@jest/globals';
 import {
     byTestId,
     createComponentFactory,
@@ -272,7 +273,9 @@ describe('DotFormComponent', () => {
                     component.$hasSingleTab = signal(true);
                     spectator.detectChanges();
 
-                    expect(tabView).toHaveClass('dot-edit-content-tabview--single-tab');
+                    expect(tabView.classList.contains('dot-edit-content-tabview--single-tab')).toBe(
+                        true
+                    );
                 });
             });
         });
@@ -325,17 +328,16 @@ describe('DotFormComponent', () => {
                 expect(workflowActions).toBeFalsy();
             });
 
-            it('should send the correct parameters when firing an action. ', () => {
+            it('should send the correct parameters when firing an action', () => {
                 const spy = jest.spyOn(store, 'fireWorkflowAction');
 
                 workflowActionsService.getWorkFlowActions.mockReturnValue(
-                    of(MOCK_SINGLE_WORKFLOW_ACTIONS) // Single workflow actions trigger the show
+                    of(MOCK_SINGLE_WORKFLOW_ACTIONS)
                 );
                 store.initializeExistingContent('inode');
                 spectator.detectChanges();
 
                 const workflowActions = spectator.query(DotWorkflowActionsComponent);
-
                 workflowActions.actionFired.emit({ id: '1' } as DotCMSWorkflowAction);
 
                 expect(spy).toHaveBeenCalledWith({
@@ -349,6 +351,7 @@ describe('DotFormComponent', () => {
                             text11: 'Tab 2 input content',
                             text2: 'content text 2',
                             text3: 'default value modified',
+                            multiselect: 'A,B,C',
                             languageId: null
                         }
                     }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -352,14 +352,13 @@ export class DotEditContentFormComponent implements OnInit {
         languageId,
         identifier
     }: DotWorkflowActionParams): void {
-        const transformedFormValues = this.$store.formValues();
         this.$store.fireWorkflowAction({
             actionId,
             inode,
             identifier,
             data: {
                 contentlet: {
-                    ...transformedFormValues,
+                    ...this.processFormValue(this.form.value),
                     contentType,
                     languageId
                 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -352,13 +352,14 @@ export class DotEditContentFormComponent implements OnInit {
         languageId,
         identifier
     }: DotWorkflowActionParams): void {
+        const transformedFormValues = this.$store.formValues();
         this.$store.fireWorkflowAction({
             actionId,
             inode,
             identifier,
             data: {
                 contentlet: {
-                    ...this.form.value,
+                    ...transformedFormValues,
                     contentType,
                     languageId
                 }

--- a/core-web/libs/edit-content/src/lib/utils/edit-content.mock.ts
+++ b/core-web/libs/edit-content/src/lib/utils/edit-content.mock.ts
@@ -161,6 +161,29 @@ export const MOCK_CONTENTTYPE_1_TAB: DotCMSContentType = {
             sortOrder: 5,
             unique: false,
             variable: 'text3'
+        },
+        {
+            clazz: 'com.dotcms.contenttype.model.field.ImmutableMultiSelectField',
+            contentTypeId: 'bec7fa8325253216d9ee23a0693baa17',
+            dataType: 'LONG_TEXT',
+            fieldType: 'Multi-Select',
+            fieldTypeLabel: 'Multi Select',
+            fieldVariables: [],
+            fixed: false,
+            forceIncludeInApi: false,
+            iDate: 1729012357000,
+            id: 'c3817bbc0b605578daca363ba752a3a3',
+            indexed: false,
+            listed: false,
+            modDate: 1729012357000,
+            name: 'Multi select',
+            values: 'A\r\nB\r\nC',
+            readOnly: false,
+            required: false,
+            searchable: false,
+            sortOrder: 5,
+            unique: false,
+            variable: 'multiselect'
         }
     ],
     fixed: false,
@@ -425,6 +448,7 @@ export const MOCK_CONTENTLET_1_TAB: DotCMSContentlet = {
     text1: 'content text 1',
     text2: 'content text 2',
     text3: 'default value modified',
+    multiselect: 'A,B,C', // stored selected options
     text11: 'Tab 2 input content', // input in the second tab
     // end content of the form
     title: '2978bb3b66e372b1ffffa9376f33c37b',
@@ -692,6 +716,29 @@ export const MOCK_CONTENTTYPE_2_TABS: DotCMSContentType = {
 
             unique: false,
             variable: 'text11'
+        },
+        {
+            clazz: 'com.dotcms.contenttype.model.field.ImmutableMultiSelectField',
+            contentTypeId: 'bec7fa8325253216d9ee23a0693baa17',
+            dataType: 'LONG_TEXT',
+            fieldType: 'Multi-Select',
+            fieldTypeLabel: 'Multi Select',
+            fieldVariables: [],
+            fixed: false,
+            forceIncludeInApi: false,
+            iDate: 1735844530000,
+            id: 'c3817bbc0b605578daca363ba752a3a3',
+            indexed: false,
+            listed: false,
+            modDate: 1735844530000,
+            name: 'Multi select',
+            readOnly: false,
+            required: false,
+            searchable: false,
+            sortOrder: 2,
+            unique: false,
+            values: 'A\r\nB\r\nC', // this are the options of the multiselect field
+            variable: 'multiselect'
         }
     ],
     fixed: false,
@@ -1091,6 +1138,30 @@ export const MOCK_FORM_CONTROL_FIELDS: DotCMSContentTypeField[] = [
         sortOrder: 9,
 
         variable: 'text11'
+    },
+
+    {
+        clazz: 'com.dotcms.contenttype.model.field.ImmutableMultiSelectField',
+        contentTypeId: 'bec7fa8325253216d9ee23a0693baa17',
+        dataType: 'LONG_TEXT',
+        fieldType: 'Multi-Select',
+        fieldTypeLabel: 'Multi Select',
+        fieldVariables: [],
+        fixed: false,
+        forceIncludeInApi: false,
+        iDate: 1735844530000,
+        id: 'c3817bbc0b605578daca363ba752a3a3',
+        indexed: false,
+        listed: false,
+        modDate: 1735844530000,
+        name: 'Multi select',
+        readOnly: false,
+        required: false,
+        searchable: false,
+        sortOrder: 2,
+        unique: false,
+        values: 'A\r\nB\r\nC', // this are the options of the multiselect field
+        variable: 'multiselect'
     }
 ];
 


### PR DESCRIPTION
This pull request includes a change to the `DotEditContentFormComponent` in the `core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts` file. The change involves transforming form values before firing a workflow action.

Key change:

* Added a new variable `transformedFormValues` to store the transformed form values from the `$store.formValues()` method and used it in place of `this.form.value` when firing a workflow action.

This PR fixes: #31038