### PR TITLE
fix(CICD): Pinning tonistiigi/binfmt version to qemu-v7.0.0-28 (#31376)

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -148,7 +148,7 @@ runs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0
       with:
-        image: tonistiigi/binfmt:qemu-v8.1.5
+        image: tonistiigi/binfmt:qemu-v7.0.0
         platforms: ${{ inputs.docker_platforms }}
 
     - name: Docker Metadata

--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -148,7 +148,7 @@ runs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0
       with:
-        image: tonistiigi/binfmt:latest
+        image: tonistiigi/binfmt:qemu-v8.1.5
         platforms: ${{ inputs.docker_platforms }}
 
     - name: Docker Metadata

--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -148,7 +148,7 @@ runs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3.0.0
       with:
-        image: tonistiigi/binfmt:qemu-v7.0.0
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
         platforms: ${{ inputs.docker_platforms }}
 
     - name: Docker Metadata

--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0
         with:
-          image: tonistiigi/binfmt:qemu-v8.1.5
+          image: tonistiigi/binfmt:qemu-v7.0.0
           platforms: ${{ inputs.docker_platforms }}
         if: success()
 

--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0
         with:
-          image: tonistiigi/binfmt:latest
+          image: tonistiigi/binfmt:qemu-v8.1.5
           platforms: ${{ inputs.docker_platforms }}
         if: success()
 

--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3.0.0
         with:
-          image: tonistiigi/binfmt:qemu-v7.0.0
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
           platforms: ${{ inputs.docker_platforms }}
         if: success()
 


### PR DESCRIPTION
### Proposed Changes

* This pull request includes updates to the Docker setup in the CI/CD pipeline to use a specific version of the QEMU binary format image. The most important changes are:

Updates to Docker setup:

* Changed the QEMU image version from `tonistiigi/binfmt:latest` to `tonistiigi/binfmt:qemu-v7.0.0-28` to ensure consistency and avoid potential issues with the latest version.
* Updated the QEMU image version from `tonistiigi/binfmt:latest` to `tonistiigi/binfmt:qemu-v7.0.0-28` to match the change in the deployment action and maintain uniformity across the CI/CD pipeline.

### Fixes
#31376 

This PR fixes: #31376