### PR TITLE
feat(edit-content): update tag field component to improve functionality

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.html
@@ -6,15 +6,14 @@
     [formControlName]="variable"
     [suggestions]="$suggestions()"
     [multiple]="true"
-    [forceSelection]="true"
-    [unique]="true"
+    [unique]="UNIQUE_CLASSES"
     [minLength]="TAG_MIN_LENGTH"
     [delay]="TAG_DELAY"
     [id]="'tag-id-' + variable"
     [inputId]="variable"
     [attr.data-testid]="'tag-field-container-' + variable"
     (completeMethod)="onSearch($event)"
-    (keydown.enter)="$event.preventDefault()">
+    (keydown.enter)="onEnterKey($event)">
     <ng-template pTemplate="removetokenicon">
         <i class="pi pi-times"></i>
     </ng-template>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.html
@@ -3,15 +3,16 @@
 
 <p-autoComplete
     #autocomplete
-    [formControlName]="variable"
+    [attr.data-testid]="'tag-field-container-' + variable"
+    [id]="'tag-id-' + variable"
+    [inputId]="variable"
     [suggestions]="$suggestions()"
     [multiple]="true"
+    [forceSelection]="false"
     [unique]="UNIQUE_CLASSES"
     [minLength]="TAG_MIN_LENGTH"
     [delay]="TAG_DELAY"
-    [id]="'tag-id-' + variable"
-    [inputId]="variable"
-    [attr.data-testid]="'tag-field-container-' + variable"
+    [formControlName]="variable"
     (completeMethod)="onSearch($event)"
     (keydown.enter)="onEnterKey($event)">
     <ng-template pTemplate="removetokenicon">

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.html
@@ -9,9 +9,9 @@
     [suggestions]="$suggestions()"
     [multiple]="true"
     [forceSelection]="false"
