### PR TITLE
feat(dotcms): enable Content Editor V2 in configuration

### DIFF
--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -845,7 +845,7 @@ storage.file-metadata.chain3=FILE_SYSTEM,DB,S3,MEMORY
 FEATURE_FLAG_TELEMETRY=false
 
 ## Content Editor V2
-CONTENT_EDITOR2_ENABLED=false
+CONTENT_EDITOR2_ENABLED=true
 
 ## Localizations Enhancements
 LOCALIZATION_ENHANCEMENTS_ENABLED=false


### PR DESCRIPTION
Updated the  file to enable the Content Editor V2 feature by setting  to true. This change allows users to access the new content editing capabilities. Refs: #31579

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Local Docker builded
![CleanShot 2025-03-14 at 17 02 28@2x](https://github.com/user-attachments/assets/280abd61-73d7-4ca8-88f1-4e1382d7e0d4)

This PR fixes: #31579