### PR TITLE
fix(UVE): Live Mode Not Working Properly with FTM

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -866,26 +866,6 @@ describe('DotEmaShellComponent', () => {
                     mode: UVE_MODE.EDIT
                 });
             });
-
-            it('should remove the current date if LIVE mode is true and publishDate is present', () => {
-                const spyStoreLoadPage = jest.spyOn(store, 'loadPageAsset');
-                const params = {
-                    ...INITIAL_PAGE_PARAMS,
-                    mode: UVE_MODE.EDIT,
-                    publishDate: '2024-01-01'
-                };
-
-                // override the new Date() to return a fixed date
-                const fixedDate = new Date('2024-01-01');
-                jest.spyOn(global, 'Date').mockImplementation(() => fixedDate);
-
-                const data = UVE_CONFIG_MOCK(BASIC_OPTIONS);
-
-                overrideRouteSnashot(activatedRoute, SNAPSHOT_MOCK({ queryParams: params, data }));
-
-                spectator.detectChanges();
-                expect(spyStoreLoadPage).toHaveBeenCalledWith({ INITIAL_PAGE_PARAMS });
-            });
         });
 
         describe('Site Changes', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -867,11 +867,12 @@ describe('DotEmaShellComponent', () => {
                 });
             });
 
-            it('should add the current date if preview param is true and publishDate is not present', () => {
+            it('should remove the current date if LIVE mode is true and publishDate is present', () => {
                 const spyStoreLoadPage = jest.spyOn(store, 'loadPageAsset');
                 const params = {
                     ...INITIAL_PAGE_PARAMS,
-                    mode: UVE_MODE.LIVE
+                    mode: UVE_MODE.EDIT,
+                    publishDate: '2024-01-01'
                 };
 
                 // override the new Date() to return a fixed date
@@ -883,10 +884,7 @@ describe('DotEmaShellComponent', () => {
                 overrideRouteSnashot(activatedRoute, SNAPSHOT_MOCK({ queryParams: params, data }));
 
                 spectator.detectChanges();
-                expect(spyStoreLoadPage).toHaveBeenCalledWith({
-                    ...params,
-                    publishDate: fixedDate.toISOString()
-                });
+                expect(spyStoreLoadPage).toHaveBeenCalledWith({ INITIAL_PAGE_PARAMS });
             });
         });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -225,10 +225,6 @@ export class DotEmaShellComponent implements OnInit {
             params.mode = UVE_MODE.EDIT;
         }
 
-        if (params.mode === UVE_MODE.LIVE) {
-            params.publishDate = params.publishDate || new Date().toISOString();
-        }
-
         if (queryParams['personaId']) {
             params['com.dotmarketing.persona.id'] = queryParams['personaId'];
         }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -225,6 +225,10 @@ export class DotEmaShellComponent implements OnInit {
             params.mode = UVE_MODE.EDIT;
         }
 
+        if (params.mode !== UVE_MODE.LIVE && params.publishDate) {
+            delete params?.['publishDate'];
+        }
+
         if (queryParams['personaId']) {
             params['com.dotmarketing.persona.id'] = queryParams['personaId'];
         }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.spec.ts
@@ -112,7 +112,7 @@ describe('DotEditorModeSelectorComponent', () => {
             });
         });
 
-        it('should include publishDate when switching to LIVE mode', () => {
+        it('should not include publishDate when switching to LIVE mode', () => {
             jest.useFakeTimers();
             const now = new Date();
             jest.setSystemTime(now);
@@ -120,7 +120,7 @@ describe('DotEditorModeSelectorComponent', () => {
             component.onModeChange(UVE_MODE.LIVE);
             expect(mockStore.loadPageAsset).toHaveBeenCalledWith({
                 mode: UVE_MODE.LIVE,
-                publishDate: now.toISOString()
+                publishDate: undefined
             });
 
             jest.useRealTimers();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.ts
@@ -89,9 +89,6 @@ export class DotEditorModeSelectorComponent {
             toMode: mode
         });
 
-        this.#store.loadPageAsset({
-            mode: mode,
-            publishDate: mode === UVE_MODE.LIVE ? new Date().toISOString() : undefined
-        });
+        this.#store.loadPageAsset({ mode: mode });
     }
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.ts
@@ -89,6 +89,7 @@ export class DotEditorModeSelectorComponent {
             toMode: mode
         });
 
-        this.#store.loadPageAsset({ mode: mode });
+        /* More info here: https://github.com/dotCMS/core/issues/31719 */
+        this.#store.loadPageAsset({ mode: mode, publishDate: undefined });
     }
 }


### PR DESCRIPTION
This pull request focuses on modifying the behavior of the `DotEmaShellComponent` and `DotEditorModeSelectorComponent` to handle the `publishDate` parameter differently based on the mode. The main changes involve removing the `publishDate` when switching to LIVE mode and ensuring it is not added in certain conditions.

Changes to `DotEmaShellComponent`:

* Updated the test description and logic to check for the removal of the `publishDate` when LIVE mode is true and the `publishDate` is present. (`core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts`)
* Modified the test to ensure `spyStoreLoadPage` is called with `INITIAL_PAGE_PARAMS` instead of adding the `publishDate`. (`core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts`)
* Changed the condition to delete the `publishDate` if the mode is not LIVE and the `publishDate` is present. (`core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts`)

Changes to `DotEditorModeSelectorComponent`:

* Updated the test description and logic to ensure the `publishDate` is not included when switching to LIVE mode. (`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.spec.ts`)
* Modified the component to load the page asset without the `publishDate` when switching to LIVE mode. (`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.ts`)

### Video

https://github.com/user-attachments/assets/35d193c8-5945-4c66-ae48-066088b04d82


This PR fixes: #31719