### PR TITLE
feat(Content Analytics): Updating connection timeout values for executing CubeJS queries

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/cube.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/cube.js
@@ -22,6 +22,10 @@ module.exports = {
     preAggregationsSchema: ({ securityContext }) =>
         `pre_aggregations_${securityContext.customerId}`,*/
 
+    orchestratorOptions: {
+        continueWaitTimeout: 30
+    },
+
     queryRewrite: (query, { securityContext }) => {
         const tokenData = resolveToken(securityContext);
         console.log(`tokenData: ${JSON.stringify(tokenData, null, 2)}`);

--- a/dotCMS/src/main/java/com/dotcms/cube/CubeJSClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cube/CubeJSClient.java
@@ -131,8 +131,22 @@ public class CubeJSClient implements EventSubscriber<SystemTableUpdatedKeyEvent>
         }
     }
 
+    /**
+     * Determines the connection timeout set for executing a CubeJS query. After that, an error will
+     * be thrown. Keep in mind that a ClickHouse Database with thousands if not millions of records
+     * may take a long time to retrieve results.
+     * <p>
+     * It's also important to note that this timeout should match the value of the
+     * {@code continueWaitTimeout} configuration property in the {@code cube.js} file for
+     * ClickHouse, which has a maximum value of {@code 90} -- in seconds. For more information, you
+     * can refer to
+     * <a href="https://cube.dev/docs/reference/configuration/config#orchestrator_options">The
+     * official documentation</a>.</p>
+     *
+     * @return The connection timeout for executing queries, in milliseconds.
+     */
     private long resolveClientTimeout() {
-        return Config.getLongProperty(CUBEJS_CLIENT_TIMEOUT_KEY, 8000);
+        return Config.getLongProperty(CUBEJS_CLIENT_TIMEOUT_KEY, 30000);
     }
 
     private Response<String> getStringResponse(final CircuitBreakerUrl cubeJSClient,


### PR DESCRIPTION
### Proposed Changes
* Updating the timeout values set by default when running CubeJS queries. This means:
  * Adding the `continueWaitTimeout` property to the `cube.js` file, and set its value to `30` -- in seconds -- by default.
  * Updating the default value of the `CUBEJS_CLIENT_TIMEOUT` env var in the `CubeJSClient` class to `30000` -- in milliseconds -- by default.
* These changes are meant to allow the execution of queries that might return a very large dataset.
* However, dealing with a large number of results requires better planning. Using pagination is a great way to avoid this problem as well.

This PR fixes: #31740