### PR TITLE
chore(edit-content): Issues with n-1 relationship

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -28,7 +28,7 @@
             [first]="pagination.offset"
             [rows]="pagination.rowsPerPage"
             [scrollable]="true"
-            [globalFilterFields]="['title', 'step', 'description']"
+            [globalFilterFields]="['title']"
             styleClass="dotTable p-datatable-existing-content w-full">
             <ng-template pTemplate="caption">
                 <div class="flex justify-content-between align-items-center w-full">
@@ -140,7 +140,7 @@
             <p-button
                 [label]="'Cancel' | dm"
                 [outlined]="true"
-                (onClick)="cancel()"
+                (onClick)="closeDialog()"
                 [text]="true"
                 severity="primary"
                 data-testId="cancel-button" />

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -140,13 +140,15 @@
             <p-button
                 [label]="'Cancel' | dm"
                 [outlined]="true"
-                (onClick)="closeDialog()"
+                (onClick)="cancel()"
                 [text]="true"
-                severity="primary" />
+                severity="primary"
+                data-testId="cancel-button" />
             <p-button
                 [disabled]="totalItems === 0"
-                (onClick)="closeDialog()"
-                [label]="$applyLabel()" />
+                (onClick)="applyChanges()"
+                [label]="$applyLabel()"
+                data-testId="apply-button" />
         </div>
     </div>
 </div>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
