### PR TITLE
feat(Edit Mode) fixes #31155 : Locale endpoint do not return ISO codes

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/model/Language.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/model/Language.java
@@ -46,31 +46,37 @@ public class Language implements Serializable, ManifestItem {
      * @param language
      * @param country
      */
-    public Language(long id, String languageCode, String countryCode, String language, String country) {
+    public Language(final long id, final String languageCode, final String countryCode, final String language, final String country) {
+        this(id, languageCode, countryCode, language, country, null);
+    }
+
+    public Language() {
+        this(0L);
+    }
+
+    public Language(long id) {
+        this(id, BLANK, BLANK, BLANK, BLANK);
+    }
+
+    /**
+     * Creates a new Language object with the specified properties.
+     *
+     * @param id           The unique identifier of the language.
+     * @param languageCode The language code of the language.
+     * @param countryCode  The country code of the language.
+     * @param language     The name of the language.
+     * @param country      The name of the country.
+     * @param isoCode      The ISO code of the language.
+     */
+    public Language(final long id, final String languageCode, final String countryCode,
+                    final String language, final String country, final String isoCode) {
         super();
         this.id = id;
         this.languageCode = languageCode;
         this.countryCode = countryCode;
         this.language = language;
         this.country = country;
-    }
-
-    public Language() {
-        super();
-        this.id = 0;
-        this.languageCode = BLANK;
-        this.countryCode = BLANK;
-        this.language = BLANK;
-        this.country = BLANK;
-    }
-
-    public Language(long id) {
-        super();
-        this.id = id;
-        this.languageCode = BLANK;
-        this.countryCode = BLANK;
-        this.language = BLANK;
-        this.country = BLANK;
+        this.isoCode = isoCode;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/transform/LanguageTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/transform/LanguageTransformer.java
@@ -1,15 +1,25 @@
 package com.dotmarketing.portlets.languagesmanager.transform;
 
-import static com.dotcms.util.ConversionUtils.toLong;
-
 import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.transform.DBTransformer;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.jetbrains.annotations.NotNull;
 
+import static com.dotcms.util.ConversionUtils.toLong;
+
+/**
+ * This transformer takes the information of one or more Languages in dotCMS from the database, and
+ * transforms it into a list of Language objects. This mechanism provides a standardized way of
+ * loading Languages stored in the database into a Java object.
+ *
+ * @author Fabrizzio Araya
+ * @since Nov 21th, 2018
+ */
 public class LanguageTransformer implements DBTransformer <Language> {
 
     private final List<Language> list;
@@ -27,6 +37,13 @@ public class LanguageTransformer implements DBTransformer <Language> {
         return this.list;
     }
 
+    /**
+     * Transforms a Map of key-value pairs into a Language object.
+     *
+     * @param resultSet The Map of key-value pairs to transform.
+     *
+     * @return A {@link Language} object.
+     */
     @NotNull
     private static Language transform(final Map<String, Object> resultSet)  {
         final long id               = toLong(resultSet.get("id"), 0L);
@@ -34,7 +51,8 @@ public class LanguageTransformer implements DBTransformer <Language> {
         final String countryCode    = (resultSet.get("country_code")!=null)     ? String.valueOf(resultSet.get("country_code")) : null;
         final String language       = (resultSet.get("language")!=null)         ? String.valueOf(resultSet.get("language"))     : null;
         final String country        = (resultSet.get("country")!=null)          ? String.valueOf(resultSet.get("country"))      : null;
-        return new Language(id, langCode, countryCode, language, country);
+        final String isoCode = StringUtils.isNotBlank(countryCode) ? langCode + "-" + countryCode : langCode;
+        return new Language(id, langCode, countryCode, language, country, null != isoCode ? isoCode.toLowerCase() : null);
     }
 
 }

--- a/dotcms-postman/src/main/resources/postman/LanguageResourceTests.json
+++ b/dotcms-postman/src/main/resources/postman/LanguageResourceTests.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0bd5957a-5481-401c-a2bf-47d85e8be155",
+		"_postman_id": "619a5b39-7d5c-433c-b55d-ccf00c6ddd2a",
 		"name": "LanguageResource",
 		"description": "This collections is focused on the /v2/languages resource\nThis should cover Language CRUD Operations",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -2627,6 +2627,255 @@
 				}
 			],
 			"description": "Delete Language associated to an Existing Content-Type Should Fail"
+		},
+		{
+			"name": "Check ISO Code",
+			"item": [
+				{
+					"name": "Create Test Content",
+					"item": [
+						{
+							"name": "Create test Content Type",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Content Type created successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the test Content Type\");",
+											"    pm.collectionVariables.set(\"testCTVarName\", jsonData.entity[0].variable);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n   \"defaultType\":false,\n   \"icon\":\"360\",\n   \"fixed\":false,\n   \"system\":false,\n   \"clazz\":\"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n   \"description\":\"\",\n   \"host\":\"8a7d5e23-da1e-420a-b4f0-471e7da8ea2d\",\n   \"folder\":\"SYSTEM_FOLDER\",\n   \"name\":\"My Test CT\",\n   \"systemActionMappings\": {\n        \"NEW\": \"\"\n    },\n    \"workflow\": [\n        \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"\n    ],\n   \"fields\": [{\n       \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n\t\t\"dataType\": \"TEXT\",\n\t\t\"fieldType\": \"Text\",\n\t\t\"fieldTypeLabel\": \"Text\",\n\t\t\"fieldVariables\": [],\n\t\t\"fixed\": false,\n\t\t\"iDate\": 1606168746000,\n\t\t\"indexed\": true,\n\t\t\"listed\": false,\n\t\t\"modDate\": 1606168746000,\n\t\t\"name\": \"Title\",\n\t\t\"readOnly\": false,\n\t\t\"required\": false,\n\t\t\"searchable\": true,\n\t\t\"sortOrder\": 1,\n\t\t\"unique\": false,\n\t\t\"variable\": \"title\"\n    }\n   ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/contenttype",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"contenttype"
+									]
+								},
+								"description": "### Create Content Type\n\nThis endpoint allows you to create a new content type. The request should be sent as an HTTP POST to `{{serverURL}}/api/v1/contenttype`.\n\n#### Request Body\n\nThe request should include the following parameters in the raw request body:\n\n- `defaultType` (boolean): Indicates whether it is the default type.\n    \n- `icon` (string): The icon for the content type.\n    \n- `fixed` (boolean): Indicates whether the content type is fixed.\n    \n- `system` (boolean): Indicates whether the content type is a system type.\n    \n- `clazz` (string): The class of the content type.\n    \n- `description` (string): Description of the content type.\n    \n- `host` (string): The host of the content type.\n    \n- `folder` (string): The folder of the content type.\n    \n- `name` (string): The name of the content type.\n    \n- `systemActionMappings` (object): System action mappings for the content type.\n    \n- `workflow` (array): Array of workflows associated with the content type.\n    \n- `fields` (array): Array of fields for the content type.\n    \n\n#### Response\n\nUpon successful execution, the response will have a status code of 200 and a JSON object with the newly created content type entity, including its fields, workflows, and other metadata."
+							},
+							"response": []
+						},
+						{
+							"name": "Create test Contentlet",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Contentlet created successfully\", function() {",
+											"    const jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the test Contentlet\");",
+											"    pm.expect(jsonData.entity.summary.affected).to.eql(1);",
+											"    const key = Object.keys(jsonData.entity.results[0]);",
+											"    pm.collectionVariables.set(\"testContentID\", jsonData.entity.results[0][key].identifier);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"{{testCTVarName}}\",\n            \"title\": \"My test contentlet\",\n            \"contentHost\": \"default\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									],
+									"query": [
+										{
+											"key": "indexPolicy",
+											"value": "WAIT_FOR"
+										}
+									]
+								},
+								"description": "### Perform Workflow Action to Publish Content\n\nThis endpoint allows you to trigger the default workflow action for publishing content.\n\n#### Request Body\n\n- The request should be sent as an HTTP POST to `{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR`.\n    \n- { \"contentlets\": \\[ { \"contentType\": \"{{testCTVarName}}\", \"title\": \"My test contentlet\", \"contentHost\": \"default\" } \\]}\n    \n\n#### Response\n\n- **Status**: 200\n    \n- **Content-Type**: application/json\n    \n- The response will include the published content entity with its details, such as auto-assign workflow status, content properties, creation date, modification date, and publishing details.\n    \n- The response also includes a summary of the affected content, success count, fail count, and time taken for the operation."
+							},
+							"response": []
+						},
+						{
+							"name": "Create test Language",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Check that the expected Language info is returned\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.entity.country).to.eql(\"\");",
+											"    pm.expect(jsonData.entity.countryCode).to.eql(\"\");",
+											"    pm.expect(jsonData.entity.defaultLanguage).to.eql(false);",
+											"    pm.expect(jsonData.entity.isoCode).to.eql(\"qwert\");",
+											"    pm.expect(jsonData.entity.language).to.eql(\"qwerty\");",
+											"    pm.expect(jsonData.entity.languageCode).to.eql(\"qwert\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"country\": \"\",\n    \"countryCode\": \"\",\n    \"language\": \"qwerty\",\n    \"languageCode\": \"qwert\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v2/languages",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v2",
+										"languages"
+									]
+								},
+								"description": "### Add Language\n\nThis endpoint allows you to add a new language with the specified country, country code, language, and language code.\n\n#### Request Body\n\n- country (string, optional): The name of the country.\n    \n- countryCode (string, optional): The country code.\n    \n- language (string): The name of the language.\n    \n- languageCode (string): The language code.\n    \n\n#### Response\n\nUpon successful execution, the API returns a JSON object with the following fields:\n\n- entity (object): Contains information about the newly added language, including country, country code, default language status, ID, ISO code, language, and language code.\n    \n- errors (array): An array of any errors encountered during the request.\n    \n- i18nMessagesMap (object): Internationalization messages map.\n    \n- messages (array): Any additional messages related to the request.\n    \n- pagination (null): Pagination information, if applicable.\n    \n- permissions (array): Permissions related to the request."
+							},
+							"response": []
+						}
+					],
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.test(\"HTTP Status code must be successful\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Getting languages for Contentlet",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"HTTP Status code must be successful\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Check that all Languages have the ISO Code\", function () {",
+									"    const entity = pm.response.json().entity;",
+									"    entity.forEach(function(lang) { ",
+									"        pm.expect(lang.isoCode).to.not.equal('', \"ISO Code for language '\" + lang.language + \"'_'\" + lang.country + \"' must ALWAYS be set\");",
+									"    });",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{serverURL}}/api/v1/content/{{testContentID}}/languages",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"content",
+								"{{testContentID}}",
+								"languages"
+							]
+						},
+						"description": "This endpoint retrieves the languages available for a specific content identified by the 'testContentID', and checks that the ISO Code is set in ALL of them.\n\n### Request\n\n- Method: GET\n    \n- URL: {{serverURL}}/api/v1/content/{{testContentID}}/languages\n    \n\n### Response\n\nThe response will be in JSON format and will include the following fields:\n\n- `entity`: An array of objects containing information about the available languages, including country, country code, language, language code, and translation status.\n    \n- `errors`: An array of any errors encountered during the request.\n    \n- `i18nMessagesMap`: An object containing internationalization messages.\n    \n- `messages`: An array of messages.\n    \n- `pagination`: Information about pagination, if applicable.\n    \n- `permissions`: An array of permissions.\n    \n\nExample response:\n\n``` json\n{\n    \"entity\": [\n        {\n            \"country\": \"\",\n            \"countryCode\": \"\",\n            \"id\": 0,\n            \"isoCode\": \"\",\n            \"language\": \"\",\n            \"languageCode\": \"\",\n            \"translated\": true\n        }\n    ],\n    \"errors\": [],\n    \"i18nMessagesMap\": {},\n    \"messages\": [],\n    \"pagination\": null,\n    \"permissions\": []\n}\n\n ```"
+					},
+					"response": []
+				}
+			],
+			"description": "Verifies that the ISO COde attribute in the Language object returned via REST is always set. This property is particularly important in the new Contentlet Edit Mode as it allows FE devs to display the list of languages that a content is/is not available in."
 		},
 		{
 			"name": "Duplicate Key Case",


### PR DESCRIPTION
### Proposed Changes
* Adds the ISO Code property when the Language is read from the database, as setting this property was missed in such a class.
* Adds a Postman test that checks that the ISO Code is always available when checking the Languages that a Content is available in.

This PR fixes: #31155