### PR TITLE
31563 creating a file in a secondary language wont return the file information

### DIFF
--- a/core-web/libs/data-access/src/lib/dot-resource-links/dot-resource-links.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-resource-links/dot-resource-links.service.spec.ts
@@ -11,7 +11,7 @@ describe('DotResourceLinksService', () => {
     it('should get file source links', (done) => {
         const props = {
             fieldVariable: 'testField',
-            inodeOrIdentifier: 'testInode'
+            inode: 'testInode'
         };
 
         const response: DotResourceLinks = {
@@ -22,13 +22,13 @@ describe('DotResourceLinksService', () => {
             versionPath: 'testVersionPath'
         };
 
-        spectator.service.getFileResourceLinks(props).subscribe((resp) => {
+        spectator.service.getFileResourceLinksByInode(props).subscribe((resp) => {
             expect(resp).toEqual(response);
             done();
         });
 
         const req = spectator.expectOne(
-            `/api/v1/content/resourcelinks/field/${props.fieldVariable}?identifier=${props.inodeOrIdentifier}`,
+            `/api/v1/content/resourcelinks/field/${props.fieldVariable}?inode=${props.inode}`,
             HttpMethod.GET
         );
 

--- a/core-web/libs/data-access/src/lib/dot-resource-links/dot-resource-links.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-resource-links/dot-resource-links.service.ts
@@ -31,6 +31,18 @@ export class DotResourceLinksService {
     private readonly httpClient = inject(HttpClient);
 
     /**
+     * Helper method to get resource links with common HTTP GET and entity plucking logic
+     *
+     * @private
+     * @param {string} url - The complete URL to make the GET request
+     * @return {*}  {Observable<DotResourceLinks>}
+     * @memberof DotResourceLinksService
+     */
+    private getResourceLinks(url: string): Observable<DotResourceLinks> {
+        return this.httpClient.get(url).pipe(pluck('entity'));
+    }
+
+    /**
      * It returns the source links for a file
      *
      * @param {DotSourceLinksProps}
@@ -41,9 +53,7 @@ export class DotResourceLinksService {
         fieldVariable,
         identifier
     }: DotSourceLinksProps): Observable<DotResourceLinks> {
-        return this.httpClient
-            .get(`${this.basePath}/${fieldVariable}?identifier=${identifier}`)
-            .pipe(pluck('entity'));
+        return this.getResourceLinks(`${this.basePath}/${fieldVariable}?identifier=${identifier}`);
     }
 
     /**
@@ -57,8 +67,6 @@ export class DotResourceLinksService {
         fieldVariable,
         inode
     }: DotSourceLinksByInodeProps): Observable<DotResourceLinks> {
-        return this.httpClient
-            .get(`${this.basePath}/${fieldVariable}?inode=${inode}`)
-            .pipe(pluck('entity'));
+        return this.getResourceLinks(`${this.basePath}/${fieldVariable}?inode=${inode}`);
     }
 }

--- a/core-web/libs/data-access/src/lib/dot-resource-links/dot-resource-links.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-resource-links/dot-resource-links.service.ts
@@ -15,7 +15,12 @@ export interface DotResourceLinks {
 
 interface DotSourceLinksProps {
     fieldVariable: string;
-    inodeOrIdentifier: string;
+    identifier: string;
+}
+
+interface DotSourceLinksByInodeProps {
+    fieldVariable: string;
+    inode: string;
 }
 
 @Injectable({
@@ -32,12 +37,28 @@ export class DotResourceLinksService {
      * @return {*}  {Observable<DotResourceLinks>}
      * @memberof DotResourceLinksService
      */
-    getFileResourceLinks({
+    getFileResourceLinksByIdentifier({
         fieldVariable,
-        inodeOrIdentifier
+        identifier
     }: DotSourceLinksProps): Observable<DotResourceLinks> {
         return this.httpClient
-            .get(`${this.basePath}/${fieldVariable}?identifier=${inodeOrIdentifier}`)
+            .get(`${this.basePath}/${fieldVariable}?identifier=${identifier}`)
+            .pipe(pluck('entity'));
+    }
+
+    /**
+     * It returns the source links for a file by inode
+     *
+     * @param {DotSourceLinksByInodeProps}
+     * @return {*}  {Observable<DotResourceLinks>}
+     * @memberof DotResourceLinksService
+     */
+    getFileResourceLinksByInode({
+        fieldVariable,
+        inode
+    }: DotSourceLinksByInodeProps): Observable<DotResourceLinks> {
+        return this.httpClient
+            .get(`${this.basePath}/${fieldVariable}?inode=${inode}`)
             .pipe(pluck('entity'));
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.spec.ts
@@ -264,7 +264,7 @@ describe('DotBinaryFieldPreviewComponent', () => {
 
             expect(spyResourceLinks).toHaveBeenCalledWith({
                 fieldVariable: 'Binary',
-                inodeOrIdentifier: CONTENTLET_MOCK.identifier
+                inode: CONTENTLET_MOCK.inode
             });
         });
 
@@ -283,7 +283,7 @@ describe('DotBinaryFieldPreviewComponent', () => {
             expect(resourceLinkElement).toBeNull();
             expect(spyResourceLinks).toHaveBeenCalledWith({
                 fieldVariable: 'Binary',
-                inodeOrIdentifier: CONTENTLET_MOCK.identifier
+                inode: CONTENTLET_MOCK.inode
             });
         });
 
@@ -304,7 +304,7 @@ describe('DotBinaryFieldPreviewComponent', () => {
 
             expect(spyResourceLinks).toHaveBeenCalledWith({
                 fieldVariable: 'Binary',
-                inodeOrIdentifier: CONTENTLET_MOCK.identifier
+                inode: CONTENTLET_MOCK.inode
             });
         }));
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.spec.ts
@@ -245,7 +245,7 @@ describe('DotBinaryFieldPreviewComponent', () => {
 
         it('should have the correct resource links', () => {
             const spyResourceLinks = jest
-                .spyOn(dotResourceLinksService, 'getFileResourceLinks')
+                .spyOn(dotResourceLinksService, 'getFileResourceLinksByInode')
                 .mockReturnValue(of(RESOURCE_LINKS));
 
             spectator.detectChanges();
@@ -270,7 +270,7 @@ describe('DotBinaryFieldPreviewComponent', () => {
 
         it('should not have the Resource-Link', () => {
             const spyResourceLinks = jest
-                .spyOn(dotResourceLinksService, 'getFileResourceLinks')
+                .spyOn(dotResourceLinksService, 'getFileResourceLinksByInode')
                 .mockReturnValue(of(RESOURCE_LINKS));
             spectator.setInput('contentlet', CONTENTLET_HTMLPAGE_MOCK);
 
@@ -289,7 +289,7 @@ describe('DotBinaryFieldPreviewComponent', () => {
 
         it('should have the loading state', fakeAsync(() => {
             const spyResourceLinks = jest
-                .spyOn(dotResourceLinksService, 'getFileResourceLinks')
+                .spyOn(dotResourceLinksService, 'getFileResourceLinksByInode')
                 .mockReturnValue(of(RESOURCE_LINKS).pipe(delay(1000)));
 
             spectator.detectChanges();

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.ts
@@ -139,9 +139,9 @@ export class DotBinaryFieldPreviewComponent implements OnInit, OnChanges {
      */
     private fetchResourceLinks(): void {
         this.#dotResourceLinksService
-            .getFileResourceLinks({
+            .getFileResourceLinksByInode({
                 fieldVariable: this.fieldVariable,
-                inodeOrIdentifier: this.contentlet.identifier
+                inode: this.contentlet.inode
             })
             .pipe(
                 catchError(() => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.ts
@@ -90,7 +90,6 @@ type SystemOptionsType = {
         InputTextModule,
         DotBinaryFieldUrlModeComponent,
         DotBinaryFieldPreviewComponent,
-        DotAIImagePromptComponent,
         TooltipModule
     ],
     providers: [

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field-preview/dot-file-field-preview.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field-preview/dot-file-field-preview.component.spec.ts
@@ -28,7 +28,7 @@ describe('DotFileFieldPreviewComponent', () => {
         providers: [provideHttpClient()],
         componentProviders: [
             mockProvider(DotResourceLinksService, {
-                getFileResourceLinks: jest.fn().mockReturnValue(
+                getFileResourceLinksByInode: jest.fn().mockReturnValue(
                     of({
                         configuredImageURL: 'testConfiguredImageURL',
                         idPath: 'testIdPath',
@@ -136,7 +136,9 @@ describe('DotFileFieldPreviewComponent', () => {
         });
 
         it('should handle a error in fetchResourceLinks', async () => {
-            dotResourceLinksService.getFileResourceLinks.mockReturnValue(throwError('error'));
+            dotResourceLinksService.getFileResourceLinksByInode.mockReturnValue(
+                throwError('error')
+            );
             spectator.detectChanges();
         });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field-preview/dot-file-field-preview.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field-preview/dot-file-field-preview.component.ts
@@ -165,9 +165,9 @@ export class DotFileFieldPreviewComponent implements OnInit {
      */
     private fetchResourceLinks(contentlet: DotCMSContentlet, contentType: string): void {
         this.#dotResourceLinksService
-            .getFileResourceLinks({
+            .getFileResourceLinksByInode({
                 fieldVariable: contentType,
-                inodeOrIdentifier: contentlet.identifier
+                inode: contentlet.inode
             })
             .pipe(
                 catchError(() => {


### PR DESCRIPTION
### Issue

#31563 

### Proposed Changes

This pull request includes changes to the `DotResourceLinksService` and related components to differentiate between fetching file resource links by inode and by identifier. The most important changes include updating method names and parameters, adjusting test cases, and modifying service calls accordingly.

### Service and Method Updates:

* [`core-web/libs/data-access/src/lib/dot-resource-links/dot-resource-links.service.ts`](diffhunk://#diff-3d7600b87cfd8feceede7f444d4d862375d7efcd5badb370334aa9021f9be515L18-R23): Introduced `DotSourceLinksByInodeProps` interface and added `getFileResourceLinksByInode` method to fetch resource links by inode. Updated `getFileResourceLinks` to `getFileResourceLinksByIdentifier` and adjusted parameters. [[1]](diffhunk://#diff-3d7600b87cfd8feceede7f444d4d862375d7efcd5badb370334aa9021f9be515L18-R23) [[2]](diffhunk://#diff-3d7600b87cfd8feceede7f444d4d862375d7efcd5badb370334aa9021f9be515L35-R61)

### Test Case Adjustments:

* [`core-web/libs/data-access/src/lib/dot-resource-links/dot-resource-links.service.spec.ts`](diffhunk://#diff-7899988cbef0683e29e899b1884de48b220bd11f1ba8ddbb3042d496d5eb0b15L14-R14): Updated test cases to use `getFileResourceLinksByInode` instead of `getFileResourceLinks`. [[1]](diffhunk://#diff-7899988cbef0683e29e899b1884de48b220bd11f1ba8ddbb3042d496d5eb0b15L14-R14) [[2]](diffhunk://#diff-7899988cbef0683e29e899b1884de48b220bd11f1ba8ddbb3042d496d5eb0b15L25-R31)
* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.spec.ts`](diffhunk://#diff-cb19f31a23d9758fc769d34090ae6488e54ef2c23d514d7144c2b6962b7fabeaL248-R248): Modified test cases to mock and use `getFileResourceLinksByInode`. [[1]](diffhunk://#diff-cb19f31a23d9758fc769d34090ae6488e54ef2c23d514d7144c2b6962b7fabeaL248-R248) [[2]](diffhunk://#diff-cb19f31a23d9758fc769d34090ae6488e54ef2c23d514d7144c2b6962b7fabeaL273-R273) [[3]](diffhunk://#diff-cb19f31a23d9758fc769d34090ae6488e54ef2c23d514d7144c2b6962b7fabeaL292-R292)
* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field-preview/dot-file-field-preview.component.spec.ts`](diffhunk://#diff-caef24a96b619132274ae663004cf76143ff13dada6d94f6169f8422661d7428L31-R31): Updated test cases to mock and use `getFileResourceLinksByInode`. [[1]](diffhunk://#diff-caef24a96b619132274ae663004cf76143ff13dada6d94f6169f8422661d7428L31-R31) [[2]](diffhunk://#diff-caef24a96b619132274ae663004cf76143ff13dada6d94f6169f8422661d7428L139-R141)

### Component Service Call Modifications:

* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-preview/dot-binary-field-preview.component.ts`](diffhunk://#diff-4cb120d0d51e1f421fd5c5ee1ad50d3a8d4b820c338a64fcdc26473048cfe1f3L142-R144): Updated service call to use `getFileResourceLinksByInode` instead of `getFileResourceLinks`.
* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field-preview/dot-file-field-preview.component.ts`](diffhunk://#diff-9d3250303440cce67e959a59ed17f44ad49d690c04e36cbf4fadc011f206001eL168-R170): Modified service call to use `getFileResourceLinksByInode` instead of `getFileResourceLinks`.

### Miscellaneous:

* [`core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.ts`](diffhunk://#diff-06beb921499e762bd5f4d25d68d0a24a22477acf79372fb0350ee6d9a7b0c01aL93): Removed unused `DotAIImagePromptComponent` from module imports.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
 <img width="596" alt="Screenshot 2025-03-10 at 3 03 22 PM" src="https://github.com/user-attachments/assets/62caad55-a952-42be-b015-3e46bfccddb6" /> | <img width="590" alt="Screenshot 2025-03-10 at 3 03 33 PM" src="https://github.com/user-attachments/assets/b5eafb41-797b-4550-9f85-3ac9d7aa60b9" />



This PR fixes: #31563