### PR TITLE
#31571: adding 'QA : Passed' label considerations

### DIFF
--- a/.github/workflows/issue_on-change_post-issue-edited.yml
+++ b/.github/workflows/issue_on-change_post-issue-edited.yml
@@ -18,7 +18,7 @@ jobs:
     uses: ./.github/workflows/issue_comp_label-conditional-labeling.yml
     with:
       issue_number: ${{ github.event.issue.number }}
-      evaluating_labels: 'QA : Approved,QA : Passed Internal,QA : Not Needed'
+      evaluating_labels: 'QA : Approved,QA : Passed Internal,QA : Passed,QA : Not Needed'
       evaluated_labels: '${{ github.event.label.name }}'
       ignore_issue_labels: 'Next Release'
       new_labels: 'Next Release'


### PR DESCRIPTION
Adding `QA : Passed` to current GHA workflow code.

This PR fixes: #31571