### PR TITLE
#30761 fix(task-detail) Data is not getting saved when wf action trigger wizard dialog

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-porlet-detail/dot-workflow-task/dot-workflow-task.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-porlet-detail/dot-workflow-task/dot-workflow-task.component.spec.ts
@@ -197,7 +197,7 @@ describe('DotWorkflowTaskComponent', () => {
             detail: {
                 name: 'workflow-wizard',
                 data: {
-                    callback: 'fileActionCallbackFromAngular'
+                    callback: 'test'
                 }
             }
         };

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-porlet-detail/dot-workflow-task/dot-workflow-task.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-porlet-detail/dot-workflow-task/dot-workflow-task.component.ts
@@ -48,7 +48,6 @@ export class DotWorkflowTaskComponent implements OnInit {
         if (['edit-task-executed-workflow', 'close'].includes($event.detail.name)) {
             this.onCloseWorkflowTaskEditor();
         } else {
-            $event.detail.data.callback = 'fileActionCallbackFromAngular';
             this.dotCustomEventHandlerService.handle($event);
         }
     }

--- a/dotCMS/src/main/webapp/html/portlet/ext/workflows/workflows_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/workflows/workflows_js_inc.jsp
@@ -189,11 +189,6 @@
 		dijit.byId('savingContentDialog').hide();
 	}
 
-	function fileActionCallbackFromAngular() {
-		showDotCMSSystemMessage("<%=LanguageUtil.get(pageContext, "Workflow-executed")%>");
-		executeEditTaskExecutedWorkflowEvent();
-	}
-
 	function executeEditTaskExecutedWorkflowEvent() {
 		var customEvent = document.createEvent("CustomEvent");
 		customEvent.initCustomEvent("ng-event", false, false,  {


### PR DESCRIPTION
### Proposed Changes
* Removed the callback overwrite in `dot-workflow-task.component.ts` for workflow actions.
* Deleted the unused `fileActionCallbackFromAngular` function in `workflows_js_inc.jsp`.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
While debugging, the issue was traced back to the callback overwrite in `dot-workflow-task.component.ts`. The flow was as follows:  
1. `edit_contentlet_js_inc.jsp.executeWfAction()` triggered the `update-workflow-action` event to refresh workflow actions.  
2. If workflow actions were available, `pushHandler.showWorkflowEnabledDialog` invoked `RemotePublisherDialog.show(isBulk, isEdit)`, which subsequently executed `_dispatchAngularWorkflowEvent`.  
3. This event created the `workflow-wizard` with a callback to `saveAssignCallBackAngular`.  
4. The `workflow-wizard` event was caught by `onCustomEvent` in `dot-contentlets.component` and `dot-workflow-task.component`. However, in `dot-workflow-task.component`, the callback was being overwritten with `fileActionCallbackFromAngular`.  

After opening the dialog and clicking on the final step, the `fireWorkflowAction` method was executed. This method checked the callback [(see code)](https://github.com/dotCMS/core/blob/main/core-web/libs/data-access/src/lib/dot-workflow-event-handler/dot-workflow-event-handler.service.ts#L246) and:  
- If it was `saveAssignCallBackAngular`, it sent the event to `dotiframeService`.  
- Otherwise, it processed the callback through `dotWorkflowActionsFireService.fireTo`.  

The callback overwrite caused errors by disrupting this flow. Removing the overwrite and the unused callback function resolves the issue and ensures correct workflow action execution.
 
### Screenshots
#### Original

https://github.com/user-attachments/assets/ae0b4e25-c428-464f-8de3-aed3fe89be88

#### Updated

https://github.com/user-attachments/assets/d2a85aa9-8451-4dee-b6f3-1c84bc0e7574


This PR fixes: #30761