### PR TITLE
feat(Edit Mode) #30799 : Creating a REST Endpoint that abstract the Lucene Query generation and return results

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
@@ -5,14 +5,13 @@ import com.dotcms.ai.app.AppConfig;
 import com.dotcms.ai.app.AppKeys;
 import com.dotcms.ai.app.ConfigService;
 import com.dotcms.ai.client.AIProxyClient;
+import com.dotcms.ai.client.JSONObjectAIRequest;
 import com.dotcms.ai.db.EmbeddingsDTO;
 import com.dotcms.ai.db.EmbeddingsDTO.Builder;
 import com.dotcms.ai.db.EmbeddingsFactory;
-import com.dotcms.ai.client.JSONObjectAIRequest;
 import com.dotcms.ai.util.ContentToStringUtil;
 import com.dotcms.ai.util.EncodingUtil;
 import com.dotcms.ai.util.VelocityContextFactory;
-import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.api.web.HttpServletResponseThreadLocal;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
@@ -21,7 +20,7 @@ import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.rendering.velocity.util.VelocityUtil;
-import com.dotcms.rest.ContentResource;
+import com.dotcms.rest.ContentHelper;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.common.model.ContentletSearch;
@@ -377,9 +376,8 @@ class EmbeddingsAPIImpl implements EmbeddingsAPI {
 
     private JSONObject dtoToContentJson(final EmbeddingsDTO dto, final User user) {
         return Try.of(() ->
-                ContentResource.contentletToJSON(
+                ContentHelper.getInstance().contentletToJSON(
                         APILocator.getContentletAPI().find(dto.inode, user, true),
-                        HttpServletRequestThreadLocal.INSTANCE.getRequest(),
                         HttpServletResponseThreadLocal.INSTANCE.getResponse(),
                         "false",
                         user,

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -949,12 +949,11 @@ public class ESContentFactoryImpl extends ContentletFactory {
      * Contentlets, if applicable.
      */
     private Contentlet processCachedContentlet(final Contentlet cachedContentlet) {
-        if (REFRESH_BLOCK_EDITOR_REFERENCES && cachedContentlet.getContentType().hasStoryBlockFields()) {
-
+        if (REFRESH_BLOCK_EDITOR_REFERENCES && null != cachedContentlet.getContentType() && cachedContentlet.getContentType().hasStoryBlockFields()) {
             final StoryBlockReferenceResult storyBlockRefreshedResult =
                     APILocator.getStoryBlockAPI().refreshReferences(cachedContentlet);
             if (storyBlockRefreshedResult.isRefreshed()) {
-                Logger.debug(this, () -> String.format("Refreshed Story Block dependencies for Contentlet '%s'",
+                Logger.debug(this, () -> String.format("Refreshed Story Block dependencies for Contentlet: '%s'",
                         cachedContentlet.getIdentifier()));
 
                 final Contentlet refreshedContentlet = (Contentlet) storyBlockRefreshedResult.getValue();

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -1,29 +1,30 @@
 package com.dotcms.graphql.datafetcher;
 
-import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.isFieldRenderable;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.renderFieldValue;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.RENDER_FIELDS;
-
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.graphql.DotGraphQLContext;
-import com.dotmarketing.util.json.JSONObject;
-import com.dotcms.rest.ContentResource;
+import com.dotcms.rest.ContentHelper;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.transform.DotContentletTransformer;
 import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import com.dotmarketing.util.json.JSONObject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liferay.portal.model.User;
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
 import io.vavr.control.Try;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+
+import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.isFieldRenderable;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.renderFieldValue;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.RENDER_FIELDS;
 
 /**
  * {@link DataFetcher} that fetches the data when the special <code>_map<code/> GraphQL Field is requested.
@@ -82,7 +83,7 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
 
             // this only adds relationships to any json. We would need to return them with the transformations already
 
-            final JSONObject jsonWithRels = ContentResource.addRelationshipsToJSON(request, response,
+            final JSONObject jsonWithRels = ContentHelper.getInstance().addRelationshipsToJSON(request, response,
                     render.toString(), user, depth, false, contentlet,
                     contentMapInJSON, null, 1, true, false,
                     true);

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -4,12 +4,11 @@ import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.api.web.HttpServletResponseThreadLocal;
 import com.dotcms.content.elasticsearch.business.ESMappingAPIImpl;
 import com.dotcms.content.elasticsearch.util.PaginationUtil;
-import com.dotcms.rest.ContentResource;
+import com.dotcms.rest.ContentHelper;
 import com.dotcms.rest.api.v1.DotObjectMapperProvider;
 import com.dotcms.util.ConversionUtils;
 import com.dotcms.util.TimeMachineUtil;
 import com.dotcms.variant.VariantAPI;
-import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.common.model.ContentletSearch;
@@ -30,6 +29,9 @@ import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.WebKeys;
 import com.dotmarketing.util.json.JSONObject;
 import com.liferay.portal.model.User;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -40,8 +42,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * The purpose of this class is to abstract the methods called from the ContentTool Viewtool
@@ -817,7 +817,7 @@ public class ContentUtils {
 
 			try {
 
-				final JSONObject jsonWithRelationShips = ContentResource.addRelationshipsToJSON(request, response,
+				final JSONObject jsonWithRelationShips = ContentHelper.getInstance().addRelationshipsToJSON(request, response,
 						request.getParameter("render"), user, depth, mode.respectAnonPerms, contentlet,
 						new JSONObject(), null, languageId, mode.showLive, false,
 						true);

--- a/dotCMS/src/main/java/com/dotcms/rest/ContentHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/ContentHelper.java
@@ -1,34 +1,63 @@
 package com.dotcms.rest;
 
+import com.dotcms.api.web.HttpServletRequestImpersonator;
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.contenttype.business.BaseTypeToContentTypeStrategy;
 import com.dotcms.contenttype.business.BaseTypeToContentTypeStrategyResolver;
+import com.dotcms.contenttype.model.field.CategoryField;
+import com.dotcms.contenttype.model.field.RelationshipField;
+import com.dotcms.contenttype.model.field.StoryBlockField;
+import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
+import com.dotcms.rendering.velocity.viewtools.content.util.ContentUtils;
 import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
-import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.JsonUtil;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.IdentifierAPI;
+import com.dotmarketing.business.RelationshipAPI;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.DotContentletValidationException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.struts.ContentletForm;
+import com.dotmarketing.portlets.contentlet.transform.DotContentletTransformer;
 import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
+import com.dotmarketing.portlets.contentlet.util.ContentletUtil;
+import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI;
+import com.dotmarketing.portlets.structure.model.ContentletRelationships;
+import com.dotmarketing.portlets.structure.model.Field;
+import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.PageMode;
+import com.dotmarketing.util.UtilHTML;
 import com.dotmarketing.util.UtilMethods;
+import com.dotmarketing.util.json.JSONArray;
+import com.dotmarketing.util.json.JSONException;
+import com.dotmarketing.util.json.JSONObject;
 import com.liferay.portal.language.LanguageUtil;
 import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
 import io.vavr.control.Try;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import javax.servlet.http.HttpServletRequest;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Encapsulate helper method for the {@link com.dotcms.rest.ContentResource}
@@ -40,6 +69,8 @@ public class ContentHelper {
     private final IdentifierAPI identifierAPI;
     private final BaseTypeToContentTypeStrategyResolver baseTypeToContentTypeStrategyResolver =
             BaseTypeToContentTypeStrategyResolver.getInstance();
+
+    public static final String[] ignoreFields = {"disabledWYSIWYG", "lowIndexPriority"};
 
     private static class SingletonHolder {
         private static final ContentHelper INSTANCE = new ContentHelper();
@@ -184,5 +215,515 @@ public class ContentHelper {
         return url;
     } // getUrl.
 
+    /**
+     *
+     * @param request
+     * @param response
+     * @param user
+     * @param query
+     * @param offset
+     * @param limit
+     * @param sort
+     * @param pageMode
+     * @return
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    public SearchView pullContent(final HttpServletRequest request,
+                                  final HttpServletResponse response, final User user,
+                                  final String query, final int offset, final int limit,
+                                  final String sort, final PageMode pageMode) throws DotDataException, DotSecurityException {
+        return pullContent(request, response, query, user, pageMode, offset, limit, sort,
+                StringPool.BLANK, "false", user, -1, -1, false);
+    }
 
-} // E:O:F:ContentHelper.
+    /**
+     *
+     * @param request
+     * @param response
+     * @param query
+     * @param resultsSize
+     * @param userForPull
+     * @param pageMode
+     * @param offset
+     * @param limit
+     * @param sort
+     * @param tmDate
+     * @param render
+     * @param user
+     * @param depth
+     * @param language
+     * @param allCategoriesInfo
+     * @return
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    public SearchView pullContent(HttpServletRequest request, HttpServletResponse response,
+                                   String query, User userForPull, PageMode pageMode, int offset, int limit,
+                                   String sort, String tmDate, String render, User user, int depth, long language,
+                                   boolean allCategoriesInfo) throws DotDataException, DotSecurityException {
+        JSONObject resultJson = new JSONObject();
+        long startAPISearchPull = 0;
+        long afterAPISearchPull = 0;
+        long startAPIPull = 0;
+        long afterAPIPull = 0;
+        long resultsSize = 0;
+        if (UtilMethods.isSet(query)) {
+            startAPISearchPull = Calendar.getInstance().getTimeInMillis();
+            resultsSize = APILocator.getContentletAPI().indexCount(query, userForPull, pageMode.respectAnonPerms);
+            afterAPISearchPull = Calendar.getInstance().getTimeInMillis();
+
+            startAPIPull = Calendar.getInstance().getTimeInMillis();
+            List<Contentlet> contentlets = ContentUtils.pull(query, offset, limit, sort, userForPull, tmDate, pageMode.respectAnonPerms);
+            resultJson = getJSONObject(contentlets, request, response, render, user, depth, pageMode.respectAnonPerms, language, pageMode.showLive, allCategoriesInfo);
+
+            afterAPIPull = Calendar.getInstance().getTimeInMillis();
+            if (contentlets.isEmpty() && offset <= resultsSize) {
+                resultsSize = 0;
+            }
+        }
+
+        final long queryTook = afterAPISearchPull - startAPISearchPull;
+        final long contentTook = afterAPIPull - startAPIPull;
+        return new SearchView(resultsSize, queryTook, contentTook, new JsonObjectView(resultJson));
+    }
+
+
+    /**
+     * Creates a JSON Object off of a list of Contentlets. Their representation will be set to the {@code contentlets}
+     * attribute in the JSON response. In case dotCMS cannot transform a piece of Content into a valid JSON Object, it
+     * will just not be included in the result object.
+     *
+     * @param contentletList       The list of {@link Contentlet} objects that will be transformed into JSON.
+     * @param request              The current {@link HttpServletRequest} object.
+     * @param response             The current {@link HttpServletResponse} object.
+     * @param render               If the rendered HTML version must be included in the response, set to {@code true}.
+     * @param user                 The {@link User} performing this action.
+     * @param depth                The required depth for related Contentlets, in case they're required.
+     * @param respectFrontendRoles If front-end Roles for the specified User must be validated, set this to {@code
+     *                             true}.
+     * @param language             The Language ID for the related Contentlets -- required only if the {@code depth}
+     *                             parameter is specified.
+     * @param live                 If the live version of the specified Contentlets must be retrieved, set this to
+     *                             {@code true}.
+     * @param allCategoriesInfo    If information about Categories must be included, set this to {@code true}.
+     *
+     * @return The JSON representation as {@link JSONArray} of the specified Contentlets.
+     *
+     * @throws IOException      An error occurred when generating the printable Contentlet map.
+     * @throws DotDataException An error occurred when interacting with the data source.
+     */
+    public JSONObject getJSONObject(final List<Contentlet> contentletList, final HttpServletRequest request,
+                                     final HttpServletResponse response, final String render, final User user,
+                                     final int depth, final boolean respectFrontendRoles, final long language,
+                                     final boolean live, final boolean allCategoriesInfo){
+        final JSONObject json = new JSONObject();
+        final JSONArray jsonContentlets = new JSONArray();
+
+        for (final Contentlet contentlet : contentletList) {
+            try {
+                final JSONObject contentAsJson = contentletToJSON(contentlet, response, render, user, allCategoriesInfo);
+                jsonContentlets.put(contentAsJson);
+                //we need to add relationships fields
+                if (depth != -1){
+                    addRelationshipsToJSON(request, response, render, user, depth,
+                            respectFrontendRoles, contentlet, contentAsJson, null, language, live, allCategoriesInfo);
+                }
+            } catch (final Exception e) {
+                final String errorMsg = String.format("An error occurred when converting Contentlet '%s' into JSON: " +
+                        "%s", contentlet.getIdentifier(), e.getMessage());
+                Logger.warn(this.getClass(), errorMsg);
+                Logger.debug(this.getClass(), errorMsg, e);
+            }
+        }
+
+        try {
+            json.put("contentlets", jsonContentlets);
+        } catch (final JSONException e) {
+            final String errorMsg = String.format("An error occurred when adding Contentlets to the result JSON " +
+                    "object: %s", e.getMessage());
+            Logger.warn(this.getClass(), errorMsg);
+            Logger.debug(this.getClass(), errorMsg, e);
+        }
+
+        return json;
+    }
+
+    /**
+     * Transforms the specified Contentlet object into its JSON representation.
+     *
+     * @param con               The {@link Contentlet} object that will be transformed.
+     * @param request           The current {@link HttpServletRequest} instance.
+     * @param response          The current {@link HttpServletResponse} instance.
+     * @param render            If the rendered HTML version must be included in the response, set to {@code true}.
+     * @param user              The {@link User} performing this action.
+     * @param allCategoriesInfo If information about Categories must be included, set to {@code true}.
+     *
+     * @return The representation of the Contentlet as a {@link JSONObject}.
+     *
+     * @throws JSONException        An error occurred when generating the JSON object.
+     * @throws IOException          An error occurred when generating the printable Contentlet map.
+     * @throws DotDataException     An error occurred when interacting with the data source.
+     * @throws DotSecurityException The specified User does not have the required permissions to perform this action.
+     */
+    public JSONObject contentletToJSON(final Contentlet con,
+                                              final HttpServletResponse response, final String render, final User user, final boolean allCategoriesInfo)
+            throws JSONException, IOException, DotDataException, DotSecurityException {
+        return contentletToJSON(con, response, render, user, allCategoriesInfo, false);
+    }
+
+    /**
+     * Transforms the specified Contentlet object into its JSON representation.
+     *
+     * @param contentlet        The {@link Contentlet} object that will be transformed.
+     * @param request           The current {@link HttpServletRequest} instance.
+     * @param response          The current {@link HttpServletResponse} instance.
+     * @param render            If the rendered HTML version must be included in the response, set to {@code true}.
+     * @param user              The {@link User} performing this action.
+     * @param allCategoriesInfo If information about Categories must be included, set to {@code true}.
+     * @param hydrateRelated
+     *
+     * @return The representation of the Contentlet as a {@link JSONObject}.
+     *
+     * @throws JSONException        An error occurred when generating the JSON object.
+     * @throws IOException          An error occurred when generating the printable Contentlet map.
+     * @throws DotDataException     An error occurred when interacting with the data source.
+     * @throws DotSecurityException The specified User does not have the required permissions to perform this action.
+     */
+    public JSONObject contentletToJSON(Contentlet contentlet,
+                                              final HttpServletResponse response, final String render, final User user,
+                                              final boolean allCategoriesInfo, final boolean hydrateRelated)
+            throws JSONException, IOException, DotDataException, DotSecurityException {
+        final JSONObject jsonObject = new JSONObject();
+        final ContentType type = contentlet.getContentType();
+
+        if(hydrateRelated) {
+            final DotContentletTransformer myTransformer = new DotTransformerBuilder()
+                    .hydratedContentMapTransformer().content(contentlet).build();
+            contentlet = myTransformer.hydrate().get(0);
+        }
+
+        final boolean doRender = (BaseContentType.WIDGET.equals(type.baseType()) && Boolean.TRUE.toString().equalsIgnoreCase(render));
+        //By default, all underlying transformer strategies that are triggered by the Widget ContentType or the option RENDER_FIELDS are enabled
+        //Therefore, we need to disable them in case the render option is not enabled to avoid undesired rendering when no explicitly requested
+        // Render field "code"
+        final Map<String, Object> map = ContentletUtil.getContentPrintableMap(user, contentlet, allCategoriesInfo, doRender);
+        final Set<String> jsonFields = getJSONFields(type);
+
+        for (final String key : map.keySet()) {
+            if (Arrays.binarySearch(ignoreFields, key) < 0) {
+                if (jsonFields.contains(key)) {
+                    Logger.debug(ContentResource.class,
+                            key + " is a json field: " + map.get(key).toString());
+                    jsonObject.put(key, new JSONObject(contentlet.getKeyValueProperty(key)));
+                } else if (isCategoryField(type, key) && map.get(key) instanceof Collection) {
+                    final Collection<?> categoryList = (Collection<?>) map.get(key);
+                    jsonObject.put(key, new JSONArray(categoryList.stream()
+                            .map(value -> new JSONObject((Map<?, ?>) value))
+                            .collect(Collectors.toList())));
+                }else if (isTagField(type, key) && map.get(key) instanceof Collection) {
+                    final Collection<?> tags = (Collection<?>) map.get(key);
+                    jsonObject.put(key, new JSONArray(tags));
+                    // this might be coming from transformers views, so let's try to make them JSONObjects
+                } else if (isStoryBlockField(type, key)) {
+                    final String fieldValue = String.class.cast(map.get(key));
+                    jsonObject.put(key, JsonUtil.isValidJSON(fieldValue) ? new JSONObject(fieldValue) : fieldValue);
+                } else if(hydrateRelated) {
+                    if(map.get(key) instanceof Map) {
+                        jsonObject.put(key, new JSONObject((Map) map.get(key)));
+                    } else {
+                        jsonObject.put(key, map.get(key));
+                    }
+                } else {
+                    jsonObject.put(key, map.get(key));
+                }
+            }
+        }
+        if (BaseContentType.WIDGET.equals(type.baseType()) && "true".equalsIgnoreCase(render)) {
+            final HttpServletRequestImpersonator impersonator = HttpServletRequestImpersonator.newInstance();
+            jsonObject.put("parsedCode", WidgetResource.parseWidget(impersonator.request(), response, contentlet));
+        }
+
+        if (BaseContentType.HTMLPAGE.equals(type.baseType())) {
+            jsonObject.put(HTMLPageAssetAPI.URL_FIELD, ContentHelper.getInstance().getUrl(contentlet));
+        }
+
+        jsonObject.put("__icon__", UtilHTML.getIconClass(contentlet));
+        jsonObject.put("contentTypeIcon", type.icon());
+        jsonObject.put("variant", contentlet.getVariantId());
+        return jsonObject;
+    }
+
+    public JSONObject addRelationshipsToJSON(final HttpServletRequest request,
+                                                    final HttpServletResponse response,
+                                                    final String render, final User user, final int depth,
+                                                    final boolean respectFrontendRoles,
+                                                    final Contentlet contentlet,
+                                                    final JSONObject jsonObject, Set<Relationship> addedRelationships, final long language,
+                                                    final boolean live, final boolean allCategoriesInfo)
+            throws DotDataException, JSONException, IOException ,  DotSecurityException {
+
+        return addRelationshipsToJSON(request, response, render, user, depth, respectFrontendRoles,
+                contentlet, jsonObject, addedRelationships, language, live, allCategoriesInfo, false);
+    }
+
+    /**
+     * Add relationships fields records to the json contentlet
+     * @param request
+     * @param response
+     * @param render
+     * @param user
+     * @param depth
+     * @param contentlet
+     * @param jsonObject
+     * @param addedRelationships
+     * @param language
+     * @param live
+     * @param allCategoriesInfo {@code "true"} to return all fields for
+     * the categories associated to the content (key, name, description), {@code "false"}
+     * to return only categories names.
+     * @return
+     * @throws DotDataException
+     * @throws JSONException
+     * @throws IOException
+     * @throws DotSecurityException
+     */
+    public JSONObject addRelationshipsToJSON(final HttpServletRequest request,
+                                                    final HttpServletResponse response,
+                                                    final String render, final User user, final int depth,
+                                                    final boolean respectFrontendRoles,
+                                                    final Contentlet contentlet,
+                                                    final JSONObject jsonObject, Set<Relationship> addedRelationships, final long language,
+                                                    final boolean live, final boolean allCategoriesInfo, final boolean hydrateRelated)
+            throws DotDataException, JSONException, IOException, DotSecurityException {
+
+        Relationship relationship;
+
+        final RelationshipAPI relationshipAPI = APILocator.getRelationshipAPI();
+
+        //filter relationships fields
+        final Map<String, com.dotcms.contenttype.model.field.Field> fields = contentlet.getContentType().fields()
+                .stream().filter(field -> field instanceof RelationshipField).collect(
+                        Collectors.toMap(field -> field.variable(), field -> field));
+
+        if (addedRelationships == null){
+            addedRelationships = new HashSet<>();
+        }
+
+        for (com.dotcms.contenttype.model.field.Field field:fields.values()) {
+
+            try {
+                relationship = relationshipAPI.getRelationshipFromField(field, user);
+            }catch(DotDataException | DotSecurityException e){
+                Logger.warn("Error getting relationship for field " + field, e.getMessage(), e);
+                continue;
+            }
+
+            if (addedRelationships.contains(relationship)){
+                continue;
+            }
+            if (!relationship.getParentStructureInode().equals(relationship.getChildStructureInode())) {
+                addedRelationships.add(relationship);
+            }
+
+            final boolean isChildField = relationshipAPI.isChildField(relationship, field);
+
+            final ContentletRelationships contentletRelationships = new ContentletRelationships(
+                    contentlet);
+            ContentletRelationships.ContentletRelationshipRecords records = contentletRelationships.new ContentletRelationshipRecords(
+                    relationship, isChildField);
+
+            JSONArray jsonArray = addRelatedContentToJsonArray(request, response,
+                    render, user, depth, respectFrontendRoles,
+                    contentlet, addedRelationships, language, live, field, isChildField,
+                    allCategoriesInfo, hydrateRelated);
+
+            jsonObject.put(field.variable(), getJSONArrayValue(jsonArray, records.doesAllowOnlyOne()));
+
+            //For self-related fields, the other side of the relationship should be added if the other-side field exists
+            if (relationshipAPI.sameParentAndChild(relationship)){
+                com.dotcms.contenttype.model.field.Field otherSideField = null;
+
+                if (relationship.getParentRelationName() != null
+                        && relationship.getChildRelationName() != null) {
+                    if (isChildField) {
+                        if (fields.containsKey(relationship.getParentRelationName())) {
+                            otherSideField = fields.get(relationship.getParentRelationName());
+                        }
+                    } else {
+                        if (fields.containsKey(relationship.getChildRelationName())) {
+                            otherSideField = fields.get(relationship.getChildRelationName());
+                        }
+                    }
+                }
+
+                if (otherSideField != null){
+
+                    records = contentletRelationships.new ContentletRelationshipRecords(
+                            relationship, !isChildField);
+                    jsonArray = addRelatedContentToJsonArray(request, response,
+                            render, user, depth, respectFrontendRoles,
+                            contentlet, addedRelationships, language, live,
+                            otherSideField, !isChildField, allCategoriesInfo, hydrateRelated);
+
+                    jsonObject.put(otherSideField.variable(),
+                            getJSONArrayValue(jsonArray, records.doesAllowOnlyOne()));
+                }
+            }
+
+        }
+
+        return jsonObject;
+    }
+
+    public Set<String> getJSONFields(ContentType type)
+            throws DotDataException, DotSecurityException {
+        Set<String> jsonFields = new HashSet<>();
+        List<Field> fields = new LegacyFieldTransformer(
+                APILocator.getContentTypeAPI(APILocator.systemUser()).
+                        find(type.inode()).fields()).asOldFieldList();
+        for (Field f : fields) {
+            if (f.getFieldType().equals(Field.FieldType.KEY_VALUE.toString())
+                    || f.getFieldType().equals(Field.FieldType.JSON_FIELD.toString()) ) {
+                jsonFields.add(f.getVelocityVarName());
+            }
+        }
+
+        return jsonFields;
+    }
+
+    private static boolean isCategoryField(final ContentType type, final String key) {
+        try {
+            Optional<com.dotcms.contenttype.model.field.Field> optionalField =
+                    type.fields().stream().filter(f -> UtilMethods.equal(key, f.variable())).findFirst();
+            if (optionalField.isPresent()) {
+                return optionalField.get() instanceof CategoryField;
+            }
+        } catch (Exception e) {
+            Logger.error(ContentResource.class, "Error getting field " + key, e);
+        }
+        return false;
+    }
+
+    private static boolean isTagField(final ContentType type, final String key) {
+        try {
+            Optional<com.dotcms.contenttype.model.field.Field> optionalField =
+                    type.fields().stream().filter(f -> UtilMethods.equal(key, f.variable())).findFirst();
+            if (optionalField.isPresent()) {
+                return optionalField.get() instanceof TagField;
+            }
+        } catch (Exception e) {
+            Logger.error(ContentResource.class, "Error getting field " + key, e);
+        }
+        return false;
+    }
+
+    /**
+     * Verifies if the specified field in a Content Type is of type {@link StoryBlockField}.
+     *
+     * @param type         The {@link ContentType} containing such a field.
+     * @param fieldVarName The Velocity Variable Name of the field that must be checked.
+     *
+     * @return If the field is of type {@link StoryBlockField}, returns {@code true}.
+     */
+    private static boolean isStoryBlockField(final ContentType type, final String fieldVarName) {
+        try {
+            final com.dotcms.contenttype.model.field.Field field = type.fieldMap().get(fieldVarName);
+            return field instanceof StoryBlockField;
+        } catch (final Exception e) {
+            Logger.error(ContentResource.class,
+                    String.format("Error checking StoryBlock type on field '%s': %s", fieldVarName, e.getMessage()), e);
+        }
+        return Boolean.FALSE;
+    }
+
+
+    /**
+     * Returns a jsonArray of related contentlets if depth = 2. If depth = 1 returns the related
+     * object, otherwise it will return a comma-separated list of identifiers
+     * @param jsonArray
+     * @return
+     * @throws JSONException
+     */
+    private static Object getJSONArrayValue(final JSONArray jsonArray, final boolean allowOnlyOne)
+            throws JSONException {
+        if (allowOnlyOne && !jsonArray.isEmpty()) {
+            return jsonArray.get(0);
+        } else {
+            return jsonArray;
+        }
+    }
+
+    /**
+     *
+     * @param request
+     * @param response
+     * @param render
+     * @param user
+     * @param depth
+     * @param respectFrontendRoles
+     * @param contentlet
+     * @param addedRelationships
+     * @param language
+     * @param live
+     * @param field
+     * @param isParent
+     * @param allCategoriesInfo
+     * @return
+     * @throws JSONException
+     * @throws IOException
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
+    private JSONArray addRelatedContentToJsonArray(HttpServletRequest request,
+                                                          HttpServletResponse response, String render, User user, int depth,
+                                                          boolean respectFrontendRoles, Contentlet contentlet,
+                                                          Set<Relationship> addedRelationships, long language, boolean live,
+                                                          com.dotcms.contenttype.model.field.Field field, final boolean isParent,
+                                                          final boolean allCategoriesInfo, final boolean hydrateRelated)
+            throws JSONException, IOException, DotDataException, DotSecurityException {
+
+
+        final JSONArray jsonArray = new JSONArray();
+
+        for (Contentlet relatedContent : contentlet.getRelated(field.variable(), user, respectFrontendRoles, isParent, language, live)) {
+            relatedContent.setProperty(field.name(), null);
+
+            switch (depth) {
+                //returns a list of identifiers
+                case 0:
+                    jsonArray.put(relatedContent.getIdentifier());
+                    break;
+
+                //returns a list of related content objects
+                case 1:
+                    jsonArray
+                            .put(contentletToJSON(relatedContent, response,
+                                    render, user, allCategoriesInfo, hydrateRelated));
+                    break;
+
+                //returns a list of related content identifiers for each of the related content
+                case 2:
+                    jsonArray.put(addRelationshipsToJSON(request, response, render, user, 0,
+                            respectFrontendRoles, relatedContent,
+                            contentletToJSON(relatedContent, response,
+                                    render, user, allCategoriesInfo, hydrateRelated),
+                            new HashSet<>(addedRelationships), language, live, allCategoriesInfo, hydrateRelated));
+                    break;
+
+                //returns a list of hydrated related content for each of the related content
+                case 3:
+                    jsonArray.put(addRelationshipsToJSON(request, response, render, user, 1,
+                            respectFrontendRoles, relatedContent,
+                            contentletToJSON(relatedContent, response,
+                                    render, user, allCategoriesInfo, hydrateRelated),
+                            new HashSet<>(addedRelationships), language, live, allCategoriesInfo, hydrateRelated));
+                    break;
+            }
+
+        }
+
+        return jsonArray;
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/ContentResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/ContentResource.java
@@ -1,13 +1,6 @@
 package com.dotcms.rest;
 
-import static com.dotmarketing.util.NumberUtil.toInt;
-import static com.dotmarketing.util.NumberUtil.toLong;
-
-import com.dotcms.api.web.HttpServletRequestImpersonator;
-import com.dotcms.contenttype.model.field.CategoryField;
 import com.dotcms.contenttype.model.field.RelationshipField;
-import com.dotcms.contenttype.model.field.StoryBlockField;
-import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
@@ -17,7 +10,6 @@ import com.dotcms.repackage.org.apache.commons.httpclient.HttpStatus;
 import com.dotcms.rest.api.v1.authentication.ResponseUtil;
 import com.dotcms.rest.exception.ForbiddenException;
 import com.dotcms.rest.exception.mapper.ExceptionMapperUtil;
-import com.dotcms.util.JsonUtil;
 import com.dotcms.util.xstream.XStreamHandler;
 import com.dotcms.uuid.shorty.ShortyId;
 import com.dotcms.uuid.shorty.ShortyIdAPI;
@@ -35,13 +27,10 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletDependencies;
 import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicyProvider;
-import com.dotmarketing.portlets.contentlet.transform.DotContentletTransformer;
-import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
 import com.dotmarketing.portlets.contentlet.util.ContentletUtil;
 import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI;
 import com.dotmarketing.portlets.structure.model.ContentletRelationships;
 import com.dotmarketing.portlets.structure.model.Field;
-import com.dotmarketing.portlets.structure.model.Field.FieldType;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction;
 import com.dotmarketing.portlets.workflows.model.WorkflowAction;
@@ -67,29 +56,12 @@ import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.nio.file.Files;
-import java.util.AbstractMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.glassfish.jersey.media.multipart.BodyPart;
+import org.glassfish.jersey.media.multipart.ContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
@@ -106,11 +78,29 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.glassfish.jersey.media.multipart.BodyPart;
-import org.glassfish.jersey.media.multipart.ContentDisposition;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.file.Files;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.dotmarketing.util.NumberUtil.toInt;
+import static com.dotmarketing.util.NumberUtil.toLong;
 
 /**
  * This REST Endpoint provides access to Contentlet data, fields, and different actions that can be
@@ -128,8 +118,6 @@ public class ContentResource {
 
     // set this only from an environmental variable so it cannot be overridden in our Config class
     private final boolean USE_XSTREAM_FOR_DESERIALIZATION = System.getenv("USE_XSTREAM_FOR_DESERIALIZATION")!=null && "true".equals(System.getenv("USE_XSTREAM_FOR_DESERIALIZATION"));
-
-    public static final String[] ignoreFields = {"disabledWYSIWYG", "lowIndexPriority"};
 
     private static final String RELATIONSHIP_KEY = "__##relationships##__";
     private static final String IP_ADDRESS = "ipAddress";
@@ -190,13 +178,6 @@ public class ContentResource {
         final String userToPullID       = searchForm.getUserId();
         final boolean allCategoriesInfo = searchForm.isAllCategoriesInfo();
         User   userForPull              = user;
-        List<Contentlet> contentlets;
-        long resultsSize                = 0;
-        long startAPISearchPull         = 0;
-        long afterAPISearchPull         = 0;
-        long startAPIPull               = 0;
-        long afterAPIPull               = 0;
-        JSONObject resultJson           = new JSONObject();
         final String tmDate = (String) request.getSession().getAttribute("tm_date");
 
         if (depth > 3) {
@@ -210,32 +191,15 @@ public class ContentResource {
             userForPull = APILocator.getUserAPI().loadUserById(userToPullID, APILocator.systemUser(),true);
         }
 
-        if (UtilMethods.isSet(query)) {
             if (rememberQuery) {
                 request.getSession().setAttribute(WebKeys.EXECUTED_LUCENE_QUERY, query);
             }
-            final String realQuery = query.contains("variant:") ? query : query + " +variant:default";
-
-            startAPISearchPull = Calendar.getInstance().getTimeInMillis();
-            resultsSize        = APILocator.getContentletAPI().indexCount(realQuery, userForPull, pageMode.respectAnonPerms);
-            afterAPISearchPull = Calendar.getInstance().getTimeInMillis();
-
-            startAPIPull       = Calendar.getInstance().getTimeInMillis();
-            contentlets        = ContentUtils.pull(processQuery(realQuery), offset, limit, sort, userForPull, tmDate, pageMode.respectAnonPerms);
-            resultJson = getJSONObject(contentlets, request, response, render, user, depth,
-                    pageMode.respectAnonPerms, language, pageMode.showLive, allCategoriesInfo);
-
-            afterAPIPull       = Calendar.getInstance().getTimeInMillis();
-
-            if(contentlets.isEmpty() && offset <= resultsSize ){
-                resultsSize = 0;
-            }
-        }
-
-        final long queryTook     = afterAPISearchPull-startAPISearchPull;
-        final long contentTook   = afterAPIPull-startAPIPull;
-        return Response.ok(new ResponseEntityView<>(
-                new SearchView(resultsSize, queryTook, contentTook, new JsonObjectView(resultJson)))).build();
+        String realQuery = query.contains("variant:") ? query : query + " +variant:default";
+        realQuery = processQuery(realQuery);
+        final SearchView searchView = this.contentHelper.pullContent(request, response, realQuery,
+                userForPull, pageMode, offset, limit, sort, tmDate, render, user, depth,
+                language, allCategoriesInfo);
+        return Response.ok(new ResponseEntityView<>(searchView)).build();
     }
 
     /**
@@ -878,7 +842,7 @@ public class ContentResource {
             m.put(HTMLPageAssetAPI.URL_FIELD, this.contentHelper.getUrl(contentlet));
         }
 
-        final Set<String> jsonFields = getJSONFields(type);
+        final Set<String> jsonFields = this.contentHelper.getJSONFields(type);
         for (String key : m.keySet()) {
             if (jsonFields.contains(key)) {
                 m.put(key, contentlet.getKeyValueProperty(key));
@@ -1112,446 +1076,9 @@ public class ContentResource {
             final HttpServletResponse response, final String render, final User user,
             final int depth, final boolean respectFrontendRoles, final long language,
             final boolean live, final boolean allCategoriesInfo){
-        final JSONObject json = this.getJSONObject(cons, request, response, render, user,
+        final JSONObject json = this.contentHelper.getJSONObject(cons, request, response, render, user,
                 depth, respectFrontendRoles, language, live, allCategoriesInfo);
         return json.toString();
-    }
-
-    /**
-     * Creates a JSON Object off of a list of Contentlets. Their representation will be set to the {@code contentlets}
-     * attribute in the JSON response. In case dotCMS cannot transform a piece of Content into a valid JSON Object, it
-     * will just not be included in the result object.
-     *
-     * @param contentletList       The list of {@link Contentlet} objects that will be transformed into JSON.
-     * @param request              The current {@link HttpServletRequest} object.
-     * @param response             The current {@link HttpServletResponse} object.
-     * @param render               If the rendered HTML version must be included in the response, set to {@code true}.
-     * @param user                 The {@link User} performing this action.
-     * @param depth                The required depth for related Contentlets, in case they're required.
-     * @param respectFrontendRoles If front-end Roles for the specified User must be validated, set this to {@code
-     *                             true}.
-     * @param language             The Language ID for the related Contentlets -- required only if the {@code depth}
-     *                             parameter is specified.
-     * @param live                 If the live version of the specified Contentlets must be retrieved, set this to
-     *                             {@code true}.
-     * @param allCategoriesInfo    If information about Categories must be included, set this to {@code true}.
-     *
-     * @return The JSON representation as {@link JSONArray} of the specified Contentlets.
-     *
-     * @throws IOException      An error occurred when generating the printable Contentlet map.
-     * @throws DotDataException An error occurred when interacting with the data source.
-     */
-    private JSONObject getJSONObject(final List<Contentlet> contentletList, final HttpServletRequest request,
-                           final HttpServletResponse response, final String render, final User user,
-                           final int depth, final boolean respectFrontendRoles, final long language,
-                           final boolean live, final boolean allCategoriesInfo){
-        final JSONObject json = new JSONObject();
-        final JSONArray jsonContentlets = new JSONArray();
-
-        for (final Contentlet contentlet : contentletList) {
-            try {
-                final JSONObject contentAsJson = contentletToJSON(contentlet, request, response, render, user, allCategoriesInfo);
-                jsonContentlets.put(contentAsJson);
-                //we need to add relationships fields
-                if (depth != -1){
-                    addRelationshipsToJSON(request, response, render, user, depth,
-                            respectFrontendRoles, contentlet, contentAsJson, null, language, live, allCategoriesInfo);
-                }
-            } catch (final Exception e) {
-                final String errorMsg = String.format("An error occurred when converting Contentlet '%s' into JSON: " +
-                                                              "%s", contentlet.getIdentifier(), e.getMessage());
-                Logger.warn(this.getClass(), errorMsg);
-                Logger.debug(this.getClass(), errorMsg, e);
-            }
-        }
-
-        try {
-            json.put("contentlets", jsonContentlets);
-        } catch (final JSONException e) {
-            final String errorMsg = String.format("An error occurred when adding Contentlets to the result JSON " +
-                                                          "object: %s", e.getMessage());
-            Logger.warn(this.getClass(), errorMsg);
-            Logger.debug(this.getClass(), errorMsg, e);
-        }
-
-        return json;
-    }
-
-    public static JSONObject addRelationshipsToJSON(final HttpServletRequest request,
-            final HttpServletResponse response,
-            final String render, final User user, final int depth,
-            final boolean respectFrontendRoles,
-            final Contentlet contentlet,
-            final JSONObject jsonObject, Set<Relationship> addedRelationships, final long language,
-            final boolean live, final boolean allCategoriesInfo)
-            throws DotDataException, JSONException, IOException ,  DotSecurityException {
-
-        return addRelationshipsToJSON(request, response, render, user, depth, respectFrontendRoles,
-                contentlet, jsonObject, addedRelationships, language, live, allCategoriesInfo, false);
-    }
-
-    /**
-     * Add relationships fields records to the json contentlet
-     * @param request
-     * @param response
-     * @param render
-     * @param user
-     * @param depth
-     * @param contentlet
-     * @param jsonObject
-     * @param addedRelationships
-     * @param language
-     * @param live
-     * @param allCategoriesInfo {@code "true"} to return all fields for
-     * the categories associated to the content (key, name, description), {@code "false"}
-     * to return only categories names.
-     * @return
-     * @throws DotDataException
-     * @throws JSONException
-     * @throws IOException
-     * @throws DotSecurityException
-     */
-    public static JSONObject addRelationshipsToJSON(final HttpServletRequest request,
-            final HttpServletResponse response,
-            final String render, final User user, final int depth,
-            final boolean respectFrontendRoles,
-            final Contentlet contentlet,
-            final JSONObject jsonObject, Set<Relationship> addedRelationships, final long language,
-            final boolean live, final boolean allCategoriesInfo, final boolean hydrateRelated)
-            throws DotDataException, JSONException, IOException, DotSecurityException {
-
-        Relationship relationship;
-
-        final RelationshipAPI relationshipAPI = APILocator.getRelationshipAPI();
-
-        //filter relationships fields
-        final Map<String, com.dotcms.contenttype.model.field.Field> fields = contentlet.getContentType().fields()
-                .stream().filter(field -> field instanceof RelationshipField).collect(
-                        Collectors.toMap(field -> field.variable(), field -> field));
-
-        if (addedRelationships == null){
-            addedRelationships = new HashSet<>();
-        }
-
-        for (com.dotcms.contenttype.model.field.Field field:fields.values()) {
-
-            try {
-                relationship = relationshipAPI.getRelationshipFromField(field, user);
-            }catch(DotDataException | DotSecurityException e){
-                Logger.warn("Error getting relationship for field " + field, e.getMessage(), e);
-                continue;
-            }
-
-            if (addedRelationships.contains(relationship)){
-                continue;
-            }
-            if (!relationship.getParentStructureInode().equals(relationship.getChildStructureInode())) {
-                addedRelationships.add(relationship);
-            }
-
-            final boolean isChildField = relationshipAPI.isChildField(relationship, field);
-
-            final ContentletRelationships contentletRelationships = new ContentletRelationships(
-                    contentlet);
-            ContentletRelationships.ContentletRelationshipRecords records = contentletRelationships.new ContentletRelationshipRecords(
-                    relationship, isChildField);
-
-            JSONArray jsonArray = addRelatedContentToJsonArray(request, response,
-                    render, user, depth, respectFrontendRoles,
-                    contentlet, addedRelationships, language, live, field, isChildField,
-                    allCategoriesInfo, hydrateRelated);
-
-            jsonObject.put(field.variable(), getJSONArrayValue(jsonArray, records.doesAllowOnlyOne()));
-
-            //For self-related fields, the other side of the relationship should be added if the other-side field exists
-            if (relationshipAPI.sameParentAndChild(relationship)){
-                com.dotcms.contenttype.model.field.Field otherSideField = null;
-
-                if (relationship.getParentRelationName() != null
-                        && relationship.getChildRelationName() != null) {
-                    if (isChildField) {
-                        if (fields.containsKey(relationship.getParentRelationName())) {
-                            otherSideField = fields.get(relationship.getParentRelationName());
-                        }
-                    } else {
-                        if (fields.containsKey(relationship.getChildRelationName())) {
-                            otherSideField = fields.get(relationship.getChildRelationName());
-                        }
-                    }
-                }
-
-                if (otherSideField != null){
-
-                    records = contentletRelationships.new ContentletRelationshipRecords(
-                            relationship, !isChildField);
-                    jsonArray = addRelatedContentToJsonArray(request, response,
-                            render, user, depth, respectFrontendRoles,
-                            contentlet, addedRelationships, language, live,
-                            otherSideField, !isChildField, allCategoriesInfo, hydrateRelated);
-
-                    jsonObject.put(otherSideField.variable(),
-                            getJSONArrayValue(jsonArray, records.doesAllowOnlyOne()));
-                }
-            }
-
-        }
-
-        return jsonObject;
-    }
-
-    /**
-     *
-     * @param request
-     * @param response
-     * @param render
-     * @param user
-     * @param depth
-     * @param respectFrontendRoles
-     * @param contentlet
-     * @param addedRelationships
-     * @param language
-     * @param live
-     * @param field
-     * @param isParent
-     * @param allCategoriesInfo
-     * @return
-     * @throws JSONException
-     * @throws IOException
-     * @throws DotDataException
-     * @throws DotSecurityException
-     */
-    private static JSONArray addRelatedContentToJsonArray(HttpServletRequest request,
-            HttpServletResponse response, String render, User user, int depth,
-            boolean respectFrontendRoles, Contentlet contentlet,
-            Set<Relationship> addedRelationships, long language, boolean live,
-            com.dotcms.contenttype.model.field.Field field, final boolean isParent,
-            final boolean allCategoriesInfo, final boolean hydrateRelated)
-            throws JSONException, IOException, DotDataException, DotSecurityException {
-
-
-        final JSONArray jsonArray = new JSONArray();
-
-        for (Contentlet relatedContent : contentlet.getRelated(field.variable(), user, respectFrontendRoles, isParent, language, live)) {
-            relatedContent.setProperty(field.name(), null);
-
-            switch (depth) {
-                //returns a list of identifiers
-                case 0:
-                    jsonArray.put(relatedContent.getIdentifier());
-                    break;
-
-                //returns a list of related content objects
-                case 1:
-                    jsonArray
-                            .put(contentletToJSON(relatedContent, request, response,
-                                    render, user, allCategoriesInfo, hydrateRelated));
-                    break;
-
-                //returns a list of related content identifiers for each of the related content
-                case 2:
-                    jsonArray.put(addRelationshipsToJSON(request, response, render, user, 0,
-                            respectFrontendRoles, relatedContent,
-                            contentletToJSON(relatedContent, request, response,
-                                    render, user, allCategoriesInfo, hydrateRelated),
-                            new HashSet<>(addedRelationships), language, live, allCategoriesInfo, hydrateRelated));
-                    break;
-
-                //returns a list of hydrated related content for each of the related content
-                case 3:
-                    jsonArray.put(addRelationshipsToJSON(request, response, render, user, 1,
-                            respectFrontendRoles, relatedContent,
-                            contentletToJSON(relatedContent, request, response,
-                                    render, user, allCategoriesInfo, hydrateRelated),
-                            new HashSet<>(addedRelationships), language, live, allCategoriesInfo, hydrateRelated));
-                    break;
-            }
-
-        }
-
-        return jsonArray;
-
-    }
-
-    /**
-     * Returns a jsonArray of related contentlets if depth = 2. If depth = 1 returns the related
-     * object, otherwise it will return a comma-separated list of identifiers
-     * @param jsonArray
-     * @return
-     * @throws JSONException
-     */
-    private static Object getJSONArrayValue(final JSONArray jsonArray, final boolean allowOnlyOne)
-            throws JSONException {
-        if (allowOnlyOne && jsonArray.length() > 0) {
-            return jsonArray.get(0);
-        } else {
-            return jsonArray;
-        }
-    }
-
-    public static Set<String> getJSONFields(ContentType type)
-            throws DotDataException, DotSecurityException {
-        Set<String> jsonFields = new HashSet<>();
-        List<Field> fields = new LegacyFieldTransformer(
-                APILocator.getContentTypeAPI(APILocator.systemUser()).
-                        find(type.inode()).fields()).asOldFieldList();
-        for (Field f : fields) {
-            if (f.getFieldType().equals(Field.FieldType.KEY_VALUE.toString())
-                    || f.getFieldType().equals(FieldType.JSON_FIELD.toString()) ) {
-                jsonFields.add(f.getVelocityVarName());
-            }
-        }
-
-        return jsonFields;
-    }
-
-    /**
-     * Transforms the specified Contentlet object into its JSON representation.
-     *
-     * @param con               The {@link Contentlet} object that will be transformed.
-     * @param request           The current {@link HttpServletRequest} instance.
-     * @param response          The current {@link HttpServletResponse} instance.
-     * @param render            If the rendered HTML version must be included in the response, set to {@code true}.
-     * @param user              The {@link User} performing this action.
-     * @param allCategoriesInfo If information about Categories must be included, set to {@code true}.
-     *
-     * @return The representation of the Contentlet as a {@link JSONObject}.
-     *
-     * @throws JSONException        An error occurred when generating the JSON object.
-     * @throws IOException          An error occurred when generating the printable Contentlet map.
-     * @throws DotDataException     An error occurred when interacting with the data source.
-     * @throws DotSecurityException The specified User does not have the required permissions to perform this action.
-     */
-    public static JSONObject contentletToJSON(final Contentlet con, final HttpServletRequest request,
-            final HttpServletResponse response, final String render, final User user, final boolean allCategoriesInfo)
-            throws JSONException, IOException, DotDataException, DotSecurityException {
-        return contentletToJSON(con, request, response, render, user, allCategoriesInfo, false);
-    }
-
-    /**
-     * Transforms the specified Contentlet object into its JSON representation.
-     *
-     * @param contentlet        The {@link Contentlet} object that will be transformed.
-     * @param request           The current {@link HttpServletRequest} instance.
-     * @param response          The current {@link HttpServletResponse} instance.
-     * @param render            If the rendered HTML version must be included in the response, set to {@code true}.
-     * @param user              The {@link User} performing this action.
-     * @param allCategoriesInfo If information about Categories must be included, set to {@code true}.
-     * @param hydrateRelated
-     *
-     * @return The representation of the Contentlet as a {@link JSONObject}.
-     *
-     * @throws JSONException        An error occurred when generating the JSON object.
-     * @throws IOException          An error occurred when generating the printable Contentlet map.
-     * @throws DotDataException     An error occurred when interacting with the data source.
-     * @throws DotSecurityException The specified User does not have the required permissions to perform this action.
-     */
-    public static JSONObject contentletToJSON(Contentlet contentlet, final HttpServletRequest request,
-            final HttpServletResponse response, final String render, final User user,
-            final boolean allCategoriesInfo, final boolean hydrateRelated)
-            throws JSONException, IOException, DotDataException, DotSecurityException {
-        final JSONObject jsonObject = new JSONObject();
-        final ContentType type = contentlet.getContentType();
-
-        if(hydrateRelated) {
-            final DotContentletTransformer myTransformer = new DotTransformerBuilder()
-                    .hydratedContentMapTransformer().content(contentlet).build();
-            contentlet = myTransformer.hydrate().get(0);
-        }
-
-        final boolean doRender = (BaseContentType.WIDGET.equals(type.baseType()) && Boolean.TRUE.toString().equalsIgnoreCase(render));
-        //By default, all underlying transformer strategies that are triggered by the Widget ContentType or the option RENDER_FIELDS are enabled
-        //Therefore, we need to disable them in case the render option is not enabled to avoid undesired rendering when no explicitly requested
-        // Render field "code"
-        final Map<String, Object> map = ContentletUtil.getContentPrintableMap(user, contentlet, allCategoriesInfo, doRender);
-        final Set<String> jsonFields = getJSONFields(type);
-
-        for (final String key : map.keySet()) {
-            if (Arrays.binarySearch(ignoreFields, key) < 0) {
-                if (jsonFields.contains(key)) {
-                    Logger.debug(ContentResource.class,
-                            key + " is a json field: " + map.get(key).toString());
-                    jsonObject.put(key, new JSONObject(contentlet.getKeyValueProperty(key)));
-                } else if (isCategoryField(type, key) && map.get(key) instanceof Collection) {
-                    final Collection<?> categoryList = (Collection<?>) map.get(key);
-                    jsonObject.put(key, new JSONArray(categoryList.stream()
-                            .map(value -> new JSONObject((Map<?, ?>) value))
-                            .collect(Collectors.toList())));
-                }else if (isTagField(type, key) && map.get(key) instanceof Collection) {
-                        final Collection<?> tags = (Collection<?>) map.get(key);
-                        jsonObject.put(key, new JSONArray(tags));
-                        // this might be coming from transformers views, so let's try to make them JSONObjects
-                } else if (isStoryBlockField(type, key)) {
-                    final String fieldValue = String.class.cast(map.get(key));
-                    jsonObject.put(key, JsonUtil.isValidJSON(fieldValue) ? new JSONObject(fieldValue) : fieldValue);
-                } else if(hydrateRelated) {
-                    if(map.get(key) instanceof Map) {
-                        jsonObject.put(key, new JSONObject((Map) map.get(key)));
-                    } else {
-                        jsonObject.put(key, map.get(key));
-                    }
-                } else {
-                    jsonObject.put(key, map.get(key));
-                }
-            }
-        }
-        if (BaseContentType.WIDGET.equals(type.baseType()) && "true".equalsIgnoreCase(render)) {
-            final HttpServletRequestImpersonator impersonator = HttpServletRequestImpersonator.newInstance();
-            jsonObject.put("parsedCode", WidgetResource.parseWidget(impersonator.request(), response, contentlet));
-        }
-
-        if (BaseContentType.HTMLPAGE.equals(type.baseType())) {
-            jsonObject.put(HTMLPageAssetAPI.URL_FIELD, ContentHelper.getInstance().getUrl(contentlet));
-        }
-
-        jsonObject.put("__icon__", UtilHTML.getIconClass(contentlet));
-        jsonObject.put("contentTypeIcon", type.icon());
-        jsonObject.put("variant", contentlet.getVariantId());
-        return jsonObject;
-    }
-
-    private static boolean isCategoryField(final ContentType type, final String key) {
-        try {
-            Optional<com.dotcms.contenttype.model.field.Field> optionalField =
-                    type.fields().stream().filter(f -> UtilMethods.equal(key, f.variable())).findFirst();
-            if (optionalField.isPresent()) {
-                return optionalField.get() instanceof CategoryField;
-            }
-        } catch (Exception e) {
-            Logger.error(ContentResource.class, "Error getting field " + key, e);
-        }
-        return false;
-    }
-
-    private static boolean isTagField(final ContentType type, final String key) {
-        try {
-            Optional<com.dotcms.contenttype.model.field.Field> optionalField =
-                    type.fields().stream().filter(f -> UtilMethods.equal(key, f.variable())).findFirst();
-            if (optionalField.isPresent()) {
-                return optionalField.get() instanceof TagField;
-            }
-        } catch (Exception e) {
-            Logger.error(ContentResource.class, "Error getting field " + key, e);
-        }
-        return false;
-    }
-
-    /**
-     * Verifies if the specified field in a Content Type is of type {@link StoryBlockField}.
-     *
-     * @param type         The {@link ContentType} containing such a field.
-     * @param fieldVarName The Velocity Variable Name of the field that must be checked.
-     *
-     * @return If the field is of type {@link StoryBlockField}, returns {@code true}.
-     */
-    private static boolean isStoryBlockField(final ContentType type, final String fieldVarName) {
-        try {
-            final com.dotcms.contenttype.model.field.Field field = type.fieldMap().get(fieldVarName);
-            return field != null && field instanceof StoryBlockField;
-        } catch (final Exception e) {
-            Logger.error(ContentResource.class,
-                    String.format("Error checking StoryBlock type on field '%s': %s", fieldVarName, e.getMessage()), e);
-        }
-        return Boolean.FALSE;
     }
 
     public class MapEntryConverter implements Converter {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentResource.java
@@ -5,20 +5,20 @@ import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.mock.response.MockHttpResponse;
 import com.dotcms.rendering.velocity.viewtools.content.util.ContentUtils;
-import com.dotcms.repackage.org.apache.commons.httpclient.HttpStatus;
 import com.dotcms.rest.AnonymousAccess;
+import com.dotcms.rest.ContentHelper;
 import com.dotcms.rest.CountView;
 import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.MapToContentletPopulator;
-import com.dotcms.rest.RESTParams;
-import com.dotcms.rest.ResourceResponse;
 import com.dotcms.rest.ResponseEntityBooleanView;
 import com.dotcms.rest.ResponseEntityContentletView;
 import com.dotcms.rest.ResponseEntityCountView;
 import com.dotcms.rest.ResponseEntityView;
+import com.dotcms.rest.SearchForm;
+import com.dotcms.rest.SearchView;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
-import com.dotcms.rest.exception.ForbiddenException;
+import com.dotcms.rest.api.v1.content.search.LuceneQueryBuilder;
 import com.dotcms.util.DotPreconditions;
 import com.dotcms.uuid.shorty.ShortType;
 import com.dotcms.uuid.shorty.ShortyId;
@@ -52,8 +52,6 @@ import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
-import com.dotmarketing.util.json.JSONException;
-import com.dotmarketing.util.json.JSONObject;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.liferay.portal.language.LanguageUtil;
@@ -103,6 +101,7 @@ public class ContentResource {
     private final IdentifierAPI  identifierAPI;
     private final LanguageWebAPI languageWebAPI;
     private final LanguageAPI languageAPI;
+    private final ContentHelper contentHelper;
 
     private final Lazy<Boolean> isDefaultContentToDefaultLanguageEnabled = Lazy.of(
             () -> Config.getBooleanProperty("DEFAULT_CONTENT_TO_DEFAULT_LANGUAGE", false));
@@ -112,7 +111,8 @@ public class ContentResource {
                 APILocator.getContentletAPI(),
                 APILocator.getIdentifierAPI(),
                 WebAPILocator.getLanguageWebAPI(),
-                APILocator.getLanguageAPI());
+                APILocator.getLanguageAPI(),
+                ContentHelper.getInstance());
     }
 
     @VisibleForTesting
@@ -120,12 +120,14 @@ public class ContentResource {
                            final ContentletAPI   contentletAPI,
                            final IdentifierAPI  identifierAPI,
                            final LanguageWebAPI languageWebAPI,
-                           final LanguageAPI    languageAPI) {
+                           final LanguageAPI    languageAPI,
+                           final ContentHelper contentHelper) {
         this.webResource    = webResource;
         this.contentletAPI  = contentletAPI;
         this.identifierAPI  = identifierAPI;
         this.languageWebAPI = languageWebAPI;
         this.languageAPI = languageAPI;
+        this.contentHelper = contentHelper;
     }
 
     /**
@@ -820,6 +822,64 @@ public class ContentResource {
         allLanguages.forEach(language -> languagesForContent.add(new ExistingLanguagesForContentletView(language,
                 existingContentLanguages.contains(language.getId()))));
         return languagesForContent.build();
+    }
+
+    /**
+     * Allows you to retrieve contents via Elasticsearch by abstracting the generation of the Lucene
+     * query, and leaving it to dotCMS itself. This endpoint uses the {@link ContentSearchForm} to
+     * define the search parameters, and returns the same {@link SearchView} object that the
+     * {@link com.dotcms.rest.ContentResource#search(HttpServletRequest, HttpServletResponse,
+     * boolean, SearchForm)} endpoint returns.
+     *
+     * @param request           The current instance of the {@link HttpServletRequest}.
+     * @param response          The current instance of the {@link HttpServletResponse}.
+     * @param contentSearchForm The {@link ContentSearchForm} object containing the search
+     *                          parameters.
+     *
+     * @return The {@link SearchView} object containing the search results.
+     *
+     * @throws DotDataException     An error occurred when interacting with the database.
+     * @throws DotSecurityException The User accessing this endpoint doesn't have the required
+     *                              permissions.
+     */
+    @POST
+    @JSONP
+    @NoCache
+    @Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+    @Path("/search")
+    @Operation(operationId = "search", summary = "Retrieves content from the dotCMS repository",
+            description = "Abstracts the generation of the required Lucene query to look for user searchable fields " +
+                    "in a Content Type, and returns the expected results.",
+            tags = {"Content"},
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "The query has been executed. It's possible that " +
+                            "no contents matched the search criteria.",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = SearchView.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Bad request. Malformed JSON body"),
+                    @ApiResponse(responseCode = "401", description = "Invalid User, or not logged in"),
+                    @ApiResponse(responseCode = "403", description = "Forbidden"),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error")
+            }
+    )
+    public ResponseEntityView<SearchView> search(@Context final HttpServletRequest request,
+                             @Context final HttpServletResponse response,
+                             final ContentSearchForm contentSearchForm) throws DotDataException, DotSecurityException {
+        Logger.debug(this, () -> "Searching for contentlets with the following parameters: " + contentSearchForm);
+        final User user = new WebResource.InitBuilder(webResource)
+                .requestAndResponse(request, response)
+                .rejectWhenNoUser(true)
+                .requiredBackendUser(true)
+                .init()
+                .getUser();
+        final PageMode pageMode = PageMode.get(request);
+        final LuceneQueryBuilder luceneQueryBuilder = new LuceneQueryBuilder(contentSearchForm, user);
+        final SearchView searchView = this.contentHelper.pullContent(request, response, user,
+                luceneQueryBuilder.build(), contentSearchForm.offset(), contentSearchForm.perPage(),
+                luceneQueryBuilder.getOrderByClause(), pageMode);
+        return new ResponseEntityView<>(searchView);
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentSearchForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentSearchForm.java
@@ -19,7 +19,7 @@ import static com.liferay.util.StringPool.BLANK;
  * <pre>
  *     <code>
  * {
- *         "globalSearch": "",
+ *         "globalSearch": "{{STRING}}",
  *         "searchableFieldsByContentType": {
  *             "{{CONTENT_TYPE_ID_OR_VAR_NAME}}": {
  *                 "binary": "{{STRING}}",
@@ -27,25 +27,23 @@ import static com.liferay.util.StringPool.BLANK;
  *                 "category": "{{STRING: Comma-separated list of Category IDs}}",
  *                 "checkbox": "{{STRING: Comma-separated list of values}}",
  *                 "custom": "{{STRING}}",
- *                 "date": "{{STRING}}: Can use ranges by including the [ and ] characters",
- *                 "dateAndTime": "{{STRING}}: Date or date and time. Can use ranges by including
- *                 the [ and ] characters",
+ *                 "date": "{{STRING}}: Can use ranges by including the TO between dates. Brackets are optional",
+ *                 "dateAndTime": "{{STRING}}: Date or date and time. Can use ranges by including the TO between dates. Brackets are optional",
  *                 "json": "{{STRING}: Matches any String in the JSON object}",
- *                 "keyValue": "{{STRING}: Matches keys and values in
- *                 "multiSelect": "{{STRING: Comma-separated list of values, not labels}}",
- *                 "radio": "{{STRING}: Matches values, not labels}",
- *                 "relationships": "{{STRING:ID of the contentlet that must be referenced by the
- *                 content(s) you want to query}}",
- *                 "select": "{{STRING}: Matches values, not labels}",
+ *                 "keyValue": "{{STRING}: Matches keys and values in the JSON object}}",
+ *                 "multiSelect": "{{STRING: Comma-separated list of values, NOT labels}}",
+ *                 "radio": "{{STRING}: Matches values, NOT labels}",
+ *                 "relationships": "{{STRING: ID of the child Contentlet that must be referenced by the Contentlet(s) you want to retrieve}}",
+ *                 "select": "{{STRING}: Matches values, NOT labels}",
  *                 "tag": "{{STRING:comma-separated list of Tag names}}",
  *                 "title": "{{STRING}}",
  *                 "textArea": "{{STRING}}",
- *                 "time": "{{STRING}: Can use ranges by including the [ and ] characters}",
+ *                 "time": "{{STRING}: Can use ranges by including the TO string between times. Brackets are optional}",
  *                 "wysiwyg": "{{STRING}}"
  *             }
  *         },
  *         "systemSearchableFields": {
- *             "siteId": "{{STRING}}",
+ *             "siteId": "{{STRING: When NOT set, and the 'systemHostContent' is NOT set either, the search will include contents under System Host}}",
  *             "languageId": {{INTEGER}},
  *             "workflowSchemeId": "{{STRING}}",
  *             "workflowStepId": "{{STRING}}",

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/DateTimeFieldStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/DateTimeFieldStrategy.java
@@ -18,14 +18,13 @@ public class DateTimeFieldStrategy implements FieldStrategy {
     public String generateQuery(final FieldContext fieldContext) {
         final String fieldName = fieldContext.fieldName();
         String value = fieldContext.fieldValue().toString();
-        if (!(value.contains(OPEN_BRACKET)
-                && value.toLowerCase().contains("to")
-                && value.contains(CLOSE_BRACKET))) {
-            value = OPEN_BRACKET + value + " TO " + value + CLOSE_BRACKET;
-        } else if (value.toLowerCase().contains("to")) {
+        if (value.toLowerCase().contains("to")) {
+            // Add brackets if they are not present
             value = !value.contains(OPEN_BRACKET) ? OPEN_BRACKET + value : value;
             value = !value.contains(CLOSE_BRACKET) ? value + CLOSE_BRACKET : value;
+        } else {
+            value = OPEN_BRACKET + value + " TO " + value + CLOSE_BRACKET;
         }
-        return "+" + fieldName + ":" + value;
+        return "+" + fieldName + ":" + value.toUpperCase();
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/GlobalSearchAttributeStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/GlobalSearchAttributeStrategy.java
@@ -17,20 +17,25 @@ public class GlobalSearchAttributeStrategy implements FieldStrategy {
 
     /** This is the RegEx used to split the values of the field into tokens */
     private static final String VALUE_SPLIT_REGEX = "[,|\\s+]";
+    private static final String SPECIAL_CHARS_TO_ESCAPE = "([+\\-!\\(\\){}\\[\\]^\"~*?:\\\\]|[&\\|]{2})";
 
     @Override
     public String generateQuery(final FieldContext fieldContext) {
         final String fieldName = fieldContext.fieldName();
-        final String value = fieldContext.fieldValue().toString();
+        String value = fieldContext.fieldValue().toString();
         final StringBuilder luceneQuery = new StringBuilder();
-        luceneQuery.append(fieldName).append(":'").append(value).append("'^15");
+        luceneQuery.append("+catchall:").append(value).append("*").append(" ");
+        luceneQuery.append(fieldName).append(":'").append(value).append("'^15").append(" ");
         final String[] titleSplit = value.split(VALUE_SPLIT_REGEX);
         if (titleSplit.length > 1) {
             for (final String term : titleSplit) {
-                luceneQuery.append(fieldName).append(":").append(term).append("^5 ");
+                luceneQuery.append(fieldName).append(":").append(term).append("^5").append(" ");
             }
         }
-        luceneQuery.append(fieldName).append("_dotraw:*").append(value).append("*^5");
+        luceneQuery.append(fieldName).append("_dotraw:*").append(value).append("*^5").append(" ");
+        value = value.replaceAll("\\*", "");
+        value = value.replaceAll(SPECIAL_CHARS_TO_ESCAPE, "\\\\$1");
+        luceneQuery.append("title:").append(value).append("*");
         return luceneQuery.toString().trim();
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/KeyValueFieldStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/KeyValueFieldStrategy.java
@@ -4,6 +4,11 @@ import com.dotcms.rest.api.v1.content.search.handlers.FieldContext;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.util.StringUtils;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static com.liferay.util.StringPool.SPACE;
+
 /**
  * This Field Strategy implementation specifies the correct syntax for querying a KeyValue Field via
  * Lucene query in dotCMS.
@@ -14,6 +19,7 @@ import com.dotmarketing.util.StringUtils;
 public class KeyValueFieldStrategy implements FieldStrategy {
 
     private static final String SPECIAL_CHARS_TO_ESCAPE_FOR_META_DATA = "([+\\-!\\(\\){}\\[\\]^\"~?:/\\\\]{2})";
+    private static final String VALUE_SPLIT_REGEX = "[,|\\s+]";
 
     @Override
     public String generateQuery(final FieldContext fieldContext) {
@@ -25,18 +31,25 @@ public class KeyValueFieldStrategy implements FieldStrategy {
             fieldValue = fieldValue.substring(0, fieldValue.length()-1);
         }
         final String[] splitter = fieldValue.split(":");
-        StringBuilder metakey = new StringBuilder();
-        for (int x = 0; x < splitter.length - 1; x++) {
-            metakey.append(splitter[x]);
-        }
-        metakey = new StringBuilder(StringUtils.camelCaseLower(metakey.toString()));
-        final String metaVal = "*" + splitter[splitter.length - 1] + "*";
-        fieldValue = metakey + ":" + metaVal;
+        if (splitter.length > 1) {
+            StringBuilder metakey = new StringBuilder();
+            for (int x = 0; x < splitter.length - 1; x++) {
+                metakey.append(splitter[x]);
+            }
+            metakey = new StringBuilder(StringUtils.camelCaseLower(metakey.toString()));
+            final String metaVal = "*" + splitter[splitter.length - 1] + "*";
+            fieldValue = metakey + ":" + metaVal;
 
-        if (fieldName.endsWith("." + FileAssetAPI.META_DATA_FIELD)) {
-            return "+" + fieldName + fieldValue.replaceAll(SPECIAL_CHARS_TO_ESCAPE_FOR_META_DATA, "\\\\$1");
+            if (fieldName.endsWith("." + FileAssetAPI.META_DATA_FIELD)) {
+                return "+" + fieldName + fieldValue.replaceAll(SPECIAL_CHARS_TO_ESCAPE_FOR_META_DATA, "\\\\$1");
+            }
         }
-        return "+" + fieldName + ".key_value" + fieldValue.replaceAll(SPECIAL_CHARS_TO_ESCAPE_FOR_META_DATA, "\\\\$1");
+        return Arrays.stream(fieldValue.split(VALUE_SPLIT_REGEX))
+                .map(String::trim)
+                .filter(token -> !token.isEmpty())
+                .map(token -> String.format("+%s%s:%s%s%s",
+                        fieldName, ".key_value", "*", token, "*"))
+                .collect(Collectors.joining(SPACE));
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/elasticsearch/ESContentResourcePortlet.java
@@ -2,7 +2,7 @@ package com.dotcms.rest.elasticsearch;
 
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
 import com.dotcms.rest.BaseRestPortlet;
-import com.dotcms.rest.ContentResource;
+import com.dotcms.rest.ContentHelper;
 import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.ResourceResponse;
 import com.dotcms.rest.WebResource;
@@ -108,15 +108,15 @@ public class ESContentResourcePortlet extends BaseRestPortlet {
 			for(Object x : esresult){
 				final Contentlet c = (Contentlet) x;
 				try {
-
-					final JSONObject jsonObject = ContentResource
-							.contentletToJSON(c, request, response,
+					final ContentHelper contentHelper = ContentHelper.getInstance();
+					final JSONObject jsonObject = contentHelper
+							.contentletToJSON(c, response,
 									"false", user, allCategoriesInfo);
 					jsonCons.put(jsonObject);
 
 					//load relationships
 					if (depth!= -1){
-						ContentResource
+						contentHelper
 								.addRelationshipsToJSON(request, response,
 										"false", user, depth, true, c,
 										jsonObject, null, -1, liveParam, allCategoriesInfo);

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/search/LuceneQueryBuilderTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/search/LuceneQueryBuilderTest.java
@@ -122,7 +122,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                         "{\n" +
                         "    \"globalSearch\": \"dummy search\"\n" +
                         "}",
-                        "+systemType:false -contentType:forms -contentType:Host title:'dummy search'^15title:dummy^5 title:search^5 title_dotraw:*dummy search*^5 +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +catchall:dummy search* title:'dummy search'^15 title:dummy^5 title:search^5 title_dotraw:*dummy search*^5 title:dummy search* +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true"),
 
                 new TestCase("Published content",
                         "{\n" +

--- a/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "bfc1f961-0779-43f2-9721-9bafe3f8c9a6",
+		"_postman_id": "148b5d29-ef10-41d7-9628-5141da636109",
 		"name": "Content Resource",
 		"description": "Content Resource test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -4114,6 +4114,16 @@
 									"listen": "test",
 									"script": {
 										"exec": [
+											"/*",
+											"    For multiple options, just add comma-separated values. For instance:",
+											"",
+											"    \"searchableFieldsByContentType\": {",
+											"        \"{{testContentTypeVarName}}\": {",
+											"            \"checkbox\": \"1,2\"",
+											"        }",
+											"    },",
+											"*/",
+											"",
 											"pm.test(\"Test First Parent Content matched successfully\", function () {",
 											"    const jsonData = pm.response.json();",
 											"    const entity = jsonData.entity;",
@@ -4134,7 +4144,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"checkbox\": \"1\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"checkbox\": \"1,2... and so on\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"checkbox\": \"1\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4506,6 +4516,16 @@
 									"listen": "test",
 									"script": {
 										"exec": [
+											"/*",
+											"    For multiple options, just add comma-separated values. For instance:",
+											"",
+											"    \"searchableFieldsByContentType\": {",
+											"        \"{{testContentTypeVarName}}\": {",
+											"            \"multiSelect\": \"1,2\"",
+											"        }",
+											"    },",
+											"*/",
+											"",
 											"pm.test(\"Test First Parent Content matched successfully\", function () {",
 											"    const jsonData = pm.response.json();",
 											"    const entity = jsonData.entity;",
@@ -4526,7 +4546,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"multiSelect\": \"1\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"multiSelect\": \"1,2... and so on\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"multiSelect\": \"1\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4702,6 +4722,16 @@
 									"listen": "test",
 									"script": {
 										"exec": [
+											"/*",
+											"    For multiple options, just add comma-separated values. For instance:",
+											"",
+											"    \"searchableFieldsByContentType\": {",
+											"        \"{{testContentTypeVarName}}\": {",
+											"            \"tag\": \"my-test-tag-1,my-test-tag-2\"",
+											"        }",
+											"    },",
+											"*/",
+											"",
 											"pm.test(\"Test First Parent Content matched successfully\", function () {",
 											"    const jsonData = pm.response.json();",
 											"    const entity = jsonData.entity;",
@@ -4722,7 +4752,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"tag\": \"{{testTagOne}}\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"multiSelect\": \"my-test-tag-1,my-test-tag-2... and so on\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"tag\": \"{{testTagOne}}\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"

--- a/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "cc82cd2a-3672-4485-9f9b-a8129c683055",
+		"_postman_id": "bfc1f961-0779-43f2-9721-9bafe3f8c9a6",
 		"name": "Content Resource",
 		"description": "Content Resource test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "30436704"
+		"_exporter_id": "5403727"
 	},
 	"item": [
 		{
@@ -3361,6 +3361,2731 @@
 			]
 		},
 		{
+			"name": "Search Endpoint with ContentSearchForm",
+			"item": [
+				{
+					"name": "Creating Global Test Data",
+					"item": [
+						{
+							"name": "Parent Category",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Information Saved Correctly\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.entity.categoryName).to.eql(\"Test Parent Category\");",
+											"    pm.collectionVariables.set(\"parentCategoryName\", \"Test Parent Category\");",
+											"    pm.collectionVariables.set(\"categoryINodeId\", jsonData.entity.inode);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key\": \"Test parent key\",\n    \"categoryName\": \"Test Parent Category\",\n    \"keywords\": \"This is a test category\",\n    \"categoryVelocityVarName\": \"TestParentKey\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/categories",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"categories"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Child Category One",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Information Saved Correctly\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.entity.categoryName).to.eql(\"Test Child Category One\");",
+											"    pm.collectionVariables.set(\"testCategoryOneInode\", jsonData.entity.inode);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key\": \"Test Child One key\",\n    \"categoryName\": \"Test Child Category One\",\n    \"keywords\": \"This is a child test category\",\n    \"categoryVelocityVarName\": \"TestChildOneKey\",\n    \"parent\": \"{{categoryINodeId}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/categories",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"categories"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Child Category Two",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Information Saved Correctly\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.entity.categoryName).to.eql(\"Test Child Category Two\");",
+											"    pm.collectionVariables.set(\"testCategoryTwoInode\", jsonData.entity.inode);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"key\": \"Test Child Two key\",\n    \"categoryName\": \"Test Child Category Two\",\n    \"keywords\": \"This is a child test category\",\n    \"categoryVelocityVarName\": \"TestChildTwoKey\",\n    \"parent\": \"{{categoryINodeId}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/categories",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"categories"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Tags",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"testTagOne\", \"my-test-tag-1\");",
+											"pm.collectionVariables.set(\"testTagTwo\", \"my-test-tag-2\");"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n   \"ownerId\":\"dotcms.org.1\",\n   \"tags\":{\n      \"{{testTagOne}}\":{\n         \"siteId\":\"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n         \"persona\":false\n      },\n      \"{{testTagTwo}}\":{\n         \"siteId\":\"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n         \"persona\":false\n      }\n   }\n}"
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v2/tags/",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v2",
+										"tags",
+										""
+									]
+								},
+								"description": "This tests the endpoint that brings back one specific App given the App-key."
+							},
+							"response": []
+						},
+						{
+							"name": "Content Type",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Content Type created successfully\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0);",
+											"    pm.collectionVariables.set(\"testContentTypeVarName\", jsonData.entity[0].variable);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"defaultType\": false,\n    \"icon\": null,\n    \"fixed\": false,\n    \"system\": false,\n    \"clazz\": \"com.dotcms.contenttype.model.type.ImmutableSimpleContentType\",\n    \"description\": \"\",\n    \"host\": \"default\",\n    \"name\": \"My Test CT\",\n    \"metadata\": {\n        \"edit_mode\": true\n    },\n    \"systemActionMappings\": {\n        \"NEW\": \"\"\n    },\n    \"workflow\": [\n        \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"\n    ],\n    \"fields\": [\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableHostFolderField\",\n            \"dataType\": \"SYSTEM\",\n            \"fieldType\": \"Host-Folder\",\n            \"fieldTypeLabel\": \"Site or Folder\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736189485000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736189485000,\n            \"name\": \"Site\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": false,\n            \"sortOrder\": 0,\n            \"unique\": false,\n            \"variable\": \"site\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableBinaryField\",\n            \"dataType\": \"SYSTEM\",\n            \"fieldType\": \"Binary\",\n            \"fieldTypeLabel\": \"Binary\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188076000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Binary\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 1,\n            \"unique\": false,\n            \"variable\": \"binary\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableStoryBlockField\",\n            \"dataType\": \"LONG_TEXT\",\n            \"fieldType\": \"Story-Block\",\n            \"fieldTypeLabel\": \"Block Editor\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188086000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Block Editor\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 2,\n            \"unique\": false,\n            \"variable\": \"blockEditor\"\n        },\n        {\n            \"categories\": {\n                \"categoryName\": \"{{testParentCategoryName}}\",\n                \"description\": null,\n                \"inode\": \"{{categoryINodeId}}\",\n                \"key\": \"Test parent key\",\n                \"keywords\": \"\",\n                \"sortOrder\": 0\n            },\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableCategoryField\",\n            \"dataType\": \"SYSTEM\",\n            \"fieldType\": \"Category\",\n            \"fieldTypeLabel\": \"Category\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188106000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Category\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 3,\n            \"unique\": false,\n            \"values\": \"9e882f2a-ada2-47e3-a441-bdf9a7254216\",\n            \"variable\": \"category\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableCheckboxField\",\n            \"dataType\": \"TEXT\",\n            \"fieldType\": \"Checkbox\",\n            \"fieldTypeLabel\": \"Checkbox\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188132000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Checkbox\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 4,\n            \"unique\": false,\n            \"values\": \"check 1|1\\r\\ncheck 2|2\",\n            \"variable\": \"checkbox\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableCustomField\",\n            \"dataType\": \"LONG_TEXT\",\n            \"fieldType\": \"Custom-Field\",\n            \"fieldTypeLabel\": \"Custom Field\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188192000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Custom\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 5,\n            \"unique\": false,\n            \"values\": \"<h1>Custom</h1>\",\n            \"variable\": \"custom\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableDateField\",\n            \"dataType\": \"DATE\",\n            \"fieldType\": \"Date\",\n            \"fieldTypeLabel\": \"Date\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188203000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Date\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 6,\n            \"unique\": false,\n            \"variable\": \"date\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableDateTimeField\",\n            \"dataType\": \"DATE\",\n            \"fieldType\": \"Date-and-Time\",\n            \"fieldTypeLabel\": \"Date and Time\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188223000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Date and Time\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 7,\n            \"unique\": false,\n            \"variable\": \"dateAndTime\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableJSONField\",\n            \"dataType\": \"LONG_TEXT\",\n            \"fieldType\": \"JSON-Field\",\n            \"fieldTypeLabel\": \"JSON Field\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188276000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"JSON\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 8,\n            \"unique\": false,\n            \"variable\": \"json\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableKeyValueField\",\n            \"dataType\": \"LONG_TEXT\",\n            \"fieldType\": \"Key-Value\",\n            \"fieldTypeLabel\": \"Key/Value\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188291000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Key Value\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 9,\n            \"unique\": false,\n            \"variable\": \"keyValue\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableMultiSelectField\",\n            \"dataType\": \"LONG_TEXT\",\n            \"fieldType\": \"Multi-Select\",\n            \"fieldTypeLabel\": \"Multi Select\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188326000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Multi select\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 10,\n            \"unique\": false,\n            \"values\": \"multi 1|1\\r\\nmulti 2|2\",\n            \"variable\": \"multiSelect\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableRadioField\",\n            \"dataType\": \"TEXT\",\n            \"fieldType\": \"Radio\",\n            \"fieldTypeLabel\": \"Radio\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188357000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Radio\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 11,\n            \"unique\": false,\n            \"values\": \"radio 1|1\\r\\nradio 2|2\",\n            \"variable\": \"radio\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableRelationshipField\",\n            \"dataType\": \"SYSTEM\",\n            \"fieldType\": \"Relationship\",\n            \"fieldTypeLabel\": \"Relationships Field\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736189224000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Relationships\",\n            \"readOnly\": false,\n            \"relationships\": {\n                \"cardinality\": 1,\n                \"isParentField\": true,\n                \"velocityVar\": \"webPageContent\"\n            },\n            \"required\": false,\n            \"searchable\": true,\n            \"skipRelationshipCreation\": false,\n            \"sortOrder\": 12,\n            \"unique\": false,\n            \"variable\": \"relationships\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableSelectField\",\n            \"dataType\": \"TEXT\",\n            \"fieldType\": \"Select\",\n            \"fieldTypeLabel\": \"Select\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188384000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Select\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 13,\n            \"unique\": false,\n            \"values\": \"select 1|1\\r\\nselect 2|2\",\n            \"variable\": \"select\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTagField\",\n            \"dataType\": \"SYSTEM\",\n            \"fieldType\": \"Tag\",\n            \"fieldTypeLabel\": \"Tag\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188421000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Tag\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 14,\n            \"unique\": false,\n            \"variable\": \"tag\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextField\",\n            \"dataType\": \"TEXT\",\n            \"fieldType\": \"Text\",\n            \"fieldTypeLabel\": \"Text\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188059000,\n            \"indexed\": true,\n            \"listed\": true,\n            \"modDate\": 1736188060000,\n            \"name\": \"Title\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 15,\n            \"unique\": false,\n            \"variable\": \"title\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTextAreaField\",\n            \"dataType\": \"LONG_TEXT\",\n            \"fieldType\": \"Textarea\",\n            \"fieldTypeLabel\": \"Textarea\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188459000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Text Area\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 16,\n            \"unique\": false,\n            \"variable\": \"textArea\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableTimeField\",\n            \"dataType\": \"DATE\",\n            \"fieldType\": \"Time\",\n            \"fieldTypeLabel\": \"Time\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188473000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Time\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 17,\n            \"unique\": false,\n            \"variable\": \"time\"\n        },\n        {\n            \"clazz\": \"com.dotcms.contenttype.model.field.ImmutableWysiwygField\",\n            \"dataType\": \"LONG_TEXT\",\n            \"fieldType\": \"WYSIWYG\",\n            \"fieldTypeLabel\": \"WYSIWYG\",\n            \"fieldVariables\": [],\n            \"fixed\": false,\n            \"forceIncludeInApi\": false,\n            \"iDate\": 1736188536000,\n            \"indexed\": true,\n            \"listed\": false,\n            \"modDate\": 1736195131000,\n            \"name\": \"Wysiwyg\",\n            \"readOnly\": false,\n            \"required\": false,\n            \"searchable\": true,\n            \"sortOrder\": 18,\n            \"unique\": false,\n            \"variable\": \"wysiwyg\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/contenttype",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"contenttype"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Child Content 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Child Content was created successfully\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the Test First Child Content\");",
+											"    pm.expect(jsonData.entity.summary.failCount).to.eql(0, \"An error occurred when creating the Test First Child Content\");",
+											"    pm.expect(jsonData.entity.summary.successCount).to.eql(1, \"One piece of content should have been created\");",
+											"    const testContentId = Object.keys(jsonData.entity.results[0])[0];",
+											"    pm.collectionVariables.set(\"testFirstChildContentId\", testContentId);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"webPageContent\",\n            \"contentHost\": \"default\",\n            \"title\": \"Test First Child Content\",\n            \"body\": \"Description 1\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									],
+									"query": [
+										{
+											"key": "indexPolicy",
+											"value": "WAIT_FOR"
+										}
+									]
+								},
+								"description": "Creates a test Contentlet of the previously generated Content Type."
+							},
+							"response": []
+						},
+						{
+							"name": "Child Content 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Child Content was created successfully\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the Test Second Child Content\");",
+											"    pm.expect(jsonData.entity.summary.failCount).to.eql(0, \"An error occurred when creating the Test Second Child Content\");",
+											"    pm.expect(jsonData.entity.summary.successCount).to.eql(1, \"One piece of content should have been created\");",
+											"    const testContentId = Object.keys(jsonData.entity.results[0])[0];",
+											"    pm.collectionVariables.set(\"testSecondChildContentId\", testContentId);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"webPageContent\",\n            \"contentHost\": \"default\",\n            \"title\": \"Test Second Child Content\",\n            \"body\": \"Description 2\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									],
+									"query": [
+										{
+											"key": "indexPolicy",
+											"value": "WAIT_FOR"
+										}
+									]
+								},
+								"description": "Creates a test Contentlet of the previously generated Content Type."
+							},
+							"response": []
+						},
+						{
+							"name": "Parent Content 1",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content created successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the Test First Parent Content\");",
+											"    //const testContentId = Object.keys(jsonData.results[0])[0];",
+											"    const testContentId = jsonData.entity.identifier;",
+											"    const firstParentTitleSearch = \"Content\" + pm.collectionVariables.get(\"randomNumber\");",
+											"    pm.collectionVariables.set(\"testFirstParentTitleSearch\", firstParentTitleSearch);",
+											"    pm.collectionVariables.set(\"testFirstParentContentId\", testContentId);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const randomNumber = Math.floor(Math.random() * (999 - 100 + 1) + 100);",
+											"pm.collectionVariables.set(\"randomNumber\", randomNumber);",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "/Users/jcastro-2022/dotCMS/git/dev/core/master/core/dotcms-postman/src/main/resources/postman/resources/testpdf.pdf"
+										},
+										{
+											"key": "json",
+											"value": "{\n    \"contentlet\":\n        {\n            \"contentType\": \"{{testContentTypeVarName}}\",\n            \"site\": \"default\",\n            \"blockEditor\": \"First Block editor\",\n            \"category\": \"{{testCategoryOneInode}}\",\n            \"checkbox\": \"1\",\n            \"custom\": \"first custom\",\n            \"date\": \"02/17/2025\",\n            \"dateAndTime\": \"02/17/2025 13:15:00\",\n            \"json\": \"{ \\\"jsonFirstKey\\\": \\\"First JSON value\\\" }\",\n            \"keyValue\": \"{ \\\"firstKey\\\": \\\"First value\\\" }\",\n            \"multiSelect\": \"1\",\n            \"radio\": \"1\",\n            \"relationships\": \"+identifier:{{testFirstChildContentId}}\",\n            \"select\": \"1\",\n            \"tag\": \"{{testTagOne}}\",\n            \"title\": \"Test First Parent Content{{randomNumber}}\",\n            \"textArea\": \"First text area\",\n            \"time\": \"10:30:00\",\n            \"wysiwyg\": \"First WYSIWYG\"\n        }\n}",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									],
+									"query": [
+										{
+											"key": "indexPolicy",
+											"value": "WAIT_FOR"
+										}
+									]
+								},
+								"description": "Creates a test Contentlet of the previously generated Content Type."
+							},
+							"response": []
+						},
+						{
+							"name": "Parent Content 2",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content created successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the Test Second Parent Content\");",
+											"    const testContentId = jsonData.entity.identifier;",
+											"    const secondParentTitleSearch = \"Content\" + pm.collectionVariables.get(\"randomNumber\");",
+											"    pm.collectionVariables.set(\"testSecondParentTitleSearch\", secondParentTitleSearch);",
+											"    pm.collectionVariables.set(\"testSecondParentContentId\", testContentId);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"const randomNumber = Math.floor(Math.random() * (999 - 100 + 1) + 100);",
+											"pm.collectionVariables.set(\"randomNumber\", randomNumber);",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "formdata",
+									"formdata": [
+										{
+											"key": "file",
+											"type": "file",
+											"src": "dot_velocity_macros.vtl"
+										},
+										{
+											"key": "json",
+											"value": "{\n    \"contentlet\":\n        {\n            \"contentType\": \"{{testContentTypeVarName}}\",\n            \"site\": \"default\",\n            \"blockEditor\": \"Second Block editor\",\n            \"category\": \"{{testCategoryTwoInode}}\",\n            \"checkbox\": \"2\",\n            \"custom\": \"second custom\",\n            \"date\": \"02/19/2025\",\n            \"dateAndTime\": \"02/19/2025 15:30:00\",\n            \"json\": \"{ \\\"jsonSecondKey\\\": \\\"Second JSON value\\\" }\",\n            \"keyValue\": \"{ \\\"secondKey\\\": \\\"Second value\\\" }\",\n            \"multiSelect\": \"2\",\n            \"radio\": \"2\",\n            \"relationships\": \"+identifier:{{testSecondChildContentId}}\",\n            \"select\": \"2\",\n            \"tag\": \"{{testTagTwo}}\",\n            \"title\": \"Test Second Parent Content{{randomNumber}}\",\n            \"textArea\": \"Second text area\",\n            \"time\": \"11:30:00\",\n            \"wysiwyg\": \"Second WYSIWYG\"\n        }\n}",
+											"type": "text"
+										}
+									]
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									],
+									"query": [
+										{
+											"key": "indexPolicy",
+											"value": "WAIT_FOR"
+										}
+									]
+								},
+								"description": "Creates a test Contentlet of the previously generated Content Type."
+							},
+							"response": []
+						}
+					],
+					"description": "Generating test data for these tests. This part of the verification process includes:\n\n- Creating a parent Category and two child Categories for it.\n    \n- Creating two test Tags.\n    \n- Creating a test Content Type with absolutely ALL fields that can be flagged as \"User Searchable\".\n    \n- Creating two test child Contentlets of type \"Rich Text\" that will be used in the \"Relationships\" fields.\n    \n- Creating two test parent Contentlets that will be used to test the new REST Endpoint.",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.test(\"HTTP Status code must be successful\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "By Content Type Fields",
+					"item": [
+						{
+							"name": "By Binary Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"binary\": \"test\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Block Editor Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"blockEditor\": \"First Block editor\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Category Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test both Parent Contents matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(2, \"Two results should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"category\": \"{{testCategoryTwoInode}},{{testCategoryOneInode}}\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Checkbox Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"checkbox\": \"1\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"checkbox\": \"1,2... and so on\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Custom Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test Second Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"custom\": \"second\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Date Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"date\": \"02/17/2025\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Date Field With Range",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"date\": \"02/16/2025 TO 02/18/2025\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Date And Time Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test Second Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"dateAndTime\": \"02/19/2025 15:30:00\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Date And Time Field With Range",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test Second Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"dateAndTime\": \"02/19/2025 15:00:00 TO 02/19/2025 15:40:00\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By JSON Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"json\": \"jsonFirstKey\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Key/Value Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"One result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test Second Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"keyValue\": \"second value\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Multi-Select Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"multiSelect\": \"1\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"multiSelect\": \"1,2... and so on\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Radio Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test Second Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"radio\": \"2\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Relationships Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"relationships\": \"{{testFirstChildContentId}}\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Select Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test Second Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"select\": \"2\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Tag Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"tag\": \"{{testTagOne}}\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"multiSelect\": \"my-test-tag-1,my-test-tag-2... and so on\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Text Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"title\": \"second\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Text Area Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"textArea\": \"first text area\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Time Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"time\": \"11:30 AM\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By Time Field With Range",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Second Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"time\": \"11:20 AM TO 11:40 AM\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "By WYSIWYG Field",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test First Parent Content matched successfully\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+											"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+											"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test First Parent Content ID should've been returned\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"wysiwyg\": \"first\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/search",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"search"
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"description": "Uses the new REST Endpoint to retrieve contents based on the test Content Type's searchable fields.",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.test(\"HTTP Status code must be successful\", function () {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "By System Searchable Fields",
+					"item": [
+						{
+							"name": "Creating Test Data",
+							"item": [
+								{
+									"name": "Parent Content in System Host",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test System Parent Content created successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the Test System Parent Content\");",
+													"    const testContentId = jsonData.entity.identifier;",
+													"    const systemParentTitleSearch = \"Content\" + pm.collectionVariables.get(\"randomNumber\");",
+													"    pm.collectionVariables.set(\"testSystemParentTitleSearch\", systemParentTitleSearch);",
+													"    pm.collectionVariables.set(\"testSystemParentContentId\", testContentId);",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const randomNumber = Math.floor(Math.random() * (999 - 100 + 1) + 100);",
+													"pm.collectionVariables.set(\"randomNumber\", randomNumber);",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "file",
+													"type": "file",
+													"src": "dotcms.png"
+												},
+												{
+													"key": "json",
+													"value": "{\n    \"contentlet\":\n        {\n            \"contentType\": \"{{testContentTypeVarName}}\",\n            \"site\": \"SYSTEM_HOST\",\n            \"blockEditor\": \"System Block editor\",\n            \"category\": \"{{testCategoryOneInode}}\",\n            \"checkbox\": \"1\",\n            \"custom\": \"System custom\",\n            \"date\": \"02/20/2025\",\n            \"dateAndTime\": \"02/20/2025 14:20:00\",\n            \"json\": \"{ \\\"jsonSystemKey\\\": \\\"System JSON value\\\" }\",\n            \"keyValue\": \"{ \\\"systemKey\\\": \\\"System value\\\" }\",\n            \"multiSelect\": \"1\",\n            \"radio\": \"1\",\n            \"relationships\": \"+identifier:{{testFirstChildContentId}}\",\n            \"select\": \"1\",\n            \"tag\": \"{{testTagOne}}\",\n            \"title\": \"Test System Parent Content{{randomNumber}}\",\n            \"textArea\": \"System text area\",\n            \"time\": \"09:30:00\",\n            \"wysiwyg\": \"System WYSIWYG\"\n        }\n}\n",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"workflow",
+												"actions",
+												"default",
+												"fire",
+												"PUBLISH"
+											],
+											"query": [
+												{
+													"key": "indexPolicy",
+													"value": "WAIT_FOR"
+												}
+											]
+										},
+										"description": "Creates a test Contentlet of the previously generated Content Type."
+									},
+									"response": []
+								}
+							],
+							"description": "Generating test data for these tests. This part of the verification process includes:\n\n- Creating a test Contentlet that lives under System Host.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "All Content Types",
+							"item": [
+								{
+									"name": "By Site ID",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Returning ALL Contentlets under the 'default' Site successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving all Contentlets under 'default'\");",
+													"    pm.expect(entity.resultsSize).to.be.greaterThan(1, \"At least one result should've been returned\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"description": "Retrieving Contentlets **of ALL types** under a given Site.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "Test Content Type",
+							"item": [
+								{
+									"name": "By System Host - Default",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Sytem Content matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    const testSystemContentId = pm.collectionVariables.get(\"testSystemParentContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Sytem Content\");",
+													"    pm.expect(entity.resultsSize).to.eql(1, \"One Contentlet should've been returned\");",
+													"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testSystemContentId, \"Test System Content ID should've been returned\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {},\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										},
+										"description": "When no `siteId` is specified, Contentlets living under System Host are returned by default **UNLESS** the `systemHostContent` attribute is set to `false`."
+									},
+									"response": []
+								},
+								{
+									"name": "By Site ID - with System Host content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Parent Contents -- including System Host content -- matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    const testFirstParentContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+													"    const testSecondParentContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+													"    const testSystemParentContentId = pm.collectionVariables.get(\"testSystemParentContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Parent Contents\");",
+													"    pm.expect(entity.resultsSize).to.eql(3, \"Three results should've been returned\");",
+													"    var count = 0;",
+													"    entity.jsonObjectView.contentlets.forEach(function(item) {",
+													"        if (item.identifier == testFirstParentContentId || item.identifier == testSecondParentContentId || item.identifier == testSystemParentContentId) {",
+													"            count += 1;",
+													"        }",
+													"    });",
+													"    pm.expect(count).to.equal(3, \"The returned Contents are missing an expected Contentlet ID\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "By Language ID",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Parent Contents matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    const testFirstParentContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+													"    const testSecondParentContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+													"    const testSystemParentContentId = pm.collectionVariables.get(\"testSystemParentContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Parent Contents\");",
+													"    pm.expect(entity.resultsSize).to.eql(3, \"Three results should've been returned\");",
+													"    var count = 0;",
+													"    entity.jsonObjectView.contentlets.forEach(function(item) {",
+													"        if (item.identifier == testFirstParentContentId || item.identifier == testSecondParentContentId || item.identifier == testSystemParentContentId) {",
+													"            count += 1;",
+													"        }",
+													"    });",
+													"    pm.expect(count).to.equal(3, \"The returned Contents are missing an expected Contentlet ID\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "By Workflow Scheme ID",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Parent Contents matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    const testFirstParentContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+													"    const testSecondParentContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+													"    const testSystemParentContentId = pm.collectionVariables.get(\"testSystemParentContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Parent Contents\");",
+													"    pm.expect(entity.resultsSize).to.eql(3, \"Three results should've been returned\");",
+													"    var count = 0;",
+													"    entity.jsonObjectView.contentlets.forEach(function(item) {",
+													"        if (item.identifier == testFirstParentContentId || item.identifier == testSecondParentContentId || item.identifier == testSystemParentContentId) {",
+													"            count += 1;",
+													"        }",
+													"    });",
+													"    pm.expect(count).to.equal(3, \"The returned Contents are missing an expected Contentlet ID\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1,\n        \"workflowSchemeId\": \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "By Workflow Step ID",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Parent Contents matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    const testFirstParentContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+													"    const testSecondParentContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+													"    const testSystemParentContentId = pm.collectionVariables.get(\"testSystemParentContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Parent Contents\");",
+													"    pm.expect(entity.resultsSize).to.eql(3, \"Three results should've been returned\");",
+													"    var count = 0;",
+													"    entity.jsonObjectView.contentlets.forEach(function(item) {",
+													"        if (item.identifier == testFirstParentContentId || item.identifier == testSecondParentContentId || item.identifier == testSystemParentContentId) {",
+													"            count += 1;",
+													"        }",
+													"    });",
+													"    pm.expect(count).to.equal(3, \"The returned Contents are missing an expected Contentlet ID\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1,\n        \"workflowSchemeId\": \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\",\n        \"workflowStepId\": \"dc3c9cd0-8467-404b-bf95-cb7df3fbc293\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "By Variant Name",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Parent Contents matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    const testFirstParentContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+													"    const testSecondParentContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+													"    const testSystemParentContentId = pm.collectionVariables.get(\"testSystemParentContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Parent Contents\");",
+													"    pm.expect(entity.resultsSize).to.eql(3, \"Three results should've been returned\");",
+													"    var count = 0;",
+													"    entity.jsonObjectView.contentlets.forEach(function(item) {",
+													"        if (item.identifier == testFirstParentContentId || item.identifier == testSecondParentContentId || item.identifier == testSystemParentContentId) {",
+													"            count += 1;",
+													"        }",
+													"    });",
+													"    pm.expect(count).to.equal(3, \"The returned Contents are missing an expected Contentlet ID\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1,\n        \"variantName\": \"non-existing variant name\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										},
+										"description": "The siteId attribute is included as the test Contentlets were created under the default Site. When such an attribute is NOT included, the Lucene query must include all Contentlets from System Host by default."
+									},
+									"response": []
+								},
+								{
+									"name": "By Excluding System Host Contents",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Parent Contents matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    const testFirstParentContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+													"    const testSecondParentContentId = pm.collectionVariables.get(\"testSecondParentContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Parent Contents\");",
+													"    pm.expect(entity.resultsSize).to.eql(2, \"Two results should've been returned\");",
+													"    var count = 0;",
+													"    entity.jsonObjectView.contentlets.forEach(function(item) {",
+													"        if (item.identifier == testFirstParentContentId || item.identifier == testSecondParentContentId) {",
+													"            count += 1;",
+													"        }",
+													"    });",
+													"    pm.expect(count).to.equal(2, \"The returned Contents are missing an expected Contentlet ID\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"systemHostContent\": false\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										},
+										"description": "The siteId attribute is included as the test Contentlets were created under the default Site. When such an attribute is NOT included, the Lucene query must include all Contentlets from System Host by default."
+									},
+									"response": []
+								}
+							],
+							"description": "Retrieving Contentlets **of the specified Test Content Type** under a given Site.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										]
+									}
+								}
+							]
+						}
+					],
+					"description": "Uses the new REST Endpoint to retrieve contents based on the System Searchable fields. That is, fields or attributes that are **NOT** Content Type fields per se, but are used by Lucene queries to filter contents. For instance:\n\n- +conhost\n    \n- +languageId\n    \n- +wfscheme\n    \n- +wfstep\n    \n- +variant"
+				},
+				{
+					"name": "By Content Status Fields",
+					"item": [
+						{
+							"name": "Creating Test Data",
+							"item": [
+								{
+									"name": "Unpublished Content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Unpublished Content created successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the Test Unpublished Content\");",
+													"    const testContentId = jsonData.entity.identifier;",
+													"    const unpublishedTitleSearch = \"Content\" + pm.collectionVariables.get(\"randomNumber\");",
+													"    pm.collectionVariables.set(\"testUnpublishedTitleSearch\", unpublishedTitleSearch);",
+													"    pm.collectionVariables.set(\"testUnpublishedContentId\", testContentId);",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const randomNumber = Math.floor(Math.random() * (999 - 100 + 1) + 100);",
+													"pm.collectionVariables.set(\"randomNumber\", randomNumber);",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "file",
+													"type": "file",
+													"src": "dotcms.png"
+												},
+												{
+													"key": "json",
+													"value": "{\n    \"contentlet\":\n        {\n            \"contentType\": \"{{testContentTypeVarName}}\",\n            \"site\": \"default\",\n            \"blockEditor\": \"Unpublished Block editor\",\n            \"category\": \"{{testCategoryTwoInode}}\",\n            \"checkbox\": \"2\",\n            \"custom\": \"Unpublished custom\",\n            \"date\": \"02/22/2025\",\n            \"dateAndTime\": \"02/22/2025 19:45:00\",\n            \"json\": \"{ \\\"jsonUnpublishedKey\\\": \\\"Unpublished JSON value\\\" }\",\n            \"keyValue\": \"{ \\\"unpublishedKey\\\": \\\"Unpublished value\\\" }\",\n            \"multiSelect\": \"2\",\n            \"radio\": \"2\",\n            \"relationships\": \"+identifier:{{testSecondChildContentId}}\",\n            \"select\": \"2\",\n            \"tag\": \"{{testTagTwo}}\",\n            \"title\": \"Test Unpublished Content{{randomNumber}}\",\n            \"textArea\": \"Unpublished text area\",\n            \"time\": \"05:15:00\",\n            \"wysiwyg\": \"Unpublished WYSIWYG\"\n        }\n}\n",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/NEW?indexPolicy=WAIT_FOR",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"workflow",
+												"actions",
+												"default",
+												"fire",
+												"NEW"
+											],
+											"query": [
+												{
+													"key": "indexPolicy",
+													"value": "WAIT_FOR"
+												}
+											]
+										},
+										"description": "Creates a test Contentlet of the previously generated Content Type."
+									},
+									"response": []
+								},
+								{
+									"name": "Locked Content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Locking the Unpublished Content successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the Test Unpublished Content\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const randomNumber = Math.floor(Math.random() * (999 - 100 + 1) + 100);",
+													"pm.collectionVariables.set(\"randomNumber\", randomNumber);",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/_lock/{{testUnpublishedContentId}}?language=1",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"_lock",
+												"{{testUnpublishedContentId}}"
+											],
+											"query": [
+												{
+													"key": "language",
+													"value": "1"
+												}
+											]
+										},
+										"description": "Creates a test Contentlet of the previously generated Content Type."
+									},
+									"response": []
+								},
+								{
+									"name": "Archived Content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Archived Content created successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the Test Archived Content\");",
+													"    const testContentId = jsonData.entity.identifier;",
+													"    const archivedTitleSearch = \"Content\" + pm.collectionVariables.get(\"randomNumber\");",
+													"    pm.collectionVariables.set(\"testArchivedTitleSearch\", archivedTitleSearch);",
+													"    pm.collectionVariables.set(\"testArchivedContentId\", testContentId);",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										},
+										{
+											"listen": "prerequest",
+											"script": {
+												"exec": [
+													"const randomNumber = Math.floor(Math.random() * (999 - 100 + 1) + 100);",
+													"pm.collectionVariables.set(\"randomNumber\", randomNumber);",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "formdata",
+											"formdata": [
+												{
+													"key": "file",
+													"type": "file",
+													"src": "/Users/jcastro-2022/dotCMS/git/dev/core/master/core/dotcms-postman/src/main/resources/postman/resources/testpdf.pdf"
+												},
+												{
+													"key": "json",
+													"value": "{\n    \"contentlet\":\n        {\n            \"contentType\": \"{{testContentTypeVarName}}\",\n            \"site\": \"default\",\n            \"blockEditor\": \"Archived Block editor\",\n            \"category\": \"{{testCategoryOneInode}}\",\n            \"checkbox\": \"1\",\n            \"custom\": \"Archived custom\",\n            \"date\": \"02/25/2025\",\n            \"dateAndTime\": \"02/25/2025 16:35:00\",\n            \"json\": \"{ \\\"jsonFirstKey\\\": \\\"Archived JSON value\\\" }\",\n            \"keyValue\": \"{ \\\"firstKey\\\": \\\"Archived value\\\" }\",\n            \"multiSelect\": \"1\",\n            \"radio\": \"1\",\n            \"relationships\": \"+identifier:{{testFirstChildContentId}}\",\n            \"select\": \"1\",\n            \"tag\": \"{{testTagOne}}\",\n            \"title\": \"Test Archived Content{{randomNumber}}\",\n            \"textArea\": \"Archived text area\",\n            \"time\": \"17:50:00\",\n            \"wysiwyg\": \"Archived WYSIWYG\"\n        }\n}",
+													"type": "text"
+												}
+											]
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/ARCHIVE?indexPolicy=WAIT_FOR",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"workflow",
+												"actions",
+												"default",
+												"fire",
+												"ARCHIVE"
+											],
+											"query": [
+												{
+													"key": "indexPolicy",
+													"value": "WAIT_FOR"
+												}
+											]
+										},
+										"description": "Creates a test Contentlet of the previously generated Content Type."
+									},
+									"response": []
+								}
+							],
+							"description": "Generating test data for these tests. This part of the verification process includes:\n\n- Creating a test Contentlet that is **Unpublished** and **Locked**.\n    \n- Creating a test Contentlet that is **Archived**.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										]
+									}
+								}
+							]
+						},
+						{
+							"name": "Content Statuses",
+							"item": [
+								{
+									"name": "By Archived Content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Archived Content matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    const testContentId = pm.collectionVariables.get(\"testArchivedContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Archived Content\");",
+													"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+													"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test Archived Content ID should've been returned\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"archivedContent\": true,\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "By Unpublished Content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Unpublished Content matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    const testContentId = pm.collectionVariables.get(\"testUnpublishedContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Unpublished Content\");",
+													"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+													"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test Unpublished Content ID should've been returned\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"unpublishedContent\": true,\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "By Locked Content",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Test Locked Content matched successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    // Using the same unpublished content for the locked check",
+													"    const testContentId = pm.collectionVariables.get(\"testUnpublishedContentId\");",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Locked Content\");",
+													"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+													"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Test Locked Content ID should've been returned\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
+										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"lockedContent\": true,\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"description": "Retrieving the Contentlets based on its status:\n\n- Archived.\n    \n- Unpulbished.\n    \n- Locked.",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"packages": {},
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											""
+										]
+									}
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "By Global Search",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Test First Parent Content matched successfully\", function () {",
+									"    const jsonData = pm.response.json();",
+									"    const entity = jsonData.entity;",
+									"    const testContentId = pm.collectionVariables.get(\"testFirstParentContentId\");",
+									"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test First Parent Content\");",
+									"    pm.expect(entity.resultsSize).to.eql(1, \"Only one result should've been returned\");",
+									"    pm.expect(entity.jsonObjectView.contentlets[0].identifier).to.eql(testContentId, \"Only one result should've been returned\");",
+									"});",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"globalSearch\": \"{{testFirstParentTitleSearch}}\",\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{serverURL}}/api/v1/content/search",
+							"host": [
+								"{{serverURL}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"content",
+								"search"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "This new REST Endpoint uses the `ContentSearchForm` class to allow users to retrieve content by abstracting the complexity o creting their own Lucene queries for it. It's based on the same business rules as the `Search` portlet in the back-end.\n\nBy default, the Lucene query will include all Contentlets:\n\n- Living under system Host.\n    \n- Live and Working.\n    \n- Unarchived.\n    \n\nIn case other business rules were missed or new ones must be included, it's very important to keep these test suite up to date with them.",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"packages": {},
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
 			"name": "invalidateSession",
 			"event": [
 				{
@@ -3902,116 +6627,6 @@
 					""
 				]
 			}
-		}
-	],
-	"variable": [
-		{
-			"key": "contentTypeID",
-			"value": ""
-		},
-		{
-			"key": "contentTypeVAR",
-			"value": ""
-		},
-		{
-			"key": "contentTypeFieldID",
-			"value": ""
-		},
-		{
-			"key": "page_id",
-			"value": ""
-		},
-		{
-			"key": "contentTypeId",
-			"value": ""
-		},
-		{
-			"key": "contentTypeName",
-			"value": ""
-		},
-		{
-			"key": "fieldId",
-			"value": ""
-		},
-		{
-			"key": "testContentOneId",
-			"value": ""
-		},
-		{
-			"key": "testContentOneInode",
-			"value": ""
-		},
-		{
-			"key": "testContentTwoId",
-			"value": ""
-		},
-		{
-			"key": "testContentTwoInode",
-			"value": ""
-		},
-		{
-			"key": "testContentThreeId",
-			"value": ""
-		},
-		{
-			"key": "testContentThreeInode",
-			"value": ""
-		},
-		{
-			"key": "relatedContentTypeId",
-			"value": ""
-		},
-		{
-			"key": "relatedContentTypeName",
-			"value": ""
-		},
-		{
-			"key": "relatedContentTypeVarName",
-			"value": ""
-		},
-		{
-			"key": "innerContentTypeId",
-			"value": ""
-		},
-		{
-			"key": "innerContentTypeName",
-			"value": ""
-		},
-		{
-			"key": "innerContentTypeVarName",
-			"value": ""
-		},
-		{
-			"key": "parentContentTypeId",
-			"value": ""
-		},
-		{
-			"key": "parentContentTypeVarName",
-			"value": ""
-		},
-		{
-			"key": "relatedTestContentId",
-			"value": ""
-		},
-		{
-			"key": "relatedTestContentInode",
-			"value": ""
-		},
-		{
-			"key": "innerTestContentId",
-			"value": ""
-		},
-		{
-			"key": "innerTestContentInode",
-			"value": ""
-		},
-		{
-			"key": "parentContentId",
-			"value": ""
-		},
-		{
-			"key": "parentContentInode",
-			"value": ""
 		}
 	]
 }

