### PR TITLE
fix(UVE): Add Params to Router Link to preserve state across portlets

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.html
@@ -20,11 +20,18 @@
 
         <a
             [routerLink]="item.isDisabled ? null : item.href"
+            [queryParams]="$params()"
             [ngClass]="{ 'edit-ema-nav-bar__item--disabled': item.isDisabled }"
             [pTooltip]="item.tooltip | dm"
             class="edit-ema-nav-bar__item"
             data-testId="nav-bar-item"
             routerLinkActive="edit-ema-nav-bar__item--active"
+            [routerLinkActiveOptions]="{
+                queryParams: 'ignored',
+                matrixParams: 'ignored',
+                paths: 'exact',
+                fragment: 'ignored'
+            }"
             queryParamsHandling="merge"
             tooltipPosition="left"
             rel="noopener">

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.spec.ts
@@ -25,6 +25,10 @@ const store = {
         palette: {
             paletteClass: 'palette-class'
         }
+    }),
+    pageParams: () => ({
+        language_id: '3',
+        personaId: '123'
     })
 };
 
@@ -115,6 +119,21 @@ describe('EditEmaNavigationBarComponent', () => {
                 expect(links[2].getAttribute('ng-reflect-router-link')).toBe('rules');
                 expect(links[3].getAttribute('ng-reflect-router-link')).toBe('experiments');
                 expect(links[4].getAttribute('ng-reflect-router-link')).toBeNull();
+            });
+
+            it('should apply correct query params when clicked', () => {
+                // Get expected values from store
+                const expectedParams = store.pageParams();
+
+                // Simulate a click on the first navigation item (Content)
+                const contentLink = spectator.query(byText('Content'));
+                spectator.click(contentLink);
+
+                // Check that router has the expected query params
+                // Note: In the test environment, the path may not change as expected,
+                // but we can still verify the query params are correctly applied
+                expect(spectator.router.url).toContain(`language_id=${expectedParams.language_id}`);
+                expect(spectator.router.url).toContain(`personaId=${expectedParams.personaId}`);
             });
 
             it("should be a button if action is defined on last item 'Action'", () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/components/edit-ema-navigation-bar/edit-ema-navigation-bar.component.ts
@@ -45,6 +45,8 @@ export class EditEmaNavigationBarComponent {
 
     $editorProps = this.uveStore.$editorProps;
 
+    $params = this.uveStore.pageParams;
+
     /**
      * Handle the click event on the item
      *


### PR DESCRIPTION
This pull request enhances the functionality of the `EditEmaNavigationBarComponent` by adding support for query parameters and improving its test coverage. The most significant changes include updates to the component's HTML template, the addition of query parameter handling in the TypeScript file, and new test cases to validate the functionality.

### Enhancements to query parameter handling:

* **HTML Template (`edit-ema-navigation-bar.component.html`)**: Added support for query parameters using the `$params()` method and configured `routerLinkActiveOptions` to ignore query parameters, matrix parameters, and fragments while matching paths exactly.
* **Component Logic (`edit-ema-navigation-bar.component.ts`)**: Introduced a new `$params` property in the component to access query parameters from the store.

### Test coverage improvements:

* **Mock Data (`edit-ema-navigation-bar.component.spec.ts`)**: Added a new `pageParams` method to the mock store to provide test data for query parameters.
* **New Test Case (`edit-ema-navigation-bar.component.spec.ts`)**: Implemented a test to verify that the correct query parameters are applied when a navigation item is clicked. This ensures the router URL contains the expected query parameters.


## Screenshot 
https://github.com/user-attachments/assets/f9be757f-fdab-4ee0-a32e-d3977ad00cfe


This PR fixes: #31919