### PR TITLE
feat(Analytics) : Analytics App fails to generate API Key

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/AnalyticsAPIImpl.java
@@ -420,13 +420,23 @@ public class AnalyticsAPIImpl implements AnalyticsAPI, EventSubscriber<SystemTab
             .setUrl(analyticsApp.getAnalyticsProperties().analyticsConfigUrl())
             .setTimeout(analyticsKeyRenewTimeout.get())
             .setTryAgainAttempts(analyticsKeyRenewAttempts.get())
-            .setAuthHeaders(accessToken.accessToken())
+            .setHeaders(analyticsKeyHeaders(accessToken))
             .setThrowWhenError(false)
             .build()
             .doResponse(AnalyticsKey.class);
         logKeyResponse(response, analyticsApp);
 
         return response;
+    }
+
+    /**
+     * Prepares access token request headers in a {@link Map} with values found in a {@link AccessToken} instance.
+     *
+     * @param accessToken access token
+     * @return map representation of http headers
+     */
+    private Map<String, String> analyticsKeyHeaders(final AccessToken accessToken) throws AnalyticsException {
+        return CircuitBreakerUrl.authHeaders(AnalyticsHelper.get().formatBearer(accessToken));
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/http/CircuitBreakerUrl.java
+++ b/dotCMS/src/main/java/com/dotcms/http/CircuitBreakerUrl.java
@@ -10,6 +10,7 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.liferay.util.StringPool;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
@@ -34,6 +35,8 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.constraints.NotNull;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -381,6 +384,13 @@ public class CircuitBreakerUrl {
         if (UtilMethods.isSet(contentLengthHeader)) {
             response.setHeader(contentLengthHeader.getName(), contentLengthHeader.getValue());
         }
+    }
+
+    public static Map<String, String> authHeaders(final String token) {
+        return ImmutableMap.<String, String>builder()
+                .put(HttpHeaders.AUTHORIZATION, token)
+                .put(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON)
+                .build();
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes
* Reverting some of the code changes made here: https://github.com/dotCMS/core/commit/1cb9b920ef201142184cd446019089102d176750#diff-6710105ea300c1ca8d936cd53f76b7ad3e29073acbe272457758dd72b1f63f13
* Part of the code changes in the previous commit modified the way the authentication header was being set when requesting the Analytics Key. After bringing the previous code back, the key is being returned as expected.

This PR fixes: #31675