@@ -1,4 +1,4 @@
-import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
+import { Spectator, byTestId, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -12,6 +12,7 @@ import { ExistingContentStore } from './store/existing-content.store';
 
 import { Column } from '../../models/column.model';
 import { RelationshipFieldService } from '../../services/relationship-field.service';
+import { Button } from 'primeng/button';
 
 const mockColumns: Column[] = [
     { field: 'title', header: 'Title' },
@@ -105,7 +106,7 @@ describe('DotSelectExistingContentComponent', () => {
             ];
             spectator.component.$selectedItems.set(mockItems);
 
-            spectator.component.closeDialog();
+            spectator.component.applyChanges();
 
             expect(dialogRef.close).toHaveBeenCalledWith(mockItems);
         });
@@ -113,9 +114,15 @@ describe('DotSelectExistingContentComponent', () => {
         it('should close dialog with empty array when no items selected', () => {
             spectator.component.$selectedItems.set([]);
 
-            spectator.component.closeDialog();
+            spectator.component.applyChanges();
 
             expect(dialogRef.close).toHaveBeenCalledWith([]);
+        });
+
+        it('should close dialog when cancel button is clicked', () => {
+            spectator.component.cancel();
+
+            expect(dialogRef.close).toHaveBeenCalledWith();
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
@@ -1,4 +1,4 @@
-import { Spectator, byTestId, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
+import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -12,7 +12,6 @@ import { ExistingContentStore } from './store/existing-content.store';
 
 import { Column } from '../../models/column.model';
 import { RelationshipFieldService } from '../../services/relationship-field.service';
-import { Button } from 'primeng/button';
 
 const mockColumns: Column[] = [
     { field: 'title', header: 'Title' },

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
@@ -119,7 +119,7 @@ describe('DotSelectExistingContentComponent', () => {
         });
 
         it('should close dialog when cancel button is clicked', () => {
-            spectator.component.cancel();
+            spectator.component.closeDialog();
 
             expect(dialogRef.close).toHaveBeenCalledWith();
         });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -170,7 +170,7 @@ export class DotSelectExistingContentComponent implements OnInit {
      * A method that closes the existing content dialog.
      * It sets the visibility signal to false, hiding the dialog.
      */
-    cancel() {
+    closeDialog() {
         this.#dialogRef.close();
     }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -162,8 +162,16 @@ export class DotSelectExistingContentComponent implements OnInit {
      * A method that closes the existing content dialog.
      * It sets the visibility signal to false, hiding the dialog.
      */
-    closeDialog() {
+    applyChanges() {
         this.#dialogRef.close(this.$items());
+    }
+
+    /**
+     * A method that closes the existing content dialog.
+     * It sets the visibility signal to false, hiding the dialog.
+     */
+    cancel() {
+        this.#dialogRef.close();
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.html
@@ -2,7 +2,6 @@
 @let attributes = $attributes();
 @let showPagination = store.totalPages() > 1;
 @let data = store.data();
-
 @let hitText = attributes.hitText;
 
 <p-table
@@ -12,7 +11,8 @@
     [first]="pagination.offset"
     [rows]="pagination.rowsPerPage"
     [reorderableColumns]="true"
-    [scrollable]="true">
+    [scrollable]="true"
+    (onRowReorder)="onRowReorder($event)">
     <ng-template pTemplate="header" styleClass="relative">
         <p-menu #menu [model]="$menuItems()" [popup]="true" appendTo="body" />
 
@@ -71,8 +71,9 @@
             </td>
         </tr>
     </ng-template>
-    @if (hitText || showPagination) {
-        <ng-template pTemplate="summary">
+
+    <ng-template pTemplate="summary">
+        @if (hitText || showPagination) {
             <div
                 class="flex align-items-center"
                 [class.justify-content-between]="hitText"
@@ -89,6 +90,6 @@
                         [currentPage]="pagination.currentPage" />
                 }
             </div>
-        </ng-template>
-    }
+        }
+    </ng-template>
 </p-table>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts
@@ -254,7 +254,7 @@ export class DotEditContentRelationshipFieldComponent implements ControlValueAcc
 
         this.#dialogRef.onClose
             .pipe(
-                filter((file) => !!file),
+                filter((items) => !!items),
                 takeUntilDestroyed(this.#destroyRef)
             )
             .subscribe((items: DotCMSContentlet[]) => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts
@@ -105,12 +105,6 @@ export class DotEditContentRelationshipFieldComponent implements ControlValueAcc
                 command: () => {
                     this.showExistingContentDialog();
                 }
-            },
-            {
-                label: this.#dotMessageService.get('dot.file.relationship.field.table.new.content'),
-                command: () => {
-                    // TODO: Implement new content
-                }
             }
         ];
     });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts
@@ -16,7 +16,7 @@ import { ButtonModule } from 'primeng/button';
 import { ChipModule } from 'primeng/chip';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { MenuModule } from 'primeng/menu';
-import { TableModule } from 'primeng/table';
+import { TableRowReorderEvent, TableModule } from 'primeng/table';
 
 import { filter } from 'rxjs/operators';
 
@@ -260,5 +260,17 @@ export class DotEditContentRelationshipFieldComponent implements ControlValueAcc
             .subscribe((items: DotCMSContentlet[]) => {
                 this.store.addData(items);
             });
+    }
+
+    /**
+     * Reorders the data in the store.
+     * @param {TableRowReorderEvent} event - The event containing the drag and drop indices.
+     */
+    onRowReorder(event: TableRowReorderEvent) {
+        if (event?.dragIndex == null || event?.dropIndex == null) {
+            return;
+        }
+
+        this.store.reorderData(event.dragIndex, event.dropIndex);
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.constants.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.constants.ts
@@ -1,5 +1,18 @@
 import { RelationshipTypes } from './models/relationship.models';
 
+/**
+ * Maps cardinality numbers to RelationshipTypes enum values.
+ * Used to determine the type of relationship between content types.
+ *
+ * @constant
+ * @type {Record<number, RelationshipTypes>}
+ *
+ * @property {RelationshipTypes} 0 - One-to-Many relationship type
+ * @property {RelationshipTypes} 1 - Many-to-Many relationship type
+ * @property {RelationshipTypes} 2 - One-to-One relationship type
+ * @property {RelationshipTypes} 3 - Many-to-One relationship type
+ */
+
 export const RELATIONSHIP_OPTIONS = {
     0: RelationshipTypes.ONE_TO_MANY,
     1: RelationshipTypes.MANY_TO_MANY,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -130,6 +130,67 @@ describe('RelationshipFieldStore', () => {
                 });
             });
         });
+
+        describe('reorderData', () => {
+            beforeEach(() => {
+                store.setData(mockData);
+            });
+
+            it('should reorder data when moving item up', () => {
+                const currentIndex = 1;
+                const newIndex = 0;
+                store.reorderData(currentIndex, newIndex);
+                
+                const reorderedData = store.data();
+                expect(reorderedData[0].inode).toBe('inode2');
+                expect(reorderedData[1].inode).toBe('inode1');
+                expect(reorderedData[2].inode).toBe('inode3');
+            });
+
+            it('should reorder data when moving item down', () => {
+                const currentIndex = 0;
+                const newIndex = 2;
+                store.reorderData(currentIndex, newIndex);
+                
+                const reorderedData = store.data();
+                expect(reorderedData[0].inode).toBe('inode2');
+                expect(reorderedData[1].inode).toBe('inode3');
+                expect(reorderedData[2].inode).toBe('inode1');
+            });
+
+            it('should not change data when current and new index are the same', () => {
+                const currentIndex = 1;
+                const newIndex = 1;
+                store.reorderData(currentIndex, newIndex);
+                
+                const reorderedData = store.data();
+                expect(reorderedData[0].inode).toBe('inode1');
+                expect(reorderedData[1].inode).toBe('inode2');
+                expect(reorderedData[2].inode).toBe('inode3');
+            });
+
+            it('should handle edge case when moving first item to last position', () => {
+                const currentIndex = 0;
+                const newIndex = mockData.length - 1;
+                store.reorderData(currentIndex, newIndex);
+                
+                const reorderedData = store.data();
+                expect(reorderedData[0].inode).toBe('inode2');
+                expect(reorderedData[1].inode).toBe('inode3');
+                expect(reorderedData[2].inode).toBe('inode1');
+            });
+
+            it('should handle edge case when moving last item to first position', () => {
+                const currentIndex = mockData.length - 1;
+                const newIndex = 0;
+                store.reorderData(currentIndex, newIndex);
+                
+                const reorderedData = store.data();
+                expect(reorderedData[0].inode).toBe('inode3');
+                expect(reorderedData[1].inode).toBe('inode1');
+                expect(reorderedData[2].inode).toBe('inode2');
+            });
+        });
     });
 
     describe('Computed Properties', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -140,7 +140,7 @@ describe('RelationshipFieldStore', () => {
                 const currentIndex = 1;
                 const newIndex = 0;
                 store.reorderData(currentIndex, newIndex);
-                
+
                 const reorderedData = store.data();
                 expect(reorderedData[0].inode).toBe('inode2');
                 expect(reorderedData[1].inode).toBe('inode1');
@@ -151,7 +151,7 @@ describe('RelationshipFieldStore', () => {
                 const currentIndex = 0;
                 const newIndex = 2;
                 store.reorderData(currentIndex, newIndex);
-                
+
                 const reorderedData = store.data();
                 expect(reorderedData[0].inode).toBe('inode2');
                 expect(reorderedData[1].inode).toBe('inode3');
@@ -162,7 +162,7 @@ describe('RelationshipFieldStore', () => {
                 const currentIndex = 1;
                 const newIndex = 1;
                 store.reorderData(currentIndex, newIndex);
-                
+
                 const reorderedData = store.data();
                 expect(reorderedData[0].inode).toBe('inode1');
                 expect(reorderedData[1].inode).toBe('inode2');
@@ -173,7 +173,7 @@ describe('RelationshipFieldStore', () => {
                 const currentIndex = 0;
                 const newIndex = mockData.length - 1;
                 store.reorderData(currentIndex, newIndex);
-                
+
                 const reorderedData = store.data();
                 expect(reorderedData[0].inode).toBe('inode2');
                 expect(reorderedData[1].inode).toBe('inode3');
@@ -184,7 +184,7 @@ describe('RelationshipFieldStore', () => {
                 const currentIndex = mockData.length - 1;
                 const newIndex = 0;
                 store.reorderData(currentIndex, newIndex);
-                
+
                 const reorderedData = store.data();
                 expect(reorderedData[0].inode).toBe('inode3');
                 expect(reorderedData[1].inode).toBe('inode1');

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -104,6 +104,21 @@ export const RelationshipFieldStore = signalStore(
                 patchState(store, { data });
             },
             /**
+             * Reorders the data in the store.
+             * @param {number} dragIndex - The index of the item to be dragged.
+             * @param {number} dropIndex - The index of the item to be dropped.
+             */
+            reorderData(dragIndex: number, dropIndex: number) {
+                const currentData = store.data();
+                const newData = [...currentData];
+                const draggedItem = newData[dragIndex];
+
+                newData.splice(dragIndex, 1);
+                newData.splice(dropIndex, 0, draggedItem);
+
+                patchState(store, { data: newData });
+            },
+            /**
              * Deletes an item from the store at the specified index.
              * @param index - The index of the item to delete.
              */

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts
@@ -8,7 +8,6 @@ import { RelationshipTypes } from '../models/relationship.models';
 describe('Relationship Field Utils', () => {
     describe('getSelectionModeByCardinality', () => {
         it('should return "single" for ONE_TO_ONE relationship', () => {
-            // Find the cardinality value for ONE_TO_ONE
             const oneToOneCardinality = Object.entries(RELATIONSHIP_OPTIONS).find(
                 ([_, value]) => value === RelationshipTypes.ONE_TO_ONE
             )?.[0];
@@ -17,8 +16,16 @@ describe('Relationship Field Utils', () => {
             expect(result).toBe('single');
         });
 
+        it('should return "single" for MANY_TO_ONE relationship', () => {
+            const manyToOneCardinality = Object.entries(RELATIONSHIP_OPTIONS).find(
+                ([_, value]) => value === RelationshipTypes.MANY_TO_ONE
+            )?.[0];
+
+            const result = getSelectionModeByCardinality(Number(manyToOneCardinality));
+            expect(result).toBe('single');
+        });
+
         it('should return "multiple" for ONE_TO_MANY relationship', () => {
-            // Find the cardinality value for ONE_TO_MANY
             const oneToManyCardinality = Object.entries(RELATIONSHIP_OPTIONS).find(
                 ([_, value]) => value === RelationshipTypes.ONE_TO_MANY
             )?.[0];
@@ -28,7 +35,10 @@ describe('Relationship Field Utils', () => {
         });
 
         it('should throw error for invalid cardinality', () => {
-            expect(() => getSelectionModeByCardinality(999)).toThrow('Invalid relationship type');
+            const invalidCardinality = 999;
+            expect(() => getSelectionModeByCardinality(invalidCardinality)).toThrow(
+                `Invalid relationship type for cardinality: ${invalidCardinality}`
+            );
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts
@@ -16,7 +16,11 @@ export function getSelectionModeByCardinality(cardinality: number) {
         throw new Error(`Invalid relationship type for cardinality: ${cardinality}`);
     }
 
-    return relationshipType === RelationshipTypes.ONE_TO_ONE ? 'single' : 'multiple';
+    const isSingleMode =
+        relationshipType === RelationshipTypes.ONE_TO_ONE ||
+        relationshipType === RelationshipTypes.MANY_TO_ONE;
+
+    return isSingleMode ? 'single' : 'multiple';
 }
 
 /**


### PR DESCRIPTION
### Proposed Changes

This pull request includes several changes to the `dot-edit-content-relationship-field` component and its associated utilities. The most important changes include removing an unimplemented command, adding detailed documentation for relationship options, updating test cases to cover additional scenarios, and modifying the logic for determining selection mode based on relationship type.

### Codebase simplification:

* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts`](diffhunk://#diff-5cb2225620beb3baaf219cbfa2241aa934812de8ece62e1d4f7e7747f5f15416L108-L113): Removed the unimplemented command for creating new content.

### Documentation improvements:

* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.constants.ts`](diffhunk://#diff-3d05c0709391bd1cad89094d58009bb0fd9837e83dbfad2c398af210bfadd969R3-R15): Added detailed documentation for the `RELATIONSHIP_OPTIONS` constant, explaining the mapping of cardinality numbers to `RelationshipTypes` enum values.

### Test coverage enhancements:

* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts`](diffhunk://#diff-d895ed8b296eedf36d10492abea40febbb6bf54779bd4fc52d1d1c52256de1bfR19-L21): Added a test case for the `MANY_TO_ONE` relationship type to ensure it returns "single" selection mode.
* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts`](diffhunk://#diff-d895ed8b296eedf36d10492abea40febbb6bf54779bd4fc52d1d1c52256de1bfL31-R41): Improved the error message for invalid cardinality values in the test case.

### Logic updates:

* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts`](diffhunk://#diff-02d1a23439f098900847a8ea3ad106b1eb8d5afe92e08186d7c9b0c82a13e5eaL19-R23): Updated the `getSelectionModeByCardinality` function to include the `MANY_TO_ONE` relationship type in the single mode condition.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)


This PR fixes: #31040