### PR TITLE
chore(actions): Update SDK Publishing action to ensure we publish under `beta` tags

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -64,14 +64,14 @@ runs:
         echo "::endgroup::"
       shell: bash
 
-     - name: 'Get current version from NPM'
+    - name: 'Get current version from NPM'
       id: current_version
       run: |
         echo "::group::Get current version"
         # This should be empty on the first run. Setting the NEXT_VERSION to 0.0.1-beta.1
         CURRENT_VERSION=$(npm view @dotcms/client dist-tags --json | jq -r '.beta')
 
-        if [ -z "$CURRENT_VERSION" ]; then
+        if [ -z "$CURRENT_VERSION" ] || [ "$CURRENT_VERSION" = "null" ]; then
           CURRENT_VERSION="0.0.1-beta.0"
         fi
 

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -70,6 +70,11 @@ runs:
         echo "::group::Get current version"
         # This should be empty on the first run. Setting the NEXT_VERSION to 0.0.1-beta.1
         CURRENT_VERSION=$(npm view @dotcms/client dist-tags --json | jq -r '.beta')
+
+        if [ -z "$CURRENT_VERSION" ]; then
+          CURRENT_VERSION="0.0.1-beta.0"
+        fi
+
         echo "Current version: $CURRENT_VERSION"
         echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
         echo "::endgroup::"
@@ -81,19 +86,15 @@ runs:
        CURRENT_VERSION: ${{ steps.current_version.outputs.current_version }}
       run: |
         echo "::group::Calculate next version"
