### PR TITLE
fix(wysiwyg): Add ID to WYSIWYG fields to make them unique

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -117,9 +117,9 @@
     }
 </style>
 
-<div class="fieldWrapper" > 
-    <% 
-    final com.dotcms.contenttype.model.field.Field newField2 = new LegacyFieldTransformer(field).from(); 
+<div class="fieldWrapper" >
+    <%
+    final com.dotcms.contenttype.model.field.Field newField2 = new LegacyFieldTransformer(field).from();
     final com.dotcms.contenttype.model.field.FieldVariable hideLabelFieldVar = newField2.fieldVariablesMap().get("hideLabel");
     if (hideLabelFieldVar == null || !Boolean.parseBoolean(hideLabelFieldVar.value())) { %>
         <div class="fieldName" id="<%=field.getVelocityVarName()%>_tag">
@@ -466,7 +466,7 @@
                         }
                     }
             %>
-                <div class="wysiwyg-container" data-select-folder="<%=String.join(", ", defaultPathFolderPathIds)%>" style="<%= fullScreenHeight%>" >
+                <div class="wysiwyg-container" id="wysiwyg-container-<%=field.getVelocityVarName()%>" data-select-folder="<%=String.join(", ", defaultPathFolderPathIds)%>" style="<%= fullScreenHeight%>" >
             <% if (dragAndDrop) {  %>
                   <dot-asset-drop-zone id="dot-asset-drop-zone-<%=field.getVelocityVarName()%>" class="wysiwyg__dot-asset-drop-zone"></dot-asset-drop-zone>
             <% }  %>

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
@@ -241,12 +241,12 @@ var cmsfile=null;
 		else if(toggleValue=="CODE"){
 			toCodeArea(id, isFullscreen);
 			updateDisabledWysiwyg(id,"CODE");
-			dojo.query(".wysiwyg-container").style({display:'none'});
+			dojo.query(`#wysiwyg-container-${id}`).style({display:'none'});
 			}
 		else if(toggleValue=="PLAIN"){
 			toPlainView(id);
 			updateDisabledWysiwyg(id,"PLAIN");
-			dojo.query(".wysiwyg-container").style({display:'block'});
+			dojo.query(`#wysiwyg-container-${id}`).style({display:'block'});
 			}
 	}
 


### PR DESCRIPTION
This pull request includes changes to improve the specificity and functionality of the WYSIWYG container in the contentlet field editing interface. The most important changes involve adding unique identifiers to the WYSIWYG container elements and updating the JavaScript to use these unique identifiers.

Improvements to WYSIWYG container:

* [`dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp`](diffhunk://#diff-56d86f13aa386cb1827964028808b975ede83f83670e89874ab7afa4207ed103L469-R469): Added an `id` attribute to the `div` with the class `wysiwyg-container` to include the field's velocity variable name, ensuring each container has a unique identifier.

JavaScript updates for unique identifiers:

* [`dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp`](diffhunk://#diff-c9dd4f1155e87bb971c01595fc5b410b264343dc638a6a321039ac5cb628a9a4L244-R249): Updated the JavaScript to query and manipulate the WYSIWYG container using the newly added unique `id` attribute instead of the class name. This change ensures that the correct container is targeted for display toggling.

## Screenshot

https://github.com/user-attachments/assets/96356573-3e04-45ca-b581-99d2b4dd5223



This PR fixes: #31343