### PR TITLE
#31692 Not inserting register in the unique_fields table when we are …

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldValidationStrategy.java
@@ -68,6 +68,18 @@ public interface  UniqueFieldValidationStrategy {
         innerValidate(contentlet, uniqueField, value, contentType);
     }
 
+    /**
+     * Validate Unique fiedla inside Preview mode, by default this method just called
+     * {@link UniqueFieldValidationStrategy#innerValidate(Contentlet, Field, Object, ContentType)} but this behavior
+     * can be overriding
+     *
+     * @param contentlet Contentlet to validate
+     * @param uniqueField Unique field to validate
+     *
+     * @throws UniqueFieldValueDuplicatedException throw if we have any duplicated value
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
     default void validateInPreview(final Contentlet contentlet, final Field uniqueField)
             throws UniqueFieldValueDuplicatedException, DotDataException, DotSecurityException {
 
@@ -109,10 +121,23 @@ public interface  UniqueFieldValidationStrategy {
                                 final ContentType contentType)
             throws UniqueFieldValueDuplicatedException, DotDataException, DotSecurityException;
 
+    /**
+     * Method to be overriding if you want to override the default behavior of the preview validation
+     * by default the preview validation in the same that the normal validation.
+     *
+     * @param contentlet Contentlet to be validated
+     * @param field Field to be validated
+     * @param fieldValue Value to be validated
+     * @param contentType
+     *
+     * @throws UniqueFieldValueDuplicatedException
+     * @throws DotDataException
+     * @throws DotSecurityException
+     */
     default void innerValidateInPreview(final Contentlet contentlet, final Field field, final Object fieldValue,
                        final ContentType contentType)
             throws UniqueFieldValueDuplicatedException, DotDataException, DotSecurityException {
-
+        innerValidate(contentlet, field, fieldValue, contentType);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldsValidationInitializer.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/UniqueFieldsValidationInitializer.java
@@ -8,7 +8,6 @@ import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Logger;
 
-import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import java.sql.SQLException;
@@ -42,7 +41,7 @@ public class UniqueFieldsValidationInitializer  implements DotInitializer {
 
         try {
             if (featureFlagDbUniqueFieldValidation && !uniqueFieldsTableExists) {
-                this.uniqueFieldDataBaseUtil.createTableAnsPopulate();
+                this.uniqueFieldDataBaseUtil.createTableAndPopulate();
             } else if (!featureFlagDbUniqueFieldValidation && uniqueFieldsTableExists) {
                 this.uniqueFieldDataBaseUtil.dropUniqueFieldsValidationTable();
             }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtil.java
@@ -55,7 +55,7 @@ public class UniqueFieldDataBaseUtil {
 
     private static final String UPDATE_CONTENT_LIST_WITH_HASH ="UPDATE unique_fields " +
             "SET supporting_values = jsonb_set(supporting_values, '{" + CONTENTLET_IDS_ATTR + "}', ?::jsonb) " +
-            "WHERE unique_key_val = encode(sha256(convert_to(?::text, 'UTF8')), 'hex')";
+            "WHERE unique_key_val = ?";
 
     private final static String GET_UNIQUE_FIELDS_BY_CONTENTLET = "SELECT * FROM unique_fields " +
             "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb " +

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtil.java
@@ -9,6 +9,7 @@ import com.dotcms.contenttype.model.type.ContentType;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.util.Logger;
 import com.liferay.util.StringPool;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -244,10 +245,18 @@ public class UniqueFieldDataBaseUtil {
 
     }
 
-    private static Map<String, Object> getSupportingValues(Map<String, Object> item) {
+    /**
+     * Return the supporting_values from a unique_field table register also turn the supporting_values from a
+     * {@link org.postgresql.util.PGobject} to a Map.
+     *
+     * @param uniqueFieldRegister
+     * @return
+     */
+    private static Map<String, Object> getSupportingValues(final Map<String, Object> uniqueFieldRegister) {
         try {
-            return com.dotcms.util.JsonUtil.getJsonFromString(item.get("supporting_values").toString());
+            return com.dotcms.util.JsonUtil.getJsonFromString(uniqueFieldRegister.get("supporting_values").toString());
         } catch (IOException e) {
+            Logger.error(UniqueFieldDataBaseUtil.class.getName(), "Error getting supporting values", e);
             throw new RuntimeException(e);
         }
     }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
@@ -454,7 +454,6 @@ public class ImportContentletsAction extends DotPortletAction {
         Logger.info(this, String.format("-> File: %s", importForm.getFileName()));
         Logger.info(this, String.format("-> Content Type ID: %s", importForm.getStructure()));
 		HashMap<String, List<String>> results = ImportUtil.importFile(importId, currentSiteId, importForm.getStructure(), importForm.getFields(), true, (importForm.getLanguage() == -1), user, importForm.getLanguage(), csvHeaders, csvreader, languageCodeHeaderColumn, countryCodeHeaderColumn, reader, importForm.getWorkflowActionId(),httpReq);
-		//HibernateUtil.rollbackTransaction();
 		req.setAttribute("previewResults", results);
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
@@ -454,6 +454,7 @@ public class ImportContentletsAction extends DotPortletAction {
         Logger.info(this, String.format("-> File: %s", importForm.getFileName()));
         Logger.info(this, String.format("-> Content Type ID: %s", importForm.getStructure()));
 		HashMap<String, List<String>> results = ImportUtil.importFile(importId, currentSiteId, importForm.getStructure(), importForm.getFields(), true, (importForm.getLanguage() == -1), user, importForm.getLanguage(), csvHeaders, csvreader, languageCodeHeaderColumn, countryCodeHeaderColumn, reader, importForm.getWorkflowActionId(),httpReq);
+		//HibernateUtil.rollbackTransaction();
 		req.setAttribute("previewResults", results);
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.portlets.contentlet.business;
 
 import com.dotcms.business.CloseDBIfOpened;
+import com.dotcms.business.WrapInTransaction;
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.variant.model.Variant;
@@ -1993,11 +1994,40 @@ public interface ContentletAPI {
 	 * @throws DotContentletValidationException will be thrown if the contentlet is not valid.  
 	 * Use the notValidFields property of the exception to get which fields where not valid
 	 */
+	@WrapInTransaction
 	public void validateContentlet(Contentlet contentlet,Map<Relationship, List<Contentlet>> contentRelationships,List<Category> cats) throws DotContentletValidationException;
 
 	@CloseDBIfOpened
+	@WrapInTransaction
 	void validateContentletNoRels(Contentlet contentlet,
 			List<Category> cats) throws DotContentletValidationException;
+
+	/**
+	 * Validate contentlet
+	 *
+	 * @param contentlet to be validated
+	 * @param contentRelationships Contentlet's relationships
+	 * @param cats Contentlet's catgories
+	 * @param preview if it true it means that it is running in preview mode
+	 * @throws DotContentletValidationException
+	 */
+	@WrapInTransaction
+	void validateContentlet(Contentlet contentlet,
+									 ContentletRelationships contentRelationships,List<Category> cats, boolean preview )
+			throws DotContentletValidationException;
+
+	/**
+	 * Validate contentlet
+	 *
+	 * @param contentlet to be validated
+	 * @param cats Contentlet's catgories
+	 * @param preview if it true it means that it is running in preview mode
+	 * @throws DotContentletValidationException
+	 */
+	@CloseDBIfOpened
+	@WrapInTransaction
+	void validateContentletNoRels(Contentlet contentlet,
+								  List<Category> cats, boolean preview) throws DotContentletValidationException;
 
 	/**
 	 * Use to validate your contentlet.
@@ -2008,7 +2038,9 @@ public interface ContentletAPI {
 	 * Use the notValidFields property of the exception to get which fields where not valid
 	 */
 	public void validateContentlet(Contentlet contentlet, ContentletRelationships contentRelationships, List<Category> cats) throws DotContentletValidationException;
-	
+
+
+
 	/**
 	 * Use to determine if if the field value is a String value withing the contentlet object
 	 * @param field

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -2315,6 +2315,40 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 	}
 
 	@Override
+	public void validateContentlet(Contentlet contentlet,
+			ContentletRelationships contentRelationships, List<Category> cats, boolean preview ) throws DotContentletValidationException {
+		for(ContentletAPIPreHook pre : preHooks){
+			boolean preResult = pre.validateContentletNoRels(contentlet, cats);
+			if(!preResult){
+				String errorMessage = String.format(PREHOOK_FAILED_MESSAGE, pre.getClass().getName());
+				Logger.error(this, errorMessage);
+				throw new DotRuntimeException(errorMessage);
+			}
+		}
+		conAPI.validateContentlet(contentlet, contentRelationships, cats, preview);
+		for(ContentletAPIPostHook post : postHooks){
+			post.validateContentletNoRels(contentlet, cats);
+		}
+	}
+
+	@Override
+	public void validateContentletNoRels(Contentlet contentlet,
+										   List<Category> cats, boolean preview) throws DotContentletValidationException {
+			for(ContentletAPIPreHook pre : preHooks){
+				boolean preResult = pre.validateContentletNoRels(contentlet, cats);
+				if(!preResult){
+					String errorMessage = String.format(PREHOOK_FAILED_MESSAGE, pre.getClass().getName());
+					Logger.error(this, errorMessage);
+					throw new DotRuntimeException(errorMessage);
+				}
+			}
+			conAPI.validateContentletNoRels(contentlet, cats, preview);
+			for(ContentletAPIPostHook post : postHooks){
+				post.validateContentletNoRels(contentlet, cats);
+			}
+	}
+
+	@Override
 	public void addPreHook(String className) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
 		Object o = Class.forName(className).newInstance();
         addPreHook( o );

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -3092,7 +3092,7 @@ public class ImportUtil {
             // Validate relationships for the contentlet
             validateRelationships(lineNumber,
                     headers, categories, cont, csvRelationshipRecordsParentOnly,
-                    csvRelationshipRecordsChildOnly, csvRelationshipRecords);
+                    csvRelationshipRecordsChildOnly, csvRelationshipRecords, true);
 
             // Process workflow
             if (!preview) {
@@ -3143,7 +3143,8 @@ public class ImportUtil {
             final Contentlet cont,
             final Map<Relationship, List<Contentlet>> csvRelationshipRecordsParentOnly,
             final Map<Relationship, List<Contentlet>> csvRelationshipRecordsChildOnly,
-            final Map<Relationship, List<Contentlet>> csvRelationshipRecords
+            final Map<Relationship, List<Contentlet>> csvRelationshipRecords,
+            final boolean preview
     ) throws DotDataException {
 
         //Check the new contentlet with the validator
@@ -3152,8 +3153,9 @@ public class ImportUtil {
                         .equals(FieldType.RELATIONSHIP.toString())));
 
         try {
+
             if (skipRelationshipsValidation) {
-                conAPI.validateContentletNoRels(cont, new ArrayList<>(categories));
+                conAPI.validateContentletNoRels(cont, new ArrayList<>(categories), preview);
 
             } else {
                 ContentletRelationships contentletRelationships = loadRelationshipRecords(
@@ -3161,7 +3163,7 @@ public class ImportUtil {
                         csvRelationshipRecords, cont);
 
                 conAPI.validateContentlet(cont, contentletRelationships,
-                        new ArrayList<>(categories));
+                        new ArrayList<>(categories), preview);
             }
         } catch (DotContentletValidationException ex) {
             final StringBuilder sb = new StringBuilder();

--- a/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImplTest.java
@@ -2159,7 +2159,7 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
      * - Populate manually the unique_fields table
      * - Update one of the Contentlet and the unique_fields table should be updated too, but the register
      * is not going to be removed because we have another Contentlet with the same value
-     * Should: Update the Contentlet and uodate the unique_fields table right
+     * Should: Update the Contentlet and update the unique_fields table right
      *
      * This can happen if the Contentlets with the duplicated values exists before the Upgrade than contains the new Database validation
      *
@@ -2231,7 +2231,8 @@ public class ESContentletAPIImplTest extends IntegrationTestBase {
             final String hash = StringUtils.hashText(contentType.id() + uniqueTextFieldFromDB.variable() +
                     language.getId() + uniqueVersionValue + host.getIdentifier());
 
-            new DotConnect().setSQL("INSERT INTO unique_fields (unique_key_val, supporting_values) VALUES(?, ?)")
+            new DotConnect().setSQL("INSERT INTO unique_fields (unique_key_val, supporting_values) " +
+                            "VALUES(encode(sha256(convert_to(?::text, 'UTF8')), 'hex'), ?)")
                     .addParam(hash)
                     .addJSONParam(supportingValues)
                     .loadObjectResults();

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtilTest.java
@@ -876,64 +876,6 @@ public class UniqueFieldDataBaseUtilTest {
 
     /**
      * Method to test: {@link UniqueFieldDataBaseUtil#updateContentListWithHash(String, List)}
-     * when: Update a unique field with a different list of contentlets
-     * Should: update the register
-     */
-    @Test
-    public void updateContentListWithHash() throws DotDataException {
-        final String uniqueValue = "unique_value";
-
-        final ContentType contentType = new ContentTypeDataGen()
-                .nextPersisted();
-
-        final Language language = new LanguageDataGen().nextPersisted();
-
-        final Field uniqueTextField = new FieldDataGen()
-                .contentTypeId(contentType.id())
-                .unique(true)
-                .type(TextField.class)
-                .nextPersisted();
-
-        final Host host = new SiteDataGen().nextPersisted();
-
-        final Contentlet contentlet = new ContentletDataGen(contentType)
-                .host(host)
-                .languageId(language.getId())
-                .setProperty(uniqueTextField.variable(), uniqueValue)
-                .nextPersisted();
-
-        final UniqueFieldCriteria uniqueFieldCriteria = new Builder().setVariantName(contentlet.getVariantId())
-                .setLanguage(language)
-                .setContentType(contentlet.getContentType())
-                .setField(uniqueTextField)
-                .setSite(host)
-                .setLive(false)
-                .setValue(uniqueValue)
-                .build();
-
-        final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
-
-        final Map<String, Object> supportingValues =  new HashMap<>(uniqueFieldCriteria.toMap());
-        supportingValues.put(CONTENTLET_IDS_ATTR, List.of(contentlet.getIdentifier()));
-        supportingValues.put(UNIQUE_PER_SITE_ATTR, false);
-
-        uniqueFieldDataBaseUtil.insert(uniqueFieldCriteria.criteria(), supportingValues);
-
-        uniqueFieldDataBaseUtil.updateContentListWithHash(uniqueFieldCriteria.criteria(), list("1", "2"));
-
-        UniqueFieldDataBaseUtil.UniqueFieldValue uniqueFieldValue = uniqueFieldDataBaseUtil.get(uniqueFieldCriteria)
-                .orElseThrow();
-
-        Map<String, Object> supportingValuesFromDB = uniqueFieldValue.getSupportingValues();
-
-        assertEquals(2, ((Collection) supportingValuesFromDB.get(CONTENTLET_IDS_ATTR)).size());
-        assertTrue(((Collection) supportingValuesFromDB.get(CONTENTLET_IDS_ATTR)).contains("1"));
-        assertTrue(((Collection) supportingValuesFromDB.get(CONTENTLET_IDS_ATTR)).contains("2"));
-    }
-
-
-    /**
-     * Method to test: {@link UniqueFieldDataBaseUtil#updateContentListWithHash(String, List)}
      * when: try to delete a unique_fields register using the hash
      * Should: delete it
      */

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -3120,7 +3120,9 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
             final List<String> results = imported.get("results");
             assertEquals(2, results.size());
 
-            assertTrue(results.contains(String.format("2 new \"%s\" were-created", contentType.name())));
+            final String expectedMessage = String.format("2 new \"%s\" were-created", contentType.name());
+            assertTrue(String.format("Expected Message %s, real messages", expectedMessage, results),
+                    results.contains(expectedMessage));
 
             final List<String> errors = imported.get("errors");
             assertTrue( errors.isEmpty());
@@ -3234,7 +3236,9 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
             final String resultErrorMessage = String.format("0 \"%s\" contentlets-updated-corresponding-to 0 repeated-contents-based-on-the-key-provided", contentType.name());
 
-            assertTrue(results.contains(String.format("0 new \"%s\" were-created", contentType.name())));
+            final String expectedMessage = String.format("0 new \"%s\" were-created", contentType.name());
+            assertTrue(String.format("Expected message %s real message %s", expectedMessage, results),
+                    results.contains(expectedMessage));
             assertTrue(results.contains(resultErrorMessage));
 
             final List<String> errors = imported.get("errors");

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -3239,7 +3239,8 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
             final String expectedMessage = String.format("0 New \"%s\" were created.", contentType.name());
             assertTrue(String.format("Expected message %s real message %s", expectedMessage, results),
                     results.contains(expectedMessage));
-            assertTrue(results.contains(resultErrorMessage));
+            assertTrue(String.format("Expected %s reals %s", resultErrorMessage, results),
+                    results.contains(resultErrorMessage));
 
             final List<String> errors = imported.get("errors");
             assertEquals(2, errors.size());

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -3234,12 +3234,12 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
             final List<String> results = imported.get("results");
             assertEquals(2, results.size());
 
-            final String resultErrorMessage = String.format("0 \"%s\" contentlets updated corresponding to 0 repeated contents based on the key provided", contentType.name());
+            final String resultErrorMessage = String.format("0 \"%s\" content updated corresponding to 0 repeated contents based on the key provided", contentType.name());
 
             final String expectedMessage = String.format("0 New \"%s\" were created.", contentType.name());
-            assertTrue(String.format("Expected message %s real message %s", expectedMessage, results),
+            assertTrue(String.format("Expected message: %s /real message: %s", expectedMessage, results),
                     results.contains(expectedMessage));
-            assertTrue(String.format("Expected %s reals %s", resultErrorMessage, results),
+            assertTrue(String.format("Expected: %s / reals: %s", resultErrorMessage, results),
                     results.contains(resultErrorMessage));
 
             final List<String> errors = imported.get("errors");

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -3234,7 +3234,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
             final List<String> results = imported.get("results");
             assertEquals(2, results.size());
 
-            final String resultErrorMessage = String.format("0 \"%s\" content updated corresponding to 0 repeated contents based on the key provided", contentType.name());
+            final String resultErrorMessage = String.format("0 \"%s\" content updated corresponding to 0 repeated content based on the key provided", contentType.name());
 
             final String expectedMessage = String.format("0 New \"%s\" were created.", contentType.name());
             assertTrue(String.format("Expected message: %s /real message: %s", expectedMessage, results),

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -3120,7 +3120,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
             final List<String> results = imported.get("results");
             assertEquals(2, results.size());
 
-            final String expectedMessage = String.format("2 new \"%s\" were-created", contentType.name());
+            final String expectedMessage = String.format("2 New \"%s\" were created.", contentType.name());
             assertTrue(String.format("Expected Message %s, real messages", expectedMessage, results),
                     results.contains(expectedMessage));
 
@@ -3236,7 +3236,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
             final String resultErrorMessage = String.format("0 \"%s\" contentlets-updated-corresponding-to 0 repeated-contents-based-on-the-key-provided", contentType.name());
 
-            final String expectedMessage = String.format("0 new \"%s\" were-created", contentType.name());
+            final String expectedMessage = String.format("0 New \"%s\" were created.", contentType.name());
             assertTrue(String.format("Expected message %s real message %s", expectedMessage, results),
                     results.contains(expectedMessage));
             assertTrue(results.contains(resultErrorMessage));

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -3234,7 +3234,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
             final List<String> results = imported.get("results");
             assertEquals(2, results.size());
 
-            final String resultErrorMessage = String.format("0 \"%s\" contentlets-updated-corresponding-to 0 repeated-contents-based-on-the-key-provided", contentType.name());
+            final String resultErrorMessage = String.format("0 \"%s\" contentlets updated corresponding to 0 repeated contents based on the key provided", contentType.name());
 
             final String expectedMessage = String.format("0 New \"%s\" were created.", contentType.name());
             assertTrue(String.format("Expected message %s real message %s", expectedMessage, results),


### PR DESCRIPTION
I found 3 thing to fix here:

- When you run Preview the unique_fields table was populated with the new values from the imported files, that is why when we try to run the preview again we got duplicated error.
- We have some queries and methods in UniqueFieldDataBaseUtil were not used anymore so I remove them
- One Query was wrong and I fixed it
- The import process trigger the validation twice so it make us got the same error that when we run the preview process

### Proposed Changes
* Remove unused methods

https://github.com/dotCMS/core/pull/31732/files#diff-b0aed2eddcc36be2a2e2f46624345a83c8698db238fe4dc228c0fb13a11e344fL239-L244

- Fix queries

https://github.com/dotCMS/core/pull/31732/files#diff-b0aed2eddcc36be2a2e2f46624345a83c8698db238fe4dc228c0fb13a11e344fR58

https://github.com/dotCMS/core/pull/31732/files#diff-b0aed2eddcc36be2a2e2f46624345a83c8698db238fe4dc228c0fb13a11e344fR88

* Create a new method to validate inside preview, in this case we are not going to insert the register in the unique_fields table

https://github.com/dotCMS/core/pull/31732/files#diff-445f8d01aa4de058eaaf883e573d17ef1123b1e74a9a98120ac156b78f4c6522R71-R91

* Make the the first validation in the import run like it was in preview, that is not a problem because any way the save process is going to run the validation again

https://github.com/dotCMS/core/pull/31732/files#diff-24bf5b53d7c8111ccaeaf3d9f80d6badb0bbc1960c73beb1a5ef892e70b2b42dR3095



This PR fixes: #31692