### PR TITLE
#31019: Fixing CubeJSClient expired access token renewal.

### DIFF
--- a/docker/docker-compose-examples/analytics/docker-compose.yml
+++ b/docker/docker-compose-examples/analytics/docker-compose.yml
@@ -124,7 +124,7 @@ services:
       - CUBEJS_DB_PASS=${CH_PWD:-clickhouse_password}
       - CUBEJS_JWK_URL=${JWKS_URL:-http://host.docker.internal:61111/realms/dotcms/protocol/openid-connect/certs}
       - CUBEJS_JWT_AUDIENCE=api-dotcms-analytics-audience
-      - CUBEJS_JWT_ISSUER=${AUTH_SERVER_URL:-http://localhost:61111/realms/dotcms}
+      - CUBEJS_JWT_ISSUER=${AUTH_SERVER_URL:-http://host.docker.internal:61111/realms/dotcms}
       - CUBEJS_JWT_ALGS=RS256
       - CUBEJS_JWT_CLAIMS_NAMESPACE=https://dotcms.com/analytics
       - CUBEJS_LOG_LEVEL=debug

--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/cube.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/cube.js
@@ -1,14 +1,9 @@
-
-
 // cube.js configuration file
 module.exports = {
-    /*
-    contextToAppId: ({ securityContext }) =>
+    /*contextToAppId: ({ securityContext }) =>
         `CUBEJS_APP_${securityContext.customerId}`,
     preAggregationsSchema: ({ securityContext }) =>
-        `pre_aggregations_${securityContext.customerId}`,
-*/
-
+        `pre_aggregations_${securityContext.customerId}`,*/
 
     queryRewrite: (query, { securityContext }) => {
 
@@ -17,7 +12,6 @@ module.exports = {
         }
 
         const tokenData = securityContext["https://dotcms.com/analytics"];
-
         const isRequestQuery = (query.measures + query.dimensions).includes("request.");
 
         if (isRequestQuery) {
@@ -26,7 +20,6 @@ module.exports = {
                 operator: 'equals',
                 values: [tokenData.clusterId],
             });
-
             query.filters.push({
                 member: 'request.customerId',
                 operator: 'equals',
@@ -34,9 +27,7 @@ module.exports = {
             });
         }
 
-
         return query;
     },
-
 
 };

--- a/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
@@ -93,11 +93,13 @@ public class AnalyticsHelper implements EventSubscriber<SystemTableUpdatedKeyEve
      * @return true if current time is in the TTL window
      */
     private boolean filterIssueDate(final AccessToken accessToken, final BiPredicate<Instant, Instant> filter) {
+        final long tokenTtl = Optional.ofNullable(accessToken.expiresIn().longValue()).orElse(accessTokenTtl.get());
         return Optional.ofNullable(accessToken.issueDate())
             .map(issuedAt -> {
                 final Instant now = Instant.now();
-                final Instant expireDate = issuedAt.plusSeconds(accessTokenTtl.get());
-                return now.isBefore(expireDate) && (filter == null || filter.test(now, expireDate));
+                final Instant expireDate = issuedAt.plusSeconds(tokenTtl);
+                return now.isBefore(expireDate) &&
+                        Optional.ofNullable(filter).map(f -> f.test(now, expireDate)).orElse (true);
             })
             .orElseGet(() -> {
                 Logger.warn(AnalyticsHelper.class, "ACCESS_TOKEN does not have a issued date, filtering token out");
@@ -224,12 +226,25 @@ public class AnalyticsHelper implements EventSubscriber<SystemTableUpdatedKeyEve
      * when add in the corresponding header.
      *
      * @param accessToken provided access token
+     * @param type token type (most of times it will be 'Bearer')
+     * @return the actual string value of token for header usage
+     * @throws AnalyticsException when validating token
+     */
+    public String formatToken(final AccessToken accessToken, final String type) throws AnalyticsException {
+        checkAccessToken(accessToken);
+        return StringUtils.defaultIfBlank(type, StringPool.BLANK) + accessToken.accessToken();
+    }
+
+    /**
+     * Extracts actual access token value from {@link AccessToken} and prepends the "Bearer " prefix to be used
+     * when add in the corresponding header.
+     *
+     * @param accessToken provided access token
      * @return the actual string value of token for header usage
      * @throws AnalyticsException when validating token
      */
     public String formatBearer(final AccessToken accessToken) throws AnalyticsException {
-        checkAccessToken(accessToken);
-        return JsonWebTokenAuthCredentialProcessor.BEARER + accessToken.accessToken();
+        return formatToken(accessToken, JsonWebTokenAuthCredentialProcessor.BEARER);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/cube/CubeJSClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cube/CubeJSClient.java
@@ -7,7 +7,6 @@ import com.dotcms.http.CircuitBreakerUrl;
 import com.dotcms.http.CircuitBreakerUrl.Method;
 import com.dotcms.http.CircuitBreakerUrl.Response;
 import com.dotcms.metrics.timing.TimeMetric;
-import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.DotPreconditions;
 import com.dotcms.util.JsonUtil;
 import com.dotmarketing.util.Logger;
@@ -22,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * CubeJS Client it allow to send a Request to a Cube JS Server.
+ * CubeJS Client it allows to send a Request to a Cube JS Server.
  * Example:
  *
  * <code>
@@ -40,7 +39,6 @@ import java.util.Map;
  */
 public class CubeJSClient {
 
-    private int PAGE_SIZE = 1000;
     private final String url;
     private final AccessToken accessToken;
 
@@ -148,9 +146,8 @@ public class CubeJSClient {
      */
     private Map<String, String> cubeJsHeaders(final AccessToken accessToken) throws AnalyticsException {
         return ImmutableMap.<String, String>builder()
-            .put(HttpHeaders.AUTHORIZATION, AnalyticsHelper.get().formatBearer(accessToken))
+            .put(HttpHeaders.AUTHORIZATION, AnalyticsHelper.get().formatToken(accessToken, null))
             .build();
     }
-
 
 }


### PR DESCRIPTION
Several fixes to several causes:
- Using JWT `expiresIn` field to determine if token is expired and adding fallback to dotCMS `ANALYTICS_ACCESSTOKEN_TTL` config value
- Removing `Bearer` prefix from Authorization header since CubeJS does not like it (or end up ignoring it)
- Finally setting `CUBEJS_JWT_ISSUER` env-var at analytics infrastructure docker-compose to 'http://host.docker.internal:61111/realms/dotcms' since most of the times this is run inside a Docker container.

This PR fixes: #31019