### PR TITLE
fix(uve): Fixed sanitize issue on url queryParam

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.ts
@@ -36,17 +36,26 @@ function confirmQueryParams(queryParams: Params): {
     didQueryParamsGetCompleted: boolean;
 } {
     const { missing, ...missingQueryParams } = DEFAULT_QUERY_PARAMS.reduce(
-        (acc, curr) => {
-            if (!queryParams[curr.key]) {
-                acc[curr.key] = curr.value;
+        (acc, { key, value }) => {
+            if (!queryParams[key]) {
+                acc[key] = value;
                 acc.missing = true;
-            } else if (curr.key === 'url') {
-                if (queryParams[curr.key] !== 'index' && queryParams[curr.key].endsWith('/index')) {
-                    acc[curr.key] = sanitizeURL(queryParams[curr.key]);
+
+                return acc;
+            }
+
+            // Handle URL parameter special cases
+            if (key === 'url') {
+                if (queryParams[key] !== 'index' && queryParams[key].endsWith('/index')) {
+                    acc[key] = sanitizeURL(queryParams[key]);
                     acc.missing = true;
-                } else if (queryParams[curr.key] === '/') {
-                    acc[curr.key] = 'index';
+                }
+
+                if (queryParams[key] === '/') {
+                    acc[key] = 'index';
                     acc.missing = true;
+
+                    return acc;
                 }
             }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withEditorToolbar.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withEditorToolbar.ts
@@ -19,7 +19,6 @@ import {
     createPageApiUrlWithQueryParams,
     createFullURL,
     getIsDefaultVariant,
-    sanitizeURL,
     computePageIsLocked
 } from '../../../../utils';
 import { UVEState } from '../../../models';
@@ -46,7 +45,7 @@ export function withEditorToolbar() {
         withComputed((store) => ({
             $toolbarProps: computed<ToolbarProps>(() => {
                 const params = store.pageParams();
-                const url = sanitizeURL(params?.url);
+                const url = params?.url;
 
                 const pageAPIQueryParams = createPageApiUrlWithQueryParams(url, params);
                 const pageAPIResponse = store.pageAPIResponse();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.ts
@@ -21,8 +21,7 @@ import {
     createFullURL,
     createPageApiUrlWithQueryParams,
     getIsDefaultVariant,
-    getOrientation,
-    sanitizeURL
+    getOrientation
 } from '../../../../utils';
 import { Orientation, UVEState } from '../../../models';
 import { EditorToolbarState, PersonaSelectorProps, UVEToolbarProps } from '../models';
@@ -54,7 +53,7 @@ export function withUVEToolbar() {
         withComputed((store) => ({
             $uveToolbar: computed<UVEToolbarProps>(() => {
                 const params = store.pageParams();
-                const url = sanitizeURL(params?.url);
+                const url = params?.url;
 
                 const experiment = store.experiment?.();
                 const pageAPIResponse = store.pageAPIResponse();
@@ -144,8 +143,9 @@ export function withUVEToolbar() {
             }),
             $apiURL: computed<string>(() => {
                 const pageParams = store.pageParams();
-                const url = sanitizeURL(pageParams?.url);
+                const url = pageParams?.url;
                 const params = createPageApiUrlWithQueryParams(url, pageParams);
+
                 const pageType = store.isTraditionalPage() ? 'render' : 'json';
                 const pageAPI = `/api/v1/page/${pageType}/${params}`;
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -57,7 +57,7 @@ const buildIframeURL = ({ pageURI, params, isTraditionalPage }) => {
     const origin = params.clientHost || window.location.origin;
     const url = new URL(pageAPIQueryParams, origin);
 
-    return sanitizeURL(url.toString());
+    return url.toString();
 };
 
 const initialState: EditorState = {
@@ -201,8 +201,10 @@ export function withEditor() {
                 $iframeURL: computed<string>(() => {
                     const page = store.pageAPIResponse().page;
                     const vanityURL = store.pageAPIResponse().vanityUrl?.url;
+
+                    const sanitizedURL = sanitizeURL(vanityURL ?? page?.pageURI);
                     const url = buildIframeURL({
-                        pageURI: vanityURL ?? page?.pageURI,
+                        pageURI: sanitizedURL,
                         params: store.pageParams(),
                         isTraditionalPage: untracked(() => store.isTraditionalPage())
                     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -199,7 +199,7 @@ function insertPositionedContentletInContainer(payload: ActionPayload): {
 export function sanitizeURL(url?: string): string {
     return url
         ?.replace(/^\/+|\/+$/g, '') // Remove starting and trailing slashes
-        ?.replace(/(?:\/)?index\/?$/, '/'); // Replace 'index' or '/index' at the end with a single slash       // Replace 'index' with a slash if it's not preceded by a slash
+        ?.replace(/^(index)$|(.*?)(?:\/)?index\/?$/, (_, g1, g2) => g1 || `${g2}/`); // Keep 'index' or add slash for paths
 }
 
 /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -319,26 +319,38 @@ describe('utils functions', () => {
             expect(sanitizeURL('/hello-there/')).toEqual('hello-there');
         });
 
-        it('should remove the index if a nested path', () => {
-            expect(sanitizeURL('i-have-the-high-ground/index')).toEqual('i-have-the-high-ground/');
-        });
-
-        it('should remove the index if a nested path with slash', () => {
-            expect(sanitizeURL('no-index-please/index/')).toEqual('no-index-please/');
-        });
-
         it('should leave as it is for valid url', () => {
             expect(sanitizeURL('this-is-where-the-fun-begins')).toEqual(
                 'this-is-where-the-fun-begins'
             );
         });
 
-        it('should leave as it is for a nested valid url', () => {
-            expect(sanitizeURL('hello-there/general-kenobi')).toEqual('hello-there/general-kenobi');
+        it('should return index if the url is index without nested path', () => {
+            expect(sanitizeURL('index')).toEqual('index');
+            expect(sanitizeURL('index/')).toEqual('index');
+            expect(sanitizeURL('/index/')).toEqual('index');
         });
 
-        it('should remove index from the end of the url but keep the slash if is a nested path', () => {
-            expect(sanitizeURL('my-nested-path/index/')).toEqual('my-nested-path/');
+        describe('nested url', () => {
+            it('should leave as it is for a nested valid url', () => {
+                expect(sanitizeURL('hello-there/general-kenobi')).toEqual(
+                    'hello-there/general-kenobi'
+                );
+            });
+
+            it('should remove index from the end of the url but keep the slash if is a nested path', () => {
+                expect(sanitizeURL('my-nested-path/index/')).toEqual('my-nested-path/');
+            });
+
+            it('should remove the index if a nested path', () => {
+                expect(sanitizeURL('i-have-the-high-ground/index')).toEqual(
+                    'i-have-the-high-ground/'
+                );
+            });
+
+            it('should remove the index if a nested path with slash', () => {
+                expect(sanitizeURL('no-index-please/index/')).toEqual('no-index-please/');
+            });
         });
     });
 


### PR DESCRIPTION
This pull request focuses on refactoring the URL sanitization process across multiple files in the `core-web/libs/portlets/edit-ema/portlet/src/lib` directory. The main changes involve removing the `sanitizeURL` function where it is no longer necessary and updating the logic to handle URLs more efficiently.

### URL Sanitization Refactoring:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.ts`](diffhunk://#diff-880595c3f64b60b4dee196fb13dc679b5a500aede2d23cf966a369a70326dddcL39-R58): Updated the `confirmQueryParams` function to handle URL parameter special cases directly within the function, removing redundant checks.

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withEditorToolbar.ts`](diffhunk://#diff-84b848ee96f021f3cb3de615db3f5591ad8d305004985ba07cb4965be2f866ddL22): Removed the `sanitizeURL` import and its usage in the `withEditorToolbar` function. [[1]](diffhunk://#diff-84b848ee96f021f3cb3de615db3f5591ad8d305004985ba07cb4965be2f866ddL22) [[2]](diffhunk://#diff-84b848ee96f021f3cb3de615db3f5591ad8d305004985ba07cb4965be2f866ddL49-R48)

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.ts`](diffhunk://#diff-e6d3fb6319626fa85a4fc6894b57935843713366be593de6dd1dc5ed68bf6afcL24-R24): Removed the `sanitizeURL` import and its usage in the `withUVEToolbar` function. [[1]](diffhunk://#diff-e6d3fb6319626fa85a4fc6894b57935843713366be593de6dd1dc5ed68bf6afcL24-R24) [[2]](diffhunk://#diff-e6d3fb6319626fa85a4fc6894b57935843713366be593de6dd1dc5ed68bf6afcL57-R56) [[3]](diffhunk://#diff-e6d3fb6319626fa85a4fc6894b57935843713366be593de6dd1dc5ed68bf6afcL147-R148)

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts`](diffhunk://#diff-86e692578757ed7f4f6cba5d0aeb07641312f3b17885825d1a45987153ae87f0L60-R60): Removed the `sanitizeURL` function from the `buildIframeURL` function and updated the `withEditor` function to sanitize the URL only when necessary. [[1]](diffhunk://#diff-86e692578757ed7f4f6cba5d0aeb07641312f3b17885825d1a45987153ae87f0L60-R60) [[2]](diffhunk://#diff-86e692578757ed7f4f6cba5d0aeb07641312f3b17885825d1a45987153ae87f0R204-R207)

### Utility Function and Tests Update:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts`](diffhunk://#diff-2fd4d225bb33327848da73766ec5efbe037e3aed1a1e51a50c19f6a2be8cdb80L202-R202): Updated the `sanitizeURL` function to handle edge cases more effectively, including retaining 'index' if it is not part of a nested path.

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts`](diffhunk://#diff-6b95047786d13d69ebdcb642c6d382bc35784a2ada53f95d1908119ab08dfb91L322-R354): Revised the test cases for `sanitizeURL` to cover the updated behavior and ensure all edge cases are tested.

This PR fixes: #31095