### PR TITLE
Using the new GHA cache service as the old one was removed

### DIFF
--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -281,8 +281,8 @@ jobs:
           platforms: ${{ inputs.docker_platforms }}
           pull: true
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=dotcms/dotcms:buildcache
+          cache-to: type=registry,ref=dotcms/dotcms:buildcache,mode=max
           build-args: |
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
         if: success()


### PR DESCRIPTION
The current cache service being used was shut down on April 15, 2025, and we need to migrate to the new service.