### PR TITLE
chore(uve): Change border color on Toggle Palette Button

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.scss
@@ -40,7 +40,6 @@
     border: 1px solid $color-palette-primary-300;
     background-color: $white;
     border-radius: 0;
-    border-right: 1px solid $white;
     height: 5.5rem;
     z-index: 10;
     position: absolute;
@@ -63,7 +62,7 @@
 
     &.closed {
         left: -2rem;
-        border-right: none; // To make the blending illusion
+        border-right: none; // To make the blending illusion with the nav bar
         ::ng-deep {
             .p-button-icon,
             .pi {
@@ -74,6 +73,8 @@
 
     &.open {
         left: -17.5rem;
+        border: 1px solid $color-palette-gray-200; // Same as the border of the palette to create a blending illusion
+        border-right: 1px solid $white;
         ::ng-deep {
             .p-button-icon,
             .pi {


### PR DESCRIPTION
This pull request includes changes to the `edit-ema-navigation-bar.component.scss` file to improve the visual consistency and blending illusion of the navigation bar. The most important changes include removing redundant border styles and adding new border styles to enhance the blending effect.

Improvements to visual consistency:

* Removed the redundant border style from the `edit-ema-navigation-bar` component.
* Updated the comment for the `closed` state border style to clarify its purpose.
* Added new border styles to the `open` state to improve the blending illusion with the palette.

## Screenshot

https://github.com/user-attachments/assets/2b25f5ad-78a2-47d0-aa94-c88423bd6526


This PR fixes: #31804