### PR TITLE
 fix(UVE): Add correct label to bookmark on old toolbar 

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.html
@@ -6,7 +6,7 @@
     (click)="toggleBookmark()"
     [icon]="bookmarked() ? 'pi pi-star-fill' : 'pi pi-star'"
     [loading]="loading()"
-    [label]="previewMode ? null : ('editpage.toolbar.bookmark.preview' | dm)"
+    [label]="previewMode ? null : ('editpage.toolbar.bookmark' | dm)"
     styleClass="p-button-text p-button-sm "
     [class.p-button-rounded]="previewMode"
     data-testId="bookmark-button" />

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.spec.ts
@@ -21,6 +21,11 @@ import { DotEmaBookmarksComponent } from './dot-ema-bookmarks.component';
 import { mockCurrentUser } from '../../../../../shared/mocks';
 import { UVEStore } from '../../../../../store/dot-uve.store';
 
+const mockStore = {
+    $previewMode: signal(false),
+    currentUser: signal(mockCurrentUser)
+};
+
 describe('DotEmaBookmarksComponent', () => {
     let spectator: Spectator<DotEmaBookmarksComponent>;
 
@@ -30,10 +35,7 @@ describe('DotEmaBookmarksComponent', () => {
         providers: [
             DialogService,
             HttpClient,
-            mockProvider(UVEStore, {
-                $previewMode: signal(false),
-                currentUser: signal(mockCurrentUser)
-            }),
+            mockProvider(UVEStore, mockStore),
             {
                 provide: LoginService,
                 useClass: LoginServiceMock
@@ -126,34 +128,20 @@ describe('DotEmaBookmarksComponent', () => {
     });
 
     it('should have a label when preview mode is false', () => {
-        const store = spectator.inject(UVEStore, true);
-        jest.spyOn(store, '$previewMode').mockReturnValue(signal(false));
-
         spectator.detectChanges();
         const button = spectator.debugElement.query(By.css('[data-testId="bookmark-button"]'));
 
-        expect(button.componentInstance.textContent).toBe('editpage.toolbar.bookmark');
+        expect(button.nativeElement.textContent).toBe('editpage.toolbar.bookmark');
     });
 
     describe('preview mode', () => {
         it('should render the bookmark button with new UVE toolbar style when preview mode is true', () => {
-            const store = spectator.inject(UVEStore, true);
-            jest.spyOn(store, '$previewMode').mockReturnValue(signal(true));
+            mockStore.$previewMode.set(true);
 
             spectator.detectChanges();
             const button = spectator.debugElement.query(By.css('[data-testId="bookmark-button"]'));
 
-            expect(button.componentInstance.textContent).toBe(undefined);
-        });
-
-        it('should not have a label when preview mode is true', () => {
-            const store = spectator.inject(UVEStore, true);
-            jest.spyOn(store, '$previewMode').mockReturnValue(signal(true));
-
-            spectator.detectChanges();
-            const button = spectator.debugElement.query(By.css('[data-testId="bookmark-button"]'));
-
-            expect(button.componentInstance.textContent).toBe(undefined);
+            expect(button.nativeElement.textContent).toBe('');
         });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.spec.ts
@@ -125,8 +125,28 @@ describe('DotEmaBookmarksComponent', () => {
         );
     });
 
+    it('should have a label when preview mode is false', () => {
+        const store = spectator.inject(UVEStore, true);
+        jest.spyOn(store, '$previewMode').mockReturnValue(signal(false));
+
+        spectator.detectChanges();
+        const button = spectator.debugElement.query(By.css('[data-testId="bookmark-button"]'));
+
+        expect(button.componentInstance.textContent).toBe('editpage.toolbar.bookmark');
+    });
+
     describe('preview mode', () => {
         it('should render the bookmark button with new UVE toolbar style when preview mode is true', () => {
+            const store = spectator.inject(UVEStore, true);
+            jest.spyOn(store, '$previewMode').mockReturnValue(signal(true));
+
+            spectator.detectChanges();
+            const button = spectator.debugElement.query(By.css('[data-testId="bookmark-button"]'));
+
+            expect(button.componentInstance.textContent).toBe(undefined);
+        });
+
+        it('should not have a label when preview mode is true', () => {
             const store = spectator.inject(UVEStore, true);
             jest.spyOn(store, '$previewMode').mockReturnValue(signal(true));
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.ts
@@ -1,4 +1,3 @@
-import { HttpClient } from '@angular/common/http';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -34,7 +33,6 @@ export class DotEmaBookmarksComponent implements OnInit {
     @Input() url = '';
 
     private readonly dotFavoritePageService = inject(DotFavoritePageService);
-    private readonly http = inject(HttpClient);
     private readonly dialogService = inject(DialogService);
     private readonly dotMessageService = inject(DotMessageService);
     private readonly destroyRef = inject(DestroyRef);


### PR DESCRIPTION
This pull request includes changes to the `DotEmaBookmarksComponent` to adjust the label behavior based on the preview mode and to add corresponding test cases. The most important changes include updating the label logic and adding tests to ensure the correct label is displayed in different preview modes.

Label logic update:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.html`](diffhunk://#diff-73e6c9911b8aabc7460882885c63c407a12739d276a9cfbf8e68a159dbc0f6bbL9-R9): Modified the label to be `editpage.toolbar.bookmark` when not in preview mode.

Test cases addition:


* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.spec.ts`](diffhunk://#diff-0f88ad4304e13721edc116c3da29e02ab5e79004a21b2cbdab6e9c57e7ca772dR128-R137): Added a test to check that the label is present when preview mode is false.
* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.spec.ts`](diffhunk://#diff-0f88ad4304e13721edc116c3da29e02ab5e79004a21b2cbdab6e9c57e7ca772dR148-R157): Added a test to check that the label is not present when preview mode is true.

## Screenshots
<img width="409" alt="Screenshot 2025-01-13 at 5 30 34 PM" src="https://github.com/user-attachments/assets/b77ae2e3-e0a1-4dc1-8ef6-b684df85d835" />

This PR fixes: #31095