### PR TITLE
#31452: removing fallback restore keys for release process

### DIFF
--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -200,8 +200,6 @@ jobs:
         with:
           path: ${{ env.DOCKER_BUILD_CONTEXT }}/context
           key: docker-context-${{ steps.set-common-vars.outputs.date }}-${{ github.run_id }}
-          restore-keys: |
-            docker-context-${{ steps.set-common-vars.outputs.date }}
         if: success()
 
       - name: Create Release


### PR DESCRIPTION
Removing unnecessary restore keys property from cache action call.

This PR fixes: #31452