### PR TITLE
fix ( Edit Content): #31083 Actions Button Disappears When Creating Language Copy with Multiple Workflows 

### DIFF
--- a/core-web/libs/edit-content/src/lib/store/features/locales.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales.feature.spec.ts
@@ -13,9 +13,11 @@ import {
     DotContentletService,
     DotHttpErrorManagerService,
     DotLanguagesService,
-    DotMessageService
+    DotMessageService,
+    DotWorkflowsActionsService
 } from '@dotcms/data-access';
 import { ComponentStatus, DotLanguage } from '@dotcms/dotcms-models';
+import { MOCK_SINGLE_WORKFLOW_ACTIONS } from '@dotcms/utils-testing';
 
 import { contentInitialState } from './content.feature';
 import { withLocales } from './locales.feature';
@@ -44,6 +46,7 @@ describe('LocalesFeature', () => {
     let dotEditContentService: SpyObject<DotEditContentService>;
     let dialogService: SpyObject<DialogService>;
     let router: SpyObject<Router>;
+    let workflowActionService: SpyObject<DotWorkflowsActionsService>;
 
     const withTest = () =>
         signalStoreFeature(
@@ -71,7 +74,8 @@ describe('LocalesFeature', () => {
             DialogService,
             DynamicDialogConfig,
             DynamicDialogRef,
-            Router
+            Router,
+            DotWorkflowsActionsService
         ]
     });
 
@@ -83,6 +87,9 @@ describe('LocalesFeature', () => {
         dotEditContentService = spectator.inject(DotEditContentService);
         dialogService = spectator.inject(DialogService);
         router = spectator.inject(Router);
+        workflowActionService = spectator.inject(DotWorkflowsActionsService);
+
+        workflowActionService.getDefaultActions.mockReturnValue(of(MOCK_SINGLE_WORKFLOW_ACTIONS));
     });
 
     it('should load locales when a new contentlet is loaded', fakeAsync(() => {

--- a/core-web/libs/edit-content/src/lib/store/features/locales.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales.feature.ts
@@ -17,13 +17,14 @@ import { Router } from '@angular/router';
 
 import { DialogService } from 'primeng/dynamicdialog';
 
-import { filter, switchMap, take } from 'rxjs/operators';
+import { filter, switchMap, take, map } from 'rxjs/operators';
 
 import {
     DotContentletService,
     DotHttpErrorManagerService,
     DotLanguagesService,
-    DotMessageService
+    DotMessageService,
+    DotWorkflowsActionsService
 } from '@dotcms/data-access';
 import { ComponentStatus, DotCMSContentlet, DotLanguage } from '@dotcms/dotcms-models';
 import { DotEditContentSidebarUntranslatedLocaleComponent } from '@dotcms/edit-content/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-untranslated-locale/dot-edit-content-sidebar-untranslated-locale.component';
@@ -35,7 +36,7 @@ import { WorkflowState } from './workflow.feature';
 
 import { DotEditContentService } from '../../services/dot-edit-content.service';
 import { EditContentRootState } from '../../store/edit-content.store';
-import { parseCurrentActions } from '../../utils/workflows.utils';
+import { parseCurrentActions, parseWorkflows } from '../../utils/workflows.utils';
 
 export interface LocalesState {
     locales: DotLanguage[] | null;
@@ -85,7 +86,8 @@ export function withLocales() {
                 dotHttpErrorManagerService = inject(DotHttpErrorManagerService),
                 dotMessageService = inject(DotMessageService),
                 dialogService = inject(DialogService),
-                router = inject(Router)
+                router = inject(Router),
+                workflowActionService = inject(DotWorkflowsActionsService)
             ) => ({
                 /**
                  * Loads the locales based on a content identifier and updates the state accordingly.
@@ -234,21 +236,28 @@ export function withLocales() {
                                 ref.onClose
                                     .pipe(
                                         take(1),
-                                        filter((value) => value)
+                                        filter((value) => value),
+                                        switchMap((copyType) => {
+                                            return workflowActionService
+                                                .getDefaultActions(store.contentType()?.variable)
+                                                .pipe(map((schemes) => ({ copyType, schemes })));
+                                        })
                                     )
-                                    .subscribe((copyType) => {
-                                        const schemes = store.schemes();
-                                        const schemeIds = Object.keys(schemes);
+                                    .subscribe(({ copyType, schemes }) => {
+                                        // Convert the schemes to an object with the schemeId as the key
+                                        const parsedSchemes = parseWorkflows(schemes);
+                                        const schemeIds = Object.keys(parsedSchemes);
                                         // If we have only one scheme, we set it as the default one
                                         const defaultSchemeId =
                                             schemeIds.length === 1 ? schemeIds[0] : null;
                                         // Parse the actions as an object with the schemeId as the key
                                         const parsedCurrentActions = parseCurrentActions(
-                                            schemes[defaultSchemeId]?.actions || []
+                                            parsedSchemes[defaultSchemeId]?.actions || []
                                         );
 
                                         patchState(store, {
                                             currentLocale: locale,
+                                            schemes: parsedSchemes,
                                             currentSchemeId: defaultSchemeId,
                                             currentContentActions: parsedCurrentActions,
                                             state: ComponentStatus.LOADED,


### PR DESCRIPTION
Show the correct workflows when creating a new language version of specific content. 

### Screenshots


Before: 

https://github.com/user-attachments/assets/8e89067e-569a-4720-9447-c9bcc7930279


After: 

https://github.com/user-attachments/assets/268c706b-ca0a-47b3-a171-041e876969de

This PR fixes: #31083