### PR TITLE
feat(uve): Button to hide palette

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -77,6 +77,7 @@
 @if ($editorProps().palette; as palette) {
     <button
         pButton
+        data-testId="toggle-palette"
         [icon]="palette.buttonIcon"
         class="p-button-outlined p-button-sm toggle-palette"
         (click)="togglePalette()"></button>

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -75,7 +75,15 @@
 </div>
 
 @if ($editorProps().palette; as palette) {
+    <button
+        pButton
+        [icon]="$paletteOpen() ? 'pi pi-angle-right' : 'pi pi-angle-left'"
+        class="p-button-outlined p-button-sm toggle-palette"
+        (click)="togglePalette()"></button>
+
     <dot-edit-ema-palette
+        [class.show-palette]="$paletteOpen()"
+        [class.hide-palette]="!$paletteOpen()"
         [languageId]="palette.languageId"
         [containers]="palette.containers"
         [variantId]="palette.variantId"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -77,13 +77,12 @@
 @if ($editorProps().palette; as palette) {
     <button
         pButton
-        [icon]="$paletteOpen() ? 'pi pi-angle-right' : 'pi pi-angle-left'"
+        [icon]="palette.buttonIcon"
         class="p-button-outlined p-button-sm toggle-palette"
         (click)="togglePalette()"></button>
 
     <dot-edit-ema-palette
-        [class.show-palette]="$paletteOpen()"
-        [class.hide-palette]="!$paletteOpen()"
+        [ngClass]="palette.paletteClass"
         [languageId]="palette.languageId"
         [containers]="palette.containers"
         [variantId]="palette.variantId"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.scss
@@ -5,10 +5,26 @@
     grid-template-rows: min-content 1fr;
     height: 100%;
 
-    // Only set two columns if the palette is present
-    &:has(dot-edit-ema-palette) {
-        grid-template-columns: 1fr 15.5rem;
+    // Default state (no palette)
+    grid-template-columns: 1fr;
+
+    // Only set two columns if the toggle palette button is present
+    &:has(.toggle-palette) {
+        grid-template-columns: 1fr 2rem;
     }
+
+    // Only set three columns if the toggle palette button and the palette are present
+    &:has(.toggle-palette):has(dot-edit-ema-palette.show-palette) {
+        grid-template-columns: 1fr 2rem 15.5rem;
+    }
+}
+
+.hide-palette {
+    display: none;
+}
+
+.show-palette {
+    display: block;
 }
 
 dot-device-selector-seo {
@@ -72,4 +88,24 @@ a,
 a:focus,
 a:active {
     text-decoration: none;
+}
+
+.p-button.p-button-outlined.toggle-palette {
+    align-self: center;
+    border: 1px solid $color-palette-primary-300;
+    background-color: $color-palette-primary-100;
+    border-radius: 0;
+    border-right: 1px solid $white;
+    z-index: 2000;
+    position: relative;
+    right: -1px;
+
+    &:active,
+    &:focus {
+        outline: none;
+    }
+
+    &:hover {
+        background-color: $color-palette-primary-200;
+    }
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -92,7 +92,13 @@ import { DotEmaDialogComponent } from '../components/dot-ema-dialog/dot-ema-dial
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
 import { DotPageApiService } from '../services/dot-page-api.service';
 import { DEFAULT_PERSONA, HOST, PERSONA_KEY } from '../shared/consts';
-import { EDITOR_STATE, NG_CUSTOM_EVENTS, UVE_STATUS } from '../shared/enums';
+import {
+    EDITOR_STATE,
+    NG_CUSTOM_EVENTS,
+    PALETTE_TOGGLE_BUTTON_ICONS,
+    PALETTE_CLASSES,
+    UVE_STATUS
+} from '../shared/enums';
 import {
     QUERY_PARAMS_MOCK,
     URL_CONTENT_MAP_MOCK,
@@ -432,6 +438,60 @@ describe('EditEmaEditorComponent', () => {
                 componentsToHide.forEach((testId) => {
                     expect(spectator.query(byTestId(testId))).toBeNull();
                 });
+            });
+
+            it('should hide palette when clicking the toggle palette button', () => {
+                // First, make sure palette is visible by default
+                expect(spectator.query(byTestId('palette')).classList).toContain(
+                    PALETTE_CLASSES.OPEN
+                );
+
+                // Click the toggle button
+                const toggleButton = spectator.debugElement.query(
+                    By.css('[data-testId="toggle-palette"]')
+                );
+
+                spectator.triggerEventHandler(toggleButton, 'click', {});
+
+                spectator.detectChanges();
+
+                // Palette should now be hidden
+                expect(spectator.query(byTestId('palette')).classList).toContain(
+                    PALETTE_CLASSES.CLOSED
+                );
+            });
+
+            it('should update store state when toggle palette button is clicked', () => {
+                const storeSpy = jest.spyOn(store, 'setPaletteOpen');
+
+                const toggleButton = spectator.query(byTestId('toggle-palette'));
+                spectator.click(toggleButton);
+
+                expect(storeSpy).toHaveBeenCalled();
+            });
+
+            it('should change the icon on palette open', () => {
+                store.setPaletteOpen(true);
+
+                spectator.detectChanges();
+
+                const toggleButton = spectator.query(byTestId('toggle-palette'));
+
+                expect(toggleButton.getAttribute('ng-reflect-icon')).toContain(
+                    PALETTE_TOGGLE_BUTTON_ICONS.OPEN
+                );
+            });
+
+            it('should change the icon on palette close', () => {
+                store.setPaletteOpen(false);
+
+                spectator.detectChanges();
+
+                const toggleButton = spectator.query(byTestId('toggle-palette'));
+
+                expect(toggleButton.getAttribute('ng-reflect-icon')).toContain(
+                    PALETTE_TOGGLE_BUTTON_ICONS.CLOSED
+                );
             });
 
             it('should have a toolbar', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -160,6 +160,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
     readonly $editorContentStyles = this.uveStore.$editorContentStyles;
     readonly ogTagsResults$ = toObservable(this.uveStore.ogTagsResults);
 
+    readonly $paletteOpen = this.uveStore.paletteOpen;
     readonly UVE_STATUS = UVE_STATUS;
 
     get contentWindow(): Window {
@@ -1453,5 +1454,9 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
             this.uveStore.setOgTags(ogTags);
             this.uveStore.setOGTagResults(results);
         });
+    }
+
+    togglePalette() {
+        this.uveStore.setPaletteOpen(!this.uveStore.paletteOpen());
     }
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/enums.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/enums.ts
@@ -49,7 +49,7 @@ export enum FormStatus {
     PRISTINE = 'PRISTINE'
 }
 
-export enum PALETTE_BUTTON_ICONS {
+export enum PALETTE_TOGGLE_BUTTON_ICONS {
     OPEN = 'pi pi-angle-left',
     CLOSED = 'pi pi-angle-right'
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/enums.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/enums.ts
@@ -50,8 +50,8 @@ export enum FormStatus {
 }
 
 export enum PALETTE_TOGGLE_BUTTON_ICONS {
-    OPEN = 'pi pi-angle-left',
-    CLOSED = 'pi pi-angle-right'
+    OPEN = 'pi pi-angle-right',
+    CLOSED = 'pi pi-angle-left'
 }
 
 export enum PALETTE_CLASSES {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/enums.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/enums.ts
@@ -48,3 +48,13 @@ export enum FormStatus {
     SAVED = 'SAVED',
     PRISTINE = 'PRISTINE'
 }
+
+export enum PALETTE_BUTTON_ICONS {
+    OPEN = 'pi pi-angle-left',
+    CLOSED = 'pi pi-angle-right'
+}
+
+export enum PALETTE_CLASSES {
+    OPEN = 'show-palette',
+    CLOSED = 'hide-palette'
+}

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
@@ -23,6 +23,7 @@ export interface EditorState {
     contentletArea?: ContentletArea;
     dragItem?: EmaDragItem;
     ogTags?: SeoMetaTags;
+    paletteOpen: boolean;
 }
 
 export interface EditorToolbarState {
@@ -81,6 +82,7 @@ export interface EditorProps {
         languageId: number;
         containers: DotPageContainerStructure;
         variantId: string;
+        shouldShowPalette: boolean;
     };
     showDialogs: boolean;
     progressBar: boolean;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
@@ -14,7 +14,7 @@ import {
     ContentletArea,
     EmaDragItem
 } from '../../../edit-ema-editor/components/ema-page-dropzone/types';
-import { EDITOR_STATE } from '../../../shared/enums';
+import { EDITOR_STATE, PALETTE_BUTTON_ICONS, PALETTE_CLASSES } from '../../../shared/enums';
 import { Orientation } from '../../models';
 
 export interface EditorState {
@@ -82,8 +82,8 @@ export interface EditorProps {
         languageId: number;
         containers: DotPageContainerStructure;
         variantId: string;
-        buttonIcon: string;
-        paletteClass: string;
+        buttonIcon: PALETTE_BUTTON_ICONS;
+        paletteClass: PALETTE_CLASSES;
     };
     showDialogs: boolean;
     progressBar: boolean;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
@@ -82,7 +82,8 @@ export interface EditorProps {
         languageId: number;
         containers: DotPageContainerStructure;
         variantId: string;
-        shouldShowPalette: boolean;
+        buttonIcon: string;
+        paletteClass: string;
     };
     showDialogs: boolean;
     progressBar: boolean;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/models.ts
@@ -14,7 +14,7 @@ import {
     ContentletArea,
     EmaDragItem
 } from '../../../edit-ema-editor/components/ema-page-dropzone/types';
-import { EDITOR_STATE, PALETTE_BUTTON_ICONS, PALETTE_CLASSES } from '../../../shared/enums';
+import { EDITOR_STATE, PALETTE_TOGGLE_BUTTON_ICONS, PALETTE_CLASSES } from '../../../shared/enums';
 import { Orientation } from '../../models';
 
 export interface EditorState {
@@ -82,7 +82,7 @@ export interface EditorProps {
         languageId: number;
         containers: DotPageContainerStructure;
         variantId: string;
-        buttonIcon: PALETTE_BUTTON_ICONS;
+        buttonIcon: PALETTE_TOGGLE_BUTTON_ICONS;
         paletteClass: PALETTE_CLASSES;
     };
     showDialogs: boolean;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
@@ -14,7 +14,12 @@ import { withEditor } from './withEditor';
 
 import { DotPageApiParams, DotPageApiService } from '../../../services/dot-page-api.service';
 import { BASE_IFRAME_MEASURE_UNIT, PERSONA_KEY } from '../../../shared/consts';
-import { EDITOR_STATE, UVE_STATUS } from '../../../shared/enums';
+import {
+    EDITOR_STATE,
+    UVE_STATUS,
+    PALETTE_TOGGLE_BUTTON_ICONS,
+    PALETTE_CLASSES
+} from '../../../shared/enums';
 import {
     ACTION_MOCK,
     ACTION_PAYLOAD_MOCK,
@@ -308,7 +313,9 @@ describe('withEditor', () => {
                     palette: {
                         variantId: DEFAULT_VARIANT_ID,
                         languageId: MOCK_RESPONSE_HEADLESS.viewAs.language.id,
-                        containers: MOCK_RESPONSE_HEADLESS.containers
+                        containers: MOCK_RESPONSE_HEADLESS.containers,
+                        buttonIcon: PALETTE_TOGGLE_BUTTON_ICONS.OPEN,
+                        paletteClass: PALETTE_CLASSES.OPEN
                     },
                     seoResults: null
                 });
@@ -633,6 +640,38 @@ describe('withEditor', () => {
                 store.updateEditorScrollState();
 
                 expect(store.contentletArea()).toBe(null);
+            });
+        });
+
+        describe('setPaletteOpen', () => {
+            it('should toggle the palette', () => {
+                store.setPaletteOpen(true);
+
+                expect(store.paletteOpen()).toBe(true);
+            });
+
+            it('should toggle the palette', () => {
+                store.setPaletteOpen(false);
+
+                expect(store.paletteOpen()).toBe(false);
+            });
+
+            it('should update the editorProps when the palette is open', () => {
+                store.setPaletteOpen(true);
+
+                expect(store.$editorProps().palette.buttonIcon).toBe(
+                    PALETTE_TOGGLE_BUTTON_ICONS.OPEN
+                );
+                expect(store.$editorProps().palette.paletteClass).toBe(PALETTE_CLASSES.OPEN);
+            });
+
+            it('should update the editorProps when the palette is closed', () => {
+                store.setPaletteOpen(false);
+
+                expect(store.$editorProps().palette.buttonIcon).toBe(
+                    PALETTE_TOGGLE_BUTTON_ICONS.CLOSED
+                );
+                expect(store.$editorProps().palette.paletteClass).toBe(PALETTE_CLASSES.CLOSED);
             });
         });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -31,7 +31,7 @@ import { DEFAULT_PERSONA } from '../../../shared/consts';
 import {
     EDITOR_STATE,
     UVE_STATUS,
-    PALETTE_BUTTON_ICONS,
+    PALETTE_TOGGLE_BUTTON_ICONS,
     PALETTE_CLASSES
 } from '../../../shared/enums';
 import {
@@ -207,8 +207,8 @@ export function withEditor() {
                                   containers: pageAPIResponse?.containers,
                                   languageId: pageAPIResponse?.viewAs.language.id,
                                   buttonIcon: paletteOpen
-                                      ? PALETTE_BUTTON_ICONS.OPEN
-                                      : PALETTE_BUTTON_ICONS.CLOSED,
+                                      ? PALETTE_TOGGLE_BUTTON_ICONS.OPEN
+                                      : PALETTE_TOGGLE_BUTTON_ICONS.CLOSED,
                                   paletteClass: paletteOpen
                                       ? PALETTE_CLASSES.OPEN
                                       : PALETTE_CLASSES.CLOSED

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -28,7 +28,12 @@ import {
     EmaDragItem
 } from '../../../edit-ema-editor/components/ema-page-dropzone/types';
 import { DEFAULT_PERSONA } from '../../../shared/consts';
-import { EDITOR_STATE, UVE_STATUS } from '../../../shared/enums';
+import {
+    EDITOR_STATE,
+    UVE_STATUS,
+    PALETTE_BUTTON_ICONS,
+    PALETTE_CLASSES
+} from '../../../shared/enums';
 import {
     ActionPayload,
     ContainerPayload,
@@ -202,9 +207,11 @@ export function withEditor() {
                                   containers: pageAPIResponse?.containers,
                                   languageId: pageAPIResponse?.viewAs.language.id,
                                   buttonIcon: paletteOpen
-                                      ? 'pi pi-angle-right'
-                                      : 'pi pi-angle-left',
-                                  paletteClass: paletteOpen ? 'show-palette' : 'hide-palette'
+                                      ? PALETTE_BUTTON_ICONS.OPEN
+                                      : PALETTE_BUTTON_ICONS.CLOSED,
+                                  paletteClass: paletteOpen
+                                      ? PALETTE_CLASSES.OPEN
+                                      : PALETTE_CLASSES.CLOSED
                               }
                             : null,
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -201,7 +201,10 @@ export function withEditor() {
                                   variantId: params?.variantName,
                                   containers: pageAPIResponse?.containers,
                                   languageId: pageAPIResponse?.viewAs.language.id,
-                                  shouldShowPalette: paletteOpen
+                                  buttonIcon: paletteOpen
+                                      ? 'pi pi-angle-right'
+                                      : 'pi pi-angle-left',
+                                  paletteClass: paletteOpen ? 'show-palette' : 'hide-palette'
                               }
                             : null,
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts
@@ -68,7 +68,8 @@ const initialState: EditorState = {
     state: EDITOR_STATE.IDLE,
     contentletArea: null,
     dragItem: null,
-    ogTags: null
+    ogTags: null,
+    paletteOpen: true
 };
 
 /**
@@ -136,6 +137,7 @@ export function withEditor() {
                     const bounds = store.bounds();
                     const dragItem = store.dragItem();
                     const isEditState = store.isEditState();
+                    const paletteOpen = store.paletteOpen();
 
                     const isPreview = params?.mode === UVE_MODE.PREVIEW;
                     const isPageReady = isTraditionalPage || isClientReady || isPreview;
@@ -198,7 +200,8 @@ export function withEditor() {
                             ? {
                                   variantId: params?.variantName,
                                   containers: pageAPIResponse?.containers,
-                                  languageId: pageAPIResponse?.viewAs.language.id
+                                  languageId: pageAPIResponse?.viewAs.language.id,
+                                  shouldShowPalette: paletteOpen
                               }
                             : null,
 
@@ -213,7 +216,7 @@ export function withEditor() {
                 $iframeURL: computed<string | InstanceType<typeof String>>(() => {
                     /*
                         Here we need to import pageAPIResponse() to create the computed dependency and have it updated every time a response is received from the PageAPI.
-                        This should change in future UVE improvements. 
+                        This should change in future UVE improvements.
                         The url should not depend on the PageAPI response since it does not change (In traditional).
                         In the future we should have a function that updates the content, independent of the url.
                         More info: https://github.com/dotCMS/core/issues/31475
@@ -351,6 +354,9 @@ export function withEditor() {
                 },
                 setOgTags(ogTags: SeoMetaTags) {
                     patchState(store, { ogTags });
+                },
+                setPaletteOpen(paletteOpen: boolean) {
+                    patchState(store, { paletteOpen });
                 }
             };
         })


### PR DESCRIPTION
This pull request introduces a new feature to toggle the visibility of the palette in the `EditEmaEditorComponent`. The changes include adding a toggle button, updating styles, modifying the component logic, and updating the store state to manage the palette's visibility. Additionally, new tests have been added to ensure the correct functionality of the toggle feature.

### New Feature: Toggle Palette Visibility

* Added a toggle button to the `edit-ema-editor.component.html` to control the palette's visibility.
* Updated styles in `edit-ema-editor.component.scss` to handle the layout changes when the palette is toggled. [[1]](diffhunk://#diff-9f57717118542461b370728d90435befd6cecc18f94bf130ab48acd3ef795ca1L8-R27) [[2]](diffhunk://#diff-9f57717118542461b370728d90435befd6cecc18f94bf130ab48acd3ef795ca1R92-R111)

### Component Logic Updates

* Introduced a new method `togglePalette` in `edit-ema-editor.component.ts` to toggle the palette's visibility.
* Added a new observable `$paletteOpen` to track the palette's state.

### Store State Management

* Updated `editor/models.ts` to include new properties for managing the palette state and icons. [[1]](diffhunk://#diff-a5d9d93bd678484a7d776d09685fcb638de6d969ac141586a1104ba5e744556bL17-R17) [[2]](diffhunk://#diff-a5d9d93bd678484a7d776d09685fcb638de6d969ac141586a1104ba5e744556bR26) [[3]](diffhunk://#diff-a5d9d93bd678484a7d776d09685fcb638de6d969ac141586a1104ba5e744556bR85-R86)
* Modified `withEditor.ts` to handle the new palette state and update editor properties accordingly. [[1]](diffhunk://#diff-86e692578757ed7f4f6cba5d0aeb07641312f3b17885825d1a45987153ae87f0L31-R36) [[2]](diffhunk://#diff-86e692578757ed7f4f6cba5d0aeb07641312f3b17885825d1a45987153ae87f0L71-R77) [[3]](diffhunk://#diff-86e692578757ed7f4f6cba5d0aeb07641312f3b17885825d1a45987153ae87f0R145) [[4]](diffhunk://#diff-86e692578757ed7f4f6cba5d0aeb07641312f3b17885825d1a45987153ae87f0L201-R214) [[5]](diffhunk://#diff-86e692578757ed7f4f6cba5d0aeb07641312f3b17885825d1a45987153ae87f0R367-R369)

### Testing

* Added new tests in `edit-ema-editor.component.spec.ts` to verify the toggle functionality and state updates.
* Updated `withEditor.spec.ts` to include tests for the new palette state management. [[1]](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbL311-R318) [[2]](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbR646-R677)

## Screenshot

https://github.com/user-attachments/assets/0d93f384-5f72-4b40-a7c2-528ad2d6aa9e


This PR fixes: #31804