### PR TITLE
fix(deployment): #31950 Cache action upgrade.

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -176,7 +176,7 @@ runs:
     - name: Docker Setup Buildx
       uses: docker/setup-buildx-action@v3.10.0
       with:
-        version: v0.20.0 # version of buildx https://github.com/docker/buildx/releases
+        version: v0.23.0 # version of buildx https://github.com/docker/buildx/releases supports API v2 GitHub cache (>= v0.21.0)
         platforms: ${{ inputs.docker_platforms }}
     - name: Build/Push Docker Image
       uses: docker/build-push-action@v6.15.0
@@ -187,7 +187,6 @@ runs:
         platforms: ${{ inputs.docker_platforms }}
         pull: true
         push: ${{ inputs.do_deploy }}
-        load: ${{ inputs.do_deploy != 'true' }}
-        cache-from: type=registry,ref=${{ inputs.image_name }}:buildcache
-        cache-to: ${{ inputs.do_deploy == 'true' && format('type=registry,ref={0}:buildcache,mode=max', inputs.image_name) || '' }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         build-args: ${{ inputs.build_args }}

--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -187,6 +187,6 @@ runs:
         platforms: ${{ inputs.docker_platforms }}
         pull: true
         push: ${{ inputs.do_deploy }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=${{ github.workflow }}
+        cache-to: type=gha,mode=max,scope=${{ github.workflow }}
         build-args: ${{ inputs.build_args }}

--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -187,6 +187,7 @@ runs:
         platforms: ${{ inputs.docker_platforms }}
         pull: true
         push: ${{ inputs.do_deploy }}
-        cache-from: type=gha,scope=${{ github.workflow }}
-        cache-to: type=gha,mode=max,scope=${{ github.workflow }}
+        load: ${{ inputs.do_deploy != 'true' }}
+        cache-from: type=registry,ref=${{ inputs.image_name }}:buildcache
+        cache-to: ${{ inputs.do_deploy == 'true' && format('type=registry,ref={0}:buildcache,mode=max', inputs.image_name) || '' }}
         build-args: ${{ inputs.build_args }}

--- a/.github/actions/core-cicd/setup-java/action.yml
+++ b/.github/actions/core-cicd/setup-java/action.yml
@@ -79,6 +79,7 @@ runs:
       with:
         path: ~/.sdkman/candidates/java/${{ steps.get-requested-version.outputs.requested_version }}
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-java-${{ steps.get-requested-version.outputs.requested_version }}
+        lookup-only: true
 
     - name: Restore Cache GraalVM SDK
       id: restore-cache-graalvm

--- a/.github/actions/core-cicd/setup-java/action.yml
+++ b/.github/actions/core-cicd/setup-java/action.yml
@@ -55,32 +55,27 @@ runs:
           echo "Using provided GraalVM version: $GRAALVM_VERSION"
         fi
         echo "graalvm_version=$GRAALVM_VERSION" >> $GITHUB_OUTPUT
-    - name: Restore Cache SDKMan install
-      id: restore-cache-sdkman
-      uses: actions/cache/restore@v4
+        
+    - name: Cache SDKMan install
+      id: cache-sdkman
+      uses: actions/cache@v4
       with:
         path: ~/.sdkman
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-install
+        
     - name: Install SDKMan
       id: install-sdkman
-      if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' }}
+      if: ${{ steps.cache-sdkman.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
         echo "Downloading SDKMAN install"
         curl -s "https://get.sdkman.io" | bash
         fi
-    - name: Save Cache SDKMan install
-      id: save-cache-sdkman
-      if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
-      with:
-        path: ~/.sdkman
-        key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-install
-
+        
     - name: Restore Cache Java SDK
       id: restore-cache-java
-      uses: actions/cache/restore@v4
+      uses: actions/cache@v4
       with:
         path: ~/.sdkman/candidates/java/${{ steps.get-requested-version.outputs.requested_version }}
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-java-${{ steps.get-requested-version.outputs.requested_version }}
@@ -88,7 +83,7 @@ runs:
     - name: Restore Cache GraalVM SDK
       id: restore-cache-graalvm
       if: ${{ inputs.require-graalvm == 'true' }}
-      uses: actions/cache/restore@v4
+      uses: actions/cache@v4
       with:
         path: ~/.sdkman/candidates/java/${{ steps.get-requested-version.outputs.graalvm_version }}
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-java-${{ steps.get-requested-version.outputs.graalvm_version }}
@@ -153,7 +148,7 @@ runs:
         java -version
 
     - name: Save Cache Java SDK
-      uses: actions/cache/save@v4
+      uses: actions/cache@v4
       if: ${{ steps.restore-cache-java.outputs.cache-hit != 'true' }}
       with:
         path: ~/.sdkman/candidates/java/${{ steps.get-requested-version.outputs.requested_version }}
@@ -161,7 +156,7 @@ runs:
 
     - name: Save Cache GraalVM SDK
       if: ${{ inputs.require-graalvm == 'true' && steps.restore-cache-graalvm.outputs.cache-hit != 'true' }}
-      uses: actions/cache/save@v4
+      uses: actions/cache@v4
       with:
         path: ~/.sdkman/candidates/java/${{ steps.get-requested-version.outputs.graalvm_version }}
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-java-${{ steps.get-requested-version.outputs.graalvm_version }}

--- a/.github/actions/core-cicd/setup-java/action.yml
+++ b/.github/actions/core-cicd/setup-java/action.yml
@@ -56,16 +56,16 @@ runs:
         fi
         echo "graalvm_version=$GRAALVM_VERSION" >> $GITHUB_OUTPUT
         
-    - name: Cache SDKMan install
-      id: cache-sdkman
-      uses: actions/cache@v4
+    - name: Restore Cache SDKMan install
+      id: restore-cache-sdkman
+      uses: actions/cache/restore@v4
       with:
         path: ~/.sdkman
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-install
         
     - name: Install SDKMan
       id: install-sdkman
-      if: ${{ steps.cache-sdkman.outputs.cache-hit != 'true' }}
+      if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
@@ -73,18 +73,25 @@ runs:
         curl -s "https://get.sdkman.io" | bash
         fi
         
+    - name: Save Cache SDKMan install
+      id: save-cache-sdkman
+      if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        path: ~/.sdkman
+        key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-install
+        
     - name: Restore Cache Java SDK
       id: restore-cache-java
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ~/.sdkman/candidates/java/${{ steps.get-requested-version.outputs.requested_version }}
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-java-${{ steps.get-requested-version.outputs.requested_version }}
-        lookup-only: true
 
     - name: Restore Cache GraalVM SDK
       id: restore-cache-graalvm
       if: ${{ inputs.require-graalvm == 'true' }}
-      uses: actions/cache@v4
+      uses: actions/cache/restore@v4
       with:
         path: ~/.sdkman/candidates/java/${{ steps.get-requested-version.outputs.graalvm_version }}
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-java-${{ steps.get-requested-version.outputs.graalvm_version }}
@@ -149,7 +156,7 @@ runs:
         java -version
 
     - name: Save Cache Java SDK
-      uses: actions/cache@v4
+      uses: actions/cache/save@v4
       if: ${{ steps.restore-cache-java.outputs.cache-hit != 'true' }}
       with:
         path: ~/.sdkman/candidates/java/${{ steps.get-requested-version.outputs.requested_version }}
@@ -157,7 +164,7 @@ runs:
 
     - name: Save Cache GraalVM SDK
       if: ${{ inputs.require-graalvm == 'true' && steps.restore-cache-graalvm.outputs.cache-hit != 'true' }}
-      uses: actions/cache@v4
+      uses: actions/cache/save@v4
       with:
         path: ~/.sdkman/candidates/java/${{ steps.get-requested-version.outputs.graalvm_version }}
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-java-${{ steps.get-requested-version.outputs.graalvm_version }}

--- a/.github/actions/core-cicd/setup-java/action.yml
+++ b/.github/actions/core-cicd/setup-java/action.yml
@@ -55,14 +55,12 @@ runs:
           echo "Using provided GraalVM version: $GRAALVM_VERSION"
         fi
         echo "graalvm_version=$GRAALVM_VERSION" >> $GITHUB_OUTPUT
-        
     - name: Restore Cache SDKMan install
       id: restore-cache-sdkman
       uses: actions/cache/restore@v4
       with:
         path: ~/.sdkman
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-install
-        
     - name: Install SDKMan
       id: install-sdkman
       if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' }}
@@ -72,7 +70,6 @@ runs:
         echo "Downloading SDKMAN install"
         curl -s "https://get.sdkman.io" | bash
         fi
-        
     - name: Save Cache SDKMan install
       id: save-cache-sdkman
       if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' }}
@@ -80,7 +77,7 @@ runs:
       with:
         path: ~/.sdkman
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-install
-        
+
     - name: Restore Cache Java SDK
       id: restore-cache-java
       uses: actions/cache/restore@v4


### PR DESCRIPTION
## Proposed Changes

This pull request updates the `action.yml` file for the Docker deployment workflow to improve compatibility and leverage new features in the Docker Buildx tool.

Workflow updates:

* [`.github/actions/core-cicd/deployment/deploy-docker/action.yml`](diffhunk://#diff-2d288712b36a346510817142c7b78b828c3b85679d1643bd69772c603ff70caaL179-R179): Updated the `Docker Setup Buildx` step to use Buildx version `v0.23.0`, which supports API v2 GitHub cache (introduced in versions `>= v0.21.0`). This ensures better caching capabilities and compatibility with newer features.

## Fixes
#31950 

This PR fixes: #31950