### PR TITLE
implementation ( Edit Content ) : #31900  Implement Standardized Page Title Pattern for Edit Content Page in Angular 

### DIFF
--- a/core-web/libs/edit-content/src/lib/store/features/content/content.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/content/content.feature.spec.ts
@@ -326,7 +326,7 @@ describe('ContentFeature', () => {
         });
 
         it('should initialize existing content successfully', fakeAsync(() => {
-            store.initializeExistingContent({ inode: '123', depth: 'PARENT_AND_CHILDREN' });
+            store.initializeExistingContent({ inode: '123' });
             tick();
 
             expect(store.contentlet()).toEqual(mockContentlet);
@@ -336,7 +336,7 @@ describe('ContentFeature', () => {
         }));
 
         it('should set the correct title for existing content', fakeAsync(() => {
-            store.initializeExistingContent({ inode: '123', depth: 'PARENT_AND_CHILDREN' });
+            store.initializeExistingContent({ inode: '123' });
             tick();
 
             expect(dotMessageService.get).toHaveBeenCalledWith(
@@ -349,7 +349,7 @@ describe('ContentFeature', () => {
             const mockError = new HttpErrorResponse({ status: 404 });
             dotEditContentService.getContentById.mockReturnValue(throwError(() => mockError));
 
-            store.initializeExistingContent({ inode: '123', depth: 'PARENT_AND_CHILDREN' });
+            store.initializeExistingContent({ inode: '123' });
             tick();
             expect(store.state()).toBe(ComponentStatus.ERROR);
             expect(store.error()).toBe(
@@ -380,7 +380,7 @@ describe('ContentFeature', () => {
             );
             workflowService.getWorkflowStatus.mockReturnValue(of(workflowStatusWithoutScheme));
 
-            store.initializeExistingContent({ inode: '123', depth: 'PARENT_AND_CHILDREN' });
+            store.initializeExistingContent({ inode: '123' });
             tick();
 
             expect(store.initialContentletState()).toBe('reset');

--- a/core-web/libs/edit-content/src/lib/store/features/content/content.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/content/content.feature.ts
@@ -5,6 +5,7 @@ import { forkJoin, of, pipe } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { computed, inject } from '@angular/core';
+import { Title } from '@angular/platform-browser';
 import { Router } from '@angular/router';
 
 import { switchMap } from 'rxjs/operators';
@@ -12,6 +13,7 @@ import { switchMap } from 'rxjs/operators';
 import {
     DotContentTypeService,
     DotHttpErrorManagerService,
+    DotMessageService,
     DotRenderMode,
     DotWorkflowsActionsService,
     DotWorkflowService
@@ -22,6 +24,8 @@ import { DotEditContentService } from '../../../services/dot-edit-content.servic
 import { transformFormDataFn } from '../../../utils/functions.util';
 import { parseCurrentActions, parseWorkflows } from '../../../utils/workflows.utils';
 import { EditContentState } from '../../edit-content.store';
+
+const DEFAULT_TITLE_PLATFORM = 'dotcms.content.management.platform.title';
 
 export function withContent() {
     return signalStoreFeature(
@@ -108,7 +112,9 @@ export function withContent() {
                 workflowActionService = inject(DotWorkflowsActionsService),
                 dotHttpErrorManagerService = inject(DotHttpErrorManagerService),
                 router = inject(Router),
-                dotWorkflowService = inject(DotWorkflowService)
+                dotWorkflowService = inject(DotWorkflowService),
+                title = inject(Title),
+                dotMessageService = inject(DotMessageService)
             ) => ({
                 /**
                  * Initializes the state for creating new content of a specified type.
@@ -147,6 +153,10 @@ export function withContent() {
                                         // Parse the actions as an object with the schemeId as the key
                                         const parsedCurrentActions = parseCurrentActions(
                                             parsedSchemes[defaultSchemeId]?.actions || []
+                                        );
+
+                                        title.setTitle(
+                                            `${dotMessageService.get('New')} ${contentType.variable} - ${dotMessageService.get(DEFAULT_TITLE_PLATFORM)}`
                                         );
 
                                         patchState(store, {
@@ -241,6 +251,10 @@ export function withContent() {
                                         // If there's no scheme or step, content is considered in 'reset' state
                                         const initialContentletState =
                                             !scheme || !step ? 'reset' : 'existing';
+
+                                        title.setTitle(
+                                            `${contentlet.title} - ${dotMessageService.get(DEFAULT_TITLE_PLATFORM)}`
+                                        );
 
                                         patchState(store, {
                                             contentType,

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5980,3 +5980,5 @@ relative.date.minute.ago=a minute ago
 relative.date.minutes.ago={0} minutes ago
 relative.date.hours.ago={0} hours ago
 
+dotcms.content.management.platform.title=dotCMS Content Management Platform
+


### PR DESCRIPTION
### Proposed Changes

This pull request focuses on enhancing the `ContentFeature` in the `core-web` library by adding support for setting the document title based on the content state. The changes include injecting new services, updating the initialization logic, and adding new test cases.


This PR fixes: #31900