### PR TITLE
task(ui): update remote announcements url refs: #31707

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/announcements/RemoteAnnouncementsLoaderImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/announcements/RemoteAnnouncementsLoaderImpl.java
@@ -32,7 +32,7 @@ public class RemoteAnnouncementsLoaderImpl implements AnnouncementsLoader{
 
     //This is the url to the dotCMS instance set to provide and feed all consumers with announcements
     static final  Lazy<String> BASE_URL_LAZY_SUPPLIER =
-            Lazy.of(() -> Config.getStringProperty("ANNOUNCEMENTS_BASE_URL", "https://www2.dotcms.com"));
+            Lazy.of(() -> Config.getStringProperty("ANNOUNCEMENTS_BASE_URL", "https://www.dotcms.com"));
 
     static final String ANNOUNCEMENTS_QUERY = "/api/content/render/false/query/+contentType:Announcement%20+languageId:1%20+deleted:false%20+live:true%20/orderby/Announcement.announcementDate%20desc";
 


### PR DESCRIPTION
This pull request includes a small change to the `RemoteAnnouncementsLoaderImpl` class. The change updates the base URL for fetching announcements from "https://www2.dotcms.com" to "https://www.dotcms.com".

* [`dotCMS/src/main/java/com/dotcms/rest/api/v1/announcements/RemoteAnnouncementsLoaderImpl.java`](diffhunk://#diff-7a3fac1e39a77b711fc221c2c902c3aebe6e2493654378fc7aec660468ebc04dL35-R35): Updated the `BASE_URL_LAZY_SUPPLIER` to use the new base URL for announcements.

This PR fixes: #31707