### PR TITLE
fix: ( datepicker): #31077 PrimeNG Datepicker Displays Incorrectly When Appended to Body 

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_calendar.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_calendar.scss
@@ -60,7 +60,7 @@
     }
 }
 
-.p-calendar .p-datepicker {
+.p-datepicker {
     padding: $spacing-3;
     background: $white;
     color: $black;


### PR DESCRIPTION
### Proposed Changes
* Display datepicker correctly when attached to body. 



### Screenshots
Before: 

<img width="600" alt="image" src="https://github.com/user-attachments/assets/c7b43575-e2f6-4427-adc3-2dd0d8fa3c9a" />

After: 

<img width="603" alt="image" src="https://github.com/user-attachments/assets/d9433050-debd-4920-9a54-e21b53fb391f" />




This PR fixes: #31077