### PR TITLE
fix(core): Respect anonymous permissions in BinaryExporterServlet

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/servlets/BinaryExporterServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/BinaryExporterServlet.java
@@ -116,8 +116,12 @@ public class BinaryExporterServlet extends HttpServlet {
 
 	
 	private final boolean ASSETS_USE_WEAK_ETAGS = Config.getBooleanProperty("ASSETS_USE_WEAK_ETAGS", true);
-	
-	
+
+	/**
+	 * A boolean constant indicating whether anonymous user permissions should always be respected.
+	 * Set to true because the binary servlet is for delivery and should respect front-end roles.
+	 */
+	private static final boolean ALWAYS_RESPECT_ANONYMOUS_PERMISSIONS = true;
 	
 	@SuppressWarnings("unchecked")
 	@Override
@@ -262,7 +266,9 @@ public class BinaryExporterServlet extends HttpServlet {
 						content = contentAPI.find(assetInode, APILocator.getUserAPI().getSystemUser(), mode.respectAnonPerms);
 					else {
 						try {
-							content = contentAPI.find(assetInode, user, mode.respectAnonPerms);
+							content = contentAPI.find(
+									assetInode, user, ALWAYS_RESPECT_ANONYMOUS_PERMISSIONS
+							);
 						} catch(DotSecurityException e) {
 							if (!mode.respectAnonPerms) {
 								content = getContentletLiveVersion(assetInode, user, lang);
@@ -302,7 +308,10 @@ public class BinaryExporterServlet extends HttpServlet {
 							query.append("+working:true ");
 						}
 
-						List<Contentlet> foundContentlets = contentletAPI.search(query.toString(), 2, -1, null, user, mode.respectAnonPerms);
+						List<Contentlet> foundContentlets = contentletAPI.search(
+								query.toString(), 2, -1, null, user,
+								ALWAYS_RESPECT_ANONYMOUS_PERMISSIONS
+						);
 						if ( foundContentlets != null && !foundContentlets.isEmpty() ) {
 							//Prefer the contentlet with the session language
 							content = foundContentlets.get(0);
@@ -691,14 +700,19 @@ public class BinaryExporterServlet extends HttpServlet {
 
 		final String currentVariantId = WebAPILocator.getVariantWebAPI().currentVariantId();
 
-		final Contentlet contentletByIdentifier = contentAPI.findContentletByIdentifier(identifier,
-				pageMode.showLive, languageId, currentVariantId, user, pageMode.respectAnonPerms);
+		final Contentlet contentletByIdentifier = contentAPI.findContentletByIdentifier(
+				identifier, pageMode.showLive, languageId, currentVariantId, user,
+				ALWAYS_RESPECT_ANONYMOUS_PERMISSIONS
+		);
 
 		if (UtilMethods.isSet(contentletByIdentifier)) {
 			return contentletByIdentifier;
 		}
 
-		return contentAPI.findContentletByIdentifier(identifier, pageMode.showLive, languageId, user, pageMode.respectAnonPerms);
+		return contentAPI.findContentletByIdentifier(
+				identifier, pageMode.showLive, languageId, user,
+				ALWAYS_RESPECT_ANONYMOUS_PERMISSIONS
+		);
 	}
 
 	private boolean isBrowserSafariAndVersionBelow14(final UserAgent userAgent) {

--- a/dotcms-integration/src/test/java/com/dotmarketing/servlets/BinaryExporterServletTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/servlets/BinaryExporterServletTest.java
@@ -4,6 +4,7 @@ import com.dotcms.auth.providers.jwt.beans.ApiToken;
 import com.dotcms.datagen.ContentletDataGen;
 import com.dotcms.datagen.FileAssetDataGen;
 import com.dotcms.datagen.FolderDataGen;
+import com.dotcms.datagen.LanguageDataGen;
 import com.dotcms.datagen.RoleDataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.UserDataGen;
@@ -19,11 +20,13 @@ import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.Role;
+import static com.dotmarketing.business.Role.DOTCMS_BACK_END_USER;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
@@ -32,18 +35,6 @@ import com.liferay.portal.util.WebKeys;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
-import org.apache.commons.lang.RandomStringUtils;
-import org.glassfish.jersey.internal.util.Base64;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -56,12 +47,20 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
-
-import static com.dotmarketing.business.Role.DOTCMS_BACK_END_USER;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.apache.commons.lang.RandomStringUtils;
+import org.glassfish.jersey.internal.util.Base64;
+import org.junit.AfterClass;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -105,9 +104,13 @@ public class BinaryExporterServletTest {
     private static final String AUTH_WITH_TOKEN = "auth-with-token";
     private static final String NO_AUTH = "no-auth";
 
+    private static final String DEFAULT_LANGUAGE = "default-language";
+    private static final String NON_DEFAULT_LANGUAGE = "non-default-language";
+
     private static Host host;
     private static Role role;
     private static User user;
+    private static Language nonDefaultLanguage;
     private static String userEmailAndPassword;
     private static ApiToken apiToken;
 
@@ -131,6 +134,8 @@ public class BinaryExporterServletTest {
                 .emailAddress(userEmail).password(userPassword)
                 .roles(role, APILocator.getRoleAPI().loadRoleByKey(DOTCMS_BACK_END_USER))
                 .nextPersisted();
+
+        nonDefaultLanguage = new LanguageDataGen().nextPersisted();
 
         apiToken = APILocator.getApiTokenAPI().persistApiToken(
            user.getUserId(), Date.from(Instant.now().plus(Duration.ofDays(10))),
@@ -169,34 +174,50 @@ public class BinaryExporterServletTest {
     @DataProvider
     public static Object[][] testCases() {
         return new Object[][] {
-                { BY_ID, NO_PERMISSIONS_REQUIRED, NO_AUTH },
-                { BY_ID, PERMISSIONS_REQUIRED, NO_AUTH },
-                { BY_ID, PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS },
-                { BY_ID, PERMISSIONS_REQUIRED, AUTH_WITH_TOKEN },
-                { BY_INODE, NO_PERMISSIONS_REQUIRED, NO_AUTH },
-                { BY_INODE, PERMISSIONS_REQUIRED, NO_AUTH },
-                { BY_INODE, PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS },
-                { BY_INODE, PERMISSIONS_REQUIRED, AUTH_WITH_TOKEN }
+                {BY_ID, NO_PERMISSIONS_REQUIRED, NO_AUTH, DEFAULT_LANGUAGE},
+                {BY_ID, NO_PERMISSIONS_REQUIRED, NO_AUTH, NON_DEFAULT_LANGUAGE},
+                {BY_ID, NO_PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS, DEFAULT_LANGUAGE},
+                {BY_ID, NO_PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS, NON_DEFAULT_LANGUAGE},
+                {BY_ID, PERMISSIONS_REQUIRED, NO_AUTH, DEFAULT_LANGUAGE},
+                {BY_ID, PERMISSIONS_REQUIRED, NO_AUTH, NON_DEFAULT_LANGUAGE},
+                {BY_ID, PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS, DEFAULT_LANGUAGE},
+                {BY_ID, PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS, NON_DEFAULT_LANGUAGE},
+                {BY_ID, PERMISSIONS_REQUIRED, AUTH_WITH_TOKEN, DEFAULT_LANGUAGE},
+                {BY_ID, PERMISSIONS_REQUIRED, AUTH_WITH_TOKEN, NON_DEFAULT_LANGUAGE},
+                {BY_INODE, NO_PERMISSIONS_REQUIRED, NO_AUTH, DEFAULT_LANGUAGE},
+                {BY_INODE, NO_PERMISSIONS_REQUIRED, NO_AUTH, NON_DEFAULT_LANGUAGE},
+                {BY_INODE, NO_PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS, DEFAULT_LANGUAGE},
+                {BY_INODE, NO_PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS, NON_DEFAULT_LANGUAGE},
+                {BY_INODE, PERMISSIONS_REQUIRED, NO_AUTH, DEFAULT_LANGUAGE},
+                {BY_INODE, PERMISSIONS_REQUIRED, NO_AUTH, NON_DEFAULT_LANGUAGE},
+                {BY_INODE, PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS, DEFAULT_LANGUAGE},
+                {BY_INODE, PERMISSIONS_REQUIRED, AUTH_WITH_CREDENTIALS, NON_DEFAULT_LANGUAGE},
+                {BY_INODE, PERMISSIONS_REQUIRED, AUTH_WITH_TOKEN, DEFAULT_LANGUAGE},
+                {BY_INODE, PERMISSIONS_REQUIRED, AUTH_WITH_TOKEN, NON_DEFAULT_LANGUAGE}
         };
     }
 
     /**
      * Method to test: {@link BinaryExporterServlet.doGet(HttpServletRequest, HttpServletResponse)}
-     * Given scenario: Request a binary file asset
-     * Expected result: Should return the binary file asset content if permissions are granted
-     * If permissions are not granted, should return 401 Unauthorized
-     * @param byIdType Identifier type (by-identifier or by-inode)
+     * Given scenario: Request a binary file asset Expected result: Should return the binary file
+     * asset content if permissions are granted If permissions are not granted, should return 401
+     * Unauthorized
+     *
+     * @param byIdType       Identifier type (by-identifier or by-inode)
      * @param permissionType Permissions required (no-permissions-required or permissions-required)
-     * @param authType Authorization type (no-auth, auth-with-credentials or auth-with-token)
+     * @param authType       Authorization type (no-auth, auth-with-credentials or auth-with-token)
+     * @param languageType   The type of language to use for the test (default-language,
+     *                       non-default-language)
      */
     @UseDataProvider("testCases")
     @Test
-    public void requestBinaryFile(
-            final String byIdType, final String permissionType, final String authType)
+    public void requestBinaryFile(final String byIdType, final String permissionType,
+            final String authType, final String languageType)
             throws DotDataException, DotSecurityException, ServletException, IOException {
 
         final boolean byIdentifier = byIdType.equals(BY_ID);
         final boolean permissionsRequired = permissionType.equals(PERMISSIONS_REQUIRED);
+        final boolean useDefaultLanguage = languageType.equals(DEFAULT_LANGUAGE);
 
         Contentlet fileAsset = null;
         final Folder folder = new FolderDataGen().site(host).nextPersisted();
@@ -223,6 +244,15 @@ public class BinaryExporterServletTest {
                 request.setHeader("Authorization",
                         "Bearer " + APILocator.getApiTokenAPI().getJWT(apiToken, user));
             }
+
+            if (!useDefaultLanguage) {
+                HttpSession sessionOpt = request.getSession(true);
+                if (sessionOpt != null) {
+                    sessionOpt.setAttribute(com.dotmarketing.util.WebKeys.HTMLPAGE_LANGUAGE,
+                            String.valueOf(nonDefaultLanguage.getId()));
+                }
+            }
+
             final HttpServletResponse response = mockServletResponse(tmpTargetFile);
 
             // Send servlet request
@@ -230,7 +260,12 @@ public class BinaryExporterServletTest {
 
             if (permissionsRequired && NO_AUTH.equals(authType)) {
                 // Verify response status
-                assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+                if (byIdentifier && !useDefaultLanguage) {
+                    assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+                } else {
+                    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+                    assertEquals(HttpServletResponse.SC_UNAUTHORIZED, response.getStatus());
+                }
             } else {
                 // Verify response
                 assertEquals(HttpServletResponse.SC_OK, response.getStatus());


### PR DESCRIPTION
Refs: #31464

This pull request includes updates to the `BinaryExporterServlet` class and its associated tests to ensure that anonymous user permissions are always respected during content retrieval. Additionally, it enhances the test coverage by including scenarios with different language settings.

Changes to `BinaryExporterServlet`:

* Introduced a new constant `ALWAYS_RESPECT_ANONYMOUS_PERMISSIONS` to ensure anonymous user permissions are always respected.
* Updated the `doGet` method to use the new `ALWAYS_RESPECT_ANONYMOUS_PERMISSIONS` constant instead of the variable `mode.respectAnonPerms`. [[1]](diffhunk://#diff-cec109c9b6151c3911e59c14adf29118d75218a891ff5f52ad4dd85dc384081dL265-R271) [[2]](diffhunk://#diff-cec109c9b6151c3911e59c14adf29118d75218a891ff5f52ad4dd85dc384081dL305-R314)
* Modified the `getContentletByIdentifier` method to use the new constant for permission checks.

Changes to `BinaryExporterServletTest`:

* Added imports for `LanguageDataGen` and `Language` to support new test cases. [[1]](diffhunk://#diff-c7ec29d1d658907b3d1fd3479332d2eefd21b26860cfb27faf01d55625185abbR7) [[2]](diffhunk://#diff-c7ec29d1d658907b3d1fd3479332d2eefd21b26860cfb27faf01d55625185abbR23-R29)
* Rearranged and added imports to organize the test file better. [[1]](diffhunk://#diff-c7ec29d1d658907b3d1fd3479332d2eefd21b26860cfb27faf01d55625185abbL35-L46) [[2]](diffhunk://#diff-c7ec29d1d658907b3d1fd3479332d2eefd21b26860cfb27faf01d55625185abbL59-R63)
* Introduced constants `DEFAULT_LANGUAGE` and `NON_DEFAULT_LANGUAGE` for language-based test scenarios.
* Persisted a non-default language for testing purposes.
* Expanded test cases to include scenarios with default and non-default languages.
* Updated the `requestBinaryFile` test method to handle different language settings and verify responses accordingly.

This PR fixes: #31464