### PR TITLE
style(edit-content): improve actions layout and single tab mode

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
@@ -99,11 +99,11 @@
 <!-- Append template to add to the tabs -->
 <ng-template #appendContent>
     <div
-        class="dot-edit-content-actions"
+        class="dot-edit-content-actions flex align-items-center w-full"
         data-testId="edit-content-actions"
         [class.dot-edit-content-actions--sidebar-open]="showSidebar">
         <!-- Left group for lock controls -->
-        <div class="dot-edit-content-actions__left">
+        <div class="dot-edit-content-actions__left flex align-items-center">
             @if (canLock) {
                 <div
                     class="dot-edit-content-actions__lock flex align-items-center gap-2"
@@ -120,7 +120,7 @@
         </div>
 
         <!-- Right group for all other actions -->
-        <div class="dot-edit-content-actions__right">
+        <div class="dot-edit-content-actions__right flex align-items-center">
             @if ($showPreviewLink()) {
                 <button
                     pButton
@@ -149,7 +149,7 @@
             }
 
             <div
-                class="dot-edit-content-actions__sidebar-toggle"
+                class="dot-edit-content-actions__sidebar-toggle flex align-items-center"
                 data-testId="sidebar-toggle"
                 [class.dot-edit-content-actions__sidebar-toggle--hidden]="showSidebar">
                 <button

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
@@ -25,6 +25,7 @@
             [class.dot-edit-content-tabview--single-tab]="$hasSingleTab()"
             (onChange)="onActiveIndexChange($event)"
             [activeIndex]="activeIndex"
+            scrollable="false"
             class="dot-edit-content-tabview">
             <!-- Add prepend and append areas to the tabs -->
             <ng-template
@@ -101,79 +102,84 @@
         class="dot-edit-content-actions"
         data-testId="edit-content-actions"
         [class.dot-edit-content-actions--sidebar-open]="showSidebar">
-        <!-- Add Content Lock Toggle here -->
-        <div
-            class="dot-edit-content-actions__lock flex align-items-center gap-2"
-            [class.locked]="isContentLocked">
+        <!-- Left group for lock controls -->
+        <div class="dot-edit-content-actions__left">
             @if (canLock) {
-                <p-inputSwitch
-                    [ngModel]="isContentLocked"
-                    [disabled]="!canLock"
-                    (onChange)="onContentLockChange($event)"
-                    inputId="lockSwitch"
-                    data-testId="content-lock-switch"></p-inputSwitch>
-                <label for="lockSwitch" class="text-sm">{{ lockSwitchLabel | dm }}</label>
+                <div
+                    class="dot-edit-content-actions__lock flex align-items-center gap-2"
+                    [class.locked]="isContentLocked">
+                    <p-inputSwitch
+                        [ngModel]="isContentLocked"
+                        [disabled]="!canLock"
+                        (onChange)="onContentLockChange($event)"
+                        inputId="lockSwitch"
+                        data-testId="content-lock-switch"></p-inputSwitch>
+                    <label for="lockSwitch" class="text-sm">{{ lockSwitchLabel | dm }}</label>
+                </div>
             }
         </div>
 
-        @if ($showPreviewLink()) {
-            <button
-                pButton
-                icon="pi pi-external-link"
-                class="p-button-link p-button-md"
-                data-testId="preview-button"
-                (click)="showPreview()">
-                {{ 'edit.content.preview-link' | dm }}
-            </button>
-        }
+        <!-- Right group for all other actions -->
+        <div class="dot-edit-content-actions__right">
+            @if ($showPreviewLink()) {
+                <button
+                    pButton
+                    icon="pi pi-external-link"
+                    class="p-button-link p-button-md"
+                    data-testId="preview-button"
+                    (click)="showPreview()">
+                    {{ 'edit.content.preview-link' | dm }}
+                </button>
+            }
 
-        @if (showWorkflowActions) {
-            <dot-workflow-actions
-                data-testId="workflow-actions"
-                (actionFired)="
-                    fireWorkflowAction({
-                        workflow: $event,
-                        inode: contentlet?.inode,
-                        contentType: contentType.variable,
-                        languageId: currentLocaleId,
-                        identifier: currentIdentifier
-                    })
-                "
-                [actions]="actions"
-                [groupActions]="true" />
-        }
+            @if (showWorkflowActions) {
+                <dot-workflow-actions
+                    data-testId="workflow-actions"
+                    (actionFired)="
+                        fireWorkflowAction({
+                            workflow: $event,
+                            inode: contentlet?.inode,
+                            contentType: contentType.variable,
+                            languageId: currentLocaleId,
+                            identifier: currentIdentifier
+                        })
+                    "
+                    [actions]="actions"
+                    [groupActions]="true" />
+            }
 
-        <div
-            class="dot-edit-content-actions__sidebar-toggle"
-            data-testId="sidebar-toggle"
-            [class.dot-edit-content-actions__sidebar-toggle--hidden]="showSidebar">
-            <button
-                class="dot-edit-content-actions__sidebar-btn p-button p-button-sm p-button-text p-button-rounded p-button-icon-only"
-                (click)="$store.toggleSidebar()"
-                data-testId="sidebar-toggle-button">
-                <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 20 20"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg">
-                    <rect
-                        x="2.70588"
-                        y="3.17659"
-                        width="14.5882"
-                        height="13.6471"
-                        rx="1.17647"
-                        stroke="#426BF0"
-                        stroke-width="1.41176" />
-                    <line
-                        x1="12.3528"
-                        y1="16.1223"
-                        x2="12.3528"
-                        y2="3.87797"
-                        stroke="#426BF0"
-                        stroke-width="1.88235" />
-                </svg>
-            </button>
+            <div
+                class="dot-edit-content-actions__sidebar-toggle"
+                data-testId="sidebar-toggle"
+                [class.dot-edit-content-actions__sidebar-toggle--hidden]="showSidebar">
+                <button
+                    class="dot-edit-content-actions__sidebar-btn p-button p-button-sm p-button-text p-button-rounded p-button-icon-only"
+                    (click)="$store.toggleSidebar()"
+                    data-testId="sidebar-toggle-button">
+                    <svg
+                        width="20"
+                        height="20"
+                        viewBox="0 0 20 20"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg">
+                        <rect
+                            x="2.70588"
+                            y="3.17659"
+                            width="14.5882"
+                            height="13.6471"
+                            rx="1.17647"
+                            stroke="#426BF0"
+                            stroke-width="1.41176" />
+                        <line
+                            x1="12.3528"
+                            y1="16.1223"
+                            x2="12.3528"
+                            y2="3.87797"
+                            stroke="#426BF0"
+                            stroke-width="1.88235" />
+                    </svg>
+                </button>
+            </div>
         </div>
     </div>
 </ng-template>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
@@ -37,9 +37,23 @@ $tab-min-height: 52px;
 // Edit Content Actions
 .dot-edit-content-actions {
     display: flex;
-    flex-wrap: wrap;
+    align-items: center;
+    width: 100%;
+    min-height: $tab-min-height;
+}
+
+.dot-edit-content-actions__left {
+    display: flex;
     align-items: center;
     gap: $spacing-4;
+    min-width: 200px; // Adjust this value based on your needs
+}
+
+.dot-edit-content-actions__right {
+    display: flex;
+    align-items: center;
+    gap: $spacing-4;
+    margin-left: auto;
 }
 
 .dot-edit-content-actions__sidebar-toggle {
@@ -76,6 +90,9 @@ $tab-min-height: 52px;
 
 // PrimeNG Tabview Overrides
 ::ng-deep {
+    .p-tabview-nav {
+        flex: none;
+    }
     .tabview-append-content {
         min-height: $tab-min-height;
         display: flex;
@@ -96,6 +113,7 @@ $tab-min-height: 52px;
         .p-tabview-nav-content .p-tabview-nav {
             border: none;
             border-left: solid 1px $color-palette-gray-300;
+            border-right: solid 1px $color-palette-gray-300;
             padding-left: $spacing-3;
             min-height: $tab-min-height;
             min-width: auto;
@@ -111,9 +129,26 @@ $tab-min-height: 52px;
         }
 
         &.dot-edit-content-tabview--single-tab {
-            .p-tabview-nav li:first-child {
+            ul.p-tabview-nav {
                 display: none;
             }
+
+            .tabview-append-content {
+                border-left: solid 1px $color-palette-gray-300;
+                padding-left: $spacing-3;
+            }
         }
+    }
+
+    .p-tabview-nav-content {
+        display: flex;
+        align-items: center;
+        width: 100%;
+    }
+
+    .tabview-append-content {
+        flex: 1;
+        display: flex;
+        align-items: center;
     }
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.scss
@@ -36,22 +36,14 @@ $tab-min-height: 52px;
 
 // Edit Content Actions
 .dot-edit-content-actions {
-    display: flex;
-    align-items: center;
-    width: 100%;
     min-height: $tab-min-height;
 }
 
 .dot-edit-content-actions__left {
-    display: flex;
-    align-items: center;
     gap: $spacing-4;
-    min-width: 200px; // Adjust this value based on your needs
 }
 
 .dot-edit-content-actions__right {
-    display: flex;
-    align-items: center;
     gap: $spacing-4;
     margin-left: auto;
 }
@@ -64,8 +56,6 @@ $tab-min-height: 52px;
     transform: translateX(0);
     overflow: hidden;
     min-height: $tab-min-height;
-    display: flex;
-    align-items: center;
 }
 
 .dot-edit-content-actions__sidebar-toggle--hidden {


### PR DESCRIPTION
- Organize action buttons into left/right groups to prevent layout jumps
- Fix single tab mode border and padding styles
- Add consistent spacing and alignment for action items

This pull request includes several changes to the `dot-edit-content-form` component in both its HTML and SCSS files. The changes focus on improving the layout and organization of the content actions and tab view.

### Improvements to HTML structure:

* Added a `scrollable="false"` attribute to the `dot-edit-content-tabview` element to disable scrolling.
* Reorganized the content actions by introducing `dot-edit-content-actions__left` and `dot-edit-content-actions__right` divs to better separate lock controls from other actions.
* Closed an unclosed div and added a new div to properly structure the content actions.

### Enhancements to SCSS styling:

* Updated `.dot-edit-content-actions` to align items center, set width to 100%, and define a minimum height.
* Added styles for `.dot-edit-content-actions__left` and `.dot-edit-content-actions__right` to properly align and space elements within these sections.
* Modified the `p-tabview-nav` and `p-tabview-nav-content` classes to ensure proper alignment and border styling within the tab view. [[1]](diffhunk://#diff-1a3e657016880498977ce74202425946ae817683630dd29a8b673b2dd4672e5aR93-R95) [[2]](diffhunk://#diff-1a3e657016880498977ce74202425946ae817683630dd29a8b673b2dd4672e5aR116) [[3]](diffhunk://#diff-1a3e657016880498977ce74202425946ae817683630dd29a8b673b2dd4672e5aL114-R152)

### Screenshots

https://github.com/user-attachments/assets/a40c0d44-b4be-4e51-b2ce-fa49c3bbcb20



This PR fixes: #31783