### PR TITLE
 #31457: Adding a better way of invalidating OpenAI models

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/client/AIClient.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/AIClient.java
@@ -1,14 +1,7 @@
 package com.dotcms.ai.client;
 
 import com.dotcms.ai.domain.AIProvider;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpPatch;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpUriRequest;
 
-import javax.ws.rs.HttpMethod;
 import java.io.OutputStream;
 import java.io.Serializable;
 
@@ -45,29 +38,6 @@ public interface AIClient {
             throw new UnsupportedOperationException("Noop client does not support sending requests");
         }
     };
-
-    /**
-     * Resolves the appropriate HTTP method for the given method name and URL.
-     *
-     * @param method the HTTP method name (e.g., "GET", "POST", "PUT", "DELETE", "patch")
-     * @param url the URL to which the request will be sent
-     * @return the corresponding {@link HttpUriRequest} for the given method and URL
-     */
-    static HttpUriRequest resolveMethod(final String method, final String url) {
-        switch(method) {
-            case HttpMethod.POST:
-                return new HttpPost(url);
-            case HttpMethod.PUT:
-                return new HttpPut(url);
-            case HttpMethod.DELETE:
-                return new HttpDelete(url);
-            case "patch":
-                return new HttpPatch(url);
-            case HttpMethod.GET:
-            default:
-                return new HttpGet(url);
-        }
-    }
 
     /**
      * Validates and casts the given AI request to a {@link JSONObjectAIRequest}.

--- a/dotCMS/src/main/java/com/dotcms/ai/client/AIRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/AIRequest.java
@@ -197,6 +197,11 @@ public class AIRequest<T extends Serializable> {
             return self();
         }
 
+        public B withMethod(final String method) {
+            this.method = method;
+            return self();
+        }
+
         public B withConfig(final AppConfig config) {
             this.config = config;
             return self();

--- a/dotCMS/src/main/java/com/dotcms/ai/client/openai/OpenAIClient.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/openai/OpenAIClient.java
@@ -2,38 +2,36 @@ package com.dotcms.ai.client.openai;
 
 import com.dotcms.ai.AiKeys;
 import com.dotcms.ai.app.AIModel;
+import com.dotcms.ai.app.AIModels;
 import com.dotcms.ai.app.AppConfig;
 import com.dotcms.ai.app.AppKeys;
 import com.dotcms.ai.client.AIClient;
-import com.dotcms.ai.domain.AIProvider;
 import com.dotcms.ai.client.AIRequest;
 import com.dotcms.ai.client.JSONObjectAIRequest;
+import com.dotcms.ai.domain.AIProvider;
 import com.dotcms.ai.domain.Model;
 import com.dotcms.ai.exception.DotAIAppConfigDisabledException;
 import com.dotcms.ai.exception.DotAIClientConnectException;
 import com.dotcms.ai.exception.DotAIModelNotFoundException;
 import com.dotcms.ai.exception.DotAIModelNotOperationalException;
+import com.dotcms.business.SystemTableUpdatedKeyEvent;
+import com.dotcms.http.CircuitBreakerUrl;
+import com.dotcms.rest.exception.GenericHttpStatusCodeException;
+import com.dotcms.system.event.local.model.EventSubscriber;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.json.JSONObject;
 import io.vavr.Lazy;
 import io.vavr.Tuple2;
-import io.vavr.control.Try;
-import org.apache.http.HttpHeaders;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
-import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.ContentType;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 
-import javax.ws.rs.core.MediaType;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.Response;
-import java.io.BufferedInputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Implementation of the {@link AIClient} interface for interacting with the OpenAI service.
@@ -52,18 +50,56 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @auhor vico
  */
