### PR TITLE
chore(uve): Clean clientHost param when the value is the default

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -102,7 +102,26 @@ export class DotEmaShellComponent implements OnInit {
      */
     readonly $updateQueryParamsEffect = effect(() => {
         const params = this.uveStore.$friendlyParams();
-        this.#updateLocation(params);
+
+        const { data } = this.#activatedRoute.snapshot;
+
+        const baseClientHost = sanitizeURL(data?.uveConfig?.url);
+
+        // If there is no base client host, just update the location with the params
+        if (!baseClientHost) {
+            this.#updateLocation(params);
+
+            return;
+        }
+
+        const cleanedParams = {
+            ...params,
+            clientHost:
+                // If the base client host is the same as the current client host, don't include it
+                baseClientHost === sanitizeURL(params.clientHost) ? null : params.clientHost
+        };
+
+        this.#updateLocation(cleanedParams);
     });
 
     ngOnInit(): void {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -39,6 +39,7 @@ import {
     checkClientHostAccess,
     getAllowedPageParams,
     getTargetUrl,
+    normalizeQueryParams,
     sanitizeURL,
     shouldNavigate
 } from '../utils';
@@ -105,21 +106,9 @@ export class DotEmaShellComponent implements OnInit {
 
         const { data } = this.#activatedRoute.snapshot;
 
-        const baseClientHost = sanitizeURL(data?.uveConfig?.url);
+        const baseClientHost = data?.uveConfig?.url;
 
-        // If there is no base client host, just update the location with the params
-        if (!baseClientHost) {
-            this.#updateLocation(params);
-
-            return;
-        }
-
-        const cleanedParams = {
-            ...params,
-            clientHost:
-                // If the base client host is the same as the current client host, don't include it
-                baseClientHost === sanitizeURL(params.clientHost) ? null : params.clientHost
-        };
+        const cleanedParams = normalizeQueryParams(params, baseClientHost);
 
         this.#updateLocation(cleanedParams);
     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -277,9 +277,10 @@ export function getFullPageURL({
  *
  * @export
  * @param {Object} params - The raw query parameters to be processed.
+ * @param {string} baseClientHost - The base client host to be used to compare with the clientHost query param.
  * @return {Object} A cleaned and formatted version of the query parameters.
  */
-export function normalizeQueryParams(params) {
+export function normalizeQueryParams(params, baseClientHost?: string) {
     const queryParams = { ...params };
 
     if (queryParams[PERSONA_KEY] === DEFAULT_PERSONA.identifier) {
@@ -289,6 +290,10 @@ export function normalizeQueryParams(params) {
     if (queryParams[PERSONA_KEY]) {
         queryParams['personaId'] = params[PERSONA_KEY];
         delete queryParams[PERSONA_KEY];
+    }
+
+    if (baseClientHost && sanitizeURL(baseClientHost) === sanitizeURL(params.clientHost)) {
+        delete queryParams.clientHost;
     }
 
     return queryParams;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -879,50 +879,107 @@ describe('utils functions', () => {
     });
 
     describe('normalizeQueryParams', () => {
-        it('should remove PERSONA_KEY if it equals DEFAULT_PERSONA.identifier', () => {
-            const params = {
-                [PERSONA_KEY]: DEFAULT_PERSONA.identifier,
-                someOtherKey: 'someValue'
-            };
+        describe('persona handling', () => {
+            it('should remove PERSONA_KEY if it equals DEFAULT_PERSONA.identifier', () => {
+                const params = {
+                    [PERSONA_KEY]: DEFAULT_PERSONA.identifier,
+                    someOtherKey: 'someValue'
+                };
 
-            const result = normalizeQueryParams(params);
+                const result = normalizeQueryParams(params);
 
-            expect(result).toEqual({
-                someOtherKey: 'someValue'
+                expect(result).toEqual({
+                    someOtherKey: 'someValue'
+                });
+            });
+
+            it('should rename PERSONA_KEY to personaId if not default', () => {
+                const params = {
+                    [PERSONA_KEY]: 'customPersonaId',
+                    anotherKey: 'anotherValue'
+                };
+
+                const result = normalizeQueryParams(params);
+
+                expect(result).toEqual({
+                    personaId: 'customPersonaId',
+                    anotherKey: 'anotherValue'
+                });
             });
         });
 
-        it('should rename PERSONA_KEY to personaId if it is present and not default', () => {
-            const params = {
-                [PERSONA_KEY]: 'customPersonaId',
-                anotherKey: 'anotherValue'
-            };
+        describe('clientHost handling', () => {
+            it('should remove clientHost when it matches baseClientHost exactly', () => {
+                const params = {
+                    clientHost: 'http://example.com',
+                    someKey: 'someValue'
+                };
 
-            const result = normalizeQueryParams(params);
+                const result = normalizeQueryParams(params, 'http://example.com');
 
-            expect(result).toEqual({
-                personaId: 'customPersonaId',
-                anotherKey: 'anotherValue'
+                expect(result).toEqual({
+                    someKey: 'someValue'
+                });
+            });
+
+            it('should remove clientHost when it matches baseClientHost with trailing slash', () => {
+                const params = {
+                    clientHost: 'http://example.com/',
+                    someKey: 'someValue'
+                };
+
+                const result = normalizeQueryParams(params, 'http://example.com');
+
+                expect(result).toEqual({
+                    someKey: 'someValue'
+                });
+            });
+
+            it('should keep clientHost if it differs from baseClientHost', () => {
+                const params = {
+                    clientHost: 'http://example.com',
+                    someKey: 'someValue'
+                };
+
+                const result = normalizeQueryParams(params, 'http://different.com');
+
+                expect(result).toEqual({
+                    clientHost: 'http://example.com',
+                    someKey: 'someValue'
+                });
+            });
+
+            it('should keep clientHost if baseClientHost is not provided', () => {
+                const params = {
+                    clientHost: 'http://example.com',
+                    someKey: 'someValue'
+                };
+
+                const result = normalizeQueryParams(params);
+
+                expect(result).toEqual(params);
             });
         });
 
-        it('should not modify params if PERSONA_KEY is absent', () => {
-            const params = {
-                someKey: 'someValue',
-                anotherKey: 'anotherValue'
-            };
+        describe('edge cases', () => {
+            it('should handle empty params object', () => {
+                const params = {};
 
-            const result = normalizeQueryParams(params);
+                const result = normalizeQueryParams(params);
 
-            expect(result).toEqual(params);
-        });
+                expect(result).toEqual({});
+            });
 
-        it('should handle empty params object', () => {
-            const params = {};
+            it('should handle params with no special keys', () => {
+                const params = {
+                    someKey: 'someValue',
+                    anotherKey: 'anotherValue'
+                };
 
-            const result = normalizeQueryParams(params);
+                const result = normalizeQueryParams(params);
 
-            expect(result).toEqual({});
+                expect(result).toEqual(params);
+            });
         });
     });
 });


### PR DESCRIPTION
This pull request introduces several changes to the `DotEmaShellComponent` to handle client host URLs more robustly. The changes include adding new test cases and modifying the component's logic to sanitize and compare URLs correctly.

Key changes:

### Test Cases Enhancements:
* Added test cases to ensure the `clientHost` is not included in the location when it matches the base client host, differs from the base client host, or when sanitized URLs are compared. (`core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts`)

### Component Logic Update:
* Updated the `$updateQueryParamsEffect` effect in `DotEmaShellComponent` to sanitize and compare URLs, ensuring the `clientHost` parameter is only included when necessary. (`core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts`)

### Screenshots

https://github.com/user-attachments/assets/dc8f917f-6864-45fb-bc73-5a8c6d22e74b


This PR fixes: #31182