### PR TITLE
ci: Update GitHub Action Docker Buildx Components to F (#31867)

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -146,7 +146,7 @@ runs:
       if: (inputs.docker_registry == 'GHCR.IO' || inputs.docker_registry == 'BOTH') && inputs.do_deploy == 'true'
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3.0.0
+      uses: docker/setup-qemu-action@v3.6.0
       with:
         image: tonistiigi/binfmt:qemu-v7.0.0-28
         platforms: ${{ inputs.docker_platforms }}
@@ -174,14 +174,12 @@ runs:
       if: success()
 
     - name: Docker Setup Buildx
-      uses: docker/setup-buildx-action@v3.0.0
+      uses: docker/setup-buildx-action@v3.10.0
       with:
-        version: latest
+        version: v0.20.0 # version of buildx https://github.com/docker/buildx/releases
         platforms: ${{ inputs.docker_platforms }}
-        driver-opts: |
-          image=moby/buildkit:v0.12.2
     - name: Build/Push Docker Image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6.15.0
       with:
         context: ${{ steps.setup-context.outputs.docker_context }}
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/cicd_manual_build-docker-context.yml
+++ b/.github/workflows/cicd_manual_build-docker-context.yml
@@ -33,17 +33,16 @@ jobs:
 
           echo "PLATFORMS=${PLATFORMS}" >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.6.0
         with:
           platforms: amd64,arm64
         if: github.event.inputs.multi_arch == 'true'
       - id: docker-setup-buildx
         name: Docker Setup Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3.10.0
         with:
+          version: v0.20.0 # version of buildx https://github.com/docker/buildx/releases
           platforms: ${{ env.PLATFORMS }}
-          driver-opts: |
-            image=moby/buildkit:v0.12.2
         if: github.event.inputs.multi_arch == 'true'
       - name: Docker Hub login
         uses: docker/login-action@v3.0.0
@@ -51,7 +50,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v6.15.0
         with:
           context: ./docker/${{ github.event.inputs.context }}
           push: ${{ github.event.inputs.push }}

--- a/.github/workflows/cicd_manual_build-java-base.yml
+++ b/.github/workflows/cicd_manual_build-java-base.yml
@@ -30,17 +30,16 @@ jobs:
 
           echo "PLATFORMS=${PLATFORMS}" >> $GITHUB_ENV
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.6.0
         with:
           platforms: amd64,arm64
         if: github.event.inputs.multi_arch == 'true'
       - id: docker-setup-buildx
         name: Docker Setup Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3.10.0
         with:
+          version: v0.20.0 # version of buildx https://github.com/docker/buildx/releases
           platforms: ${{ env.PLATFORMS }}
-          driver-opts: |
-            image=moby/buildkit:v0.12.2
         if: github.event.inputs.multi_arch == 'true'
       - name: Docker Hub login
         uses: docker/login-action@v3.0.0
@@ -48,7 +47,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5.0.0
+        uses: docker/build-push-action@v6.15.0
         with:
           context: ./docker/java-base
           push: ${{ github.event.inputs.push }}

--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -256,7 +256,7 @@ jobs:
         if: success()
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3.0.0
+        uses: docker/setup-qemu-action@v3.6.0
         with:
           image: tonistiigi/binfmt:qemu-v7.0.0-28
           platforms: ${{ inputs.docker_platforms }}
@@ -264,16 +264,14 @@ jobs:
 
       - name: Docker Setup Buildx
         id: docker-setup-buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3.10.0
         with:
-          version: latest
+          version: v0.20.0 # version of buildx https://github.com/docker/buildx/releases
           platforms: ${{ inputs.docker_platforms }}
-          driver-opts: |
-            image=moby/buildkit:v0.12.2
         if: success()
 
       - name: Build/Push Docker Image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6.15.0
         with:
           context: ${{ env.DOCKER_BUILD_CONTEXT }}/context
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
### Proposed Changes
* Update the version of the buildx environment to remove old github caching version
* Will need testing on core-workflow-test and the builx docker build is not done during a PR


### Additional Info
This PR resolves #31867 (Update GitHub Action Docker Buildx Components to F).


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #31867