-public class OpenAIClient implements AIClient {
+public class OpenAIClient implements AIClient, EventSubscriber<SystemTableUpdatedKeyEvent> {
 
+    private static final String AI_OPEN_AI_TIMEOUT_KEY = "AI_PROVIDERS_OPENAI_TIMEOUT";
+    private static final String AI_OPEN_AI_ATTEMPTS_KEY = "AI_PROVIDERS_OPENAI_ATTEMPTS";
     private static final Lazy<OpenAIClient> INSTANCE = Lazy.of(OpenAIClient::new);
-
-    private final ConcurrentHashMap<AIModel, Long> lastRestCall;
 
     public static OpenAIClient get() {
         return INSTANCE.get();
     }
 
+    private static long resolveTimeout() {
+        return Config.getLongProperty(AI_OPEN_AI_TIMEOUT_KEY, 5000L);
+    }
+
+    private static int resolveAttempts() {
+        return Config.getIntProperty(AI_OPEN_AI_ATTEMPTS_KEY, 5);
+    }
+
+    private static CircuitBreakerUrl.Method resolveMethod(final JSONObjectAIRequest request) {
+        switch(request.getMethod().toUpperCase()) {
+            case HttpMethod.POST:
+                return CircuitBreakerUrl.Method.POST;
+            case HttpMethod.PUT:
+                return CircuitBreakerUrl.Method.PUT;
+            case HttpMethod.DELETE:
+                return CircuitBreakerUrl.Method.DELETE;
+            case HttpMethod.PATCH:
+                return CircuitBreakerUrl.Method.PATCH;
+            case HttpMethod.GET:
+            default:
+                return CircuitBreakerUrl.Method.GET;
+        }
+    }
+
+    private final AtomicLong openAiTimeout;
+    private final AtomicInteger openAiAttempts;
+
     private OpenAIClient() {
-        lastRestCall = new ConcurrentHashMap<>();
+        openAiTimeout = new AtomicLong(resolveTimeout());
+        openAiAttempts = new AtomicInteger(resolveAttempts());
+    }
+
+    @Override
+    public void notify(final SystemTableUpdatedKeyEvent event) {
+        Logger.info(this, String.format("Notify for event [%s]", event.getKey()));
+        if (event.getKey().contains(AI_OPEN_AI_TIMEOUT_KEY)) {
+            openAiTimeout.set(resolveTimeout());
+        } else if (event.getKey().contains(AI_OPEN_AI_ATTEMPTS_KEY)) {
+            openAiAttempts.set(resolveAttempts());
+        }
     }
 
     /**
@@ -82,19 +118,19 @@ public class OpenAIClient implements AIClient {
         final JSONObjectAIRequest jsonRequest = AIClient.useRequestOrThrow(request);
         final AppConfig appConfig = jsonRequest.getConfig();
 
-        request.getConfig().debugLogger(
+        appConfig.debugLogger(
                 OpenAIClient.class,
                 () -> String.format(
                         "Posting to [%s] with method [%s]%s  with app config:%s%s  the payload: %s",
                         jsonRequest.getUrl(),
                         jsonRequest.getMethod(),
                         System.lineSeparator(),
-                        appConfig.toString(),
+                        appConfig,
                         System.lineSeparator(),
                         jsonRequest.payloadToString()));
 
         if (!appConfig.isEnabled()) {
-            request.getConfig().debugLogger(OpenAIClient.class, () -> "App dotAI is not enabled and will not send request.");
+            appConfig.debugLogger(OpenAIClient.class, () -> "App dotAI is not enabled and will not send request.");
             throw new DotAIAppConfigDisabledException("App dotAI config without API urls or API key");
         }
 
@@ -103,58 +139,34 @@ public class OpenAIClient implements AIClient {
                 .ofNullable(payload.optString(AiKeys.MODEL))
                 .orElseThrow(() -> new DotAIModelNotFoundException("Model is not present in the request"));
         final Tuple2<AIModel, Model> modelTuple = appConfig.resolveModelOrThrow(modelName, jsonRequest.getType());
-        final AIModel aiModel = modelTuple._1;
+        //final AIModel aiModel = modelTuple._1;
 
         if (!modelTuple._2.isOperational()) {
-            request.getConfig().debugLogger(
+            appConfig.debugLogger(
                     getClass(),
                     () -> String.format("Resolved model [%s] is not operational, avoiding its usage", modelName));
             throw new DotAIModelNotOperationalException(String.format("Model [%s] is not operational", modelName));
         }
 
-
-        final long sleep = lastRestCall.computeIfAbsent(aiModel, m -> 0L)
-                + aiModel.minIntervalBetweenCalls()
-                - System.currentTimeMillis();
-        if (sleep > 0) {
-            Logger.info(
-                    this,
-                    "Rate limit:"
-                            + aiModel.getApiPerMinute()
-                            + "/minute, or 1 every "
-                            + aiModel.minIntervalBetweenCalls()
-                            + "ms. Sleeping:"
-                            + sleep);
-            Try.run(() -> Thread.sleep(sleep));
-        }
-
-        lastRestCall.put(aiModel, System.currentTimeMillis());
-
-        try (final CloseableHttpClient httpClient = HttpClients.createDefault()) {
-            final StringEntity jsonEntity = new StringEntity(payload.toString(), ContentType.APPLICATION_JSON);
-            final HttpUriRequest httpRequest = AIClient.resolveMethod(jsonRequest.getMethod(), jsonRequest.getUrl());
-            httpRequest.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-            httpRequest.setHeader(HttpHeaders.AUTHORIZATION, "Bearer " + appConfig.getApiKey());
-
-            if (!payload.getAsMap().isEmpty()) {
-                Try.run(() -> ((HttpEntityEnclosingRequestBase) httpRequest).setEntity(jsonEntity));
-            }
-
-            try (final CloseableHttpResponse response = httpClient.execute(httpRequest)) {
-                onStreamCheckFotStatusCode(modelName, payload, response);
-
-                final BufferedInputStream in = new BufferedInputStream(response.getEntity().getContent());
-                final byte[] buffer = new byte[1024];
-                int len;
-                while ((len = in.read(buffer)) != -1) {
-                    output.write(buffer, 0, len);
-                    output.flush();
-                }
-            }
-        } catch (DotAIModelNotFoundException e) {
-            throw e;
+        try {
+            CircuitBreakerUrl.builder()
+                    .setMethod(resolveMethod(jsonRequest))
+                    .setAuthHeaders(AIModels.BEARER + appConfig.getApiKey())
+                    .setUrl(jsonRequest.getUrl())
+                    .setRawData(payload.toString())
+                    .setTimeout(openAiTimeout.get())
+                    .setTryAgainAttempts(openAiAttempts.get())
+                    .setOverrideException(statusCode -> new GenericHttpStatusCodeException(
+                            String.format(
+                                    "Got invalid response for url: [%s] response: [%d]",
+                                    jsonRequest.getUrl(),
+                                    statusCode),
+                            Response.Status.fromStatusCode(statusCode)))
+                    .setRaiseFailsafe(true)
+                    .build()
+                    .doOut(output);
         } catch (Exception e) {
-            if (appConfig.getConfigBoolean(AppKeys.DEBUG_LOGGING)){
+            if (appConfig.getConfigBoolean(AppKeys.DEBUG_LOGGING)) {
                 Logger.warn(this, "INVALID REQUEST: " + e.getMessage(), e);
             } else {
                 Logger.warn(this, "INVALID REQUEST: " + e.getMessage());
@@ -165,18 +177,4 @@ public class OpenAIClient implements AIClient {
             throw new DotAIClientConnectException("Error while sending request to OpenAI", e);
         }
     }
-
-    private static void onStreamCheckFotStatusCode(final String modelName,
-                                                   final JSONObject payload,
-                                                   final CloseableHttpResponse response) {
-        if (payload.optBoolean(AiKeys.STREAM, false)) {
-            final int statusCode = response.getStatusLine().getStatusCode();
-            if (Response.Status.Family.familyOf(statusCode) == Response.Status.Family.CLIENT_ERROR) {
-                throw new DotAIModelNotFoundException(String.format(
-                        "Model used [%s] in request in stream mode is not found",
-                        modelName));
-            }
-        }
-    }
-
 }

--- a/dotCMS/src/main/java/com/dotcms/ai/client/openai/OpenAIResponseEvaluator.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/openai/OpenAIResponseEvaluator.java
@@ -6,10 +6,12 @@ import com.dotcms.ai.domain.AIResponseData;
 import com.dotcms.ai.domain.ModelStatus;
 import com.dotcms.ai.exception.DotAIModelNotFoundException;
 import com.dotcms.ai.exception.DotAIModelNotOperationalException;
+import com.dotcms.rest.exception.GenericHttpStatusCodeException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.json.JSONObject;
 import io.vavr.Lazy;
 
+import javax.ws.rs.core.Response;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -34,8 +36,7 @@ public class OpenAIResponseEvaluator implements AIResponseEvaluator {
         return INSTANCE.get();
     }
 
-    private OpenAIResponseEvaluator() {
-    }
+    private OpenAIResponseEvaluator() {}
 
     /**
      * {@inheritDoc}
@@ -85,7 +86,15 @@ public class OpenAIResponseEvaluator implements AIResponseEvaluator {
             return ModelStatus.INVALID;
         }
 
+
+        if (throwable instanceof GenericHttpStatusCodeException) {
+            final GenericHttpStatusCodeException statusCodeException = (GenericHttpStatusCodeException) throwable;
+            final Response.Status status = Response.Status.fromStatusCode(statusCodeException.getResponse().getStatus());
+            if (status == Response.Status.NOT_FOUND) {
+                return ModelStatus.INVALID;
+            }
+        }
+
         return ModelStatus.UNKNOWN;
     }
-
 }

--- a/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPI.java
@@ -17,6 +17,7 @@ import java.time.Instant;
  */
 public interface AnalyticsAPI {
 
+    String BEARER = "Bearer ";
     String ANALYTICS_IDP_URL_KEY = "ANALYTICS_IDP_URL";
     String ANALYTICS_USE_DUMMY_TOKEN_KEY = "ANALYTICS_USE_DUMMY_TOKEN";
     String ANALYTICS_ACCESS_TOKEN_KEY_PREFIX = "ANALYTICS_ACCESS_TOKEN";
@@ -31,7 +32,7 @@ public interface AnalyticsAPI {
     AccessToken DUMMY_TOKEN = AccessToken.builder()
         .accessToken("dummy_token")
         .clientId("dummy")
-        .tokenType("Bearer")
+        .tokenType(BEARER.trim())
         .expiresIn(Integer.MAX_VALUE)
         .status(AccessTokenStatus.builder().tokenStatus(TokenStatus.OK).build())
         .issueDate(Instant.now())

--- a/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPIImpl.java
@@ -369,7 +369,7 @@ public class AnalyticsAPIImpl implements AnalyticsAPI, EventSubscriber<SystemTab
             .setTryAgainAttempts(accessTokenRenewAttempts.get())
             .setHeaders(accessTokenHeaders())
             .setRawData(prepareRequestData(analyticsApp))
-            .setThrowWhenNot2xx(false)
+            .setThrowWhenError(false)
             .build()
             .doResponse(AccessToken.class);
         logTokenResponse(response, analyticsApp);
@@ -414,13 +414,14 @@ public class AnalyticsAPIImpl implements AnalyticsAPI, EventSubscriber<SystemTab
     private CircuitBreakerUrl.Response<AnalyticsKey> requestAnalyticsKey(final AnalyticsApp analyticsApp,
                                                                          final AccessToken accessToken)
             throws AnalyticsException {
+        AnalyticsHelper.get().checkAccessToken(accessToken);
         final CircuitBreakerUrl.Response<AnalyticsKey> response = CircuitBreakerUrl.builder()
             .setMethod(CircuitBreakerUrl.Method.GET)
             .setUrl(analyticsApp.getAnalyticsProperties().analyticsConfigUrl())
             .setTimeout(analyticsKeyRenewTimeout.get())
             .setTryAgainAttempts(analyticsKeyRenewAttempts.get())
-            .setHeaders(analyticsKeyHeaders(accessToken))
-            .setThrowWhenNot2xx(false)
+            .setAuthHeaders(accessToken.accessToken())
+            .setThrowWhenError(false)
             .build()
             .doResponse(AnalyticsKey.class);
         logKeyResponse(response, analyticsApp);
@@ -428,13 +429,4 @@ public class AnalyticsAPIImpl implements AnalyticsAPI, EventSubscriber<SystemTab
         return response;
     }
 
-    /**
-     * Prepares access token request headers in a {@link Map} with values found in a {@link AccessToken} instance.
-     *
-     * @param accessToken access token
-     * @return map representation of http headers
-     */
-    private Map<String, String> analyticsKeyHeaders(final AccessToken accessToken) throws AnalyticsException {
-        return CircuitBreakerUrl.authHeaders(AnalyticsHelper.get().formatBearer(accessToken));
-    }
 }

--- a/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
@@ -7,7 +7,6 @@ import com.dotcms.analytics.model.AccessTokenErrorType;
 import com.dotcms.analytics.model.AccessTokenStatus;
 import com.dotcms.analytics.model.AnalyticsKey;
 import com.dotcms.analytics.model.TokenStatus;
-import com.dotcms.auth.providers.jwt.JsonWebTokenAuthCredentialProcessor;
 import com.dotcms.business.SystemTableUpdatedKeyEvent;
 import com.dotcms.exception.AnalyticsException;
 import com.dotcms.exception.UnrecoverableAnalyticsException;
@@ -244,7 +243,7 @@ public class AnalyticsHelper implements EventSubscriber<SystemTableUpdatedKeyEve
      * @throws AnalyticsException when validating token
      */
     public String formatBearer(final AccessToken accessToken) throws AnalyticsException {
-        return formatToken(accessToken, JsonWebTokenAuthCredentialProcessor.BEARER);
+        return formatToken(accessToken, AnalyticsAPI.BEARER);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/http/CircuitBreakerPool.java
+++ b/dotCMS/src/main/java/com/dotcms/http/CircuitBreakerPool.java
@@ -1,6 +1,5 @@
 package com.dotcms.http;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -11,7 +10,7 @@ import com.google.common.cache.CacheBuilder;
 
 import net.jodah.failsafe.CircuitBreaker;
 
-public class CurcuitBreakerPool {
+public class CircuitBreakerPool {
     
 
     final static int FAIL_AFTER = Config.getIntProperty("CIRCUIT_BREAKER_URL_MAX_FAILURES", 5);
@@ -27,15 +26,10 @@ public class CurcuitBreakerPool {
     @VisibleForTesting
     public static CircuitBreaker getBreaker(final String key)  {
         try {
-            return pool.get(key, new Callable<CircuitBreaker>() {
-                @Override
-                public CircuitBreaker call() {
-                    return new CircuitBreaker()
-                                    .withFailureThreshold(FAIL_AFTER)
-                                    .withSuccessThreshold(TRY_AGAIN_ATTEMPTS)
-                                    .withDelay(TRY_AGAIN_DELAY_SEC, TimeUnit.SECONDS);
-                }
-            });
+            return pool.get(key, () -> new CircuitBreaker()
+                            .withFailureThreshold(FAIL_AFTER)
+                            .withSuccessThreshold(TRY_AGAIN_ATTEMPTS)
+                            .withDelay(TRY_AGAIN_DELAY_SEC, TimeUnit.SECONDS));
         } catch (ExecutionException e) {
             throw new DotExecutionException(e);
         }
@@ -44,15 +38,10 @@ public class CurcuitBreakerPool {
     @VisibleForTesting
     public static CircuitBreaker getBreaker(final String key, int failAfter, int tryAgainAfter, int workAgainAfter)  {
         try {
-            return pool.get(key, new Callable<CircuitBreaker>() {
-                @Override
-                public CircuitBreaker call() {
-                    return new CircuitBreaker()
-                                    .withFailureThreshold(failAfter)
-                                    .withSuccessThreshold(tryAgainAfter)
-                                    .withDelay(workAgainAfter, TimeUnit.SECONDS);
-                }
-            });
+            return pool.get(key, () -> new CircuitBreaker()
+                            .withFailureThreshold(failAfter)
+                            .withSuccessThreshold(tryAgainAfter)
+                            .withDelay(workAgainAfter, TimeUnit.SECONDS));
         } catch (ExecutionException e) {
             throw new DotExecutionException(e);
         }

--- a/dotCMS/src/main/java/com/dotcms/http/CircuitBreakerUrlBuilder.java
+++ b/dotCMS/src/main/java/com/dotcms/http/CircuitBreakerUrlBuilder.java
@@ -1,7 +1,10 @@
 package com.dotcms.http;
 
 import java.util.Map;
+import java.util.function.Function;
 
+import com.dotcms.rest.exception.HttpStatusCodeException;
+import com.google.common.collect.ImmutableMap;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -15,6 +18,9 @@ import com.google.common.collect.Maps;
 
 import net.jodah.failsafe.CircuitBreaker;
 
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
 
 public class CircuitBreakerUrlBuilder {
     String proxyUrl = null;
@@ -24,12 +30,14 @@ public class CircuitBreakerUrlBuilder {
     Map<String, String> headers = Maps.newHashMap();
     Method method = Method.GET;
     boolean verbose = false;
-    int failAfter = CurcuitBreakerPool.FAIL_AFTER;
-    int tryAgainAttempts = CurcuitBreakerPool.TRY_AGAIN_ATTEMPTS;
-    int tryAgainAfterDelay = CurcuitBreakerPool.TRY_AGAIN_DELAY_SEC;
+    int failAfter = CircuitBreakerPool.FAIL_AFTER;
+    int tryAgainAttempts = CircuitBreakerPool.TRY_AGAIN_ATTEMPTS;
+    int tryAgainAfterDelay = CircuitBreakerPool.TRY_AGAIN_DELAY_SEC;
     String rawData = null;
     boolean allowRedirects=Config.getBooleanProperty("REMOTE_CALL_ALLOW_REDIRECTS", false);
-    boolean throwWhenNot2xx = true;
+    boolean throwWhenError = true;
+    Function<Integer, HttpStatusCodeException> overrideException;
+    boolean raiseFailsafe = false;
 
     public CircuitBreakerUrlBuilder setUrl(String proxyUrl) {
         this.proxyUrl = proxyUrl;
@@ -66,8 +74,13 @@ public class CircuitBreakerUrlBuilder {
         return this;
     }
 
-    public CircuitBreakerUrlBuilder setThrowWhenNot2xx(boolean throwWhenNot2xx) {
-        this.throwWhenNot2xx = throwWhenNot2xx;
+    public CircuitBreakerUrlBuilder setThrowWhenError(boolean throwWhenError) {
+        this.throwWhenError = throwWhenError;
+        return this;
+    }
+
+    public CircuitBreakerUrlBuilder setRaiseFailsafe(final boolean raiseFailsafe) {
+        this.raiseFailsafe = raiseFailsafe;
         return this;
     }
     
@@ -92,6 +105,21 @@ public class CircuitBreakerUrlBuilder {
         return this;
     }
 
+    public CircuitBreakerUrlBuilder setAuthHeaders(final String token) {
+        return setHeaders(ImmutableMap.<String, String>builder()
+                .put(HttpHeaders.AUTHORIZATION, token)
+                .put(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+                .put(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                .build());
+    }
+
+    public CircuitBreakerUrlBuilder setOverrideException(
+            final Function<Integer, HttpStatusCodeException> overrideException) {
+
+        this.overrideException = overrideException;
+        return this;
+    }
+
     public CircuitBreakerUrlBuilder setMethod(Method method) {
         this.method = method;
         return this;
@@ -107,7 +135,7 @@ public class CircuitBreakerUrlBuilder {
             throw new DotStateException("A URL must be set to use CircuitBreakerUrl");
         }
         if (this.circuitBreaker == null) {
-            this.circuitBreaker = CurcuitBreakerPool.getBreaker(this.proxyUrl + this.timeout, failAfter, tryAgainAttempts, tryAgainAfterDelay);
+            this.circuitBreaker = CircuitBreakerPool.getBreaker(this.proxyUrl + this.timeout, failAfter, tryAgainAttempts, tryAgainAfterDelay);
         }
         final HttpRequestBase request;
         switch (this.method) {
@@ -135,7 +163,9 @@ public class CircuitBreakerUrlBuilder {
             this.verbose,
             this.rawData,
             this.allowRedirects,
-            this.throwWhenNot2xx);
+            this.throwWhenError,
+            this.overrideException,
+            this.raiseFailsafe);
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/jitsu/EventLogRunnable.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/EventLogRunnable.java
@@ -117,7 +117,7 @@ public class EventLogRunnable implements Runnable {
             .setParams(Map.of("token", analyticsApp.getAnalyticsProperties().analyticsKey()))
             .setTimeout(4000)
             .setHeaders(POSTING_HEADERS)
-            .setThrowWhenNot2xx(false);
+            .setThrowWhenError(false);
     }
 
 

--- a/dotCMS/src/main/java/com/dotcms/rest/exception/GenericHttpStatusCodeException.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/exception/GenericHttpStatusCodeException.java
@@ -1,0 +1,20 @@
+package com.dotcms.rest.exception;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Exception class representing a generic HTTP status code error.
+ *
+ * <p>This exception is thrown when a generic HTTP status code error occurs in the application.
+ * It extends the {@link HttpStatusCodeException} class and provides additional constructors
+ * to handle different error scenarios.</p>
+ *
+ * @author vico
+ */
+public class GenericHttpStatusCodeException extends HttpStatusCodeException {
+
+    public GenericHttpStatusCodeException(final String message, final Response.Status status) {
+        super(null, status, null, message);
+    }
+}
+ 

--- a/dotCMS/src/test/java/com/dotcms/analytics/helper/AnalyticsHelperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/analytics/helper/AnalyticsHelperTest.java
@@ -1,6 +1,7 @@
 package com.dotcms.analytics.helper;
 
 import com.dotcms.UnitTestBase;
+import com.dotcms.analytics.AnalyticsAPI;
 import com.dotcms.analytics.AnalyticsTestUtils;
 import com.dotcms.analytics.model.AccessToken;
 import com.dotcms.analytics.model.AccessTokenErrorType;
@@ -22,7 +23,6 @@ import java.time.Instant;
 import java.util.Base64;
 import java.util.concurrent.TimeUnit;
 
-import static com.dotcms.auth.providers.jwt.JsonWebTokenAuthCredentialProcessor.BEARER;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -219,22 +219,12 @@ public class AnalyticsHelperTest extends UnitTestBase {
 
     /**
      * Given an {@link AccessToken} instance
-     * Then evaluate token cannot be formatted since exception is thrown due to token validation
-     */
-    @Test(expected = AnalyticsException.class)
-    public void test_formatBearer_fail() throws AnalyticsException {
-        final AccessToken accessToken = createAccessToken(TokenStatus.NOOP);
-        AnalyticsHelper.get().formatBearer(accessToken);
-    }
-
-    /**
-     * Given an {@link AccessToken} instance
      * Then evaluate token can be formatted with Bearer type
      */
     @Test
     public void test_formatBearer() throws AnalyticsException {
         final AccessToken accessToken = createFreshAccessToken();
-        assertEquals(BEARER + accessToken.accessToken(), AnalyticsHelper.get().formatBearer(accessToken));
+        assertEquals(AnalyticsAPI.BEARER + accessToken.accessToken(), AnalyticsHelper.get().formatBearer(accessToken));
     }
 
     /**
@@ -242,7 +232,7 @@ public class AnalyticsHelperTest extends UnitTestBase {
      * Then evaluate key can be formatted with Basic type
      */
     @Test
-    public void test_formatBasic() throws AnalyticsException {
+    public void test_formatBasic() {
         final String key = "this-is-a-key";
         final AnalyticsKey analyticsKey = AnalyticsKey.builder().jsKey(key).build();
         assertEquals(WebResource.BASIC + key, AnalyticsHelper.get().formatBasic(analyticsKey));

--- a/dotcms-integration/src/test/java/com/dotcms/http/CircuitBreakerUrlTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/http/CircuitBreakerUrlTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 import com.dotcms.http.CircuitBreakerUrl.Method;
 import com.dotmarketing.util.UUIDUtil;
-import com.dotmarketing.util.UtilMethods;
 import com.google.common.collect.ImmutableMap;
 
 import net.jodah.failsafe.CircuitBreaker;
@@ -38,21 +37,17 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-
 public class CircuitBreakerUrlTest {
 
-    final static String goodUrl = "https://www.dotcms.com";
+    private static final String GOOD_URL = "https://www.dotcms.com";
+    private static final String REDIRECT_URL = "http://www.dotcms.com"; // this will redirect to https
+    private static final String BAD_URL = "https://localhost:9999/test";
+    private static final String HEADER = "X-MY-HEADER";
+    private static final String HEADER_VALUE = "SEEMS TO BE WORKING";
+    private static final String PARAM = "X-MY-PARAM";
+    private static final String PARAM_VALUE = "PARAM SEEMS TO BE WORKING";
 
-    // this will redirect to https
-    final static String redirectUrl = "http://www.dotcms.com";
-    final static String badUrl = "https://localhost:9999/test";
-
-    final static String HEADER="X-MY-HEADER";
-    final static String HEADER_VALUE="SEEMS TO BE WORKING";
-    final static String PARAM="X-MY-PARAM";
-    final static String PARAM_VALUE="PARAM SEEMS TO BE WORKING";
-
-    private CircuitBreakerUrl.Response response;
+    private CircuitBreakerUrl.Response<?> response;
 
     @Before
     public void setup() {
@@ -101,26 +96,24 @@ public class CircuitBreakerUrlTest {
     @Test
     public void testGoodBreaker() throws Exception {
 
-
         final NullOutputStream nos = new NullOutputStream();
 
         final String key = "testBreaker";
         final int timeout = 2000;
 
-        CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
+        CircuitBreaker breaker = CircuitBreakerPool.getBreaker(key);
 
         assert (breaker.isClosed());
 
         for (int i = 0; i < 10; i++) {
 
-            CircuitBreakerUrl cburl = CircuitBreakerUrl.builder().setUrl(goodUrl).setTimeout(timeout).setCircuitBreaker(breaker).build();
+            CircuitBreakerUrl cburl = CircuitBreakerUrl.builder().setUrl(GOOD_URL).setTimeout(timeout).setCircuitBreaker(breaker).build();
 
             cburl.doOut(nos);
         }
-        breaker = CurcuitBreakerPool.getBreaker(key);
+        breaker = CircuitBreakerPool.getBreaker(key);
         assert (breaker.isClosed());
     }
-
 
     @Test
     public void testBadBreaker() {
@@ -131,19 +124,19 @@ public class CircuitBreakerUrlTest {
             final String key = "testBadBreaker";
             final int timeout = 2000;
 
-            CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
+            CircuitBreaker breaker = CircuitBreakerPool.getBreaker(key);
             assert (breaker.isClosed());
 
             IPUtils.disabledIpPrivateSubnet(true);
 
             for (int i = 0; i < 10; i++) {
                 try {
-                    new CircuitBreakerUrl(badUrl, timeout, breaker).doOut(nos);
+                    new CircuitBreakerUrl(BAD_URL, timeout, breaker).doOut(nos);
                 } catch (Exception e) {
                     assert (e instanceof CircuitBreakerOpenException);
                 }
             }
-            breaker = CurcuitBreakerPool.getBreaker(key);
+            breaker = CircuitBreakerPool.getBreaker(key);
 
             assert (breaker.isOpen());
         }finally {
@@ -159,16 +152,15 @@ public class CircuitBreakerUrlTest {
             final String key = "testPrivateIP";
             final int timeout = 2000;
 
-            CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
+            CircuitBreaker breaker = CircuitBreakerPool.getBreaker(key);
             assert (breaker.isClosed());
 
             try {
-                new CircuitBreakerUrl(badUrl, timeout, breaker).doOut(nos);
+                new CircuitBreakerUrl(BAD_URL, timeout, breaker).doOut(nos);
             } catch (Exception e) {
                 assert (e instanceof DotRuntimeException);
                 assert (e.getMessage().contains("Remote HttpRequests cannot access private subnets"));
             }
-
     }
 
     /*
@@ -177,8 +169,6 @@ public class CircuitBreakerUrlTest {
      * which can be run via docker
      * docker run -p 80:80 kennethreitz/httpbin
      */
-
-
     //@Test
     public void testHeaders() throws CircuitBreakerOpenException, IOException {
         Map<String, String> headers = ImmutableMap.of(HEADER, HEADER_VALUE);
@@ -186,15 +176,12 @@ public class CircuitBreakerUrlTest {
         CircuitBreakerUrl cburl = CircuitBreakerUrl.builder().setMethod(Method.GET).setUrl("http://localhost/get").setTimeout(1000)
                 .setHeaders(headers).build();
 
-
         for (int i = 0; i < 10; i++) {
             String x = cburl.doString();
             assert (x.contains(HEADER_VALUE));
         }
-
     }
     
-
     /*
      * This requires 
      * http://httpbin.org
@@ -213,8 +200,8 @@ public class CircuitBreakerUrlTest {
             String x = cburl.doString();
             assert (x.contains(PARAM_VALUE));
         }
-
     }
+
     /*
      * @BeforeClass public static void prepare() throws Exception{ //Setting web app environment
      * IntegrationTestInitService.getInstance().init(); }
@@ -230,13 +217,13 @@ public class CircuitBreakerUrlTest {
             final String key = "testRecoveryBreaker";
             final int timeout = 2000;
 
-            CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
+            CircuitBreaker breaker = CircuitBreakerPool.getBreaker(key);
             breaker.withDelay(5, TimeUnit.SECONDS);
             assert (breaker.isClosed());
 
             for (int i = 0; i < breaker.getSuccessThreshold().denominator; i++) {
                 try {
-                    new CircuitBreakerUrl(goodUrl, timeout, breaker).doOut(nos);
+                    new CircuitBreakerUrl(GOOD_URL, timeout, breaker).doOut(nos);
                 } catch (Exception e) {
                     // shoud not be here
                     assert (false);
@@ -247,7 +234,7 @@ public class CircuitBreakerUrlTest {
 
             for (int i = 0; i < breaker.getFailureThreshold().denominator; i++) {
                 try {
-                    new CircuitBreakerUrl(badUrl, timeout, breaker).doOut(nos);
+                    new CircuitBreakerUrl(BAD_URL, timeout, breaker).doOut(nos);
                 } catch (Exception e) {
                     assert (e instanceof CircuitBreakerOpenException);
                 }
@@ -255,7 +242,7 @@ public class CircuitBreakerUrlTest {
             assert (breaker.isOpen());
             for (int i = 0; i < breaker.getFailureThreshold().denominator; i++) {
                 try {
-                    new CircuitBreakerUrl(badUrl, timeout, breaker).doOut(nos);
+                    new CircuitBreakerUrl(BAD_URL, timeout, breaker).doOut(nos);
                 } catch (CircuitBreakerOpenException e) {
                     assert (e instanceof CircuitBreakerOpenException);
                 }
@@ -263,7 +250,7 @@ public class CircuitBreakerUrlTest {
             Thread.sleep(breaker.getDelay().toMillis() + 1000);
 
             try {
-                new CircuitBreakerUrl(goodUrl, timeout, breaker).doOut(nos);
+                new CircuitBreakerUrl(GOOD_URL, timeout, breaker).doOut(nos);
             } catch (Exception e) {
                 // shoud not be here
                 assert (false);
@@ -273,7 +260,7 @@ public class CircuitBreakerUrlTest {
 
             for (int i = 0; i < breaker.getSuccessThreshold().denominator; i++) {
                 try {
-                    new CircuitBreakerUrl(goodUrl, timeout, breaker).doOut(nos);
+                    new CircuitBreakerUrl(GOOD_URL, timeout, breaker).doOut(nos);
                 } catch (Exception e) {
                     // shoud not be here
                     assert (false);
@@ -289,20 +276,18 @@ public class CircuitBreakerUrlTest {
     @Test
     public void testBreakerPool() {
 
-
         final String key = UUIDUtil.uuid();
         final int success = 500;
 
-        CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
+        CircuitBreaker breaker = CircuitBreakerPool.getBreaker(key);
         assert (breaker.isClosed());
         breaker.withSuccessThreshold(success);
         assert (breaker.getSuccessThreshold().denominator == success);
 
-        CircuitBreaker breaker2 = CurcuitBreakerPool.getBreaker(key);
+        CircuitBreaker breaker2 = CircuitBreakerPool.getBreaker(key);
 
         assert (breaker.equals(breaker2));
         assert (breaker2.getSuccessThreshold().denominator == success);
-
     }
 
     @Test
@@ -311,17 +296,14 @@ public class CircuitBreakerUrlTest {
         final String key = "testBreaker";
         final int timeout = 2000;
 
-        CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
+        CircuitBreaker breaker = CircuitBreakerPool.getBreaker(key);
         assert (breaker.isClosed());
 
         for (int i = 0; i < 10; i++) {
-            String x = new CircuitBreakerUrl(goodUrl, timeout, breaker).doString();
+            String x = new CircuitBreakerUrl(GOOD_URL, timeout, breaker).doString();
             assert (x.length() > 100);
         }
-
-
     }
-
 
     @Test(expected = BadRequestException.class)
     public void disallowRedirects() throws Exception {
@@ -329,53 +311,18 @@ public class CircuitBreakerUrlTest {
         final String key = "testBreaker";
         final int timeout = 2000;
 
-        CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
+        CircuitBreaker breaker = CircuitBreakerPool.getBreaker(key);
         assert (breaker.isClosed());
 
 
-        new CircuitBreakerUrl(redirectUrl, timeout, breaker).doString();
-    }
-
-
-
-
-
-    public void testMemory() throws Exception {
-        System.gc();
-
-        Thread.sleep(3000);
-
-
-        long startMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-        final NullOutputStream nos = new NullOutputStream();
-
-
-        final String key = "testBreaker";
-        final int timeout = 2000;
-
-        CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
-        assert (breaker.isClosed());
-
-        for (int i = 0; i < 1000; i++) {
-            new CircuitBreakerUrl(goodUrl, timeout, breaker).doOut(nos);
-        }
-        breaker = CurcuitBreakerPool.getBreaker(key);
-        assert (breaker.isClosed());
-        CurcuitBreakerPool.flushPool();
-        System.gc();
-        Thread.sleep(3000);
-        long endMem = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-
-        System.out.println("start:" + UtilMethods.prettyMemory(startMem));
-        System.out.println("end  :" + UtilMethods.prettyMemory(endMem));
-        System.out.println("diff :" + UtilMethods.prettyMemory(endMem - startMem));
+        new CircuitBreakerUrl(REDIRECT_URL, timeout, breaker).doString();
     }
 
     @Test
     public void testGet() {
         for (int i = 0; i < 10; i++) {
             try {
-                String x = new CircuitBreakerUrl(goodUrl, 2000).doString();
+                String x = new CircuitBreakerUrl(GOOD_URL, 2000).doString();
                 assert (x.contains("content=\"dotCMS\""));
 
             } catch (Exception e) {
@@ -396,7 +343,7 @@ public class CircuitBreakerUrlTest {
         final String key = "testBreaker";
         final int timeout = 2000;
 
-        CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
+        CircuitBreaker breaker = CircuitBreakerPool.getBreaker(key);
 
         assert (breaker.isClosed());
 
@@ -424,7 +371,7 @@ public class CircuitBreakerUrlTest {
         final String key = "testBreaker";
         final int timeout = 2000;
 
-        CircuitBreaker breaker = CurcuitBreakerPool.getBreaker(key);
+        CircuitBreaker breaker = CircuitBreakerPool.getBreaker(key);
 
         assert (breaker.isClosed());
 
@@ -433,7 +380,7 @@ public class CircuitBreakerUrlTest {
             .setUrl("https://run.mocky.io/v3/434b4b0e-9a8b-4895-88e3-beab1b8d0a0d")
             .setMethod(Method.POST)
             .setTimeout(timeout).setCircuitBreaker(breaker)
-            .setThrowWhenNot2xx(false)
+            .setThrowWhenError(false)
             .build();
         cburl.doOut(nos);
 
@@ -469,5 +416,4 @@ public class CircuitBreakerUrlTest {
         when(response.getStatusCode()).thenReturn(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         assertFalse(CircuitBreakerUrl.isSuccessResponse(response));
     }
-
 }

--- a/justfile
+++ b/justfile
@@ -126,15 +126,15 @@ build-core-only:
 test-integration-ide:
     ./mvnw -pl :dotcms-integration pre-integration-test -Dcoreit.test.skip=false -Dtomcat.port=8080
 
+# Stops integration test services
+test-integration-stop:
+    ./mvnw -pl :dotcms-integration -Pdocker-stop -Dcoreit.test.skip=false
+
 test-postman-ide:
     ./mvnw -pl :dotcms-test-karate pre-integration-test -Dpostman.test.skip=false -Dtomcat.port=8080
 
 test-karate-ide:
     ./mvnw -pl :dotcms-test-karate pre-integration-test -Dkarate.test.skip=false -Dtomcat.port=8080
-
-# Stops integration test services
-test-integration-stop:
-    ./mvnw -pl :dotcms-integration -Pdocker-stop -Dcoreit.test.skip=false
 
 # Executes Java E2E tests
 test-e2e-java:


### PR DESCRIPTION
Introducing usage of `CircuitBreakerUrl` instead of custom HTTP client wrapper to provide a  more robust way of consuming the OpenAI API.
Better way of identifying errors from OpenAI to handle and whether or not to end up invalidating the model if it is justified enough.
Unit and ITs were updated.


This PR fixes: #31457