### PR TITLE
chore(core-web): Add `/ext` path to the dev proxy

### DIFF
--- a/core-web/apps/dotcms-ui/proxy-dev.conf.mjs
+++ b/core-web/apps/dotcms-ui/proxy-dev.conf.mjs
@@ -17,7 +17,8 @@ export default [
             '/categoriesServlet',
             '/JSONTags',
             '/api/vtl',
-            '/tinymce'
+            '/tinymce',
+            '/ext'
         ],
         target: 'http://localhost:8080',
         secure: false,


### PR DESCRIPTION
This pull request includes a small change to the `core-web/apps/dotcms-ui/proxy-dev.conf.mjs` file. The change adds a new proxy path to the configuration.

* Added the `/ext` path to the list of proxy paths in `core-web/apps/dotcms-ui/proxy-dev.conf.mjs`.

This PR fixes: #31848