### PR TITLE
Add a preview button to Edit Contentlet

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
@@ -81,6 +81,17 @@
         class="dot-edit-content-actions"
         data-testId="edit-content-actions"
         [class.dot-edit-content-actions--sidebar-open]="showSidebar">
+        @if ($showPreviewLink()) {
+            <button
+                pButton
+                icon="pi pi-external-link"
+                class="p-button-link p-button-md"
+                data-testId="preview-button"
+                (click)="showPreview()">
+                {{ 'edit.content.preview-link' | dm }}
+            </button>
+        }
+
         @if (showWorkflowActions) {
             <dot-workflow-actions
                 data-testId="workflow-actions"

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
@@ -74,20 +74,6 @@ $tab-min-height: 52px;
     transition: all $basic-speed ease-in-out;
 }
 
-.preview-link {
-    display: inline-flex;
-    align-items: center;
-    gap: $spacing-1;
-}
-
-.preview-link .pi {
-    text-decoration: none;
-}
-
-.preview-link:hover {
-    text-decoration: underline;
-}
-
 // PrimeNG Tabview Overrides
 ::ng-deep {
     .tabview-append-content {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
@@ -74,6 +74,20 @@ $tab-min-height: 52px;
     transition: all $basic-speed ease-in-out;
 }
 
+.preview-link {
+    display: inline-flex;
+    align-items: center;
+    gap: $spacing-1;
+}
+
+.preview-link .pi {
+    text-decoration: none;
+}
+
+.preview-link:hover {
+    text-decoration: underline;
+}
+
 // PrimeNG Tabview Overrides
 ::ng-deep {
     .tabview-append-content {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -299,6 +299,7 @@ describe('DotFormComponent', () => {
                 of(MOCK_SINGLE_WORKFLOW_ACTIONS)
             );
             dotWorkflowService.getWorkflowStatus.mockReturnValue(of(MOCK_WORKFLOW_STATUS));
+            workflowActionsFireService.fireTo.mockReturnValue(of(MOCK_CONTENTLET_1_OR_2_TABS));
 
             store.initializeExistingContent({
                 inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -46,6 +46,7 @@ import {
     MOCK_WORKFLOW_ACTIONS_NEW_ITEMNTTYPE_1_TAB,
     MOCK_WORKFLOW_STATUS
 } from '../../utils/edit-content.mock';
+import { generatePreviewUrl } from '../../utils/functions.util';
 import { MockResizeObserver } from '../../utils/mocks';
 
 describe('DotFormComponent', () => {
@@ -374,6 +375,95 @@ describe('DotFormComponent', () => {
                         }
                     }
                 });
+            });
+        });
+    });
+
+    describe('Preview Button', () => {
+        let windowOpenSpy: jest.SpyInstance;
+
+        afterEach(() => {
+            // Restore the original implementation of window.open
+            windowOpenSpy.mockRestore();
+        });
+
+        describe('With URL Map', () => {
+            beforeEach(() => {
+                // Mock window.open
+                windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+                dotContentTypeService.getContentType.mockReturnValue(of(MOCK_CONTENTTYPE_2_TABS));
+                dotEditContentService.getContentById.mockReturnValue(
+                    of({
+                        ...MOCK_CONTENTLET_1_OR_2_TABS,
+                        URL_MAP_FOR_CONTENT: '/blog/post/5-snow-sports-to-try-this-winter'
+                    })
+                );
+                workflowActionsService.getByInode.mockReturnValue(
+                    of(MOCK_WORKFLOW_ACTIONS_NEW_ITEMNTTYPE_1_TAB)
+                );
+                workflowActionsService.getWorkFlowActions.mockReturnValue(
+                    of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+                );
+                dotWorkflowService.getWorkflowStatus.mockReturnValue(of(MOCK_WORKFLOW_STATUS));
+
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,
+                    depth: DotContentletDepths.ONE
+                });
+                spectator.detectChanges();
+            });
+            it('should render the preview button when $showPreviewLink is true', () => {
+                const previewButton = spectator.query(byTestId('preview-button'));
+                expect(previewButton).toBeTruthy();
+            });
+
+            it('should call showPreview when the preview button is clicked', () => {
+                const showPreviewSpy = jest.spyOn(component, 'showPreview');
+                const previewButton = spectator.query(byTestId('preview-button'));
+
+                spectator.click(previewButton);
+
+                expect(showPreviewSpy).toHaveBeenCalled();
+            });
+
+            it('should call window.open when showPreview is executed', () => {
+                const expectedUrl = generatePreviewUrl({
+                    ...MOCK_CONTENTLET_1_OR_2_TABS,
+                    URL_MAP_FOR_CONTENT: '/blog/post/5-snow-sports-to-try-this-winter'
+                });
+                component.showPreview();
+                expect(windowOpenSpy).toHaveBeenCalledWith(expectedUrl, '_blank');
+            });
+        });
+
+        describe('Without URL Map', () => {
+            beforeEach(() => {
+                // Mock window.open
+                windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+                dotContentTypeService.getContentType.mockReturnValue(of(MOCK_CONTENTTYPE_2_TABS));
+                dotEditContentService.getContentById.mockReturnValue(
+                    of(MOCK_CONTENTLET_1_OR_2_TABS)
+                );
+                workflowActionsService.getByInode.mockReturnValue(
+                    of(MOCK_WORKFLOW_ACTIONS_NEW_ITEMNTTYPE_1_TAB)
+                );
+                workflowActionsService.getWorkFlowActions.mockReturnValue(
+                    of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+                );
+                dotWorkflowService.getWorkflowStatus.mockReturnValue(of(MOCK_WORKFLOW_STATUS));
+
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,
+                    depth: DotContentletDepths.ONE
+                });
+                spectator.detectChanges();
+            });
+
+            it('should not render the preview button when $showPreviewLink is false', () => {
+                const previewButton = spectator.query(byTestId('preview-button'));
+                expect(previewButton).toBeFalsy();
             });
         });
     });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -408,12 +408,14 @@ export class DotEditContentFormComponent implements OnInit {
         const contentlet = this.$store.contentlet();
         const realUrl = generatePreviewUrl(contentlet);
 
-        if (realUrl) {
-            window.open(realUrl, '_blank');
-        } else {
+        if (!realUrl) {
             console.warn(
                 'Preview URL could not be generated due to missing contentlet attributes.'
             );
+
+            return;
         }
+
+        window.open(realUrl, '_blank');
     }
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -24,7 +24,7 @@ import { ButtonModule } from 'primeng/button';
 import { TabViewModule } from 'primeng/tabview';
 
 import { DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
-import { DotWorkflowActionsComponent } from '@dotcms/ui';
+import { DotMessagePipe, DotWorkflowActionsComponent } from '@dotcms/ui';
 
 import { resolutionValue } from './utils';
 
@@ -38,7 +38,11 @@ import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
 import { FormValues } from '../../models/dot-edit-content-form.interface';
 import { DotWorkflowActionParams } from '../../models/dot-edit-content.model';
 import { DotEditContentStore } from '../../store/edit-content.store';
-import { getFinalCastedValue, isFilteredType } from '../../utils/functions.util';
+import {
+    generatePreviewUrl,
+    getFinalCastedValue,
+    isFilteredType
+} from '../../utils/functions.util';
 import { DotEditContentFieldComponent } from '../dot-edit-content-field/dot-edit-content-field.component';
 
 /**
@@ -75,7 +79,8 @@ import { DotEditContentFieldComponent } from '../dot-edit-content-field/dot-edit
         TabViewModule,
         DotWorkflowActionsComponent,
         TabViewInsertDirective,
-        NgTemplateOutlet
+        NgTemplateOutlet,
+        DotMessagePipe
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,
     animations: [
@@ -114,6 +119,17 @@ export class DotEditContentFormComponent implements OnInit {
     $formFields = computed(
         () => this.$store.contentType()?.fields?.filter((field) => !isFilteredType(field)) ?? []
     );
+
+    /**
+     * Computed property that determines if the preview link should be shown.
+     *
+     * @memberof DotEditContentFormComponent
+     */
+    $showPreviewLink = computed(() => {
+        const contentlet = this.$store.contentlet();
+
+        return contentlet?.baseType === 'CONTENT' && !!contentlet.URL_MAP_FOR_CONTENT;
+    });
 
     /**
      * FormGroup instance that contains the form controls for the fields in the content type
@@ -381,5 +397,19 @@ export class DotEditContentFormComponent implements OnInit {
         this.#router.navigate([CONTENT_SEARCH_ROUTE], {
             queryParams: { filter: contentTypeVariable }
         });
+    }
+
+    /**
+     * Opens the preview URL in a new browser tab.
+     *
+     * @memberof DotEditContentFormComponent
+     */
+    showPreview(): void {
+        const contentlet = this.$store.contentlet();
+
+        if (contentlet) {
+            const realUrl = generatePreviewUrl(contentlet);
+            window.open(realUrl, '_blank');
+        }
     }
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -406,10 +406,14 @@ export class DotEditContentFormComponent implements OnInit {
      */
     showPreview(): void {
         const contentlet = this.$store.contentlet();
+        const realUrl = generatePreviewUrl(contentlet);
 
-        if (contentlet) {
-            const realUrl = generatePreviewUrl(contentlet);
+        if (realUrl) {
             window.open(realUrl, '_blank');
+        } else {
+            console.warn(
+                'Preview URL could not be generated due to missing contentlet attributes.'
+            );
         }
     }
 }

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 
 import {
+    DotCMSContentlet,
     DotCMSContentTypeField,
     DotCMSContentTypeFieldVariable,
     DotLanguage
@@ -10,6 +11,7 @@ import { MOCK_CONTENTTYPE_2_TABS, MOCK_FORM_CONTROL_FIELDS } from './edit-conten
 import * as functionsUtil from './functions.util';
 import {
     createPaths,
+    generatePreviewUrl,
     getFieldVariablesParsed,
     getPersistSidebarState,
     isFilteredType,
@@ -713,6 +715,51 @@ describe('Utils Functions', () => {
             const result = sortLocalesTranslatedFirst(locales);
 
             expect(result).toEqual(locales);
+        });
+    });
+
+    describe('generatePreviewUrl', () => {
+        it('should generate the correct preview URL when all attributes are present', () => {
+            const contentlet = {
+                URL_MAP_FOR_CONTENT: '/blog/post/5-snow-sports-to-try-this-winter',
+                host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
+                languageId: 1
+            } as unknown as DotCMSContentlet;
+
+            const expectedUrl =
+                'http://localhost/dotAdmin/#/edit-page/content?url=%2Fblog%2Fpost%2F5-snow-sports-to-try-this-winter%3Fhost_id%3D48190c8c-42c4-46af-8d1a-0cd5db894797&language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit';
+
+            expect(generatePreviewUrl(contentlet)).toBe(expectedUrl);
+        });
+
+        it('should return an empty string if URL_MAP_FOR_CONTENT is missing', () => {
+            const contentlet = {
+                URL_MAP_FOR_CONTENT: undefined,
+                host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
+                languageId: 1
+            } as unknown as DotCMSContentlet;
+
+            expect(generatePreviewUrl(contentlet)).toBe('');
+        });
+
+        it('should return an empty string if host is missing', () => {
+            const contentlet = {
+                URL_MAP_FOR_CONTENT: '/blog/post/5-snow-sports-to-try-this-winter',
+                host: undefined,
+                languageId: 1
+            } as unknown as DotCMSContentlet;
+
+            expect(generatePreviewUrl(contentlet)).toBe('');
+        });
+
+        it('should return an empty string if languageId is missing', () => {
+            const contentlet = {
+                URL_MAP_FOR_CONTENT: '/blog/post/5-snow-sports-to-try-this-winter',
+                host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
+                languageId: undefined
+            } as unknown as DotCMSContentlet;
+
+            expect(generatePreviewUrl(contentlet)).toBe('');
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -5,6 +5,7 @@ import {
     DotCMSContentTypeFieldVariable,
     DotLanguage
 } from '@dotcms/dotcms-models';
+import { createFakeContentlet } from '@dotcms/utils-testing';
 
 import { MOCK_CONTENTTYPE_2_TABS, MOCK_FORM_CONTROL_FIELDS } from './edit-content.mock';
 import * as functionsUtil from './functions.util';
@@ -21,7 +22,6 @@ import {
 } from './functions.util';
 import { CALENDAR_FIELD_TYPES, JSON_FIELD_MOCK, MULTIPLE_TABS_MOCK } from './mocks';
 
-import { createFakeContentlet } from '../../../../utils-testing/src/lib/dot-contentlet.mock';
 import { FLATTENED_FIELD_TYPES } from '../models/dot-edit-content-field.constant';
 import { DotEditContentFieldSingleSelectableDataType } from '../models/dot-edit-content-field.enum';
 import { NON_FORM_CONTROL_FIELD_TYPES } from '../models/dot-edit-content-form.enum';

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from '@jest/globals';
 
 import {
-    DotCMSContentlet,
     DotCMSContentTypeField,
     DotCMSContentTypeFieldVariable,
     DotLanguage
@@ -22,6 +21,7 @@ import {
 } from './functions.util';
 import { CALENDAR_FIELD_TYPES, JSON_FIELD_MOCK, MULTIPLE_TABS_MOCK } from './mocks';
 
+import { createFakeContentlet } from '../../../../utils-testing/src/lib/dot-contentlet.mock';
 import { FLATTENED_FIELD_TYPES } from '../models/dot-edit-content-field.constant';
 import { DotEditContentFieldSingleSelectableDataType } from '../models/dot-edit-content-field.enum';
 import { NON_FORM_CONTROL_FIELD_TYPES } from '../models/dot-edit-content-form.enum';
@@ -720,11 +720,11 @@ describe('Utils Functions', () => {
 
     describe('generatePreviewUrl', () => {
         it('should generate the correct preview URL when all attributes are present', () => {
-            const contentlet = {
+            const contentlet = createFakeContentlet({
                 URL_MAP_FOR_CONTENT: '/blog/post/5-snow-sports-to-try-this-winter',
                 host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
                 languageId: 1
-            } as unknown as DotCMSContentlet;
+            });
 
             const expectedUrl =
                 'http://localhost/dotAdmin/#/edit-page/content?url=%2Fblog%2Fpost%2F5-snow-sports-to-try-this-winter%3Fhost_id%3D48190c8c-42c4-46af-8d1a-0cd5db894797&language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit';
@@ -733,31 +733,31 @@ describe('Utils Functions', () => {
         });
 
         it('should return an empty string if URL_MAP_FOR_CONTENT is missing', () => {
-            const contentlet = {
+            const contentlet = createFakeContentlet({
                 URL_MAP_FOR_CONTENT: undefined,
                 host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
                 languageId: 1
-            } as unknown as DotCMSContentlet;
+            });
 
             expect(generatePreviewUrl(contentlet)).toBe('');
         });
 
         it('should return an empty string if host is missing', () => {
-            const contentlet = {
+            const contentlet = createFakeContentlet({
                 URL_MAP_FOR_CONTENT: '/blog/post/5-snow-sports-to-try-this-winter',
                 host: undefined,
                 languageId: 1
-            } as unknown as DotCMSContentlet;
+            });
 
             expect(generatePreviewUrl(contentlet)).toBe('');
         });
 
         it('should return an empty string if languageId is missing', () => {
-            const contentlet = {
+            const contentlet = createFakeContentlet({
                 URL_MAP_FOR_CONTENT: '/blog/post/5-snow-sports-to-try-this-winter',
                 host: '48190c8c-42c4-46af-8d1a-0cd5db894797',
                 languageId: undefined
-            } as unknown as DotCMSContentlet;
+            });
 
             expect(generatePreviewUrl(contentlet)).toBe('');
         });

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -321,8 +321,7 @@ export const generatePreviewUrl = (contentlet: DotCMSContentlet): string => {
         contentlet.languageId === undefined
     ) {
         console.warn('Missing required contentlet attributes to generate preview URL');
-
-        return '';
+        return ''; // Return an empty string or handle as needed
     }
 
     const baseUrl = `${window.location.origin}/dotAdmin/#/edit-page/content`;

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -297,7 +297,6 @@ export const transformFormDataFn = (contentType: DotCMSContentType): Tab[] => {
 };
 
 /**
-<<<<<<< HEAD
  * Sorts an array of locales, placing translated locales first.
  *
  * @param {DotLanguage[]} locales - The array of locales to be sorted.
@@ -308,8 +307,9 @@ export const sortLocalesTranslatedFirst = (locales: DotLanguage[]): DotLanguage[
     const untranslatedLocales = locales.filter((locale) => !locale.translated);
 
     return [...translatedLocales, ...untranslatedLocales];
-=======
- * Generates a preview URL for a given contentlet.
+};
+
+/* Generates a preview URL for a given contentlet.
  *
  * @param {DotCMSContentlet} contentlet - The contentlet object containing the necessary data.
  * @returns {string} The generated preview URL.
@@ -328,15 +328,10 @@ export const generatePreviewUrl = (contentlet: DotCMSContentlet): string => {
     const baseUrl = `${window.location.origin}/dotAdmin/#/edit-page/content`;
     const params = new URLSearchParams();
 
-<<<<<<< HEAD
-    return `${baseUrl}?url=${url}%3Fhost_id%3D${hostId}&language_id=${languageId}&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit`;
->>>>>>> 1c803c0496 (fix(edit-content) add preview butto)
-=======
     params.set('url', `${contentlet.URL_MAP_FOR_CONTENT}?host_id=${contentlet.host}`);
     params.set('language_id', contentlet.languageId.toString());
     params.set('com.dotmarketing.persona.id', 'modes.persona.no.persona');
     params.set('editorMode', 'edit');
 
     return `${baseUrl}?${params.toString()}`;
->>>>>>> 303337fee7 (feat(edit-content) fix comments)
 };

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -321,14 +321,22 @@ export const generatePreviewUrl = (contentlet: DotCMSContentlet): string => {
         contentlet.languageId === undefined
     ) {
         console.warn('Missing required contentlet attributes to generate preview URL');
-        return ''; // Return an empty string or handle as needed
+
+        return '';
     }
 
     const baseUrl = `${window.location.origin}/dotAdmin/#/edit-page/content`;
-    const url = encodeURIComponent(contentlet.URL_MAP_FOR_CONTENT);
-    const hostId = contentlet.host;
-    const languageId = contentlet.languageId;
+    const params = new URLSearchParams();
 
+<<<<<<< HEAD
     return `${baseUrl}?url=${url}%3Fhost_id%3D${hostId}&language_id=${languageId}&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit`;
 >>>>>>> 1c803c0496 (fix(edit-content) add preview butto)
+=======
+    params.set('url', `${contentlet.URL_MAP_FOR_CONTENT}?host_id=${contentlet.host}`);
+    params.set('language_id', contentlet.languageId.toString());
+    params.set('com.dotmarketing.persona.id', 'modes.persona.no.persona');
+    params.set('editorMode', 'edit');
+
+    return `${baseUrl}?${params.toString()}`;
+>>>>>>> 303337fee7 (feat(edit-content) fix comments)
 };

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -315,6 +315,16 @@ export const sortLocalesTranslatedFirst = (locales: DotLanguage[]): DotLanguage[
  * @returns {string} The generated preview URL.
  */
 export const generatePreviewUrl = (contentlet: DotCMSContentlet): string => {
+    if (
+        !contentlet.URL_MAP_FOR_CONTENT ||
+        !contentlet.host ||
+        contentlet.languageId === undefined
+    ) {
+        console.warn('Missing required contentlet attributes to generate preview URL');
+
+        return '';
+    }
+
     const baseUrl = `${window.location.origin}/dotAdmin/#/edit-page/content`;
     const url = encodeURIComponent(contentlet.URL_MAP_FOR_CONTENT);
     const hostId = contentlet.host;

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -1,4 +1,5 @@
 import {
+    DotCMSContentlet,
     DotCMSContentType,
     DotCMSContentTypeField,
     DotCMSContentTypeFieldVariable,
@@ -296,6 +297,7 @@ export const transformFormDataFn = (contentType: DotCMSContentType): Tab[] => {
 };
 
 /**
+<<<<<<< HEAD
  * Sorts an array of locales, placing translated locales first.
  *
  * @param {DotLanguage[]} locales - The array of locales to be sorted.
@@ -306,4 +308,18 @@ export const sortLocalesTranslatedFirst = (locales: DotLanguage[]): DotLanguage[
     const untranslatedLocales = locales.filter((locale) => !locale.translated);
 
     return [...translatedLocales, ...untranslatedLocales];
+=======
+ * Generates a preview URL for a given contentlet.
+ *
+ * @param {DotCMSContentlet} contentlet - The contentlet object containing the necessary data.
+ * @returns {string} The generated preview URL.
+ */
+export const generatePreviewUrl = (contentlet: DotCMSContentlet): string => {
+    const baseUrl = `${window.location.origin}/dotAdmin/#/edit-page/content`;
+    const url = encodeURIComponent(contentlet.URL_MAP_FOR_CONTENT);
+    const hostId = contentlet.host;
+    const languageId = contentlet.languageId;
+
+    return `${baseUrl}?url=${url}%3Fhost_id%3D${hostId}&language_id=${languageId}&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit`;
+>>>>>>> 1c803c0496 (fix(edit-content) add preview butto)
 };

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5926,4 +5926,4 @@ uve.preview.mode.search.engine.subheader=Search Engine
 
 coming.soon=Coming Soon
 
-edit.content.preview.link=Preview Link
+edit.content.preview.link=Preview

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5925,3 +5925,5 @@ uve.preview.mode.search.engine.subheader=Search Engine
 
 
 coming.soon=Coming Soon
+
+edit.content.preview.link=Preview Link


### PR DESCRIPTION
### Proposed Changes
* Add a preview button to Edit Contentlet

This pull request introduces a new feature to show a preview link in the content editing form, along with the necessary styling and tests. The most important changes include adding the preview button, updating the styles, and writing tests for the new functionality. 

### New Feature: Preview Link

* Added a preview button in the `dot-edit-content-form.component.html` that appears conditionally based on the `$showPreviewLink` property.
* Defined the `$showPreviewLink` computed property to determine whether the preview link should be shown based on the contentlet's properties.
* Implemented the `showPreview` method to open the preview URL in a new browser tab.

### Styling

* Added CSS styles for the preview link button in `dot-edit-content-form.component.scss` to ensure proper alignment and appearance.

### Testing

* Added tests in `dot-edit-content-form.component.spec.ts` to verify the rendering and functionality of the preview button, including cases with and without a URL map.

### Utility Function

* Created a `generatePreviewUrl` function in `functions.util.ts` to generate the preview URL based on the contentlet's properties.

### Miscellaneous

* Updated imports in `dot-edit-content-form.component.ts` to include the new utility function and `DotMessagePipe`. [[1]](diffhunk://#diff-52fdc67adc70be54cf6c07ee18c9340c26cbf50a4d8fe5ed14a21d33def30a23L27-R27) [[2]](diffhunk://#diff-52fdc67adc70be54cf6c07ee18c9340c26cbf50a4d8fe5ed14a21d33def30a23L41-R45) [[3]](diffhunk://#diff-52fdc67adc70be54cf6c07ee18c9340c26cbf50a4d8fe5ed14a21d33def30a23L78-R83)

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

This PR fixes: #30797