### PR TITLE
fix(FTM) viewTool pull fix for zero limit Refs: #31730

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtils.java
@@ -234,7 +234,7 @@ public class ContentUtils {
 				//need to send the query with the defaults --- 
 			    List<Contentlet> contentlets=null;
 			    if(tmDate!=null && query.contains("+live:true")) {
-			        // with timemachine on!
+			        // with time machine on!
                     final Date futureDate = new Date(Long.parseLong(tmDate));
                     query = query.replaceAll("\\+live\\:true", "")
                             .replaceAll("\\+working\\:true", "");
@@ -282,12 +282,11 @@ public class ContentUtils {
 	    	            });
 		            }
 		            
-		            // truncate to respect limit
-		            if(contentlets.size()>limit){
+		            // truncate to respect limit, remember 0 means no limit
+		            if(limit > 0 && contentlets.size() > limit){
 		                contentlets = contentlets.subList(0, limit);
 		            }
-			    }
-			    else {
+			    } else {
 			        // normal query
 			        PaginatedArrayList<Contentlet> conts=(PaginatedArrayList<Contentlet>)conAPI.search(query, limit, offset, sort, user, respectFrontendRoles);
 			        ret.setTotalResults(conts.getTotalResults());

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtilsTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/util/ContentUtilsTest.java
@@ -69,6 +69,7 @@ import static com.dotcms.datagen.TestDataUtils.relateContentTypes;
 import static com.dotcms.util.CollectionsUtils.list;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -133,14 +134,16 @@ public class ContentUtilsTest {
         boolean publishAll;
         int resultsSize;
 
-        public TestCase(final LANGUAGE_TYPE_FILTER languageType, final PUBLISH_TYPE_FILTER publishType,
-                final boolean pullParents, final boolean addCondition, final int resultsSize, final boolean publishAll) {
+        public TestCase(final LANGUAGE_TYPE_FILTER languageType,
+                final PUBLISH_TYPE_FILTER publishType,
+                final boolean pullParents, final boolean addCondition, final int resultsSize,
+                final boolean publishAll) {
             this.languageType = languageType;
             this.publishType = publishType;
             this.pullParents = pullParents;
             this.addCondition = addCondition;
             this.resultsSize = resultsSize;
-            this.publishAll  = publishAll;
+            this.publishAll = publishAll;
         }
     }
 
@@ -159,83 +162,155 @@ public class ContentUtilsTest {
     @DataProvider
     public static Object[] testCases() {
         return new TestCase[]{
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, true, false, 2, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, true, true, 2, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, false, false, 2, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, false, true, 2, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, true, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, true, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, false, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, false, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, true, false, 2, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, true, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, false, false, 2, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, false, true, 1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, true, false,
+                        2, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, true, true,
+                        2, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, false,
+                        false, 2, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, false, true,
+                        2, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, true, false, 1,
+                        false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, true, true, 1,
+                        false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, false, false,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, false, true, 1,
+                        false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, true, false,
+                        2, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, true, true,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, false,
+                        false, 2, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, false, true,
+                        1, false),
 
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, true, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, true, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, false, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, false, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, true, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, true, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, false, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, false, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, true, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, true, true, 0, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, false, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, false, true, 0, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, true, false,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, true, true,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, false,
+                        false, 1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, false, true,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, true, false, 1,
+                        false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, true, true, 1,
+                        false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, false, false,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, false, true, 1,
+                        false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, true, false,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, true, true,
+                        0, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, false,
+                        false, 1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, false, true,
+                        0, false),
 
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, true, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, true, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, false, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, false, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, true, false, 0, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, true, true, 0, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, false, false, 0, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, false, true, 0, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, true, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, true, true, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, false, false, 1, false),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, false, true, 1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, true, false,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, true, true,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, false,
+                        false, 1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, false, true,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, true, false, 0,
+                        false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, true, true, 0,
+                        false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, false, false,
+                        0, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, false, true, 0,
+                        false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, true, false,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, true, true,
+                        1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, false,
+                        false, 1, false),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, false, true,
+                        1, false),
 
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, true, false, 2, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, true, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, false, false, 2, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, false, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, true, false, 2, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, true, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, false, false, 2, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, false, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, true, false, 2, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, true, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, false, false, 2, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, false, true, 0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, true, false,
+                        2, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, true, true,
+                        0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, false,
+                        false, 2, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.DEFAULT, false, true,
+                        0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, true, false, 2,
+                        true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, true, true, 0,
+                        true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, false, false,
+                        2, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.LIVE, false, true, 0,
+                        true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, true, false,
+                        2, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, true, true,
+                        0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, false,
+                        false, 2, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.DEFAULT, PUBLISH_TYPE_FILTER.WORKING, false, true,
+                        0, true),
 
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, true, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, true, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, false, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, false, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, true, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, true, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, false, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, false, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, true, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, true, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, false, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, false, true, 0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, true, false,
+                        1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, true, true,
+                        0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, false,
+                        false, 1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.DEFAULT, false, true,
+                        0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, true, false, 1,
+                        true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, true, true, 0,
+                        true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, false, false,
+                        1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.LIVE, false, true, 0,
+                        true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, true, false,
+                        1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, true, true,
+                        0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, false,
+                        false, 1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.ENGLISH, PUBLISH_TYPE_FILTER.WORKING, false, true,
+                        0, true),
 
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, true, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, true, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, false, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, false, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, true, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, true, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, false, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, false, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, true, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, true, true, 0, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, false, false, 1, true),
-                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, false, true, 0, true)
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, true, false,
+                        1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, true, true,
+                        0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, false,
+                        false, 1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.DEFAULT, false, true,
+                        0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, true, false, 1,
+                        true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, true, true, 0,
+                        true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, false, false,
+                        1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.LIVE, false, true, 0,
+                        true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, true, false,
+                        1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, true, true,
+                        0, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, false,
+                        false, 1, true),
+                new TestCase(LANGUAGE_TYPE_FILTER.SPANISH, PUBLISH_TYPE_FILTER.WORKING, false, true,
+                        0, true)
         };
     }
 
