### PR TITLE
#31022 Setting host Id in Url Map events

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/PageDetailCollector.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/PageDetailCollector.java
@@ -95,6 +95,7 @@ public class PageDetailCollector implements Collector {
 
         if (Objects.nonNull(site)) {
             collectorPayloadBean.put(SITE_NAME, site.getHostname());
+            collectorPayloadBean.put(SITE_ID, site.getIdentifier());
         }
         return collectorPayloadBean;
     }

--- a/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/PageDetailCollectorTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/PageDetailCollectorTest.java
@@ -103,6 +103,7 @@ public class PageDetailCollectorTest extends IntegrationTestBase {
         final Map<String, Object> expectedDataMap = Map.of(
                 Collector.EVENT_TYPE, EventType.PAGE_REQUEST.getType(),
                 Collector.SITE_NAME, testSite.getHostname(),
+                Collector.SITE_ID, testSite.getIdentifier(),
                 Collector.LANGUAGE, language.getIsoCode(),
                 Collector.URL, TEST_URL_MAP_DETAIL_PAGE_URL,
                 Collector.OBJECT, Map.of(

--- a/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/Util.java
+++ b/dotcms-integration/src/test/java/com/dotcms/analytics/track/collectors/Util.java
@@ -37,6 +37,7 @@ import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
+import graphql.AssertException;
 import io.vavr.control.Try;
 
 import javax.servlet.http.HttpServletRequest;
@@ -325,6 +326,8 @@ public class Util {
                     assertEquals("Collected value must be equal to expected value for key: " + key,
                             expectedValue, collectedValue);
                 }
+            } else {
+                throw new AssertException("Expected key in the Collected value: " + key);
             }
         }
     }


### PR DESCRIPTION
### Proposed Changes
* Setting conHost in the Url Map events

https://github.com/dotCMS/core/pull/31092/files#diff-ace471e1bb6fabbd5bf415f1a2deb9f5e6c376bfb90522c81a5c680ae2ec2989R98

* Fixing util test methods to compare 2 Map, if the collected Map does not contains a expected key we must failed the test

https://github.com/dotCMS/core/pull/31092/files#diff-0ca21ccadd3dee8d7347179578d8a7e675396246effe31a9f74a302d4142b0d1R329-R330 

This PR fixes: #31022