### PR TITLE
fix(UVE): Respect App URL Configuration in the UVE

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
@@ -257,6 +257,36 @@ describe('withEditor', () => {
                     'http://localhost/first?language_id=1&variantName=DEFAULT&personaId=dot%3Apersona'
                 );
             });
+
+            it('should set the right iframe url when the clientHost is present', () => {
+                patchState(store, {
+                    pageAPIResponse: {
+                        ...MOCK_RESPONSE_HEADLESS
+                    },
+                    pageParams: {
+                        ...emptyParams,
+                        url: 'test-url',
+                        clientHost: 'http://localhost:3000'
+                    }
+                });
+
+                expect(store.$iframeURL()).toBe('http://localhost:3000/test-url');
+            });
+
+            it('should set the right iframe url when the clientHost is present with a aditional path', () => {
+                patchState(store, {
+                    pageAPIResponse: {
+                        ...MOCK_RESPONSE_HEADLESS
+                    },
+                    pageParams: {
+                        ...emptyParams,
+                        url: 'test-url',
+                        clientHost: 'http://localhost:3000/test'
+                    }
+                });
+
+                expect(store.$iframeURL()).toBe('http://localhost:3000/test/test-url');
+            });
         });
 
         describe('$editorProps', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -55,8 +55,10 @@ const buildIframeURL = ({ url, params, isTraditionalPage }) => {
         return new String('');
     }
 
+    // Remove trailing slash from host
+    const host = (params.clientHost || window.location.origin).replace(/\/$/, '');
     const pageURL = getFullPageURL({ url, params, userFriendlyParams: true });
-    const iframeURL = new URL(pageURL, params.clientHost || window.location.origin); // Add Host to iframeURL
+    const iframeURL = new URL(`${host}/${pageURL}`);
 
     return iframeURL.toString();
 };


### PR DESCRIPTION
This pull request includes changes to the `core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor` module to enhance the handling of iframe URLs. The most important changes are the addition of new test cases to verify the correct iframe URL generation and the modification of the URL construction logic to handle trailing slashes in the client host.

Enhancements to iframe URL handling:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts`](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbR260-R289): Added new test cases to verify that the iframe URL is correctly set when the `clientHost` is present, both with and without an additional path.

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts`](diffhunk://#diff-86e692578757ed7f4f6cba5d0aeb07641312f3b17885825d1a45987153ae87f0R58-R61): Modified the `buildIframeURL` function to remove trailing slashes from the `clientHost` before constructing the iframe URL. This ensures that the URL is correctly formatted regardless of the presence of trailing slashes.

### Video


https://github.com/user-attachments/assets/44993bab-2c44-425f-ab62-0218a047e9df


This PR fixes: #31752