### PR TITLE
#31571: enabling multi-release per day version naming strategy

### DIFF
--- a/.github/workflows/cicd_release-cli.yml
+++ b/.github/workflows/cicd_release-cli.yml
@@ -266,8 +266,28 @@ jobs:
             NPM_PACKAGE_VERSION=${MVN_BASE_VERSION}${RC_SUFFIX}
           else
             echo "::debug::Release version found."
+            # Normalize release version by removing leading zeros from each component
+            # Split the version into main version and pre-release parts (if any)
+            MAIN_VERSION=$(echo "$MVN_PACKAGE_VERSION" | cut -d '-' -f 1)
+            PRE_RELEASE=$(echo "$MVN_PACKAGE_VERSION" | cut -s -d '-' -f 2)
+          
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$MAIN_VERSION"
+            MAJOR=$(echo "$MAJOR" | sed 's/^0*//')
+            MINOR=$(echo "$MINOR" | sed 's/^0*//')
+            PATCH=$(echo "$PATCH" | sed 's/^0*//')
+            NORMALIZED_MAIN="${MAJOR}.${MINOR}.${PATCH}"
+
+            if [[ -n "$PRE_RELEASE" ]]; then
+              # Remove leading zeros from the pre-release part as well
+              PRE_RELEASE=$(echo "$PRE_RELEASE" | sed 's/^0*//')
+              NORMALIZED_VERSION="${NORMALIZED_MAIN}-${PRE_RELEASE}"
+            else
+              NORMALIZED_VERSION="${NORMALIZED_MAIN}"
+            fi
+
             NPM_PACKAGE_VERSION_TAG="latest"
-            NPM_PACKAGE_VERSION=${MVN_PACKAGE_VERSION}
+            NPM_PACKAGE_VERSION="${NORMALIZED_VERSION}"
+            echo "::debug::Normalized NPM_PACKAGE_VERSION: ${NPM_PACKAGE_VERSION}"
           fi;
           echo "::debug::NPM_PACKAGE_VERSION: $NPM_PACKAGE_VERSION"
           echo "::debug::NPM_PACKAGE_VERSION_TAG: $NPM_PACKAGE_VERSION_TAG"

--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -178,7 +178,7 @@ jobs:
             if [[ "${is_trunk}" == 'true' ]]; then
               is_trunk_snapshot=true
             fi
-          elif [[ ${version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}$ ]]; then
+          elif [[ ${version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}-[0-9]{1,2}$ ]]; then
             is_release=true
             is_latest=true
           elif [[ ${version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}_lts$ ]]; then

--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Release Version (yy.mm.dd_## or yy.mm.dd_lts_v##] ##: counter)'
+        description: 'Release Version (yy.mm.dd-## or yy.mm.dd_lts_v##] ##: counter)'
         required: true
       release_commit:
         description: 'Commit Hash (default to latest commit)'

--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Validate Inputs
         run: |
           release_version=${{ github.event.inputs.release_version }}
-          if [[ ! ${release_version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}(_[0-9]{1,2}|_lts_v[0-9]{1,2})$ ]]; then
+          if [[ ! ${release_version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}(-[0-9]{1,2}|_lts_v[0-9]{1,2})$ ]]; then
             echo 'Release version must be in the format yy.mm.dd-counter or yy.mm.dd_lts_v##'
             exit 1
           fi

--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Release Version (yy.mm.dd[_lts_v##]])'
+        description: 'Release Version (yy.mm.dd_## or yy.mm.dd_lts_v##] ##: counter)'
         required: true
       release_commit:
         description: 'Commit Hash (default to latest commit)'
@@ -47,8 +47,9 @@ jobs:
     steps:
       - name: Validate Inputs
         run: |
-          if [[ ! ${{ github.event.inputs.release_version }} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}(_lts_v[0-9]{1,2})?$ ]]; then
-            echo 'Release version must be in the format yy.mm.dd or yy.mm.dd_lts_v##'
+          release_version=${{ github.event.inputs.release_version }}
+          if [[ ! ${release_version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}(_[0-9]{1,2}|_lts_v[0-9]{1,2})$ ]]; then
+            echo 'Release version must be in the format yy.mm.dd-counter or yy.mm.dd_lts_v##'
             exit 1
           fi
 
@@ -311,13 +312,20 @@ jobs:
       - name: Update Plugins
         run: |
           release_version=${{ needs.prepare-release.outputs.release_version }}
-          curl -L \
+          response=$(curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.CI_MACHINE_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/dotCMS/plugin-seeds/dispatches \
-            -d "{\"event_type\": \"on-plugins-release\", \"client_payload\": {\"release_version\": \"$release_version\"}}"
+            -d "{\"event_type\": \"on-plugins-release\", \"client_payload\": {\"release_version\": \"$release_version\"}}" \
+            -w "\n%{http_code}" \
+            -s)
+          http_code=$(echo "$response" | tail -n1)
+          if [ "${http_code}" != "204" ]; then
+            echo "Failed to dispatch workflow. HTTP code: $http_code"
+            echo "Response: $response"
+          fi
         if: github.event.inputs.update_plugins == 'true'
 
   build-push-image:


### PR DESCRIPTION
### Proposed changes
* Introducing new release version naming convention to allow having more than one release per day.
* This pull request includes several changes to the CI/CD workflow files to normalize version numbers and improve validation and error handling. The most important changes include normalizing release versions by removing leading zeros, updating version validation patterns, and improving error handling for HTTP requests.

Normalization of release versions:

* Added steps to normalize release version by removing leading zeros from each component and pre-release part.

Validation pattern updates:

* Updated the version validation pattern to include an optional counter part.
* Updated the description and validation pattern for `release_version` input to include an optional counter part. 

Improved error handling:

* Enhanced error handling for the HTTP request to dispatch a workflow by capturing and checking the HTTP response code.

### Fixes
#31546 

This PR fixes: #31546