### PR TITLE
fix ( content search) : #31933 The "Select All Content" option is intermittently not appearing 

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
@@ -1786,9 +1786,10 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
         }
 
         function selectAllContentsMessage() {
-                var checkAll = document.getElementById("checkAll");
+                var checkAllDijit = dijit.byId("checkAll");
+                var isChecked = checkAllDijit.checked;
                 var table = $('tablemessage');
-                if (checkAll.checked) {
+                if (isChecked) {
                         var html = '' +
                                 '       <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "all")) %> ' + cbContentInodeList.length + ' <%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "contents-on-this-page-are-selected")) %>';
                                 if (perPage < totalContents) {


### PR DESCRIPTION
### Proposed Changes
* using the `document.getElementById` to find the dojo element, at some point give the out of date value of the checkbox and always return `false`,  so never show the message to the user. 
* use `dijit.byId` get the accurate value. 


This PR fixes: #31933