### PR TITLE
Add auth to download files servlet

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
@@ -554,8 +554,8 @@ public  class WebResource {
         }
 
 
-        if( UserAPI.CMS_ANON_USER_ID.equals(user.getUserId()) && access == AnonymousAccess.NONE) {
-
+        if(Arrays.stream(authCheckOptions).noneMatch(AuthCheckOptions.SKIP_CHECK_ANONYMOUS_PERMISSIONS::equals)
+                && UserAPI.CMS_ANON_USER_ID.equals(user.getUserId()) && access == AnonymousAccess.NONE) {
             throw new SecurityException("Invalid User", Response.Status.UNAUTHORIZED);
         } 
 
@@ -664,13 +664,11 @@ public  class WebResource {
 
                 throw e;
             } catch (Exception e) {  // doLogin throwing Exception
-
                 Logger.warn(WebResource.class, "Request IP: " + ip + ". Can't authenticate user. Username: " + username);
                 SecurityLogger.logDebug(WebResource.class, "Request IP: " + ip + ". Can't authenticate user. Username: " + username);
                 throw new SecurityException("Authentication credentials are required", e, Response.Status.UNAUTHORIZED);
             }
         } else if(StringUtils.isNotEmpty(username) || StringUtils.isNotEmpty(password)) { // providing login or password
-
             Logger.warn(WebResource.class, "Request IP: " + ip + ". Can't authenticate user.");
             SecurityLogger.logDebug(WebResource.class, "Request IP: " + ip + ". Can't authenticate user.");
             throw new SecurityException("Authentication credentials are required", Response.Status.UNAUTHORIZED);

--- a/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
@@ -328,12 +328,16 @@ public  class WebResource {
      */
     public InitDataObject init(final InitBuilder builder) throws SecurityException {
 
-        checkForceSSL(builder.request);
+        if (!builder.authCheckOptions.contains(AuthCheckOptions.SKIP_CHECK_FORCE_SSL)) {
+            checkForceSSL(builder.request);
+        }
 
         final InitDataObject initData = new InitDataObject();
         Map<String,String> paramsMap = builder.paramsMap();
 
-        final User user = getCurrentUser(builder.request, builder.response, paramsMap, builder.anonAccess);
+        final User user = getCurrentUser(
+                builder.request, builder.response, paramsMap, builder.anonAccess,
+                builder.authCheckOptions.toArray(new AuthCheckOptions[0]));
 
         checkAdminPermissions(builder, user);
         checkAnonymousPermissions(builder, user);
@@ -353,6 +357,9 @@ public  class WebResource {
      */
     @VisibleForTesting
     void checkAnonymousPermissions(final InitBuilder builder, @NotNull User user) {
+        if (builder.authCheckOptions.contains(AuthCheckOptions.SKIP_CHECK_ANONYMOUS_PERMISSIONS)) {
+            return;
+        }
         // if we are not an anonymous user
         if (user != null && !user.isAnonymousUser()) {
             return;
@@ -433,24 +440,27 @@ public  class WebResource {
      * @param response {@link HttpServletResponse}
      * @param paramsMap {@link Map}
      * @param access {@link AnonymousAccess}
+     * @param authCheckOptions {@link AuthCheckOptions}
      *
      * @return the login user or the login as user if exist any
      */
     public User getCurrentUser(final HttpServletRequest  request,
                                final HttpServletResponse response,
-                               final Map<String, String> paramsMap, final AnonymousAccess access) {
+                               final Map<String, String> paramsMap,
+                               final AnonymousAccess access,
+                               final AuthCheckOptions... authCheckOptions) throws SecurityException {
 
         User user = PortalUtil.getUser(request);
 
         if(user==null) {
-            user = authenticate(request, response, paramsMap, access);
+            user = authenticate(request, response, paramsMap, access, authCheckOptions);
         }
         return user;
     }
 
     /**
      * @deprecated
-     * @see #getCurrentUser(HttpServletRequest, HttpServletResponse, Map, AnonymousAccess) 
+     * @see #getCurrentUser(HttpServletRequest, HttpServletResponse, Map, AnonymousAccess, AuthCheckOptions...)
      *
      * Return the current login user.<br>
      * if exist a user login by login as then return this user not the principal user
@@ -471,7 +481,7 @@ public  class WebResource {
 
     /**
      * @deprecated
-     * @see #authenticate(HttpServletRequest, HttpServletResponse, Map, AnonymousAccess)
+     * @see #authenticate(HttpServletRequest, HttpServletResponse, Map, AnonymousAccess, AuthCheckOptions...)
      * Returns an authenticated {@link User}. There are five ways to get the User's credentials.
      * They are executed in the specified order. When found, the remaining ways won't be executed.
      * <br>1) Using username and password contained in <code>params</code>.
@@ -497,9 +507,12 @@ public  class WebResource {
      * <br>5) If no user found, tries to get the Frontend logged in user.
      */
     public User authenticate(HttpServletRequest request, final HttpServletResponse response,
-                             final Map<String, String> params, final AnonymousAccess access) throws SecurityException {
+                             final Map<String, String> params, final AnonymousAccess access,
+                             final AuthCheckOptions... authCheckOptions) throws SecurityException {
 
-        ServletPreconditions.checkSslIsEnabledIfRequired(request);
+        if (Arrays.stream(authCheckOptions).noneMatch(AuthCheckOptions.SKIP_CHECK_FORCE_SSL::equals)) {
+            ServletPreconditions.checkSslIsEnabledIfRequired(request);
+        }
 
         User user = null;
 
@@ -766,6 +779,14 @@ public  class WebResource {
         }
     }
 
+    /**
+     * This enum includes the different options to check for the user authentication
+     */
+   public enum AuthCheckOptions {
+        SKIP_CHECK_FORCE_SSL,
+        SKIP_CHECK_ANONYMOUS_PERMISSIONS,
+   }
+
    public static class InitBuilder {
 
         private final WebResource webResource;
@@ -779,6 +800,8 @@ public  class WebResource {
         private final Set<String> requiredRolesSet = new HashSet<>();
         private AnonymousAccess anonAccess=AnonymousAccess.NONE;
         private boolean requireLicense = false;
+        private final Set<AuthCheckOptions> authCheckOptions = new HashSet<>();
+
         public InitBuilder() {
           this(new WebResource());
 
@@ -886,6 +909,11 @@ public  class WebResource {
             return this;
         }
 
+        public InitBuilder authCheckOptions(final AuthCheckOptions... options){
+            this.authCheckOptions.addAll(Arrays.asList(options));
+            return this;
+        }
+
         public InitDataObject init() {
 
             response = (response == null ? new EmptyHttpResponse() : response);
@@ -903,7 +931,8 @@ public  class WebResource {
             }
 
 
-            if (anonAccess != AnonymousAccess.NONE) {
+            if (!authCheckOptions.contains(AuthCheckOptions.SKIP_CHECK_ANONYMOUS_PERMISSIONS)
+                    && anonAccess != AnonymousAccess.NONE) {
 
                 if(UtilMethods.isSet(requiredPortlet) || UtilMethods.isSet(requiredRolesSet)){
                     Logger.debug(InitBuilder.class,

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/ServletUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/ServletUtils.java
@@ -1,0 +1,42 @@
+package com.dotmarketing.servlets;
+
+import com.dotcms.rest.WebResource;
+import com.dotmarketing.util.UtilMethods;
+import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Utility class for servlets
+ */
+public class ServletUtils {
+
+    private ServletUtils() {
+        // Utility class
+    }
+
+    /**
+     * Get the current user from the request and authenticate if
+     * an authentication method is included in the request (Basic, Bearer (JWT), etc.)
+     *
+     * @param webResource the web resource
+     * @param req the request
+     * @param resp the response
+     * @return the current user (authenticated if a method is included in the request)
+     */
+    static User getUserAndAuthenticateIfRequired(
+            final WebResource webResource,
+            final HttpServletRequest req, final HttpServletResponse resp) {
+
+        return new WebResource.InitBuilder(webResource)
+            .requestAndResponse(req, resp)
+            .params(UtilMethods.isSet(req.getPathInfo()) ?
+                req.getPathInfo().substring(1) : StringPool.BLANK)
+            .authCheckOptions(WebResource.AuthCheckOptions.SKIP_CHECK_FORCE_SSL,
+                WebResource.AuthCheckOptions.SKIP_CHECK_ANONYMOUS_PERMISSIONS)
+            .init().getUser();
+
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
@@ -43,7 +43,6 @@ import com.dotmarketing.tag.model.Tag;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.SecurityLogger;
-import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
 import com.liferay.portal.language.LanguageUtil;
@@ -270,7 +269,7 @@ public class ShortyServlet extends HttpServlet {
     try {
         final User user = ServletUtils.getUserAndAuthenticateIfRequired(
                 this.webResource, request, response);
-        Logger.debug(this, () -> "User: " + user);
+        Logger.debug(ShortyServlet.class, () -> "User: " + user);
     } catch (SecurityException e) {
         SecurityLogger.logInfo(ShortyServlet.class, e.getMessage());
         Logger.debug(ShortyServlet.class, e,  () -> "Error getting user and authenticating");
@@ -338,7 +337,7 @@ public class ShortyServlet extends HttpServlet {
     final Language language =WebAPILocator.getLanguageWebAPI().getLanguage(request);
     try {
 
-        
+
         String inodePath = null;
         if(shorty.type!= ShortType.TEMP_FILE) {
           final Optional<Contentlet> conOpt = (shorty.type == ShortType.IDENTIFIER)

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
@@ -1,5 +1,7 @@
 package com.dotmarketing.servlets;
 
+import com.dotcms.rest.WebResource;
+import com.dotcms.rest.exception.SecurityException;
 import com.dotcms.variant.business.web.VariantWebAPI.RenderContext;
 import java.io.IOException;
 import java.util.Objects;
@@ -40,6 +42,8 @@ import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.tag.model.Tag;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
+import com.dotmarketing.util.SecurityLogger;
+import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
 import com.liferay.portal.language.LanguageUtil;
@@ -59,7 +63,7 @@ public class ShortyServlet extends HttpServlet {
   private final HostWebAPI     hostWebAPI     = WebAPILocator.getHostWebAPI();
   private final VersionableAPI versionableAPI = APILocator.getVersionableAPI();
   private final ShortyIdAPI    shortyIdAPI    = APILocator.getShortyAPI();
-
+  private final WebResource    webResource    = new WebResource();
 
   private static final String  JPEG                        = ".jpeg";
   private static final String  JPEGP                       = ".jpegp";
@@ -263,6 +267,16 @@ public class ShortyServlet extends HttpServlet {
   private void serve(final HttpServletRequest request,
                      final HttpServletResponse response) throws Exception {
 
+    try {
+        final User user = ServletUtils.getUserAndAuthenticateIfRequired(
+                this.webResource, request, response);
+        Logger.debug(this, () -> "User: " + user);
+    } catch (SecurityException e) {
+        SecurityLogger.logInfo(ShortyServlet.class, e.getMessage());
+        Logger.debug(ShortyServlet.class, e,  () -> "Error getting user and authenticating");
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
+    }
 
     final PageMode mode = PageMode.get(request);
 

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/SpeedyAssetServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/SpeedyAssetServlet.java
@@ -26,7 +26,6 @@ import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
-import com.dotmarketing.util.SecurityLogger;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
@@ -34,7 +33,6 @@ import com.liferay.portal.language.LanguageException;
 import com.liferay.portal.language.LanguageUtil;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.User;
-import com.liferay.util.StringPool;
 
 public class SpeedyAssetServlet extends HttpServlet {
 
@@ -60,9 +58,8 @@ public class SpeedyAssetServlet extends HttpServlet {
         try {
             final User user = ServletUtils.getUserAndAuthenticateIfRequired(
                     webResource, request, response);
-            Logger.debug(this, () -> "User: " + user);
+            Logger.debug(ShortyServlet.class, () -> "User: " + user);
         } catch (SecurityException e) {
-            SecurityLogger.logInfo(SpeedyAssetServlet.class, e.getMessage());
             Logger.debug(SpeedyAssetServlet.class, e,  () -> "Error getting user and authenticating");
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
             return;

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/SpeedyAssetServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/SpeedyAssetServlet.java
@@ -1,5 +1,7 @@
 package com.dotmarketing.servlets;
 
+import com.dotcms.rest.WebResource;
+import com.dotcms.rest.exception.SecurityException;
 import com.dotmarketing.filters.Constants;
 import java.io.IOException;
 import java.util.Optional;
@@ -10,7 +12,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
 
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
@@ -25,16 +26,21 @@ import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
+import com.dotmarketing.util.SecurityLogger;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
 import com.liferay.portal.language.LanguageException;
 import com.liferay.portal.language.LanguageUtil;
 import com.liferay.portal.model.Company;
+import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
 
 public class SpeedyAssetServlet extends HttpServlet {
 
 	private static final long serialVersionUID = 1L;
+
+    private WebResource webResource = new WebResource();
 
     public void init(ServletConfig config) throws ServletException {
       if (Config.CONTEXT == null) {
@@ -50,6 +56,17 @@ public class SpeedyAssetServlet extends HttpServlet {
     protected void service(HttpServletRequest request, HttpServletResponse response)
             throws ServletException, IOException {
         Logger.debug(this, "======Starting SpeedyAssetServlet_service=====");
+
+        try {
+            final User user = ServletUtils.getUserAndAuthenticateIfRequired(
+                    webResource, request, response);
+            Logger.debug(this, () -> "User: " + user);
+        } catch (SecurityException e) {
+            SecurityLogger.logInfo(SpeedyAssetServlet.class, e.getMessage());
+            Logger.debug(SpeedyAssetServlet.class, e,  () -> "Error getting user and authenticating");
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
 
         /*
 		 * Getting host object form the session

--- a/dotcms-integration/src/test/java/com/dotmarketing/servlets/BinaryExporterServletTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/servlets/BinaryExporterServletTest.java
@@ -1,15 +1,13 @@
 package com.dotmarketing.servlets;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.matches;
-
+import com.dotcms.auth.providers.jwt.beans.ApiToken;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.FileAssetDataGen;
 import com.dotcms.datagen.FolderDataGen;
 import com.dotcms.datagen.RoleDataGen;
 import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.UserDataGen;
+import com.dotcms.mock.request.MockHeaderRequest;
 import com.dotcms.mock.request.MockHttpRequestIntegrationTest;
 import com.dotcms.mock.request.MockServletPathRequest;
 import com.dotcms.mock.request.MockSessionRequest;
@@ -17,12 +15,9 @@ import com.dotcms.mock.response.MockHttpCaptureResponse;
 import com.dotcms.mock.response.MockHttpContentTypeResponse;
 import com.dotcms.mock.response.MockHttpResponse;
 import com.dotcms.mock.response.MockHttpStatusResponse;
-import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
-import com.dotmarketing.beans.Permission;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.PermissionAPI;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -30,33 +25,43 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.WebKeys;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import java.io.Closeable;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import org.apache.tools.ant.taskdefs.Classloader;
+import org.apache.commons.lang.RandomStringUtils;
+import org.glassfish.jersey.internal.util.Base64;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+import static com.dotmarketing.business.Role.DOTCMS_BACK_END_USER;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.matches;
 
 @RunWith(DataProviderRunner.class)
 public class BinaryExporterServletTest {
@@ -90,12 +95,22 @@ public class BinaryExporterServletTest {
     private static final String BY_ID = "by-identifier";
     private static final String BY_INODE = "by-inode";
 
-    private static final String READ_PERMISSIONS = "has-read-permissions";
-    private static final String NO_PERMISSIONS = "no-permissions";
+    private static final String NO_PERMISSIONS_REQUIRED = "no-permissions-required";
+    private static final String PERMISSIONS_REQUIRED = "permissions-required";
+
+    private static final String AUTH_WITH_CREDENTIALS = "auth-with-credentials";
+    private static final String AUTH_WITH_TOKEN = "auth-with-token";
+    private static final String NO_AUTH = "no-auth";
 
     private static Host host;
     private static Role role;
+    private static User user;
+    private static String userEmailAndPassword;
+    private static ApiToken apiToken;
 
+    /**
+     * Prepare testing environment
+     */
     @BeforeClass
     public static void prepare() throws Exception {
 
@@ -105,26 +120,80 @@ public class BinaryExporterServletTest {
         host = new SiteDataGen().nextPersisted();
         role = new RoleDataGen().nextPersisted();
 
+        final String userPassword = RandomStringUtils.randomAlphabetic(10);
+        final String userEmail = RandomStringUtils.randomAlphabetic(5) + "@dotcms.com";
+        userEmailAndPassword = userEmail + ":" + userPassword;
+
+        user = new UserDataGen()
+                .emailAddress(userEmail).password(userPassword)
+                .roles(role, APILocator.getRoleAPI().loadRoleByKey(DOTCMS_BACK_END_USER))
+                .nextPersisted();
+
+        apiToken = APILocator.getApiTokenAPI().persistApiToken(
+           user.getUserId(), Date.from(Instant.now().plus(Duration.ofDays(10))),
+           APILocator.systemUser().getUserId() , "127.0.0.1");
+
     }
 
+    /**
+     * Clean up testing environment
+     */
+    @AfterClass
+    public static void cleanup() {
+        User systemUser = APILocator.systemUser();
+        if (UtilMethods.isSet(host) && UtilMethods.isSet(host.getIdentifier())) {
+            try {
+                host.setIndexPolicy(IndexPolicy.WAIT_FOR);
+                APILocator.getHostAPI().unpublish(host, systemUser, false);
+                APILocator.getHostAPI().archive(host, systemUser, false);
+                APILocator.getHostAPI().delete(host, systemUser, false);
+            } catch (DotDataException | DotSecurityException e) {
+                Logger.error(BinaryExporterServletTest.class, "Unable to remove Host.", e);
+            }
+        }
+        if (UtilMethods.isSet(role) && UtilMethods.isSet(role.getId())) {
+            RoleDataGen.remove(role);
+        }
+        if (UtilMethods.isSet(user) && UtilMethods.isSet(user.getUserId())) {
+            UserDataGen.remove(user);
+        }
+    }
+
+    /**
+     * Data provider for test cases of requestBinaryFile test method
+     * @return Test cases data
+     */
     @DataProvider
     public static Object[][] testCases() {
         return new Object[][] {
-                { BY_ID, READ_PERMISSIONS },
-                { BY_ID, NO_PERMISSIONS },
-                { BY_INODE, READ_PERMISSIONS },
-                { BY_INODE, NO_PERMISSIONS },
+                { BY_ID, NO_PERMISSIONS_REQUIRED, NO_AUTH },
+                { BY_ID, PERMISSIONS_REQUIRED, NO_AUTH },
+                { BY_ID, PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS },
+                { BY_ID, PERMISSIONS_REQUIRED, AUTH_WITH_TOKEN },
+                { BY_INODE, NO_PERMISSIONS_REQUIRED, NO_AUTH },
+                { BY_INODE, PERMISSIONS_REQUIRED, NO_AUTH },
+                { BY_INODE, PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS },
+                { BY_INODE, PERMISSIONS_REQUIRED, AUTH_WITH_TOKEN }
         };
     }
 
+    /**
+     * Method to test: {@link BinaryExporterServlet.doGet(HttpServletRequest, HttpServletResponse)}
+     * Given scenario: Request a binary file asset
+     * Expected result: Should return the binary file asset content if permissions are granted
+     * If permissions are not granted, should return 401 Unauthorized
+     * @param byIdType Identifier type (by-identifier or by-inode)
+     * @param permissionType Permissions required (no-permissions-required or permissions-required)
+     * @param authType Authorization type (no-auth, auth-with-credentials or auth-with-token)
+     */
     @UseDataProvider("testCases")
     @Test
     public void requestBinaryFile(
-            final String byIdType, final String permissionType)
+            final String byIdType, final String permissionType, final String authType)
             throws DotDataException, DotSecurityException, ServletException, IOException {
 
         final boolean byIdentifier = byIdType.equals(BY_ID);
-        final boolean permissionsRequired = permissionType.equals(NO_PERMISSIONS);
+        final boolean permissionsRequired = permissionType.equals(PERMISSIONS_REQUIRED);
 
         Contentlet fileAsset = null;
         final Folder folder = new FolderDataGen().site(host).nextPersisted();
@@ -136,24 +205,32 @@ public class BinaryExporterServletTest {
 
             // Set asset permissions
             if (permissionsRequired) {
-                addPermissions(fileAsset);
+                ServletTestUtils.addPermissions(fileAsset, role);
             }
 
             // Build request and response
             final String fileURI = "/contentAsset/raw-data/"
                     + (byIdentifier ? fileAsset.getIdentifier() : fileAsset.getInode())
                     + "/fileAsset/";
-            final HttpServletRequest request = mockServletRequest(fileURI);
+            final MockHeaderRequest request = new MockHeaderRequest(mockServletRequest(fileURI));
+            if (AUTH_WITH_CREDENTIALS.equals(authType)) {
+                request.setHeader("Authorization",
+                        "Basic " + new String(Base64.encode(userEmailAndPassword.getBytes())));
+            } else if (AUTH_WITH_TOKEN.equals(authType)) {
+                request.setHeader("Authorization",
+                        "Bearer " + APILocator.getApiTokenAPI().getJWT(apiToken, user));
+            }
             final HttpServletResponse response = mockServletResponse(tmpTargetFile);
 
             // Send servlet request
             sendRequest(request, response);
 
-            if (permissionsRequired) {
+            if (permissionsRequired && NO_AUTH.equals(authType)) {
                 // Verify response status
                 assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
             } else {
                 // Verify response
+                assertEquals(HttpServletResponse.SC_OK, response.getStatus());
                 final byte[] responseContent = Files.readAllBytes(tmpTargetFile.getPath());
                 assertArrayEquals(ShortyServletAndTitleImageTest.pngPixel, responseContent);
             }
@@ -324,28 +401,6 @@ public class BinaryExporterServletTest {
         final BinaryExporterServlet binaryExporterServlet = new BinaryExporterServlet();
         binaryExporterServlet.init();
         binaryExporterServlet.doGet(request, response);
-
-    }
-
-    private void addPermissions(final Contentlet fileAsset)
-            throws DotSecurityException, DotDataException {
-
-        final User systemUser = APILocator.systemUser();
-        final Role anonymousRole = APILocator.getRoleAPI().loadCMSAnonymousRole();
-
-        final Permission anonPermission = new Permission();
-        anonPermission.setInode(fileAsset.getPermissionId());
-        anonPermission.setRoleId(anonymousRole.getId());
-        anonPermission.setPermission(0);
-
-        final Permission permission = new Permission();
-        permission.setInode(fileAsset.getPermissionId());
-        permission.setRoleId(role.getId());
-        permission.setPermission(PermissionAPI.PERMISSION_READ);
-
-        APILocator.getPermissionAPI().save(
-                CollectionsUtils.list(anonPermission, permission),
-                fileAsset, systemUser, false);
 
     }
 

--- a/dotcms-integration/src/test/java/com/dotmarketing/servlets/ServletTestUtils.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/servlets/ServletTestUtils.java
@@ -1,0 +1,164 @@
+package com.dotmarketing.servlets;
+
+import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.FolderDataGen;
+import com.dotcms.datagen.RoleDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.TestDataUtils;
+import com.dotcms.datagen.UserDataGen;
+import com.dotcms.mock.request.MockHeaderRequest;
+import com.dotcms.mock.request.MockHttpRequestIntegrationTest;
+import com.dotcms.mock.response.MockHttpStatusResponse;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.beans.Permission;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.business.Role;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
+import com.dotmarketing.portlets.folders.model.Folder;
+import com.liferay.portal.model.User;
+import org.apache.commons.lang.RandomStringUtils;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.function.Function;
+
+import static com.dotmarketing.business.Role.DOTCMS_BACK_END_USER;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class ServletTestUtils {
+
+    /**
+     * Add read permissions to a role for a given contentlet
+     * Also removes all permissions for the CMS Anonymous role
+     * @param contentlet contentlet to add permissions to
+     * @param role role to add permissions for
+     * @throws DotDataException if there is an data error adding permissions
+     * @throws DotSecurityException if there is a permissions error adding permissions
+     */
+    public static void addPermissions(
+            final Contentlet contentlet, final Role role)
+            throws DotDataException, DotSecurityException {
+
+        final User systemUser = APILocator.systemUser();
+        final Role anonymousRole = APILocator.getRoleAPI().loadCMSAnonymousRole();
+
+        final Permission anonPermission = new Permission();
+        anonPermission.setInode(contentlet.getPermissionId());
+        anonPermission.setRoleId(anonymousRole.getId());
+        anonPermission.setPermission(0);
+
+        final Permission permission = new Permission();
+        permission.setInode(contentlet.getPermissionId());
+        permission.setRoleId(role.getId());
+        permission.setPermission(PermissionAPI.PERMISSION_READ);
+
+        APILocator.getPermissionAPI().save(
+                List.of(anonPermission, permission),
+                contentlet, systemUser, false);
+
+    }
+
+    /**
+     * Test a servlet with an authenticated user
+     * First, the servlet is tested with an unauthenticated user and the status code is verified to be 401
+     * Then, the servlet is tested with an authenticated user and the request is verified to be forwarded
+     * @param servlet servlet to test
+     * @param urlGenerator function to generate a URL for the servlet
+     * @throws DotDataException if there is a data error
+     * @throws DotSecurityException if there is a security error
+     * @throws ServletException if there is a servlet error
+     * @throws IOException if there is an I/O error
+     */
+    public static void testServletWithAuthenticatedUser(
+            final HttpServlet servlet, final Function<String, String> urlGenerator)
+            throws DotDataException, DotSecurityException, ServletException, IOException {
+        Host testHost = null;
+        Role testRole = null;
+        User testUser = null;
+        try {
+            // Create a test host, role, and user
+            final String userPassword = RandomStringUtils.randomAlphabetic(10);
+            final String userEmail = RandomStringUtils.randomAlphabetic(5) + "@dotcms.com";
+            final String userEmailAndPassword = userEmail + ":" + userPassword;
+            final String userEmailAndInvalidPassword = userEmail + ":"
+                    + RandomStringUtils.randomAlphabetic(5) + userPassword;
+
+            testHost = new SiteDataGen().nextPersisted();
+            testRole = new RoleDataGen().nextPersisted();
+            testUser = new UserDataGen().roles(testRole,
+                    APILocator.getRoleAPI().loadRoleByKey(DOTCMS_BACK_END_USER))
+                    .emailAddress(userEmail).password(userPassword).nextPersisted();
+
+            // Create a dot asset and publish it
+            // Add permissions to the asset for the test role
+            final Folder folder = new FolderDataGen().site(testHost).nextPersisted();
+            final Contentlet dotAssset = TestDataUtils.getDotAssetLikeContentlet(folder);
+            addPermissions(dotAssset, testRole);
+            ContentletDataGen.publish(dotAssset);
+
+            // Generate URL for the asset
+            final String assetId = dotAssset.getIdentifier();
+            final String assetShortyURL = urlGenerator.apply(assetId);
+
+            // Mock the request and response
+            final MockHeaderRequest request = spy(new MockHeaderRequest(
+                    new MockHttpRequestIntegrationTest(
+                            "localhost", assetShortyURL).request()));
+
+            final RequestDispatcher dispatcher = mock(RequestDispatcher.class);
+            doReturn(dispatcher).when(request).getRequestDispatcher(anyString());
+
+            final HttpServletResponse response = new MockHttpStatusResponse(
+                    mock(HttpServletResponse.class));
+
+            // Send request to the servlet with a non-authenticated user
+            request.setHeader("Authorization",
+                    "Basic " + Base64.getEncoder().encodeToString(
+                            userEmailAndInvalidPassword.getBytes()));
+            servlet.service(request, response);
+
+            // Verify that the status code is 401
+            assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+
+            // Send request to the servlet with an authenticated user
+            request.setHeader("Authorization",
+                    "Basic " + Base64.getEncoder().encodeToString(
+                            userEmailAndPassword.getBytes()));
+            servlet.service(request, response);
+
+            // Verify that the request was forwarded
+            verify(dispatcher).forward(any(), any());
+
+        } finally {
+            // Clean up
+            if (testHost != null) {
+                final User systemUser = APILocator.systemUser();
+                testHost.setIndexPolicy(IndexPolicy.WAIT_FOR);
+                APILocator.getHostAPI().unpublish(testHost, systemUser, false);
+                APILocator.getHostAPI().archive(testHost, systemUser, false);
+                APILocator.getHostAPI().delete(testHost, systemUser, false);
+            }
+            if (testRole != null) {
+                RoleDataGen.remove(testRole);
+            }
+            if (testUser != null) {
+                UserDataGen.remove(testUser);
+            }
+        }
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotmarketing/servlets/ShortyServletAndTitleImageTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/servlets/ShortyServletAndTitleImageTest.java
@@ -1,28 +1,16 @@
 package com.dotmarketing.servlets;
 
-import static org.junit.Assert.*;
-
-import java.io.File;
-import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Base64;
-
-import java.util.Optional;
-
-import com.dotcms.contenttype.model.type.DotAssetContentType;
-import com.dotcms.datagen.*;
-import com.dotcms.junit.CustomDataProviderRunner;
-
-import com.dotmarketing.portlets.languagesmanager.model.Language;
-import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
+import com.dotcms.DataProviderWeldRunner;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.ImmutableBinaryField;
 import com.dotcms.contenttype.model.field.ImmutableImageField;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.DotAssetContentType;
+import com.dotcms.datagen.ContentTypeDataGen;
+import com.dotcms.datagen.FileAssetDataGen;
+import com.dotcms.datagen.FolderDataGen;
+import com.dotcms.datagen.LanguageDataGen;
+import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
@@ -32,15 +20,29 @@ import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.liferay.portal.model.User;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @ApplicationScoped
-@RunWith(CustomDataProviderRunner.class)
+@RunWith(DataProviderWeldRunner.class)
 public class ShortyServletAndTitleImageTest {
     
 
@@ -371,8 +373,6 @@ public class ShortyServletAndTitleImageTest {
         assertEquals(uri.cropWidth, uri.expectedCopWidth);
         assertEquals(uri.cropHeight, uri.expectedCropHeight);
         assertEquals(uri.isImage, uri.expectedIsImage);
-
-
     }
 
     /**
@@ -386,5 +386,21 @@ public class ShortyServletAndTitleImageTest {
         Uri uri = new Uri("/data/shared/assets/tmp_upload/temp_2e1056205c/webPageContent.vtl", 0, 0, 0, 0, 0, 0, 0, 0, 0, false);
         assertEquals(uri.isImage, uri.expectedIsImage);
     }
-    
+
+    /**
+     * Method to test: {@link ShortyServlet#serve(HttpServletRequest, HttpServletResponse)}
+     * Given Scenario: A shorty URL is requested by an authenticated user
+     * ExpectedResult: The method should forward the request for an authenticated user
+     * For a non-authenticated user, the method should return a 401 status code
+     */
+    @Test
+    public void test_ShortyServlet_With_AuthenticatedUser() throws Exception {
+
+        final HttpServlet servlet = new ShortyServlet();
+        ServletTestUtils.testServletWithAuthenticatedUser(
+                servlet, assetId -> "/dA/"
+                        + APILocator.getShortyAPI().shortify(assetId) + "/image/test.jpg");
+
+    }
+
 }

--- a/dotcms-integration/src/test/java/com/dotmarketing/servlets/SpeedyAssetServletTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/servlets/SpeedyAssetServletTest.java
@@ -1,0 +1,47 @@
+package com.dotmarketing.servlets;
+
+import com.dotcms.JUnit4WeldRunner;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.exception.DotRuntimeException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.servlet.http.HttpServlet;
+
+/**
+ * Test for {@link SpeedyAssetServlet}
+ */
+@ApplicationScoped
+@RunWith(JUnit4WeldRunner.class)
+public class SpeedyAssetServletTest {
+
+    /**
+     * Prepare the testing environment
+     */
+    @BeforeClass
+    public static void prepare()  {
+        try {
+            IntegrationTestInitService.getInstance().init();
+        } catch (Exception e) {
+            throw new DotRuntimeException(e);
+        }
+    }
+
+    /**
+     * Method to test: {@link SpeedyAssetServlet#serve(HttpServletRequest, HttpServletResponse)}
+     * Given Scenario: A request to the servlet with an authenticated user
+     * Expected Result: The request should be forwarded for an authenticated user,
+     * For a non-authenticated user, the status code should be 401
+     */
+    @Test
+    public void speedyAssetWithAuthenticatedUser() throws Exception {
+
+        final HttpServlet servlet = new SpeedyAssetServlet();
+        ServletTestUtils.testServletWithAuthenticatedUser(servlet,
+                assetId -> "/dotAsset/" + assetId);
+
+    }
+
+}


### PR DESCRIPTION
Closes #29869

### Proposed Changes
* This pull request includes the authentication mechanisms from the `WebResource` class into the 3 binary download servlets: BinaryExporterServlet, ShortyServlet and SpeedyAssetServlet. This allows users to send requests including authentication information (credentials or JWT token) when downloading files using the servlets.
* The WebResource class has been changed to include the new `AuthCheckOptions` enum with options `SKIP_CHECK_FORCE_SSL` and `SKIP_CHECK_ANONYMOUS_PERMISSIONS`. These options are used when authentication is done in the servlets to skip SSL and anonymous permissions checks that are used in authentication for API re
* Also, a new `ServletUtils` class with a method `getUserAndAuthenticateIfRequired` was created to streamline user authentication in servlets.

### Checklist
- [x] Tests

This PR fixes: #29869