### PR TITLE
fix(template-builder): Ignore `gridstack` files on Jest Transform step

### DIFF
--- a/core-web/libs/template-builder/jest.config.ts
+++ b/core-web/libs/template-builder/jest.config.ts
@@ -28,7 +28,7 @@ export default {
     // https://github.com/nrwl/nx/issues/7844#issuecomment-1016624608
     // This is a bottleneck, it's taking way too long to start the tests
     // https://github.com/dotCMS/core/issues/31729
-    transformIgnorePatterns: ['<rootDir>/node_modules/(?!.*\\.mjs$)'],
+    transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$|gridstack)'],
     snapshotSerializers: [
         'jest-preset-angular/build/serializers/no-ng-attributes',
         'jest-preset-angular/build/serializers/ng-snapshot',

--- a/core-web/libs/template-builder/jest.config.ts
+++ b/core-web/libs/template-builder/jest.config.ts
@@ -25,9 +25,6 @@ export default {
             }
         ]
     },
-    // https://github.com/nrwl/nx/issues/7844#issuecomment-1016624608
-    // This is a bottleneck, it's taking way too long to start the tests
-    // https://github.com/dotCMS/core/issues/31729
     transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$|gridstack)'],
     snapshotSerializers: [
         'jest-preset-angular/build/serializers/no-ng-attributes',


### PR DESCRIPTION
This pull request includes a small update to the Jest configuration in the `core-web/libs/template-builder/jest.config.ts` file. The change modifies the `transformIgnorePatterns` property to include an exception for the `gridstack` library.

- [`core-web/libs/template-builder/jest.config.ts`](diffhunk://#diff-ffe331fbd44eff4ad040083f0f2401ec15592608a175d47d85d54e2191f539a7L31-R31): Updated `transformIgnorePatterns` to `['node_modules/(?!.*\.mjs$|gridstack)']` to ensure the `gridstack` library is not ignored during transformation.

This PR fixes: #31729