### PR TITLE
Fix save category field

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-selected/dot-category-field-selected.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-selected/dot-category-field-selected.component.ts
@@ -8,7 +8,6 @@ import { TooltipModule } from 'primeng/tooltip';
 import { DotMessagePipe } from '@dotcms/ui';
 
 import { DotCategoryFieldKeyValueObj } from '../../models/dot-category-field.models';
-import { DotCategoryFieldSearchListComponent } from '../dot-category-field-search-list/dot-category-field-search-list.component';
 
 /**
  * Represents the Dot Category Field Selected Component.
@@ -19,13 +18,7 @@ import { DotCategoryFieldSearchListComponent } from '../dot-category-field-searc
 @Component({
     selector: 'dot-category-field-selected',
     standalone: true,
-    imports: [
-        ButtonModule,
-        DotMessagePipe,
-        DotCategoryFieldSearchListComponent,
-        ChipModule,
-        TooltipModule
-    ],
+    imports: [ButtonModule, DotMessagePipe, ChipModule, TooltipModule],
     templateUrl: './dot-category-field-selected.component.html',
     styleUrl: './dot-category-field-selected.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.spec.ts
@@ -87,8 +87,8 @@ describe('DotEditContentCategoryFieldComponent', () => {
 
             it('should categoryFieldControl has the values loaded on the store', () => {
                 const categoryValue = spectator.component.categoryFieldControl.value;
-
-                expect(categoryValue).toEqual(MOCK_SELECTED_CATEGORIES_OBJECT);
+                const expectedInodes = MOCK_SELECTED_CATEGORIES_OBJECT.map((cat) => cat.inode);
+                expect(categoryValue).toEqual(expectedInodes);
             });
         });
 
@@ -187,8 +187,8 @@ describe('DotEditContentCategoryFieldComponent', () => {
 
             // Check if the form has the correct value
             const categoryValue = spectator.component.categoryFieldControl.value;
-
-            expect(categoryValue).toEqual(MOCK_SELECTED_CATEGORIES_OBJECT);
+            const expectedInodes = MOCK_SELECTED_CATEGORIES_OBJECT.map((cat) => cat.inode);
+            expect(categoryValue).toEqual(expectedInodes);
         }));
 
         it('should set categoryFieldControl value when adding a new category', () => {
@@ -199,38 +199,30 @@ describe('DotEditContentCategoryFieldComponent', () => {
                 path: CATEGORY_LEVEL_2[0].categoryName
             };
 
-            // this apply selected to the dialog
             store.openDialog();
-
-            // Add the new category
             store.addSelected(newItem);
-            // Apply the selected to the field
             store.applyDialogSelection();
-
             spectator.detectChanges();
 
             const categoryValues = spectator.component.categoryFieldControl.value;
+            const expectedInodes = [...MOCK_SELECTED_CATEGORIES_OBJECT, newItem].map(
+                (cat) => cat.inode
+            );
 
-            expect(categoryValues).toEqual([...MOCK_SELECTED_CATEGORIES_OBJECT, newItem]);
+            expect(categoryValues).toEqual(expectedInodes);
         });
 
         it('should set categoryFieldControl value when removing a category', () => {
-            const categoryValue: DotCategoryFieldKeyValueObj[] =
-                spectator.component.categoryFieldControl.value;
+            const initialValue = spectator.component.categoryFieldControl.value;
+            const expectedInodes = [initialValue[0]];
 
-            const expectedSelected = [categoryValue[0]];
-
-            expect(categoryValue.length).toBe(2);
-            store.openDialog(); // this apply selected to the dialog
-
-            store.removeSelected(categoryValue[1].key);
-            store.applyDialogSelection(); // this apply the selected in the dialog to the final selected
-
+            store.openDialog();
+            store.removeSelected(MOCK_SELECTED_CATEGORIES_OBJECT[1].key);
+            store.applyDialogSelection();
             spectator.detectChanges();
 
             const newCategoryValue = spectator.component.categoryFieldControl.value;
-
-            expect(newCategoryValue).toEqual(expectedSelected);
+            expect(newCategoryValue).toEqual(expectedInodes);
             expect(newCategoryValue.length).toBe(1);
         });
     });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
@@ -98,7 +98,8 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
                 const categoryValues = this.store.selected();
 
                 if (this.categoryFieldControl) {
-                    this.categoryFieldControl.setValue(categoryValues);
+                    const inodes = categoryValues?.map((category) => category.inode) ?? [];
+                    this.categoryFieldControl.setValue(inodes);
                 }
             },
             {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
@@ -73,7 +73,7 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
      *
      * @returns {Boolean} - True if there are selected categories, false otherwise.
      */
-    $hasSelectedCategories = computed(() => !!this.store.selected());
+    $hasSelectedCategories = computed(() => this.store.selected().length > 0);
 
     /**
      * Getter to retrieve the category field control.


### PR DESCRIPTION
### Proposed Changes

This pull request includes various changes to the `dot-edit-content-category-field` component and its related files in the `core-web/libs/edit-content` directory. The changes primarily focus on improving the handling of category values and simplifying the code.

Improvements to handling category values:

* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.spec.ts`](diffhunk://#diff-d4d690e99ce8700bc874daeecc8f568b7546a5f6a345af8cbc17e47069e79d2aL90-R91): Updated the tests to compare only the `inode` values of the categories instead of the entire category objects. [[1]](diffhunk://#diff-d4d690e99ce8700bc874daeecc8f568b7546a5f6a345af8cbc17e47069e79d2aL90-R91) [[2]](diffhunk://#diff-d4d690e99ce8700bc874daeecc8f568b7546a5f6a345af8cbc17e47069e79d2aL190-R191) [[3]](diffhunk://#diff-d4d690e99ce8700bc874daeecc8f568b7546a5f6a345af8cbc17e47069e79d2aL202-R225)

Code simplification:

* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-selected/dot-category-field-selected.component.ts`](diffhunk://#diff-753627492d17f7410abc5e62d290a97b5e7241487e619b2dce1c5c4f0d693739L11): Removed the unnecessary import of `DotCategoryFieldSearchListComponent` and reformatted the imports array. [[1]](diffhunk://#diff-753627492d17f7410abc5e62d290a97b5e7241487e619b2dce1c5c4f0d693739L11) [[2]](diffhunk://#diff-753627492d17f7410abc5e62d290a97b5e7241487e619b2dce1c5c4f0d693739L22-R21)
* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts`](diffhunk://#diff-cd105931423917928c0b12eb8b422717061ebe58686e6819cc774f19cf88625eL76-R76): Modified the `$hasSelectedCategories` computed property to directly check the length of the selected categories array and updated the `setValue` method to only set the `inode` values. [[1]](diffhunk://#diff-cd105931423917928c0b12eb8b422717061ebe58686e6819cc774f19cf88625eL76-R76) [[2]](diffhunk://#diff-cd105931423917928c0b12eb8b422717061ebe58686e6819cc774f19cf88625eL101-R102)

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **


This PR fixes: #31042