### PR TITLE
fix ( edit content): #31669 Don't disabled form fields when content is blocked. 

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -189,14 +189,13 @@ export class DotEditContentFormComponent implements OnInit {
 
     constructor() {
         /**
-         * Effect that enables or disables the form based on the loading or locked state.
+         * Effect that enables or disables the form based on the loading state.
          */
         effect(
             () => {
                 const isLoading = this.$store.isLoading();
-                const isLocked = this.$store.isContentLocked();
 
-                if (isLoading || isLocked) {
+                if (isLoading) {
                     this.form.disable();
                 } else {
                     this.form.enable();


### PR DESCRIPTION
### Proposed Changes
* Form fields should not be disabled when the content is locked.

This PR fixes: #31669