### PR TITLE
fix(CDI) IllegalStateException restarting an OSGI-plugin Refs:#31185

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/config/ContainerReloader.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/config/ContainerReloader.java
@@ -2,8 +2,6 @@ package com.dotcms.rest.config;
 
 import com.dotmarketing.util.Logger;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.ext.Provider;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.spi.AbstractContainerLifecycleListener;
 import org.glassfish.jersey.server.spi.Container;
@@ -11,11 +9,15 @@ import org.glassfish.jersey.server.spi.Container;
 /**
  * A new Re-loader will get created on each reload there can only be one container at a time
  */
-@Provider
-@ApplicationScoped
-public class ContainerReloader extends AbstractContainerLifecycleListener {
+class ContainerReloader extends AbstractContainerLifecycleListener {
+
+    private static final ContainerReloader INSTANCE = new ContainerReloader();
 
     private static final AtomicReference<Container> containerRef = new AtomicReference<>();
+
+    public static ContainerReloader getInstance() {
+        return INSTANCE;
+    }
 
     @Override
     public void onStartup(Container container) {
@@ -35,9 +37,9 @@ public class ContainerReloader extends AbstractContainerLifecycleListener {
     }
 
     public void reload() {
-        Container container = containerRef.get();
-        Logger.debug(ContainerReloader.class, "Jersey Reloading request");
-        if (container != null) {
+        final Container container = containerRef.get();
+        if (null != container) {
+            Logger.debug(ContainerReloader.class, "Jersey Reloading request");
             container.reload(ResourceConfig.forApplicationClass(DotRestApplication.class));
         }
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/config/DotRestApplication.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/config/DotRestApplication.java
@@ -1,6 +1,5 @@
 package com.dotcms.rest.config;
 
-import com.dotcms.cdi.CDIUtils;
 import com.dotcms.telemetry.rest.TelemetryResource;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
@@ -10,16 +9,13 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.vavr.Lazy;
-import org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider;
-import org.glassfish.jersey.media.multipart.MultiPartFeature;
-import org.glassfish.jersey.server.ResourceConfig;
-
-import javax.ws.rs.ApplicationPath;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.ws.rs.ApplicationPath;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.server.ResourceConfig;
 
 /**
  * This class provides the list of all the REST end-points in dotCMS. Every new
@@ -69,8 +65,7 @@ public class DotRestApplication extends ResourceConfig {
 		register(MultiPartFeature.class).
 		register(JacksonJaxbJsonProvider.class).
 		registerClasses(customClasses.keySet()).
-		packages(packages.toArray(new String[0])).
-		register(CdiComponentProvider.class);
+		packages(packages.toArray(new String[0]));
 	}
 
 	/**
@@ -92,8 +87,7 @@ public class DotRestApplication extends ResourceConfig {
 			return;
 		}
 		if (Boolean.TRUE.equals(customClasses.computeIfAbsent(clazz,c -> true))) {
-			final Optional<ContainerReloader> reloader = CDIUtils.getBean(ContainerReloader.class);
-            reloader.ifPresent(ContainerReloader::reload);
+			ContainerReloader.getInstance().reload();
 		}
 	}
 
@@ -106,8 +100,7 @@ public class DotRestApplication extends ResourceConfig {
 			return;
 		}
 		if(customClasses.remove(clazz) != null){
-			final Optional<ContainerReloader> reloader = CDIUtils.getBean(ContainerReloader.class);
-			reloader.ifPresent(ContainerReloader::reload);
+			ContainerReloader.getInstance().reload();
 		}
 	}
 


### PR DESCRIPTION
### Proposed Changes
* This comes to fix a jersey bug that leaves the application in a useless state after stopping an OSG plugin 
* The problem was caused by the ContainerReloader component that we had to restart the Servlet container on the fly. This component shouldn't be a Managed bean so it can survive a restart with no problem. 
* This ContainerReloader was made singleton, as it used to be before we added CDI
* I am removing CdiComponentProvider since it's an internal dependency that is already part of Jersey 



This PR fixes: #31185