### PR TITLE
chore(UVE): Enhance UX on Personalization workflow

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dialog.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_dialog.scss
@@ -58,7 +58,7 @@
     background: $white;
     color: $black;
     padding: $spacing-4;
-    word-break: break-all;
+    word-break: break-word;
 }
 .p-dialog:has(.p-dialog-header) .p-dialog-content {
     padding-top: 0;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.scss
@@ -41,10 +41,6 @@
         .p-dialog-content {
             padding: 0 $spacing-6 $spacing-6 $spacing-6;
         }
-
-        .p-dialog-footer {
-            padding-top: 0;
-        }
     }
 
     dot-experiments-shell dot-experiments-list {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -231,13 +231,27 @@ export class DotUveToolbarComponent {
                 accept: () => {
                     this.#personalizeService
                         .personalized(persona.pageId, persona.keyTag)
-                        .subscribe(() => {
-                            this.#store.loadPageAsset({
-                                'com.dotmarketing.persona.id': persona.identifier
-                            });
 
-                            this.$personaSelector().fetchPersonas();
-                        }); // This does a take 1 under the hood
+                        .subscribe(
+                            () => {
+                                this.#store.loadPageAsset({
+                                    'com.dotmarketing.persona.id': persona.identifier
+                                });
+
+                                this.$personaSelector().fetchPersonas();
+                            },
+                            () => {
+                                this.#messageService.add({
+                                    severity: 'error',
+                                    summary: this.#dotMessageService.get('error'),
+                                    detail: this.#dotMessageService.get(
+                                        'uve.personalize.empty.page.error'
+                                    )
+                                });
+
+                                this.$personaSelector().resetValue();
+                            }
+                        ); // This does a take 1 under the hood
                 },
                 reject: () => {
                     this.$personaSelector().resetValue();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -231,16 +231,15 @@ export class DotUveToolbarComponent {
                 accept: () => {
                     this.#personalizeService
                         .personalized(persona.pageId, persona.keyTag)
-
-                        .subscribe(
-                            () => {
+                        .subscribe({
+                            next: () => {
                                 this.#store.loadPageAsset({
                                     'com.dotmarketing.persona.id': persona.identifier
                                 });
 
                                 this.$personaSelector().fetchPersonas();
                             },
-                            () => {
+                            error: () => {
                                 this.#messageService.add({
                                     severity: 'error',
                                     summary: this.#dotMessageService.get('error'),
@@ -251,7 +250,7 @@ export class DotUveToolbarComponent {
 
                                 this.$personaSelector().resetValue();
                             }
-                        ); // This does a take 1 under the hood
+                        });
                 },
                 reject: () => {
                     this.$personaSelector().resetValue();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.html
@@ -46,6 +46,10 @@
                 icon="pi pi-arrows-alt" />
             <p-button
                 (click)="delete.emit(contentletArea.payload)"
+                [disabled]="!!disableDeleteButton"
+                [pTooltip]="disableDeleteButton | dm"
+                tooltipPosition="bottom"
+                [escape]="false"
                 data-testId="delete-button"
                 styleClass="p-button-rounded p-button-raised delete"
                 icon="pi pi-times" />

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.scss
@@ -27,8 +27,12 @@
             box-shadow: $shadow-s;
             transition: all 0.15s ease-in-out;
 
-            &:hover,
-            &:enabled:focus {
+            &:disabled {
+                pointer-events: auto;
+            }
+
+            &:hover:enabled,
+            &:focus:enabled {
                 background-color: $color-palette-primary-100;
                 color: $color-palette-primary-500;
                 box-shadow: $shadow-s;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.spec.ts
@@ -288,6 +288,20 @@ describe('EmaContentletToolsComponent', () => {
                 });
             });
         });
+
+        describe('delete button', () => {
+            it('should enable delete button when disableDeleteButton is false', () => {
+                spectator.setInput('disableDeleteButton', null);
+                const deleteButton = spectator.query(byTestId('delete-button'));
+                expect(deleteButton.getAttribute('ng-reflect-disabled')).toBe('false');
+            });
+
+            it('should disable delete button when disableDeleteButton is true', () => {
+                spectator.setInput('disableDeleteButton', 'Cannot delete this contentlet');
+                const deleteButton = spectator.query(byTestId('delete-button'));
+                expect(deleteButton.getAttribute('ng-reflect-disabled')).toBe('true');
+            });
+        });
     });
 
     describe('small contentlet', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/ema-contentlet-tools/ema-contentlet-tools.component.ts
@@ -17,8 +17,10 @@ import {
 import { MenuItem } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Menu, MenuModule } from 'primeng/menu';
+import { TooltipModule } from 'primeng/tooltip';
 
 import { DotMessageService } from '@dotcms/data-access';
+import { DotMessagePipe } from '@dotcms/ui';
 
 import { ActionPayload, VTLFile } from '../../../shared/models';
 import { ContentletArea } from '../ema-page-dropzone/types';
@@ -33,7 +35,7 @@ const INITIAL_ACTIONS_CONTAINER_WIDTH = 128;
 @Component({
     selector: 'dot-ema-contentlet-tools',
     standalone: true,
-    imports: [NgStyle, ButtonModule, MenuModule, JsonPipe],
+    imports: [NgStyle, ButtonModule, MenuModule, JsonPipe, TooltipModule, DotMessagePipe],
     templateUrl: './ema-contentlet-tools.component.html',
     styleUrls: ['./ema-contentlet-tools.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -47,6 +49,7 @@ export class EmaContentletToolsComponent implements OnChanges {
 
     @Input() contentletArea: ContentletArea;
     @Input() isEnterprise: boolean;
+    @Input() disableDeleteButton: string;
 
     @Output() addContent = new EventEmitter<ActionPayload>();
     @Output() addForm = new EventEmitter<ActionPayload>();
@@ -93,6 +96,7 @@ export class EmaContentletToolsComponent implements OnChanges {
     ];
 
     readonly items = signal<MenuItem[]>(this.#comunityItems);
+
     protected styles: Record<string, { [klass: string]: unknown }> = {};
 
     ngOnChanges(changes: SimpleChanges): void {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -61,6 +61,7 @@
                 [hide]="contentletTools.hide"
                 [contentletArea]="contentletTools.contentletArea"
                 [isEnterprise]="contentletTools.isEnterprise"
+                [disableDeleteButton]="contentletTools.disableDeleteButton"
                 data-testId="contentlet-tools" />
         }
         @if ($editorProps().dropzone; as dropzone) {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
@@ -37,6 +37,7 @@ export interface DotPageApiResponse {
     urlContentMap?: DotCMSContentlet;
     vanityUrl?: VanityUrl;
     runningExperimentId?: string;
+    numberContents: number;
 }
 
 export interface DotPageApiParams {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
@@ -161,6 +161,7 @@ export const MOCK_RESPONSE_HEADLESS: DotPageApiResponse = {
         lockedByName: '',
         live: true
     },
+    numberContents: 6,
     viewAs: {
         language: {
             id: 1,
@@ -225,6 +226,7 @@ export const MOCK_RESPONSE_VTL: DotPageApiResponse = {
         liveInode: '1234',
         stInode: '12345'
     },
+    numberContents: 6,
     viewAs: {
         language: {
             id: 1,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
@@ -71,6 +71,7 @@ export interface EditorProps {
         contentletArea: ContentletArea;
         hide: boolean;
         isEnterprise: boolean;
+        disableDeleteButton?: string;
     };
     dropzone?: {
         bounds: Container[];

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
@@ -842,7 +842,35 @@ describe('withEditor', () => {
                     expect(store.$editorProps().contentletTools).toEqual({
                         isEnterprise: true,
                         contentletArea: MOCK_CONTENTLET_AREA,
-                        hide: false
+                        hide: false,
+                        disableDeleteButton: null
+                    });
+                });
+
+                it('should have disableDeleteButton message when there is only one content and a non-default persona', () => {
+                    patchState(store, {
+                        isEditState: true,
+                        canEditPage: true,
+                        contentletArea: MOCK_CONTENTLET_AREA,
+                        state: EDITOR_STATE.IDLE,
+                        pageAPIResponse: {
+                            ...MOCK_RESPONSE_HEADLESS,
+                            numberContents: 1,
+                            viewAs: {
+                                ...MOCK_RESPONSE_HEADLESS.viewAs,
+                                persona: {
+                                    ...MOCK_RESPONSE_HEADLESS.viewAs.persona,
+                                    identifier: 'non-default-persona'
+                                }
+                            }
+                        }
+                    });
+
+                    expect(store.$editorProps().contentletTools).toEqual({
+                        isEnterprise: true,
+                        contentletArea: MOCK_CONTENTLET_AREA,
+                        hide: false,
+                        disableDeleteButton: 'uve.disable.delete.button.on.personalization'
                     });
                 });
 
@@ -857,7 +885,8 @@ describe('withEditor', () => {
                     expect(store.$editorProps().contentletTools).toEqual({
                         isEnterprise: true,
                         contentletArea: MOCK_CONTENTLET_AREA,
-                        hide: true
+                        hide: true,
+                        disableDeleteButton: null
                     });
                 });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -28,6 +28,7 @@ import {
     ContentletArea,
     EmaDragItem
 } from '../../../edit-ema-editor/components/ema-page-dropzone/types';
+import { DEFAULT_PERSONA } from '../../../shared/consts';
 import { EDITOR_STATE, UVE_STATUS } from '../../../shared/enums';
 import {
     ActionPayload,
@@ -160,6 +161,15 @@ export function withEditor() {
 
                     const wrapper = getWrapperMeasures(device, store.orientation());
 
+                    const shouldDisableDeleteButton =
+                        pageAPIResponse?.numberContents === 1 && // If there is only one content, we should disable the delete button
+                        pageAPIResponse?.viewAs?.persona && // If there is a persona, we should disable the delete button
+                        pageAPIResponse?.viewAs?.persona?.identifier !== DEFAULT_PERSONA.identifier; // If the persona is not the default persona, we should disable the delete button
+
+                    const message = 'uve.disable.delete.button.on.personalization';
+
+                    const disableDeleteButton = shouldDisableDeleteButton ? message : null;
+
                     return {
                         showDialogs,
                         showBlockEditorSidebar,
@@ -173,7 +183,8 @@ export function withEditor() {
                             ? {
                                   isEnterprise,
                                   contentletArea,
-                                  hide: dragIsActive
+                                  hide: dragIsActive,
+                                  disableDeleteButton
                               }
                             : null,
                         dropzone: showDropzone

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5921,6 +5921,7 @@ uve.preview.mode.device.subheader=Custom Devices
 uve.preview.mode.social.media.subheader=Social Media Tiles
 uve.preview.mode.search.engine.subheader=Search Engine
 uve.disable.delete.button.on.personalization=A personalized page should have at least <b>one</b> content item.
+uve.personalize.empty.page.error=Page is empty, please add content to personalize it.
 
 
 coming.soon=Coming Soon

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5920,6 +5920,7 @@ uve.preview.mode=Preview Mode
 uve.preview.mode.device.subheader=Custom Devices
 uve.preview.mode.social.media.subheader=Social Media Tiles
 uve.preview.mode.search.engine.subheader=Search Engine
+uve.disable.delete.button.on.personalization=A personalized page should have at least <b>one</b> content item.
 
 
 coming.soon=Coming Soon

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5920,8 +5920,8 @@ uve.preview.mode=Preview Mode
 uve.preview.mode.device.subheader=Custom Devices
 uve.preview.mode.social.media.subheader=Social Media Tiles
 uve.preview.mode.search.engine.subheader=Search Engine
-uve.disable.delete.button.on.personalization=A personalized page should have at least <b>one</b> content item.
-uve.personalize.empty.page.error=Page is empty, please add content to personalize it.
+uve.disable.delete.button.on.personalization=Personalization requires a minimum of <b>one</b> content item.
+uve.personalize.empty.page.error=Personalization requires page content. Add some first.
 
 
 coming.soon=Coming Soon


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and user experience of the `dot-ema-editor` components, as well as updates to the tests to cover new scenarios. The most important changes include updates to the `DotUveToolbarComponent` and `EmaContentletToolsComponent` components, as well as modifications to the SCSS files and test cases.

### Component Updates:

* [`dot-uve-toolbar.component.ts`](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30L234-R254): Added error handling for the personalization confirmation process. If the process fails, an error message is displayed, and the persona selector is reset.

* [`ema-contentlet-tools.component.ts`](diffhunk://#diff-08f74ff61175a0977e14d11a274497b21130e0ea56fdec99b636c0e8207f477dR52): Added a new input property `disableDeleteButton` to control the state of the delete button. The button is disabled and shows a tooltip when `disableDeleteButton` is set.

### SCSS Updates:

* [`dotcms-theme/components/_dialog.scss`](diffhunk://#diff-123bc2019d92d71d5d2d93da360b73b30eefd6efb45c2c4686e92f6ed2995c68L61-R61): Changed the `word-break` property from `break-all` to `break-word` for better text handling.

* [`dot-ema-shell.component.scss`](diffhunk://#diff-47e09a72b73f6fe223ca726339f5e7a2370d482440adedc9c97af2bea9272b08L44-L47): Removed unnecessary padding styles from the `.p-dialog-footer` class.

### Test Updates:

* [`dot-uve-toolbar.component.spec.ts`](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1L191-R224): Added new test cases to cover the error handling in the personalization process and the use of the `personaEventMock` for consistent test data. [[1]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1L191-R224) [[2]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1L483-R544)

* [`ema-contentlet-tools.component.spec.ts`](diffhunk://#diff-b2ac9d0e3ff7999e99ce6e62e37794a97a1028aa67f6c57ede85e216ab80b388R291-R304): Added test cases to verify the behavior of the delete button based on the `disableDeleteButton` input property.

### Store and Mock Updates:

* [`models.ts`](diffhunk://#diff-a5d9d93bd678484a7d776d09685fcb638de6d969ac141586a1104ba5e744556bR74): Added `disableDeleteButton` to the `EditorProps` interface to support the new functionality in the `EmaContentletToolsComponent`.

* [`withEditor.spec.ts`](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbL845-R873): Updated tests to include scenarios where the `disableDeleteButton` property is set based on the number of contents and the persona state. [[1]](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbL845-R873) [[2]](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbL860-R889)

## Screenshot

https://github.com/user-attachments/assets/c49cc2ed-b01f-46c4-9658-ae58c9ead283


This PR fixes: #31098