### PR TITLE
chore(FTM): Resolve feedback found on IQA

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.html
@@ -34,8 +34,6 @@
         iconPos="right"
         [label]="$moreButtonLabel() | dm"
         [class.active]="$isMoreButtonActive()"
-        [pTooltip]="$moreButtonLabel() | dm"
-        tooltipPosition="bottom"
         styleClass="p-button-text p-2 p-button-sm"
         (click)="menu.toggle($event)"
         data-testId="more-button" />

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.spec.ts
@@ -59,7 +59,6 @@ const baseUVEState = {
     $uveToolbar: signal(baseUVEToolbarState),
     setDevice: jest.fn(),
     setSEO: jest.fn(),
-    setSocialMedia: jest.fn(),
     pageParams: signal(params),
     pageAPIResponse: signal(MOCK_RESPONSE_VTL),
     $apiURL: signal($apiURL),

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
@@ -20,7 +20,8 @@
                 (ngModelChange)="fetchPageOnDate($event)"
                 [showTime]="true"
                 [hourFormat]="'12'"
-                [minDate]="CURRENT_DATE"
+                dataType="date"
+                [minDate]="MIN_DATE"
                 [readonlyInput]="true" />
             <p-button
                 styleClass="uve-toolbar-chips"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
@@ -55,7 +55,6 @@ const $apiURL = '/api/v1/page/json/123-xyz-567-xxl?host_id=123-xyz-567-xxl&langu
 
 const params = HEADLESS_BASE_QUERY_PARAMS;
 const url = sanitizeURL(params?.url);
-const MOCKED_DATE = new Date('2025-01-29');
 
 const pageAPIQueryParams = createPageApiUrlWithQueryParams(url, params);
 const pageAPI = `/api/v1/page/${'json'}/${pageAPIQueryParams}`;
@@ -621,7 +620,6 @@ describe('DotUveToolbarComponent', () => {
             });
 
             store = spectator.inject(UVEStore, true);
-            jest.useFakeTimers().setSystemTime(MOCKED_DATE);
         });
 
         it('should have a device selector', () => {
@@ -670,8 +668,15 @@ describe('DotUveToolbarComponent', () => {
             });
 
             it('should have a minDate of current date on 0h 0min 0s 0ms', () => {
+                baseUVEState.$isPreviewMode.set(false);
+                baseUVEState.$isLiveMode.set(true);
+                baseUVEState.socialMedia.set(null);
+                spectator.detectChanges();
+
                 const calendar = spectator.query('p-calendar');
-                const expectedMinDate = new Date(MOCKED_DATE);
+
+                const expectedMinDate = new Date(fixedDate);
+
                 expectedMinDate.setHours(0, 0, 0, 0);
 
                 expect(calendar.getAttribute('ng-reflect-min-date')).toBeDefined();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
@@ -55,6 +55,7 @@ const $apiURL = '/api/v1/page/json/123-xyz-567-xxl?host_id=123-xyz-567-xxl&langu
 
 const params = HEADLESS_BASE_QUERY_PARAMS;
 const url = sanitizeURL(params?.url);
+const MOCKED_DATE = new Date('2025-01-29');
 
 const pageAPIQueryParams = createPageApiUrlWithQueryParams(url, params);
 const pageAPI = `/api/v1/page/${'json'}/${pageAPIQueryParams}`;
@@ -620,6 +621,7 @@ describe('DotUveToolbarComponent', () => {
             });
 
             store = spectator.inject(UVEStore, true);
+            jest.useFakeTimers().setSystemTime(MOCKED_DATE);
         });
 
         it('should have a device selector', () => {
@@ -665,6 +667,17 @@ describe('DotUveToolbarComponent', () => {
                 spectator.detectChanges();
 
                 expect(spectator.query('p-calendar')).toBeFalsy();
+            });
+
+            it('should have a minDate of current date on 0h 0min 0s 0ms', () => {
+                const calendar = spectator.query('p-calendar');
+                const expectedMinDate = new Date(MOCKED_DATE);
+                expectedMinDate.setHours(0, 0, 0, 0);
+
+                expect(calendar.getAttribute('ng-reflect-min-date')).toBeDefined();
+                expect(new Date(calendar.getAttribute('ng-reflect-min-date'))).toEqual(
+                    expectedMinDate
+                );
             });
         });
     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -116,9 +116,11 @@ export class DotUveToolbarComponent {
     );
 
     protected readonly $pageParams = this.#store.pageParams;
-    protected readonly $previewDate = computed<Date>(() =>
-        this.$pageParams().publishDate ? new Date(this.$pageParams().publishDate) : new Date()
-    );
+    protected readonly $previewDate = computed<Date>(() => {
+        return this.$pageParams().publishDate
+            ? new Date(this.$pageParams().publishDate)
+            : new Date();
+    });
 
     readonly $pageInode = computed(() => {
         return this.#store.pageAPIResponse()?.page.inode;
@@ -128,7 +130,15 @@ export class DotUveToolbarComponent {
     readonly $workflowLoding = this.#store.workflowLoading;
 
     defaultDevices = DEFAULT_DEVICES;
-    CURRENT_DATE = new Date();
+    get MIN_DATE() {
+        const currentDate = new Date();
+
+        // We need to set this to 0 so the minDate does not collide with the previewDate value when we are initializing
+        // This prevents the input from being empty on init
+        currentDate.setHours(0, 0, 0, 0);
+
+        return currentDate;
+    }
 
     /**
      * Fetch the page on a given date


### PR DESCRIPTION
This pull request includes several updates to the `dot-uve-toolbar` and `dot-uve-device-selector` components in the `edit-ema-editor` module. The main changes focus on modifying date handling, updating tooltips, and enhancing test coverage.

### Changes to Date Handling:
* [`dot-uve-toolbar.component.html`](diffhunk://#diff-9937556e73b051b878ba22ad1ce971a70019a617d7979b3e0bcc814801ad350bL23-R24): Changed the `minDate` attribute to use `MIN_DATE` and added `dataType="date"` to the calendar component.
* [`dot-uve-toolbar.component.ts`](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30L131-R141): Added a `MIN_DATE` getter that sets the time to 0 hours, 0 minutes, 0 seconds, and 0 milliseconds to ensure the minimum date does not collide with the preview date.

### Tooltip and Button Updates:
* [`dot-uve-device-selector.component.html`](diffhunk://#diff-13b3f8a3ba001e8aac1ac47383a943b96b6af0c99c43aa91154da1cf1be5d6a6L37-L38): Removed the tooltip attribute and its position from the "more" button.

### Test Enhancements:
* [`dot-uve-toolbar.component.spec.ts`](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1R624): Added a mock date and a test to verify the `minDate` attribute of the calendar component. [[1]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1R624) [[2]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1R671-R681)
* [`dot-uve-device-selector.component.spec.ts`](diffhunk://#diff-652f846aa914e51df03471614a9ffc9b80757f275a3639fe1131def21c40b39dL62): Removed the `setSocialMedia` mock function from the base UVE state.
* [`dot-uve-toolbar.component.spec.ts`](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1R58): Added a mock date initialization in the `describe` block.

### Code Refactoring:
* [`dot-uve-toolbar.component.ts`](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30L119-R123): Refactored the `$previewDate` computed property to use a more readable function block.

This PR fixes: #31208