### PR TITLE
fix(graphql) make graphql accept GETs

### DIFF
--- a/dotcms-integration/src/test/java/com/dotcms/graphql/DotGraphQLHttpServletTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/DotGraphQLHttpServletTest.java
@@ -39,7 +39,7 @@ public class DotGraphQLHttpServletTest {
     public void testing_GETRequestToGraphQLServer_returnResponseWithExpectedHeaders()
             throws ServletException, IOException {
 
-        MockHttpRequestIntegrationTest request = new MockHttpRequestIntegrationTest("localhost", "/");
+        MockHttpRequestIntegrationTest request = new MockHttpRequestIntegrationTest("localhost", "/?qid=123abc");
         MockHeaderResponse response = new MockHeaderResponse(new MockHttpResponse());
         DotGraphQLHttpServlet graphQLHttpServlet = new DotGraphQLHttpServlet();
         graphQLHttpServlet.init(null);


### PR DESCRIPTION
This pull request introduces several changes to the `DotGraphQLHttpServlet` class in order to improve the handling of GraphQL requests. The key modifications include adding a new request wrapper class and updating the `doGet` method to enforce the presence of a query id `?qid=abc123` parameter that can be used to enforce uniqueness in the responses.


ref: #31395

This PR fixes: #31395