### PR TITLE
refactor(core): remove 'Parent Issue' field from defect, feature, and task templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yaml
+++ b/.github/ISSUE_TEMPLATE/defect.yaml
@@ -10,16 +10,6 @@ body:
         If you have any questions about how to use this form, check out [How dotCMS uses GitHub](https://docs.google.com/presentation/d/1C1oCESIL9Z84xXo1DPWQZh48c4BSGlVRAn1DYGEFMUw).
 
   - type: textarea
-    id: parent-issue
-    attributes:
-      label: "Parent Issue"
-      description: "If this work is part of another epic or story, please please include a GitHub issue link to the parent issue."
-      placeholder:
-      value: 
-    validations:
-      required: false
-
-  - type: textarea
     id: problem-statement
     attributes:
       label: "Problem Statement"

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -11,16 +11,6 @@ body:
         If you have any questions about how to use this form, check out [How dotCMS uses GitHub](https://docs.google.com/presentation/d/1C1oCESIL9Z84xXo1DPWQZh48c4BSGlVRAn1DYGEFMUw).
 
   - type: textarea
-    id: parent-issue
-    attributes:
-      label: "Parent Issue"
-      description: "If this work is part of another epic or story, please please include a GitHub issue link to the parent issue."
-      placeholder:
-      value: 
-    validations:
-      required: false
-
-  - type: textarea
     id: user-story
     attributes:
       label: "User Story"

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -9,16 +9,6 @@ body:
     attributes:
       value: |
         If you have any questions about how to use this form, check out [How dotCMS uses GitHub](https://docs.google.com/presentation/d/1C1oCESIL9Z84xXo1DPWQZh48c4BSGlVRAn1DYGEFMUw).
-
-  - type: textarea
-    id: parent-issue
-    attributes:
-      label: "Parent Issue"
-      description: "If this work is part of another epic or story, please please include a GitHub issue link to the parent issue."
-      placeholder:
-      value: 
-    validations:
-      required: false
       
   - type: textarea
     id: task-body


### PR DESCRIPTION
### Proposed Changes

This pull request involves updates to the GitHub issue templates by removing the "Parent Issue" field from multiple templates. The changes are aimed at simplifying the issue creation process.

Changes to GitHub issue templates:

* [`.github/ISSUE_TEMPLATE/defect.yaml`](diffhunk://#diff-1fbf14bf5c9a66f985e0ddc2a78388f794294e49367c4ec1dc4872d566f5e4d3L12-L21): Removed the "Parent Issue" field to streamline the defect reporting process.
* [`.github/ISSUE_TEMPLATE/feature.yaml`](diffhunk://#diff-6beb416586c4731c5c2194db41281446efceebf9f99cdbe2fa569d4a50e2d06fL13-L22): Removed the "Parent Issue" field to simplify the feature request form.
* [`.github/ISSUE_TEMPLATE/task.yaml`](diffhunk://#diff-8a66f0993793dfea458176fce664e6d39e3be13d3c1aadf0e53225f4ca4f0a49L13-L22): Removed the "Parent Issue" field to make the task creation form more straightforward.


### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)


