### PR TITLE
Fix bug when limited user tries to copy contentlet

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerAPIImpl.java
@@ -1179,11 +1179,15 @@ public class ContainerAPIImpl extends BaseWebAssetAPI implements ContainerAPI, D
 				hostsToFound.put(currentHost.getInode(), currentHost);
 			}
 		} catch(DotSecurityException e) {
-
+			//ignore: If the user lacks permission for this Host, we skip attempting to resolve the Container with it
 		}
 
-		final Host defaultHost = APILocator.getHostAPI().findDefaultHost(user, respectFrontEndEndRoles);
-		hostsToFound.put(defaultHost.getInode(), defaultHost);
+		try {
+			final Host defaultHost = APILocator.getHostAPI().findDefaultHost(user, respectFrontEndEndRoles);
+			hostsToFound.put(defaultHost.getInode(), defaultHost);
+		} catch(DotSecurityException e) {
+			//ignore: If the user lacks permission for this Host, we skip attempting to resolve the Container with it
+		}
 
 		return find(relativePath, hostsToFound, user, live, respectFrontEndEndRoles);
 	}


### PR DESCRIPTION
Bug Description
The issue occurs when attempting to copy a Contentlet from a Page that contains a FileContainer while using a limited user account that lacks READ permission on the DEFAULT host.

Proposed Fix
In the Copy Contentlet process, we resolve the FileContainer path using the getLiveContainerByFolderPath method. This happens after saving the Contentlet to create a new MultiTree entry, linking the new Contentlet with the Page.

Code Reference:
[ContainerAPIImpl.java#L1151-L1189](https://github.com/dotCMS/core/blob/main/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerAPIImpl.java#L1151-L1189)

Related Logic:
[PageResourceHelper.java#L467-L499](https://github.com/dotCMS/core/blob/65c8ebbbf258630b0e053d8f7b06e39062dde4d8/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java#L467-L499)

Path Resolution Steps
When resolving the path, the system attempts to:

Use the host from the inputPath parameter.
Use the current host (if there is an active request in the thread).
Use the DEFAULT host.
Currently, all three host options are pre-fetched, and the system attempts to resolve the path for each. However, if the user lacks READ permission on the DEFAULT host, a DotSecurityException is thrown.

Fix Implementation
The DEFAULT host is unnecessary for path resolution when the host is already included in the inputPath. Additionally, if the user lacks READ permission and the host is missing from the path, resolution will fail regardless—since the system cannot locate the Container on the DEFAULT host.

Solution: Ignore the DotSecurityException and exclude the DEFAULT host from the resolution process.

Fix Reference:
[PR #31344](https://github.com/dotCMS/core/pull/31344/files#diff-c627ef648a3d8efeafa59e5035157f16ea8ebd05131cecd2375fd2f9d74be5afR1185-R1190)