### PR TITLE
Creating a new Collector to collec the HTTP code response

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
@@ -115,9 +115,19 @@ cube(`Events`, {
   dataSource: `default`
 });
 
+cube('HttpResponses', {
+  sql: `SELECT request_id, http_response_code
+        FROM events 
+        WHERE event_type = 'HTTP_RESPONSE'`,
+  dimensions: {
+    requestId: { sql: 'request_id', type: `string` },
+    httpResponseCode: { sql: 'http_response_code', type: `string` }
+  }
+});
+
 cube('request', {
   sql: `SELECT *
-        FROM events
+        FROM events 
         WHERE ${FILTER_PARAMS.request.customerId.filter('customer_id')}
         AND ${FILTER_PARAMS.request.cluster_id ? FILTER_PARAMS.request.cluster_id.filter('cluster_id') : '(cluster_id IS NULL OR cluster_id = \'\')'}`,
   /*preAggregations: {
@@ -176,6 +186,11 @@ cube('request', {
     }
   },*/
   dimensions: {
+    id: {
+      sql: `CONCAT(${CUBE}.request_id, '-', ${CUBE}.event_type)`,
+      type: `string`,
+      primaryKey: true
+    },
     conHost: { sql: 'conhost', type: `string` },
     conHostName: { sql: 'conhostname', type: `string` },
     contentTypeName: { sql: 'object_contenttypename', type: `string` },
@@ -202,7 +217,11 @@ cube('request', {
     forwardTo: { sql: 'object_forwardto', type: `string` },
     action: { sql: 'object_action', type: `string` },
     eventType: { sql: 'event_type', type: `string` },
-    eventSource: { sql: 'event_source', type: `string` }
+    eventSource: { sql: 'event_source', type: `string` },
+    httpResponseCode: {
+      sql: `${HttpResponses.httpResponseCode}`,
+      type: `string`
+    }
   },
   measures: {
     count: {
@@ -242,6 +261,12 @@ cube('request', {
       sql: `(${totalRequest} - (${fileRequest} + ${pageRequest})) / NULLIF(${totalRequest}, 0)`,
       type: 'number',
       title: 'No FIle OR Page Average'
+    }
+  },
+  joins: {
+    HttpResponses: {
+      sql: `${CUBE}.request_id = ${HttpResponses.requestId}`,
+      relationship: `one_to_one`
     }
   }
 });

--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
@@ -121,7 +121,7 @@ cube('HttpResponses', {
         WHERE event_type = 'HTTP_RESPONSE'`,
   dimensions: {
     requestId: { sql: 'request_id', type: `string` },
-    httpResponseCode: { sql: 'http_response_code', type: `string` }
+    httpResponseCode: { sql: 'http_response_code', type: `number` }
   }
 });
 
@@ -187,7 +187,7 @@ cube('request', {
   },*/
   dimensions: {
     id: {
-      sql: `CONCAT(${CUBE}.request_id, '-', ${CUBE}.event_type)`,
+      sql: `CONCAT(${CUBE}.request_id, '-', ${CUBE}.event_type, '-', ${CUBE}.object_identifier)`,
       type: `string`,
       primaryKey: true
     },
@@ -218,10 +218,7 @@ cube('request', {
     action: { sql: 'object_action', type: `string` },
     eventType: { sql: 'event_type', type: `string` },
     eventSource: { sql: 'event_source', type: `string` },
-    httpResponseCode: {
-      sql: `${HttpResponses.httpResponseCode}`,
-      type: `string`
-    }
+    httpResponseCode: { sql: `${HttpResponses.httpResponseCode}`, type: `number` }
   },
   measures: {
     count: {

--- a/docker/docker-compose-examples/analytics/setup/db/clickhouse/init-scripts/init.sql
+++ b/docker/docker-compose-examples/analytics/setup/db/clickhouse/init-scripts/init.sql
@@ -120,3 +120,7 @@ ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS customer_name Str
 ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS customer_category String;
 ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS environment_name String;
 ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS environment_version String;
+
+ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS http_response_code String;
+
+ALTER TABLE clickhouse_test_db.events ADD INDEX IF NOT EXISTS idx_request_event (request_id, event_type) TYPE minmax GRANULARITY 1;

--- a/docker/docker-compose-examples/analytics/setup/db/clickhouse/init-scripts/init.sql
+++ b/docker/docker-compose-examples/analytics/setup/db/clickhouse/init-scripts/init.sql
@@ -121,6 +121,6 @@ ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS customer_category
 ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS environment_name String;
 ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS environment_version String;
 
-ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS http_response_code String;
+ALTER TABLE clickhouse_test_db.events ADD COLUMN IF NOT EXISTS http_response_code UInt16;
 
 ALTER TABLE clickhouse_test_db.events ADD INDEX IF NOT EXISTS idx_request_event (request_id, event_type) TYPE minmax GRANULARITY 1;

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptor.java
@@ -42,7 +42,7 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
     private transient final AnalyticsWebAPI analyticsWebAPI;
     private final WhiteBlackList whiteBlackList;
     private final AtomicBoolean isTurnedOn;
-    private final WebEventsCollectorServiceFactory webEventsCollectorServiceFactory;
+    private final Lazy<WebEventsCollectorServiceFactory> webEventsCollectorServiceFactory;
 
     private static final String AUTO_INJECT_LIB_WEB_PATH = "/s/ca-lib.js";
     private static final String AUTO_INJECT_LIB_CLASS_PATH = "/ca/ca-lib.js";
@@ -57,11 +57,11 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
                                 "ANALYTICS_BLACKLISTED_KEYS", new String[]{}), DEFAULT_BLACKLISTED_PROPS)).build(),
                 new AtomicBoolean(Config.getBooleanProperty(ANALYTICS_TURNED_ON_KEY, true)),
                 WebAPILocator.getAnalyticsWebAPI(),
-                WebEventsCollectorServiceFactory.getInstance(),
+                Lazy.of(WebEventsCollectorServiceFactory::getInstance),
                 new PagesAndUrlMapsRequestMatcher(),
                 new FilesRequestMatcher(),
                 //       new RulesRedirectsRequestMatcher(),
-                //new HttpResponseMatcher(),
+                new HttpResponseMatcher(),
                 new VanitiesRequestMatcher());
 
     }
@@ -72,13 +72,14 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
                                         final AnalyticsWebAPI analyticsWebAPI,
                                         final RequestMatcher... requestMatchers) {
 
-        this(whiteBlackList, isTurnedOn, analyticsWebAPI, WebEventsCollectorServiceFactory.getInstance(), requestMatchers);
+        this(whiteBlackList, isTurnedOn, analyticsWebAPI, Lazy.of(WebEventsCollectorServiceFactory::getInstance),
+                requestMatchers);
     }
 
     public AnalyticsTrackWebInterceptor(final WhiteBlackList whiteBlackList,
                                         final AtomicBoolean isTurnedOn,
                                         final AnalyticsWebAPI analyticsWebAPI,
-                                        final WebEventsCollectorServiceFactory webEventsCollectorServiceFactory,
+                                        final Lazy<WebEventsCollectorServiceFactory> webEventsCollectorServiceFactory,
                                         final RequestMatcher... requestMatchers) {
 
         this.whiteBlackList = whiteBlackList;
@@ -215,7 +216,7 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
 
         Logger.debug(this, ()-> "fireNext, uri: " + request.getRequestURI() +
                 " requestMatcher: " + requestMatcher.getId());
-        webEventsCollectorServiceFactory.getWebEventsCollectorService().fireCollectors(request, response, requestMatcher);
+        webEventsCollectorServiceFactory.get().getWebEventsCollectorService().fireCollectors(request, response, requestMatcher);
     }
 
 

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptor.java
@@ -61,7 +61,7 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
                 new PagesAndUrlMapsRequestMatcher(),
                 new FilesRequestMatcher(),
                 //       new RulesRedirectsRequestMatcher(),
-                new HttpResponseMatcher(),
+                //new HttpResponseMatcher(),
                 new VanitiesRequestMatcher());
 
     }

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptor.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptor.java
@@ -1,10 +1,7 @@
 package com.dotcms.analytics.track;
 
 import com.dotcms.analytics.track.collectors.WebEventsCollectorServiceFactory;
-import com.dotcms.analytics.track.matchers.FilesRequestMatcher;
-import com.dotcms.analytics.track.matchers.PagesAndUrlMapsRequestMatcher;
-import com.dotcms.analytics.track.matchers.RequestMatcher;
-import com.dotcms.analytics.track.matchers.VanitiesRequestMatcher;
+import com.dotcms.analytics.track.matchers.*;
 import com.dotcms.analytics.web.AnalyticsWebAPI;
 import com.dotcms.business.SystemTableUpdatedKeyEvent;
 import com.dotcms.featureflag.FeatureFlagName;
@@ -17,6 +14,7 @@ import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDUtil;
+import com.google.common.annotations.VisibleForTesting;
 import com.liferay.util.FileUtil;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
@@ -44,6 +42,7 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
     private transient final AnalyticsWebAPI analyticsWebAPI;
     private final WhiteBlackList whiteBlackList;
     private final AtomicBoolean isTurnedOn;
+    private final WebEventsCollectorServiceFactory webEventsCollectorServiceFactory;
 
     private static final String AUTO_INJECT_LIB_WEB_PATH = "/s/ca-lib.js";
     private static final String AUTO_INJECT_LIB_CLASS_PATH = "/ca/ca-lib.js";
@@ -58,16 +57,28 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
                                 "ANALYTICS_BLACKLISTED_KEYS", new String[]{}), DEFAULT_BLACKLISTED_PROPS)).build(),
                 new AtomicBoolean(Config.getBooleanProperty(ANALYTICS_TURNED_ON_KEY, true)),
                 WebAPILocator.getAnalyticsWebAPI(),
+                WebEventsCollectorServiceFactory.getInstance(),
                 new PagesAndUrlMapsRequestMatcher(),
                 new FilesRequestMatcher(),
                 //       new RulesRedirectsRequestMatcher(),
+                new HttpResponseMatcher(),
                 new VanitiesRequestMatcher());
 
+    }
+
+    @VisibleForTesting
+    public AnalyticsTrackWebInterceptor(final WhiteBlackList whiteBlackList,
+                                        final AtomicBoolean isTurnedOn,
+                                        final AnalyticsWebAPI analyticsWebAPI,
+                                        final RequestMatcher... requestMatchers) {
+
+        this(whiteBlackList, isTurnedOn, analyticsWebAPI, WebEventsCollectorServiceFactory.getInstance(), requestMatchers);
     }
 
     public AnalyticsTrackWebInterceptor(final WhiteBlackList whiteBlackList,
                                         final AtomicBoolean isTurnedOn,
                                         final AnalyticsWebAPI analyticsWebAPI,
+                                        final WebEventsCollectorServiceFactory webEventsCollectorServiceFactory,
                                         final RequestMatcher... requestMatchers) {
 
         this.whiteBlackList = whiteBlackList;
@@ -75,7 +86,9 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
         addRequestMatcher(requestMatchers);
         this.caLib = Lazy.of(() -> FileUtil.toStringFromResourceAsStreamNoThrown(AUTO_INJECT_LIB_CLASS_PATH));
         this.analyticsWebAPI = analyticsWebAPI;
+        this.webEventsCollectorServiceFactory = webEventsCollectorServiceFactory;
     }
+
 
     /**
      * Add a request matchers
@@ -202,7 +215,7 @@ public class AnalyticsTrackWebInterceptor  implements WebInterceptor, EventSubsc
 
         Logger.debug(this, ()-> "fireNext, uri: " + request.getRequestURI() +
                 " requestMatcher: " + requestMatcher.getId());
-        WebEventsCollectorServiceFactory.getInstance().getWebEventsCollectorService().fireCollectors(request, response, requestMatcher);
+        webEventsCollectorServiceFactory.getWebEventsCollectorService().fireCollectors(request, response, requestMatcher);
     }
 
 

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/Collector.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/Collector.java
@@ -64,6 +64,7 @@ public interface Collector {
     String CUSTOMER_CATEGORY = "customer_category";
     String ENVIRONMENT_NAME = "environment_name";
     String ENVIRONMENT_VERSION = "environment_version";
+    String HTTP_RESPONSE_CODE = "http_response_code";
 
     /**
      * Test if the collector should run

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/EventType.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/EventType.java
@@ -9,8 +9,8 @@ public enum EventType {
     FILE_REQUEST("FILE_REQUEST"),
     PAGE_REQUEST("PAGE_REQUEST"),
     CUSTOM_USER_EVENT("CUSTOM_USER_EVENT"),
-
-    URL_MAP("URL_MAP");
+    URL_MAP("URL_MAP"),
+    HTTP_RESPONSE("HTTP_RESPONSE");
 
     private final String type;
     private EventType(String type) {

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/HttpResponseCollector.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/HttpResponseCollector.java
@@ -5,6 +5,9 @@ import com.dotcms.api.web.HttpServletResponseThreadLocal;
 
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * Collect the HTTP Response code
+ */
 public class HttpResponseCollector implements Collector {
     @Override
     public boolean test(CollectorContextMap collectorContextMap) {

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/HttpResponseCollector.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/HttpResponseCollector.java
@@ -1,0 +1,26 @@
+package com.dotcms.analytics.track.collectors;
+
+import com.dotcms.analytics.track.matchers.HttpResponseMatcher;
+import com.dotcms.api.web.HttpServletResponseThreadLocal;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class HttpResponseCollector implements Collector {
+    @Override
+    public boolean test(CollectorContextMap collectorContextMap) {
+        return HttpResponseMatcher.HTTP_RESPONSE_MATCHER.equals(collectorContextMap.getRequestMatcher().getId()) ;
+    }
+
+    @Override
+    public CollectorPayloadBean collect(CollectorContextMap collectorContextMap, CollectorPayloadBean collectorPayloadBean) {
+        final HttpServletResponse response = HttpServletResponseThreadLocal.INSTANCE.getResponse();
+
+        collectorPayloadBean.put(HTTP_RESPONSE_CODE, response.getStatus());
+        collectorPayloadBean.put(EVENT_TYPE, EventType.HTTP_RESPONSE.getType());
+
+        final String uri = (String)collectorContextMap.get(CollectorContextMap.URI);
+        collectorPayloadBean.put(URL, uri);
+
+        return collectorPayloadBean;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/WebEventsCollectorServiceFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/collectors/WebEventsCollectorServiceFactory.java
@@ -69,7 +69,7 @@ public class WebEventsCollectorServiceFactory {
 
             addCollector(new BasicProfileCollector(), new FilesCollector(), new PagesCollector(),
                     new PageDetailCollector(), new SyncVanitiesCollector(), new AsyncVanitiesCollector(),
-                    new CustomerEventCollector());
+                    new CustomerEventCollector(), new HttpResponseCollector());
         }
 
         @VisibleForTesting

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/matchers/HttpResponseMatcher.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/matchers/HttpResponseMatcher.java
@@ -1,0 +1,35 @@
+package com.dotcms.analytics.track.matchers;
+
+import com.dotcms.visitor.filter.characteristics.Character;
+import com.dotcms.visitor.filter.characteristics.CharacterWebAPI;
+import com.dotmarketing.business.web.WebAPILocator;
+import com.dotmarketing.filters.CMSFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Objects;
+
+/**
+ * Matcher to be executed all the time before response
+ * @author jsanca
+ */
+public class HttpResponseMatcher implements RequestMatcher {
+
+    public static final String HTTP_RESPONSE_MATCHER = "http-response-matcher";
+
+    @Override
+    public boolean runAfterRequest() {
+        return true;
+    }
+
+    @Override
+    public boolean match(final HttpServletRequest request, final HttpServletResponse response) {
+
+        return true;
+    }
+
+    @Override
+    public String getId() {
+        return HTTP_RESPONSE_MATCHER;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/analytics/track/matchers/HttpResponseMatcher.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/track/matchers/HttpResponseMatcher.java
@@ -10,7 +10,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Objects;
 
 /**
- * Matcher to be executed all the time before response
+ * Matcher to be executed all the time before response, it allows us to include Response data
+ * in the Analytics Events
  * @author jsanca
  */
 public class HttpResponseMatcher implements RequestMatcher {

--- a/dotCMS/src/test/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptorTest.java
@@ -1,6 +1,9 @@
 package com.dotcms.analytics.track;
 
 import com.dotcms.analytics.app.AnalyticsApp;
+import com.dotcms.analytics.track.collectors.WebEventsCollectorService;
+import com.dotcms.analytics.track.collectors.WebEventsCollectorServiceFactory;
+import com.dotcms.analytics.track.matchers.HttpResponseMatcher;
 import com.dotcms.analytics.track.matchers.RequestMatcher;
 import com.dotcms.analytics.web.AnalyticsWebAPI;
 import com.dotcms.security.apps.AppSecrets;
@@ -11,6 +14,7 @@ import com.dotmarketing.business.web.HostWebAPI;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.UUIDUtil;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import org.apache.commons.lang3.mutable.MutableBoolean;
@@ -24,6 +28,10 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 /**
  * This test is for the AnalyticsTrackWebInterceptor class.
@@ -146,6 +154,41 @@ public class AnalyticsTrackWebInterceptorTest {
         }catch (Exception e) {}
 
         Assert.assertTrue("The test matcher should be called", testMatcher.wasCalled());
+    }
+
+    /**
+     * Method to test: {@link AnalyticsTrackWebInterceptor#intercept(HttpServletRequest, HttpServletResponse)}
+     *                  and {@link AnalyticsTrackWebInterceptor#afterIntercept(HttpServletRequest, HttpServletResponse)}
+     * When:
+     * should:
+     */
+    @Test
+    public void httpResponse() throws IOException {
+        Config.CONTEXT = Mockito.mock(ServletContext.class);
+        final AnalyticsWebAPI analyticsWebAPI = Mockito.mock(AnalyticsWebAPI.class);
+        final WhiteBlackList whiteBlackList  = new WhiteBlackList.Builder()
+                .addWhitePatterns(new String[]{StringPool.BLANK}) // allows everything
+                .addBlackPatterns(new String[]{StringPool.BLANK}).build();
+        final AtomicBoolean isTurnedOn = new AtomicBoolean(true); // turn on the feature flag
+        final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        final HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        final HttpResponseMatcher httpResponseMatcher = new HttpResponseMatcher();
+        final WebEventsCollectorServiceFactory webEventsCollectorServiceFactory = Mockito.mock(WebEventsCollectorServiceFactory.class);
+        final WebEventsCollectorService webEventsCollectorService = Mockito.mock(WebEventsCollectorService.class);
+
+        Mockito.when(request.getRequestURI()).thenReturn("/some-uri");
+        Mockito.when(analyticsWebAPI.anyAnalyticsConfig(request)).thenReturn(true);
+        Mockito.when(webEventsCollectorServiceFactory.getWebEventsCollectorService()).thenReturn(webEventsCollectorService);
+
+        final AnalyticsTrackWebInterceptor interceptor = new AnalyticsTrackWebInterceptor(
+                whiteBlackList, isTurnedOn, analyticsWebAPI, webEventsCollectorServiceFactory, httpResponseMatcher);
+
+        interceptor.intercept(request, response);
+
+        interceptor.afterIntercept(request, response);
+
+        verify(request).setAttribute(eq("requestId"), anyString());
+        verify(webEventsCollectorService).fireCollectors(request, response, httpResponseMatcher);
     }
 
 }

--- a/dotCMS/src/test/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/track/AnalyticsTrackWebInterceptorTest.java
@@ -17,6 +17,7 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.UUIDUtil;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
+import io.vavr.Lazy;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.Assert;
 import org.junit.Test;
@@ -181,7 +182,7 @@ public class AnalyticsTrackWebInterceptorTest {
         Mockito.when(webEventsCollectorServiceFactory.getWebEventsCollectorService()).thenReturn(webEventsCollectorService);
 
         final AnalyticsTrackWebInterceptor interceptor = new AnalyticsTrackWebInterceptor(
-                whiteBlackList, isTurnedOn, analyticsWebAPI, webEventsCollectorServiceFactory, httpResponseMatcher);
+                whiteBlackList, isTurnedOn, analyticsWebAPI, Lazy.of(() -> webEventsCollectorServiceFactory), httpResponseMatcher);
 
         interceptor.intercept(request, response);
 


### PR DESCRIPTION
### Proposed Changes
* Create a Matcher to be executed after request

https://github.com/dotCMS/core/pull/31550/files#diff-eead20ed4a7d38c7089697f9fb0d6eba70a97bb13827788395c6770ce5d2ec0eR16

We need to include the http response code all the time that is why the match method return true all the time

* Create a new Collector to include the Http Res ponse Code in the Analytics Event

https://github.com/dotCMS/core/pull/31550/files#diff-3010bec323465791a8e1c0dd4bf0a436a915f554c7a4564bb8e4594eea4523c0R8

* Include a new column to save the HTTP Response code, also add a new index suggest by the AI to improve performance

https://github.com/dotCMS/core/pull/31550/files#diff-b7660db1f904ea5449d236e0725581e6627b4953792263cf9bcfc7655e9cbaccR124-R126

* Change the CubeJS Schema to include this new HTTP Code Response as a dimensions

Create a new cube to take just the HTTP RESPONSE CODE

https://github.com/dotCMS/core/pull/31550/files#diff-c291c8a51311832c67ceb2e3fb2a2d4fe1d9c4e02abda400c156e10bed18200eR118

JOIN with request cube 

https://github.com/dotCMS/core/pull/31550/files#diff-c291c8a51311832c67ceb2e3fb2a2d4fe1d9c4e02abda400c156e10bed18200eR266-R270

Include new dimensions

https://github.com/dotCMS/core/pull/31550/files#diff-c291c8a51311832c67ceb2e3fb2a2d4fe1d9c4e02abda400c156e10bed18200eR221-R224

The Join is translate as a LEFT JOIN in the SQL Code, this is just add if the httpResponseCode dimensions is include in the CubeJS Query.

Examples

1. From this CubeJS Query 

```
{
    "measures": ["request.count"],
    "dimensions": ["request.url", "request.httpResponseCode"]
}
```

it generated the follow SQL Statement using the JOIN

```
SELECT `http_responses`.http_response_code `request__http_response_code`, 
    `request`.url `request__url`, 
     count(CONCAT(`request`.request_id, '-', `request`.event_type)) `request__count` 
FROM (SELECT * FROM events WHERE (1 = 1) AND (1 = 1)) AS `request` 
   LEFT JOIN (
      SELECT request_id,  http_response_code 
     FROM events 
     WHERE event_type = 'HTTP_RESPONSE') AS `http_responses` 
        ON `request`.request_id = `http_responses`.request_id 
GROUP BY `request__http_response_code`, `request__url` 
ORDER BY `request__count` DESC LIMIT 10000
```

2. From this CubeJS Query 

```
{
    "measures": ["request.count"],
    "dimensions": ["request.url"]
}
```

it generated the follow SQL Statement 

```
SELECT `request`.url `request__url`, 
               count(CONCAT(`request`.request_id, '-', `request`.event_type)) `request__count` 
FROM (
   SELECT * 
   FROM events 
   WHERE (1 = 1) AND (1 = 1)) AS `request` 
    GROUP BY `request__url` ORDER BY `request__count` DESC LIMIT 10000
)
```


This PR fixes: #30193