### PR TITLE
feat(SDK): Update SDK Library and UVE search bar to Use "personaId" Key 

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -46,7 +46,7 @@ import { DotEmaShellComponent } from './dot-ema-shell.component';
 import { DotEmaDialogComponent } from '../components/dot-ema-dialog/dot-ema-dialog.component';
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
 import { DotPageApiService } from '../services/dot-page-api.service';
-import { DEFAULT_PERSONA, WINDOW } from '../shared/consts';
+import { DEFAULT_PERSONA, PERSONA_KEY, WINDOW } from '../shared/consts';
 import { FormStatus, NG_CUSTOM_EVENTS } from '../shared/enums';
 import {
     dotPropertiesServiceMock,
@@ -115,7 +115,7 @@ const INITIAL_PAGE_PARAMS = {
     language_id: 1,
     url: 'index',
     variantName: 'DEFAULT',
-    'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+    [PERSONA_KEY]: 'modes.persona.no.persona',
     editorMode: UVE_MODE.EDIT
 };
 
@@ -534,7 +534,7 @@ describe('DotEmaShellComponent', () => {
                     language_id: 2,
                     url: 'my-awesome-page',
                     variantName: 'DEFAULT',
-                    'com.dotmarketing.persona.id': 'SomeCoolDude',
+                    [PERSONA_KEY]: 'SomeCoolDude',
                     editorMode: UVE_MODE.EDIT
                 };
 
@@ -836,7 +836,7 @@ describe('DotEmaShellComponent', () => {
                 store.loadPageAsset({
                     url: '/test-url',
                     language_id: '1',
-                    'com.dotmarketing.persona.id': '1'
+                    [PERSONA_KEY]: '1'
                 });
 
                 spectator.detectChanges();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -330,7 +330,7 @@ describe('DotEmaShellComponent', () => {
                 spectator.detectChanges();
                 expect(spyloadPageAsset).toHaveBeenCalledWith({ ...params, url: 'index' });
                 expect(spyLocation).toHaveBeenCalledWith(
-                    '/?language_id=1&url=index&variantName=DEFAULT&editorMode=edit&personaId=modes.persona.no.persona'
+                    '/?language_id=1&url=index&variantName=DEFAULT&editorMode=edit'
                 );
             });
 
@@ -355,7 +355,7 @@ describe('DotEmaShellComponent', () => {
                     url: 'some-url/some-nested-url'
                 });
                 expect(spyLocation).toHaveBeenCalledWith(
-                    '/?language_id=1&url=some-url%2Fsome-nested-url&variantName=DEFAULT&editorMode=edit&personaId=modes.persona.no.persona'
+                    '/?language_id=1&url=some-url%2Fsome-nested-url&variantName=DEFAULT&editorMode=edit'
                 );
             });
 
@@ -376,7 +376,7 @@ describe('DotEmaShellComponent', () => {
                 spectator.detectChanges();
                 expect(spyloadPageAsset).toHaveBeenCalledWith({ ...params, url: 'some-url/' });
                 expect(spyLocation).toHaveBeenCalledWith(
-                    '/?language_id=1&url=some-url%2F&variantName=DEFAULT&editorMode=edit&personaId=modes.persona.no.persona'
+                    '/?language_id=1&url=some-url%2F&variantName=DEFAULT&editorMode=edit'
                 );
             });
         });
@@ -477,7 +477,7 @@ describe('DotEmaShellComponent', () => {
             expect(spyloadPageAsset).toHaveBeenCalledWith(INITIAL_PAGE_PARAMS);
             expect(spyStoreLoadPage).toHaveBeenCalledWith(INITIAL_PAGE_PARAMS);
             expect(spyLocation).toHaveBeenCalledWith(
-                '/?language_id=1&url=index&variantName=DEFAULT&editorMode=edit&personaId=modes.persona.no.persona'
+                '/?language_id=1&url=index&variantName=DEFAULT&editorMode=edit'
             );
         });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -379,6 +379,35 @@ describe('DotEmaShellComponent', () => {
                     '/?language_id=1&url=some-url%2F&variantName=DEFAULT&editorMode=edit'
                 );
             });
+
+            it('should receive `personaId` query param', () => {
+                const spyloadPageAsset = jest.spyOn(store, 'loadPageAsset');
+                const spyLocation = jest.spyOn(location, 'go');
+
+                const queryParams = {
+                    url: '/some-url/index',
+                    language_id: 1,
+                    personaId: 'someCoolDude'
+                };
+
+                const expectedParams = {
+                    url: 'some-url/',
+                    [PERSONA_KEY]: 'someCoolDude',
+                    editorMode: 'edit',
+                    language_id: 1
+                };
+
+                overrideRouteSnashot(
+                    activatedRoute,
+                    SNAPSHOT_MOCK({ queryParams, data: UVE_CONFIG_MOCK(BASIC_OPTIONS) })
+                );
+
+                spectator.detectChanges();
+                expect(spyloadPageAsset).toHaveBeenCalledWith(expectedParams);
+                expect(spyLocation).toHaveBeenCalledWith(
+                    '/?url=some-url%2F&language_id=1&editorMode=edit&personaId=someCoolDude'
+                );
+            });
         });
 
         it('should patch viewParams with empty object when the editorMode is edit', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -330,7 +330,7 @@ describe('DotEmaShellComponent', () => {
                 spectator.detectChanges();
                 expect(spyloadPageAsset).toHaveBeenCalledWith({ ...params, url: 'index' });
                 expect(spyLocation).toHaveBeenCalledWith(
-                    '/?language_id=1&url=index&variantName=DEFAULT&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit'
+                    '/?language_id=1&url=index&variantName=DEFAULT&editorMode=edit&personaId=modes.persona.no.persona'
                 );
             });
 
@@ -355,7 +355,7 @@ describe('DotEmaShellComponent', () => {
                     url: 'some-url/some-nested-url'
                 });
                 expect(spyLocation).toHaveBeenCalledWith(
-                    '/?language_id=1&url=some-url%2Fsome-nested-url&variantName=DEFAULT&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit'
+                    '/?language_id=1&url=some-url%2Fsome-nested-url&variantName=DEFAULT&editorMode=edit&personaId=modes.persona.no.persona'
                 );
             });
 
@@ -376,7 +376,7 @@ describe('DotEmaShellComponent', () => {
                 spectator.detectChanges();
                 expect(spyloadPageAsset).toHaveBeenCalledWith({ ...params, url: 'some-url/' });
                 expect(spyLocation).toHaveBeenCalledWith(
-                    '/?language_id=1&url=some-url%2F&variantName=DEFAULT&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit'
+                    '/?language_id=1&url=some-url%2F&variantName=DEFAULT&editorMode=edit&personaId=modes.persona.no.persona'
                 );
             });
         });
@@ -477,7 +477,7 @@ describe('DotEmaShellComponent', () => {
             expect(spyloadPageAsset).toHaveBeenCalledWith(INITIAL_PAGE_PARAMS);
             expect(spyStoreLoadPage).toHaveBeenCalledWith(INITIAL_PAGE_PARAMS);
             expect(spyLocation).toHaveBeenCalledWith(
-                '/?language_id=1&url=index&variantName=DEFAULT&com.dotmarketing.persona.id=modes.persona.no.persona&editorMode=edit'
+                '/?language_id=1&url=index&variantName=DEFAULT&editorMode=edit&personaId=modes.persona.no.persona'
             );
         });
 
