### PR TITLE
#31107 adding first draft to avoid to show separators wf by default

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowActionSeparatorForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowActionSeparatorForm.java
@@ -1,0 +1,29 @@
+package com.dotcms.rest.api.v1.workflow;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Encapsulate the form for the WorkflowActionSeparator
+ * @author jsanca
+ */
+public class WorkflowActionSeparatorForm {
+
+    private final String schemeId;
+    private final String stepId;
+
+    @JsonCreator
+    public WorkflowActionSeparatorForm(@JsonProperty("schemeId") final String schemeId,
+                                       @JsonProperty("stepId") final String stepId) {
+        this.schemeId = schemeId;
+        this.stepId = stepId;
+    }
+
+    public String getSchemeId() {
+        return schemeId;
+    }
+
+    public String getStepId() {
+        return stepId;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
@@ -1677,6 +1677,63 @@ public class WorkflowResource {
     } // save
 
     /**
+     * Saves an action separator to a schema and step.
+     * @param request               {@link HttpServletRequest}
+     * @param response              {@link HttpServletResponse}
+     * @param workflowActionForm    {@link WorkflowActionSeparatorForm}
+     * @return Response
+     */
+    @POST
+    @Path("/actions/separator")
+    @JSONP
+    @NoCache
+    @Consumes({MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+    @Operation(operationId = "addSeparatorAction", summary = "Creates workflow action separator",
+            description = "Creates a [workflow action] separator(https://www.dotcms.com/docs/latest/managing-workflows#Actions) " +
+                    "from the properties specified in the payload. Returns the created workflow action.",
+            tags = {"Workflow"},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Workflow action created successfully",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = WorkflowAction.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Bad request"),
+                    @ApiResponse(responseCode = "415", description = "Unsupported Media Type")
+            }
+    )
+    public final WorkflowActionView addSeparatorAction(@Context final HttpServletRequest request,
+                                     @Context final HttpServletResponse response,
+                                     @RequestBody(
+                                             description = "Body consists of a JSON object containing " +
+                                                     "a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) " +
+                                                     "form. This includes the following properties:\n\n" +
+                                                     "| Property | Type | Description |\n" +
+                                                     "|-|-|-|\n" +
+                                                     "| `schemeId` | String | The [workflow scheme](https://www.dotcms.com/docs/latest" +
+                                                     "/managing-workflows#Schemes) under which the action will be created. |\n" +
+                                                     "| `stepId` | String |  The [workflow step](https://www.dotcms.com/docs/latest",
+                                             required = true,
+                                             content = @Content(
+                                                     schema = @Schema(implementation = WorkflowActionSeparatorForm.class)
+                                             )
+                                     ) final WorkflowActionSeparatorForm workflowActionForm) throws NotFoundException {
+
+        final InitDataObject initDataObject = this.webResource.init
+                (null, request, response, true, null);
+
+        Logger.debug(this, ()-> "Saving new workflow action separator to the scheme id: " + workflowActionForm.getSchemeId() +
+                " and step id: " + workflowActionForm.getStepId());
+        DotPreconditions.notNull(workflowActionForm,"Expected Request body was empty.");
+        final WorkflowActionForm.Builder builder = new WorkflowActionForm.Builder();
+        builder.separator(workflowActionForm.getSchemeId(), workflowActionForm.getStepId());
+        builder.whoCanUse(Collections.emptyList());
+        final WorkflowAction newAction = this.workflowHelper.saveAction(builder.build(), initDataObject.getUser());
+        return toWorkflowActionView(newAction);
+    } // addSeparatorAction
+
+    /**
      * Updates an existing action
      * @param request HttpServletRequest
      * @param actionId String
@@ -5190,7 +5247,7 @@ public class WorkflowResource {
      * @return Response
      */
     @GET
-    @Path("/initialactions/contenttype/{contentTypeId}")
+        @Path("/initialactions/contenttype/{contentTypeId}")
     @JSONP
     @NoCache
     @Produces({MediaType.APPLICATION_JSON, "application/javascript"})

--- a/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
@@ -1935,8 +1935,11 @@ public class WorkflowHelper {
     }
 
     private boolean isNotWorkflowSeparator(final WorkflowAction workflowAction) {
-        return Objects.isNull(workflowAction) && UtilMethods.isSet(workflowAction.getMetadata())
-                && !workflowAction.getMetadata().containsKey("subtype") && !WorkflowAction.SEPARATOR.equals(workflowAction.getMetadata().get("subtype"));
+
+        final boolean isSeparator = Objects.nonNull(workflowAction) && UtilMethods.isSet(workflowAction.getMetadata())
+                && workflowAction.getMetadata().containsKey("subtype") && WorkflowAction.SEPARATOR.equals(workflowAction.getMetadata().get("subtype"));
+
+        return !isSeparator;
     }
 
 

--- a/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/workflow/helper/WorkflowHelper.java
@@ -1936,7 +1936,7 @@ public class WorkflowHelper {
 
     private boolean isNotWorkflowSeparator(final WorkflowAction workflowAction) {
 
-        final boolean isSeparator = Objects.nonNull(workflowAction) && UtilMethods.isSet(workflowAction.getMetadata())
+            final boolean isSeparator = Objects.nonNull(workflowAction) && UtilMethods.isSet(workflowAction.getMetadata())
                 && workflowAction.getMetadata().containsKey("subtype") && WorkflowAction.SEPARATOR.equals(workflowAction.getMetadata().get("subtype"));
 
         return !isSeparator;

--- a/dotcms-postman/src/main/resources/postman/Workflow_Resource_Tests.json
+++ b/dotcms-postman/src/main/resources/postman/Workflow_Resource_Tests.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "5ccc1142-2412-44f1-a682-d9ee757e8ecb",
+		"_postman_id": "c6b0fcb8-b713-4dee-941f-5aba04d2711b",
 		"name": "Workflow Resource Tests [/api/v1/workflows]",
 		"description": "Test the necesary validations to every end point of the worlflow resource ",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -18516,6 +18516,229 @@
 				}
 			],
 			"description": "Creates a French language and them creates a rich text in english and finally the french version of the english one previously created\n\nshould has the same id but diff language\n\nSince will use the system working, uses the safe action to creates the contentlets"
+		},
+		{
+			"name": "Metadata",
+			"item": [
+				{
+					"name": "UpdateArchiveActionAsPrimary",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"actionId\": \"4da13a42-5d59-480c-ad8f-94a3adf809fe\",\n    \"actionCondition\": \"\",\n    \"metadata\": {\n        \"primary\":true\n    },\n    \"whoCanUse\":[],\n    \"actionName\": \"Archive\",\n    \"actionNextAssign\": \"654b0931-1027-41f7-ad4d-173115ed8ec1\",\n    \"actionNextStep\": \"d6b095b6-b65f-4bdb-bbfd-701d663dfee2\",\n    \"actionRoleHierarchyForAssign\": false,\n    \"schemeId\": \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\",\n    \"showOn\": [\n        \"ARCHIVED\",\n        \"LISTING\",\n        \"UNLOCKED\",\n        \"UNPUBLISHED\"\n    ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/actions/4da13a42-5d59-480c-ad8f-94a3adf809fe",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"actions",
+								"4da13a42-5d59-480c-ad8f-94a3adf809fe"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "WFActionSeparators",
+			"item": [
+				{
+					"name": "Add Separator",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonDataAsText = pm.response.text();",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Do not contains a separator\", function () {",
+									"    let textToCheck = \"separator\";",
+									"    pm.expect(jsonDataAsText).to.include(textToCheck);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"schemeId\":\"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\",\n    \"stepId\":\"6cb7e3bd-1710-4eed-8838-d3db60f78f19\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/actions/separator",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"actions",
+								"separator"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetInitialStepsWithoutSeparators",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonDataAsText = pm.response.text();",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Do not contains a separator\", function () {",
+									"    let textToCheck = \"SEPARATOR\";",
+									"    pm.expect(jsonDataAsText).to.not.include(textToCheck);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/initialactions/contenttype/webPageContent",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"initialactions",
+								"contenttype",
+								"webPageContent"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "GetInitialStepsWithSeparator",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var jsonDataAsText = pm.response.text();",
+									"",
+									"pm.test(\"Status code should be ok 200\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Do not contains a separator\", function () {",
+									"    let textToCheck = \"SEPARATOR\";",
+									"    pm.expect(jsonDataAsText).to.include(textToCheck);",
+									"});"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwt}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/workflow/initialactions/contenttype/webPageContent?includeSeparator=true",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"workflow",
+								"initialactions",
+								"contenttype",
+								"webPageContent"
+							],
+							"query": [
+								{
+									"key": "includeSeparator",
+									"value": "true"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"event": [

--- a/dotcms-postman/src/main/resources/postman/Workflow_Resource_Tests.json
+++ b/dotcms-postman/src/main/resources/postman/Workflow_Resource_Tests.json
@@ -18579,7 +18579,7 @@
 									"});",
 									"",
 									"pm.test(\"Do not contains a separator\", function () {",
-									"    let textToCheck = \"separator\";",
+									"    let textToCheck = \"SEPARATOR\";",
 									"    pm.expect(jsonDataAsText).to.include(textToCheck);",
 									"});"
 								],
@@ -18692,7 +18692,7 @@
 									"    pm.response.to.have.status(200);",
 									"});",
 									"",
-									"pm.test(\"Do not contains a separator\", function () {",
+									"pm.test(\"Do contains a separator\", function () {",
 									"    let textToCheck = \"SEPARATOR\";",
 									"    pm.expect(jsonDataAsText).to.include(textToCheck);",
 									"});"


### PR DESCRIPTION
The wf separator actions were introduced while ago, now we have to include with a conditional to skip or not these separators in these two actions
/contentlet/{inode}/actions?includeSeparator=true
Or
/initialactions/contenttype/{contentTypeId}?includeSeparator=true

This PR fixes: #31107