### PR TITLE
fix(core): Validating null ttls in dotParse and dotCache directives

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotCacheDirective.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotCacheDirective.java
@@ -1,5 +1,6 @@
 package com.dotcms.rendering.velocity.directive;
 
+import com.dotmarketing.util.Logger;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringWriter;
@@ -40,7 +41,14 @@ public class DotCacheDirective extends Directive {
         HttpServletRequest request = (HttpServletRequest) context.get("request");
         boolean shouldCache = shouldCache(request);
         boolean refreshCache = refreshCache(request);
-        final int ttl = (Integer) node.jjtGetChild(1).value(context);
+
+        int ttl = 0;
+        Object ttlObj = node.jjtGetChild(1).value(context);
+        if (ttlObj instanceof Integer) {
+            ttl = (Integer) node.jjtGetChild(1).value(context);
+        } else{
+            Logger.debug(this.getClass(), "TTL value for #dotcache must be an Integer and cannot be null. Using ttl = 0");
+        }
         if (!shouldCache || ttl <= 0) {
             node.jjtGetChild(2).render(context, writer);
             return true;

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotParse.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotParse.java
@@ -204,7 +204,12 @@ public class DotParse extends DotDirective {
      */
     void afterRender(final String render, String[] arguments) {
         if (arguments.length > 1) {
-            CacheLocator.getBlockDirectiveCache().add(getTTLCacheKey(arguments), Map.of(RENDER, render), Integer.parseInt(arguments[1]));
+            try {
+                int ttl = Integer.parseInt(arguments[1]);
+                CacheLocator.getBlockDirectiveCache().add(getTTLCacheKey(arguments), Map.of(RENDER, render), ttl);
+            } catch (NumberFormatException e) {
+                Logger.debug(this.getClass(), "Invalid TTL value in dotParse: " + arguments[1]);
+            }
         }
     }
 


### PR DESCRIPTION
### Proposed Changes
* TTL values are verified before a cast/parse to avoid NumberFormatExceptions in dotParse and dotCache

Refs: #31980

This PR fixes: #31980