### PR TITLE
chore(UVE): Hide Workflow Action Button on Variants

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.html
@@ -34,7 +34,7 @@
         iconPos="right"
         [label]="'more' | dm"
         [class.active]="$isMoreButtonActive()"
-        styleClass="p-button-text p-2"
+        styleClass="p-button-text p-2 p-button-sm"
         (click)="menu.toggle($event)"
         data-testId="more-button" />
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
@@ -1,7 +1,7 @@
 @let preview = $isPreviewMode();
 @let runningExperiment = $toolbar().runningExperiment;
 
-<p-toolbar [styleClass]="$styleToolbarClass()">
+<p-toolbar styleClass="uve-toolbar">
     <div class="p-toolbar-group-start" [ngClass]="{ 'p-0': preview }">
         @if (preview) {
             <ng-container [ngTemplateOutlet]="previewLeftOptionsTemplate"></ng-container>

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
@@ -47,7 +47,7 @@
             #personaSelector
             data-testId="uve-toolbar-persona-selector" />
 
-        @if (!preview) {
+        @if ($showWorkflowActions()) {
             <dot-uve-workflow-actions />
         }
     </div>

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
@@ -105,6 +105,7 @@ const baseUVEState = {
         { id: 2, translated: false },
         { id: 3, translated: true }
     ]),
+    $showWorkflowsActions: signal(true),
     patchViewParams: jest.fn(),
     orientation: signal(''),
     clearDeviceAndSocialMedia: jest.fn(),
@@ -476,6 +477,9 @@ describe('DotUveToolbarComponent', () => {
         });
 
         it('should not have a dot-uve-workflow-actions component', () => {
+            baseUVEState.$showWorkflowsActions.set(false);
+            spectator.detectChanges();
+
             const workflowActions = spectator.query(DotUveWorkflowActionsComponent);
 
             expect(workflowActions).toBeNull();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -99,14 +99,6 @@ export class DotUveToolbarComponent {
 
     protected readonly CURRENT_DATE = new Date();
 
-    readonly $styleToolbarClass = computed(() => {
-        if (!this.$isPreviewMode()) {
-            return 'uve-toolbar';
-        }
-
-        return 'uve-toolbar uve-toolbar-preview';
-    });
-
     protected readonly publishDateParam = this.#store.pageParams().publishDate;
     protected readonly $previewDate = model<Date>(
         this.publishDateParam ? new Date(this.publishDateParam) : null

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -85,6 +85,7 @@ export class DotUveToolbarComponent {
     readonly #deviceService = inject(DotDevicesService);
 
     readonly $toolbar = this.#store.$uveToolbar;
+    readonly $showWorkflowActions = this.#store.$showWorkflowsActions;
     readonly $isPreviewMode = this.#store.$isPreviewMode;
     readonly $apiURL = this.#store.$apiURL;
     readonly $personaSelectorProps = this.#store.$personaSelector;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.spec.ts
@@ -5,8 +5,9 @@ import { of } from 'rxjs';
 
 import { ActivatedRoute, Router } from '@angular/router';
 
+import { UVE_MODE } from '@dotcms/client';
 import { CurrentUser } from '@dotcms/dotcms-js';
-import { DEFAULT_VARIANT_NAME } from '@dotcms/dotcms-models';
+import { DEFAULT_VARIANT_ID, DEFAULT_VARIANT_NAME } from '@dotcms/dotcms-models';
 import { getRunningExperimentMock, mockDotDevices } from '@dotcms/utils-testing';
 
 import { withUVEToolbar } from './withUVEToolbar';
@@ -249,6 +250,48 @@ describe('withEditor', () => {
                     });
 
                     expect(store.$infoDisplayProps()).toBe(null);
+                });
+            });
+
+            describe('$showWorkflowsActions', () => {
+                it('should return false when in preview mode', () => {
+                    patchState(store, {
+                        pageParams: {
+                            ...store.pageParams(),
+                            editorMode: UVE_MODE.PREVIEW
+                        }
+                    });
+                    expect(store.$showWorkflowsActions()).toBe(false);
+                });
+
+                it('should return true when not in preview mode and is default variant', () => {
+                    patchState(store, {
+                        pageParams: {
+                            ...store.pageParams(),
+                            editorMode: UVE_MODE.EDIT
+                        },
+                        pageAPIResponse: {
+                            ...store.pageAPIResponse(),
+                            viewAs: {
+                                ...store.pageAPIResponse().viewAs,
+                                variantId: DEFAULT_VARIANT_ID
+                            }
+                        }
+                    });
+                    expect(store.$showWorkflowsActions()).toBe(true);
+                });
+
+                it('should return false when not in preview mode and is not default variant', () => {
+                    patchState(store, {
+                        pageAPIResponse: {
+                            ...store.pageAPIResponse(),
+                            viewAs: {
+                                ...store.pageAPIResponse().viewAs,
+                                variantId: 'some-other-variant'
+                            }
+                        }
+                    });
+                    expect(store.$showWorkflowsActions()).toBe(false);
                 });
             });
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.ts
@@ -195,6 +195,15 @@ export function withUVEToolbar() {
                 }
 
                 return null;
+            }),
+            $showWorkflowsActions: computed<boolean>(() => {
+                const isPreviewMode = store.pageParams()?.editorMode === UVE_MODE.PREVIEW;
+
+                const isDefaultVariant = getIsDefaultVariant(
+                    store.pageAPIResponse()?.viewAs.variantId
+                );
+
+                return !isPreviewMode && isDefaultVariant;
             })
         })),
         withMethods((store) => ({


### PR DESCRIPTION
This pull request introduces changes to the `core-web` library, specifically within the `edit-ema` portlet, to add functionality for displaying workflow actions based on certain conditions. The most important changes include modifications to the `DotUveToolbarComponent` and its related tests, as well as updates to the `withUVEToolbar` store feature.

### Enhancements to `DotUveToolbarComponent`:

* Modified the HTML template to conditionally display the `dot-uve-workflow-actions` component based on the `$showWorkflowActions` method.
* Added the `$showWorkflowActions` observable to the component class to determine whether to show workflow actions.
* Fix height on preview mode

### Updates to `DotUveToolbarComponent` tests:

* Added a new signal `$showWorkflowsActions` to the `baseUVEState` in the component's spec file.
* Updated the test suite to include a test case for ensuring the `dot-uve-workflow-actions` component is not present when `$showWorkflowsActions` is set to false.

### Changes to `withUVEToolbar` store feature:

* Imported `UVE_MODE` and `DEFAULT_VARIANT_ID` for use in the store feature.
* Added a new computed property `$showWorkflowsActions` to determine whether to show workflow actions based on the editor mode and variant ID.
* Added test cases for the `$showWorkflowsActions` property to ensure correct behavior based on different conditions.

## Screenshots

https://github.com/user-attachments/assets/7f66d8be-2936-43d9-9f8d-495d3250d51d


This PR fixes: #30940