### PR TITLE
feat(Edit Mode) fix #31745 : Allowing the specification of Folder ID for the new content search

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESMappingAPIImpl.java
@@ -403,7 +403,7 @@ public class ESMappingAPIImpl implements ContentMappingAPI {
 			contentletMap.put(ESMappingConstants.IDENTIFIER, contentIdentifier.getId());
 			contentletMap.put(ESMappingConstants.CONTENTLET_HOST, contentIdentifier.getHostId());
 			contentletMap.put(ESMappingConstants.CONTENTLET_HOSTNAME, contentSite.getHostname());
-			contentletMap.put(ESMappingConstants.CONTENTLET_FOLER, InodeUtils.isSet(contentFolder.getInode()) ? contentFolder.getInode() : contentlet.getFolder());
+			contentletMap.put(ESMappingConstants.CONTENTLET_FOLDER, InodeUtils.isSet(contentFolder.getInode()) ? contentFolder.getInode() : contentlet.getFolder());
 			contentletMap.put(ESMappingConstants.PARENT_PATH, contentIdentifier.getParentPath());
 			contentletMap.put(ESMappingConstants.PATH, contentIdentifier.getPath());
 			// makes shorties searchable regardless of length

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/constants/ESMappingConstants.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/constants/ESMappingConstants.java
@@ -66,7 +66,7 @@ public final class ESMappingConstants {
     public static final String IDENTIFIER = "identifier";
     public static final String CONTENTLET_HOST = "conHost";
     public static final String CONTENTLET_HOSTNAME = "conHostName";
-    public static final String CONTENTLET_FOLER = "conFolder";
+    public static final String CONTENTLET_FOLDER = "conFolder";
     public static final String PARENT_PATH = "parentPath";
     public static final String PATH = "path";
     public static final String SHORT_ID = "shortId";

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentSearchForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentSearchForm.java
@@ -43,7 +43,8 @@ import static com.liferay.util.StringPool.BLANK;
  *             }
  *         },
  *         "systemSearchableFields": {
- *             "siteId": "{{STRING: When NOT set, and the 'systemHostContent' is NOT set either, the search will include contents under System Host}}",
+ *             "siteId": "{{STRING: The ID of the Site that contains the contents to look for. When NOT set, and the 'systemHostContent' is NOT set either, the search will include contents under System Host}}",
+ *             "folderId": "{{STRING}}: The ID of the Folder that contains the contents to look for. When set, the 'siteId' attribute is completely ignored",
  *             "languageId": {{INTEGER}},
  *             "workflowSchemeId": "{{STRING}}",
  *             "workflowStepId": "{{STRING}}",
@@ -171,6 +172,15 @@ public class ContentSearchForm implements Serializable {
     }
 
     /**
+     * Returns the ID of the Folder containing the contents that will be filtered.
+     *
+     * @return The folder ID to filter the content by.
+     */
+    public String folderId() {
+        return (String) this.systemSearchableFields().getOrDefault("folderId", BLANK);
+    }
+
+    /**
      * Returns the language ID to filter the content by.
      *
      * @return The language ID to filter the content by.
@@ -207,10 +217,10 @@ public class ContentSearchForm implements Serializable {
     }
 
     /**
-     * Returns a boolean indicating whether the generated Lucene query must look for content living
-     * under System host or not.
+     * Returns a boolean indicating whether the generated Lucene query must also look for content
+     * living under System Host or not.
      *
-     * @return If the generated Lucene query must look for content living under System host, returns
+     * @return If the generated Lucene query must look for content living under System Host, returns
      * {@code true}.
      */
     public boolean systemHostContent() {
@@ -239,19 +249,22 @@ public class ContentSearchForm implements Serializable {
     }
 
     /**
-     * Returns a boolean indicating whether the search results must include archived content or not.
+     * Returns a String indicating whether the search results must include archived content or not.
+     * This is an optional parameter, so it's being handled as a String to NOT add it to the Lucene
+     * query when it's not specified in the form.
      *
-     * @return If the search results must include archived content, returns {@code true}.
+     * @return If the search results must include archived content, returns {@code "true"}.
      */
     public String archivedContent() {
         return this.archivedContent;
     }
 
     /**
-     * Returns a boolean indicating whether the search results must include unpublished content or
-     * not.
+     * Returns a String indicating whether the search results must include unpublished content or
+     * not. This is an optional parameter, so it's being handled as a String to NOT add it to the
+     * Lucene query when it's not specified in the form.
      *
-     * @return If the search results must include unpublished content, returns {@code true}.
+     * @return If the search results must include unpublished content, returns {@code "true"}.
      */
     public String unpublishedContent() {
         return this.unpublishedContent;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/FieldHandlerId.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/FieldHandlerId.java
@@ -12,7 +12,10 @@ public enum FieldHandlerId {
 
     GLOBAL_SEARCH("globalSearch"),
     CONTENT_TYPE_IDS("contentTypeIds"),
+    // Even though the same field in the UI is used to select the Site or the Folder, they are
+    // separate handlers here because Lucene uses a different search term for each of them
     SITE_ID("siteId"),
+    FOLDER_ID("folderId"),
     TEXT("text"),
     BINARY("binary"),
     DATE_TIME("dateTime"),

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/FieldStrategyFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/FieldStrategyFactory.java
@@ -19,15 +19,16 @@ public class FieldStrategyFactory {
 
     static {
         // Here, we're associating each Field Handler with its corresponding Field Strategy for the
-        // System Searchable fields/attributes. It's worth noting that These are NOT actual Content
-        // Type fields per se. But, they allow users to query contents via Lucene
+        // System-Searchable fields/attributes. It's worth noting that These are NOT actual Content
+        // Type fields per se. But they allow users to query contents via Lucene
         SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.CONTENT_TYPE_IDS, new ContentTypesFieldStrategy());
         SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.SITE_ID, new SiteAttributeStrategy());
+        SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.FOLDER_ID, new FolderAttributeStrategy());
         SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.GLOBAL_SEARCH, new GlobalSearchAttributeStrategy());
         SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.VARIANT, new VariantAttributeStrategy());
         SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.LANGUAGE, new LanguageAttributeStrategy());
