### PR TITLE
Issue 31908 navigate edit mode scope change

### DIFF
--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -272,8 +272,8 @@ jobs:
           platforms: ${{ inputs.docker_platforms }}
           pull: true
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=dotcms/dotcms:buildcache
+          cache-to: type=registry,ref=dotcms/dotcms:buildcache,mode=max
           build-args: |
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
         if: success()

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,3 @@
 -Dprod=true
--Drevision=24.12.27
+-Drevision=24.12.27_lts_v4
 -Dchangelist=

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,3 @@
 -Dprod=true
--Drevision=24.12.27_lts_v4
+-Drevision=24.12.27_lts
 -Dchangelist=

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,3 @@
 -Dprod=true
--Drevision=24.12.27_lts
+-Drevision=24.12.27
 -Dchangelist=

--- a/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PageMode.java
@@ -18,7 +18,7 @@ import javax.servlet.http.HttpSession;
  *
  * if( PageMode.get(request).isAdmin){ doAdminStuff(); }
  *
- * contentAPI.find("sad", user, mode.respectAnonPerms);
+ * contentAPI.find("happy", user, mode.respectAnonPerms);
  *
  * contentAPI.findByIdentifier("id", 1, mode.showLive, user, mode.respectAnonPerms);
  *


### PR DESCRIPTION
### Proposed Changes
This is a specific change that has already been incorporated into the main branch. It prevents an individual request from leaving the ‘navigate edit mode’ value in the session, which previously caused the flow to redirect to a servlet that processes Velocity templates at an inappropriate time. The new UVE no longer requires this processing.