@@ -258,7 +333,8 @@ public class ContentUtilsTest {
 
     @Test
     @UseDataProvider("testCases")
-    public void testPullRelated(final TestCase testCase) throws DotDataException, DotSecurityException {
+    public void testPullRelated(final TestCase testCase)
+            throws DotDataException, DotSecurityException {
         final long time = System.currentTimeMillis();
         ContentType parentContentType = null;
         ContentType childContentType = null;
@@ -280,15 +356,17 @@ public class ContentUtilsTest {
 
             //Adding a RelationshipField to the parent
             final Field parentTypeRelationshipField = createAndSaveRelationshipField("myChildren",
-                    parentContentType.id(), childContentType.variable(), RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal());
+                    parentContentType.id(), childContentType.variable(),
+                    RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal());
 
             final String fullFieldVar =
-                    parentContentType.variable() + StringPool.PERIOD + parentTypeRelationshipField.variable();
+                    parentContentType.variable() + StringPool.PERIOD
+                            + parentTypeRelationshipField.variable();
 
             //Adding a RelationshipField to the child
             createAndSaveRelationshipField("myParents",
-                    childContentType.id(), fullFieldVar, RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal());
-
+                    childContentType.id(), fullFieldVar,
+                    RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal());
 
             final Relationship relationship = relationshipAPI.byTypeValue(fullFieldVar);
 
@@ -303,7 +381,7 @@ public class ContentUtilsTest {
                     .languageId(spanishLanguage.getId())
                     .setPolicy(IndexPolicy.FORCE).nextPersisted();
 
-            if (testCase.publishAll){
+            if (testCase.publishAll) {
                 ContentletDataGen.publish(childInSpanish);
             }
 
@@ -326,7 +404,7 @@ public class ContentUtilsTest {
 
             parentInEnglish = ContentletDataGen.publish(parentInEnglish);
 
-            if (testCase.publishAll){
+            if (testCase.publishAll) {
                 ContentletDataGen.publish(parentInSpanish);
             }
 
@@ -367,8 +445,8 @@ public class ContentUtilsTest {
             }
 
             String condition = null;
-            if (testCase.addCondition){
-               condition = testCase.publishAll? "+live:false":"+working:true";
+            if (testCase.addCondition) {
+                condition = testCase.publishAll ? "+live:false" : "+working:true";
             }
 
             final List<Contentlet> results = ContentUtils
@@ -381,9 +459,9 @@ public class ContentUtilsTest {
             validateResults(testCase, defaultLanguage, spanishLanguage, results);
 
             //Validate results for cached results
-            if (!testCase.addCondition){
+            if (!testCase.addCondition) {
                 final List<Contentlet> cachedResults = ContentUtils
-                        .pullRelated(fullFieldVar, contentletToPullFrom.getIdentifier(),null,
+                        .pullRelated(fullFieldVar, contentletToPullFrom.getIdentifier(), null,
                                 testCase.pullParents, -1, null, user, null,
                                 languageParam, liveParam);
 
@@ -409,7 +487,8 @@ public class ContentUtilsTest {
      * @throws DotSecurityException
      * @throws DotDataException
      */
-    private Field createAndSaveRelationshipField(final String relationshipName, final String parentTypeId,
+    private Field createAndSaveRelationshipField(final String relationshipName,
+            final String parentTypeId,
             final String childTypeVar, final int cardinality)
             throws DotSecurityException, DotDataException {
 
@@ -466,7 +545,7 @@ public class ContentUtilsTest {
                             .name("parentContentType" + time)
                             .owner(user.getUserId()).build());
 
-            if (!testCase.selfRelated){
+            if (!testCase.selfRelated) {
                 childContentType = contentTypeAPI
                         .save(ContentTypeBuilder.builder(SimpleContentType.class)
                                 .folder(FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST)
@@ -539,17 +618,17 @@ public class ContentUtilsTest {
         final long time = System.currentTimeMillis();
         final Relationship relationship = new Relationship();
         //Set Parent Info
-        relationship.setParentStructureInode( parentStructureInode );
-        relationship.setParentRelationName( "parent" );
+        relationship.setParentStructureInode(parentStructureInode);
+        relationship.setParentRelationName("parent");
         //Set Child Info
-        relationship.setChildStructureInode( childStructureInode );
-        relationship.setChildRelationName( "child" );
+        relationship.setChildStructureInode(childStructureInode);
+        relationship.setChildRelationName("child");
         //Set general info
-        relationship.setRelationTypeValue( "parent-child" + time);
+        relationship.setRelationTypeValue("parent-child" + time);
         relationship.setCardinality(cardinality);
 
         //Save it
-        APILocator.getRelationshipAPI().save( relationship );
+        APILocator.getRelationshipAPI().save(relationship);
 
         return relationship;
     }
@@ -580,9 +659,11 @@ public class ContentUtilsTest {
 
             //Adding a RelationshipField to the parent
             final Field parentTypeRelationshipField = createAndSaveRelationshipField("myChild",
-                    parentContentType.id(), childContentType.variable(), RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal());
+                    parentContentType.id(), childContentType.variable(),
+                    RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal());
 
-            final String fullFieldVar = parentContentType.variable() + StringPool.PERIOD + parentTypeRelationshipField.variable();
+            final String fullFieldVar = parentContentType.variable() + StringPool.PERIOD
+                    + parentTypeRelationshipField.variable();
 
             final Relationship relationship = relationshipAPI.byTypeValue(fullFieldVar);
 
@@ -650,7 +731,6 @@ public class ContentUtilsTest {
     }
 
     /**
-     *
      * @param childInode
      * @param fullFieldVar
      * @param childContent
@@ -674,7 +754,6 @@ public class ContentUtilsTest {
     }
 
     /**
-     *
      * @param expectedInode
      * @param relationshipName
      * @param contentlet
@@ -693,7 +772,8 @@ public class ContentUtilsTest {
 
     @Test
     @UseDataProvider("sortTestCases")
-    public void testSortPullRelated(final SortTestCase testCase) throws DotDataException, DotSecurityException {
+    public void testSortPullRelated(final SortTestCase testCase)
+            throws DotDataException, DotSecurityException {
         final long time = System.currentTimeMillis();
         ContentType parentContentType = null;
         ContentType childContentType = null;
@@ -706,7 +786,7 @@ public class ContentUtilsTest {
                             .folder(FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST)
                             .name("parentContentType" + time)
                             .owner(user.getUserId()).build());
-            childContentType = testCase.selfRelated? parentContentType: contentTypeAPI
+            childContentType = testCase.selfRelated ? parentContentType : contentTypeAPI
                     .save(ContentTypeBuilder.builder(SimpleContentType.class)
                             .folder(FolderAPI.SYSTEM_FOLDER).host(Host.SYSTEM_HOST)
                             .name("childContentType" + time)
@@ -723,11 +803,13 @@ public class ContentUtilsTest {
             fieldAPI.save(customField, user);
 
             final String fullFieldVar =
-                    parentContentType.variable() + StringPool.PERIOD + parentTypeRelationshipField.variable();
+                    parentContentType.variable() + StringPool.PERIOD
+                            + parentTypeRelationshipField.variable();
 
             //Adding a RelationshipField to the child
             createAndSaveRelationshipField("otherSideRel",
-                    childContentType.id(), fullFieldVar, RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal());
+                    childContentType.id(), fullFieldVar,
+                    RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal());
 
             final Relationship relationship = relationshipAPI.byTypeValue(fullFieldVar);
 
@@ -741,20 +823,22 @@ public class ContentUtilsTest {
 
             //Save related content
             relatedContent1 = new ContentletDataGen(childContentType.id())
-                    .languageId(defaultLanguage.getId()).setPolicy(IndexPolicy.FORCE).setProperty("myCustomDate",
+                    .languageId(defaultLanguage.getId()).setPolicy(IndexPolicy.FORCE)
+                    .setProperty("myCustomDate",
                             new Date(System.currentTimeMillis()))
                     .nextPersisted();
 
             relatedContent2 = new ContentletDataGen(childContentType.id())
-                    .languageId(defaultLanguage.getId()).setPolicy(IndexPolicy.FORCE).setProperty("myCustomDate",
+                    .languageId(defaultLanguage.getId()).setPolicy(IndexPolicy.FORCE)
+                    .setProperty("myCustomDate",
                             new Date(System.currentTimeMillis() + 24 * 60 * 60 * 1000))
                     .nextPersisted();
 
             relatedContent3 = new ContentletDataGen(childContentType.id())
-                    .languageId(defaultLanguage.getId()).setPolicy(IndexPolicy.FORCE).setProperty("myCustomDate",
+                    .languageId(defaultLanguage.getId()).setPolicy(IndexPolicy.FORCE)
+                    .setProperty("myCustomDate",
                             new Date(System.currentTimeMillis() + 48 * 60 * 60 * 1000))
                     .nextPersisted();
-
 
             final ContentletRelationships contentletRelationships = new ContentletRelationships(
                     contentlet);
@@ -764,9 +848,8 @@ public class ContentUtilsTest {
             records.setRecords(list(relatedContent1, relatedContent2, relatedContent3));
             contentletRelationships.getRelationshipsRecords().add(records);
 
-            contentlet = contentletAPI.checkin(contentlet,contentletRelationships,
-                    null,null, user, false);
-
+            contentlet = contentletAPI.checkin(contentlet, contentletRelationships,
+                    null, null, user, false);
 
             //Clean up cache
             CacheLocator.getContentletCache().remove(contentlet);
@@ -798,7 +881,6 @@ public class ContentUtilsTest {
                             null, -1,
                             false);
 
-
             assertNotNull(results);
             assertEquals(3, results.size());
             assertEquals(relatedContent3.getIdentifier(), results.get(0).getIdentifier());
@@ -818,9 +900,9 @@ public class ContentUtilsTest {
     }
 
     /**
-     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)}
-     * When: there is a content with a publish date in the future and the time machine parameter in null
-     * Should: Not return the content
+     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)} When: there is a
+     * content with a publish date in the future and the time machine parameter in null Should: Not
+     * return the content
      */
     @Test
     public void whenTheTimeMachineDateIsNullAndPublishDateInFutureShouldNotReturnAnything() {
@@ -836,7 +918,8 @@ public class ContentUtilsTest {
 
         final String query = String.format(QUERY_BY_STRUCTURE_NAME, contentType.variable());
 
-        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null, APILocator.systemUser(), timeMachine);
+        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null,
+                APILocator.systemUser(), timeMachine);
 
         assertEquals(0, contentlets.size());
 
@@ -846,9 +929,9 @@ public class ContentUtilsTest {
     }
 
     /**
-     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)}
-     * When: there is a content with a publish date set to tomorrow and the time machine date is the date after tomorrow
-     * Should: return one content
+     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)} When: there is a
+     * content with a publish date set to tomorrow and the time machine date is the date after
+     * tomorrow Should: return one content
      */
     @Test
     public void whenTheTimeMachineDateAndPublishDateAreTomorrowShouldReturnOneContent() {
@@ -865,19 +948,20 @@ public class ContentUtilsTest {
 
         final String query = String.format(QUERY_BY_STRUCTURE_NAME, contentType.variable());
 
-        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null, APILocator.systemUser(),
+        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null,
+                APILocator.systemUser(),
                 String.valueOf(timeMachine.getTime().getTime()));
 
-        assertEquals(1  , contentlets.size());
+        assertEquals(1, contentlets.size());
         assertEquals(contentlet.getIdentifier(), contentlets.get(0).getIdentifier());
 
         assertEquals(0, ContentUtils.pull(query, 10, null, APILocator.systemUser(), null).size());
     }
 
     /**
-     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)}
-     * When: there is a content with a expire  date set to tomorrow and the time machine date is the date after tomorrow
-     * Should: return one content
+     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)} When: there is a
+     * content with a expire  date set to tomorrow and the time machine date is the date after
+     * tomorrow Should: return one content
      */
     @Test
     public void whenTheTimeMachineDateIsAfterTomorrowAndExpireDateIsTomorrowShouldNotReturnContent() {
@@ -896,7 +980,8 @@ public class ContentUtilsTest {
 
         final String query = String.format(QUERY_BY_STRUCTURE_NAME, contentType.variable());
 
-        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null, APILocator.systemUser(), timeMachine);
+        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null,
+                APILocator.systemUser(), timeMachine);
 
         assertEquals(0, contentlets.size());
 
@@ -906,10 +991,9 @@ public class ContentUtilsTest {
     }
 
     /**
-     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)}
-     * When: there is a content with a publish date set to tomorrow and expire date set in the future
-     * and the time machine date is set to tomorrow
-     * Should: return one content
+     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)} When: there is a
+     * content with a publish date set to tomorrow and expire date set in the future and the time
+     * machine date is set to tomorrow Should: return one content
      */
     @Test
     public void whenTheTimeMachineDateIsAfterTomorrowAndExpireDateIsInFutureShouldReturnContent() {
@@ -931,21 +1015,22 @@ public class ContentUtilsTest {
 
         final String query = String.format(QUERY_BY_STRUCTURE_NAME, contentType.variable());
 
-        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null, APILocator.systemUser(),
+        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null,
+                APILocator.systemUser(),
                 String.valueOf(timeMachine.getTime().getTime()));
 
         assertEquals(1, contentlets.size());
         assertEquals(contentlet.getIdentifier(), contentlets.get(0).getIdentifier());
 
-        final List<Contentlet> contentNotTM = ContentUtils.pull(query, 10, null, APILocator.systemUser(), null);
+        final List<Contentlet> contentNotTM = ContentUtils.pull(query, 10, null,
+                APILocator.systemUser(), null);
         assertEquals(0, contentNotTM.size());
     }
 
     /**
-     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)}
-     * When: there is a content with a publish date set to tomorrow and expire date set to after tomorrow
-     * and the time machine date set after that
-     * Should: return no one content
+     * Method to test: {@link ContentUtils#pull(String, int, String, User, String)} When: there is a
+     * content with a publish date set to tomorrow and expire date set to after tomorrow and the
+     * time machine date set after that Should: return no one content
      */
     @Test
     public void whenPublishAndExpireDatesAreInTheFutureAndTimeMachineIsAfterBoth() {
@@ -967,45 +1052,57 @@ public class ContentUtilsTest {
 
         final String query = String.format(QUERY_BY_STRUCTURE_NAME, contentType.variable());
 
-        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null, APILocator.systemUser(),
+        final List<Contentlet> contentlets = ContentUtils.pull(query, 10, null,
+                APILocator.systemUser(),
                 String.valueOf(timeMachine.getTime().getTime()));
 
         assertEquals(0, contentlets.size());
 
-        final List<Contentlet> contentNoTM = ContentUtils.pull(String.format("+structureName:%s", contentType.variable()), 10, null,
+        final List<Contentlet> contentNoTM = ContentUtils.pull(
+                String.format("+structureName:%s", contentType.variable()), 10, null,
                 APILocator.systemUser(), null);
         assertEquals(1, contentNoTM.size());
     }
 
     /**
-     * Method to test: {@link ContentUtils#find(String, User, boolean, long)}
-     * When: there is a contentlet in multiligual we should get the one with the sessionLang
-     * Should: contentlet with the sessionLang
+     * Method to test: {@link ContentUtils#find(String, User, boolean, long)} When: there is a
+     * contentlet in multiligual we should get the one with the sessionLang Should: contentlet with
+     * the sessionLang
      */
     @Test
-    public void test_find_multilingual_contentlet_getContentletSuccessfully() throws DotSecurityException,
-                                                                                                 DotDataException {
+    public void test_find_multilingual_contentlet_getContentletSuccessfully()
+            throws DotSecurityException,
+            DotDataException {
         final Host host = new SiteDataGen().nextPersisted();
         final long spanishLangId = TestDataUtils.getSpanishLanguage().getId();
         final int sessionLanguage = 1;
-        final Contentlet contentlet = TestDataUtils.getGenericContentContent(true, sessionLanguage, host);
-        final Contentlet contentletNewLang = APILocator.getContentletAPI().checkout(contentlet.getInode(), user, false);
+        final Contentlet contentlet = TestDataUtils.getGenericContentContent(true, sessionLanguage,
+                host);
+        final Contentlet contentletNewLang = APILocator.getContentletAPI()
+                .checkout(contentlet.getInode(), user, false);
         contentletNewLang.setLanguageId(spanishLangId);
         APILocator.getContentletAPI().checkin(contentletNewLang, user, false);
         final boolean workingVersion = Boolean.TRUE;
-        final Contentlet contentletFound = ContentUtils.find(contentlet.getIdentifier(), user, workingVersion,
+        final Contentlet contentletFound = ContentUtils.find(contentlet.getIdentifier(), user,
+                workingVersion,
                 sessionLanguage);
 
-        assertEquals("Contentlet created with session language must match the one retrieved via the API",
+        assertEquals(
+                "Contentlet created with session language must match the one retrieved via the API",
                 contentlet.getInode(), contentletFound.getInode());
-        assertEquals("Contentlet created with session language and the one retrieved via the API must have the same " +
-                             "language ID", contentlet.getLanguageId(), contentletFound.getLanguageId());
+        assertEquals(
+                "Contentlet created with session language and the one retrieved via the API must have the same "
+                        +
+                        "language ID", contentlet.getLanguageId(), contentletFound.getLanguageId());
     }
 
     /**
-     * Method to test: {@link ContentUtils#pullRelatedField(Relationship, String, String, int, int, String, User, String, boolean, long, Boolean)}
-     * Given Scenario: Pulling related content should consider the order defined in the relationship if the sort criteria is empty or not set
-     * ExpectedResult: The relationship order is used when a sort criteria is not set
+     * Method to test:
+     * {@link ContentUtils#pullRelatedField(Relationship, String, String, int, int, String, User,
+     * String, boolean, long, Boolean)} Given Scenario: Pulling related content should consider the
+     * order defined in the relationship if the sort criteria is empty or not set ExpectedResult:
+     * The relationship order is used when a sort criteria is not set
+     *
      * @throws DotDataException
      * @throws DotSecurityException
      */
@@ -1039,7 +1136,7 @@ public class ContentUtilsTest {
             //creates child contentlet
             dataGen = new ContentletDataGen(commentsContentType.id());
 
-            for (int i=1; i<5 ;i++){
+            for (int i = 1; i < 5; i++) {
                 commentsContentlet = dataGen
                         .languageId(languageId)
                         .setProperty("title", "Comment for News " + i)
@@ -1065,16 +1162,17 @@ public class ContentUtilsTest {
                             3, 0, "", user, null, false, languageId, false);
 
             assertNotNull(result);
-            assertEquals(3,result.size());
+            assertEquals(3, result.size());
 
             //related content should be returned in the default order
-            assertEquals(relatedComments.get(0).getIdentifier(),result.get(0).getIdentifier());
-            assertEquals(relatedComments.get(1).getIdentifier(),result.get(1).getIdentifier());
-            assertEquals(relatedComments.get(2).getIdentifier(),result.get(2).getIdentifier());
+            assertEquals(relatedComments.get(0).getIdentifier(), result.get(0).getIdentifier());
+            assertEquals(relatedComments.get(1).getIdentifier(), result.get(1).getIdentifier());
+            assertEquals(relatedComments.get(2).getIdentifier(), result.get(2).getIdentifier());
 
             //let's reorder the related content and pull them again
             newsContentlet = contentletAPI.checkin(newsContentlet,
-                    Map.of(relationship, list(relatedComments.get(3), relatedComments.get(1), relatedComments.get(0), relatedComments.get(2))),
+                    Map.of(relationship, list(relatedComments.get(3), relatedComments.get(1),
+                            relatedComments.get(0), relatedComments.get(2))),
                     null, user, false);
 
             //now, we pull the related content again. Limit and offset were set to invalid values to make sure that it keeps working as expected
@@ -1083,7 +1181,7 @@ public class ContentUtilsTest {
                             5, -1000, "", user, null, false, languageId, false);
 
             assertNotNull(result);
-            assertEquals(relatedComments.size(),result.size());
+            assertEquals(relatedComments.size(), result.size());
 
             //the new order should be preserved
             assertEquals(relatedComments.get(3).getIdentifier(), result.get(0).getIdentifier());
@@ -1096,7 +1194,7 @@ public class ContentUtilsTest {
                 ContentletDataGen.remove(newsContentlet);
             }
 
-            for (final Contentlet contentlet: relatedComments){
+            for (final Contentlet contentlet : relatedComments) {
                 ContentletDataGen.remove(contentlet);
             }
         }
@@ -1104,11 +1202,14 @@ public class ContentUtilsTest {
 
 
     /**
-     * Method to test: {@link ContentUtils#pullRelatedField(Relationship, String, String, int, int, String, User, String, boolean, long, Boolean)}
-     * Given Scenario: Pulling related content when the offset is greater than the limit
-     * ExpectedResult: Should return results, if they're available.
+     * Method to test:
+     * {@link ContentUtils#pullRelatedField(Relationship, String, String, int, int, String, User,
+     * String, boolean, long, Boolean)} Given Scenario: Pulling related content when the offset is
+     * greater than the limit ExpectedResult: Should return results, if they're available.
+     * <p>
+     * In this test 5 items are related, and we're passing offset = 3 and limit = 1, so 1 item
+     * should be returned.
      *
-     * In this test 5 items are related, and we're passing offset = 3 and limit = 1, so 1 item should be returned.
      * @throws DotDataException
      * @throws DotSecurityException
      */
@@ -1142,7 +1243,7 @@ public class ContentUtilsTest {
             //creates child contentlet
             dataGen = new ContentletDataGen(commentsContentType.id());
 
-            for (int i=1; i<5 ;i++){
+            for (int i = 1; i < 5; i++) {
                 commentsContentlet = dataGen
                         .languageId(languageId)
                         .setProperty("title", "Comment for News " + i)
@@ -1168,14 +1269,14 @@ public class ContentUtilsTest {
                             1, 3, "", user, null, false, languageId, false);
 
             assertNotNull(result);
-            assertEquals(1,result.size());
+            assertEquals(1, result.size());
 
         } finally {
             if (null != newsContentlet && UtilMethods.isSet(newsContentlet.getInode())) {
                 ContentletDataGen.remove(newsContentlet);
             }
 
-            for (final Contentlet contentlet: relatedComments){
+            for (final Contentlet contentlet : relatedComments) {
                 ContentletDataGen.remove(contentlet);
             }
         }
@@ -1183,9 +1284,13 @@ public class ContentUtilsTest {
 
 
     /**
-     * Method to test: {@link ContentUtils#addRelationships(Contentlet, User, PageMode, long, int, HttpServletRequest, HttpServletResponse)} 
-     * Given Scenario: Creates a content parent with a children many to many relationship, create a few instances of the child type and related to the parent
-     * ExpectedResult: Calling the parameter with depth in 0 should retrieve the children contentlets
+     * Method to test:
+     * {@link ContentUtils#addRelationships(Contentlet, User, PageMode, long, int,
+     * HttpServletRequest, HttpServletResponse)} Given Scenario: Creates a content parent with a
+     * children many to many relationship, create a few instances of the child type and related to
+     * the parent ExpectedResult: Calling the parameter with depth in 0 should retrieve the children
+     * contentlets
+     *
      * @throws DotDataException
      * @throws DotSecurityException
      */
@@ -1194,11 +1299,14 @@ public class ContentUtilsTest {
             throws DotDataException, DotSecurityException {
 
         // 1) create the child content type
-        final ContentType childContentType = new ContentTypeDataGen().velocityVarName("child"+System.currentTimeMillis()).nextPersisted();
+        final ContentType childContentType = new ContentTypeDataGen().velocityVarName(
+                "child" + System.currentTimeMillis()).nextPersisted();
         // 2) create parent content type and add a relationship to the child content type
-        final ContentType parentContentType = new ContentTypeDataGen().velocityVarName("parent"+System.currentTimeMillis()).nextPersisted();
+        final ContentType parentContentType = new ContentTypeDataGen().velocityVarName(
+                "parent" + System.currentTimeMillis()).nextPersisted();
         Field field = FieldBuilder.builder(RelationshipField.class).name("children")
-                .contentTypeId(parentContentType.id()).values(String.valueOf(RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal()))
+                .contentTypeId(parentContentType.id())
+                .values(String.valueOf(RELATIONSHIP_CARDINALITY.MANY_TO_MANY.ordinal()))
                 .relationType(childContentType.variable()).build();
 
         APILocator.getContentTypeFieldAPI().save(field, APILocator.systemUser());
@@ -1209,15 +1317,18 @@ public class ContentUtilsTest {
         final Contentlet child3 = new ContentletDataGen(childContentType.id()).nextPersisted();
         // 4) create a instance of the parent and add the child instances to the relationship
         // 5) save it
-        final Contentlet parent = new ContentletDataGen(parentContentType.id()).setProperty("children", Arrays.asList(child1, child2, child3)).nextPersisted();
+        final Contentlet parent = new ContentletDataGen(parentContentType.id()).setProperty(
+                "children", Arrays.asList(child1, child2, child3)).nextPersisted();
 
         // 6) retrieve again
-        final Contentlet parentRetrieved = APILocator.getContentletAPI().findContentletByIdentifierAnyLanguage(parent.getIdentifier());
+        final Contentlet parentRetrieved = APILocator.getContentletAPI()
+                .findContentletByIdentifierAnyLanguage(parent.getIdentifier());
         Assert.assertNotNull(parentRetrieved);
         Assert.assertEquals(parent.getIdentifier(), parentRetrieved.getIdentifier());
         // 7) call the addRelationships method with depth = 1
         final int depth = 0;  // only ids
-        final HttpServletRequest  request  = new MockHttpRequestIntegrationTest("localhost", "/api/v1/test").request();
+        final HttpServletRequest request = new MockHttpRequestIntegrationTest("localhost",
+                "/api/v1/test").request();
         final HttpServletResponse response = new MockHttpResponse().response();
         ContentUtils.addRelationships(parentRetrieved, user, PageMode.EDIT_MODE,
                 APILocator.getLanguageAPI().getDefaultLanguage().getId(), depth, request, response);
@@ -1234,23 +1345,19 @@ public class ContentUtilsTest {
 
     /**
      * Test method: testFuturePublishDateContentRetrieval
-     *
-     * Given:
-     *   - Two versions of the same content (same identifier, different inodes)
-     *   - V1 is published immediately
-     *   - V2 has a publish date set 10 days in the future
-     *   - A query is made with a date after V2's publish date
-     *
-     * Scenario:
-     *   - Content is searched by identifier and by inode with a specific future date
-     *   - Content is searched in EDIT mode without specifying a date
-     *   - Content is searched in LIVE mode without specifying a date
-     *
-     * Expected Results:
-     *   - When searching with a future date (after the publish date),
-     *     it should return V2 regardless of whether searching by identifier or inode
-     *   - When searching in EDIT mode without a date, it should return V2 (most recent version)
-     *   - When searching in LIVE mode without a date, it should return V1 (currently published version)
+     * <p>
+     * Given: - Two versions of the same content (same identifier, different inodes) - V1 is
+     * published immediately - V2 has a publish date set 10 days in the future - A query is made
+     * with a date after V2's publish date
+     * <p>
+     * Scenario: - Content is searched by identifier and by inode with a specific future date -
+     * Content is searched in EDIT mode without specifying a date - Content is searched in LIVE mode
+     * without specifying a date
+     * <p>
+     * Expected Results: - When searching with a future date (after the publish date), it should
+     * return V2 regardless of whether searching by identifier or inode - When searching in EDIT
+     * mode without a date, it should return V2 (most recent version) - When searching in LIVE mode
+     * without a date, it should return V1 (currently published version)
      */
     @Test
     public void testFuturePublishDateContentRetrieval() {
@@ -1280,7 +1387,6 @@ public class ContentUtilsTest {
             final Instant relativeInstant2 = relativeDate2.atZone(utc.toZoneId()).toInstant();
             final Date futureDate = Date.from(relativeInstant2);
 
-
             //Let's create two versions of a content they must share the same identifier
             blogsDataGen
                     .setProperty("title", "v1");
@@ -1293,7 +1399,8 @@ public class ContentUtilsTest {
                     .setProperty("publishDate", publishDate);  // Set the publish-date in the future
             final Contentlet blogV2 = blogsDataGen.nextPersisted();
 
-            final MockAttributeRequest mockAttributeRequest = new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/?mode=LIVE").request());
+            final MockAttributeRequest mockAttributeRequest = new MockAttributeRequest(
+                    new MockHttpRequestIntegrationTest("localhost", "/?mode=LIVE").request());
             HttpServletRequestThreadLocal.INSTANCE.setRequest(mockAttributeRequest);
 
             //Let's make sure that the identifier is the same
@@ -1303,30 +1410,100 @@ public class ContentUtilsTest {
             final String dateAsString = String.valueOf(futureDate.getTime());
 
             //Find by identifier and inode
-            final Contentlet blogV1ByIdentifier = ContentUtils.find(blogV1.getIdentifier(), user, dateAsString, true, language.getId());
-            final Contentlet blogV1ByInode = ContentUtils.find(blogV1.getInode(), user, dateAsString, true, language.getId());
+            final Contentlet blogV1ByIdentifier = ContentUtils.find(blogV1.getIdentifier(), user,
+                    dateAsString, true, language.getId());
+            final Contentlet blogV1ByInode = ContentUtils.find(blogV1.getInode(), user,
+                    dateAsString, true, language.getId());
             Assert.assertNotNull(blogV1ByIdentifier);
             Assert.assertNotNull(blogV1ByInode);
             //Here we should always get v2 regardless of the identifier or inode because they both have a future version matching the publish-date
-            Assert.assertEquals("v2",blogV1ByIdentifier.getTitle());
-            Assert.assertEquals("v2",blogV1ByInode.getTitle());
+            Assert.assertEquals("v2", blogV1ByIdentifier.getTitle());
+            Assert.assertEquals("v2", blogV1ByInode.getTitle());
             //Here again we should always get v2 regardless of the identifier or inode because they both have a future version matching the publish-date
-            final Contentlet blogV2ByIdentifier = ContentUtils.find(blogV2.getIdentifier(), user, dateAsString, true, language.getId());
-            final Contentlet blogV2ByInode = ContentUtils.find(blogV2.getInode(), user, dateAsString, true, language.getId());
+            final Contentlet blogV2ByIdentifier = ContentUtils.find(blogV2.getIdentifier(), user,
+                    dateAsString, true, language.getId());
+            final Contentlet blogV2ByInode = ContentUtils.find(blogV2.getInode(), user,
+                    dateAsString, true, language.getId());
             Assert.assertNotNull(blogV2ByIdentifier);
             Assert.assertNotNull(blogV2ByInode);
-            Assert.assertEquals("v2",blogV2ByIdentifier.getTitle());
-            Assert.assertEquals("v2",blogV2ByInode.getTitle());
+            Assert.assertEquals("v2", blogV2ByIdentifier.getTitle());
+            Assert.assertEquals("v2", blogV2ByInode.getTitle());
 
             //If we request Preview or Edit we should continue to get the same unpublished version
-            final Contentlet blogByIdentifierNoDateEdit = ContentUtils.find(blogV2.getIdentifier(), user, null, true, language.getId());
+            final Contentlet blogByIdentifierNoDateEdit = ContentUtils.find(blogV2.getIdentifier(),
+                    user, null, true, language.getId());
             Assert.assertNotNull(blogByIdentifierNoDateEdit);
-            Assert.assertEquals("v2",blogByIdentifierNoDateEdit.getTitle());
+            Assert.assertEquals("v2", blogByIdentifierNoDateEdit.getTitle());
 
             //Now if we request the live version we should get the v1
-            final Contentlet blogByIdentifierNoDateLive = ContentUtils.find(blogV2.getIdentifier(), user, null, false, language.getId());
+            final Contentlet blogByIdentifierNoDateLive = ContentUtils.find(blogV2.getIdentifier(),
+                    user, null, false, language.getId());
             Assert.assertNotNull(blogByIdentifierNoDateLive);
-            Assert.assertEquals("v1",blogByIdentifierNoDateLive.getTitle());
+            Assert.assertEquals("v1", blogByIdentifierNoDateLive.getTitle());
+
+        } finally {
+            TimeZone.setDefault(defaultZone);
+        }
+    }
+
+    /**
+     * Test method: ContentUtils.pull(String, int, String, User, String)
+     * Given Scenario: - We're simply testing that a query that is meant to 1 result, returns 1 result plus a future version of the content when passing a tmDate
+     * Expected Results: - The query should return 2 result
+     */
+    @Test
+    public void testContentPullLimit() {
+        final TimeZone defaultZone = TimeZone.getDefault();
+        try {
+            final TimeZone utc = TimeZone.getTimeZone("UTC");
+            TimeZone.setDefault(utc);
+
+            final Host host = new SiteDataGen().nextPersisted();
+            final Language language = APILocator.getLanguageAPI().getDefaultLanguage();
+            final ContentType blogLikeContentType = TestDataUtils.getBlogLikeContentType();
+            final ContentletDataGen blogsDataGen = new ContentletDataGen(blogLikeContentType.id())
+                    .languageId(language.getId())
+                    .host(host)
+                    .setProperty("body", TestDataUtils.BLOCK_EDITOR_DUMMY_CONTENT)
+                    .setPolicy(IndexPolicy.WAIT_FOR)
+                    .languageId(language.getId())
+                    .setProperty(Contentlet.IS_TEST_MODE, true);
+
+            //Ten days from now
+            final LocalDateTime relativeDate = LocalDateTime.now().plusDays(10).plusHours(1);
+            final Instant relativeInstant = relativeDate.atZone(utc.toZoneId()).toInstant();
+            final Date publishDate = Date.from(relativeInstant);
+
+            //Any date after publish date
+            final LocalDateTime relativeDate2 = LocalDateTime.now().plusDays(11).plusHours(1);
+            final Instant elevenDaysInTheFuture = relativeDate2.atZone(utc.toZoneId()).toInstant();
+
+            //Let's create two versions of a content they must share the same identifier
+            blogsDataGen
+                    .setProperty("title", "v1");
+            final Contentlet blogV1 =
+                    blogsDataGen.nextPersistedAndPublish();
+
+            blogsDataGen
+                    .setProperty("identifier", blogV1.getIdentifier())
+                    .setProperty("title", "v2")
+                    .setProperty("publishDate", publishDate);  // Set the publish-date in the future
+            //And persist the future version
+            final Contentlet blogV2 = blogsDataGen.nextPersisted();
+            assertNotNull(blogV2);
+
+            final String tmDate = elevenDaysInTheFuture.toEpochMilli() + "";
+            final String query = "+contentType:" + blogLikeContentType.variable() + " +live:true ";
+            final List<Contentlet> listNoLimit = ContentUtils.pull(query,-1,0,"modDate desc", user,
+                    tmDate, false);
+            assertEquals("We expect the live version plus the future version since we're passing the tmDate", 2, listNoLimit.size());
+            final Contentlet contentlet1 = listNoLimit.get(0);
+            assertEquals(blogV1.getIdentifier(), contentlet1.getIdentifier());
+
+            final List<Contentlet> listWithLimit1 = ContentUtils.pull(query,-1,1,"modDate desc", user,
+                    tmDate, false);
+            assertEquals("We expect only 1 entry here. Since we used a limit 1", 1, listWithLimit1.size());
+            //We don't know which one will be returned, but it should be one of the two
 
         } finally {
             TimeZone.setDefault(defaultZone);


### PR DESCRIPTION
Docs says that limit zero means no limit. 
When the time machine was on, the following construct was returning an empty array

`
#set($footerContent = $dotcontent.pull("+contentType:FooterMenu",0,"modDate desc"))
`


This PR fixes: #31730