### PR TITLE
fix(sdk): Error Throw outside UVE

### DIFF
--- a/core-web/libs/sdk/uve/src/internal/constants.ts
+++ b/core-web/libs/sdk/uve/src/internal/constants.ts
@@ -28,3 +28,18 @@ export const __UVE_EVENTS__: Record<string, UVEEvent> = {
         };
     }
 };
+
+/**
+ * Default UVE event
+ *
+ * @param {string} event - The event to subscribe to.
+ * @internal
+ */
+export const __UVE_EVENT_ERROR_FALLBACK__ = (event: string) => {
+    return {
+        unsubscribe: () => {
+            /* do nothing */
+        },
+        event
+    };
+};

--- a/core-web/libs/sdk/uve/src/lib/utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/utils.ts
@@ -76,13 +76,31 @@ export function getUVEState(): UVEState | undefined {
  */
 export function createUVESubscription(event: string, callback: UVECallback): UVESubscription {
     if (!getUVEState()) {
-        throw new Error('UVE Subscription: Not running inside UVE');
+        console.warn('UVE Subscription: Not running inside UVE');
+
+        return {
+            unsubscribe: () => {
+                /*
+                 * Do nothing
+                 */
+            },
+            event
+        };
     }
 
     const eventCallback = __UVE_EVENTS__[event];
 
     if (!eventCallback) {
-        throw new Error(`UVE Subscription: Event ${event} not found`);
+        console.error(`UVE Subscription: Event ${event} not found`);
+
+        return {
+            unsubscribe: () => {
+                /*
+                 * Do nothing
+                 */
+            },
+            event
+        };
     }
 
     return eventCallback(callback);

--- a/core-web/libs/sdk/uve/src/lib/utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import { UVE_MODE, UVECallback, UVEState, UVESubscription } from './types';
 
-import { __UVE_EVENTS__ } from '../internal/constants';
+import { __UVE_EVENTS__, __UVE_EVENT_ERROR_FALLBACK__ } from '../internal/constants';
 
 /**
  * Gets the current state of the Universal Visual Editor (UVE).
@@ -78,14 +78,7 @@ export function createUVESubscription(event: string, callback: UVECallback): UVE
     if (!getUVEState()) {
         console.warn('UVE Subscription: Not running inside UVE');
 
-        return {
-            unsubscribe: () => {
-                /*
-                 * Do nothing
-                 */
-            },
-            event
-        };
+        return __UVE_EVENT_ERROR_FALLBACK__(event);
     }
 
     const eventCallback = __UVE_EVENTS__[event];
@@ -93,14 +86,7 @@ export function createUVESubscription(event: string, callback: UVECallback): UVE
     if (!eventCallback) {
         console.error(`UVE Subscription: Event ${event} not found`);
 
-        return {
-            unsubscribe: () => {
-                /*
-                 * Do nothing
-                 */
-            },
-            event
-        };
+        return __UVE_EVENT_ERROR_FALLBACK__(event);
     }
 
     return eventCallback(callback);


### PR DESCRIPTION
This pull request includes changes to the `createUVESubscription` function and its related tests to improve error handling and logging. The most important changes are as follows:

### Improvements to Error Handling and Logging:

* [`core-web/libs/sdk/uve/src/lib/utils.ts`](diffhunk://#diff-9cb9e61b3ad482cd4dafebfdb3d19e42876b180919442cc0e19e0d4a5b30bab7L79-R103): Modified `createUVESubscription` to log warnings and errors instead of throwing exceptions when not running inside UVE or when an invalid event is provided. The function now returns a subscription object with an `unsubscribe` method that does nothing in these cases.

### Updates to Unit Tests:

* [`core-web/libs/sdk/uve/src/lib/utils.spec.ts`](diffhunk://#diff-3171d3b9211959cd7faf576c2af2e689b837cbf14b375017e85fa03644d05fdaL270-R293): Updated the test case for when not running inside UVE to check for a logged warning instead of an error, and to verify the returned subscription object.
* [`core-web/libs/sdk/uve/src/lib/utils.spec.ts`](diffhunk://#diff-3171d3b9211959cd7faf576c2af2e689b837cbf14b375017e85fa03644d05fdaL297-R314): Updated the test case for an invalid event to check for a logged error instead of an exception, and to verify the returned subscription object.

This PR fixes: #31226