### PR TITLE
docs: k8s example statefulset.yaml

### DIFF
--- a/docker/k8s-aws-eks-manifest-examples/statefulset.yaml
+++ b/docker/k8s-aws-eks-manifest-examples/statefulset.yaml
@@ -102,7 +102,7 @@ spec:
                 fi; ln -s /data/shared/assets/.backup /data/local/dotsecure/backup;
         startupProbe:
           httpGet:
-            path: /api/v1/heavy
+            path: /api/v1/probes/startup
             port: 8082
           initialDelaySeconds: 30
           periodSeconds: 5
@@ -111,7 +111,7 @@ spec:
           timeoutSeconds: 1
         livenessProbe:
           httpGet:
-            path: /api/v1/light
+            path: /api/v1/probes/alive
             port: 8082
           initialDelaySeconds: 1
           periodSeconds: 30
@@ -120,7 +120,7 @@ spec:
           timeoutSeconds: 10
         readinessProbe:
           httpGet:
-            path: /api/v1/light
+            path: /api/v1/probes/alive
             port: 8082
           initialDelaySeconds: 1
           periodSeconds: 10


### PR DESCRIPTION
This pull request updates the Kubernetes manifest file `statefulset.yaml` to improve the clarity and consistency of probe endpoint paths. The changes ensure that the paths for startup, liveness, and readiness probes are more descriptive and aligned with their purposes.

### Probe endpoint updates:

* Updated the `startupProbe` HTTP GET path from `/api/v1/heavy` to `/api/v1/probes/startup` for better clarity and alignment with its function.
* Updated the `livenessProbe` HTTP GET path from `/api/v1/light` to `/api/v1/probes/alive` to make the endpoint name more descriptive.
* Updated the `readinessProbe` HTTP GET path from `/api/v1/light` to `/api/v1/probes/alive` to match the naming convention and improve consistency.### Proposed Changes
