### PR TITLE
feat(sdk): Added initUVE function

### DIFF
--- a/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
@@ -38,7 +38,7 @@ import {
  */
 export function getUVEState(): UVEState | undefined {
     if (typeof window === 'undefined' || window.parent === window || !window.location) {
-        return;
+        return undefined;
     }
 
     const url = new URL(window.location.href);

--- a/core-web/libs/sdk/uve/src/lib/editor/public.spec.ts
+++ b/core-web/libs/sdk/uve/src/lib/editor/public.spec.ts
@@ -1,0 +1,144 @@
+import { DotCMSReorderMenuConfig } from '@dotcms/uve/internal';
+
+import { sendMessageToUVE, editContentlet, reorderMenu, initUVE } from './public';
+
+import * as utils from '../../script/utils';
+import { Contentlet, DotCMSUVEAction } from '../types/editor/public';
+
+describe('UVE Public Functions', () => {
+    let postMessageSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        // Mock window.parent.postMessage
+        postMessageSpy = jest.spyOn(window.parent, 'postMessage');
+
+        // Mock all utility functions
+        jest.spyOn(utils, 'scrollHandler').mockImplementation();
+        jest.spyOn(utils, 'addClassToEmptyContentlets').mockImplementation();
+        jest.spyOn(utils, 'listenBlockEditorInlineEvent').mockImplementation();
+        jest.spyOn(utils, 'setClientIsReady').mockImplementation();
+        jest.spyOn(utils, 'registerUVEEvents').mockReturnValue({
+            subscriptions: [
+                { unsubscribe: jest.fn(), event: 'test1' },
+                { unsubscribe: jest.fn(), event: 'test2' }
+            ]
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('sendMessageToUVE', () => {
+        it('should send message to parent window', () => {
+            const message = {
+                action: DotCMSUVEAction.EDIT_CONTENTLET,
+                payload: { data: 'test' }
+            };
+
+            sendMessageToUVE(message);
+
+            expect(postMessageSpy).toHaveBeenCalledWith(message, '*');
+        });
+    });
+
+    describe('editContentlet', () => {
+        it('should send edit contentlet message to UVE', () => {
+            const contentlet = {
+                identifier: '123',
+                inode: '456',
+                languageId: 1
+            };
+
+            editContentlet(contentlet as Contentlet<typeof contentlet>);
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                {
+                    action: DotCMSUVEAction.EDIT_CONTENTLET,
+                    payload: contentlet
+                },
+                '*'
+            );
+        });
+    });
+
+    describe('reorderMenu', () => {
+        it('should send reorder menu message with default values when no config provided', () => {
+            reorderMenu();
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                {
+                    action: DotCMSUVEAction.REORDER_MENU,
+                    payload: { startLevel: 1, depth: 2 }
+                },
+                '*'
+            );
+        });
+
+        it('should send reorder menu message with custom config', () => {
+            const config = { startLevel: 2, depth: 3 };
+            reorderMenu(config);
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                {
+                    action: DotCMSUVEAction.REORDER_MENU,
+                    payload: config
+                },
+                '*'
+            );
+        });
+
+        it('should use default values for missing config properties', () => {
+            reorderMenu({ startLevel: 2 } as DotCMSReorderMenuConfig);
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                {
+                    action: DotCMSUVEAction.REORDER_MENU,
+                    payload: { startLevel: 2, depth: 2 }
+                },
+                '*'
+            );
+        });
+    });
+
+    describe('initUVE', () => {
+        it('should initialize all required handlers and listeners', () => {
+            initUVE();
+
+            expect(utils.scrollHandler).toHaveBeenCalled();
+            expect(utils.addClassToEmptyContentlets).toHaveBeenCalled();
+            expect(utils.listenBlockEditorInlineEvent).toHaveBeenCalled();
+            expect(utils.setClientIsReady).toHaveBeenCalled();
+            expect(utils.registerUVEEvents).toHaveBeenCalled();
+        });
+
+        it('should return destroy function that unsubscribes all subscriptions', () => {
+            // Create spy functions for unsubscribe
+            const unsubscribeSpy1 = jest.fn();
+            const unsubscribeSpy2 = jest.fn();
+
+            // Mock registerUVEEvents with these spy functions
+            jest.spyOn(utils, 'registerUVEEvents').mockReturnValue({
+                subscriptions: [
+                    { unsubscribe: unsubscribeSpy1, event: 'test1' },
+                    { unsubscribe: unsubscribeSpy2, event: 'test2' }
+                ]
+            });
+
+            const { destroyUVESubscriptions } = initUVE();
+
+            destroyUVESubscriptions();
+
+            expect(unsubscribeSpy1).toHaveBeenCalled();
+            expect(unsubscribeSpy2).toHaveBeenCalled();
+        });
+
+        it('should handle empty subscriptions array', () => {
+            jest.spyOn(utils, 'registerUVEEvents').mockReturnValue({ subscriptions: [] });
+
+            const { destroyUVESubscriptions } = initUVE();
+
+            expect(() => destroyUVESubscriptions()).not.toThrow();
+        });
+    });
+});