-        SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.WORKFLOW_SCHEME, new WorkflowSchemeAttributeAction());
-        SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.WORKFLOW_STEP, new WorkflowStepAttributeAction());
+        SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.WORKFLOW_SCHEME, new WorkflowSchemeAttributeStrategy());
+        SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.WORKFLOW_STEP, new WorkflowStepAttributeStrategy());
         SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.ARCHIVED_CONTENT, new ArchivedContentAttributeStrategy());
         SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.LOCKED_CONTENT, new LockedContentAttributeStrategy());
         SYSTEM_FIELD_STRATEGY_MAP.put(FieldHandlerId.LIVE_CONTENT, new UnpublishedContentAttributeStrategy());

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/FolderAttributeStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/FolderAttributeStrategy.java
@@ -1,0 +1,24 @@
+package com.dotcms.rest.api.v1.content.search.strategies;
+
+import com.dotcms.rest.api.v1.content.search.handlers.FieldContext;
+
+/**
+ * This Strategy Field implementation provides a default way to format the value of the Folder ID
+ * that will be used in the Lucene query, if required. This particular Strategy does not belong to
+ * a specific Content Type field, but to the parameter that allows you to specify the Folder ID in a
+ * Lucene query via the following term:
+ * {@link com.dotcms.content.elasticsearch.constants.ESMappingConstants#CONTENTLET_FOLDER}
+ *
+ * @author Jose Castro
+ * @since Mar 26th, 2025
+ */
+public class FolderAttributeStrategy implements FieldStrategy {
+
+    @Override
+    public String generateQuery(final FieldContext fieldContext) {
+        final String value = (String) fieldContext.fieldValue();
+        final String velocityVarName = fieldContext.fieldName();
+        return "+" + velocityVarName + ":" + value + "*";
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/FolderAttributeStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/FolderAttributeStrategy.java
@@ -18,7 +18,7 @@ public class FolderAttributeStrategy implements FieldStrategy {
     public String generateQuery(final FieldContext fieldContext) {
         final String value = (String) fieldContext.fieldValue();
         final String velocityVarName = fieldContext.fieldName();
-        return "+" + velocityVarName + ":" + value + "*";
+        return new StringBuilder().append("+").append(velocityVarName).append(":").append(value).append("*").toString();
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/WorkflowSchemeAttributeStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/WorkflowSchemeAttributeStrategy.java
@@ -12,7 +12,7 @@ import com.dotcms.rest.api.v1.content.search.handlers.FieldContext;
  * @author Jose Castro
  * @since Jan 31st, 2025
  */
-public class WorkflowSchemeAttributeAction implements FieldStrategy {
+public class WorkflowSchemeAttributeStrategy implements FieldStrategy {
 
     @Override
     public String generateQuery(final FieldContext fieldContext) {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/WorkflowStepAttributeStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/search/strategies/WorkflowStepAttributeStrategy.java
@@ -13,7 +13,7 @@ import com.dotcms.rest.api.v1.content.search.handlers.FieldContext;
  * @author Jose Castro
  * @since Jan 31st, 2025
  */
-public class WorkflowStepAttributeAction implements FieldStrategy {
+public class WorkflowStepAttributeStrategy implements FieldStrategy {
 
     @Override
     public String generateQuery(final FieldContext fieldContext) {

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/search/LuceneQueryBuilderTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/search/LuceneQueryBuilderTest.java
@@ -116,43 +116,43 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                         "{\n" +
                                 "    " +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:false +working:true"),
 
                 new TestCase("Global Search",
                         "{\n" +
                         "    \"globalSearch\": \"dummy search\"\n" +
                         "}",
-                        "+systemType:false -contentType:forms -contentType:Host +catchall:dummy search* title:'dummy search'^15 title:dummy^5 title:search^5 title_dotraw:*dummy search*^5 title:dummy search* +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true"),
+                        "+catchall:dummy search* title:'dummy search'^15 title:dummy^5 title:search^5 title_dotraw:*dummy search*^5 title:dummy search* +systemType:false -contentType:forms -contentType:Host +variant:default +deleted:false +working:true"),
 
                 new TestCase("Published content",
                         "{\n" +
                                 "    \"unpublishedContent\": false\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +variant:default +deleted:false +live:true +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:false +live:true +working:true"),
 
                 new TestCase("Unpublished content",
                         "{\n" +
                         "    \"unpublishedContent\": true\n" +
                         "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +variant:default +deleted:false +live:false +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:false +live:false +working:true"),
 
                 new TestCase("Locked content",
                         "{\n" +
                                 "    \"lockedContent\": true\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +variant:default +deleted:false +locked:true +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:false +locked:true +working:true"),
 
                 new TestCase("Unlocked content",
                         "{\n" +
                                 "    \"lockedContent\": false\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +variant:default +deleted:false +locked:false +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:false +locked:false +working:true"),
 
                 new TestCase("Archived content",
                         "{\n" +
                                 "    \"archivedContent\": true\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +variant:default +deleted:true +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:true +working:true"),
 
                 new TestCase("With all attributes present",
                         "{\n" +
@@ -163,7 +163,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "    \"page\": 0,\n" +
                                 "    \"perPage\": 40\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +variant:default +deleted:true +locked:true +live:false +working:true")
+                        "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:true +locked:true +live:false +working:true")
         };
     }
 
@@ -197,12 +197,13 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
     }
 
     /**
-     * This DataProvider provides the test cases for the different system searchable fields. These
+     * This DataProvider provides the test cases for the different system-searchable fields. These
      * fields are NOT actual fields in a Contentlet per se, but rather fields that allow you to
      * filter contents in a way that provides additional value to users. For instance, you can
      * filter them based on:
      * <ul>
      *     <li>Site ID.</li>
+     *     <li>Folder ID.</li>
      *     <li>Language ID.</li>
      *     <li>Workflow Scheme ID.</li>
      *     <li>Workflow Step ID.</li>
@@ -229,7 +230,15 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        \"siteId\": \"\"\n" +
                                 "    }\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:false +working:true"),
+
+                new TestCase("With Folder ID",
+                        "{\n" +
+                                "    \"systemSearchableFields\": {\n" +
+                                "        \"folderId\": \"83bb5752-4264-43c4-84c8-28176603431a\"\n" +
+                                "    }\n" +
+                                "}",
+                        "+systemType:false -contentType:forms -contentType:Host +conFolder:83bb5752-4264-43c4-84c8-28176603431a* +variant:default +deleted:false +working:true"),
 
                 new TestCase("With Language ID",
                         "{\n" +
@@ -237,7 +246,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        \"languageId\": 1\n" +
                                 "    }\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +languageId:1 +variant:default +deleted:false +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +languageId:1 +variant:default +deleted:false +working:true"),
 
                 new TestCase("With Workflow Scheme ID",
                         "{\n" +
@@ -245,7 +254,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        \"workflowSchemeId\": \"d61a59e1-a49c-46f2-a929-db2b4bfa88b2\"\n" +
                                 "    }\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +(wfscheme:d61a59e1-a49c-46f2-a929-db2b4bfa88b2*) +variant:default +deleted:false +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +(wfscheme:d61a59e1-a49c-46f2-a929-db2b4bfa88b2*) +variant:default +deleted:false +working:true"),
 
                 new TestCase("With Workflow Step ID",
                         "{\n" +
@@ -253,7 +262,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        \"workflowStepId\": \"dc3c9cd0-8467-404b-bf95-cb7df3fbc293\"\n" +
                                 "    }\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +(wfstep:dc3c9cd0-8467-404b-bf95-cb7df3fbc293*) +variant:default +deleted:false +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +(wfstep:dc3c9cd0-8467-404b-bf95-cb7df3fbc293*) +variant:default +deleted:false +working:true"),
 
                 new TestCase("With Variant Name",
                         "{\n" +
@@ -261,9 +270,17 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        \"variantName\": \"test-variant-name\"\n" +
                                 "    }\n" +
                                 "}",
-                        "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +(variant:test-variant-name OR variant:default) +deleted:false +working:true"),
+                        "+systemType:false -contentType:forms -contentType:Host +(variant:test-variant-name OR variant:default) +deleted:false +working:true"),
 
                 new TestCase("With System Host Content",
+                        "{\n" +
+                                "    \"systemSearchableFields\": {\n" +
+                                "        \"systemHostContent\": true\n" +
+                                "    }\n" +
+                                "}",
+                        "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:false +working:true"),
+
+                new TestCase("Without System Host Content",
                         "{\n" +
                                 "    \"systemSearchableFields\": {\n" +
                                 "        \"systemHostContent\": false\n" +
@@ -327,7 +344,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
         final ContentType testContentType = this.createTestContentType(TEST_CONTENT_TYPE_NAME, TEST_CONTENT_TYPE_NAME);
         try {
             String jsonBody = "{ }";
-            String expectedQuery = "+systemType:false -contentType:forms -contentType:Host +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true";
+            String expectedQuery = "+systemType:false -contentType:forms -contentType:Host +variant:default +deleted:false +working:true";
 
             ContentSearchForm contentSearchForm = jsonMapper.readValue(jsonBody, ContentSearchForm.class);
             LuceneQueryBuilder luceneQueryBuilder = new LuceneQueryBuilder(contentSearchForm, adminUser);
@@ -344,7 +361,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                     "        }\n" +
                     "    }\n" +
                     "}";
-            expectedQuery = "+contentType:(" + TEST_CONTENT_TYPE_NAME + ") +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true";
+            expectedQuery = "+contentType:(" + TEST_CONTENT_TYPE_NAME + ") +variant:default +deleted:false +working:true";
 
             contentSearchForm = jsonMapper.readValue(jsonBody, ContentSearchForm.class);
             luceneQueryBuilder = new LuceneQueryBuilder(contentSearchForm, adminUser);
@@ -414,7 +431,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +SSS.binary:*value*"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +SSS.binary:*value*"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Checkbox Field",
@@ -426,7 +443,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS.checkbox:*value1* SSS.checkbox_dotraw:*value1*) +(SSS.checkbox:*value2* SSS.checkbox_dotraw:*value2*)"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS.checkbox:*value1* SSS.checkbox_dotraw:*value1*) +(SSS.checkbox:*value2* SSS.checkbox_dotraw:*value2*)"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Custom Field",
@@ -438,7 +455,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS.custom:*value* SSS.custom_dotraw:*value*)"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS.custom:*value* SSS.custom_dotraw:*value*)"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Date Field",
@@ -450,7 +467,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +SSS.date:[02/03/2025 TO 02/03/2025]"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +SSS.date:[02/03/2025 TO 02/03/2025]"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Date and Time Field",
@@ -462,7 +479,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +SSS.dateAndTime:[01/07/2025 13:50:00 TO 01/07/2025 13:50:00]"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +SSS.dateAndTime:[01/07/2025 13:50:00 TO 01/07/2025 13:50:00]"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With JSON Field",
@@ -474,7 +491,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS.json:*value* SSS.json_dotraw:*value*)"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS.json:*value* SSS.json_dotraw:*value*)"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Key/Value Field",
@@ -486,7 +503,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +SSS.keyValue.key_value:*value*"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +SSS.keyValue.key_value:*value*"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Multi-Select Field",
@@ -498,7 +515,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS.multiSelect:*multi1* SSS.multiSelect_dotraw:*multi1*) +(SSS.multiSelect:*multi2* SSS.multiSelect_dotraw:*multi2*)"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS.multiSelect:*multi1* SSS.multiSelect_dotraw:*multi1*) +(SSS.multiSelect:*multi2* SSS.multiSelect_dotraw:*multi2*)"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Radio Field",
@@ -510,7 +527,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS.radio:*radio1* SSS.radio_dotraw:*radio1*)"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS.radio:*radio1* SSS.radio_dotraw:*radio1*)"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Select Field",
@@ -522,7 +539,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS.select:*select1* SSS.select_dotraw:*select1*)"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS.select:*select1* SSS.select_dotraw:*select1*)"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Tag Field",
@@ -534,7 +551,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +SSS.tag:\"beach\" +SSS.tag:\"mountain\""
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +SSS.tag:\"beach\" +SSS.tag:\"mountain\""
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Text Field",
@@ -546,7 +563,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS.text:*value* SSS.text_dotraw:*value*)"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS.text:*value* SSS.text_dotraw:*value*)"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Text Area Field",
@@ -558,7 +575,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS.textArea:*some* SSS.textArea_dotraw:*some*) +(SSS.textArea:*values* SSS.textArea_dotraw:*values*)"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS.textArea:*some* SSS.textArea_dotraw:*some*) +(SSS.textArea:*values* SSS.textArea_dotraw:*values*)"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With Time Field",
@@ -570,7 +587,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +SSS.time:[12:30PM TO 12:30PM]"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +SSS.time:[12:30PM TO 12:30PM]"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
 
                 new TestCase("With WYSIWYG Field",
@@ -582,7 +599,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                                 "        }\n" +
                                 "    }\n" +
                                 "}",
-                        "+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS.wysiwyg:*some* SSS.wysiwyg_dotraw:*some*) +(SSS.wysiwyg:*values* SSS.wysiwyg_dotraw:*values*)"
+                        "+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS.wysiwyg:*some* SSS.wysiwyg_dotraw:*some*) +(SSS.wysiwyg:*values* SSS.wysiwyg_dotraw:*values*)"
                                 .replaceAll("SSS", TEST_CONTENT_TYPE_NAME)),
         };
     }
@@ -665,7 +682,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                     "        }\n" +
                     "    }\n" +
                     "}";
-            String expectedQuery = ("+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +(SSS." + categoryFieldName + ":" + testCategoryOne.getKey() + " SSS." + categoryFieldName + ":" + testCategoryTwo.getKey() + ")")
+            String expectedQuery = ("+contentType:(SSS) +variant:default +deleted:false +working:true +(SSS." + categoryFieldName + ":" + testCategoryOne.getKey() + " SSS." + categoryFieldName + ":" + testCategoryTwo.getKey() + ")")
                     .replaceAll("SSS", TEST_CONTENT_TYPE_NAME);
 
             ContentSearchForm contentSearchForm = jsonMapper.readValue(jsonBody, ContentSearchForm.class);
@@ -767,7 +784,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                     "        }\n" +
                     "    }\n" +
                     "}";
-            final String expectedQuery = ("+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +identifier:(" + parentTestContent.getIdentifier() + ")")
+            final String expectedQuery = ("+contentType:(SSS) +variant:default +deleted:false +working:true +identifier:(" + parentTestContent.getIdentifier() + ")")
                     .replaceAll("SSS", parentCt.variable());
 
             final ContentSearchForm contentSearchForm = jsonMapper.readValue(jsonBody, ContentSearchForm.class);
@@ -855,7 +872,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
                     "        }\n" +
                     "    }\n" +
                     "}";
-            String expectedQuery = ("+contentType:(SSS) +conHost:SYSTEM_HOST +variant:default +deleted:false +working:true +my_test_ct." + relationshipsFieldName + ":" + childTestContent.getIdentifier())
+            String expectedQuery = ("+contentType:(SSS) +variant:default +deleted:false +working:true +my_test_ct." + relationshipsFieldName + ":" + childTestContent.getIdentifier())
                     .replaceAll("SSS", parentCt.variable());
 
             ContentSearchForm contentSearchForm = jsonMapper.readValue(jsonBody, ContentSearchForm.class);

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/search/LuceneQueryBuilderTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/search/LuceneQueryBuilderTest.java
@@ -99,6 +99,7 @@ public class LuceneQueryBuilderTest extends IntegrationTestBase {
      * <ul>
      *     <li>Global Search. This is basically the top center Search field you can see in the
      *     {@code Search} portlet, and the field in the search dialog of the Relationships field.
+     *     It's worth noting the use of the {@code catchall} clause for this specific search case.
      *     </li>
      *     <li>Unpublished content.</li>
      *     <li>Locked content.</li>

--- a/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Resource.postman_collection.json
@@ -3376,7 +3376,7 @@
 											"pm.test(\"Getting 'default' Site ID\", function () {",
 											"    const jsonData = pm.response.json();",
 											"    const entity = jsonData.entity;",
-											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the Test Second Parent Content\");",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving the 'default' Site ID\");",
 											"    pm.collectionVariables.set(\"defaultSiteId\", entity.identifier);",
 											"});",
 											""
@@ -3408,6 +3408,64 @@
 										"v1",
 										"site",
 										"_byname"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Parent Folder",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Creating test Parent Folder\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const entity = jsonData.entity[0];",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the test Parent Folder\");",
+											"    pm.collectionVariables.set(\"testParentFolderId\", entity.identifier);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "[\"/test-parent-folder-contentsearch\"]",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/folder/createfolders/default",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"folder",
+										"createfolders",
+										"default"
 									]
 								}
 							},
@@ -3928,6 +3986,65 @@
 									]
 								},
 								"description": "Creates a test Contentlet of the previously generated Content Type."
+							},
+							"response": []
+						},
+						{
+							"name": "Parent Content 3",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Third Parent Content was created successfully\", function () {",
+											"    var jsonData = pm.response.json();",
+											"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when creating the Test Third Parent Content\");",
+											"    pm.expect(jsonData.entity.summary.failCount).to.eql(0, \"An error occurred when creating the Test Third Parent Content\");",
+											"    pm.expect(jsonData.entity.summary.successCount).to.eql(1, \"One piece of content should have been created\");",
+											"    const testContentId = Object.keys(jsonData.entity.results[0])[0];",
+											"    pm.collectionVariables.set(\"testThirdParentContentId\", testContentId);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlets\": [\n        {\n            \"contentType\": \"webPageContent\",\n            \"contentHost\": \"{{testParentFolderId}}\",\n            \"title\": \"Test Contentlet in Folder\",\n            \"body\": \"This is a test Contentlet in Folder\"\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"default",
+										"fire",
+										"PUBLISH"
+									],
+									"query": [
+										{
+											"key": "indexPolicy",
+											"value": "WAIT_FOR"
+										}
+									]
+								},
+								"description": "### HTTP POST /api/v1/workflow/actions/default/fire/PUBLISH?indexPolicy=WAIT_FOR\n\nCreates a test Contentlet of Rich Text Content Type that lives under the Test Parent Folder.\n\n#### Request Body\n\n- { \"contentlets\": \\[ { \"contentType\": \"webPageContent\", \"contentHost\": \"{{testParentFolderId}}\", \"title\": \"Test Contentlet in Folder\", \"body\": \"This is a test Contentlet in Folder\" } \\]}\n    \n\n#### Response\n\n- Status: 200\n    \n- {\"entity\": { \"results\": \\[ { \"3bb07ba71470b6b12c13971d908fdf5f\": { \"AUTO_ASSIGN_WORKFLOW\": true, \"__IS_NEW_CONTENT__\": true, \"__icon__\": \"\", \"archived\": true, \"baseType\": \"\", \"body\": \"\", \"contentType\": \"\", \"contentTypeIcon\": \"\", \"creationDate\": 0, \"folder\": \"\", \"hasLiveVersion\": true, \"hasTitleImage\": true, \"host\": \"\", \"hostName\": \"\", \"identifier\": \"\", \"inode\": \"\", \"languageId\": 0, \"live\": true, \"locked\": true, \"modDate\": 0, \"modUser\": \"\", \"modUserName\": \"\", \"owner\": \"\", \"ownerName\": \"\", \"publishDate\": 0, \"publishUser\": \"\", \"publishUserName\": \"\", \"shortyId\": \"\", \"sortOrder\": 0, \"stInode\": \"\", \"title\": \"\", \"titleImage\": \"\", \"url\": \"\", \"variant\": \"\", \"working\": true } } \\], \"summary\": { \"affected\": 0, \"failCount\": 0, \"successCount\": 0, \"time\": 0 }},\"errors\": \\[\\],\"i18nMessagesMap\": {},\"messages\": \\[\\],\"permissions\": \\[\\]}"
 							},
 							"response": []
 						}
@@ -5307,7 +5424,7 @@
 													"    const jsonData = pm.response.json();",
 													"    const entity = jsonData.entity;",
 													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving all Contentlets under 'default'\");",
-													"    pm.expect(entity.resultsSize).to.be.greaterThan(1, \"At least one result should've been returned\");",
+													"    pm.expect(entity.resultsSize).to.be.greaterThanOrEqual(1, \"At least one result should've been returned\");",
 													"});",
 													""
 												],
@@ -5339,7 +5456,56 @@
 												"content",
 												"search"
 											]
+										},
+										"description": "### Content Search\n\nThis endpoint allows you to search for Contentlets of any type under a given Site.\n\n#### Request\n\n- Method: POST\n    \n- URL: `{{serverURL}}/api/v1/content/search`\n    \n- Body:\n    \n    - Type: JSON\n        \n    - Description: Payload for content search request\n        \n    - { \"systemSearchableFields\": { \"siteId\": \"{{defaultSiteId}}\" }, \"page\": 0, \"perPage\": 40}\n        \n\n#### Response\n\nThe response for this request is provided as a JSON schema."
+									},
+									"response": []
+								},
+								{
+									"name": "By Folder ID",
+									"event": [
+										{
+											"listen": "test",
+											"script": {
+												"exec": [
+													"pm.test(\"Returning ALL Contentlets under the Test Parent Folder successfully\", function () {",
+													"    const jsonData = pm.response.json();",
+													"    const entity = jsonData.entity;",
+													"    pm.expect(jsonData.errors.length).to.eql(0, \"An error occurred when retrieving all Contentlets under the Test Parent Folder\");",
+													"    pm.expect(entity.resultsSize).to.be.greaterThanOrEqual(1, \"At least one result should've been returned\");",
+													"});",
+													""
+												],
+												"type": "text/javascript",
+												"packages": {}
+											}
 										}
+									],
+									"request": {
+										"method": "POST",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n    \"systemSearchableFields\": {\n        \"folderId\": \"{{testParentFolderId}}\"\n    },\n    \"page\": 0,\n    \"perPage\": 40\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "{{serverURL}}/api/v1/content/search",
+											"host": [
+												"{{serverURL}}"
+											],
+											"path": [
+												"api",
+												"v1",
+												"content",
+												"search"
+											]
+										},
+										"description": "### Search Content\n\nThis endpoint allows users to search for Contentlets of any type that live under a specific Folder.\n\n#### Request Body\n\n- `systemSearchableFields` (object, required): Defines the fields to be searched.\n    \n    - `siteId` (string): The ID of the site to search within.\n        \n- `page` (integer): The page number for paginated results.\n    \n- `perPage` (integer): The number of results to be displayed per page.\n    \n\n#### Response Body\n\nThe response will include the search results based on the specified criteria."
 									},
 									"response": []
 								}


### PR DESCRIPTION
### Proposed Changes
* Allows developers to query for Contentlets that live under a specific Folder, which is exactly the way the current `Search` portlet works.
* Updated some Javadoc.
* Fixed/updated Integration Tests and Postman test to reflect the new changes.
* As part of the testing, I found out that the `+conHost:SYSTEM_HOST` term was ALWAYS being added to the Lucene query, which is not correct. This was fixed as well.

This PR fixes: #31745