### PR TITLE
fix: Fix for CATALINA_OPTS issue introduced in PR#31691

### DIFF
--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -7,8 +7,6 @@ export JAVA_OPTS_BASE=${JAVA_OPTS_BASE:-"-Djava.awt.headless=true -Dfile.encodin
 
 export JAVA_OPTS_MEMORY=${JAVA_OPTS_MEMORY:-"-Xmx1G"}
 
-# CATALINA_OPTS is used for the settings specifically for the Tomcat JVM
-export CATALINA_OPTS=${CATALINA_OPTS:-"$JAVA_OPTS_BASE $JAVA_OPTS_AGENT $JAVA_OPTS_MEMORY $CMS_JAVA_OPTS"}
 # Asset and Internal Paths
 export DOT_ASSET_REAL_PATH=${DOT_ASSET_REAL_PATH:-"/data/shared/assets"}
 export DOT_DYNAMIC_CONTENT_PATH=${DOT_DYNAMIC_CONTENT_PATH:-"/data/local/dotsecure"}

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -7,6 +7,8 @@ export JAVA_OPTS_BASE=${JAVA_OPTS_BASE:-"-Djava.awt.headless=true -Dfile.encodin
 
 export JAVA_OPTS_MEMORY=${JAVA_OPTS_MEMORY:-"-Xmx1G"}
 
+# CATALINA_OPTS is used for the settings specifically for the Tomcat JVM
+export CATALINA_OPTS=${CATALINA_OPTS:-"$JAVA_OPTS_BASE $JAVA_OPTS_AGENT $JAVA_OPTS_MEMORY $CMS_JAVA_OPTS"}
 # Asset and Internal Paths
 export DOT_ASSET_REAL_PATH=${DOT_ASSET_REAL_PATH:-"/data/shared/assets"}
 export DOT_DYNAMIC_CONTENT_PATH=${DOT_DYNAMIC_CONTENT_PATH:-"/data/local/dotsecure"}

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -7,8 +7,9 @@ export JAVA_OPTS_BASE=${JAVA_OPTS_BASE:-"-Djava.awt.headless=true -Dfile.encodin
 
 export JAVA_OPTS_MEMORY=${JAVA_OPTS_MEMORY:-"-Xmx1G"}
 
-# CATALINA_OPTS is used for the settings specifically for the Tomcat JVM
-export CATALINA_OPTS=${CATALINA_OPTS:-"$JAVA_OPTS_BASE $JAVA_OPTS_AGENT $JAVA_OPTS_MEMORY $CMS_JAVA_OPTS"}
+# $CMS_JAVA_OPTS is last so it trumps them all
+export JAVA_OPTS=${JAVA_OPTS:-"$JAVA_OPTS_BASE $JAVA_OPTS_AGENT $JAVA_OPTS_MEMORY $CMS_JAVA_OPTS"}
+
 # Asset and Internal Paths
 export DOT_ASSET_REAL_PATH=${DOT_ASSET_REAL_PATH:-"/data/shared/assets"}
 export DOT_DYNAMIC_CONTENT_PATH=${DOT_DYNAMIC_CONTENT_PATH:-"/data/local/dotsecure"}


### PR DESCRIPTION
### Proposed Changes
* Fix mixup between CATALINA_OPTS and JAVA_OPTS to use existing behavior. 

When Specifiying CATALINA_OPTS in the dockerfile it was discovered a change in the merge and removal of 00-config-defaults.sh had an error.  in using CATALINA_OPTS instead of JAVA_OPTS.   These options will need to be cleaned up but we return to the old behavior with this PR


![](https://files.slack.com/files-pri/T028R2630-F08KVJF0C9W/cleanshot_2025-03-25_at_09.50.59_2x.png)


```
dotcms-1         | Importing data from starter https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20250318/starter-20250318.zip...
dotcms-1         | 
dotcms-1         | Starting dotCMS ...
dotcms-1         | -------------------
dotcms-1         | 
dotcms-1         | /srv/dotserver/tomcat/bin/catalina.sh: 11: export: -Xms1g: bad variable name
dotcms-1 exited with code 2
```

This PR fixes: #285