### PR TITLE
feat(edit-content): introduce Line Divider field type

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
@@ -97,7 +97,6 @@
     }
     @case (fieldTypes.CUSTOM_FIELD) {
         @defer (on immediate) {
-            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-custom-field
                 [field]="field"
                 [contentType]="contentType"

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
@@ -1,14 +1,21 @@
-<label
-    [attr.data-testId]="'label-' + field.variable"
-    [checkIsRequiredControl]="field.variable"
-    [for]="field.variable"
-    dotFieldRequired>
-    {{ field.name }}
-</label>
+<ng-template #labelTemplate>
+    <label
+        [attr.data-testId]="'label-' + field.variable"
+        [checkIsRequiredControl]="field.variable"
+        [for]="field.variable"
+        dotFieldRequired>
+        {{ field.name }}
+    </label>
+</ng-template>
 
 @switch (field.fieldType) {
+    @case (fieldTypes.LINE_DIVIDER) {
+        <h3 class="m-0 text-gray-700">{{ field.name }}</h3>
+        <p-divider />
+    }
     @case (fieldTypes.SELECT) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-select-field
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -16,6 +23,7 @@
     }
     @case (fieldTypes.RADIO) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-radio-field
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -23,6 +31,7 @@
     }
     @case (fieldTypes.TEXT) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-text-field
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -30,6 +39,7 @@
     }
     @case (fieldTypes.TEXTAREA) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-text-area
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -37,6 +47,7 @@
     }
     @case (fieldTypes.CHECKBOX) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-checkbox-field
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -44,6 +55,7 @@
     }
     @case (fieldTypes.MULTI_SELECT) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-multi-select-field
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -51,6 +63,7 @@
     }
     @case (calendarTypes.includes(field.fieldType) ? field.fieldType : '') {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-calendar-field
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -58,6 +71,7 @@
     }
     @case (fieldTypes.TAG) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-tag-field
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -65,6 +79,7 @@
     }
     @case (fieldTypes.JSON) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-json-field
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -72,6 +87,7 @@
     }
     @case (fieldTypes.BINARY) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-binary-field
                 [formControlName]="field.variable"
                 [contentlet]="contentlet"
@@ -81,6 +97,7 @@
     }
     @case (fieldTypes.CUSTOM_FIELD) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-custom-field
                 [field]="field"
                 [contentType]="contentType"
@@ -89,6 +106,7 @@
     }
     @case (fieldTypes.BLOCK_EDITOR) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-block-editor
                 [formControlName]="field.variable"
                 [contentlet]="contentlet"
@@ -98,6 +116,7 @@
     }
     @case (fieldTypes.KEY_VALUE) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-key-value
                 [formControlName]="field.variable"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -105,6 +124,7 @@
     }
     @case (fieldTypes.WYSIWYG) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-wysiwyg-field
                 [field]="field"
                 [contentlet]="contentlet"
@@ -113,6 +133,7 @@
     }
     @case (fieldTypes.HOST_FOLDER) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-host-folder-field
                 [field]="field"
                 [attr.data-testId]="'field-' + field.variable" />
@@ -120,6 +141,7 @@
     }
     @case (fieldTypes.CATEGORY) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-category-field
                 [attr.data-testId]="'field-' + field.variable"
                 [contentlet]="contentlet"
@@ -128,6 +150,7 @@
     }
     @case (fieldTypes.FILE) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-file-field
                 [formControlName]="field.variable"
                 [attr.data-testId]="'field-' + field.variable"
@@ -136,6 +159,7 @@
     }
     @case (fieldTypes.IMAGE) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-file-field
                 [formControlName]="field.variable"
                 [attr.data-testId]="'field-' + field.variable"
