### PR TITLE
feat(clone): allow maxSize limit to prevent downloading huge assets (videos) when cloning as site

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/view_cms_maintenance.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/view_cms_maintenance.jsp
@@ -1238,8 +1238,6 @@ function assetHostListTable_deleteHost(hostId){
                 }
                 let oldAssets = dijit.byId("oldAssetsRadioIdTrue").checked;
                 let maxFileSize = dijit.byId("maxFileSize").get("value");
-
-                alert(downloadUrl + "?oldAssets=" + oldAssets + "&maxSize=" + maxFileSize)
                 location.href = downloadUrl + "?oldAssets=" + oldAssets + "&maxSize=" + maxFileSize;
                 assetExportDialog.hide();
             }


### PR DESCRIPTION
### Proposed Changes
* Just removing a debugging `alert` JS call when downloading the Starter ZIP file.

This PR fixes: #31591