### PR TITLE
bug: websockets don't reconnect on error

### DIFF
--- a/core-web/libs/dotcms-js/src/lib/core/util/dot-event-socket.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/util/dot-event-socket.ts
@@ -1,8 +1,8 @@
-import { Subject, Observable } from 'rxjs';
+import { Subject, Observable, timer } from 'rxjs';
 
 import { Injectable } from '@angular/core';
 
-import { tap, pluck } from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 
 import { LongPollingProtocol } from './long-polling-protocol';
 import { DotEventMessage } from './models/dot-event-message';
@@ -23,10 +23,11 @@ enum ConnectionStatus {
 }
 
 /**
- * It is a socket to receive notifications when a event is tiggered by the server, first this try to stablish a web socket
- * connection if it fail then try to a Long polling connection instead.
+ * It is a socket to receive notifications when a event is triggered by the server, first this try to establish a web socket
+ * connection if it fails then try a Long polling connection instead.
  *
- * If the connection is lost in any point the it try to reconnect automaticatly after a time set by configuration parameters.
+ * If the connection is lost at any point it will try to reconnect automatically after a time set by configuration parameters.
+ * It implements an exponential backoff strategy with jitter for reconnection attempts.
  *
  * @export
  */
@@ -38,6 +39,10 @@ export class DotEventsSocket {
     private _message: Subject<DotEventMessage> = new Subject<DotEventMessage>();
     private _open: Subject<boolean> = new Subject<boolean>();
     private webSocketConfigParams: WebSocketConfigParams;
+    private readonly MAX_RETRIES = 100000;
+    private readonly INITIAL_RETRY_DELAY = 1000;
+    private readonly MAX_RETRY_DELAY = 30000; // 30 seconds max delay
+    private retryCount = 0;
 
     /**
      * Initializes this service with the configuration properties that are
@@ -61,8 +66,15 @@ export class DotEventsSocket {
      * @memberof DotEventsSocket
      */
     connect(): Observable<ConfigParams> {
-        return this.init().pipe(
-            tap(() => {
+        // Using the init method and making sure the return type is correct
+        return this.dotcmsConfigService.getConfig().pipe(
+            tap((config) => {
+                this.webSocketConfigParams = config.websocket;
+                this.protocolImpl =
+                    this.isWebSocketsBrowserSupport() &&
+                    !this.webSocketConfigParams.disabledWebsockets
+                        ? this.getWebSocketProtocol()
+                        : this.getLongPollingProtocol();
                 this.status = ConnectionStatus.CONNECTING;
                 this.connectProtocol();
             })
@@ -113,23 +125,12 @@ export class DotEventsSocket {
         return this.status === ConnectionStatus.CONNECTED;
     }
 
-    private init(): Observable<any> {
-        return this.dotcmsConfigService.getConfig().pipe(
-            pluck('websocket'),
-            tap((webSocketConfigParams: WebSocketConfigParams) => {
-                this.webSocketConfigParams = webSocketConfigParams;
-                this.protocolImpl =
-                    this.isWebSocketsBrowserSupport() && !webSocketConfigParams.disabledWebsockets
-                        ? this.getWebSocketProtocol()
-                        : this.getLongPollingProtocol();
-            })
-        );
-    }
-
     private connectProtocol(): void {
         this.protocolImpl.open$().subscribe(() => {
             this.status = ConnectionStatus.CONNECTED;
             this._open.next(true);
+            // Reset retry counter on successful connection
+            this.retryCount = 0;
         });
 
         this.protocolImpl.error$().subscribe(() => {
@@ -142,24 +143,74 @@ export class DotEventsSocket {
                 this.protocolImpl = this.getLongPollingProtocol();
                 this.connectProtocol();
             } else {
-                setTimeout(() => {
-                    this.status = this.getAfterErrorStatus();
-                    this.protocolImpl.connect();
-                }, this.webSocketConfigParams.websocketReconnectTime);
+                this.reconnect();
             }
         });
 
         this.protocolImpl.close$().subscribe((_event) => {
-            this.status = ConnectionStatus.CLOSED;
+            if (this.status !== ConnectionStatus.CLOSED) {
+                this.loggerService.info('Connection closed unexpectedly, attempting to reconnect');
+                this.reconnect();
+            } else {
+                this.loggerService.debug('Connection closed normally');
+            }
         });
 
         this.protocolImpl.message$().subscribe(
             (res) => this._message.next(res),
-            (e) => this.loggerService.debug('Error in the System Events service: ' + e.message),
+            (e) => {
+                this.loggerService.debug('Error in the System Events service: ' + e.message);
+                this.reconnect();
+            },
             () => this.loggerService.debug('Completed')
         );
 
         this.protocolImpl.connect();
+    }
+
+    private reconnect(): void {
+        // Don't attempt more reconnections than MAX_RETRIES (which is a big number because we always want to reconnect)
+        if (this.retryCount >= this.MAX_RETRIES) {
+            this.loggerService.info(
+                `Maximum reconnection attempts (${this.MAX_RETRIES}) reached. Giving up.`
+            );
+            this.status = ConnectionStatus.CLOSED;
+
+            return;
+        }
+
+        this.status = this.getAfterErrorStatus();
+        this.retryCount++;
+
+        const delay = this.calculateReconnectDelay();
+
+        this.loggerService.info(
+            `Scheduling reconnection attempt ${this.retryCount}/${this.MAX_RETRIES} in ${delay}ms`
+        );
+
+        timer(delay).subscribe(() => {
+            if (this.status !== ConnectionStatus.CLOSED) {
+                this.loggerService.info('Attempting to reconnect');
+                this.protocolImpl.connect();
+            }
+        });
+    }
+
+    private calculateReconnectDelay(): number {
+        // Use configured time or default delay with a random jitter to prevent thundering herd
+        const baseDelay =
+            this.webSocketConfigParams?.websocketReconnectTime || this.INITIAL_RETRY_DELAY;
+
+        // Exponential backoff with jitter, capped at MAX_RETRY_DELAY
+        const exponentialDelay = Math.min(
+            baseDelay * Math.pow(2, Math.min(this.retryCount, 10)), // Cap exponential growth
+            this.MAX_RETRY_DELAY
+        );
+
+        // Add random jitter to prevent reconnection thundering herd problems
+        const jitter = Math.random() * 1000; // Up to 1 second of jitter
+
+        return exponentialDelay + jitter;
     }
 
     private getAfterErrorStatus(): ConnectionStatus {


### PR DESCRIPTION
This pull request includes significant changes to the `DotEventsSocket` class in the `dot-event-socket.ts` file, focusing on improving the reconnection strategy and cleaning up the code. **The most important change** is making sure if the code hits an error, it will not just error out but actively try to reconnect.

https://github.com/dotCMS/core/blob/v25.04.08-1/core-web/libs/dotcms-js/src/lib/core/util/dot-event-socket.ts#L158

It also includes the addition of an exponential backoff strategy for reconnection attempts, the removal of the `init` method, and updates to the import statements.

### Reconnection Strategy Improvements:
* Implemented an exponential backoff strategy with jitter for reconnection attempts, including new constants for retry limits and delays (`MAX_RETRIES`, `INITIAL_RETRY_DELAY`, `MAX_RETRY_DELAY`) and a `retryCount` variable. [[1]](diffhunk://#diff-3a76b4f86832ff56df6a702cd491e6bfe49375d2a5b7eb297e24204af3312e21R42-R45) [[2]](diffhunk://#diff-3a76b4f86832ff56df6a702cd491e6bfe49375d2a5b7eb297e24204af3312e21L145-R215)
* Added a `reconnect` method to handle reconnection logic and a `calculateReconnectDelay` method to compute delays with jitter.

### Code Cleanup:
* Removed the `init` method and integrated its functionality directly into the `connect` method, ensuring the return type is correct. [[1]](diffhunk://#diff-3a76b4f86832ff56df6a702cd491e6bfe49375d2a5b7eb297e24204af3312e21L116-R133) [[2]](diffhunk://#diff-3a76b4f86832ff56df6a702cd491e6bfe49375d2a5b7eb297e24204af3312e21L64-R77)
* Updated import statements to remove unused imports and add necessary ones (`timer`).

### Documentation and Comments:
* Fixed typos and improved comments in the class documentation to enhance clarity.

This PR fixes: #31891