@@ -530,25 +530,33 @@ describe('DotEmaShellComponent', () => {
             beforeEach(() => spectator.detectChanges());
 
             it('should update parms when loadPage is triggered', () => {
-                const newParams = {
-                    language_id: 2,
+                const baseParams = {
+                    language_id: '2',
                     url: 'my-awesome-page',
                     variantName: 'DEFAULT',
-                    [PERSONA_KEY]: 'SomeCoolDude',
                     editorMode: UVE_MODE.EDIT
                 };
+                const pageParams = {
+                    ...baseParams,
+                    [PERSONA_KEY]: 'SomeCoolDude'
+                };
 
-                const url = router.createUrlTree([], { queryParams: newParams });
+                const userParams = {
+                    ...baseParams,
+                    personaId: 'SomeCoolDude'
+                };
 
+                const expectURL = router.createUrlTree([], { queryParams: userParams });
                 const spyStoreLoadPage = jest.spyOn(store, 'loadPageAsset');
                 const spyUrlTree = jest.spyOn(router, 'createUrlTree');
                 const spyLocation = jest.spyOn(location, 'go');
 
-                store.loadPageAsset(newParams);
+                store.loadPageAsset(pageParams);
                 spectator.detectChanges();
-                expect(spyStoreLoadPage).toHaveBeenCalledWith(newParams);
-                expect(spyUrlTree).toHaveBeenCalledWith([], { queryParams: newParams });
-                expect(spyLocation).toHaveBeenCalledWith(url.toString());
+
+                expect(spyStoreLoadPage).toHaveBeenCalledWith(pageParams);
+                expect(spyUrlTree).toHaveBeenCalledWith([], { queryParams: userParams });
+                expect(spyLocation).toHaveBeenCalledWith(expectURL.toString());
             });
         });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -37,7 +37,6 @@ import { UVEStore } from '../store/dot-uve.store';
 import { DotUveViewParams } from '../store/models';
 import {
     checkClientHostAccess,
-    normalizeQueryParams,
     getAllowedPageParams,
     getTargetUrl,
     sanitizeURL,
@@ -102,19 +101,8 @@ export class DotEmaShellComponent implements OnInit {
      * @memberof DotEmaShellComponent
      */
     readonly $updateQueryParamsEffect = effect(() => {
-        const userParams = this.uveStore.pageParams();
-        const viewParams = this.uveStore.viewParams();
-
-        if (!userParams && !viewParams) {
-            return;
-        }
-
-        const queryParams = normalizeQueryParams({
-            ...(userParams ?? {}),
-            ...(viewParams ?? {})
-        });
-
-        this.#updateLocation(queryParams);
+        const params = this.uveStore.$friendlyParams();
+        this.#updateLocation(params);
     });
 
     ngOnInit(): void {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -232,6 +232,10 @@ export class DotEmaShellComponent implements OnInit {
             params.publishDate = params.publishDate || new Date().toISOString();
         }
 
+        if (queryParams['personaId']) {
+            params['com.dotmarketing.persona.id'] = queryParams['personaId'];
+        }
+
         return params;
     }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -37,7 +37,7 @@ import { UVEStore } from '../store/dot-uve.store';
 import { DotUveViewParams } from '../store/models';
 import {
     checkClientHostAccess,
-    createUserQueryParams,
+    normalizeQueryParams,
     getAllowedPageParams,
     getTargetUrl,
     sanitizeURL,
@@ -109,7 +109,7 @@ export class DotEmaShellComponent implements OnInit {
             return;
         }
 
-        const queryParams = createUserQueryParams({
+        const queryParams = normalizeQueryParams({
             ...(userParams ?? {}),
             ...(viewParams ?? {})
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -101,15 +101,15 @@ export class DotEmaShellComponent implements OnInit {
      * @memberof DotEmaShellComponent
      */
     readonly $updateQueryParamsEffect = effect(() => {
-        const pageParams = this.uveStore.pageParams();
+        const userParams = this.uveStore.$friendlyParams();
         const viewParams = this.uveStore.viewParams();
 
-        if (!pageParams && !viewParams) {
+        if (!userParams && !viewParams) {
             return;
         }
 
         const queryParams = {
-            ...(pageParams ?? {}),
+            ...(userParams ?? {}),
             ...(viewParams ?? {})
         };
 
@@ -117,12 +117,15 @@ export class DotEmaShellComponent implements OnInit {
     });
 
     ngOnInit(): void {
+        // Unify this getUVEParams
         const params = this.#getPageParams();
-
         const viewParams = this.#getViewParams(params.editorMode);
-
+        // setUVEParams
         this.uveStore.patchViewParams(viewParams);
-
+        // parseUVEParamsForPage
+        // convertUVEToPageParams
+        // extractPageParamsFromUVE
+        //
         this.uveStore.loadPageAsset(params);
 
         // We need to skip one because it's the initial value
@@ -228,8 +231,8 @@ export class DotEmaShellComponent implements OnInit {
             params.editorMode = UVE_MODE.EDIT;
         }
 
-        if (params.editorMode === UVE_MODE.LIVE && !params.publishDate) {
-            params.publishDate = new Date().toISOString();
+        if (params.editorMode === UVE_MODE.LIVE) {
+            params.publishDate = params.publishDate || new Date().toISOString();
         }
 
         return params;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -37,6 +37,7 @@ import { UVEStore } from '../store/dot-uve.store';
 import { DotUveViewParams } from '../store/models';
 import {
     checkClientHostAccess,
+    createUserQueryParams,
     getAllowedPageParams,
     getTargetUrl,
     sanitizeURL,
@@ -101,31 +102,27 @@ export class DotEmaShellComponent implements OnInit {
      * @memberof DotEmaShellComponent
      */
     readonly $updateQueryParamsEffect = effect(() => {
-        const userParams = this.uveStore.$friendlyParams();
+        const userParams = this.uveStore.pageParams();
         const viewParams = this.uveStore.viewParams();
 
         if (!userParams && !viewParams) {
             return;
         }
 
-        const queryParams = {
+        const queryParams = createUserQueryParams({
             ...(userParams ?? {}),
             ...(viewParams ?? {})
-        };
+        });
 
         this.#updateLocation(queryParams);
     });
 
     ngOnInit(): void {
-        // Unify this getUVEParams
         const params = this.#getPageParams();
         const viewParams = this.#getViewParams(params.editorMode);
-        // setUVEParams
+
         this.uveStore.patchViewParams(viewParams);
-        // parseUVEParamsForPage
-        // convertUVEToPageParams
-        // extractPageParamsFromUVE
-        //
+
         this.uveStore.loadPageAsset(params);
 
         // We need to skip one because it's the initial value

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.spec.ts
@@ -7,13 +7,14 @@ import { DotMessageService } from '@dotcms/data-access';
 
 import { DotEditorModeSelectorComponent } from './dot-editor-mode-selector.component';
 
+import { PERSONA_KEY } from '../../../../../shared/consts';
 import { MOCK_RESPONSE_HEADLESS } from '../../../../../shared/mocks';
 import { UVEStore } from '../../../../../store/dot-uve.store';
 
 const pageParams = {
     url: 'test-url',
     language_id: 'en',
-    'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+    [PERSONA_KEY]: 'modes.persona.no.persona',
     editorMode: UVE_MODE.EDIT
 };
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.spec.ts
@@ -20,7 +20,7 @@ import { UVEStore } from '../../../../../store/dot-uve.store';
 import { Orientation } from '../../../../../store/models';
 import {
     sanitizeURL,
-    buildFullPageURL,
+    getFullPageURL,
     createFavoritePagesURL,
     createFullURL
 } from '../../../../../utils';
@@ -30,7 +30,7 @@ const $apiURL = '/api/v1/page/json/123-xyz-567-xxl?host_id=123-xyz-567-xxl&langu
 const params = HEADLESS_BASE_QUERY_PARAMS;
 const url = sanitizeURL(params?.url);
 
-const pageAPIQueryParams = buildFullPageURL(url, params);
+const pageAPIQueryParams = getFullPageURL({ url, params });
 const pageAPI = `/api/v1/page/${'json'}/${pageAPIQueryParams}`;
 const pageAPIResponse = MOCK_RESPONSE_HEADLESS;
 const shouldShowInfoDisplay = false || pageAPIResponse?.page.locked;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-uve-device-selector/dot-uve-device-selector.component.spec.ts
@@ -20,7 +20,7 @@ import { UVEStore } from '../../../../../store/dot-uve.store';
 import { Orientation } from '../../../../../store/models';
 import {
     sanitizeURL,
-    createPageApiUrlWithQueryParams,
+    buildFullPageURL,
     createFavoritePagesURL,
     createFullURL
 } from '../../../../../utils';
@@ -30,7 +30,7 @@ const $apiURL = '/api/v1/page/json/123-xyz-567-xxl?host_id=123-xyz-567-xxl&langu
 const params = HEADLESS_BASE_QUERY_PARAMS;
 const url = sanitizeURL(params?.url);
 
-const pageAPIQueryParams = createPageApiUrlWithQueryParams(url, params);
+const pageAPIQueryParams = buildFullPageURL(url, params);
 const pageAPI = `/api/v1/page/${'json'}/${pageAPIQueryParams}`;
 const pageAPIResponse = MOCK_RESPONSE_HEADLESS;
 const shouldShowInfoDisplay = false || pageAPIResponse?.page.locked;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/edit-ema-persona-selector/edit-ema-persona-selector.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/edit-ema-persona-selector/edit-ema-persona-selector.component.ts
@@ -97,12 +97,11 @@ export class EditEmaPersonaSelectorComponent implements AfterViewInit, OnChanges
      * @memberof EditEmaPersonaSelectorComponent
      */
     onSelect({ value }: { value: DotPersona }) {
-        if (value.identifier !== this.value.identifier) {
-            this.selected.emit({
-                ...value,
-                pageId: this.pageId
-            });
+        if (value.identifier === this.value.identifier) {
+            return;
         }
+
+        this.selected.emit({ ...value, pageId: this.pageId });
     }
 
     /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
@@ -37,7 +37,7 @@ import { EditEmaPersonaSelectorComponent } from './components/edit-ema-persona-s
 import { DotUveToolbarComponent } from './dot-uve-toolbar.component';
 
 import { DotPageApiService } from '../../../services/dot-page-api.service';
-import { DEFAULT_DEVICES, DEFAULT_PERSONA } from '../../../shared/consts';
+import { DEFAULT_DEVICES, DEFAULT_PERSONA, PERSONA_KEY } from '../../../shared/consts';
 import {
     HEADLESS_BASE_QUERY_PARAMS,
     MOCK_RESPONSE_HEADLESS,
@@ -471,7 +471,7 @@ describe('DotUveToolbarComponent', () => {
                 spectator.detectChanges();
 
                 expect(spyloadPageAsset).toHaveBeenCalledWith({
-                    'com.dotmarketing.persona.id': '123'
+                    [PERSONA_KEY]: '123'
                 });
             });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
@@ -44,19 +44,14 @@ import {
     MOCK_RESPONSE_VTL
 } from '../../../shared/mocks';
 import { UVEStore } from '../../../store/dot-uve.store';
-import {
-    buildFullPageURL,
-    createFavoritePagesURL,
-    createFullURL,
-    sanitizeURL
-} from '../../../utils';
+import { getFullPageURL, createFavoritePagesURL, createFullURL, sanitizeURL } from '../../../utils';
 
 const $apiURL = '/api/v1/page/json/123-xyz-567-xxl?host_id=123-xyz-567-xxl&language_id=1';
 
 const params = HEADLESS_BASE_QUERY_PARAMS;
 const url = sanitizeURL(params?.url);
 
-const pageAPIQueryParams = buildFullPageURL(url, params);
+const pageAPIQueryParams = getFullPageURL({ url, params });
 const pageAPI = `/api/v1/page/${'json'}/${pageAPIQueryParams}`;
 const pageAPIResponse = MOCK_RESPONSE_HEADLESS;
 const shouldShowInfoDisplay = false || pageAPIResponse?.page.locked;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
@@ -45,9 +45,9 @@ import {
 } from '../../../shared/mocks';
 import { UVEStore } from '../../../store/dot-uve.store';
 import {
+    buildFullPageURL,
     createFavoritePagesURL,
     createFullURL,
-    createPageApiUrlWithQueryParams,
     sanitizeURL
 } from '../../../utils';
 
@@ -56,7 +56,7 @@ const $apiURL = '/api/v1/page/json/123-xyz-567-xxl?host_id=123-xyz-567-xxl&langu
 const params = HEADLESS_BASE_QUERY_PARAMS;
 const url = sanitizeURL(params?.url);
 
-const pageAPIQueryParams = createPageApiUrlWithQueryParams(url, params);
+const pageAPIQueryParams = buildFullPageURL(url, params);
 const pageAPI = `/api/v1/page/${'json'}/${pageAPIQueryParams}`;
 const pageAPIResponse = MOCK_RESPONSE_HEADLESS;
 const shouldShowInfoDisplay = false || pageAPIResponse?.page.locked;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -198,48 +198,48 @@ export class DotUveToolbarComponent {
      * @memberof DotEmaComponent
      */
     onPersonaSelected(persona: DotPersona & { pageId: string }) {
-        if (persona.identifier === DEFAULT_PERSONA.identifier || persona.personalized) {
-            this.#store.loadPageAsset({
-                [PERSONA_KEY]: persona.identifier
-            });
-        } else {
-            this.#confirmationService.confirm({
-                header: this.#dotMessageService.get('editpage.personalization.confirm.header'),
-                message: this.#dotMessageService.get(
-                    'editpage.personalization.confirm.message',
-                    persona.name
-                ),
-                acceptLabel: this.#dotMessageService.get('dot.common.dialog.accept'),
-                rejectLabel: this.#dotMessageService.get('dot.common.dialog.reject'),
-                accept: () => {
-                    this.#personalizeService
-                        .personalized(persona.pageId, persona.keyTag)
-                        .subscribe({
-                            next: () => {
-                                this.#store.loadPageAsset({
-                                    [PERSONA_KEY]: persona.identifier
-                                });
+        const existPersona =
+            persona.identifier === DEFAULT_PERSONA.identifier || persona.personalized;
 
-                                this.$personaSelector().fetchPersonas();
-                            },
-                            error: () => {
-                                this.#messageService.add({
-                                    severity: 'error',
-                                    summary: this.#dotMessageService.get('error'),
-                                    detail: this.#dotMessageService.get(
-                                        'uve.personalize.empty.page.error'
-                                    )
-                                });
+        if (existPersona) {
+            this.#store.loadPageAsset({ [PERSONA_KEY]: persona.identifier });
 
-                                this.$personaSelector().resetValue();
-                            }
-                        });
-                },
-                reject: () => {
-                    this.$personaSelector().resetValue();
-                }
-            });
+            return;
         }
+
+        const confirmationData = {
+            header: this.#dotMessageService.get('editpage.personalization.confirm.header'),
+            message: this.#dotMessageService.get(
+                'editpage.personalization.confirm.message',
+                persona.name
+            ),
+            acceptLabel: this.#dotMessageService.get('dot.common.dialog.accept'),
+            rejectLabel: this.#dotMessageService.get('dot.common.dialog.reject')
+        };
+
+        this.#confirmationService.confirm({
+            ...confirmationData,
+            accept: () => {
+                this.#personalizeService.personalized(persona.pageId, persona.keyTag).subscribe({
+                    next: () => {
+                        this.#store.loadPageAsset({ [PERSONA_KEY]: persona.identifier });
+                        this.$personaSelector().fetchPersonas();
+                    },
+                    error: () => {
+                        this.#messageService.add({
+                            severity: 'error',
+                            summary: this.#dotMessageService.get('error'),
+                            detail: this.#dotMessageService.get('uve.personalize.empty.page.error')
+                        });
+
+                        this.$personaSelector().resetValue();
+                    }
+                });
+            },
+            reject: () => {
+                this.$personaSelector().resetValue();
+            }
+        });
     }
 
     /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -48,7 +48,7 @@ import { DotUveWorkflowActionsComponent } from './components/dot-uve-workflow-ac
 import { EditEmaLanguageSelectorComponent } from './components/edit-ema-language-selector/edit-ema-language-selector.component';
 import { EditEmaPersonaSelectorComponent } from './components/edit-ema-persona-selector/edit-ema-persona-selector.component';
 
-import { DEFAULT_DEVICES, DEFAULT_PERSONA } from '../../../shared/consts';
+import { DEFAULT_DEVICES, DEFAULT_PERSONA, PERSONA_KEY } from '../../../shared/consts';
 import { DotPage } from '../../../shared/models';
 import { UVEStore } from '../../../store/dot-uve.store';
 
@@ -200,7 +200,7 @@ export class DotUveToolbarComponent {
     onPersonaSelected(persona: DotPersona & { pageId: string }) {
         if (persona.identifier === DEFAULT_PERSONA.identifier || persona.personalized) {
             this.#store.loadPageAsset({
-                'com.dotmarketing.persona.id': persona.identifier
+                [PERSONA_KEY]: persona.identifier
             });
         } else {
             this.#confirmationService.confirm({
@@ -217,7 +217,7 @@ export class DotUveToolbarComponent {
                         .subscribe({
                             next: () => {
                                 this.#store.loadPageAsset({
-                                    'com.dotmarketing.persona.id': persona.identifier
+                                    [PERSONA_KEY]: persona.identifier
                                 });
 
                                 this.$personaSelector().fetchPersonas();
@@ -265,7 +265,7 @@ export class DotUveToolbarComponent {
 
                         if (persona.selected) {
                             this.#store.loadPageAsset({
-                                'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                                [PERSONA_KEY]: DEFAULT_PERSONA.identifier
                             });
                         }
                     }); // This does a take 1 under the hood

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -201,9 +201,6 @@ export class DotUveToolbarComponent {
         const existPersona =
             persona.identifier === DEFAULT_PERSONA.identifier || persona.personalized;
 
-        // console.log("existPersona:", existPersona);
-        // console.log("persona:", persona);
-
         if (existPersona) {
             this.#store.loadPageAsset({ [PERSONA_KEY]: persona.identifier });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -201,6 +201,9 @@ export class DotUveToolbarComponent {
         const existPersona =
             persona.identifier === DEFAULT_PERSONA.identifier || persona.personalized;
 
+        // console.log("existPersona:", existPersona);
+        // console.log("persona:", persona);
+
         if (existPersona) {
             this.#store.loadPageAsset({ [PERSONA_KEY]: persona.identifier });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -88,7 +88,7 @@ import { DotBlockEditorSidebarComponent } from '../components/dot-block-editor-s
 import { DotEmaDialogComponent } from '../components/dot-ema-dialog/dot-ema-dialog.component';
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
 import { DotPageApiService } from '../services/dot-page-api.service';
-import { DEFAULT_PERSONA, WINDOW, HOST } from '../shared/consts';
+import { DEFAULT_PERSONA, WINDOW, HOST, PERSONA_KEY } from '../shared/consts';
 import { EDITOR_STATE, NG_CUSTOM_EVENTS, UVE_STATUS } from '../shared/enums';
 import {
     QUERY_PARAMS_MOCK,
@@ -396,7 +396,7 @@ describe('EditEmaEditorComponent', () => {
                 clientHost: 'http://localhost:3000',
                 url: 'index',
                 language_id: '1',
-                'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                [PERSONA_KEY]: DEFAULT_PERSONA.identifier
             });
 
             spectator.detectChanges();
@@ -442,7 +442,7 @@ describe('EditEmaEditorComponent', () => {
                 store.loadPageAsset({
                     url: 'index',
                     language_id: '5',
-                    'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier,
+                    [PERSONA_KEY]: DEFAULT_PERSONA.identifier,
                     variantName: 'hello-there',
                     experimentId: 'i-have-a-running-experiment'
                 });
@@ -464,7 +464,7 @@ describe('EditEmaEditorComponent', () => {
                 store.loadPageAsset({
                     url: 'index',
                     language_id: '5',
-                    'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                    [PERSONA_KEY]: DEFAULT_PERSONA.identifier
                 });
 
                 spectator.detectChanges();
@@ -691,7 +691,7 @@ describe('EditEmaEditorComponent', () => {
                         clientHost: 'http://localhost:3000',
                         url: 'index',
                         language_id: '1',
-                        'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier
                     });
 
                     spectator.detectChanges();
@@ -2585,7 +2585,7 @@ describe('EditEmaEditorComponent', () => {
                         store.loadPageAsset({
                             url: 'index',
                             language_id: '3',
-                            'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier,
+                            [PERSONA_KEY]: DEFAULT_PERSONA.identifier,
                             clientHost: undefined
                         });
                     });
@@ -2625,7 +2625,7 @@ describe('EditEmaEditorComponent', () => {
                         store.loadPageAsset({
                             url: 'index',
                             language_id: '4',
-                            'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                            [PERSONA_KEY]: DEFAULT_PERSONA.identifier
                         });
 
                         spectator.detectChanges();
@@ -2665,7 +2665,7 @@ describe('EditEmaEditorComponent', () => {
 
                     expect(spyloadPageAsset).toHaveBeenCalledWith({
                         url: '/some',
-                        'com.dotmarketing.persona.id': 'modes.persona.no.persona'
+                        [PERSONA_KEY]: 'modes.persona.no.persona'
                     });
                 });
 
@@ -2708,7 +2708,7 @@ describe('EditEmaEditorComponent', () => {
                     );
 
                     expect(spyloadPageAsset).toHaveBeenCalledWith({
-                        'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                        [PERSONA_KEY]: 'modes.persona.no.persona',
                         url: '/some'
                     });
                 });
@@ -2721,7 +2721,7 @@ describe('EditEmaEditorComponent', () => {
                     store.loadPageAsset({
                         url,
                         language_id: '5',
-                        'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier
                     });
 
                     spectator.detectChanges();
@@ -2760,7 +2760,7 @@ describe('EditEmaEditorComponent', () => {
                     store.loadPageAsset({
                         url: 'index',
                         language_id: '5',
-                        'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier,
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier,
                         variantName: 'hello-there',
                         experimentId: 'i have a variant'
                     });
@@ -2958,7 +2958,7 @@ describe('EditEmaEditorComponent', () => {
                         clientHost: 'http://localhost:3000',
                         url: 'index',
                         language_id: '2',
-                        'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier
                     });
 
                     const loadPageAssetSpy = jest.spyOn(store, 'loadPageAsset');
@@ -2999,7 +2999,7 @@ describe('EditEmaEditorComponent', () => {
                         clientHost: 'http://localhost:3000',
                         url: 'test-url',
                         language_id: '1',
-                        'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier
                     });
 
                     const loadPageAssetSpy = jest.spyOn(store, 'loadPageAsset');

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2573,7 +2573,7 @@ describe('EditEmaEditorComponent', () => {
                     const iframe = spectator.debugElement.query(By.css('[data-testId="iframe"]'));
 
                     expect(iframe.nativeElement.src).toBe(
-                        'http://localhost:3000/page-one?clientHost=http%3A%2F%2Flocalhost%3A3000&language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT'
+                        'http://localhost:3000/page-one?clientHost=http%3A%2F%2Flocalhost%3A3000&language_id=1&personaId=modes.persona.no.persona'
                     );
                 });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2573,7 +2573,7 @@ describe('EditEmaEditorComponent', () => {
                     const iframe = spectator.debugElement.query(By.css('[data-testId="iframe"]'));
 
                     expect(iframe.nativeElement.src).toBe(
-                        'http://localhost:3000/page-one?clientHost=http%3A%2F%2Flocalhost%3A3000&language_id=1&personaId=modes.persona.no.persona'
+                        'http://localhost:3000/page-one?clientHost=http%3A%2F%2Flocalhost%3A3000&language_id=1'
                     );
                 });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -70,7 +70,7 @@ import { DotBlockEditorSidebarComponent } from '../components/dot-block-editor-s
 import { DotEmaDialogComponent } from '../components/dot-ema-dialog/dot-ema-dialog.component';
 import { DotPageApiService } from '../services/dot-page-api.service';
 import { InlineEditService } from '../services/inline-edit/inline-edit.service';
-import { DEFAULT_PERSONA, IFRAME_SCROLL_ZONE, WINDOW } from '../shared/consts';
+import { DEFAULT_PERSONA, IFRAME_SCROLL_ZONE, PERSONA_KEY, WINDOW } from '../shared/consts';
 import { EDITOR_STATE, NG_CUSTOM_EVENTS, UVE_STATUS } from '../shared/enums';
 import {
     ActionPayload,
@@ -881,7 +881,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
                 } else {
                     this.uveStore.loadPageAsset({
                         url: payload.url,
-                        'com.dotmarketing.persona.id': DEFAULT_PERSONA.identifier
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier
                     });
                 }
             },

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -34,6 +34,7 @@ import { EditEmaLayoutComponent } from './edit-ema-layout.component';
 
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
 import { DotPageApiService } from '../services/dot-page-api.service';
+import { PERSONA_KEY } from '../shared/consts';
 import { UVE_STATUS } from '../shared/enums';
 import { UVEStore } from '../store/dot-uve.store';
 
@@ -136,7 +137,7 @@ describe('EditEmaLayoutComponent', () => {
             clientHost: 'http://localhost:3000',
             language_id: '1',
             url: 'test',
-            'com.dotmarketing.persona.id': 'SuperCoolDude'
+            [PERSONA_KEY]: 'SuperCoolDude'
         });
 
         spectator.detectChanges();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.spec.ts
@@ -26,7 +26,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/json/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT&depth=0&mode=EDIT_MODE',
+                '/api/v1/page/json/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
                 HttpMethod.GET
             );
         });
@@ -43,7 +43,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT&depth=0&mode=EDIT_MODE',
+                '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
                 HttpMethod.GET
             );
         });
@@ -95,7 +95,7 @@ describe('DotPageApiService', () => {
             .subscribe();
 
         spectator.expectOne(
-            '/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT&depth=0&mode=EDIT_MODE',
+            '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
             HttpMethod.GET
         );
     });
@@ -110,7 +110,7 @@ describe('DotPageApiService', () => {
             .subscribe();
 
         spectator.expectOne(
-            '/api/v1/page/render/my-folder/?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT&depth=0&mode=EDIT_MODE',
+            '/api/v1/page/render/my-folder/?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
             HttpMethod.GET
         );
     });
@@ -139,7 +139,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT&depth=0&mode=PREVIEW_MODE',
+                '/api/v1/page/render/test-url?mode=PREVIEW_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
                 HttpMethod.GET
             );
         });
@@ -157,7 +157,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT&depth=0&mode=LIVE',
+                '/api/v1/page/render/test-url?mode=LIVE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
                 HttpMethod.GET
             );
         });
@@ -192,7 +192,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT&depth=1&mode=EDIT_MODE',
+                '/api/v1/page/render/test-url?mode=EDIT_MODE&depth=1&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
                 HttpMethod.GET
             );
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.spec.ts
@@ -19,6 +19,7 @@ describe('DotPageApiService', () => {
             spectator.service
                 .get({
                     url: 'test-url',
+                    mode: 'EDIT_MODE',
                     language_id: 'en',
                     [PERSONA_KEY]: 'modes.persona.no.persona',
                     clientHost: 'some-host'
@@ -37,6 +38,7 @@ describe('DotPageApiService', () => {
             spectator.service
                 .get({
                     url: 'test-url',
+                    mode: 'EDIT_MODE',
                     language_id: 'en',
                     [PERSONA_KEY]: 'modes.persona.no.persona'
                 })
@@ -89,6 +91,7 @@ describe('DotPageApiService', () => {
         spectator.service
             .get({
                 url: '///test-url',
+                mode: 'EDIT_MODE',
                 language_id: 'en',
                 [PERSONA_KEY]: 'modes.persona.no.persona'
             })
@@ -104,6 +107,7 @@ describe('DotPageApiService', () => {
         spectator.service
             .get({
                 url: '///my-folder///',
+                mode: 'EDIT_MODE',
                 language_id: 'en',
                 [PERSONA_KEY]: 'modes.persona.no.persona'
             })
@@ -139,7 +143,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/render/test-url?mode=PREVIEW_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+                '/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=preview',
                 HttpMethod.GET
             );
         });
@@ -157,7 +161,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/render/test-url?mode=LIVE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+                '/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=live',
                 HttpMethod.GET
             );
         });
@@ -166,6 +170,7 @@ describe('DotPageApiService', () => {
     describe('getClientPage', () => {
         const baseParams = {
             url: '///test-url',
+            mode: 'EDIT_MODE',
             language_id: 'en',
             [PERSONA_KEY]: 'modes.persona.no.persona'
         };
@@ -192,7 +197,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/render/test-url?mode=EDIT_MODE&depth=1&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+                '/api/v1/page/render/test-url?depth=1&mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
                 HttpMethod.GET
             );
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.spec.ts
@@ -4,6 +4,8 @@ import { UVE_MODE } from '@dotcms/client';
 
 import { DotPageApiService } from './dot-page-api.service';
 
+import { PERSONA_KEY } from '../shared/consts';
+
 describe('DotPageApiService', () => {
     let spectator: SpectatorHttp<DotPageApiService>;
     const createHttp = createHttpFactory(DotPageApiService);
@@ -18,7 +20,7 @@ describe('DotPageApiService', () => {
                 .get({
                     url: 'test-url',
                     language_id: 'en',
-                    'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                    [PERSONA_KEY]: 'modes.persona.no.persona',
                     clientHost: 'some-host'
                 })
                 .subscribe();
@@ -36,7 +38,7 @@ describe('DotPageApiService', () => {
                 .get({
                     url: 'test-url',
                     language_id: 'en',
-                    'com.dotmarketing.persona.id': 'modes.persona.no.persona'
+                    [PERSONA_KEY]: 'modes.persona.no.persona'
                 })
                 .subscribe();
 
@@ -55,7 +57,7 @@ describe('DotPageApiService', () => {
                 params: {
                     url: 'test-url',
                     language_id: 'en',
-                    'com.dotmarketing.persona.id': 'modes.persona.no.persona'
+                    [PERSONA_KEY]: 'modes.persona.no.persona'
                 }
             })
             .subscribe();
@@ -71,7 +73,7 @@ describe('DotPageApiService', () => {
                 params: {
                     url: 'test-url',
                     language_id: 'en',
-                    'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                    [PERSONA_KEY]: 'modes.persona.no.persona',
                     variantName: 'i-have-the-high-ground'
                 }
             })
@@ -88,7 +90,7 @@ describe('DotPageApiService', () => {
             .get({
                 url: '///test-url',
                 language_id: 'en',
-                'com.dotmarketing.persona.id': 'modes.persona.no.persona'
+                [PERSONA_KEY]: 'modes.persona.no.persona'
             })
             .subscribe();
 
@@ -103,7 +105,7 @@ describe('DotPageApiService', () => {
             .get({
                 url: '///my-folder///',
                 language_id: 'en',
-                'com.dotmarketing.persona.id': 'modes.persona.no.persona'
+                [PERSONA_KEY]: 'modes.persona.no.persona'
             })
             .subscribe();
 
@@ -131,7 +133,7 @@ describe('DotPageApiService', () => {
                 .get({
                     url: 'test-url',
                     language_id: 'en',
-                    'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                    [PERSONA_KEY]: 'modes.persona.no.persona',
                     editorMode: UVE_MODE.PREVIEW
                 })
                 .subscribe();
@@ -149,7 +151,7 @@ describe('DotPageApiService', () => {
                 .get({
                     url: 'test-url',
                     language_id: 'en',
-                    'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                    [PERSONA_KEY]: 'modes.persona.no.persona',
                     editorMode: UVE_MODE.LIVE
                 })
                 .subscribe();
@@ -165,7 +167,7 @@ describe('DotPageApiService', () => {
         const baseParams = {
             url: '///test-url',
             language_id: 'en',
-            'com.dotmarketing.persona.id': 'modes.persona.no.persona'
+            [PERSONA_KEY]: 'modes.persona.no.persona'
         };
 
         it('should get the page using graphql if the client send a query', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
@@ -18,7 +18,7 @@ import {
     VanityUrl
 } from '@dotcms/dotcms-models';
 
-import { UVE_MODE_TO_PAGE_MODE } from '../shared/consts';
+import { PERSONA_KEY, UVE_MODE_TO_PAGE_MODE } from '../shared/consts';
 import { PAGE_MODE } from '../shared/enums';
 import { DotPage, DotPageAssetParams, SavePagePayload } from '../shared/models';
 import { ClientRequestProps } from '../store/features/client/withClient';
@@ -44,7 +44,7 @@ export interface DotPageApiResponse {
 export interface DotPageApiParams {
     url: string;
     language_id: string;
-    'com.dotmarketing.persona.id': string;
+    [PERSONA_KEY]: string;
     variantName?: string;
     experimentId?: string;
     mode?: string;
@@ -114,7 +114,7 @@ export class DotPageApiService {
 
         const pageApiUrl = createPageApiUrlWithQueryParams(url, {
             language_id,
-            'com.dotmarketing.persona.id': params?.['com.dotmarketing.persona.id'],
+            [PERSONA_KEY]: params[PERSONA_KEY],
             variantName,
             experimentId,
             depth,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
@@ -22,7 +22,7 @@ import { PERSONA_KEY, UVE_MODE_TO_PAGE_MODE } from '../shared/consts';
 import { PAGE_MODE } from '../shared/enums';
 import { DotPage, DotPageAssetParams, SavePagePayload } from '../shared/models';
 import { ClientRequestProps } from '../store/features/client/withClient';
-import { buildPageApiUrl, cleanPageURL } from '../utils';
+import { buildFullPageURL, cleanPageURL } from '../utils';
 
 export interface DotPageApiResponse {
     page: DotPage;
@@ -102,7 +102,7 @@ export class DotPageApiService {
         // This should be not controled here
         const pageType = clientHost ? 'json' : 'render';
         const mode = UVE_MODE_TO_PAGE_MODE[editorMode] ?? PAGE_MODE.EDIT;
-        const pageURL = buildPageApiUrl(pagePath, { mode, ...pageParams });
+        const pageURL = buildFullPageURL(pagePath, { mode, ...pageParams });
 
         return this.http
             .get<{

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
@@ -18,11 +18,10 @@ import {
     VanityUrl
 } from '@dotcms/dotcms-models';
 
-import { PERSONA_KEY, UVE_MODE_TO_PAGE_MODE } from '../shared/consts';
-import { PAGE_MODE } from '../shared/enums';
+import { PERSONA_KEY } from '../shared/consts';
 import { DotPage, DotPageAssetParams, SavePagePayload } from '../shared/models';
 import { ClientRequestProps } from '../store/features/client/withClient';
-import { buildFullPageURL, cleanPageURL } from '../utils';
+import { getFullPageURL } from '../utils';
 
 export interface DotPageApiResponse {
     page: DotPage;
@@ -95,14 +94,10 @@ export class DotPageApiService {
      * @return {*}  {Observable<DotPageApiResponse>}
      * @memberof DotPageApiService
      */
-    get(params: DotPageAssetParams): Observable<DotPageApiResponse> {
-        const { url, clientHost, editorMode, ...pageParams } = params;
-        const pagePath = cleanPageURL(url);
-
-        // This should be not controled here
+    get(queryParams: DotPageAssetParams): Observable<DotPageApiResponse> {
+        const { clientHost, ...params } = queryParams;
         const pageType = clientHost ? 'json' : 'render';
-        const mode = UVE_MODE_TO_PAGE_MODE[editorMode] ?? PAGE_MODE.EDIT;
-        const pageURL = buildFullPageURL(pagePath, { mode, ...pageParams });
+        const pageURL = getFullPageURL({ url: params.url, params });
 
         return this.http
             .get<{

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
@@ -61,6 +61,7 @@ export enum DotPageAssetKeys {
     LANGUAGE_ID = 'language_id',
     EXPERIMENT_ID = 'experimentId',
     PERSONA_ID = 'com.dotmarketing.persona.id',
+    PERSONA_ID_FRIENDLY = 'personaId',
     PUBLISH_DATE = 'publishDate',
     EDITOR_MODE = 'editorMode'
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
@@ -61,7 +61,6 @@ export enum DotPageAssetKeys {
     LANGUAGE_ID = 'language_id',
     EXPERIMENT_ID = 'experimentId',
     PERSONA_ID = 'com.dotmarketing.persona.id',
-    PERSONA_ID_FRIENDLY = 'personaId',
     PUBLISH_DATE = 'publishDate',
     EDITOR_MODE = 'editorMode'
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.spec.ts
@@ -7,6 +7,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { editEmaGuard } from './edit-ema.guard';
 
+import { PERSONA_KEY } from '../../shared/consts';
+
 describe('EditEmaGuard', () => {
     let router: Router;
 
@@ -37,7 +39,7 @@ describe('EditEmaGuard', () => {
             },
             queryParams: {
                 url: '/some-url',
-                'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                [PERSONA_KEY]: 'modes.persona.no.persona',
                 language_id: 1
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -58,7 +60,7 @@ describe('EditEmaGuard', () => {
             },
             queryParams: {
                 url: '/im-just-a-cool-index-index',
-                'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                [PERSONA_KEY]: 'modes.persona.no.persona',
                 language_id: 1
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -79,7 +81,7 @@ describe('EditEmaGuard', () => {
             },
             queryParams: {
                 url: '/im-just-a-cool-index-index/index-something',
-                'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                [PERSONA_KEY]: 'modes.persona.no.persona',
                 language_id: 1
             }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -106,7 +108,7 @@ describe('EditEmaGuard', () => {
 
         expect(router.navigate).toHaveBeenCalledWith(['/edit-page/content'], {
             queryParams: {
-                'com.dotmarketing.persona.id': 'modes.persona.no.persona',
+                [PERSONA_KEY]: 'modes.persona.no.persona',
                 language_id: 1,
                 url: 'index'
             },

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/guards/edit-ema.guard.ts
@@ -1,12 +1,12 @@
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Params, Router } from '@angular/router';
 
-import { DEFAULT_PERSONA } from '../../shared/consts';
+import { DEFAULT_PERSONA, PERSONA_KEY } from '../../shared/consts';
 
 type EmaQueryParams = {
     url: string;
     language_id: number;
-    'com.dotmarketing.persona.id': string;
+    [PERSONA_KEY]: string;
     variantName: string;
 };
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/consts.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/consts.ts
@@ -8,6 +8,8 @@ import { CommonErrorsInfo } from './models';
 
 export const LAYOUT_URL = '/c/portal/layout';
 
+export const PERSONA_KEY = 'com.dotmarketing.persona.id';
+
 export const CONTENTLET_SELECTOR_URL = `/html/ng-contentlet-selector.jsp`;
 
 export const HOST = 'http://localhost:3000';

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/mocks.ts
@@ -15,7 +15,7 @@ import {
     dotcmsContentletMock
 } from '@dotcms/utils-testing';
 
-import { DEFAULT_PERSONA } from './consts';
+import { DEFAULT_PERSONA, PERSONA_KEY } from './consts';
 import { ActionPayload, ClientData } from './models';
 
 import {
@@ -28,7 +28,7 @@ import { DotPageApiResponse } from '../services/dot-page-api.service';
 export const HEADLESS_BASE_QUERY_PARAMS = {
     url: 'test-url',
     language_id: '1',
-    'com.dotmarketing.persona.id': DEFAULT_PERSONA.keyTag,
+    [PERSONA_KEY]: DEFAULT_PERSONA.keyTag,
     variantName: DEFAULT_VARIANT_ID,
     clientHost: 'http://localhost:3000'
 };
@@ -36,7 +36,7 @@ export const HEADLESS_BASE_QUERY_PARAMS = {
 export const VTL_BASE_QUERY_PARAMS = {
     url: 'test-url',
     language_id: '1',
-    'com.dotmarketing.persona.id': DEFAULT_PERSONA.keyTag,
+    [PERSONA_KEY]: DEFAULT_PERSONA.keyTag,
     variantName: DEFAULT_VARIANT_ID
 };
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.spec.ts
@@ -33,9 +33,10 @@ import {
 } from '@dotcms/utils-testing';
 
 import { UVEStore } from './dot-uve.store';
+import { Orientation } from './models';
 
 import { DotPageApiService } from '../services/dot-page-api.service';
-import { COMMON_ERRORS } from '../shared/consts';
+import { COMMON_ERRORS, PERSONA_KEY } from '../shared/consts';
 import { UVE_STATUS } from '../shared/enums';
 import {
     BASE_SHELL_ITEMS,
@@ -46,6 +47,7 @@ import {
     MOCK_RESPONSE_VTL,
     VTL_BASE_QUERY_PARAMS
 } from '../shared/mocks';
+import { normalizeQueryParams } from '../utils';
 
 const buildPageAPIResponseFromMock =
     (mock) =>
@@ -386,6 +388,27 @@ describe('UVEStore', () => {
                 store.loadPageAsset({ editorMode: null });
 
                 expect(store.$isLiveMode()).toBe(false);
+            });
+        });
+
+        describe('$friendlyParams', () => {
+            it('should return a readable user params', () => {
+                const pageParams = {
+                    url: '/index',
+                    language_id: '1',
+                    [PERSONA_KEY]: 'someCoolDude'
+                };
+
+                const viewParams = {
+                    orientation: Orientation.LANDSCAPE,
+                    device: '',
+                    seo: ''
+                };
+
+                const expected = normalizeQueryParams({ ...pageParams, ...viewParams });
+
+                patchState(store, { pageParams, viewParams });
+                expect(store.$friendlyParams()).toEqual(expected);
             });
         });
     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
@@ -13,7 +13,7 @@ import { DotUveViewParams, ShellProps, TranslateProps, UVEState } from './models
 import { DotPageApiResponse } from '../services/dot-page-api.service';
 import { UVE_FEATURE_FLAGS } from '../shared/consts';
 import { UVE_STATUS } from '../shared/enums';
-import { getErrorPayload, getRequestHostName, sanitizeURL } from '../utils';
+import { createUserQueryParams, getErrorPayload, getRequestHostName, sanitizeURL } from '../utils';
 
 // Some properties can be computed
 // Ticket: https://github.com/dotCMS/core/issues/30760
@@ -24,6 +24,7 @@ const initialState: UVEState = {
     currentUser: null,
     experiment: null,
     errorCode: null,
+    // uveParams
     pageParams: null,
     viewParams: null,
     status: UVE_STATUS.LOADING,
@@ -132,6 +133,13 @@ export const UVEStore = signalStore(
                 }),
                 $isLiveMode: computed<boolean>(() => {
                     return pageParams()?.editorMode === UVE_MODE.LIVE;
+                }),
+                $friendlyParams: computed(() => {
+                    if (!pageParams()) {
+                        return null;
+                    }
+
+                    return createUserQueryParams(pageParams());
                 })
             };
         }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
@@ -13,7 +13,7 @@ import { DotUveViewParams, ShellProps, TranslateProps, UVEState } from './models
 import { DotPageApiResponse } from '../services/dot-page-api.service';
 import { UVE_FEATURE_FLAGS } from '../shared/consts';
 import { UVE_STATUS } from '../shared/enums';
-import { getErrorPayload, getRequestHostName, sanitizeURL } from '../utils';
+import { getErrorPayload, getRequestHostName, normalizeQueryParams, sanitizeURL } from '../utils';
 
 // Some properties can be computed
 // Ticket: https://github.com/dotCMS/core/issues/30760
@@ -37,7 +37,15 @@ export const UVEStore = signalStore(
     { protectedState: false }, // TODO: remove when the unit tests are fixed
     withState<UVEState>(initialState),
     withComputed(
-        ({ pageAPIResponse, pageParams, languages, errorCode: error, status, isEnterprise }) => {
+        ({
+            pageAPIResponse,
+            pageParams,
+            viewParams,
+            languages,
+            errorCode: error,
+            status,
+            isEnterprise
+        }) => {
             return {
                 $translateProps: computed<TranslateProps>(() => {
                     const response = pageAPIResponse();
@@ -132,6 +140,14 @@ export const UVEStore = signalStore(
                 }),
                 $isLiveMode: computed<boolean>(() => {
                     return pageParams()?.editorMode === UVE_MODE.LIVE;
+                }),
+                $friendlyParams: computed(() => {
+                    const params = {
+                        ...(pageParams() ?? {}),
+                        ...(viewParams() ?? {})
+                    };
+
+                    return normalizeQueryParams(params);
                 })
             };
         }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
@@ -13,7 +13,7 @@ import { DotUveViewParams, ShellProps, TranslateProps, UVEState } from './models
 import { DotPageApiResponse } from '../services/dot-page-api.service';
 import { UVE_FEATURE_FLAGS } from '../shared/consts';
 import { UVE_STATUS } from '../shared/enums';
-import { createUserQueryParams, getErrorPayload, getRequestHostName, sanitizeURL } from '../utils';
+import { getErrorPayload, getRequestHostName, sanitizeURL } from '../utils';
 
 // Some properties can be computed
 // Ticket: https://github.com/dotCMS/core/issues/30760
@@ -24,7 +24,6 @@ const initialState: UVEState = {
     currentUser: null,
     experiment: null,
     errorCode: null,
-    // uveParams
     pageParams: null,
     viewParams: null,
     status: UVE_STATUS.LOADING,
@@ -133,13 +132,6 @@ export const UVEStore = signalStore(
                 }),
                 $isLiveMode: computed<boolean>(() => {
                     return pageParams()?.editorMode === UVE_MODE.LIVE;
-                }),
-                $friendlyParams: computed(() => {
-                    if (!pageParams()) {
-                        return null;
-                    }
-
-                    return createUserQueryParams(pageParams());
                 })
             };
         }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.spec.ts
@@ -12,7 +12,7 @@ import { getRunningExperimentMock, mockDotDevices } from '@dotcms/utils-testing'
 import { withUVEToolbar } from './withUVEToolbar';
 
 import { DotPageApiService } from '../../../../services/dot-page-api.service';
-import { DEFAULT_PERSONA } from '../../../../shared/consts';
+import { DEFAULT_PERSONA, PERSONA_KEY } from '../../../../shared/consts';
 import { UVE_STATUS } from '../../../../shared/enums';
 import { MOCK_RESPONSE_HEADLESS, mockCurrentUser } from '../../../../shared/mocks';
 import { Orientation, UVEState } from '../../../models';
@@ -20,7 +20,7 @@ import { Orientation, UVEState } from '../../../models';
 const pageParams = {
     url: 'test-url',
     language_id: '1',
-    'com.dotmarketing.persona.id': 'dot:persona',
+    [PERSONA_KEY]: 'dot:persona',
     variantName: 'DEFAULT',
     clientHost: 'http://localhost:3000'
 };

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.ts
@@ -24,7 +24,7 @@ import {
     computePageIsLocked,
     createFavoritePagesURL,
     createFullURL,
-    createPageApiUrlWithQueryParams,
+    buildFullPageURL,
     getIsDefaultVariant,
     getOrientation
 } from '../../../../utils';
@@ -62,7 +62,7 @@ export function withUVEToolbar() {
 
                 const experiment = store.experiment?.();
                 const pageAPIResponse = store.pageAPIResponse();
-                const pageAPIQueryParams = createPageApiUrlWithQueryParams(url, params);
+                const pageAPIQueryParams = buildFullPageURL(url, params);
 
                 const pageAPI = `/api/v1/page/${
                     store.isTraditionalPage() ? 'render' : 'json'
@@ -150,7 +150,7 @@ export function withUVEToolbar() {
             $apiURL: computed<string>(() => {
                 const pageParams = store.pageParams();
                 const url = pageParams?.url;
-                const params = createPageApiUrlWithQueryParams(url, pageParams);
+                const params = buildFullPageURL(url, pageParams);
 
                 const pageType = store.isTraditionalPage() ? 'render' : 'json';
                 const pageAPI = `/api/v1/page/${pageType}/${params}`;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.ts
@@ -24,7 +24,7 @@ import {
     computePageIsLocked,
     createFavoritePagesURL,
     createFullURL,
-    buildFullPageURL,
+    getFullPageURL,
     getIsDefaultVariant,
     getOrientation
 } from '../../../../utils';
@@ -62,7 +62,7 @@ export function withUVEToolbar() {
 
                 const experiment = store.experiment?.();
                 const pageAPIResponse = store.pageAPIResponse();
-                const pageAPIQueryParams = buildFullPageURL(url, params);
+                const pageAPIQueryParams = getFullPageURL({ url, params });
 
                 const pageAPI = `/api/v1/page/${
                     store.isTraditionalPage() ? 'render' : 'json'
@@ -148,12 +148,11 @@ export function withUVEToolbar() {
                 };
             }),
             $apiURL: computed<string>(() => {
-                const pageParams = store.pageParams();
-                const url = pageParams?.url;
-                const params = buildFullPageURL(url, pageParams);
+                const params = store.pageParams();
+                const pageURL = getFullPageURL({ url: params.url, params });
 
                 const pageType = store.isTraditionalPage() ? 'render' : 'json';
-                const pageAPI = `/api/v1/page/${pageType}/${params}`;
+                const pageAPI = `/api/v1/page/${pageType}/${pageURL}`;
 
                 return pageAPI;
             }),

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
@@ -13,7 +13,7 @@ import { mockDotDevices, seoOGTagsMock } from '@dotcms/utils-testing';
 import { withEditor } from './withEditor';
 
 import { DotPageApiParams, DotPageApiService } from '../../../services/dot-page-api.service';
-import { BASE_IFRAME_MEASURE_UNIT } from '../../../shared/consts';
+import { BASE_IFRAME_MEASURE_UNIT, PERSONA_KEY } from '../../../shared/consts';
 import { EDITOR_STATE, UVE_STATUS } from '../../../shared/enums';
 import {
     ACTION_MOCK,
@@ -40,7 +40,7 @@ const initialState: UVEState = {
         ...emptyParams,
         url: 'test-url',
         language_id: '1',
-        'com.dotmarketing.persona.id': 'dot:persona',
+        [PERSONA_KEY]: 'dot:persona',
         variantName: 'DEFAULT',
         clientHost: 'http://localhost:3000'
     },

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
@@ -214,7 +214,7 @@ describe('withEditor', () => {
         describe('$iframeURL', () => {
             it("should return the iframe's URL", () => {
                 expect(store.$iframeURL()).toBe(
-                    'http://localhost:3000/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000'
+                    'http://localhost:3000/test-url?language_id=1&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000&personaId=dot%3Apersona'
                 );
             });
 
@@ -248,7 +248,7 @@ describe('withEditor', () => {
                 });
 
                 expect(store.$iframeURL()).toBe(
-                    'http://localhost:3000/first?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000'
+                    'http://localhost:3000/first?language_id=1&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000&personaId=dot%3Apersona'
                 );
             });
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -43,7 +43,7 @@ import {
     sanitizeURL,
     getWrapperMeasures,
     createUserQueryParams,
-    buildPageApiUrl
+    buildFullPageURL
 } from '../../../utils';
 import { UVEState } from '../../models';
 import { withClient } from '../client/withClient';
@@ -57,7 +57,7 @@ const buildIframeURL = ({ pageURI, params, isTraditionalPage }) => {
     }
 
     const queryParams = createUserQueryParams(params);
-    const pageAPIQueryParams = buildPageApiUrl(pageURI, queryParams);
+    const pageAPIQueryParams = buildFullPageURL(pageURI, queryParams);
     const url = new URL(pageAPIQueryParams, params.clientHost || window.location.origin);
 
     return url.toString();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -40,9 +40,10 @@ import {
     getPersonalization,
     areContainersEquals,
     getEditorStates,
-    createPageApiUrlWithQueryParams,
     sanitizeURL,
-    getWrapperMeasures
+    getWrapperMeasures,
+    createUserQueryParams,
+    buildPageApiUrl
 } from '../../../utils';
 import { UVEState } from '../../models';
 import { withClient } from '../client/withClient';
@@ -55,9 +56,9 @@ const buildIframeURL = ({ pageURI, params, isTraditionalPage }) => {
         return new String('');
     }
 
-    const pageAPIQueryParams = createPageApiUrlWithQueryParams(pageURI, params);
-    const origin = params.clientHost || window.location.origin;
-    const url = new URL(pageAPIQueryParams, origin);
+    const queryParams = createUserQueryParams(params);
+    const pageAPIQueryParams = buildPageApiUrl(pageURI, queryParams);
+    const url = new URL(pageAPIQueryParams, params.clientHost || window.location.origin);
 
     return url.toString();
 };

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -42,7 +42,7 @@ import {
     getEditorStates,
     sanitizeURL,
     getWrapperMeasures,
-    createUserQueryParams,
+    normalizeQueryParams,
     buildFullPageURL
 } from '../../../utils';
 import { UVEState } from '../../models';
@@ -56,7 +56,7 @@ const buildIframeURL = ({ pageURI, params, isTraditionalPage }) => {
         return new String('');
     }
 
-    const queryParams = createUserQueryParams(params);
+    const queryParams = normalizeQueryParams(params);
     const pageAPIQueryParams = buildFullPageURL(pageURI, queryParams);
     const url = new URL(pageAPIQueryParams, params.clientHost || window.location.origin);
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/load/withLoad.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/load/withLoad.spec.ts
@@ -31,6 +31,7 @@ import {
 import { withLoad } from './withLoad';
 
 import { DotPageApiParams, DotPageApiService } from '../../../services/dot-page-api.service';
+import { PERSONA_KEY } from '../../../shared/consts';
 import { UVE_STATUS } from '../../../shared/enums';
 import {
     getVanityUrl,
@@ -57,7 +58,7 @@ const buildPageAPIResponseFromMock =
 const pageParams: DotPageApiParams = {
     url: 'new-url',
     language_id: '1',
-    'com.dotmarketing.persona.id': '2'
+    [PERSONA_KEY]: '2'
 };
 
 const initialState: UVEState = {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
@@ -9,6 +9,7 @@ import { mockWorkflowsActions } from '@dotcms/utils-testing';
 import { withWorkflow } from './withWorkflow';
 
 import { DotPageApiParams } from '../../../services/dot-page-api.service';
+import { PERSONA_KEY } from '../../../shared/consts';
 import { UVE_STATUS } from '../../../shared/enums';
 import { MOCK_RESPONSE_HEADLESS } from '../../../shared/mocks';
 import { UVEState } from '../../models';
@@ -16,7 +17,7 @@ import { UVEState } from '../../models';
 const pageParams: DotPageApiParams = {
     url: 'new-url',
     language_id: '1',
-    'com.dotmarketing.persona.id': '2'
+    [PERSONA_KEY]: '2'
 };
 
 const initialState: UVEState = {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -255,6 +255,47 @@ export function createPageApiUrlWithQueryParams(
 }
 
 /**
+ * Create a page api url with query params
+ *
+ * @export
+ * @param {string} url
+ * @param {Record<string, string>} params
+ * @return {*}  {string}
+ */
+export function buildPageApiUrl(url: string, params: Record<string, string>): string {
+    const queryParams = { ...params };
+
+    // Delete url from QP
+    delete queryParams['url'];
+
+    // Filter out undefined values
+    Object.keys(queryParams).forEach(
+        (key) => queryParams[key] === undefined && delete queryParams[key]
+    );
+
+    const queryParamsString = new URLSearchParams({
+        ...queryParams
+    }).toString();
+
+    return queryParamsString ? `${url}?${queryParamsString}` : url;
+}
+
+export function createUserQueryParams(params) {
+    const queryParams = { ...params };
+
+    if (queryParams[PERSONA_KEY] === DEFAULT_PERSONA.identifier) {
+        delete queryParams.personaId;
+    }
+
+    if (queryParams[PERSONA_KEY]) {
+        queryParams['personaId'] = params[PERSONA_KEY];
+        delete queryParams[PERSONA_KEY];
+    }
+
+    return queryParams;
+}
+
+/**
  * Check if the variant is the default one
  *
  * @export

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -252,11 +252,22 @@ export function buildFullPageURL(
     return queryParamsString ? `${url}?${queryParamsString}` : url;
 }
 
-export function createUserQueryParams(params) {
+/**
+ * Cleans and transforms query parameters for better readability and usability.
+ *
+ * This function processes the given query parameters by removing unnecessary values
+ * (e.g., default identifiers) and renaming specific keys for a more user-friendly format.
+ * Additional transformations can be applied as needed.
+ *
+ * @export
+ * @param {Object} params - The raw query parameters to be processed.
+ * @return {Object} A cleaned and formatted version of the query parameters.
+ */
+export function normalizeQueryParams(params) {
     const queryParams = { ...params };
 
     if (queryParams[PERSONA_KEY] === DEFAULT_PERSONA.identifier) {
-        delete queryParams.personaId;
+        delete queryParams[PERSONA_KEY];
     }
 
     if (queryParams[PERSONA_KEY]) {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -222,34 +222,51 @@ export const getPersonalization = (persona: Record<string, string>) => {
 };
 
 /**
- * Create full page URL including the Query Params
+ * Constructs a full page URL by appending query parameters.
+ *
+ * This function takes a base URL and a set of parameters, optionally normalizing them,
+ * and returns a complete URL with the query parameters appended. It ensures that any
+ * undefined values are removed and that the 'url' parameter is not included in the query string.
  *
  * @export
- * @param {string} url
- * @param {Record<string, string> | DotPageAssetParams} params
- * @return {*}  {string}
+ * @param {FullPageURLParams} { url, params, userFriendlyParams = false } - The parameters for constructing the URL.
+ * @param {string} url - The base URL to which query parameters will be appended.
+ * @param {DotPageAssetParams} params - The query parameters to append to the URL.
+ * @param {boolean} [userFriendlyParams=false] - If true, the query parameters are normalized to be more readable and user-friendly. This may involve renaming keys or removing default values that are not necessary for end-users.
+ * @return {string} The full URL with query parameters appended.
  */
-export function buildFullPageURL(
-    url: string,
-    params: Record<string, string> | DotPageAssetParams
-): string {
-    const queryParams = { ...params };
+export function getFullPageURL({
+    url,
+    params,
+    userFriendlyParams = false
+}: {
+    url: string;
+    params: DotPageAssetParams;
+    userFriendlyParams?: boolean;
+}): string {
+    const searchParams = userFriendlyParams ? normalizeQueryParams(params) : { ...params };
 
-    // Delete url from QP\
-    if (queryParams.url) {
-        delete queryParams['url'];
+    // Remove 'url' from query parameters if present
+    if (searchParams.url) {
+        delete searchParams['url'];
     }
 
-    // Filter out undefined values
-    Object.keys(queryParams).forEach(
-        (key) => queryParams[key] === undefined && delete queryParams[key]
+    if (searchParams.editorMode) {
+        searchParams.mode = searchParams.editorMode;
+        delete searchParams['editorMode'];
+    }
+
+    // Filter out undefined values from query parameters
+    Object.keys(searchParams).forEach(
+        (key) => searchParams[key] === undefined && delete searchParams[key]
     );
 
-    const queryParamsString = new URLSearchParams({
-        ...queryParams
+    const path = cleanPageURL(url);
+    const paramsAsString = new URLSearchParams({
+        ...searchParams
     }).toString();
 
-    return queryParamsString ? `${url}?${queryParamsString}` : url;
+    return paramsAsString ? `${path}?${paramsAsString}` : path;
 }
 
 /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -14,7 +14,12 @@ import {
 
 import { EmaDragItem } from '../edit-ema-editor/components/ema-page-dropzone/types';
 import { DotPageAssetKeys, DotPageApiParams } from '../services/dot-page-api.service';
-import { BASE_IFRAME_MEASURE_UNIT, COMMON_ERRORS, DEFAULT_PERSONA } from '../shared/consts';
+import {
+    BASE_IFRAME_MEASURE_UNIT,
+    COMMON_ERRORS,
+    DEFAULT_PERSONA,
+    PERSONA_KEY
+} from '../shared/consts';
 import { EDITOR_STATE } from '../shared/enums';
 import {
     ActionPayload,
@@ -232,8 +237,7 @@ export function createPageApiUrlWithQueryParams(
     const completedParams = {
         ...params,
         language_id: params?.language_id ?? '1',
-        'com.dotmarketing.persona.id':
-            params?.['com.dotmarketing.persona.id'] ?? DEFAULT_PERSONA.identifier,
+        [PERSONA_KEY]: params?.['com.dotmarketing.persona.id'] ?? DEFAULT_PERSONA.identifier,
         variantName: params?.variantName ?? DEFAULT_VARIANT_ID
     };
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -222,51 +222,23 @@ export const getPersonalization = (persona: Record<string, string>) => {
 };
 
 /**
- * Create a page api url with query params
+ * Create full page URL including the Query Params
  *
  * @export
  * @param {string} url
- * @param {Partial<DotPageAssetParams>} params
+ * @param {Record<string, string> | DotPageAssetParams} params
  * @return {*}  {string}
  */
-export function createPageApiUrlWithQueryParams(
+export function buildFullPageURL(
     url: string,
-    params: Partial<DotPageAssetParams>
+    params: Record<string, string> | DotPageAssetParams
 ): string {
-    // Set default values
-    const completedParams = {
-        ...params,
-        language_id: params?.language_id ?? '1',
-        [PERSONA_KEY]: params?.['com.dotmarketing.persona.id'] ?? DEFAULT_PERSONA.identifier,
-        variantName: params?.variantName ?? DEFAULT_VARIANT_ID
-    };
-
-    // Filter out undefined values and url
-    Object.keys(completedParams).forEach(
-        (key) =>
-            (completedParams[key] === undefined || key === 'url') && delete completedParams[key]
-    );
-
-    const queryParams = new URLSearchParams({
-        ...completedParams
-    }).toString();
-
-    return queryParams.length ? `${url}?${queryParams}` : url;
-}
-
-/**
- * Create a page api url with query params
- *
- * @export
- * @param {string} url
- * @param {Record<string, string>} params
- * @return {*}  {string}
- */
-export function buildPageApiUrl(url: string, params: Record<string, string>): string {
     const queryParams = { ...params };
 
-    // Delete url from QP
-    delete queryParams['url'];
+    // Delete url from QP\
+    if (queryParams.url) {
+        delete queryParams['url'];
+    }
 
     // Filter out undefined values
     Object.keys(queryParams).forEach(

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -25,6 +25,7 @@ import {
 } from '.';
 
 import { DotPageApiParams } from '../services/dot-page-api.service';
+import { PERSONA_KEY } from '../shared/consts';
 import { PAGE_MODE } from '../shared/enums';
 import { dotPageContainerStructureMock } from '../shared/mocks';
 import { ContentletDragPayload, ContentTypeDragPayload, DotPage } from '../shared/models';
@@ -375,7 +376,7 @@ describe('utils functions', () => {
             const queryParams = {
                 variantName: 'test',
                 language_id: '20',
-                'com.dotmarketing.persona.id': 'the-chosen-one',
+                [PERSONA_KEY]: 'the-chosen-one',
                 experimentId: '123',
                 mode: PAGE_MODE.LIVE
             };
@@ -636,7 +637,7 @@ describe('utils functions', () => {
         const params = {
             url: 'page',
             language_id: '1',
-            'com.dotmarketing.persona.id': 'persona',
+            [PERSONA_KEY]: 'persona',
             variantName: 'new',
             experimentId: '1',
             mode: 'EDIT_MODE',
@@ -771,7 +772,7 @@ describe('utils functions', () => {
                 variantName: 'variant',
                 language_id: '1',
                 experimentId: 'exp123',
-                'com.dotmarketing.persona.id': 'persona123'
+                [PERSONA_KEY]: 'persona123'
             } as DotPageApiParams;
 
             const params: Params = {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -8,7 +8,7 @@ import {
     insertContentletInContainer,
     sanitizeURL,
     getPersonalization,
-    createPageApiUrlWithQueryParams,
+    buildFullPageURL,
     SDK_EDITOR_SCRIPT_SOURCE,
     computePageIsLocked,
     computeCanEditPage,
@@ -371,7 +371,7 @@ describe('utils functions', () => {
         });
     });
 
-    describe('createPageApiUrlWithQueryParams', () => {
+    describe('buildFullPageURL', () => {
         it('should return the correct query params', () => {
             const queryParams = {
                 variantName: 'test',
@@ -380,17 +380,9 @@ describe('utils functions', () => {
                 experimentId: '123',
                 mode: PAGE_MODE.LIVE
             };
-            const result = createPageApiUrlWithQueryParams('test', queryParams);
+            const result = buildFullPageURL('test', queryParams);
             expect(result).toBe(
                 'test?variantName=test&language_id=20&com.dotmarketing.persona.id=the-chosen-one&experimentId=123&mode=LIVE'
-            );
-        });
-
-        it('should return url with default query params if no query params', () => {
-            const queryParams = {};
-            const result = createPageApiUrlWithQueryParams('test', queryParams);
-            expect(result).toBe(
-                'test?language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT'
             );
         });
 
@@ -399,10 +391,8 @@ describe('utils functions', () => {
                 variantName: 'test',
                 experimentId: undefined
             };
-            const result = createPageApiUrlWithQueryParams('test', queryParams);
-            expect(result).toBe(
-                'test?variantName=test&language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona'
-            );
+            const result = buildFullPageURL('test', queryParams);
+            expect(result).toBe('test?variantName=test');
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -8,7 +8,7 @@ import {
     insertContentletInContainer,
     sanitizeURL,
     getPersonalization,
-    buildFullPageURL,
+    getFullPageURL,
     SDK_EDITOR_SCRIPT_SOURCE,
     computePageIsLocked,
     computeCanEditPage,
@@ -371,28 +371,34 @@ describe('utils functions', () => {
         });
     });
 
-    describe('buildFullPageURL', () => {
+    describe('getFullPageURL', () => {
         it('should return the correct query params', () => {
-            const queryParams = {
+            const params = {
+                url: 'test',
                 variantName: 'test',
                 language_id: '20',
                 [PERSONA_KEY]: 'the-chosen-one',
                 experimentId: '123',
                 mode: PAGE_MODE.LIVE
             };
-            const result = buildFullPageURL('test', queryParams);
+            const result = getFullPageURL({ url: 'test', params });
             expect(result).toBe(
                 'test?variantName=test&language_id=20&com.dotmarketing.persona.id=the-chosen-one&experimentId=123&mode=LIVE'
             );
         });
 
         it('should ignore the undefined queryParams', () => {
-            const queryParams = {
+            const params = {
+                url: 'test',
+                language_id: '20',
+                [PERSONA_KEY]: 'the-chosen-one',
                 variantName: 'test',
                 experimentId: undefined
             };
-            const result = buildFullPageURL('test', queryParams);
-            expect(result).toBe('test?variantName=test');
+            const result = getFullPageURL({ url: 'test', params });
+            expect(result).toBe(
+                'test?language_id=20&com.dotmarketing.persona.id=the-chosen-one&variantName=test'
+            );
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -21,11 +21,12 @@ import {
     createReorderMenuURL,
     getAllowedPageParams,
     getOrientation,
-    getWrapperMeasures
+    getWrapperMeasures,
+    normalizeQueryParams
 } from '.';
 
 import { DotPageApiParams } from '../services/dot-page-api.service';
-import { PERSONA_KEY } from '../shared/consts';
+import { DEFAULT_PERSONA, PERSONA_KEY } from '../shared/consts';
 import { PAGE_MODE } from '../shared/enums';
 import { dotPageContainerStructureMock } from '../shared/mocks';
 import { ContentletDragPayload, ContentTypeDragPayload, DotPage } from '../shared/models';
@@ -859,6 +860,54 @@ describe('utils functions', () => {
 
             const result = getOrientation(device);
             expect(result).toBe(Orientation.LANDSCAPE);
+        });
+    });
+
+    describe('normalizeQueryParams', () => {
+        it('should remove PERSONA_KEY if it equals DEFAULT_PERSONA.identifier', () => {
+            const params = {
+                [PERSONA_KEY]: DEFAULT_PERSONA.identifier,
+                someOtherKey: 'someValue'
+            };
+
+            const result = normalizeQueryParams(params);
+
+            expect(result).toEqual({
+                someOtherKey: 'someValue'
+            });
+        });
+
+        it('should rename PERSONA_KEY to personaId if it is present and not default', () => {
+            const params = {
+                [PERSONA_KEY]: 'customPersonaId',
+                anotherKey: 'anotherValue'
+            };
+
+            const result = normalizeQueryParams(params);
+
+            expect(result).toEqual({
+                personaId: 'customPersonaId',
+                anotherKey: 'anotherValue'
+            });
+        });
+
+        it('should not modify params if PERSONA_KEY is absent', () => {
+            const params = {
+                someKey: 'someValue',
+                anotherKey: 'anotherValue'
+            };
+
+            const result = normalizeQueryParams(params);
+
+            expect(result).toEqual(params);
+        });
+
+        it('should handle empty params object', () => {
+            const params = {};
+
+            const result = normalizeQueryParams(params);
+
+            expect(result).toEqual({});
         });
     });
 });


### PR DESCRIPTION
This pull request includes several updates to the `dot-ema-shell` and related components in the `core-web` library. The primary focus is on refactoring the code to use a new constant `PERSONA_KEY` instead of hardcoded persona identifiers and improving the handling of query parameters.

### Refactoring for `PERSONA_KEY` usage:
* [`dot-ema-shell.component.spec.ts`](diffhunk://#diff-8843e3a4ce8c16e83408b1a6dcc3ad54eaddd17f8e986bbdb502e11bd4446ab4L49-R49): Replaced hardcoded persona identifiers with `PERSONA_KEY` in multiple test cases. [[1]](diffhunk://#diff-8843e3a4ce8c16e83408b1a6dcc3ad54eaddd17f8e986bbdb502e11bd4446ab4L49-R49) [[2]](diffhunk://#diff-8843e3a4ce8c16e83408b1a6dcc3ad54eaddd17f8e986bbdb502e11bd4446ab4L118-R118) [[3]](diffhunk://#diff-8843e3a4ce8c16e83408b1a6dcc3ad54eaddd17f8e986bbdb502e11bd4446ab4L333-R333) [[4]](diffhunk://#diff-8843e3a4ce8c16e83408b1a6dcc3ad54eaddd17f8e986bbdb502e11bd4446ab4L358-R358) [[5]](diffhunk://#diff-8843e3a4ce8c16e83408b1a6dcc3ad54eaddd17f8e986bbdb502e11bd4446ab4L379-R379) [[6]](diffhunk://#diff-8843e3a4ce8c16e83408b1a6dcc3ad54eaddd17f8e986bbdb502e11bd4446ab4L480-R480) [[7]](diffhunk://#diff-8843e3a4ce8c16e83408b1a6dcc3ad54eaddd17f8e986bbdb502e11bd4446ab4L533-R559) [[8]](diffhunk://#diff-8843e3a4ce8c16e83408b1a6dcc3ad54eaddd17f8e986bbdb502e11bd4446ab4L839-R847)
* [`dot-uve-toolbar.component.spec.ts`](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1L40-L50): Updated tests to use `PERSONA_KEY` for persona-related parameters. [[1]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1L40-L50) [[2]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1L474-R474)
* [`edit-ema-editor.component.spec.ts`](diffhunk://#diff-34ddc5fbacaf04b962f2037385ed284310d5faf35ba409d5705b2caadd5d796aL399-R399): Modified tests to replace hardcoded persona identifiers with `PERSONA_KEY`. [[1]](diffhunk://#diff-34ddc5fbacaf04b962f2037385ed284310d5faf35ba409d5705b2caadd5d796aL399-R399) [[2]](diffhunk://#diff-34ddc5fbacaf04b962f2037385ed284310d5faf35ba409d5705b2caadd5d796aL445-R445) [[3]](diffhunk://#diff-34ddc5fbacaf04b962f2037385ed284310d5faf35ba409d5705b2caadd5d796aL467-R467)

### Codebase improvements:
* [`dot-ema-shell.component.ts`](diffhunk://#diff-677330662fea6dadc7e48fd8455ec2a6fe60d624c7ed1f01f0a3e985aacd05c6R40): Introduced the `normalizeQueryParams` utility function to streamline query parameter handling and ensure consistency. [[1]](diffhunk://#diff-677330662fea6dadc7e48fd8455ec2a6fe60d624c7ed1f01f0a3e985aacd05c6R40) [[2]](diffhunk://#diff-677330662fea6dadc7e48fd8455ec2a6fe60d624c7ed1f01f0a3e985aacd05c6L104-L121)
* [`dot-uve-toolbar.component.ts`](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30L201-R232): Refactored the `onPersonaSelected` method to use `PERSONA_KEY` and improved the confirmation dialog logic for persona selection. [[1]](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30L201-R232) [[2]](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30L268-R268)

### Utility function updates:
* Replaced `createPageApiUrlWithQueryParams` with `buildFullPageURL` in multiple test files to enhance URL handling and consistency. [[1]](diffhunk://#diff-652f846aa914e51df03471614a9ffc9b80757f275a3639fe1131def21c40b39dL23-R23) [[2]](diffhunk://#diff-652f846aa914e51df03471614a9ffc9b80757f275a3639fe1131def21c40b39dL33-R33) [[3]](diffhunk://#diff-3eaa147616a5d1ff374a5fa27b0f38f0159a9039ef7e8d672dec43631f48a9e1L59-R59)

These changes ensure that the codebase is more maintainable and consistent, particularly in handling persona-related parameters and query parameters.

### Video

https://github.com/user-attachments/assets/df074781-d62f-4c5a-993a-3363e17109e2


This PR fixes: #28819