### PR TITLE
fix(edit-content): check relationship format properly

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts
@@ -30,6 +30,7 @@ import { DotMessagePipe } from '@dotcms/ui';
 import { HeaderComponent } from './components/header/header.component';
 import { PaginationComponent } from './components/pagination/pagination.component';
 import { RelationshipFieldStore } from './store/relationship-field.store';
+import { getContentTypeIdFromRelationship } from './utils';
 
 @Component({
     selector: 'dot-edit-content-relationship-field',
@@ -169,7 +170,7 @@ export class DotEditContentRelationshipFieldComponent implements ControlValueAcc
         const field = this.$field();
 
         return {
-            contentTypeId: field?.relationships?.velocityVar || null,
+            contentTypeId: getContentTypeIdFromRelationship(field),
             hitText: field?.hint || null
         };
     });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts
@@ -1,6 +1,10 @@
-import { createFakeContentlet } from '@dotcms/utils-testing';
+import { createFakeContentlet, createFakeRelationshipField } from '@dotcms/utils-testing';
 
-import { getSelectionModeByCardinality, getRelationshipFromContentlet } from './index';
+import {
+    getSelectionModeByCardinality,
+    getRelationshipFromContentlet,
+    getContentTypeIdFromRelationship
+} from './index';
 
 import { RELATIONSHIP_OPTIONS } from '../dot-edit-content-relationship-field.constants';
 import { RelationshipTypes } from '../models/relationship.models';
@@ -137,6 +141,69 @@ describe('Relationship Field Utils', () => {
                 variable: 'testVar'
             });
             expect(result).toEqual([]);
