### PR TITLE
fix(uve): Fixed issue when open self hosted angular page in UVE

### DIFF
--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -272,8 +272,8 @@ jobs:
           platforms: ${{ inputs.docker_platforms }}
           pull: true
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=dotcms/dotcms:buildcache
+          cache-to: type=registry,ref=dotcms/dotcms:buildcache,mode=max
           build-args: |
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
         if: success()

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2622,7 +2622,7 @@ describe('EditEmaEditorComponent', () => {
                     const iframe = spectator.debugElement.query(By.css('[data-testId="iframe"]'));
 
                     expect(iframe.nativeElement.src).toBe(
-                        'http://localhost:3000/page-one?clientHost=http%3A%2F%2Flocalhost%3A3000&language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT'
+                        'http://localhost:3000/page-one?clientHost=http%3A%2F%2Flocalhost%3A3000&language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT&mode=EDIT_MODE'
                     );
                 });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.spec.ts
@@ -18,7 +18,8 @@ const pageParams = {
     language_id: '1',
     'com.dotmarketing.persona.id': 'dot:persona',
     variantName: 'DEFAULT',
-    clientHost: 'http://localhost:3000'
+    clientHost: 'http://localhost:3000',
+    mode: 'EDIT_MODE'
 };
 
 const initialState: UVEState = {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
@@ -115,14 +115,14 @@ describe('withEditor', () => {
             describe('$toolbarProps', () => {
                 it('should return the base info', () => {
                     expect(store.$toolbarProps()).toEqual({
-                        apiUrl: '/api/v1/page/json/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000',
+                        apiUrl: '/api/v1/page/json/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000&mode=EDIT_MODE',
                         bookmarksUrl: '/test-url?host_id=123-xyz-567-xxl&language_id=1',
                         copyUrl:
                             'http://localhost:3000/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&host_id=123-xyz-567-xxl',
                         currentLanguage: MOCK_RESPONSE_HEADLESS.viewAs.language,
                         deviceSelector: {
                             apiLink:
-                                'http://localhost:3000/api/v1/page/json/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000',
+                                'http://localhost:3000/api/v1/page/json/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000&mode=EDIT_MODE',
                             hideSocialMedia: true
                         },
                         personaSelector: {
@@ -562,7 +562,7 @@ describe('withEditor', () => {
                 it('should return the base info', () => {
                     expect(store.$uveToolbar()).toEqual({
                         editor: {
-                            apiUrl: '/api/v1/page/json/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000',
+                            apiUrl: '/api/v1/page/json/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000&mode=EDIT_MODE',
                             bookmarksUrl: '/test-url?host_id=123-xyz-567-xxl&language_id=1',
                             copyUrl:
                                 'http://localhost:3000/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&host_id=123-xyz-567-xxl'
@@ -675,7 +675,7 @@ describe('withEditor', () => {
         describe('$iframeURL', () => {
             it("should return the iframe's URL", () => {
                 expect(store.$iframeURL()).toBe(
-                    'http://localhost:3000/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000'
+                    'http://localhost:3000/test-url?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000&mode=EDIT_MODE'
                 );
             });
 
@@ -709,7 +709,7 @@ describe('withEditor', () => {
                 });
 
                 expect(store.$iframeURL()).toBe(
-                    'http://localhost:3000/first?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000'
+                    'http://localhost:3000/first?language_id=1&com.dotmarketing.persona.id=dot%3Apersona&variantName=DEFAULT&clientHost=http%3A%2F%2Flocalhost%3A3000&mode=EDIT_MODE'
                 );
             });
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -1,5 +1,6 @@
 import { Params } from '@angular/router';
 
+import { UVE_MODE } from '@dotcms/client';
 import { CurrentUser } from '@dotcms/dotcms-js';
 import {
     DEFAULT_VARIANT_ID,
@@ -232,7 +233,12 @@ export function createPageApiUrlWithQueryParams(
         language_id: params?.language_id ?? '1',
         'com.dotmarketing.persona.id':
             params?.['com.dotmarketing.persona.id'] ?? DEFAULT_PERSONA.identifier,
-        variantName: params?.variantName ?? DEFAULT_VARIANT_ID
+        variantName: params?.variantName ?? DEFAULT_VARIANT_ID,
+        /**
+         * We add this "mode" param to avoid issue when the UVE render a "local" application as headless
+         * More info: https://github.com/dotCMS/core/issues/31908#issuecomment-2824517688
+         * */
+        mode: params.mode ?? (params?.editorMode === UVE_MODE.PREVIEW ? 'PREVIEW' : 'EDIT_MODE')
     };
 
     // Filter out undefined values and url

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -374,7 +374,7 @@ describe('utils functions', () => {
             const queryParams = {};
             const result = createPageApiUrlWithQueryParams('test', queryParams);
             expect(result).toBe(
-                'test?language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT'
+                'test?language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&variantName=DEFAULT&mode=EDIT_MODE'
             );
         });
 
@@ -385,7 +385,7 @@ describe('utils functions', () => {
             };
             const result = createPageApiUrlWithQueryParams('test', queryParams);
             expect(result).toBe(
-                'test?variantName=test&language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona'
+                'test?variantName=test&language_id=1&com.dotmarketing.persona.id=modes.persona.no.persona&mode=EDIT_MODE'
             );
         });
     });


### PR DESCRIPTION


https://github.com/user-attachments/assets/97620f3f-0891-4310-a8fa-e5721d93c931



This pull request introduces a new `mode` query parameter to URLs across the application to differentiate between "EDIT_MODE" and "PREVIEW" modes. This change ensures proper rendering of local applications as headless within the UVE (Unified Visual Editor). The most important changes include updates to URL generation utilities, test cases, and related components.

### Updates to URL generation:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts`](diffhunk://#diff-2fd4d225bb33327848da73766ec5efbe037e3aed1a1e51a50c19f6a2be8cdb80L235-R241): Added a `mode` parameter to the `createPageApiUrlWithQueryParams` function to handle "EDIT_MODE" or "PREVIEW" based on the `editorMode` value. This change addresses a rendering issue in the UVE.

### Test case updates:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts`](diffhunk://#diff-6b95047786d13d69ebdcb642c6d382bc35784a2ada53f95d1908119ab08dfb91L377-R377): Updated test cases for `createPageApiUrlWithQueryParams` to include the new `mode` parameter in the expected URLs. [[1]](diffhunk://#diff-6b95047786d13d69ebdcb642c6d382bc35784a2ada53f95d1908119ab08dfb91L377-R377) [[2]](diffhunk://#diff-6b95047786d13d69ebdcb642c6d382bc35784a2ada53f95d1908119ab08dfb91L388-R388)
* [`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts`](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbL118-R125): Modified multiple test cases to append the `mode=EDIT_MODE` parameter to URLs in various scenarios. [[1]](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbL118-R125) [[2]](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbL565-R565) [[3]](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbL678-R678) [[4]](diffhunk://#diff-48915538475425e5656151bb2a73df7a99b4c80c2817c085f96352ef3252d5cbL712-R712)
* [`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/toolbar/withUVEToolbar.spec.ts`](diffhunk://#diff-7a5de702ac1dc81304f4c31816f5c0363aa56141f8afa583a87856e7a0d8482dL21-R22): Updated test data to include the `mode=EDIT_MODE` parameter in the `pageParams` object.
* [`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts`](diffhunk://#diff-34ddc5fbacaf04b962f2037385ed284310d5faf35ba409d5705b2caadd5d796aL2625-R2625): Adjusted iframe URL expectations to include the `mode=EDIT_MODE` parameter.

### Dependency updates:

* [`core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts`](diffhunk://#diff-2fd4d225bb33327848da73766ec5efbe037e3aed1a1e51a50c19f6a2be8cdb80R3): Imported `UVE_MODE` from `@dotcms/client` to determine the appropriate mode for the `mode` parameter.

This PR fixes: #31908