@@ -144,6 +168,7 @@
     }
     @case (fieldTypes.RELATIONSHIP) {
         @defer (on immediate) {
+            <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-relationship-field
                 [formControlName]="field.variable"
                 [attr.data-testId]="'field-' + field.variable"

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
@@ -249,11 +249,13 @@ describe.each([...FIELDS_TO_BE_RENDER])('DotEditContentFieldComponent all fields
     });
 
     describe(`${fieldMock.fieldType} - ${fieldMock.dataType}`, () => {
-        it('should render the label', () => {
-            spectator.detectChanges();
-            const label = spectator.query(byTestId(`label-${fieldMock.variable}`));
-            expect(label?.textContent).toContain(fieldMock.name);
-        });
+        if (fieldMock.fieldType !== FIELD_TYPES.CUSTOM_FIELD) {
+            it('should render the label', () => {
+                spectator.detectChanges();
+                const label = spectator.query(byTestId(`label-${fieldMock.variable}`));
+                expect(label?.textContent).toContain(fieldMock.name);
+            });
+        }
 
         if (fieldMock.fieldType !== FIELD_TYPES.RELATIONSHIP) {
             it('should render the hint if present', () => {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
@@ -192,6 +192,9 @@ const FIELD_TYPES_COMPONENTS: Record<FIELD_TYPES, Type<unknown> | DotEditFieldTe
     },
     [FIELD_TYPES.HIDDEN]: {
         component: null // this field is not being rendered for now.
+    },
+    [FIELD_TYPES.LINE_DIVIDER]: {
+        component: null
     }
 };
 
@@ -206,7 +209,10 @@ describe('FIELD_TYPES and FIELDS_MOCK', () => {
 });
 
 const FIELDS_TO_BE_RENDER = FIELDS_MOCK.filter(
-    (field) => field.fieldType !== FIELD_TYPES.CONSTANT && field.fieldType !== FIELD_TYPES.HIDDEN
+    (field) =>
+        field.fieldType !== FIELD_TYPES.CONSTANT &&
+        field.fieldType !== FIELD_TYPES.HIDDEN &&
+        field.fieldType !== FIELD_TYPES.LINE_DIVIDER
 );
 
 describe.each([...FIELDS_TO_BE_RENDER])('DotEditContentFieldComponent all fields', (fieldMock) => {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
@@ -1,5 +1,8 @@
+import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, HostBinding, inject, Input } from '@angular/core';
 import { ControlContainer, ReactiveFormsModule } from '@angular/forms';
+
+import { DividerModule } from 'primeng/divider';
 
 import { BlockEditorModule } from '@dotcms/block-editor';
 import { DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
@@ -58,7 +61,9 @@ import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
         DotEditContentKeyValueComponent,
         DotEditContentWYSIWYGFieldComponent,
         DotEditContentFileFieldComponent,
-        DotEditContentRelationshipFieldComponent
+        DotEditContentRelationshipFieldComponent,
+        DividerModule,
+        NgTemplateOutlet
     ]
 })
 export class DotEditContentFieldComponent {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/utils.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/utils.ts
@@ -63,5 +63,6 @@ export const resolutionValue: Record<FIELD_TYPES, FnResolutionValue> = {
 
         return field.defaultValue ?? [];
     },
-    [FIELD_TYPES.RELATIONSHIP]: defaultResolutionFn
+    [FIELD_TYPES.RELATIONSHIP]: defaultResolutionFn,
+    [FIELD_TYPES.LINE_DIVIDER]: () => ''
 };

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.html
@@ -1,7 +1,7 @@
 <iframe
     (load)="onIframeLoad()"
     [src]="src | safeUrl"
-    [ngClass]="{ 'legacy-custom-field--fullscreen': isFullscreen }"
+    [class.legacy-custom-field--fullscreen]="isFullscreen"
     [ngStyle]="!isFullscreen && { height: variables?.height, width: variables?.width }"
     [title]="'Content Type ' + field.variable + ' and field ' + field.name"
     class="legacy-custom-field"

--- a/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.enum.ts
+++ b/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.enum.ts
@@ -31,5 +31,6 @@ export enum FIELD_TYPES {
     TEXTAREA = 'Textarea',
     TIME = 'Time',
     WYSIWYG = 'WYSIWYG',
-    RELATIONSHIP = 'Relationship'
+    RELATIONSHIP = 'Relationship',
+    LINE_DIVIDER = 'Line_divider'
 }

--- a/core-web/libs/edit-content/src/lib/utils/mocks.ts
+++ b/core-web/libs/edit-content/src/lib/utils/mocks.ts
@@ -737,6 +737,29 @@ export const HIDDEN_FIELD_MOCK: DotCMSContentTypeField = {
     variable: 'hidden'
 };
 
+export const LINE_DIVIDER_MOCK: DotCMSContentTypeField = {
+    clazz: 'com.dotcms.contenttype.model.field.ImmutableLineDividerField',
+    contentTypeId: '799f176a-d32e-4844-a07c-1b5fcd107578',
+    dataType: 'SYSTEM',
+    fieldType: 'Line_divider',
+    fieldTypeLabel: 'Line Divider',
+    fieldVariables: [],
+    fixed: false,
+    forceIncludeInApi: false,
+    iDate: 1685464291000,
+    id: '0cc62946e4889894f3fe83a18a8bdffa',
+    indexed: false,
+    listed: false,
+    modDate: 1735915174000,
+    name: 'Open Graph (OG Meta Tags)',
+    readOnly: false,
+    required: false,
+    searchable: false,
+    sortOrder: 27,
+    unique: false,
+    variable: 'openGraph'
+};
+
 export const FIELDS_MOCK: DotCMSContentTypeField[] = [
     TEXT_FIELD_MOCK,
     TEXT_AREA_FIELD_MOCK,
@@ -766,7 +789,8 @@ export const FIELDS_MOCK: DotCMSContentTypeField[] = [
     CATEGORY_MOCK,
     CONSTANT_FIELD_MOCK,
     HIDDEN_FIELD_MOCK,
-    RELATIONSHIP_FIELD_MOCK
+    RELATIONSHIP_FIELD_MOCK,
+    LINE_DIVIDER_MOCK
 ];
 
 export const FIELD_MOCK: DotCMSContentTypeField = TEXT_FIELD_MOCK;

--- a/core-web/tsconfig.base.json
+++ b/core-web/tsconfig.base.json
@@ -1,74 +1,154 @@
 {
-    "compileOnSave": false,
-    "compilerOptions": {
-        "rootDir": ".",
-        "sourceMap": true,
-        "declaration": false,
-        "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true,
-        "moduleResolution": "node",
-        "emitDecoratorMetadata": true,
-        "experimentalDecorators": true,
-        "importHelpers": true,
-        "target": "es2021",
-        "module": "esnext",
-        "lib": ["es2017", "es2020", "dom", "dom.iterable"],
-        "skipLibCheck": true,
-        "skipDefaultLibCheck": true,
-        "baseUrl": ".",
-        "paths": {
-            "@components/*": ["apps/dotcms-ui/src/app/view/components/*"],
-            "@directives/*": ["apps/dotcms-ui/src/app/view/directives/*"],
-            "@dotcms/analytics": ["libs/sdk/analytics/src/index.ts"],
-            "@dotcms/angular": ["libs/sdk/angular/src/index.ts"],
-            "@dotcms/app/*": ["apps/dotcms-ui/src/app/*"],
-            "@dotcms/block-editor": ["libs/block-editor/src/public-api.ts"],
-            "@dotcms/client": ["libs/sdk/client/src/index.ts"],
-            "@dotcms/contenttype-fields": ["libs/contenttype-fields/src/index.ts"],
-            "@dotcms/data-access": ["libs/data-access/src/index.ts"],
-            "@dotcms/dot-layout-grid": ["libs/dot-layout-grid/src/public_api.ts"],
-            "@dotcms/dot-rules": ["libs/dot-rules/src/public_api.ts"],
-            "@dotcms/dotcms": ["libs/dotcms/src/index.ts"],
-            "@dotcms/dotcms-field-elements": ["libs/dotcms-field-elements/src/index.ts"],
-            "@dotcms/dotcms-field-elements/loader": ["dist/libs/dotcms-field-elements/loader"],
-            "@dotcms/dotcms-js": ["libs/dotcms-js/src/public_api.ts"],
-            "@dotcms/dotcms-models": ["libs/dotcms-models/src/index.ts"],
-            "@dotcms/dotcms-webcomponents": ["libs/dotcms-webcomponents/src/index.ts"],
-            "@dotcms/dotcms-webcomponents/loader": ["dist/libs/dotcms-webcomponents/loader"],
-            "@dotcms/edit-content": ["libs/edit-content/src/index.ts"],
-            "@dotcms/edit-content/*": ["libs/edit-content/src/lib/*"],
-            "@dotcms/experiments": ["libs/sdk/experiments/src/index.ts"],
-            "@dotcms/portlets/dot-analytics-search/portlet": [
-                "libs/portlets/dot-analytics-search/portlet/src/index.ts"
-            ],
-            "@dotcms/portlets/dot-ema": ["libs/portlets/edit-ema/portlet/src/index.ts"],
-            "@dotcms/portlets/dot-ema/ui": ["libs/portlets/edit-ema/ui/src/index.ts"],
-            "@dotcms/portlets/dot-experiments/data-access": [
-                "libs/portlets/dot-experiments/data-access/src/index.ts"
-            ],
-            "@dotcms/portlets/dot-experiments/portlet": [
-                "libs/portlets/dot-experiments/portlet/src/index.ts"
-            ],
-            "@dotcms/portlets/dot-locales/portlet": [
-                "libs/portlets/dot-locales/portlet/src/index.ts"
-            ],
-            "@dotcms/portlets/dot-locales/portlet/data-access": [
-                "libs/portlets/dot-locales/data-access/src/index.ts"
-            ],
-            "@dotcms/react": ["libs/sdk/react/src/index.ts"],
-            "@dotcms/react/mocks": ["libs/sdk/react/src/lib/mocks/index.ts"],
-            "@dotcms/template-builder": ["libs/template-builder/src/index.ts"],
-            "@dotcms/ui": ["libs/ui/src/index.ts"],
-            "@dotcms/utils": ["libs/utils/src"],
-            "@dotcms/utils-testing": ["libs/utils-testing/src/index.ts"],
-            "@dotcms/utils/*": ["libs/utils/src/*"],
-            "@models/*": ["apps/dotcms-ui/src/app/shared/models/*"],
-            "@pipes/*": ["apps/dotcms-ui/src/app/view/pipes/*"],
-            "@portlets/*": ["apps/dotcms-ui/src/app/portlets/*"],
-            "@services/*": ["apps/dotcms-ui/src/app/api/services/*"],
-            "@shared/*": ["apps/dotcms-ui/src/app/shared/*"],
-            "@tests/*": ["apps/dotcms-ui/src/app/test/*"]
-        }
-    },
-    "exclude": ["node_modules", "tmp"]
+  "compileOnSave": false,
+  "compilerOptions": {
+    "rootDir": ".",
+    "sourceMap": true,
+    "declaration": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "target": "es2021",
+    "module": "esnext",
+    "lib": [
+      "es2017",
+      "es2020",
+      "dom",
+      "dom.iterable"
+    ],
+    "skipLibCheck": true,
+    "skipDefaultLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": [
+        "apps/dotcms-ui/src/app/view/components/*"
+      ],
+      "@directives/*": [
+        "apps/dotcms-ui/src/app/view/directives/*"
+      ],
+      "@dotcms/analytics": [
+        "libs/sdk/analytics/src/index.ts"
+      ],
+      "@dotcms/angular": [
+        "libs/sdk/angular/src/index.ts"
+      ],
+      "@dotcms/app/*": [
+        "apps/dotcms-ui/src/app/*"
+      ],
+      "@dotcms/block-editor": [
+        "libs/block-editor/src/public-api.ts"
+      ],
+      "@dotcms/client": [
+        "libs/sdk/client/src/index.ts"
+      ],
+      "@dotcms/contenttype-fields": [
+        "libs/contenttype-fields/src/index.ts"
+      ],
+      "@dotcms/data-access": [
+        "libs/data-access/src/index.ts"
+      ],
+      "@dotcms/dot-layout-grid": [
+        "libs/dot-layout-grid/src/public_api.ts"
+      ],
+      "@dotcms/dot-rules": [
+        "libs/dot-rules/src/public_api.ts"
+      ],
+      "@dotcms/dotcms": [
+        "libs/dotcms/src/index.ts"
+      ],
+      "@dotcms/dotcms-field-elements": [
+        "libs/dotcms-field-elements/src/index.ts"
+      ],
+      "@dotcms/dotcms-field-elements/loader": [
+        "dist/libs/dotcms-field-elements/loader"
+      ],
+      "@dotcms/dotcms-js": [
+        "libs/dotcms-js/src/public_api.ts"
+      ],
+      "@dotcms/dotcms-models": [
+        "libs/dotcms-models/src/index.ts"
+      ],
+      "@dotcms/dotcms-webcomponents": [
+        "libs/dotcms-webcomponents/src/index.ts"
+      ],
+      "@dotcms/dotcms-webcomponents/loader": [
+        "dist/libs/dotcms-webcomponents/loader"
+      ],
+      "@dotcms/edit-content": [
+        "libs/edit-content/src/index.ts"
+      ],
+      "@dotcms/edit-content/*": [
+        "libs/edit-content/src/lib/*"
+      ],
+      "@dotcms/experiments": [
+        "libs/sdk/experiments/src/index.ts"
+      ],
+      "@dotcms/portlets/dot-analytics-search/portlet": [
+        "libs/portlets/dot-analytics-search/portlet/src/index.ts"
+      ],
+      "@dotcms/portlets/dot-ema": [
+        "libs/portlets/edit-ema/portlet/src/index.ts"
+      ],
+      "@dotcms/portlets/dot-ema/ui": [
+        "libs/portlets/edit-ema/ui/src/index.ts"
+      ],
+      "@dotcms/portlets/dot-experiments/data-access": [
+        "libs/portlets/dot-experiments/data-access/src/index.ts"
+      ],
+      "@dotcms/portlets/dot-experiments/portlet": [
+        "libs/portlets/dot-experiments/portlet/src/index.ts"
+      ],
+      "@dotcms/portlets/dot-locales/portlet": [
+        "libs/portlets/dot-locales/portlet/src/index.ts"
+      ],
+      "@dotcms/portlets/dot-locales/portlet/data-access": [
+        "libs/portlets/dot-locales/data-access/src/index.ts"
+      ],
+      "@dotcms/react": [
+        "libs/sdk/react/src/index.ts"
+      ],
+      "@dotcms/react/mocks": [
+        "libs/sdk/react/src/lib/mocks/index.ts"
+      ],
+      "@dotcms/template-builder": [
+        "libs/template-builder/src/index.ts"
+      ],
+      "@dotcms/ui": [
+        "libs/ui/src/index.ts"
+      ],
+      "@dotcms/utils": [
+        "libs/utils/src"
+      ],
+      "@dotcms/utils-testing": [
+        "libs/utils-testing/src/index.ts"
+      ],
+      "@dotcms/utils/*": [
+        "libs/utils/src/*"
+      ],
+      "@models/*": [
+        "apps/dotcms-ui/src/app/shared/models/*"
+      ],
+      "@pipes/*": [
+        "apps/dotcms-ui/src/app/view/pipes/*"
+      ],
+      "@portlets/*": [
+        "apps/dotcms-ui/src/app/portlets/*"
+      ],
+      "@services/*": [
+        "apps/dotcms-ui/src/app/api/services/*"
+      ],
+      "@shared/*": [
+        "apps/dotcms-ui/src/app/shared/*"
+      ],
+      "@tests/*": [
+        "apps/dotcms-ui/src/app/test/*"
+      ]
+    }
+  },
+  "exclude": [
+    "node_modules",
+    "tmp"
+  ]
 }

--- a/core-web/tsconfig.base.json
+++ b/core-web/tsconfig.base.json
@@ -1,154 +1,74 @@
 {
-  "compileOnSave": false,
-  "compilerOptions": {
-    "rootDir": ".",
-    "sourceMap": true,
-    "declaration": false,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "moduleResolution": "node",
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "importHelpers": true,
-    "target": "es2021",
-    "module": "esnext",
-    "lib": [
-      "es2017",
-      "es2020",
-      "dom",
-      "dom.iterable"
-    ],
-    "skipLibCheck": true,
-    "skipDefaultLibCheck": true,
-    "baseUrl": ".",
-    "paths": {
-      "@components/*": [
-        "apps/dotcms-ui/src/app/view/components/*"
-      ],
-      "@directives/*": [
-        "apps/dotcms-ui/src/app/view/directives/*"
-      ],
-      "@dotcms/analytics": [
-        "libs/sdk/analytics/src/index.ts"
-      ],
-      "@dotcms/angular": [
-        "libs/sdk/angular/src/index.ts"
-      ],
-      "@dotcms/app/*": [
-        "apps/dotcms-ui/src/app/*"
-      ],
-      "@dotcms/block-editor": [
-        "libs/block-editor/src/public-api.ts"
-      ],
-      "@dotcms/client": [
-        "libs/sdk/client/src/index.ts"
-      ],
-      "@dotcms/contenttype-fields": [
-        "libs/contenttype-fields/src/index.ts"
-      ],
-      "@dotcms/data-access": [
-        "libs/data-access/src/index.ts"
-      ],
-      "@dotcms/dot-layout-grid": [
-        "libs/dot-layout-grid/src/public_api.ts"
-      ],
-      "@dotcms/dot-rules": [
-        "libs/dot-rules/src/public_api.ts"
-      ],
-      "@dotcms/dotcms": [
-        "libs/dotcms/src/index.ts"
-      ],
-      "@dotcms/dotcms-field-elements": [
-        "libs/dotcms-field-elements/src/index.ts"
-      ],
-      "@dotcms/dotcms-field-elements/loader": [
-        "dist/libs/dotcms-field-elements/loader"
-      ],
-      "@dotcms/dotcms-js": [
-        "libs/dotcms-js/src/public_api.ts"
-      ],
-      "@dotcms/dotcms-models": [
-        "libs/dotcms-models/src/index.ts"
-      ],
-      "@dotcms/dotcms-webcomponents": [
-        "libs/dotcms-webcomponents/src/index.ts"
-      ],
-      "@dotcms/dotcms-webcomponents/loader": [
-        "dist/libs/dotcms-webcomponents/loader"
-      ],
-      "@dotcms/edit-content": [
-        "libs/edit-content/src/index.ts"
-      ],
-      "@dotcms/edit-content/*": [
-        "libs/edit-content/src/lib/*"
-      ],
-      "@dotcms/experiments": [
-        "libs/sdk/experiments/src/index.ts"
-      ],
-      "@dotcms/portlets/dot-analytics-search/portlet": [
-        "libs/portlets/dot-analytics-search/portlet/src/index.ts"
-      ],
-      "@dotcms/portlets/dot-ema": [
-        "libs/portlets/edit-ema/portlet/src/index.ts"
-      ],
-      "@dotcms/portlets/dot-ema/ui": [
-        "libs/portlets/edit-ema/ui/src/index.ts"
-      ],
-      "@dotcms/portlets/dot-experiments/data-access": [
-        "libs/portlets/dot-experiments/data-access/src/index.ts"
-      ],
-      "@dotcms/portlets/dot-experiments/portlet": [
-        "libs/portlets/dot-experiments/portlet/src/index.ts"
-      ],
-      "@dotcms/portlets/dot-locales/portlet": [
-        "libs/portlets/dot-locales/portlet/src/index.ts"
-      ],
-      "@dotcms/portlets/dot-locales/portlet/data-access": [
-        "libs/portlets/dot-locales/data-access/src/index.ts"
-      ],
-      "@dotcms/react": [
-        "libs/sdk/react/src/index.ts"
-      ],
-      "@dotcms/react/mocks": [
-        "libs/sdk/react/src/lib/mocks/index.ts"
-      ],
-      "@dotcms/template-builder": [
-        "libs/template-builder/src/index.ts"
-      ],
-      "@dotcms/ui": [
-        "libs/ui/src/index.ts"
-      ],
-      "@dotcms/utils": [
-        "libs/utils/src"
-      ],
-      "@dotcms/utils-testing": [
-        "libs/utils-testing/src/index.ts"
-      ],
-      "@dotcms/utils/*": [
-        "libs/utils/src/*"
-      ],
-      "@models/*": [
-        "apps/dotcms-ui/src/app/shared/models/*"
-      ],
-      "@pipes/*": [
-        "apps/dotcms-ui/src/app/view/pipes/*"
-      ],
-      "@portlets/*": [
-        "apps/dotcms-ui/src/app/portlets/*"
-      ],
-      "@services/*": [
-        "apps/dotcms-ui/src/app/api/services/*"
-      ],
-      "@shared/*": [
-        "apps/dotcms-ui/src/app/shared/*"
-      ],
-      "@tests/*": [
-        "apps/dotcms-ui/src/app/test/*"
-      ]
-    }
-  },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+    "compileOnSave": false,
+    "compilerOptions": {
+        "rootDir": ".",
+        "sourceMap": true,
+        "declaration": false,
+        "esModuleInterop": true,
+        "allowSyntheticDefaultImports": true,
+        "moduleResolution": "node",
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
+        "importHelpers": true,
+        "target": "es2021",
+        "module": "esnext",
+        "lib": ["es2017", "es2020", "dom", "dom.iterable"],
+        "skipLibCheck": true,
+        "skipDefaultLibCheck": true,
+        "baseUrl": ".",
+        "paths": {
+            "@components/*": ["apps/dotcms-ui/src/app/view/components/*"],
+            "@directives/*": ["apps/dotcms-ui/src/app/view/directives/*"],
+            "@dotcms/analytics": ["libs/sdk/analytics/src/index.ts"],
+            "@dotcms/angular": ["libs/sdk/angular/src/index.ts"],
+            "@dotcms/app/*": ["apps/dotcms-ui/src/app/*"],
+            "@dotcms/block-editor": ["libs/block-editor/src/public-api.ts"],
+            "@dotcms/client": ["libs/sdk/client/src/index.ts"],
+            "@dotcms/contenttype-fields": ["libs/contenttype-fields/src/index.ts"],
+            "@dotcms/data-access": ["libs/data-access/src/index.ts"],
+            "@dotcms/dot-layout-grid": ["libs/dot-layout-grid/src/public_api.ts"],
+            "@dotcms/dot-rules": ["libs/dot-rules/src/public_api.ts"],
+            "@dotcms/dotcms": ["libs/dotcms/src/index.ts"],
+            "@dotcms/dotcms-field-elements": ["libs/dotcms-field-elements/src/index.ts"],
+            "@dotcms/dotcms-field-elements/loader": ["dist/libs/dotcms-field-elements/loader"],
+            "@dotcms/dotcms-js": ["libs/dotcms-js/src/public_api.ts"],
+            "@dotcms/dotcms-models": ["libs/dotcms-models/src/index.ts"],
+            "@dotcms/dotcms-webcomponents": ["libs/dotcms-webcomponents/src/index.ts"],
+            "@dotcms/dotcms-webcomponents/loader": ["dist/libs/dotcms-webcomponents/loader"],
+            "@dotcms/edit-content": ["libs/edit-content/src/index.ts"],
+            "@dotcms/edit-content/*": ["libs/edit-content/src/lib/*"],
+            "@dotcms/experiments": ["libs/sdk/experiments/src/index.ts"],
+            "@dotcms/portlets/dot-analytics-search/portlet": [
+                "libs/portlets/dot-analytics-search/portlet/src/index.ts"
+            ],
+            "@dotcms/portlets/dot-ema": ["libs/portlets/edit-ema/portlet/src/index.ts"],
+            "@dotcms/portlets/dot-ema/ui": ["libs/portlets/edit-ema/ui/src/index.ts"],
+            "@dotcms/portlets/dot-experiments/data-access": [
+                "libs/portlets/dot-experiments/data-access/src/index.ts"
+            ],
+            "@dotcms/portlets/dot-experiments/portlet": [
+                "libs/portlets/dot-experiments/portlet/src/index.ts"
+            ],
+            "@dotcms/portlets/dot-locales/portlet": [
+                "libs/portlets/dot-locales/portlet/src/index.ts"
+            ],
+            "@dotcms/portlets/dot-locales/portlet/data-access": [
+                "libs/portlets/dot-locales/data-access/src/index.ts"
+            ],
+            "@dotcms/react": ["libs/sdk/react/src/index.ts"],
+            "@dotcms/react/mocks": ["libs/sdk/react/src/lib/mocks/index.ts"],
+            "@dotcms/template-builder": ["libs/template-builder/src/index.ts"],
+            "@dotcms/ui": ["libs/ui/src/index.ts"],
+            "@dotcms/utils": ["libs/utils/src"],
+            "@dotcms/utils-testing": ["libs/utils-testing/src/index.ts"],
+            "@dotcms/utils/*": ["libs/utils/src/*"],
+            "@models/*": ["apps/dotcms-ui/src/app/shared/models/*"],
+            "@pipes/*": ["apps/dotcms-ui/src/app/view/pipes/*"],
+            "@portlets/*": ["apps/dotcms-ui/src/app/portlets/*"],
+            "@services/*": ["apps/dotcms-ui/src/app/api/services/*"],
+            "@shared/*": ["apps/dotcms-ui/src/app/shared/*"],
+            "@tests/*": ["apps/dotcms-ui/src/app/test/*"]
+        }
+    },
+    "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
### Parent Issue

https://github.com/dotCMS/core/issues/31066

### Proposed Changes

This pull request introduces a new `LINE_DIVIDER` field type to the `dot-edit-content-field` component and updates the project configuration. The most important changes include the addition of the `LINE_DIVIDER` field type, updates to the HTML template to use `ngTemplateOutlet`, and modifications to the TypeScript configuration.

### Addition of `LINE_DIVIDER` Field Type:

* [`core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html`](diffhunk://#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR1-R90): Added `LINE_DIVIDER` case and updated other field cases to use `ngTemplateOutlet` for the label template. [[1]](diffhunk://#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR1-R90) [[2]](diffhunk://#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR100) [[3]](diffhunk://#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR109) [[4]](diffhunk://#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR119-R127) [[5]](diffhunk://#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR136-R144) [[6]](diffhunk://#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR153) [[7]](diffhunk://#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR162) [[8]](diffhunk://#diff-685da2f87189fff825b7aec2666cfbabdb33c40f8f9d8c82df77ebb8652ccd4aR171)
* [`core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts`](diffhunk://#diff-23d2e2fd9b71e1819e10ae720cb79ecf5e4d75e51fee641b020017fe8186640fR195-R197): Added `LINE_DIVIDER` to the `FIELD_TYPES_COMPONENTS` and excluded it from fields to be rendered. [[1]](diffhunk://#diff-23d2e2fd9b71e1819e10ae720cb79ecf5e4d75e51fee641b020017fe8186640fR195-R197) [[2]](diffhunk://#diff-23d2e2fd9b71e1819e10ae720cb79ecf5e4d75e51fee641b020017fe8186640fL209-R215)
* [`core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts`](diffhunk://#diff-f03434ad88316542a23c3fb0bf50b6650130632c3e7953d7ee3c882cb5950d06R1-R6): Imported `NgTemplateOutlet` and `DividerModule` to support the new field type. [[1]](diffhunk://#diff-f03434ad88316542a23c3fb0bf50b6650130632c3e7953d7ee3c882cb5950d06R1-R6) [[2]](diffhunk://#diff-f03434ad88316542a23c3fb0bf50b6650130632c3e7953d7ee3c882cb5950d06L61-R66)
* [`core-web/libs/edit-content/src/lib/components/dot-edit-content-form/utils.ts`](diffhunk://#diff-48cac5197bbc560a4fdfa7a0c9bfab65eaab91bc8e90313f0b0644bdac7ec8b7L66-R67): Added resolution function for `LINE_DIVIDER`.
* [`core-web/libs/edit-content/src/lib/models/dot-edit-content-field.enum.ts`](diffhunk://#diff-aa72329fa1c18891b5d44042ac6ae09ff3d915621f16a084982f87d068c2453aL34-R35): Added `LINE_DIVIDER` to the `FIELD_TYPES` enum.
* [`core-web/libs/edit-content/src/lib/utils/mocks.ts`](diffhunk://#diff-044e3c643ab55d05bd081afffe7251b7ebec1f4c383851aa1a219cdc626093f1R740-R762): Added mock data for `LINE_DIVIDER`. [[1]](diffhunk://#diff-044e3c643ab55d05bd081afffe7251b7ebec1f4c383851aa1a219cdc626093f1R740-R762) [[2]](diffhunk://#diff-044e3c643ab55d05bd081afffe7251b7ebec1f4c383851aa1a219cdc626093f1L769-R793)

### TypeScript Configuration Update:

* [`core-web/tsconfig.base.json`](diffhunk://#diff-a96484261b73ba1eb1e119e1aa36e6be97f219d53cdbdbf3fc718cf11bfa98ebL15-R96): Reformatted the `paths` section for better readability and consistency. [[1]](diffhunk://#diff-a96484261b73ba1eb1e119e1aa36e6be97f219d53cdbdbf3fc718cf11bfa98ebL15-R96) [[2]](diffhunk://#diff-a96484261b73ba1eb1e119e1aa36e6be97f219d53cdbdbf3fc718cf11bfa98ebL58-R153)

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
![MacBook Pro-1736191191675](https://github.com/user-attachments/assets/ea22efac-5386-4fc6-9bf2-89657e1659a8)  |  ![MacBook Pro-1736191805768](https://github.com/user-attachments/assets/6de86c86-8f31-4e27-8e25-7985ef6c2fa2)

