### PR TITLE
fix(import): Fix issue when importing contents with relationship due to language

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -219,6 +219,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -8330,10 +8331,17 @@ public class ESContentletAPIImpl implements ContentletAPI {
                                         .getRelationTypeValue() + "] is required.");
                         cve.addRequiredRelationship(relationship, contentsInRelationship);
                     }
+                    //grouping by id to avoid duplicate contents due to different languages
+                    List<Contentlet> contentsInRelationshipSameLanguage = new ArrayList<>(contentsInRelationship.stream()
+                            .collect(Collectors.toMap(
+                                    Contentlet::getIdentifier,
+                                    Function.identity(),
+                                    (existing, replacement) -> existing
+                            ))
+                            .values());
+
                     // If there's a 1-N relationship and the child content is
                     // trying to relate to one more parent...
-
-                    List <Contentlet> contentsInRelationshipSameLanguage = contentsInRelationship.stream().filter(c -> c.getLanguageId() == contentlet.getLanguageId()).collect(Collectors.toList());
 
                     if (relationship.getCardinality()
                             == RELATIONSHIP_CARDINALITY.ONE_TO_MANY.ordinal()

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -8332,9 +8332,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     }
                     // If there's a 1-N relationship and the child content is
                     // trying to relate to one more parent...
+
+                    List <Contentlet> contentsInRelationshipSameLanguage = contentsInRelationship.stream().filter(c -> c.getLanguageId() == contentlet.getLanguageId()).collect(Collectors.toList());
+
                     if (relationship.getCardinality()
                             == RELATIONSHIP_CARDINALITY.ONE_TO_MANY.ordinal()
-                            && contentsInRelationship.size() > 1) {
+                            && contentsInRelationshipSameLanguage.size() > 1) {
                         final StringBuilder error = new StringBuilder();
                         error.append("ERROR! Child content [").append(contentletId)
                                 .append("] is already related to another parent content [");


### PR DESCRIPTION
Problem
During the import process, an error was occurring when a contentlet was related to another contentlet that had versions in multiple languages. The issue was that the code treats a content with different languages as distinct entities — it incorrectly assumed they were different contents, although the content is the same.

Fix
When validating if the content is trying to relate to more contents that the one already has, we group by identifier the array of the contents related, this way although the content has more than one language versions, it would be interpreted as an unique relation. So in the scenario the issue shows it won't throw an error. If we have a case in where the content has more than one relation with the same language, then we are going to get the error.

This PR fixes: #31712