### PR TITLE
#31683 adding to SAML the ability to map role groups from content

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/ContentTypeRoleGroupMappingStrategyImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/ContentTypeRoleGroupMappingStrategyImpl.java
@@ -4,6 +4,8 @@ import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.saml.IdentityProviderConfiguration;
 import com.dotcms.saml.SamlName;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
@@ -80,31 +82,38 @@ public class ContentTypeRoleGroupMappingStrategyImpl implements RoleGroupMapping
             final ContentType roleMapContentType = APILocator.getContentTypeAPI(APILocator.systemUser()).find(roleMapKeyName);
             if (Objects.nonNull(roleMapContentType)) {
 
-                final List<Contentlet> roleMapContentlets = APILocator.getContentletAPI().findByStructure(roleMapContentType.id(),
-                        APILocator.systemUser(), false, 0, 0);
-                if (UtilMethods.isSet(roleMapContentlets)) {
-
-                    Logger.debug(this, () -> "Role Map Contentlets: " + roleMapContentlets.size());
-
-                    for (final Contentlet roleMapContentlet : roleMapContentlets) {
-
-                        final String roleGroupKey = roleMapContentlet.getStringProperty(roleMapFieldKeyName);
-                        final String roleKeyCommaSeparatedList = roleMapContentlet.getStringProperty(roleMapKeyValuesName);
-
-                        Logger.debug(this, () -> "Role Group Key: " + roleGroupKey +
-                                ", Role Key Comma Separated List: " + roleKeyCommaSeparatedList);
-
-                        if (UtilMethods.isSet(roleKeyCommaSeparatedList)) {
-
-                            this.roleKeyMappingsMap.put(roleGroupKey, Arrays.asList(StringUtils.split(roleKeyCommaSeparatedList, StringPool.COMMA)));
-                        } else {
-                            Logger.debug(this, () -> "Empty Role Map found for this key: " + roleGroupKey);
-                        }
-                    }
-                }
+                loadMappingRoles(roleMapContentType, roleMapFieldKeyName, roleMapKeyValuesName);
             }
         } catch (Exception e) {
             Logger.error(this, e.getMessage(), e);
+        }
+    }
+
+    private void loadMappingRoles(final ContentType roleMapContentType,
+                                  final String roleMapFieldKeyName,
+                                  final String roleMapKeyValuesName) throws DotDataException, DotSecurityException {
+
+        final List<Contentlet> roleMapContentlets = APILocator.getContentletAPI().findByStructure(roleMapContentType.id(),
+                APILocator.systemUser(), false, 0, 0);
+        if (UtilMethods.isSet(roleMapContentlets)) {
+
+            Logger.debug(this, () -> "Role Map Contentlets: " + roleMapContentlets.size());
+
+            for (final Contentlet roleMapContentlet : roleMapContentlets) {
+
+                final String roleGroupKey = roleMapContentlet.getStringProperty(roleMapFieldKeyName);
+                final String roleKeyCommaSeparatedList = roleMapContentlet.getStringProperty(roleMapKeyValuesName);
+
+                Logger.debug(this, () -> "Role Group Key: " + roleGroupKey +
+                        ", Role Key Comma Separated List: " + roleKeyCommaSeparatedList);
+
+                if (UtilMethods.isSet(roleKeyCommaSeparatedList)) {
+
+                    this.roleKeyMappingsMap.put(roleGroupKey, Arrays.asList(StringUtils.split(roleKeyCommaSeparatedList, StringPool.COMMA)));
+                } else {
+                    Logger.debug(this, () -> "Empty Role Map found for this key: " + roleGroupKey);
+                }
+            }
         }
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/ContentTypeRoleGroupMappingStrategyImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/ContentTypeRoleGroupMappingStrategyImpl.java
@@ -1,0 +1,110 @@
+package com.dotcms.auth.providers.saml.v1;
+
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.saml.IdentityProviderConfiguration;
+import com.dotcms.saml.SamlName;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
+import com.liferay.util.StringPool;
+import org.apache.velocity.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This implementation is based on a content type to role group mapping.
+ * If there is not configuration on SAML to the content type mapping, will use the following keys as a default:
+ * - ContentType Varname: RoleMap
+ * - ContentType Field Varname for Group Key: fromRoleName
+ * - ContentType Field Varname for Group Key:toRoleNames
+ * @author jsanca
+ */
+public class ContentTypeRoleGroupMappingStrategyImpl implements RoleGroupMappingStrategy {
+
+    public static final String ROLE_MAP_CONTENT_TYPE_NAME = "RoleMap";
+
+    public static final String ROLE_MAP_KEY_FIELD_NAME = "fromRoleName";
+
+    public static final String ROLE_MAP_VALUES_FIELD_NAME = "toRoleNames";
+
+    private final Map<String, Collection<String>> roleKeyMappingsMap = new ConcurrentHashMap<>();
+
+    @Override
+    public Collection<String> getRolesForGroup(final String roleGroupKey,
+                                               final IdentityProviderConfiguration identityProviderConfiguration) {
+
+        if (roleKeyMappingsMap.isEmpty()) {
+            Logger.debug(this, () -> "Loading Role Mappings");
+            loadRoleMappings(identityProviderConfiguration);
+        }
+
+        Logger.debug(this, () -> "Retrieving the getRolesForGroup, Role Group Key: " + roleGroupKey);
+        return this.roleKeyMappingsMap.getOrDefault(roleGroupKey, Arrays.asList(roleGroupKey));
+    }
+
+
+    private synchronized void loadRoleMappings(final IdentityProviderConfiguration identityProviderConfiguration) {
+
+        try {
+            final String samlAppContentTypeRoleGroupMappingConfigValue = identityProviderConfiguration.containsOptionalProperty(
+                        SamlName.DOT_SAML_ROLES_GROUP_MAPPING_BY_CONTENT_TYPE.getPropertyName()) ?
+                    identityProviderConfiguration.getOptionalProperty(SamlName.DOT_SAML_ROLES_GROUP_MAPPING_BY_CONTENT_TYPE.getPropertyName()).toString() : null;
+
+            Logger.debug(this, () -> "SAML App Content Type Role Group Mapping Config Value: " + samlAppContentTypeRoleGroupMappingConfigValue);
+            final String[] samlAppContentTypeRoleGroupMappingConfigValueArray = Objects.nonNull(samlAppContentTypeRoleGroupMappingConfigValue) ?
+                    StringUtils.split(samlAppContentTypeRoleGroupMappingConfigValue, StringPool.COMMA) : new String[]{null, null, null};
+
+            Logger.debug(this, () -> "SAML App Content Type Role Group Mapping Config Value Array: " + Arrays.toString(samlAppContentTypeRoleGroupMappingConfigValueArray));
+            final String roleMapKeyName = samlAppContentTypeRoleGroupMappingConfigValueArray.length > 0 &&
+                    Objects.nonNull(samlAppContentTypeRoleGroupMappingConfigValueArray[0]) ?
+                    samlAppContentTypeRoleGroupMappingConfigValueArray[0] : ROLE_MAP_CONTENT_TYPE_NAME;
+
+            Logger.debug(this, () -> "Role Map Key Name: " + roleMapKeyName);
+            final String roleMapFieldKeyName = samlAppContentTypeRoleGroupMappingConfigValueArray.length > 1 &&
+                    Objects.nonNull(samlAppContentTypeRoleGroupMappingConfigValueArray[1]) ?
+                    samlAppContentTypeRoleGroupMappingConfigValueArray[1] : ROLE_MAP_KEY_FIELD_NAME;
+
+            Logger.debug(this, () -> "Role Map Field Key Name: " + roleMapFieldKeyName);
+            final String roleMapKeyValuesName = samlAppContentTypeRoleGroupMappingConfigValueArray.length > 2 &&
+                    Objects.nonNull(samlAppContentTypeRoleGroupMappingConfigValueArray[2]) ?
+                    samlAppContentTypeRoleGroupMappingConfigValueArray[2] : ROLE_MAP_VALUES_FIELD_NAME;
+
+            Logger.debug(this, () -> "Role Map Key Values Name: " + roleMapKeyValuesName);
+
+            final ContentType roleMapContentType = APILocator.getContentTypeAPI(APILocator.systemUser()).find(roleMapKeyName);
+            if (Objects.nonNull(roleMapContentType)) {
+
+                final List<Contentlet> roleMapContentlets = APILocator.getContentletAPI().findByStructure(roleMapContentType.id(),
+                        APILocator.systemUser(), false, 0, 0);
+                if (UtilMethods.isSet(roleMapContentlets)) {
+
+                    Logger.debug(this, () -> "Role Map Contentlets: " + roleMapContentlets.size());
+
+                    for (final Contentlet roleMapContentlet : roleMapContentlets) {
+
+                        final String roleGroupKey = roleMapContentlet.getStringProperty(roleMapFieldKeyName);
+                        final String roleKeyCommaSeparatedList = roleMapContentlet.getStringProperty(roleMapKeyValuesName);
+
+                        Logger.debug(this, () -> "Role Group Key: " + roleGroupKey +
+                                ", Role Key Comma Separated List: " + roleKeyCommaSeparatedList);
+
+                        if (UtilMethods.isSet(roleKeyCommaSeparatedList)) {
+
+                            this.roleKeyMappingsMap.put(roleGroupKey, Arrays.asList(StringUtils.split(roleKeyCommaSeparatedList, StringPool.COMMA)));
+                        } else {
+                            Logger.debug(this, () -> "Empty Role Map found for this key: " + roleGroupKey);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Logger.error(this, e.getMessage(), e);
+        }
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/RoleGroupMappingStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/RoleGroupMappingStrategy.java
@@ -1,0 +1,21 @@
+package com.dotcms.auth.providers.saml.v1;
+
+import com.dotcms.saml.IdentityProviderConfiguration;
+
+import java.util.Collection;
+
+/**
+ * This class is in charge of mapping the group roles from the SAML response to the collection role keys in dotCMS.
+ * @author jsanca
+ */
+@FunctionalInterface
+public interface RoleGroupMappingStrategy {
+
+    /**
+     * Returns the roles group key for the given role group name.
+     * If role group key does not exist, it is returned as the only element in the collection.
+     * @param roleGroupKey String
+     * @return Collection<String>
+     */
+    Collection<String> getRolesForGroup(String roleGroupKey, IdentityProviderConfiguration identityProviderConfiguration);
+}

--- a/dotCMS/src/main/java/com/dotcms/saml/SamlName.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/SamlName.java
@@ -356,7 +356,20 @@ public enum SamlName {
 	 * role.key.substitution=/_sepsep_/ /
 	 * That substitution expression will replace the string _sepsep_ with white space before matching role name from IdP against role key from dotCMS.
 	 */
-	DOT_SAML_ROLE_KEY_SUBSTITUTION("role.key.substitution");
+	DOT_SAML_ROLE_KEY_SUBSTITUTION("role.key.substitution"),
+
+	/**
+	 * In case you want to use a different strategy to map the group roles from the IdP to the role keys in dotCMS.
+	 */
+	DOTCMS_SAML_ROLE_GROUP_MAPPING_STRATEGY("role.group.mapping.strategy"),
+
+	/**
+	 * This contains the mapping by content type configuration based on contenttype-varname,contenttype-key,contenttype-value
+	 * Where contenttype-varname is the var name of the content type which encapsulates the role mapping group
+	 * contenttype-key: is the content type property var name that index the group key
+	 * contenttype-value: is the collection of 1 to N role keys that maps this group key
+	 */
+	DOT_SAML_ROLES_GROUP_MAPPING_BY_CONTENT_TYPE("saml.roles.group.mapping.bycontenttype");
 
 	private final String propertyName;
 

--- a/dotcms-integration/src/test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
@@ -3,6 +3,11 @@ package com.dotcms.auth.providers.saml.v1;
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.cms.login.LoginServiceAPI;
 import com.dotcms.company.CompanyAPI;
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.datagen.ContentTypeDataGen;
+import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.FieldDataGen;
 import com.dotcms.datagen.UserDataGen;
 import com.dotcms.saml.Attributes;
 import com.dotcms.saml.DotSamlConstants;
@@ -36,6 +41,7 @@ import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.io.Writer;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -472,5 +478,137 @@ public class SAMLHelperTest extends IntegrationTestBase {
         Assert.assertEquals(nohashUuid, uuid);
     }
 
+    /**
+     * Method to test: testing the resolveUser of the {@link RoleGroupMappingStrategy#getRolesForGroup(String, IdentityProviderConfiguration)}
+     * Given Scenario: the test creates a content type with the default content type based on the default fields + creates a contentlet for the role group mapping
+     * ExpectedResult: Must return the 3 roles mapped
+     *
+     */
+    @Test()
+    public void test_ContentTypeRoleGroupMappingStrategyImpl() throws DotDataException, DotSecurityException, IOException {
 
+        final IdentityProviderConfiguration identityProviderConfiguration = mock(IdentityProviderConfiguration.class);
+        final CompanyAPI companyAPI                                       = mock(CompanyAPI.class);
+        final Company    company                                          = new Company();
+        // wants login by id
+        company.setAuthType(Company.AUTH_TYPE_EA);
+        when(companyAPI.getDefaultCompany()).thenReturn(company);
+
+        when(identityProviderConfiguration.containsOptionalProperty(SamlName.DOT_SAML_ALLOW_USER_SYNCHRONIZATION.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.containsOptionalProperty(SamlName.DOTCMS_SAML_BUILD_ROLES.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.containsOptionalProperty(SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.getOptionalProperty(SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.getOptionalProperty(SamlName.DOTCMS_SAML_BUILD_ROLES.getPropertyName())).thenReturn(DotSamlConstants.DOTCMS_SAML_BUILD_ROLES_NONE_VALUE);
+
+        final SamlConfigurationService samlConfigurationService  = mock(SamlConfigurationService.class);
+        SAMLHelper.setThirdPartySamlConfigurationService(samlConfigurationService);
+
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOT_SAML_ALLOW_USER_SYNCHRONIZATION)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOTCMS_SAML_BUILD_ROLES)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsString(identityProviderConfiguration, SamlName.DOTCMS_SAML_BUILD_ROLES)).thenReturn(DotSamlConstants.DOTCMS_SAML_BUILD_ROLES_NONE_VALUE);
+
+        // Create role map contentlet
+        final ContentType contentType = new ContentTypeDataGen().baseContentType(BaseContentType.CONTENT).velocityVarName("RoleMap").nextPersisted();
+        new FieldDataGen().contentTypeId(contentType.id()).velocityVarName("fromRoleName").nextPersisted();
+        new FieldDataGen().contentTypeId(contentType.id()).velocityVarName("toRoleNames").nextPersisted();
+
+        new ContentletDataGen(contentType).setProperty("fromRoleName", "roleGroupKey").setProperty("toRoleNames", "role1,role2,role3").nextPersisted();
+        final RoleGroupMappingStrategy roleGroupMappingStrategy = new ContentTypeRoleGroupMappingStrategyImpl();
+        final Collection<String> roleMappedKeys = roleGroupMappingStrategy.getRolesForGroup("roleGroupKey", identityProviderConfiguration);
+
+        Assert.assertNotNull(roleMappedKeys);
+        Assert.assertEquals(3, roleMappedKeys.size());
+        Assert.assertTrue(roleMappedKeys.contains("role1"));
+        Assert.assertTrue(roleMappedKeys.contains("role2"));
+        Assert.assertTrue(roleMappedKeys.contains("role3"));
+    }
+
+    /**
+     * Method to test: testing the resolveUser of the {@link RoleGroupMappingStrategy#getRolesForGroup(String, IdentityProviderConfiguration)}
+     * Given Scenario: the test creates a content type with the NON default content type based on the default fields + creates a contentlet for the role group mapping
+     * ExpectedResult: Must return the 3 roles mapped
+     *
+     */
+    @Test()
+    public void test_ContentTypeRoleGroupMappingStrategyImpl_with_non_default_type_fields() throws DotDataException, DotSecurityException, IOException {
+
+        final IdentityProviderConfiguration identityProviderConfiguration = mock(IdentityProviderConfiguration.class);
+        final CompanyAPI companyAPI                                       = mock(CompanyAPI.class);
+        final Company    company                                          = new Company();
+        // wants login by id
+        company.setAuthType(Company.AUTH_TYPE_EA);
+        when(companyAPI.getDefaultCompany()).thenReturn(company);
+
+        when(identityProviderConfiguration.containsOptionalProperty(SamlName.DOT_SAML_ALLOW_USER_SYNCHRONIZATION.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.containsOptionalProperty(SamlName.DOTCMS_SAML_BUILD_ROLES.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.containsOptionalProperty(SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.getOptionalProperty(SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.getOptionalProperty(SamlName.DOTCMS_SAML_BUILD_ROLES.getPropertyName())).thenReturn(DotSamlConstants.DOTCMS_SAML_BUILD_ROLES_NONE_VALUE);
+
+        final SamlConfigurationService samlConfigurationService  = mock(SamlConfigurationService.class);
+        SAMLHelper.setThirdPartySamlConfigurationService(samlConfigurationService);
+
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOT_SAML_ALLOW_USER_SYNCHRONIZATION)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOTCMS_SAML_BUILD_ROLES)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsString(identityProviderConfiguration, SamlName.DOTCMS_SAML_BUILD_ROLES)).thenReturn(DotSamlConstants.DOTCMS_SAML_BUILD_ROLES_NONE_VALUE);
+        when(samlConfigurationService.getConfigAsString(identityProviderConfiguration, SamlName.DOT_SAML_ROLES_GROUP_MAPPING_BY_CONTENT_TYPE)).thenReturn("MyRoleMap,myFromRoleName,myFoRoleNames");
+
+        // Create role map contentlet
+        final ContentType contentType = new ContentTypeDataGen().baseContentType(BaseContentType.CONTENT).velocityVarName("MyRoleMap").nextPersisted();
+        new FieldDataGen().contentTypeId(contentType.id()).velocityVarName("myFromRoleName").nextPersisted();
+        new FieldDataGen().contentTypeId(contentType.id()).velocityVarName("myFoRoleNames").nextPersisted();
+
+        new ContentletDataGen(contentType).setProperty("myFromRoleName", "roleGroupKey").setProperty("myFoRoleNames", "role1,role2,role3").nextPersisted();
+        final RoleGroupMappingStrategy roleGroupMappingStrategy = new ContentTypeRoleGroupMappingStrategyImpl();
+        final Collection<String> roleMappedKeys = roleGroupMappingStrategy.getRolesForGroup("roleGroupKey", identityProviderConfiguration);
+
+        Assert.assertNotNull(roleMappedKeys);
+        Assert.assertEquals(3, roleMappedKeys.size());
+        Assert.assertTrue(roleMappedKeys.contains("role1"));
+        Assert.assertTrue(roleMappedKeys.contains("role2"));
+        Assert.assertTrue(roleMappedKeys.contains("role3"));
+    }
+
+    /**
+     * Method to test: testing the resolveUser of the {@link RoleGroupMappingStrategy#getRolesForGroup(String, IdentityProviderConfiguration)}
+     * Given Scenario: test the default strategy which basically does nothing
+     * ExpectedResult: Must return the 1 roles mapped (which is identity itself)
+     *
+     */
+    @Test()
+    public void test_DEFAULT_ROLE_GROUP_MAPPING_STRATEGY() throws DotDataException, DotSecurityException, IOException {
+
+        final IdentityProviderConfiguration identityProviderConfiguration = mock(IdentityProviderConfiguration.class);
+        final CompanyAPI companyAPI                                       = mock(CompanyAPI.class);
+        final Company    company                                          = new Company();
+        // wants login by id
+        company.setAuthType(Company.AUTH_TYPE_EA);
+        when(companyAPI.getDefaultCompany()).thenReturn(company);
+
+        when(identityProviderConfiguration.containsOptionalProperty(SamlName.DOT_SAML_ALLOW_USER_SYNCHRONIZATION.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.containsOptionalProperty(SamlName.DOTCMS_SAML_BUILD_ROLES.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.containsOptionalProperty(SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.getOptionalProperty(SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL.getPropertyName())).thenReturn(true);
+        when(identityProviderConfiguration.getOptionalProperty(SamlName.DOTCMS_SAML_BUILD_ROLES.getPropertyName())).thenReturn(DotSamlConstants.DOTCMS_SAML_BUILD_ROLES_NONE_VALUE);
+
+        final SamlConfigurationService samlConfigurationService  = mock(SamlConfigurationService.class);
+        SAMLHelper.setThirdPartySamlConfigurationService(samlConfigurationService);
+
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOT_SAML_ALLOW_USER_SYNCHRONIZATION)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOTCMS_SAML_BUILD_ROLES)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsBoolean(identityProviderConfiguration, SamlName.DOTCMS_SAML_LOGIN_UPDATE_EMAIL)).thenReturn(true);
+        when(samlConfigurationService.getConfigAsString(identityProviderConfiguration, SamlName.DOTCMS_SAML_BUILD_ROLES)).thenReturn(DotSamlConstants.DOTCMS_SAML_BUILD_ROLES_NONE_VALUE);
+
+        final RoleGroupMappingStrategy roleGroupMappingStrategy = SAMLHelper.DEFAULT_ROLE_GROUP_MAPPING_STRATEGY;
+        final Collection<String> roleMappedKeys = roleGroupMappingStrategy.getRolesForGroup("roleGroupKey", identityProviderConfiguration);
+
+        Assert.assertNotNull(roleMappedKeys);
+        Assert.assertEquals(1, roleMappedKeys.size());
+        Assert.assertTrue(roleMappedKeys.contains("roleGroupKey"));
+    }
 }


### PR DESCRIPTION
Adds the ability to set a role group mapping on SAML, based on a contentlet 1 to M mappings

If a client sends as a group/claims/roles a list of roles that are actually group roles (not a roles key itself), if the config is set, for instance:

role.group.mapping.strategy=saml.roles.group.mapping.strategy.bycontenttype

Will use an strategy to load all content types that contains a key -> values where encapsulates the mapping between role group to role keys

By default it is expecting a content type such as
RoleMap as content type variable name
fromRoleName as a field role group key name
toRoleNames as a field role values name

However the client can override via custom properties on the SAML app by using:

saml.roles.group.mapping.bycontenttype=<RoleMap>,<fromRoleName>,<toRoleNames>

where <RoleMap> is a place holder to be replaced by the right content type variable name

This PR fixes: #31683