### PR TITLE
feat(sdk): Added validation to blocks prop on BlockEditorRenderer

### DIFF
--- a/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.spec.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.spec.tsx
@@ -58,11 +58,11 @@ describe('BlockEditorRenderer', () => {
             jest.spyOn(client, 'isInsideEditor').mockImplementation(() => true);
             const consoleSpy = jest.spyOn(console, 'error');
 
-            const { getByText } = render(<BlockEditorRenderer blocks={'' as unknown as Block} />);
+            const { getByTestId } = render(<BlockEditorRenderer blocks={'' as unknown as Block} />);
 
-            expect(
-                getByText('Error: Blocks must be an object, but received: string')
-            ).toBeInTheDocument();
+            expect(getByTestId('invalid-blocks-message')).toHaveTextContent(
+                'Error: Blocks must be an object, but received: string'
+            );
             expect(consoleSpy).toHaveBeenCalledWith(
                 'Error: Blocks must be an object, but received: string'
             );
@@ -72,11 +72,11 @@ describe('BlockEditorRenderer', () => {
             jest.spyOn(client, 'isInsideEditor').mockImplementation(() => false);
             const consoleSpy = jest.spyOn(console, 'error');
 
-            const { queryByText } = render(
+            const { queryByTestId } = render(
                 <BlockEditorRenderer blocks={{ content: [] } as unknown as Block} />
             );
 
-            expect(queryByText('Error: Blocks must have a doc type')).toBeNull();
+            expect(queryByTestId('invalid-blocks-message')).not.toBeInTheDocument();
             expect(consoleSpy).toHaveBeenCalledWith('Error: Blocks must have a doc type');
         });
 
@@ -84,11 +84,11 @@ describe('BlockEditorRenderer', () => {
             jest.spyOn(client, 'isInsideEditor').mockImplementation(() => false);
             const consoleSpy = jest.spyOn(console, 'error');
 
-            const { queryByText } = render(
+            const { queryByTestId } = render(
                 <BlockEditorRenderer blocks={{ content: [], type: 'doc' } as unknown as Block} />
             );
 
-            expect(queryByText('Error: Blocks content is empty')).toBeNull();
+            expect(queryByTestId('invalid-blocks-message')).not.toBeInTheDocument();
             expect(consoleSpy).toHaveBeenCalledWith('Error: Blocks content is empty');
         });
     });

--- a/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.spec.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.spec.tsx
@@ -10,6 +10,7 @@ import { Block } from '../../models/blocks.interface';
 
 describe('BlockEditorRenderer', () => {
     const blocks = {
+        type: 'doc',
         content: [
             {
                 type: 'paragraph',
@@ -50,6 +51,26 @@ describe('BlockEditorRenderer', () => {
         );
         expect(container.firstChild).toHaveClass('test-class');
         expect(container.firstChild).toHaveStyle('color: red');
+    });
+
+    it('should render console error and the invalid blocks message', () => {
+        jest.spyOn(client, 'isInsideEditor').mockImplementation(() => true);
+        const consoleSpy = jest.spyOn(console, 'error');
+
+        const { getByText } = render(<BlockEditorRenderer blocks={{} as Block} />);
+
+        expect(getByText('BlockEditorRenderer Error: Invalid prop "blocks"')).toBeInTheDocument();
+        expect(consoleSpy).toHaveBeenCalledWith('BlockEditorRenderer Error: Invalid prop "blocks"');
+    });
+
+    it('should render console error and not render the invalid blocks message', () => {
+        jest.spyOn(client, 'isInsideEditor').mockImplementation(() => false);
+        const consoleSpy = jest.spyOn(console, 'error');
+
+        const { queryByText } = render(<BlockEditorRenderer blocks={{} as Block} />);
+
+        expect(queryByText('BlockEditorRenderer Error: Invalid prop "blocks"')).toBeNull();
+        expect(consoleSpy).toHaveBeenCalledWith('BlockEditorRenderer Error: Invalid prop "blocks"');
     });
 
     describe('when the editable prop is true', () => {

--- a/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.spec.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.spec.tsx
@@ -53,24 +53,44 @@ describe('BlockEditorRenderer', () => {
         expect(container.firstChild).toHaveStyle('color: red');
     });
 
-    it('should render console error and the invalid blocks message', () => {
-        jest.spyOn(client, 'isInsideEditor').mockImplementation(() => true);
-        const consoleSpy = jest.spyOn(console, 'error');
+    describe('Error Handling', () => {
+        it('should show error message when blocks object is not valid', () => {
+            jest.spyOn(client, 'isInsideEditor').mockImplementation(() => true);
+            const consoleSpy = jest.spyOn(console, 'error');
 
-        const { getByText } = render(<BlockEditorRenderer blocks={{} as Block} />);
+            const { getByText } = render(<BlockEditorRenderer blocks={'' as unknown as Block} />);
 
-        expect(getByText('BlockEditorRenderer Error: Invalid prop "blocks"')).toBeInTheDocument();
-        expect(consoleSpy).toHaveBeenCalledWith('BlockEditorRenderer Error: Invalid prop "blocks"');
-    });
+            expect(
+                getByText('Error: Blocks must be an object, but received: string')
+            ).toBeInTheDocument();
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Error: Blocks must be an object, but received: string'
+            );
+        });
 
-    it('should render console error and not render the invalid blocks message', () => {
-        jest.spyOn(client, 'isInsideEditor').mockImplementation(() => false);
-        const consoleSpy = jest.spyOn(console, 'error');
+        it('should show error message when blocks object dont have a doc type', () => {
+            jest.spyOn(client, 'isInsideEditor').mockImplementation(() => false);
+            const consoleSpy = jest.spyOn(console, 'error');
 
-        const { queryByText } = render(<BlockEditorRenderer blocks={{} as Block} />);
+            const { queryByText } = render(
+                <BlockEditorRenderer blocks={{ content: [] } as unknown as Block} />
+            );
 
-        expect(queryByText('BlockEditorRenderer Error: Invalid prop "blocks"')).toBeNull();
-        expect(consoleSpy).toHaveBeenCalledWith('BlockEditorRenderer Error: Invalid prop "blocks"');
+            expect(queryByText('Error: Blocks must have a doc type')).toBeNull();
+            expect(consoleSpy).toHaveBeenCalledWith('Error: Blocks must have a doc type');
+        });
+
+        it('should show error message when blocks content array is empty', () => {
+            jest.spyOn(client, 'isInsideEditor').mockImplementation(() => false);
+            const consoleSpy = jest.spyOn(console, 'error');
+
+            const { queryByText } = render(
+                <BlockEditorRenderer blocks={{ content: [], type: 'doc' } as unknown as Block} />
+            );
+
+            expect(queryByText('Error: Blocks content is empty')).toBeNull();
+            expect(consoleSpy).toHaveBeenCalledWith('Error: Blocks content is empty');
+        });
     });
 
     describe('when the editable prop is true', () => {

--- a/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.tsx
@@ -55,7 +55,6 @@ export const BlockEditorRenderer = ({
 }: BlockEditorRendererProps) => {
     const ref = useRef<HTMLDivElement>(null);
     const [blockEditorState, setBlockEditorState] = useState<BlockEditorState>({
-        isValid: true,
         error: null
     });
 
@@ -121,15 +120,15 @@ export const BlockEditorRenderer = ({
         const validationResult = isValidBlocks(blocks);
         setBlockEditorState(validationResult);
 
-        if (!validationResult.isValid) {
+        if (validationResult.error) {
             console.error(validationResult.error);
         }
     }, [blocks]);
 
-    if (!blockEditorState.isValid) {
+    if (blockEditorState.error) {
         console.error(blockEditorState.error);
         if (isInsideEditor()) {
-            return <div key="invalid-blocks-message">{blockEditorState.error}</div>;
+            return <div data-testid="invalid-blocks-message">{blockEditorState.error}</div>;
         }
 
         return null;

--- a/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.tsx
+++ b/core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.tsx
@@ -5,7 +5,7 @@ import { initInlineEditing, isInsideEditor } from '@dotcms/client';
 import { BlockEditorBlock } from './item/BlockEditorBlock';
 
 import { DotCMSContentlet } from '../../models';
-import { Block } from '../../models/blocks.interface';
+import { Block, BlockEditorState } from '../../models/blocks.interface';
 import { CustomRenderer } from '../../models/content-node.interface';
 import { isValidBlocks } from '../../utils/utils';
 
@@ -29,11 +29,6 @@ interface NonEditableProps extends BaseProps {
 }
 
 type BlockEditorRendererProps = EditableProps | NonEditableProps;
-
-interface BlockEditorState {
-    isValid: boolean;
-    error: string | null;
-}
 
 /**
  * BlockEditorRenderer component for rendering block editor field.
@@ -113,22 +108,21 @@ export const BlockEditorRenderer = ({
     }, [editable, contentlet, blocks, fieldName]);
 
     /**
-     * Validates the blocks prop and updates the BlockEditorState accordingly.
-     * If blocks is valid, clears any error state.
-     * If blocks is invalid, sets error state and logs error message.
+     * Validates the blocks structure and updates the block editor state.
+     *
+     * This effect:
+     * 1. Validates that blocks have the correct structure (doc type, content array, etc)
+     * 2. Updates the block editor state with validation result
+     * 3. Logs any validation errors to console
+     *
+     * @dependency {Block} blocks - The content blocks to validate
      */
     useEffect(() => {
-        if (isValidBlocks(blocks)) {
-            setBlockEditorState({
-                isValid: true,
-                error: null
-            });
-        } else {
-            setBlockEditorState({
-                isValid: false,
-                error: 'BlockEditorRenderer Error: Invalid prop "blocks"'
-            });
-            console.error('BlockEditorRenderer Error: Invalid prop "blocks"');
+        const validationResult = isValidBlocks(blocks);
+        setBlockEditorState(validationResult);
+
+        if (!validationResult.isValid) {
+            console.error(validationResult.error);
         }
     }, [blocks]);
 

--- a/core-web/libs/sdk/react/src/lib/models/blocks.interface.ts
+++ b/core-web/libs/sdk/react/src/lib/models/blocks.interface.ts
@@ -8,6 +8,7 @@ import { ContentNode } from './content-node.interface';
  */
 export interface Block {
     content: ContentNode[];
+    type: string;
 }
 
 /**

--- a/core-web/libs/sdk/react/src/lib/models/blocks.interface.ts
+++ b/core-web/libs/sdk/react/src/lib/models/blocks.interface.ts
@@ -89,6 +89,5 @@ export enum Blocks {
  * @property {string | null} error - Error message if blocks are invalid, null otherwise
  */
 export interface BlockEditorState {
-    isValid: boolean;
-    error: string | null;
+    error?: string ;
 }

--- a/core-web/libs/sdk/react/src/lib/models/blocks.interface.ts
+++ b/core-web/libs/sdk/react/src/lib/models/blocks.interface.ts
@@ -89,5 +89,5 @@ export enum Blocks {
  * @property {string | null} error - Error message if blocks are invalid, null otherwise
  */
 export interface BlockEditorState {
-    error?: string ;
+    error?: string;
 }

--- a/core-web/libs/sdk/react/src/lib/models/blocks.interface.ts
+++ b/core-web/libs/sdk/react/src/lib/models/blocks.interface.ts
@@ -80,3 +80,15 @@ export enum Blocks {
     TABLE = 'table',
     DOT_CONTENT = 'dotContent'
 }
+
+/**
+ * Represents the validation state of a Block Editor instance
+ *
+ * @interface BlockEditorState
+ * @property {boolean} isValid - Whether the blocks structure is valid
+ * @property {string | null} error - Error message if blocks are invalid, null otherwise
+ */
+export interface BlockEditorState {
+    isValid: boolean;
+    error: string | null;
+}

--- a/core-web/libs/sdk/react/src/lib/utils/utils.ts
+++ b/core-web/libs/sdk/react/src/lib/utils/utils.ts
@@ -1,4 +1,5 @@
 import { ContainerData, DotCMSPageContext } from '../models';
+import { Block } from '../models/blocks.interface';
 
 const endClassMap: Record<number, string> = {
     1: 'col-end-1',
@@ -94,4 +95,19 @@ export const getPositionStyleClasses = (start: number, end: number) => {
         startClass,
         endClass
     };
+};
+
+/**
+ * Validates if the provided blocks object has the correct structure for the Block Editor.
+ *
+ * @param {Block} blocks - The blocks object to validate
+ * @returns {boolean} True if the blocks object is valid, false otherwise
+ */
+export const isValidBlocks = (blocks: Block) => {
+    if (!blocks || typeof blocks !== 'object') return false;
+    if (blocks.type !== 'doc') return false;
+
+    if (!blocks.content || !Array.isArray(blocks.content)) return false;
+
+    return true;
 };

--- a/core-web/libs/sdk/react/src/lib/utils/utils.ts
+++ b/core-web/libs/sdk/react/src/lib/utils/utils.ts
@@ -1,5 +1,5 @@
 import { ContainerData, DotCMSPageContext } from '../models';
-import { Block } from '../models/blocks.interface';
+import { Block, BlockEditorState } from '../models/blocks.interface';
 
 const endClassMap: Record<number, string> = {
     1: 'col-end-1',
@@ -98,16 +98,49 @@ export const getPositionStyleClasses = (start: number, end: number) => {
 };
 
 /**
- * Validates if the provided blocks object has the correct structure for the Block Editor.
+ * Validates the structure of a Block Editor block.
  *
- * @param {Block} blocks - The blocks object to validate
- * @returns {boolean} True if the blocks object is valid, false otherwise
+ * This function checks that:
+ * 1. The blocks parameter is a valid object
+ * 2. The block has a 'doc' type
+ * 3. The block has a valid content array that is not empty
+ *
+ * @param {Block} blocks - The blocks structure to validate
+ * @returns {BlockEditorState} Object containing validation state and any error message
+ * @property {boolean} BlockEditorState.isValid - Whether the blocks structure is valid
+ * @property {string | null} BlockEditorState.error - Error message if invalid, null if valid
  */
-export const isValidBlocks = (blocks: Block) => {
-    if (!blocks || typeof blocks !== 'object') return false;
-    if (blocks.type !== 'doc') return false;
+export const isValidBlocks = (blocks: Block): BlockEditorState => {
+    if (!blocks || typeof blocks !== 'object') {
+        return {
+            isValid: false,
+            error: `Error: Blocks must be an object, but received: ${typeof blocks}`
+        };
+    }
 
-    if (!blocks.content || !Array.isArray(blocks.content)) return false;
+    if (blocks.type !== 'doc') {
+        return {
+            isValid: false,
+            error: 'Error: Blocks must have a doc type'
+        };
+    }
 
-    return true;
+    if (!blocks.content || !Array.isArray(blocks.content)) {
+        return {
+            isValid: false,
+            error: 'Error: Blocks must have a valid content array'
+        };
+    }
+
+    if (blocks.content.length === 0) {
+        return {
+            isValid: false,
+            error: 'Error: Blocks content is empty'
+        };
+    }
+
+    return {
+        isValid: true,
+        error: null
+    };
 };

--- a/core-web/libs/sdk/react/src/lib/utils/utils.ts
+++ b/core-web/libs/sdk/react/src/lib/utils/utils.ts
@@ -113,34 +113,29 @@ export const getPositionStyleClasses = (start: number, end: number) => {
 export const isValidBlocks = (blocks: Block): BlockEditorState => {
     if (!blocks || typeof blocks !== 'object') {
         return {
-            isValid: false,
             error: `Error: Blocks must be an object, but received: ${typeof blocks}`
         };
     }
 
     if (blocks.type !== 'doc') {
         return {
-            isValid: false,
             error: 'Error: Blocks must have a doc type'
         };
     }
 
     if (!blocks.content || !Array.isArray(blocks.content)) {
         return {
-            isValid: false,
             error: 'Error: Blocks must have a valid content array'
         };
     }
 
     if (blocks.content.length === 0) {
         return {
-            isValid: false,
             error: 'Error: Blocks content is empty'
         };
     }
 
     return {
-        isValid: true,
         error: null
     };
 };


### PR DESCRIPTION


https://github.com/user-attachments/assets/1753a058-b9af-4219-a13f-bbac1b716af1



This pull request introduces several changes to the `BlockEditorRenderer` component and its related files to improve validation and error handling for the `blocks` prop. The most important changes include adding a new validation utility, updating the component state to handle validation errors, and adding corresponding tests.

### Enhancements to `BlockEditorRenderer` component:

* [`core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.tsx`](diffhunk://#diff-c9fe945c43e268578d05f50d2302d2ec5caa376720ce5316472bf7663e52cefdL1-R1): Added state management for validation errors and implemented a new effect to validate the `blocks` prop using the `isValidBlocks` utility. If the `blocks` prop is invalid, an error message is logged and displayed conditionally based on the editor context. [[1]](diffhunk://#diff-c9fe945c43e268578d05f50d2302d2ec5caa376720ce5316472bf7663e52cefdL1-R1) [[2]](diffhunk://#diff-c9fe945c43e268578d05f50d2302d2ec5caa376720ce5316472bf7663e52cefdR10) [[3]](diffhunk://#diff-c9fe945c43e268578d05f50d2302d2ec5caa376720ce5316472bf7663e52cefdR33-R37) [[4]](diffhunk://#diff-c9fe945c43e268578d05f50d2302d2ec5caa376720ce5316472bf7663e52cefdR62-R81) [[5]](diffhunk://#diff-c9fe945c43e268578d05f50d2302d2ec5caa376720ce5316472bf7663e52cefdR115-R143)

### New validation utility:

* [`core-web/libs/sdk/react/src/lib/utils/utils.ts`](diffhunk://#diff-24fbd19d63c599f72373e849029ab266457a7c614ab67aca3530d78003506865R2): Introduced the `isValidBlocks` utility function to validate the structure of the `blocks` object, ensuring it has the correct type and content properties. [[1]](diffhunk://#diff-24fbd19d63c599f72373e849029ab266457a7c614ab67aca3530d78003506865R2) [[2]](diffhunk://#diff-24fbd19d63c599f72373e849029ab266457a7c614ab67aca3530d78003506865R99-R113)

### Updates to `Block` interface:

* [`core-web/libs/sdk/react/src/lib/models/blocks.interface.ts`](diffhunk://#diff-a445c20df92ec29029618009247f1300349020a2509376a1975ecfc886212414R11): Added a `type` property to the `Block` interface to support the new validation logic.

### Test enhancements:

* [`core-web/libs/sdk/react/src/lib/components/BlockEditorRenderer/BlockEditorRenderer.spec.tsx`](diffhunk://#diff-00246bf45c5d583e9f0929525d681adc61a351ee44cad8d121a3ef0413be000bR13): Added tests to verify that the `BlockEditorRenderer` component logs an error and conditionally renders an error message when the `blocks` prop is invalid. [[1]](diffhunk://#diff-00246bf45c5d583e9f0929525d681adc61a351ee44cad8d121a3ef0413be000bR13) [[2]](diffhunk://#diff-00246bf45c5d583e9f0929525d681adc61a351ee44cad8d121a3ef0413be000bR56-R75)

This PR fixes: #30962