### PR TITLE
implementation ( Edit Content): #30987 Integrate endpoint modifications to support creation of content in a second language 

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -363,7 +363,6 @@ describe('DotFormComponent', () => {
                 expect(spy).toHaveBeenCalledWith({
                     actionId: '1',
                     inode: 'cc120e84-ae80-49d8-9473-36d183d0c1c9',
-                    identifier: null,
                     data: {
                         contentlet: {
                             contentType: 'TestMock',
@@ -372,7 +371,8 @@ describe('DotFormComponent', () => {
                             text2: 'content text 2',
                             text3: 'default value modified',
                             multiselect: 'A,B,C',
-                            languageId: null
+                            languageId: null,
+                            identifier: null
                         }
                     }
                 });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -371,12 +371,12 @@ export class DotEditContentFormComponent implements OnInit {
         this.$store.fireWorkflowAction({
             actionId,
             inode,
-            identifier,
             data: {
                 contentlet: {
                     ...this.processFormValue(this.form.value),
                     contentType,
-                    languageId
+                    languageId,
+                    identifier
                 }
             }
         });

--- a/core-web/libs/edit-content/src/lib/store/features/locales.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales.feature.ts
@@ -252,7 +252,6 @@ export function withLocales() {
                                             currentSchemeId: defaultSchemeId,
                                             currentContentActions: parsedCurrentActions,
                                             state: ComponentStatus.LOADED,
-                                            currentIdentifier: store.contentlet()?.identifier,
                                             initialContentletState: 'copy',
                                             error: null,
                                             formValues: null,


### PR DESCRIPTION
### Proposed Changes
* After the modification in the endpoint, pass the identifier to make a new version of the content in other locale. 
 

https://github.com/user-attachments/assets/540ba7d0-17dc-4fe9-acab-81b9312e8d1c


This PR fixes: #30987