### PR TITLE
chore(UVE): Remove Bottleneck on Test init

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/jest.config.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/jest.config.ts
@@ -14,7 +14,7 @@ export default {
             }
         ]
     },
-    transformIgnorePatterns: ['<rootDir>/node_modules/(?!.*\\.mjs$)'],
+    transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
     snapshotSerializers: [
         'jest-preset-angular/build/serializers/no-ng-attributes',
         'jest-preset-angular/build/serializers/ng-snapshot',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts
@@ -66,6 +66,13 @@ const PAGE_RESPONSE = {
     }
 };
 
+// Gridstack has some issues with importing (esm/cjs), Jest need to process it to work using the transformIgnorePatterns, but that takes a lot of time
+// So we mock it to avoid that
+jest.mock('gridstack', () => ({
+    __esModule: true,
+    default: jest.fn()
+}));
+
 describe('EditEmaLayoutComponent', () => {
     let spectator: Spectator<EditEmaLayoutComponent>;
     let component: EditEmaLayoutComponent;

--- a/core-web/libs/portlets/edit-ema/portlet/src/test-setup.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/test-setup.ts
@@ -9,3 +9,8 @@ console.error = (...params) => {
         originalConsoleError(...params);
     }
 };
+
+// Filter all console warnings during tests
+console.warn = () => {
+    // do nothing so it doesn't print warnings that are not relevant to the tests
+};

--- a/core-web/libs/template-builder/jest.config.ts
+++ b/core-web/libs/template-builder/jest.config.ts
@@ -26,6 +26,8 @@ export default {
         ]
     },
     // https://github.com/nrwl/nx/issues/7844#issuecomment-1016624608
+    // This is a bottleneck, it's taking way too long to start the tests
+    // https://github.com/dotCMS/core/issues/31729
     transformIgnorePatterns: ['<rootDir>/node_modules/(?!.*\\.mjs$)'],
     snapshotSerializers: [
         'jest-preset-angular/build/serializers/no-ng-attributes',


### PR DESCRIPTION
This pull request includes several changes to the `core-web/libs/portlets/edit-ema/portlet` directory to improve the testing setup and performance. The most important changes include modifying the Jest configuration, adding a mock for the `gridstack` library, and filtering console warnings during tests.

Improvements to testing setup and performance:

* [`core-web/libs/portlets/edit-ema/portlet/jest.config.ts`](diffhunk://#diff-ca0903d5f6450264b437d534e46de0d7c62089c2bb05183a0b5fa340296104e2L17-R17): Updated the `transformIgnorePatterns` to exclude the `<rootDir>` prefix for better compatibility with Jest.
* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-layout/edit-ema-layout.component.spec.ts`](diffhunk://#diff-bb8e289f778f062af74dededdbde614d6458884afa3454e84cfc581dd0ea70efR69-R75): Added a mock for the `gridstack` library to avoid slow processing during tests.
* [`core-web/libs/portlets/edit-ema/portlet/src/test-setup.ts`](diffhunk://#diff-c9591bb36b38824c4ffa7d6fef0962111cdd4ab5f812d504b9a10b39c9585435R12-R16): Added a filter to suppress console warnings during tests to avoid irrelevant output.

This PR fixes: #31727