### PR TITLE
Issue 30933 EsReadOnlyMonitorJob still shows error

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250107RemoveEsReadOnlyMonitorJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250107RemoveEsReadOnlyMonitorJob.java
@@ -1,0 +1,66 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.startup.StartupTask;
+
+import java.util.ArrayList;
+
+public class Task250107RemoveEsReadOnlyMonitorJob implements StartupTask {
+
+
+    private final String JOB_NAME = "EsReadOnlyMonitorJob";
+    private final String TRIGGER_NAME = "trigger29";
+    private final String CRON_TABLE_NAME = "qrtz_excl_cron_triggers";
+    private final String TRIGGER_TABLE_NAME = "qrtz_excl_triggers";
+    private final String JOB_TABLE_NAME = "qrtz_excl_job_details";
+
+    /**
+     * Determines if the task should be forced to run.
+     *
+     * @return true if EsReadOnlyMonitorJob is found, false otherwise.
+     */
+    @Override
+    public boolean forceRun() {
+        String sql=String.format("SELECT * FROM %s WHERE job_name=?", JOB_TABLE_NAME);
+        DotConnect dc=new DotConnect();
+        dc.setSQL(sql);
+
+        dc.addParam(JOB_NAME);
+        try {
+            ArrayList results=dc.loadResults();
+            if (!results.isEmpty()){
+                return true;
+            }
+        } catch (DotDataException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    @Override
+    public void executeUpgrade() throws DotDataException, DotRuntimeException {
+        removeCron();
+        removeTrigger();
+        removeJob();
+    }
+
+    private void removeJob() throws DotDataException {
+        DotConnect dc = new DotConnect();
+        dc.setSQL(String.format("DELETE FROM %s WHERE job_name = %s", JOB_TABLE_NAME, JOB_NAME));
+        dc.loadResult();
+    }
+
+    private void removeTrigger() throws DotDataException {
+        DotConnect dc = new DotConnect();
+        dc.setSQL(String.format("DELETE FROM %s WHERE job_name = %s", TRIGGER_TABLE_NAME, JOB_NAME));
+        dc.loadResult();
+    }
+
+    private void removeCron() throws DotDataException {
+        DotConnect dc = new DotConnect();
+        dc.setSQL(String.format("DELETE FROM %s WHERE trigger_name = %s", CRON_TABLE_NAME, TRIGGER_NAME));
+        dc.loadResult();
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -252,6 +252,7 @@ import com.dotmarketing.startup.runonce.Task241013RemoveFullPathLcColumnFromIden
 import com.dotmarketing.startup.runonce.Task241014AddTemplateValueOnContentletIndex;
 import com.dotmarketing.startup.runonce.Task241015ReplaceLanguagesWithLocalesPortlet;
 import com.dotmarketing.startup.runonce.Task241016AddCustomLanguageVariablesPortletToLayout;
+import com.dotmarketing.startup.runonce.Task250107RemoveEsReadOnlyMonitorJob;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -576,7 +577,8 @@ public class TaskLocatorUtil {
 		.add(Task241013RemoveFullPathLcColumnFromIdentifier.class)
 		.add(Task241014AddTemplateValueOnContentletIndex.class)
 		.add(Task241015ReplaceLanguagesWithLocalesPortlet.class)
-    .add(Task241016AddCustomLanguageVariablesPortletToLayout.class)
+    	.add(Task241016AddCustomLanguageVariablesPortletToLayout.class)
+		.add(Task250107RemoveEsReadOnlyMonitorJob.class)
 		.build();
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
 	}


### PR DESCRIPTION
The job was still in the database, so an upgrade task was created to remove it from the tables that were related to the job.