### PR TITLE
fix(view-categories): Simplify hash decoding in view_categories.jsp

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories.jsp
@@ -84,7 +84,7 @@
     var actions = "";
 
     function refresh() {
-        var hashReceived = decodeURIComponent(dojo.hash());
+        var hashReceived = dojo.hash();
         var inode = "0";
         var name = "<%= LanguageUtil.get(pageContext, "Top-Level") %>";
         var hashToSend = null;


### PR DESCRIPTION
### Issue

#31564 

### Proposed Changes

This pull request includes a small change to the `dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories.jsp` file. The change simplifies the `hashReceived` variable assignment by removing the `decodeURIComponent` function.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)



This PR fixes: #31564