### PR TITLE
test: fixing npe on host.getTagStroage

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/beans/Host.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/Host.java
@@ -10,6 +10,7 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.liferay.portal.model.User;
 
+import io.vavr.control.Try;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -185,7 +186,14 @@ public class Host extends Contentlet implements Permissionable,Treeable,Parentab
 	}
 
 	public String getTagStorage() {
-		return (String) map.get(TAG_STORAGE);
+		Host host = Try.of(()->
+				APILocator.getHostAPI().find(map.get(TAG_STORAGE).toString(), APILocator.systemUser(), false)).getOrNull();
+
+		if(host!=null) {
+			return host.getIdentifier();
+		}
+
+		return Host.SYSTEM_HOST;
 	}
 
 	public void setTagStorage(String tagStorageId) {

--- a/dotCMS/src/main/java/com/dotmarketing/beans/Host.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/Host.java
@@ -1,6 +1,7 @@
 package com.dotmarketing.beans;
 
 import com.dotcms.api.tree.Parentable;
+import com.dotmarketing.util.UtilMethods;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.dotmarketing.business.*;
 import com.dotmarketing.exception.DotDataException;
@@ -189,7 +190,7 @@ public class Host extends Contentlet implements Permissionable,Treeable,Parentab
 		Host host = Try.of(()->
 				APILocator.getHostAPI().find(map.get(TAG_STORAGE).toString(), APILocator.systemUser(), false)).getOrNull();
 
-		if(host!=null) {
+		if(UtilMethods.isSet(()->host.getIdentifier())) {
 			return host.getIdentifier();
 		}
 

--- a/dotcms-integration/src/test/java/com/dotmarketing/beans/HostTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/beans/HostTest.java
@@ -1,9 +1,12 @@
 package com.dotmarketing.beans;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.business.APILocator;
+import io.vavr.control.Try;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -39,5 +42,33 @@ public class HostTest {
         host.setDefault(false);
         assertFalse(host.isDefault());
     }
+
+    @Test
+    public void insureTagStorageWorks() {
+
+        Host host = new Host();
+        host.setTagStorage("SYSTEM_HOST");
+        assertTrue(host.getTagStorage().equals(Host.SYSTEM_HOST));
+
+        host = new Host();
+        host.setTagStorage("IDONTEXIST_" + System.currentTimeMillis());
+        assertTrue(host.getTagStorage().equals(Host.SYSTEM_HOST));
+
+        Host defaultHost = Try.of(()->APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false)).getOrNull();
+
+
+        host = new Host();
+        host.setTagStorage(defaultHost.getIdentifier());
+
+        assertEquals(host.getTagStorage(), defaultHost.getIdentifier());
+
+
+
+
+    }
+
+
+
+
 
 }


### PR DESCRIPTION
This pull request includes changes to the `Host` class in the `dotCMS` project, focusing on improving the handling of the `tagStorage` attribute and adding relevant tests. The most important changes include updating the `getTagStorage` method to use the `Try` class for error handling and adding a new test method to ensure the updated functionality works correctly.

### Improvements to `Host` class:

* [`dotCMS/src/main/java/com/dotmarketing/beans/Host.java`](diffhunk://#diff-9b11e0803028bbd952585ed75c35becfef165bb32222dca4ed0b0ab06e201ca3L188-R196): Updated the `getTagStorage` method to use `Try` for error handling and return the host identifier or `Host.SYSTEM_HOST` if the host is not found.
* [`dotCMS/src/main/java/com/dotmarketing/beans/Host.java`](diffhunk://#diff-9b11e0803028bbd952585ed75c35becfef165bb32222dca4ed0b0ab06e201ca3R13): Added import for `Try` from `io.vavr.control` to support the new error handling mechanism.

### Additions to tests:

* [`dotcms-integration/src/test/java/com/dotmarketing/beans/HostTest.java`](diffhunk://#diff-a27f8d6452af05e16631d9760ad975bc15d4144fdafd910bb7a024c90c4cbcdbR46-R73): Added a new test method `insureTagStorageWorks` to verify the updated `getTagStorage` functionality.
* [`dotcms-integration/src/test/java/com/dotmarketing/beans/HostTest.java`](diffhunk://#diff-a27f8d6452af05e16631d9760ad975bc15d4144fdafd910bb7a024c90c4cbcdbR3-R9): Added necessary imports for `Try` and `APILocator` to support the new test method.ref: #31824

This PR fixes: #31824