-    [unique]="UNIQUE_CLASSES"
-    [minLength]="TAG_MIN_LENGTH"
-    [delay]="TAG_DELAY"
+    [unique]="AUTO_COMPLETE_UNIQUE"
+    [minLength]="AUTO_COMPLETE_MIN_LENGTH"
+    [delay]="AUTO_COMPLETE_DELAY"
     [formControlName]="variable"
     (completeMethod)="onSearch($event)"
     (keydown.enter)="onEnterKey($event)">

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.spec.ts
@@ -41,9 +41,8 @@ describe('DotEditContentTagFieldComponent', () => {
     });
 
     beforeEach(() => {
-        formGroup = new FormGroup({
-            [TAG_FIELD_MOCK.variable]: new FormControl([])
-        });
+        formGroup = new FormGroup({});
+        formGroup.addControl(TAG_FIELD_MOCK.variable, new FormControl([]));
 
         formGroupDirective = new FormGroupDirective([], []);
         formGroupDirective.form = formGroup;
@@ -68,10 +67,6 @@ describe('DotEditContentTagFieldComponent', () => {
         spectator.detectChanges();
     });
 
-    it('should create component', () => {
-        expect(spectator.component).toBeTruthy();
-    });
-
     describe('Component Configuration', () => {
         it('should render autocomplete with correct attributes', () => {
             const autocomplete = spectator.query(AutoComplete);
@@ -84,17 +79,16 @@ describe('DotEditContentTagFieldComponent', () => {
             expect(autocomplete.id).toBe(`tag-id-${TAG_FIELD_MOCK.variable}`);
             expect(autocomplete.inputId).toBe(TAG_FIELD_MOCK.variable);
             expect(autocomplete.multiple).toBe(true);
-            expect(autocomplete.forceSelection).toBe(true);
+            expect(autocomplete.forceSelection).toBe(false);
             expect(autocomplete.unique).toBe(AUTO_COMPLETE_UNIQUE);
             expect(autocomplete.minLength).toBe(AUTO_COMPLETE_MIN_LENGTH);
             expect(autocomplete.delay).toBe(AUTO_COMPLETE_DELAY);
         });
 
         it('should be connected to form control', () => {
-            const control = spectator.component.formControl;
-            const controlContainer = spectator.inject(ControlContainer, true);
-            expect(control).toBeDefined();
-            expect(control).toBe(controlContainer.control?.get(TAG_FIELD_MOCK.variable));
+            const control = formGroup.get(TAG_FIELD_MOCK.variable);
+            expect(spectator.component.formControl).toBeDefined();
+            expect(spectator.component.formControl).toBe(control);
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.spec.ts
@@ -110,6 +110,71 @@ describe('DotEditContentTagFieldComponent', () => {
             expect(service.getTags).toHaveBeenCalledWith('type');
             expect(spectator.component.$suggestions()).toEqual(expectedTags);
         });
+
+        describe('Enter key behavior', () => {
+            let autocomplete: AutoComplete;
+            let autocompleteInput: HTMLInputElement;
+
+            beforeEach(() => {
+                autocomplete = spectator.query(AutoComplete);
+                autocompleteInput = spectator.query('input[role="combobox"]');
+            });
+
+            const simulateEnterKey = () => {
+                const enterEvent = new KeyboardEvent('keydown', {
+                    key: 'Enter',
+                    bubbles: true,
+                    cancelable: true
+                });
+                autocompleteInput.dispatchEvent(enterEvent);
+            };
+
+            it('should add new tag when Enter is pressed with non-empty value', () => {
+                const newTag = 'newTag';
+                autocompleteInput.value = newTag;
+
+                simulateEnterKey();
+                spectator.detectChanges();
+
+                expect(spectator.component.formControl?.value).toEqual([newTag]);
+                expect(autocompleteInput.value).toBe('');
+            });
+
+            it('should not add empty tag when Enter is pressed with empty value', () => {
+                autocompleteInput.value = '   ';
+
+                simulateEnterKey();
+                spectator.detectChanges();
+
+                expect(spectator.component.formControl?.value).toEqual([]);
+            });
+
+            it('should append new tag to existing tags', () => {
+                const existingTags = ['tag1', 'tag2'];
+                const newTag = 'tag3';
+                spectator.component.formControl?.setValue(existingTags);
+                autocompleteInput.value = newTag;
+
+                simulateEnterKey();
+                spectator.detectChanges();
+
+                expect(spectator.component.formControl?.value).toEqual([...existingTags, newTag]);
+                expect(autocompleteInput.value).toBe('');
+            });
+
+            it('should not add duplicate tag due to AutoComplete unique property', () => {
+                const existingTag = 'existingTag';
+                spectator.component.formControl?.setValue([existingTag]);
+                autocompleteInput.value = existingTag;
+
+                simulateEnterKey();
+                spectator.detectChanges();
+
+                expect(spectator.component.formControl?.value).toEqual([existingTag]);
+                expect(autocompleteInput.value).toBe(existingTag);
+                expect(autocomplete.unique).toBe(true);
+            });
+        });
     });
 
     describe('Form Integration', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.spec.ts
@@ -13,7 +13,12 @@ import { By } from '@angular/platform-browser';
 
 import { AutoComplete, AutoCompleteCompleteEvent } from 'primeng/autocomplete';
 
-import { DotEditContentTagFieldComponent } from './dot-edit-content-tag-field.component';
+import {
+    AUTO_COMPLETE_DELAY,
+    AUTO_COMPLETE_MIN_LENGTH,
+    AUTO_COMPLETE_UNIQUE,
+    DotEditContentTagFieldComponent
+} from './dot-edit-content-tag-field.component';
 
 import { DotEditContentService } from '../../services/dot-edit-content.service';
 import { TAG_FIELD_MOCK } from '../../utils/mocks';
@@ -80,9 +85,9 @@ describe('DotEditContentTagFieldComponent', () => {
             expect(autocomplete.inputId).toBe(TAG_FIELD_MOCK.variable);
             expect(autocomplete.multiple).toBe(true);
             expect(autocomplete.forceSelection).toBe(true);
-            expect(autocomplete.unique).toBe(true);
-            expect(autocomplete.minLength).toBe(2);
-            expect(autocomplete.delay).toBe(300);
+            expect(autocomplete.unique).toBe(AUTO_COMPLETE_UNIQUE);
+            expect(autocomplete.minLength).toBe(AUTO_COMPLETE_MIN_LENGTH);
+            expect(autocomplete.delay).toBe(AUTO_COMPLETE_DELAY);
         });
 
         it('should be connected to form control', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.ts
@@ -21,9 +21,12 @@ import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
 
 import { DotEditContentService } from '../../services/dot-edit-content.service';
 
-const TAG_MIN_LENGTH = 2;
-const TAG_DELAY = 300;
-const UNIQUE_CLASSES = true;
+export const AUTO_COMPLETE_MIN_LENGTH = 2;
+
+export const AUTO_COMPLETE_DELAY = 300;
+
+export const AUTO_COMPLETE_UNIQUE = true;
+
 /**
  * Component that handles tag field input using PrimeNG's AutoComplete.
  * It provides tag suggestions as the user types with a minimum of 2 characters.
@@ -46,9 +49,9 @@ export class DotEditContentTagFieldComponent {
     #editContentService = inject(DotEditContentService);
     #controlContainer = inject(ControlContainer);
 
-    protected readonly TAG_MIN_LENGTH = TAG_MIN_LENGTH;
-    protected readonly TAG_DELAY = TAG_DELAY;
-    protected readonly UNIQUE_CLASSES = UNIQUE_CLASSES;
+    protected readonly AUTO_COMPLETE_MIN_LENGTH = AUTO_COMPLETE_MIN_LENGTH;
+    protected readonly AUTO_COMPLETE_DELAY = AUTO_COMPLETE_DELAY;
+    protected readonly AUTO_COMPLETE_UNIQUE = AUTO_COMPLETE_UNIQUE;
 
     /**
      * Required input that defines the field configuration

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.ts
@@ -114,8 +114,18 @@ export class DotEditContentTagFieldComponent {
     }
 
     /**
-     * Handles the Enter key event
-     * Prevents the default behavior of the Enter key
+     * Handles the Enter key press event in the tag input field.
+     * 
+     * This method:
+     * - Prevents the default Enter key behavior
+     * - Gets the current input value and trims whitespace
+     * - If the value is not empty and not already in the list:
+     *   - Adds it to the existing tags list
+     *   - Clears the input field
+     * - Maintains uniqueness by checking for duplicates
+     * 
+     * @param {Event} event - The keyboard event object
+     * @memberof DotEditContentTagFieldComponent
      */
     onEnterKey(event: Event): void {
         event.preventDefault();

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.ts
@@ -23,7 +23,7 @@ import { DotEditContentService } from '../../services/dot-edit-content.service';
 
 const TAG_MIN_LENGTH = 2;
 const TAG_DELAY = 300;
-
+const UNIQUE_CLASSES = true;
 /**
  * Component that handles tag field input using PrimeNG's AutoComplete.
  * It provides tag suggestions as the user types with a minimum of 2 characters.
@@ -48,6 +48,7 @@ export class DotEditContentTagFieldComponent {
 
     protected readonly TAG_MIN_LENGTH = TAG_MIN_LENGTH;
     protected readonly TAG_DELAY = TAG_DELAY;
+    protected readonly UNIQUE_CLASSES = UNIQUE_CLASSES;
 
     /**
      * Required input that defines the field configuration
@@ -110,6 +111,25 @@ export class DotEditContentTagFieldComponent {
      */
     onSearch(event: AutoCompleteCompleteEvent): void {
         this.#searchTerms$.next(event.query);
+    }
+
+    /**
+     * Handles the Enter key event
+     * Prevents the default behavior of the Enter key
+     */
+    onEnterKey(event: Event): void {
+        event.preventDefault();
+
+        const input = event.target as HTMLInputElement;
+        const value = input.value.trim();
+
+        if (value) {
+            const currentValues = this.formControl.value || [];
+            if (!currentValues.includes(value)) {
+                this.formControl.setValue([...currentValues, value]);
+                input.value = '';
+            }
+        }
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.ts
@@ -115,17 +115,9 @@ export class DotEditContentTagFieldComponent {
 
     /**
      * Handles the Enter key press event in the tag input field.
-     * 
-     * This method:
-     * - Prevents the default Enter key behavior
-     * - Gets the current input value and trims whitespace
-     * - If the value is not empty and not already in the list:
-     *   - Adds it to the existing tags list
-     *   - Clears the input field
-     * - Maintains uniqueness by checking for duplicates
-     * 
+     * Prevents form submission and allows custom values while maintaining uniqueness.
+     *
      * @param {Event} event - The keyboard event object
-     * @memberof DotEditContentTagFieldComponent
      */
     onEnterKey(event: Event): void {
         event.preventDefault();
@@ -134,9 +126,11 @@ export class DotEditContentTagFieldComponent {
         const value = input.value.trim();
 
         if (value) {
-            const currentValues = this.formControl.value || [];
-            if (!currentValues.includes(value)) {
-                this.formControl.setValue([...currentValues, value]);
+            const currentValues = this.formControl?.value || [];
+            const isDuplicate = currentValues.includes(value);
+
+            if (!isDuplicate) {
+                this.formControl?.setValue([...currentValues, value]);
                 input.value = '';
             }
         }


### PR DESCRIPTION
This commit enhances the  component by introducing a new method to handle the Enter key event, allowing users to add tags more intuitively. Additionally, the  property is now set to a constant value, improving clarity in the component's configuration.

Key changes include:
- Added  method to manage Enter key events and prevent default behavior.
- Updated the  property to use a constant for better maintainability.

These changes aim to enhance user experience and streamline tag input functionality.
This pull request introduces enhancements and fixes to the `DotEditContentTagFieldComponent` in the `core-web/libs/edit-content` library. The key changes include replacing hardcoded values with constants for better maintainability, adding a new method to handle the Enter key event, and updating the component's HTML template accordingly.

### Enhancements to maintainability:
* Introduced a new constant `UNIQUE_CLASSES` to replace the hardcoded `true` value for the `[unique]` attribute in the HTML template. This change centralizes the configuration and improves readability. (`[[1]](diffhunk://#diff-30bb1f12aceeea97b2f89056a5668a9d33ab5552ec127765abc5a81db4693118L26-R26)`, `[[2]](diffhunk://#diff-30bb1f12aceeea97b2f89056a5668a9d33ab5552ec127765abc5a81db4693118R51)`, `[[3]](diffhunk://#diff-ee30951eddf537d5ad5b49e46e2d91f7395539c0f3d615f6143154fd2b5f950eL9-R16)`)

### New functionality:
* Added an `onEnterKey` method to handle the Enter key event. The method prevents the default behavior, trims the input value, and adds it to the form control if it is not already present. This improves user experience by allowing users to add tags directly via the Enter key. (`[[1]](diffhunk://#diff-30bb1f12aceeea97b2f89056a5668a9d33ab5552ec127765abc5a81db4693118R116-R134)`, `[[2]](diffhunk://#diff-ee30951eddf537d5ad5b49e46e2d91f7395539c0f3d615f6143154fd2b5f950eL9-R16)`)

### Updates to the HTML template:
* Updated the `(keydown.enter)` event binding in the HTML template to use the new `onEnterKey` method instead of the previous `$event.preventDefault()` inline logic. (`[core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.htmlL9-R16](diffhunk://#diff-ee30951eddf537d5ad5b49e46e2d91f7395539c0f3d615f6143154fd2b5f950eL9-R16)`)

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
https://github.com/user-attachments/assets/6ae43df9-b628-4990-8295-f5662dc16cf4


This PR fixes: #31899