### PR TITLE
Revert "Including second level related content (#31054)"

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
@@ -479,9 +479,10 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
                 if(publisherFilter.isRelationships() && publisherFilter.isDependencies()) {
                     for (Entry<Relationship, List<Contentlet>> relationshipListEntry : contentRelationships
                             .entrySet()) {
+                        contentsToProcess.addAll(relationshipListEntry.getValue());
 
-                        tryToAddAllAndProcessDependencies(PusheableAsset.CONTENTLET,
-                                relationshipListEntry.getValue(), ManifestReason.INCLUDE_DEPENDENCY_FROM.getMessage(relationshipListEntry.getKey()));
+                        tryToAddAll(PusheableAsset.CONTENTLET, relationshipListEntry.getValue(),
+                                ManifestReason.INCLUDE_DEPENDENCY_FROM.getMessage(relationshipListEntry.getKey()));
                     }
                 }
 


### PR DESCRIPTION
Some customers reported that after change #31036, their Push actions included too many items. To address this, we decided to revert the change and look for a better solution to the original issue.

We created a new card to work in the new fix #31400

### Proposed Changes
* reverting this PR https://github.com/dotCMS/core/commit/af3b96721b253551b200e85923a2542c80411872