### PR TITLE
fix(block-editor): #30801 properly display bubble menu on mobile and tablet

### DIFF
--- a/core-web/libs/block-editor/src/lib/extensions/bubble-menu/bubble-menu.component.scss
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-menu/bubble-menu.component.scss
@@ -16,6 +16,11 @@
     padding: 0.35 * $dot-editor-size;
     height: 2.5 * $dot-editor-size;
 
+    @media screen and (max-width: 960px) {
+        flex-wrap: wrap;
+        height: auto;
+    }
+
     .btn-dropdown {
         background: none;
         border: none;

--- a/core-web/libs/block-editor/src/lib/extensions/bubble-menu/utils/index.ts
+++ b/core-web/libs/block-editor/src/lib/extensions/bubble-menu/utils/index.ts
@@ -37,6 +37,14 @@ export const shouldShowBubbleMenu = ({ editor, state, from, to }: ShouldShowProp
     const isEmptyTextBlock = !doc.textBetween(from, to).length && isTextSelection(state.selection);
     const isTextInsideTable = node?.type.name === 'text' && parentNode?.type.name === 'table';
 
+    // Detect if the screen width is less than or equal to 960px
+    const isMobile = typeof window !== 'undefined' && window.innerWidth <= 960;
+
+    // If the device is tablet or mobile and the editor is focused - then alway show the bubble menu.
+    if (isMobile && view.hasFocus()) {
+        return true;
+    }
+
     // Is a text node inside the table
     if (isTextInsideTable && !isEmptyTextBlock) {
         return true;


### PR DESCRIPTION
### Proposed Changes

- Fixed an issue where the bubble menu in the block editor was poorly displayed or inaccessible on tablet and phone devices.
- Improved responsive styles and positioning to ensure the bubble menu is usable and visible on all screen sizes.
- The menu now adapts its layout for different devices and remains accessible on mobile and tablet.

### Screenshots

![image](https://github.com/user-attachments/assets/6e197a0d-c962-4dcb-a576-e14ed858cf0e)
