### PR TITLE
fix(uve): Fixed double touch and color in FTM p-calendar

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_calendar.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_calendar.scss
@@ -98,7 +98,7 @@
 
         &.p-highlight:not(.p-disabled) {
             // Selected
-            background: $color-accessible-text-blue-bg;
+            background: $color-palette-primary-op-10;
             color: $color-accessible-text-blue;
         }
     }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html
@@ -21,7 +21,7 @@
                 [showTime]="true"
                 [hourFormat]="'12'"
                 dataType="date"
-                [minDate]="MIN_DATE"
+                [minDate]="$MIN_DATE()"
                 [readonlyInput]="true" />
             <p-button
                 styleClass="uve-toolbar-chips"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -10,7 +10,8 @@ import {
     inject,
     Output,
     viewChild,
-    Signal
+    Signal,
+    signal
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -130,15 +131,7 @@ export class DotUveToolbarComponent {
     readonly $workflowLoding = this.#store.workflowLoading;
 
     defaultDevices = DEFAULT_DEVICES;
-    get MIN_DATE() {
-        const currentDate = new Date();
-
-        // We need to set this to 0 so the minDate does not collide with the previewDate value when we are initializing
-        // This prevents the input from being empty on init
-        currentDate.setHours(0, 0, 0, 0);
-
-        return currentDate;
-    }
+    $MIN_DATE = signal(this.#getMinDate());
 
     /**
      * Fetch the page on a given date
@@ -304,6 +297,24 @@ export class DotUveToolbarComponent {
                 this.$languageSelector().listbox.writeValue(this.$toolbar().currentLanguage);
             }
         });
+    }
+
+    /**
+     * Gets the minimum allowed date for the calendar component.
+     * Sets hours/minutes/seconds/milliseconds to 0 to avoid collisions with preview date
+     * when initializing, which would cause the input to be empty.
+     *
+     * @returns {Date} The minimum allowed date with time set to midnight
+     * @private
+     */
+    #getMinDate() {
+        const currentDate = new Date();
+
+        // We need to set this to 0 so the minDate does not collide with the previewDate value when we are initializing
+        // This prevents the input from being empty on init
+        currentDate.setHours(0, 0, 0, 0);
+
+        return currentDate;
     }
 
     /**


### PR DESCRIPTION


https://github.com/user-attachments/assets/36df8c72-ec8b-4ef0-a7a3-b696e9bd96d6



This pull request includes changes to improve the styling and functionality of the `dot-uve-toolbar` component and update the calendar component's theme. The most important changes include updating the background color for the selected calendar date, modifying the minimum date handling in the `dot-uve-toolbar` component, and adding a new method to get the minimum date.

Styling updates:

* [`core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_calendar.scss`](diffhunk://#diff-275e3842fd0804fa57ecc4febce1fd83b8210b193643d925d1c187ac3cfa28bfL101-R101): Updated the background color for the selected date in the calendar component to use the primary color palette with 10% opacity.

Functionality improvements:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.html`](diffhunk://#diff-9937556e73b051b878ba22ad1ce971a70019a617d7979b3e0bcc814801ad350bL24-R24): Changed the `minDate` binding to use the `$MIN_DATE()` method instead of the `MIN_DATE` property.
* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts`](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30L13-R14): Added the `signal` import and replaced the `MIN_DATE` getter with the `$MIN_DATE` signal. [[1]](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30L13-R14) [[2]](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30L133-R134)
* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts`](diffhunk://#diff-217a9e619d6590c4f652e85353b9637ba5e464ddeb0424be35aef39bb8dceb30R302-R319): Added a private `#getMinDate` method to encapsulate the logic for calculating the minimum date.

This PR fixes: #31299