--- a/core-web/libs/sdk/uve/src/lib/editor/public.spec.ts
+++ b/core-web/libs/sdk/uve/src/lib/editor/public.spec.ts
@@ -13,9 +13,13 @@ describe('UVE Public Functions', () => {
         postMessageSpy = jest.spyOn(window.parent, 'postMessage');
 
         // Mock all utility functions
-        jest.spyOn(utils, 'scrollHandler').mockImplementation();
+        jest.spyOn(utils, 'scrollHandler').mockImplementation(() => ({
+            destroyScrollHandler: jest.fn()
+        }));
         jest.spyOn(utils, 'addClassToEmptyContentlets').mockImplementation();
-        jest.spyOn(utils, 'listenBlockEditorInlineEvent').mockImplementation();
+        jest.spyOn(utils, 'listenBlockEditorInlineEvent').mockImplementation(() => ({
+            destroyListenBlockEditorInlineEvent: jest.fn()
+        }));
         jest.spyOn(utils, 'setClientIsReady').mockImplementation();
         jest.spyOn(utils, 'registerUVEEvents').mockReturnValue({
             subscriptions: [
@@ -116,6 +120,8 @@ describe('UVE Public Functions', () => {
             // Create spy functions for unsubscribe
             const unsubscribeSpy1 = jest.fn();
             const unsubscribeSpy2 = jest.fn();
+            const destroyScrollHandler = jest.fn();
+            const destroyListenBlockEditorInlineEvent = jest.fn();
 
             // Mock registerUVEEvents with these spy functions
             jest.spyOn(utils, 'registerUVEEvents').mockReturnValue({
@@ -125,12 +131,22 @@ describe('UVE Public Functions', () => {
                 ]
             });
 
+            jest.spyOn(utils, 'scrollHandler').mockReturnValue({
+                destroyScrollHandler
+            });
+
+            jest.spyOn(utils, 'listenBlockEditorInlineEvent').mockReturnValue({
+                destroyListenBlockEditorInlineEvent
+            });
+
             const { destroyUVESubscriptions } = initUVE();
 
             destroyUVESubscriptions();
 
             expect(unsubscribeSpy1).toHaveBeenCalled();
             expect(unsubscribeSpy2).toHaveBeenCalled();
+            expect(destroyScrollHandler).toHaveBeenCalled();
+            expect(destroyListenBlockEditorInlineEvent).toHaveBeenCalled();
         });
 
         it('should handle empty subscriptions array', () => {

--- a/core-web/libs/sdk/uve/src/lib/editor/public.ts
+++ b/core-web/libs/sdk/uve/src/lib/editor/public.ts
@@ -104,16 +104,18 @@ export function initInlineEditing(
  * ```
  */
 export function initUVE() {
-    scrollHandler();
     addClassToEmptyContentlets();
-    listenBlockEditorInlineEvent();
     setClientIsReady();
 
     const { subscriptions } = registerUVEEvents();
+    const { destroyScrollHandler } = scrollHandler();
+    const { destroyListenBlockEditorInlineEvent } = listenBlockEditorInlineEvent();
 
     return {
         destroyUVESubscriptions: () => {
             subscriptions.forEach((subscription) => subscription.unsubscribe());
+            destroyScrollHandler();
+            destroyListenBlockEditorInlineEvent();
         }
     };
 }

--- a/core-web/libs/sdk/uve/src/lib/editor/public.ts
+++ b/core-web/libs/sdk/uve/src/lib/editor/public.ts
@@ -1,3 +1,10 @@
+import {
+    addClassToEmptyContentlets,
+    listenBlockEditorInlineEvent,
+    registerUVEEvents,
+    scrollHandler,
+    setClientIsReady
+} from '../../script/utils';
 import { DotCMSReorderMenuConfig, DotCMSUVEMessage } from '../types/editor/internal';
 import { Contentlet, DotCMSUVEAction } from '../types/editor/public';
 import { DotCMSInlineEditingPayload, DotCMSInlineEditingType } from '../types/events/public';
@@ -73,4 +80,40 @@ export function initInlineEditing(
             data
         }
     });
+}
+
+/**
+ * Initializes the Universal Visual Editor (UVE) with required handlers and event listeners.
+ *
+ * This function sets up:
+ * - Scroll handling
+ * - Empty contentlet styling
+ * - Block editor inline event listening
+ * - Client ready state
+ * - UVE event subscriptions
+ *
+ * @returns {Object} An object containing the cleanup function
+ * @returns {Function} destroyUVESubscriptions - Function to clean up all UVE event subscriptions
+ *
+ * @example
+ * ```typescript
+ * const { destroyUVESubscriptions } = initUVE();
+ *
+ * // When done with UVE
+ * destroyUVESubscriptions();
+ * ```
+ */
+export function initUVE() {
+    scrollHandler();
+    addClassToEmptyContentlets();
+    listenBlockEditorInlineEvent();
+    setClientIsReady();
+
+    const { subscriptions } = registerUVEEvents();
+
+    return {
+        destroyUVESubscriptions: () => {
+            subscriptions.forEach((subscription) => subscription.unsubscribe());
+        }
+    };
 }

--- a/core-web/libs/sdk/uve/src/script/utils.ts
+++ b/core-web/libs/sdk/uve/src/script/utils.ts
@@ -63,34 +63,52 @@ export function addClassToEmptyContentlets(): void {
  * scroll event handling.
  */
 export function registerUVEEvents() {
-    createUVESubscription(UVEEventType.PAGE_RELOAD, () => {
+    const pageReloadSubscription = createUVESubscription(UVEEventType.PAGE_RELOAD, () => {
         window.location.reload();
     });
 
-    createUVESubscription(UVEEventType.REQUEST_BOUNDS, (bounds) => {
-        setBounds(bounds);
-    });
-
-    createUVESubscription(UVEEventType.IFRAME_SCROLL, (direction) => {
-        if (
-            (window.scrollY === 0 && direction === 'up') ||
-            (computeScrollIsInBottom() && direction === 'down')
-        ) {
-            // If the iframe scroll is at the top or bottom, do not send anything.
-            // This avoids losing the scrollend event.
-            return;
+    const requestBoundsSubscription = createUVESubscription(
+        UVEEventType.REQUEST_BOUNDS,
+        (bounds) => {
+            setBounds(bounds);
         }
+    );
 
-        const scrollY = direction === 'up' ? -120 : 120;
-        window.scrollBy({ left: 0, top: scrollY, behavior: 'smooth' });
-    });
+    const iframeScrollSubscription = createUVESubscription(
+        UVEEventType.IFRAME_SCROLL,
+        (direction) => {
+            if (
+                (window.scrollY === 0 && direction === 'up') ||
+                (computeScrollIsInBottom() && direction === 'down')
+            ) {
+                // If the iframe scroll is at the top or bottom, do not send anything.
+                // This avoids losing the scrollend event.
+                return;
+            }
 
-    createUVESubscription(UVEEventType.CONTENTLET_HOVERED, (contentletHovered) => {
-        sendMessageToUVE({
-            action: DotCMSUVEAction.SET_CONTENTLET,
-            payload: contentletHovered
-        });
-    });
+            const scrollY = direction === 'up' ? -120 : 120;
+            window.scrollBy({ left: 0, top: scrollY, behavior: 'smooth' });
+        }
+    );
+
+    const contentletHoveredSubscription = createUVESubscription(
+        UVEEventType.CONTENTLET_HOVERED,
+        (contentletHovered) => {
+            sendMessageToUVE({
+                action: DotCMSUVEAction.SET_CONTENTLET,
+                payload: contentletHovered
+            });
+        }
+    );
+
+    return {
+        subscriptions: [
+            pageReloadSubscription,
+            requestBoundsSubscription,
+            iframeScrollSubscription,
+            contentletHoveredSubscription
+        ]
+    };
 }
 
 /**

--- a/core-web/libs/sdk/uve/src/script/utils.ts
+++ b/core-web/libs/sdk/uve/src/script/utils.ts
@@ -10,7 +10,7 @@ import { DotCMSUVEAction, UVEEventType } from '../lib/types/editor/public';
  * Adds listeners for both 'scroll' and 'scrollend' events, sending appropriate messages
  * to the editor when these events occur.
  */
-export function scrollHandler(): void {
+export function scrollHandler() {
     const scrollCallback = () => {
         sendMessageToUVE({
             action: DotCMSUVEAction.IFRAME_SCROLL
@@ -25,6 +25,13 @@ export function scrollHandler(): void {
 
     window.addEventListener('scroll', scrollCallback);
     window.addEventListener('scrollend', scrollEndCallback);
+
+    return {
+        destroyScrollHandler: () => {
+            window.removeEventListener('scroll', scrollCallback);
+            window.removeEventListener('scrollend', scrollEndCallback);
+        }
+    };
 }
 
 /**
@@ -130,16 +137,26 @@ export function setClientIsReady(): void {
 /**
  * Listen for block editor inline event.
  */
-export const listenBlockEditorInlineEvent = (): void => {
+export function listenBlockEditorInlineEvent() {
     if (document.readyState === 'complete') {
         // The page is fully loaded or interactive
         listenBlockEditorClick();
 
-        return;
+        return {
+            destroyListenBlockEditorInlineEvent: () => {
+                window.removeEventListener('load', () => listenBlockEditorClick());
+            }
+        };
     }
 
     window.addEventListener('load', () => listenBlockEditorClick());
-};
+
+    return {
+        destroyListenBlockEditorInlineEvent: () => {
+            window.removeEventListener('load', () => listenBlockEditorClick());
+        }
+    };
+}
 
 const listenBlockEditorClick = (): void => {
     const editBlockEditorNodes: NodeListOf<HTMLElement> = document.querySelectorAll(


### PR DESCRIPTION


https://github.com/user-attachments/assets/ff8c829e-f4e9-4603-a625-fc79fdabe0b3




This pull request introduces a new function to initialize the Universal Visual Editor (UVE) with necessary handlers and event listeners, and refactors the existing `registerUVEEvents` function to use named subscriptions for better management. The key changes are:

### New Functionality:

* [`core-web/libs/sdk/uve/src/lib/editor/public.ts`](diffhunk://#diff-dafb1a0d66a8cdf6b6bef1edaace11856185883ccc9040b1185ce0a143bc11eeR84-R119): Added the `initUVE` function, which sets up scroll handling, empty contentlet styling, block editor inline event listening, client ready state, and UVE event subscriptions. This function also returns a cleanup function to destroy UVE event subscriptions.

### Refactoring:

* [`core-web/libs/sdk/uve/src/script/utils.ts`](diffhunk://#diff-0aeba835f7122ce16900ea7fbfc3c7da0cc82ea6e00d138110e88427cd9f4ef3L66-R79): Refactored the `registerUVEEvents` function to use named subscriptions (`pageReloadSubscription`, `requestBoundsSubscription`, `iframeScrollSubscription`, `contentletHoveredSubscription`) and return them in an array for easier management and cleanup. [[1]](diffhunk://#diff-0aeba835f7122ce16900ea7fbfc3c7da0cc82ea6e00d138110e88427cd9f4ef3L66-R79) [[2]](diffhunk://#diff-0aeba835f7122ce16900ea7fbfc3c7da0cc82ea6e00d138110e88427cd9f4ef3L86-R111)

### Imports:

* [`core-web/libs/sdk/uve/src/lib/editor/public.ts`](diffhunk://#diff-dafb1a0d66a8cdf6b6bef1edaace11856185883ccc9040b1185ce0a143bc11eeR1-R7): Added imports for utility functions (`addClassToEmptyContentlets`, `listenBlockEditorInlineEvent`, `registerUVEEvents`, `scrollHandler`, `setClientIsReady`) to support the new `initUVE` function.

This PR fixes: #31835