### PR TITLE
chore(UVE): Remove temporal patch

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.ts
@@ -13,7 +13,7 @@ import { ButtonModule } from 'primeng/button';
 import { DialogService } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
 
-import { delay, map, retryWhen, takeWhile } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 
 import { DotFavoritePageService, DotMessageService } from '@dotcms/data-access';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
@@ -84,16 +84,6 @@ export class DotEmaBookmarksComponent implements OnInit {
             })
             .pipe(
                 takeUntilDestroyed(this.destroyRef),
-                retryWhen((errors) =>
-                    errors.pipe(
-                        delay(500),
-                        takeWhile((error) => {
-                            // This request is returning null in some cases and we need to retry
-                            return error instanceof TypeError;
-                        })
-                    )
-                ),
-
                 map((res) => res.jsonObjectView.contentlets[0])
             )
             .subscribe((favoritePage) => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/store/edit-ema-palette.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/store/edit-ema-palette.store.ts
@@ -4,7 +4,7 @@ import { EMPTY, Observable, forkJoin } from 'rxjs';
 
 import { Injectable, inject } from '@angular/core';
 
-import { catchError, delay, map, retryWhen, switchMap, takeWhile, tap } from 'rxjs/operators';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
 
 import {
     DotContentTypeService,
@@ -248,15 +248,6 @@ export class DotPaletteStore extends ComponentStore<DotPaletteState> {
                 DotConfigurationVariables.CONTENT_PALETTE_HIDDEN_CONTENT_TYPES
             )
         }).pipe(
-            retryWhen((errors) =>
-                errors.pipe(
-                    delay(500),
-                    takeWhile((error) => {
-                        // The request is returning null in some cases and we need to retry
-                        return error instanceof TypeError;
-                    })
-                )
-            ),
             map(({ contentTypes, widgets, hiddenContentTypes }) => {
                 /**
                  * This filter is used to prevent widgets from being repeated.


### PR DESCRIPTION
This pull request focuses on simplifying the code by removing unnecessary operators from RxJS pipelines in two components: `DotEmaBookmarksComponent` and `DotPaletteStore`.

### Code simplification:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.ts`](diffhunk://#diff-6cdfb5abade6eb8396ed84d8a8d520e262cc6edef0cdf48f908e150724f920abL87-L96): Removed `retryWhen`, `delay`, and `takeWhile` operators from the RxJS pipeline in the `DotEmaBookmarksComponent` class.
* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/store/edit-ema-palette.store.ts`](diffhunk://#diff-e60190c318aa61ddbc495b1c20398bb42e7baa8429b8241aa6964267f3ddd445L251-L259): Removed `retryWhen`, `delay`, and `takeWhile` operators from the RxJS pipeline in the `DotPaletteStore` class.

### Import cleanup:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-ema-bookmarks/dot-ema-bookmarks.component.ts`](diffhunk://#diff-6cdfb5abade6eb8396ed84d8a8d520e262cc6edef0cdf48f908e150724f920abL16-R16): Removed unused imports `delay`, `retryWhen`, and `takeWhile` from RxJS operators.
* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/edit-ema-palette/store/edit-ema-palette.store.ts`](diffhunk://#diff-e60190c318aa61ddbc495b1c20398bb42e7baa8429b8241aa6964267f3ddd445L7-R7): Removed unused imports `delay`, `retryWhen`, and `takeWhile` from RxJS operators.

## Screenshot

https://github.com/user-attachments/assets/df101b84-4521-47b8-a8fb-8177975f0dd7


This PR fixes: #31081