### PR TITLE
task: upgrade to java 21.0.7

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # sets the SDKMAN_JAVA_VERSION for dotCMS
 # this is the version of java that will be used as the base image for the docker build
-java=21.0.4-ms
+java=21.0.7-ms


### PR DESCRIPTION
This pull request updates the Java SDK version used in the `.sdkmanrc` file for the dotCMS project. The change ensures the project uses a more recent version of the Java SDK.

This jdk includes a fix to the issues we saw with running dotCMS in docker on an m4 apple that required the `-XX:UseSVE=0` parameter in order to run.





* [`.sdkmanrc`](diffhunk://#diff-909bca673d9d35e9c0672dd22a0dd6bbe1d6dcbe94ccc9221d26021badf1171dL3-R3): Updated the `SDKMAN_JAVA_VERSION` from `21.0.4-ms` to `21.0.7-ms` to align with the latest available version.ref: #32005

This PR fixes: #32005