-        if [ -z "$CURRENT_VERSION" ]; then
-          NEXT_VERSION="0.0.1-beta.1"
-        else
-          VERSION_PARTS=(${CURRENT_VERSION//./ })
-          BASE_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
-          BETA_PART=${VERSION_PARTS[3]#*-}
-          BETA_NUMBER=${BETA_PART#*.}
-          NEW_BETA_NUMBER=$((BETA_NUMBER + 1))
-          NEXT_VERSION="${BASE_VERSION}.${NEW_BETA_NUMBER}"
-        fi
-          echo "Next version: $NEXT_VERSION"
-          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
-          echo "::endgroup::"
+        VERSION_PARTS=(${CURRENT_VERSION//./ })
+        BASE_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
+        BETA_PART=${VERSION_PARTS[3]#*-}
+        BETA_NUMBER=${BETA_PART#*.}
+        NEW_BETA_NUMBER=$((BETA_NUMBER + 1))
+        NEXT_VERSION="${BASE_VERSION}.${NEW_BETA_NUMBER}"
+        echo "Next version: $NEXT_VERSION"
+        echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
 
       shell: bash
 

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -1,14 +1,14 @@
-# Note: The versions of the SDK libraries will be incremented in the NPM registry, 
-# but they will not be updated in the codebase itself through this process. 
-# This simplification avoids automatic pull requests and all the considerations 
-# necessary due to protections on the main branch, as well as the lengthy execution 
+# Note: The versions of the SDK libraries will be incremented in the NPM registry,
+# but they will not be updated in the codebase itself through this process.
+# This simplification avoids automatic pull requests and all the considerations
+# necessary due to protections on the main branch, as well as the lengthy execution
 # process that would be required to ultimately publish the libraries.
-# 
-# This is a temporary solution until we determine the most appropriate pattern 
-# to handle the lifecycle of each module that needs to be released individually 
+#
+# This is a temporary solution until we determine the most appropriate pattern
+# to handle the lifecycle of each module that needs to be released individually
 # (e.g., dotCLI and the SDKs).
 #
-# Additionally, the example projects should point to the 'latest' tag to ensure 
+# Additionally, the example projects should point to the 'next' tag to ensure
 # that version updates do not impact their functionality due to version inconsistency.
 name: 'SDK Publish NPM Packages'
 description: 'Publish the dotCMS SDK libs on NPM registry.'
@@ -23,10 +23,10 @@ inputs:
   npm-package-tag:
     description: 'Package tag'
     required: false
-    default: 'alpha'
+    default: 'beta'
   github-token:
     description: 'GitHub Token'
-    required: true    
+    required: true
 outputs:
   npm-package-version:
     description: 'SDK libs - NPM package version'
@@ -62,16 +62,17 @@ runs:
         ls -R $BASE_PATH
         echo "PATH=$PATH:${BASE_PATH}/node/:${BASE_PATH}/node/yarn/dist/bin" >> $GITHUB_ENV
         echo "::endgroup::"
-      shell: bash               
+      shell: bash
 
-    - name: 'Get current version from NPM'
+     - name: 'Get current version from NPM'
       id: current_version
       run: |
-       echo "::group::Get current version"
-       CURRENT_VERSION=$(npm view @dotcms/client dist-tags --json | jq -r '.alpha')
-       echo "Current version: $CURRENT_VERSION"
-       echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-       echo "::endgroup::"
+        echo "::group::Get current version"
+        # This should be empty on the first run. Setting the NEXT_VERSION to 0.0.1-beta.1
+        CURRENT_VERSION=$(npm view @dotcms/client dist-tags --json | jq -r '.beta')
+        echo "Current version: $CURRENT_VERSION"
+        echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
       shell: bash
 
     - name: 'Calculate next version'
@@ -79,16 +80,21 @@ runs:
       env:
        CURRENT_VERSION: ${{ steps.current_version.outputs.current_version }}
       run: |
-       echo "::group::Calculate next version"
-       VERSION_PARTS=(${CURRENT_VERSION//./ })
-       BASE_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
-       ALPHA_PART=${VERSION_PARTS[3]#*-}
-       ALPHA_NUMBER=${ALPHA_PART#*.}
-       NEW_ALPHA_NUMBER=$((ALPHA_NUMBER + 1))
-       NEXT_VERSION="${BASE_VERSION}.${NEW_ALPHA_NUMBER}"
-       echo "Next version: $NEXT_VERSION"
-       echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
-       echo "::endgroup::"
+        echo "::group::Calculate next version"
+        if [ -z "$CURRENT_VERSION" ]; then
+          NEXT_VERSION="0.0.1-beta.1"
+        else
+          VERSION_PARTS=(${CURRENT_VERSION//./ })
+          BASE_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
+          BETA_PART=${VERSION_PARTS[3]#*-}
+          BETA_NUMBER=${BETA_PART#*.}
+          NEW_BETA_NUMBER=$((BETA_NUMBER + 1))
+          NEXT_VERSION="${BASE_VERSION}.${NEW_BETA_NUMBER}"
+        fi
+          echo "Next version: $NEXT_VERSION"
+          echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+
       shell: bash
 
     - name: 'Printing versions'
@@ -110,13 +116,13 @@ runs:
         EXAMPLES_PATH: ${{ github.workspace }}/examples
       run: |
         echo "Updating version to $NEXT_VERSION"
-        
+
         # Function to update the version in package.json using jq
         update_version() {
           local pkg_dir="$1"
           local new_version="$2"
           local package_json_path="$pkg_dir/package.json"
-          
+
           if [ -f "$package_json_path" ]; then
             jq --arg new_version "$new_version" '.version = $new_version' "$package_json_path" > tmp.$$.json && mv tmp.$$.json "$package_json_path"
             echo "Updated version in $package_json_path to $new_version"
@@ -124,13 +130,13 @@ runs:
             echo "::warn::Warning: No package.json found in $pkg_dir"
           fi
         }
-        
+
         # Function to update peerDependencies in package.json
         update_peer_dependencies() {
           local pkg_dir="$1"
           local new_version="$2"
           local package_json_path="$pkg_dir/package.json"
-          
+
           if [ -f "$package_json_path" ]; then
             for dep in "${sdk_packages[@]}"; do
               if jq -e ".peerDependencies[\"@dotcms/$dep\"]" "$package_json_path" >/dev/null; then
@@ -144,13 +150,13 @@ runs:
             echo "::warn::Warning: No package.json found in $pkg_dir"
           fi
         }
-        
+
         # Function to update dependencies in examples package.json
         update_dependencies_in_examples() {
           local example_dir="$1"
           local new_version="$2"
           local package_json_path="$example_dir/package.json"
-          
+
           if [ -f "$package_json_path" ]; then
             for dep in "${sdk_packages[@]}"; do
               if jq -e ".dependencies[\"@dotcms/$dep\"]" "$package_json_path" >/dev/null; then
@@ -166,20 +172,20 @@ runs:
             echo "::warn::Warning: No package.json found in $example_dir"
           fi
         }
-        
+
         # Detect all SDK packages dynamically in the libs/sdk directory
         sdk_packages=($(find . -maxdepth 1 -type d -exec basename {} \; | grep -v "^\.$"))
-        
+
         # Step 1: Update the version in each SDK package
         for sdk in "${sdk_packages[@]}"; do
           update_version "$sdk" "$NEXT_VERSION"
         done
-        
+
         # Step 2: Update peerDependencies in each SDK package
         for sdk in "${sdk_packages[@]}"; do
           update_peer_dependencies "$sdk" "$NEXT_VERSION"
         done
-        
+
         # Step 3: Update dependencies in example projects
         example_packages=$(find $EXAMPLES_PATH -name "package.json" -not -path "*/node_modules/*")
 
@@ -201,19 +207,19 @@ runs:
         echo "::group::Printing SDK and Example packages"
         echo "SDK libs:"
         print_packages "$SDK_LIBS_PATH"
-        echo ""        
+        echo ""
         echo "Examples:"
         print_packages "$EXAMPLES_PATH"
         echo "::endgroup::"
-      shell: bash   
+      shell: bash
 
     - name: 'Install project'
       working-directory: ${{ github.workspace }}/core-web/
-      run: | 
+      run: |
         yarn install
         npm --version
         node --version
-        npx --version               
+        npx --version
       shell: bash
 
     - name: 'Build SDK packages'
@@ -229,14 +235,14 @@ runs:
         NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
         NPM_TAG: ${{ inputs.npm-package-tag }}
       run: |
-        echo "::group::Publishing SDK packages"        
+        echo "::group::Publishing SDK packages"
         sdks=$(ls)
         for sdk in $sdks; do
           echo "Publishing SDK lib [${sdk}]"
           cd $sdk && echo "$(pwd)"
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
           npm publish --access public --tag $NPM_TAG
-          npm dist-tag add @dotcms/${sdk}@${NEXT_VERSION} latest
+          npm dist-tag add @dotcms/${sdk}@${NEXT_VERSION} next
           cd ..
         done
         echo "::endgroup::"


### PR DESCRIPTION
This pull request includes several changes to the deployment workflow for the JavaScript SDK in the `.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml` file. The changes primarily focus on updating the versioning strategy from using the 'alpha' tag to the 'beta' tag.

Versioning Strategy Updates:

* Updated the example projects to point to the 'next' tag instead of the 'latest' tag to ensure version consistency.
* Changed the default npm package tag from 'alpha' to 'beta'.
* Modified the script to fetch the current version based on the 'beta' tag instead of the 'alpha' tag. Added logic to handle the initial version setting to '0.0.1-beta.0' if no version is found.
* Updated the version calculation logic to increment the 'beta' version number instead of the 'alpha' version number.
* Changed the npm dist-tag addition from 'latest' to 'next' during the publishing process.

This PR fixes: #31277