### PR TITLE
fix(edit-content): Allowed save empty file type on Binary Field

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-binary-settings/dot-binary-settings.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-binary-settings/dot-binary-settings.component.spec.ts
@@ -1,7 +1,12 @@
-import { Spectator, SpyObject, byTestId, createComponentFactory } from '@ngneat/spectator';
+import {
+    Spectator,
+    SpyObject,
+    byTestId,
+    createComponentFactory,
+    mockProvider
+} from '@ngneat/spectator';
 import { of, throwError } from 'rxjs';
 
-import { NgFor } from '@angular/common';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { DividerModule } from 'primeng/divider';
@@ -33,132 +38,170 @@ describe('DotBinarySettingsComponent', () => {
     let dotFieldVariableService: SpyObject<DotFieldVariablesService>;
     let dotHttpErrorManagerService: SpyObject<DotHttpErrorManagerService>;
 
-    const createComponent = createComponentFactory({
-        component: DotBinarySettingsComponent,
-        imports: [
-            NgFor,
-            FormsModule,
-            ReactiveFormsModule,
-            InputTextModule,
-            InputSwitchModule,
-            DividerModule,
-            DotMessagePipe
-        ],
-        providers: [
-            FormBuilder,
-            {
-                provide: DotFieldVariablesService,
-                useValue: {
-                    load: () =>
-                        of([
-                            {
-                                clazz: 'com.dotcms.contenttype.model.field.ImmutableStoryBlockField',
-                                fieldId: 'f965a51b-130a-435f-b646-41e07d685363',
-                                id: '9671d2c3-793b-41af-a485-e2c5fcba5fb',
-                                key: 'systemOptions',
-                                value: SYSTEM_OPTIONS
-                            },
-                            {
-                                clazz: 'com.dotcms.contenttype.model.field.ImmutableStoryBlockField',
-                                fieldId: 'f965a51b-130a-435f-b646-41e07d685363',
-                                id: '9671d2c3-793b-41af-a485-e2c5fcba5fb',
-                                key: 'accept',
-                                value: 'image/*'
-                            }
-                        ]),
-                    save: () => of([]),
-                    delete: () => of([])
+    const getFieldVariableMock = (value = 'image/*') => ({
+        load: () =>
+            of([
+                {
+                    clazz: 'com.dotcms.contenttype.model.field.ImmutableStoryBlockField',
+                    fieldId: 'f965a51b-130a-435f-b646-41e07d685363',
+                    id: '9671d2c3-793b-41af-a485-e2c5fcba5fb',
+                    key: 'systemOptions',
+                    value: SYSTEM_OPTIONS
+                },
+                {
+                    clazz: 'com.dotcms.contenttype.model.field.ImmutableStoryBlockField',
+                    fieldId: 'f965a51b-130a-435f-b646-41e07d685363',
+                    id: '9671d2c3-793b-41af-a485-e2c5fcba5fb',
+                    key: 'accept',
+                    value: value
                 }
-            },
-            {
-                provide: DotMessageService,
-                useValue: messageServiceMock
-            },
-            {
-                provide: DotHttpErrorManagerService,
-                useValue: {
-                    handle: () => of([])
-                }
-            }
-        ]
+            ]),
+        save: () => of([]),
+        delete: () => of([])
     });
 
-    beforeEach(() => {
-        spectator = createComponent();
-        dotFieldVariableService = spectator.inject(DotFieldVariablesService);
-        dotHttpErrorManagerService = spectator.inject(DotHttpErrorManagerService);
+    describe('with value', () => {
+        const createComponent = createComponentFactory({
+            component: DotBinarySettingsComponent,
+            imports: [
+                FormsModule,
+                ReactiveFormsModule,
+                InputTextModule,
+                InputSwitchModule,
+                DividerModule,
+                DotMessagePipe
+            ],
+            providers: [
+                FormBuilder,
+                mockProvider(DotFieldVariablesService, getFieldVariableMock()),
+                {
+                    provide: DotMessageService,
+                    useValue: messageServiceMock
+                },
+                {
+                    provide: DotHttpErrorManagerService,
+                    useValue: {
+                        handle: () => of([])
+                    }
+                }
+            ]
+        });
 
-        component = spectator.component;
-    });
+        beforeEach(() => {
+            spectator = createComponent();
+            dotFieldVariableService = spectator.inject(DotFieldVariablesService);
+            dotHttpErrorManagerService = spectator.inject(DotHttpErrorManagerService);
 
-    it('should setup form values', () => {
-        expect(component.form.get('accept').value).toBe('image/*');
-        expect(component.form.get('systemOptions').value).toEqual({
-            allowURLImport: false,
-            allowCodeWrite: true,
-            allowGenerateImg: false
+            component = spectator.component;
+        });
+
+        it('should setup form values', () => {
+            expect(component.form.get('accept').value).toBe('image/*');
+            expect(component.form.get('systemOptions').value).toEqual({
+                allowURLImport: false,
+                allowCodeWrite: true,
+                allowGenerateImg: false
+            });
+        });
+
+        it('should emit changeControls when isVisible input is true', () => {
+            spyOn(component.changeControls, 'emit');
+
+            spectator.setInput('isVisible', true);
+
+            expect(component.changeControls.emit).toHaveBeenCalled();
+        });
+
+        it('should emit valid output on form change', () => {
+            spyOn(component.valid, 'emit');
+
+            const acceptInput = spectator.query(byTestId('setting-accept'));
+            spectator.typeInElement('text/*', acceptInput);
+
+            expect(component.valid.emit).toHaveBeenCalled();
+        });
+
+        it('should handler error if save properties failed', () => {
+            spyOn(dotFieldVariableService, 'save').and.returnValue(throwError({}));
+            spyOn(dotHttpErrorManagerService, 'handle').and.returnValue(of());
+            spyOn(component.save, 'emit');
+
+            component.saveSettings();
+
+            expect(dotHttpErrorManagerService.handle).toHaveBeenCalledTimes(1);
+            expect(component.save.emit).not.toHaveBeenCalled();
+        });
+
+        it('should have 3 switches with the corresponding control name', () => {
+            const switches = spectator.queryAll(byTestId('setting-switch'));
+
+            expect(switches.length).toBe(3);
+            expect(
+                switches.find((s) => s.getAttribute('ng-reflect-name') === 'allowURLImport')
+            ).not.toBeNull();
+            expect(
+                switches.find((s) => s.getAttribute('ng-reflect-name') === 'allowCodeWrite')
+            ).not.toBeNull();
+            expect(
+                switches.find((s) => s.getAttribute('ng-reflect-name') === 'allowGenerateImg')
+            ).not.toBeNull();
+        });
+
+        it('should have 1 input with the control name accept', () => {
+            const [acceptInput] = spectator.queryAll(byTestId('setting-accept'));
+
+            expect(acceptInput).not.toBeNull();
+
+            expect(acceptInput.getAttribute('ng-reflect-name')).toBe('accept');
         });
     });
 
-    it('should emit changeControls when isVisible input is true', () => {
-        spyOn(component.changeControls, 'emit');
+    describe('without value', () => {
+        const createComponent = createComponentFactory({
+            component: DotBinarySettingsComponent,
+            imports: [
+                FormsModule,
+                ReactiveFormsModule,
+                InputTextModule,
+                InputSwitchModule,
+                DividerModule,
+                DotMessagePipe
+            ],
+            providers: [
+                FormBuilder,
+                mockProvider(DotFieldVariablesService, getFieldVariableMock('')),
+                {
+                    provide: DotMessageService,
+                    useValue: messageServiceMock
+                },
+                {
+                    provide: DotHttpErrorManagerService,
+                    useValue: {
+                        handle: () => of([])
+                    }
+                }
+            ]
+        });
 
-        spectator.setInput('isVisible', true);
+        beforeEach(() => {
+            spectator = createComponent();
+            dotFieldVariableService = spectator.inject(DotFieldVariablesService);
+            dotHttpErrorManagerService = spectator.inject(DotHttpErrorManagerService);
 
-        expect(component.changeControls.emit).toHaveBeenCalled();
-    });
+            component = spectator.component;
+        });
 
-    it('should emit valid output on form change', () => {
-        spyOn(component.valid, 'emit');
+        it('should not call save or delete when is empty and not previous variable exist', () => {
+            spyOn(dotFieldVariableService, 'delete').and.returnValue(of([]));
+            spyOn(dotFieldVariableService, 'save').and.returnValue(of([]));
 
-        const acceptInput = spectator.query(byTestId('setting-accept'));
-        spectator.typeInElement('text/*', acceptInput);
+            spectator.detectChanges();
 
-        expect(component.valid.emit).toHaveBeenCalled();
-    });
+            component.form.get('accept').setValue('');
+            component.saveSettings();
 
-    it('should handler error if save properties failed', () => {
-        spyOn(dotFieldVariableService, 'save').and.returnValue(throwError({}));
-        spyOn(dotHttpErrorManagerService, 'handle').and.returnValue(of());
-        spyOn(component.save, 'emit');
-
-        component.saveSettings();
-
-        expect(dotHttpErrorManagerService.handle).toHaveBeenCalledTimes(1);
-        expect(component.save.emit).not.toHaveBeenCalled();
-    });
-    it('should not call save or delete when is empty and not previous variable exist', () => {
-        spyOn(dotFieldVariableService, 'load');
-        spyOn(dotFieldVariableService, 'delete').and.returnValue(of([]));
-        spyOn(dotFieldVariableService, 'save').and.returnValue(of([]));
-
-        component.form.get('accept').setValue('');
-        component.saveSettings();
-
-        expect(dotFieldVariableService.delete).not.toHaveBeenCalled();
-        expect(dotFieldVariableService.save).not.toHaveBeenCalledTimes(2); // One for accept and one for systemOptions, accept should not call save or delete
-    });
-
-    it('should have 3 switches with the corresponding control name', () => {
-        const switches = spectator.queryAll(byTestId('setting-switch'));
-
-        expect(switches.length).toBe(3);
-        expect(
-            switches.find((s) => s.getAttribute('ng-reflect-name') === 'allowURLImport')
-        ).not.toBeNull();
-        expect(
-            switches.find((s) => s.getAttribute('ng-reflect-name') === 'allowCodeWrite')
-        ).not.toBeNull();
-        expect(
-            switches.find((s) => s.getAttribute('ng-reflect-name') === 'allowGenerateImg')
-        ).not.toBeNull();
-    });
-
-    it('should have 1 input with the control name accept', () => {
-        const [acceptInput] = spectator.queryAll(byTestId('setting-accept'));
-
-        expect(acceptInput).not.toBeNull();
-
-        expect(acceptInput.getAttribute('ng-reflect-name')).toBe('accept');
+            expect(dotFieldVariableService.delete).not.toHaveBeenCalled();
+            expect(dotFieldVariableService.save).not.toHaveBeenCalledTimes(2); // One for accept and one for systemOptions, accept should not call save or delete
+        });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-binary-settings/dot-binary-settings.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-binary-settings/dot-binary-settings.component.ts
@@ -1,6 +1,5 @@
 import { forkJoin, of } from 'rxjs';
 
-import { NgFor } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import {
     ChangeDetectionStrategy,
@@ -33,7 +32,6 @@ import { DotFieldVariablesService } from '../fields/dot-content-type-fields-vari
     selector: 'dot-binary-settings',
     standalone: true,
     imports: [
-        NgFor,
         FormsModule,
         ReactiveFormsModule,
         InputTextModule,
@@ -120,6 +118,7 @@ export class DotBinarySettingsComponent implements OnInit, OnChanges {
     saveSettings(): void {
         const updateActions = Object.keys(this.form.controls).map((key) => {
             const control = this.form.get(key);
+
             const value =
                 control instanceof FormGroup ? JSON.stringify(control.value) : control.value;
             const fieldVariable: DotFieldVariable = {
@@ -128,7 +127,9 @@ export class DotBinarySettingsComponent implements OnInit, OnChanges {
                 value
             };
 
-            if (!value) {
+            const controlIsEmpty = !value && !this.FIELD_VARIABLES[key]?.value;
+
+            if (controlIsEmpty) {
                 return of({});
             }
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/5fc8e01f-cfe9-44d1-a8f4-b06ee479308f



This pull request includes changes to the `DotBinarySettingsComponent` in the `dotcms-ui` application to improve the handling of form control values and enhance the test coverage. The most important changes include adding mock providers, refactoring the component initialization, and improving the test cases.

### Improvements to test coverage:

* [`core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-binary-settings/dot-binary-settings.component.spec.ts`](diffhunk://#diff-0b252db3537c84f875312a755301b5d59c75c85a389e0141ed36540e4961fa9cL1-L4): Added `mockProvider` from `@ngneat/spectator` to mock services used in the component tests.

* [`core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-binary-settings/dot-binary-settings.component.spec.ts`](diffhunk://#diff-0b252db3537c84f875312a755301b5d59c75c85a389e0141ed36540e4961fa9cL36-R41): Refactored the component initialization to use `createComponentFactory` with different scenarios (`with value` and `without value`). [[1]](diffhunk://#diff-0b252db3537c84f875312a755301b5d59c75c85a389e0141ed36540e4961fa9cL36-R41) [[2]](diffhunk://#diff-0b252db3537c84f875312a755301b5d59c75c85a389e0141ed36540e4961fa9cR158-R207)

### Enhancements to form control value handling:

* [`core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-binary-settings/dot-binary-settings.component.ts`](diffhunk://#diff-e7c98ecc3b58672e93d0567eb4720314169ba43a62c3c6e08e1704a771fedbf2L131-R132): Improved the `saveSettings` method to check if the form control value is empty and if no previous variable exists before making save or delete calls.

### Codebase simplification:

* [`core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-binary-settings/dot-binary-settings.component.ts`](diffhunk://#diff-e7c98ecc3b58672e93d0567eb4720314169ba43a62c3c6e08e1704a771fedbf2L3): Removed unnecessary `NgFor` import. [[1]](diffhunk://#diff-e7c98ecc3b58672e93d0567eb4720314169ba43a62c3c6e08e1704a771fedbf2L3) [[2]](diffhunk://#diff-e7c98ecc3b58672e93d0567eb4720314169ba43a62c3c6e08e1704a771fedbf2L36)

This PR fixes: #31034