### PR TITLE
fix(ContentSelector): Remove event.stopPropagation() from selectButton click handler

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
@@ -1322,7 +1322,6 @@ dojo.declare(
                     );
                     if (selectButton.onclick == undefined) {
                         selectButton.onclick = dojo.hitch(this, function (event) {
-                            event.stopPropagation();
                             selected(this, asset);
                         });
                     }


### PR DESCRIPTION
### Issue

#31601 

### Proposed Changes

This pull request includes a small change to the `ContentSelector.js` file. The change removes the call to `event.stopPropagation()` within the `selectButton.onclick` function to prevent event propagation from being stopped when an asset is selected.

* [`dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js`](diffhunk://#diff-3c939da7ae98cd8b01189b9ac69f351c5206c43b9109710ba216327898c836f3L1325): Removed the call to `event.stopPropagation()` in the `selectButton.onclick` function.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info

https://github.com/user-attachments/assets/900a27aa-3cfb-4f60-9ad4-d3a85b2a0c7a



This PR fixes: #31601