+        });
+    });
+
+    describe('getContentTypeIdFromRelationship', () => {
+        it('should extract content type ID from relationship field with dot notation', () => {
+            const field = createFakeRelationshipField({
+                relationships: {
+                    cardinality: 0,
+                    isParentField: true,
+                    velocityVar: 'contentTypeId.fieldName'
+                }
+            });
+
+            const result = getContentTypeIdFromRelationship(field);
+            expect(result).toBe('contentTypeId');
+        });
+
+        it('should extract content type ID from relationship field', () => {
+            const field = createFakeRelationshipField({
+                relationships: {
+                    cardinality: 0,
+                    isParentField: true,
+                    velocityVar: 'contentTypeId'
+                }
+            });
+
+            const result = getContentTypeIdFromRelationship(field);
+            expect(result).toBe('contentTypeId');
+        });
+
+        it('should throw error when relationships property is missing', () => {
+            const field = createFakeRelationshipField({
+                contentTypeId: null,
+                relationships: null
+            });
+
+            expect(() => getContentTypeIdFromRelationship(field)).toThrow(
+                'Content type ID not found in relationship field'
+            );
+        });
+
+        it('should throw error when velocityVar is missing', () => {
+            const field = createFakeRelationshipField({
+                relationships: null
+            });
+
+            expect(() => getContentTypeIdFromRelationship(field)).toThrow(
+                'Content type ID not found in relationship field'
+            );
+        });
+
+        it('should throw error when velocityVar has invalid format', () => {
+            const field = createFakeRelationshipField({
+                relationships: {
+                    cardinality: 0,
+                    isParentField: true,
+                    velocityVar: ''
+                }
+            });
+
+            expect(() => getContentTypeIdFromRelationship(field)).toThrow(
+                'Content type ID not found in relationship field'
+            );
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts
@@ -1,4 +1,4 @@
-import { DotCMSContentlet } from '@dotcms/dotcms-models';
+import { DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
 
 import { RELATIONSHIP_OPTIONS } from '../dot-edit-content-relationship-field.constants';
 import { RelationshipTypes } from '../models/relationship.models';
@@ -54,4 +54,21 @@ export function getRelationshipFromContentlet({
     }
 
     return isArray ? relationship : [relationship];
+}
+
+/**
+ * Extracts the content type ID from a relationship field.
+ *
+ * @param field - The DotCMS content type field object containing the relationship data
+ * @returns The content type ID
+ * @throws An error if the content type ID is not found
+ */
+export function getContentTypeIdFromRelationship(field: DotCMSContentTypeField): string {
+    if (!field?.relationships?.velocityVar) {
+        throw new Error('Content type ID not found in relationship field');
+    }
+
+    const [contentTypeId] = field.relationships.velocityVar.split('.');
+
+    return contentTypeId;
 }

--- a/core-web/libs/utils-testing/src/lib/field-util.ts
+++ b/core-web/libs/utils-testing/src/lib/field-util.ts
@@ -1,9 +1,10 @@
+import { faker } from '@faker-js/faker';
+
 import {
     DotCMSContentTypeField,
     DotCMSContentTypeLayoutRow,
     DotCMSContentTypeLayoutColumn
 } from '@dotcms/dotcms-models';
-import { fa, faker } from '@faker-js/faker';
 
 export const EMPTY_FIELD: DotCMSContentTypeField = {
     contentTypeId: null,

--- a/core-web/libs/utils-testing/src/lib/field-util.ts
+++ b/core-web/libs/utils-testing/src/lib/field-util.ts
@@ -3,6 +3,7 @@ import {
     DotCMSContentTypeLayoutRow,
     DotCMSContentTypeLayoutColumn
 } from '@dotcms/dotcms-models';
+import { fa, faker } from '@faker-js/faker';
 
 export const EMPTY_FIELD: DotCMSContentTypeField = {
     contentTypeId: null,
@@ -49,6 +50,41 @@ const COLUMN_BREAK_FIELD = {
     clazz: 'contenttype.column.break',
     name: 'Column'
 };
+
+export function createFakeRelationshipField(
+    overrides: Partial<DotCMSContentTypeField> = {}
+): DotCMSContentTypeField {
+    return {
+        clazz: 'com.dotcms.contenttype.model.field.ImmutableRelationshipField',
+        contentTypeId: faker.string.uuid(),
+        dataType: 'SYSTEM',
+        fieldType: 'Relationship',
+        fieldTypeLabel: 'Relationships Field',
+        fieldVariables: [],
+        fixed: faker.datatype.boolean(),
+        forceIncludeInApi: faker.datatype.boolean(),
+        iDate: faker.date.recent().getTime(),
+        id: faker.string.uuid(),
+        indexed: faker.datatype.boolean(),
+        listed: faker.datatype.boolean(),
+        modDate: faker.date.recent().getTime(),
+        name: 'Relationship Field',
+        readOnly: false,
+        relationships: {
+            cardinality: 0,
+            isParentField: true,
+            velocityVar: 'AllTypes'
+        },
+        required: false,
+        searchable: false,
+        skipRelationshipCreation: false,
+        sortOrder: 6,
+        unique: false,
+        variable: 'relationshipField',
+        hint: 'Helper label to be displayed below the field',
+        ...overrides
+    };
+}
 
 export class FieldUtil {
     /**


### PR DESCRIPTION
### Parent Issue

#31040 

### Proposed Changes

This pull request introduces a new utility function to extract the content type ID from a relationship field and includes updates to the relevant files to integrate and test this new functionality.

Key changes include:

### Utility Function Addition:
* Added `getContentTypeIdFromRelationship` function to extract the content type ID from a relationship field in `core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts`.

### Integration:
* Updated `DotEditContentRelationshipFieldComponent` to use the new utility function `getContentTypeIdFromRelationship` for extracting the content type ID in `core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.ts`.

### Testing:
* Added tests for `getContentTypeIdFromRelationship` in `core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts`.
* Updated imports in `core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts` to include the new utility function.

### Utility Functions:
* Added `createFakeRelationshipField` utility function for testing purposes in `core-web/libs/utils-testing/src/lib/field-util.ts`.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #31040