### PR TITLE
Issue 31101 Copy url in experiments fails

### DIFF
--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.html
@@ -38,7 +38,7 @@
 
                         <dot-copy-button
                             *ngIf="variant.url"
-                            [copy]="variant.url"
+                            [copy]="url + '&variantName=' + variant.id"
                             [label]="'editpage.header.copy' | dm"
                             [tooltipText]="
                                 'dot.common.message.pageurl.copy.clipboard' | dm

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
@@ -81,6 +81,7 @@ export class DotExperimentsConfigurationVariantsComponent {
     protected readonly maxInputTitleLength = MAX_INPUT_TITLE_LENGTH;
     protected readonly DotExperimentStatusList = DotExperimentStatus;
     private componentRef: ComponentRef<DotExperimentsConfigurationVariantsAddComponent>;
+    protected readonly url = this.getUrl();
 
     constructor(
         private readonly dotExperimentsConfigurationStore: DotExperimentsConfigurationStore,
@@ -186,5 +187,35 @@ export class DotExperimentsConfigurationVariantsComponent {
         if (this.componentRef) {
             this.sidebarHost.viewContainerRef.clear();
         }
+    }
+
+    private getUrl(): string {
+        const firstUrl = window.location.href;
+        const splitUrl = firstUrl.split('url=')[1].replace("&","?").replace(/%3A/g, ':').replace(/%2F/g, '/');
+
+        let finalUrl: string;
+
+
+        let url: URL;
+
+        try {
+            // Sometimes the host is specified in the url so this will work
+            url = new URL(
+                `${splitUrl}${
+                    splitUrl.indexOf('?') != -1 ? '&' : '?'
+                }disabledNavigateMode=true&mode=LIVE`
+            );
+        } catch {
+            // In case it is not a valid URL, we will use the current location
+            url = new URL(
+                `${window.location.origin}/${splitUrl}${
+                    splitUrl.indexOf('?') != -1 ? '&' : '?'
+                }disabledNavigateMode=true&mode=LIVE`
+            );
+        } finally {
+            finalUrl = url.toString();
+        }
+
+        return finalUrl;
     }
 }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
@@ -191,7 +191,20 @@ export class DotExperimentsConfigurationVariantsComponent {
 
     private getUrl(): string {
         const firstUrl = window.location.href;
-        const splitUrl = firstUrl
+
+        // Check if 'url=' exists in the current URL
+        if (!firstUrl.includes('url=')) {
+            return window.location.origin;
+        }
+
+        const splitUrl = firstUrl.split('url=')[1] || '';
+
+        // Ensure splitUrl is not empty before applying .replace()
+        if (!splitUrl.trim()) {
+            return window.location.origin;
+        }
+
+        const processedUrl = firstUrl
             .split('url=')[1]
             .replace('&', '?')
             .replace(/%3A/g, ':')
@@ -202,17 +215,17 @@ export class DotExperimentsConfigurationVariantsComponent {
         let url: URL;
 
         try {
-            // Sometimes the host is specified in the url so this will work
+            // Try parsing as a full URL
             url = new URL(
-                `${splitUrl}${
-                    splitUrl.indexOf('?') != -1 ? '&' : '?'
+                `${processedUrl}${
+                    processedUrl.indexOf('?') != -1 ? '&' : '?'
                 }disabledNavigateMode=true&mode=LIVE`
             );
         } catch {
-            // In case it is not a valid URL, we will use the current location
+            // Fallback to relative URL using window.location.origin
             url = new URL(
-                `${window.location.origin}/${splitUrl}${
-                    splitUrl.indexOf('?') != -1 ? '&' : '?'
+                `${window.location.origin}/${processedUrl}${
+                    processedUrl.indexOf('?') != -1 ? '&' : '?'
                 }disabledNavigateMode=true&mode=LIVE`
             );
         } finally {

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/components/dot-experiments-configuration-variants/dot-experiments-configuration-variants.component.ts
@@ -191,10 +191,13 @@ export class DotExperimentsConfigurationVariantsComponent {
 
     private getUrl(): string {
         const firstUrl = window.location.href;
-        const splitUrl = firstUrl.split('url=')[1].replace("&","?").replace(/%3A/g, ':').replace(/%2F/g, '/');
+        const splitUrl = firstUrl
+            .split('url=')[1]
+            .replace('&', '?')
+            .replace(/%3A/g, ':')
+            .replace(/%2F/g, '/');
 
         let finalUrl: string;
-
 
         let url: URL;
 


### PR DESCRIPTION
The url that was being saved in a variant was only the path to the page, so a new url in the copy button was added. This url is processed and made by a new function inside the component, that gets the current location and creates a complete url.

Now the url copied is for example http://localhost:8082/blog/post/french-polynesia-everything-you-need-to-know?language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit&disabledNavigateMode=true&mode=LIVE&variantName=DEFAULT

This url should open the page in the specified variant live version of the page as client, just like clicking on _"Open Published Version"_. 

This PR fixes: #31101