### PR TITLE
fix(jobs): change DropOldContent job to work with large datasets

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -42,6 +42,7 @@ import com.dotmarketing.common.db.Params;
 import com.dotmarketing.common.model.ContentletSearch;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.db.HibernateUtil;
+import com.dotmarketing.db.LocalTransaction;
 import com.dotmarketing.db.commands.DatabaseCommand.QueryReplacements;
 import com.dotmarketing.db.commands.UpsertCommand;
 import com.dotmarketing.db.commands.UpsertCommandFactory;
@@ -75,6 +76,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import com.liferay.portal.model.User;
+import io.vavr.Lazy;
 import io.vavr.control.Try;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
@@ -232,7 +234,8 @@ public class ESContentFactoryImpl extends ContentletFactory {
             "bool24", "bool25"};
 
     private static final int MAX_FIELDS_ALLOWED = 25;
-    private static final int OLD_CONTENT_BATCH_SIZE = 8192;
+    private static final Lazy<Integer> OLD_CONTENT_BATCH_SIZE = Lazy.of(
+            () -> Config.getIntProperty("OLD_CONTENT_BATCH_SIZE", 8192));
 
     private final ContentletCache contentletCache;
 	private final LanguageAPI languageAPI;
@@ -711,26 +714,12 @@ public class ESContentFactoryImpl extends ContentletFactory {
         dc.setSQL(countSQL);
         List<Map<String, String>> result = dc.loadResults();
         final int before = Integer.parseInt(result.get(0).get("count"));
-        final String query = "SELECT DISTINCT c.inode FROM contentlet c"
-                + " LEFT JOIN contentlet_version_info vi_w ON vi_w.working_inode = c.inode"
-                + " LEFT JOIN contentlet_version_info vi_l ON vi_l.live_inode = c.inode"
-                + " WHERE c.identifier <> 'SYSTEM_HOST' AND c.mod_date < ?"
-                + " AND vi_w.working_inode IS NULL AND vi_l.live_inode IS NULL"
-                + " LIMIT ?";
 
+        final int batchSize = OLD_CONTENT_BATCH_SIZE.get();
         int oldInodesCount;
         do {
-            dc = new DotConnect();
-            dc.setSQL(query);
-            dc.addParam(date);
-            dc.addParam(OLD_CONTENT_BATCH_SIZE);
-            result = dc.loadResults();
-            oldInodesCount = result.size();
-            if (oldInodesCount > 0) {
-                final List<String> inodeList = result.stream().map(row -> row.get("inode")).collect(Collectors.toList());
-                deleteContentData(inodeList);
-            }
-        } while (oldInodesCount == OLD_CONTENT_BATCH_SIZE);
+            oldInodesCount = deleteContentBatch(date, batchSize);
+        } while (oldInodesCount == batchSize);
 
         dc = new DotConnect();
         dc.setSQL(countSQL);
@@ -741,6 +730,35 @@ public class ESContentFactoryImpl extends ContentletFactory {
             deleteOrphanedBinaryFiles();
         }
         return deleted;
+    }
+
+    /**
+     * Deletes a batch of Contentlets that are older than the specified date. The batch size is
+     * determined by the {@code batchSize} parameter.
+     * @param date The date as of which all contents older than that will be deleted.
+     * @param batchSize The number of Contentlets to delete in each batch.
+     * @return The number of Contentlets deleted by this operation.
+     * @throws DotDataException An error occurred when interacting with the data source.
+     */
+    @WrapInTransaction(externalize = true)
+    private int deleteContentBatch(final Date date, final int batchSize) throws DotDataException {
+        final String query = "SELECT c.inode FROM contentlet c"
+                + " WHERE c.identifier <> 'SYSTEM_HOST' AND c.mod_date < ?"
+                + " AND NOT EXISTS (SELECT 1 FROM contentlet_version_info vi"
+                + " WHERE vi.working_inode = c.inode OR vi.live_inode = c.inode)"
+                + " LIMIT ?";
+        final DotConnect dc = new DotConnect();
+        dc.setSQL(query);
+        dc.addParam(date);
+        dc.addParam(batchSize);
+        final List<Map<String, String>> results = dc.loadResults();
+        final int resultCount = results.size();
+        if (resultCount > 0) {
+            final List<String> inodeList = results.stream().map(
+                    row -> row.get("inode")).collect(Collectors.toList());
+            deleteContentData(inodeList);
+        }
+        return resultCount;
     }
 
     /**


### PR DESCRIPTION
Closes #30353

### Proposed Changes
* This pull request includes changes to the `deleteOldContent` method from `ESContentFactoryImpl` class. The changes focus on improving the deletion of old content and optimizing the batch processing of content.

This PR fixes: #30353