--- a/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
@@ -3361,11 +3361,58 @@
 			]
 		},
 		{
-			"name": "Search Endpoint with ContentSearchForm",
+			"name": "Search endpoint with ContentSearchForm",
 			"item": [
 				{
 					"name": "Creating Global Test Data",
 					"item": [
+						{
+							"name": "Get default Site ID",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Getting 'default' Site ID\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity;",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.collectionVariables.set(\"defaultSiteId\", entity.identifier);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"siteName\": \"default\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/site/_byname",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"site",
+										"_byname"
+									]
+								}
+							},
+							"response": []
+						},
 						{
 							"name": "Parent Category",
 							"event": [
@@ -3373,7 +3420,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Information Saved Correctly\", function () {",
+											"pm.test(\"Saving parent Category\", function () {",
 											"    var jsonData = pm.response.json();",
 											"    pm.expect(jsonData.entity.categoryName).to.eql(\"Test Parent Category\");",
 											"    pm.collectionVariables.set(\"parentCategoryName\", \"Test Parent Category\");",
@@ -3419,7 +3466,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Information Saved Correctly\", function () {",
+											"pm.test(\"Saving child Category One\", function () {",
 											"    var jsonData = pm.response.json();",
 											"    pm.expect(jsonData.entity.categoryName).to.eql(\"Test Child Category One\");",
 											"    pm.collectionVariables.set(\"testCategoryOneInode\", jsonData.entity.inode);",
@@ -3464,7 +3511,7 @@
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Information Saved Correctly\", function () {",
+											"pm.test(\"Saving child Category One\", function () {",
 											"    var jsonData = pm.response.json();",
 											"    pm.expect(jsonData.entity.categoryName).to.eql(\"Test Child Category Two\");",
 											"    pm.collectionVariables.set(\"testCategoryTwoInode\", jsonData.entity.inode);",
@@ -3538,7 +3585,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n   \"ownerId\":\"dotcms.org.1\",\n   \"tags\":{\n      \"{{testTagOne}}\":{\n         \"siteId\":\"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n         \"persona\":false\n      },\n      \"{{testTagTwo}}\":{\n         \"siteId\":\"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n         \"persona\":false\n      }\n   }\n}"
+									"raw": "{\n   \"ownerId\":\"dotcms.org.1\",\n   \"tags\":{\n      \"{{testTagOne}}\":{\n         \"siteId\":\"{{defaultSiteId}}\",\n         \"persona\":false\n      },\n      \"{{testTagTwo}}\":{\n         \"siteId\":\"{{defaultSiteId}}\",\n         \"persona\":false\n      }\n   }\n}"
 								},
 								"url": {
 									"raw": "{{serverURL}}/api/v2/tags/",
@@ -3942,7 +3989,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"binary\": \"test\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"binary\": \"test\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -3991,7 +4038,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"blockEditor\": \"First Block editor\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"blockEditor\": \"First Block editor\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4038,7 +4085,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"category\": \"{{testCategoryTwoInode}},{{testCategoryOneInode}}\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"category\": \"{{testCategoryTwoInode}},{{testCategoryOneInode}}\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4087,7 +4134,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"checkbox\": \"1\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"checkbox\": \"1,2... and so on\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"checkbox\": \"1\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"checkbox\": \"1,2... and so on\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4136,7 +4183,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"custom\": \"second\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"custom\": \"second\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4185,7 +4232,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"date\": \"02/17/2025\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"date\": \"02/17/2025\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4234,7 +4281,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"date\": \"02/16/2025 TO 02/18/2025\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"date\": \"02/16/2025 TO 02/18/2025\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4283,7 +4330,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"dateAndTime\": \"02/19/2025 15:30:00\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"dateAndTime\": \"02/19/2025 15:30:00\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4332,7 +4379,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"dateAndTime\": \"02/19/2025 15:00:00 TO 02/19/2025 15:40:00\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"dateAndTime\": \"02/19/2025 15:00:00 TO 02/19/2025 15:40:00\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4381,7 +4428,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"json\": \"jsonFirstKey\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"json\": \"jsonFirstKey\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4430,7 +4477,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"keyValue\": \"second value\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"keyValue\": \"second value\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4479,7 +4526,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"multiSelect\": \"1\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"multiSelect\": \"1,2... and so on\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"multiSelect\": \"1\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"multiSelect\": \"1,2... and so on\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4528,7 +4575,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"radio\": \"2\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"radio\": \"2\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4577,7 +4624,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"relationships\": \"{{testFirstChildContentId}}\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"relationships\": \"{{testFirstChildContentId}}\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4626,7 +4673,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"select\": \"2\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"select\": \"2\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4675,7 +4722,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"tag\": \"{{testTagOne}}\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"multiSelect\": \"my-test-tag-1,my-test-tag-2... and so on\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"tag\": \"{{testTagOne}}\"\n            // For multiple options, just add comma-separated values. For instance:\n            //\"multiSelect\": \"my-test-tag-1,my-test-tag-2... and so on\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4724,7 +4771,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"title\": \"second\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"title\": \"second\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4773,7 +4820,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"textArea\": \"first text area\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"textArea\": \"first text area\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4822,7 +4869,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"time\": \"11:30 AM\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"time\": \"11:30 AM\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4871,7 +4918,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"time\": \"11:20 AM TO 11:40 AM\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"time\": \"11:20 AM TO 11:40 AM\"\n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4920,7 +4967,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"wysiwyg\": \"first\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+									"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {\n            \"wysiwyg\": \"first\"\n            \n        }\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -5109,7 +5156,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5247,7 +5294,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5304,7 +5351,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5361,7 +5408,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1,\n        \"workflowSchemeId\": \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1,\n        \"workflowSchemeId\": \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5418,7 +5465,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1,\n        \"workflowSchemeId\": \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\",\n        \"workflowStepId\": \"dc3c9cd0-8467-404b-bf95-cb7df3fbc293\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1,\n        \"workflowSchemeId\": \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\",\n        \"workflowStepId\": \"dc3c9cd0-8467-404b-bf95-cb7df3fbc293\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5475,7 +5522,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1,\n        \"variantName\": \"non-existing variant name\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1,\n        \"variantName\": \"non-existing variant name\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5532,7 +5579,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"systemHostContent\": false\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"systemHostContent\": false\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5860,7 +5907,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"archivedContent\": true,\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\"\n    },\n    \"archivedContent\": true,\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5909,7 +5956,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"unpublishedContent\": true,\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\"\n    },\n    \"unpublishedContent\": true,\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -5959,7 +6006,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\"\n    },\n    \"lockedContent\": true,\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"raw": "{\n    \"searchableFieldsByContentType\": {\n        \"{{testContentTypeVarName}}\": {}\n    },\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\"\n    },\n    \"lockedContent\": true,\n    \"page\": 0,\n    \"perPage\": 40\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -6038,7 +6085,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"globalSearch\": \"{{testFirstParentTitleSearch}}\",\n    \"systemSearchableFields\": {\n        \"siteId\": \"9b2a2ff9f2e4d47be477ee682f1a9dec\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+							"raw": "{\n    \"globalSearch\": \"{{testFirstParentTitleSearch}}\",\n    \"systemSearchableFields\": {\n        \"siteId\": \"{{defaultSiteId}}\",\n        \"languageId\": 1\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
@@ -3820,7 +3820,7 @@
 										{
 											"key": "file",
 											"type": "file",
-											"src": "/Users/jcastro-2022/dotCMS/git/dev/core/master/core/dotcms-postman/src/main/resources/postman/resources/testpdf.pdf"
+											"src": "resources/testpdf.pdf"
 										},
 										{
 											"key": "json",
@@ -3897,7 +3897,7 @@
 										{
 											"key": "file",
 											"type": "file",
-											"src": "dot_velocity_macros.vtl"
+											"src": "resources/dot_velocity_macros.vtl"
 										},
 										{
 											"key": "json",
@@ -5066,7 +5066,7 @@
 												{
 													"key": "file",
 													"type": "file",
-													"src": "dotcms.png"
+													"src": "resources/dotcms.png"
 												},
 												{
 													"key": "json",
@@ -5682,7 +5682,7 @@
 												{
 													"key": "file",
 													"type": "file",
-													"src": "dotcms.png"
+													"src": "resources/dotcms.png"
 												},
 												{
 													"key": "json",
@@ -5815,7 +5815,7 @@
 												{
 													"key": "file",
 													"type": "file",
-													"src": "/Users/jcastro-2022/dotCMS/git/dev/core/master/core/dotcms-postman/src/main/resources/postman/resources/testpdf.pdf"
+													"src": "resources/testpdf.pdf"
 												},
 												{
 													"key": "json",


### PR DESCRIPTION
### Proposed Changes
* Provides a new REST Endpoint that allow users/developers to retrieve content via Lucene from Elasticsearch.
* Uses the recently created `LuceneQueryBuilder` service to generate the appropriate query, and passes it down to the API to retrieve contents.
* The new Endpoint re-uses the part of the code used by the old `/api/content/_search` that:
  * Retrieves the results from Elasticsearch.
  * Generates the View object with such results and additional search metadata.
* The re-usable code was moved to the `ContentHelper` class. All classes in the core project that used such methods were updated, but are NOT part of the goal of this PR.
* Some code issues were found during the creation of the Postman tests. The respective code fixes are included as well. 

This PR fixes: #30799