### PR TITLE
Implemented service for EditablePageAsset on angular sdk

### DIFF
--- a/core-web/libs/sdk/angular/next/components/dotcms-layout-body/components/container/container.component.ts
+++ b/core-web/libs/sdk/angular/next/components/dotcms-layout-body/components/container/container.component.ts
@@ -42,7 +42,7 @@ import { ContentletComponent } from '../../components/contentlet/contentlet.comp
             <dotcms-empty-container />
         } @else {
             @for (contentlet of $contentlets(); track contentlet.identifier) {
-                <dotcms-contentlet [contentlet]="contentlet" [container]="container.identifier" />
+                <dotcms-contentlet [contentlet]="contentlet" [containerData]="$containerData()!" />
             }
         }
     `,

--- a/core-web/libs/sdk/angular/next/components/dotcms-layout-body/components/contentlet/contentlet.component.spec.ts
+++ b/core-web/libs/sdk/angular/next/components/dotcms-layout-body/components/contentlet/contentlet.component.spec.ts
@@ -57,7 +57,12 @@ describe('ContentletComponent', () => {
         spectator = createComponent({
             props: {
                 contentlet: mockContentlet,
-                container: 'test-container'
+                containerData: {
+                    identifier: 'test-container-id',
+                    acceptTypes: 'test-accept-types',
+                    maxContentlets: 10,
+                    uuid: 'test-uuid'
+                }
             },
             providers: [
                 {
@@ -83,6 +88,7 @@ describe('ContentletComponent', () => {
         expect(hostElement.getAttribute('data-dot-basetype')).toBeDefined();
         expect(hostElement.getAttribute('data-dot-title')).toBeDefined();
         expect(hostElement.getAttribute('data-dot-inode')).toBeDefined();
+        expect(hostElement.getAttribute('data-dot-container')).toBeDefined();
     });
 
     it('should set dot attributes in dev mode', () => {

--- a/core-web/libs/sdk/angular/next/components/dotcms-layout-body/components/contentlet/contentlet.component.ts
+++ b/core-web/libs/sdk/angular/next/components/dotcms-layout-body/components/contentlet/contentlet.component.ts
@@ -12,7 +12,7 @@ import {
     ViewChild
 } from '@angular/core';
 
-import { DotCMSBasicContentlet } from '@dotcms/types';
+import { DotCMSBasicContentlet, EditableContainerData } from '@dotcms/types';
 import { DotContentletAttributes } from '@dotcms/types/internal';
 import { CUSTOM_NO_COMPONENT, getDotContentletAttributes } from '@dotcms/uve/internal';
 
@@ -49,7 +49,7 @@ import { FallbackComponent } from '../fallback-component/fallback-component.comp
 })
 export class ContentletComponent implements OnChanges {
     @Input({ required: true }) contentlet!: DotCMSBasicContentlet;
-    @Input({ required: true }) container!: string;
+    @Input({ required: true }) containerData!: EditableContainerData;
     @ViewChild('contentletRef') contentletRef!: ElementRef;
     @HostBinding('attr.data-dot-object') dotObject = 'contentlet';
 
@@ -67,7 +67,7 @@ export class ContentletComponent implements OnChanges {
         const contentlet = this.$contentlet();
         if (!contentlet || !this.$isDevMode()) return {} as DotContentletAttributes;
 
-        return getDotContentletAttributes(contentlet, this.container);
+        return getDotContentletAttributes(contentlet, this.containerData.identifier);
     });
 
     @HostBinding('attr.data-dot-identifier') identifier: string | null = null;
@@ -88,7 +88,7 @@ export class ContentletComponent implements OnChanges {
         this.title = this.$dotAttributes()['data-dot-title'];
         this.inode = this.$dotAttributes()['data-dot-inode'];
         this.type = this.$dotAttributes()['data-dot-type'];
-        this.containerAttribute = this.$dotAttributes()['data-dot-container'];
+        this.containerAttribute = JSON.stringify(this.containerData);
         this.onNumberOfPages = this.$dotAttributes()['data-dot-on-number-of-pages'];
         this.styleAttribute = this.$style();
     }

--- a/core-web/libs/sdk/angular/next/public_api.ts
+++ b/core-web/libs/sdk/angular/next/public_api.ts
@@ -7,3 +7,5 @@ export { DotCMSEditableTextComponent } from './components/dotcms-editable-text/d
 export { DotCMSBlockEditorRendererComponent } from './components/dotcms-block-editor-renderer/dotcms-block-editor-renderer.component';
 
 export { DotCMSLayoutBodyComponent } from './components/dotcms-layout-body/dotcms-layout-body.component';
+
+export { DotCMSEditablePageService } from './services/dotcms-editable-page.service';

--- a/core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.spec.ts
+++ b/core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.spec.ts
@@ -1,0 +1,138 @@
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
+
+import { updateNavigation } from '@dotcms/client';
+import { UVEEventType, DotCMSEditablePage } from '@dotcms/types';
+import { getUVEState, initUVE, createUVESubscription } from '@dotcms/uve';
+
+import { DotCMSEditablePageService } from './dotcms-editable-page.service';
+
+// Import the mocked modules
+// Mock external dependencies
+jest.mock('@dotcms/uve', () => ({
+    getUVEState: jest.fn(),
+    initUVE: jest.fn(),
+    createUVESubscription: jest.fn()
+}));
+
+jest.mock('@dotcms/client', () => ({
+    updateNavigation: jest.fn()
+}));
+
+describe('DotCMSEditablePageService', () => {
+    let spectator: SpectatorService<DotCMSEditablePageService>;
+    let service: DotCMSEditablePageService;
+    let unsubscribeMock: jest.Mock;
+
+    const mockPageAsset: DotCMSEditablePage = {
+        page: {
+            pageURI: '/test-page',
+            title: 'Test Page'
+        }
+    } as DotCMSEditablePage;
+
+    const mockUpdatedPageAsset: DotCMSEditablePage = {
+        page: {
+            pageURI: '/test-page',
+            title: 'Updated Test Page'
+        }
+    } as DotCMSEditablePage;
+
+    const createService = createServiceFactory({
+        service: DotCMSEditablePageService
+    });
+
+    beforeEach(() => {
+        // Reset all mocks
+        jest.clearAllMocks();
+
+        // Setup default mock behaviors
+        unsubscribeMock = jest.fn();
+        (getUVEState as jest.Mock).mockReturnValue(true);
+        (createUVESubscription as jest.Mock).mockReturnValue({ unsubscribe: unsubscribeMock });
+
+        spectator = createService();
+        service = spectator.service;
+    });
+
+    describe('listenEditablePage', () => {
+        it('should initialize UVE and setup subscriptions', () => {
+            (getUVEState as jest.Mock).mockReturnValue(true);
+
+            const result = service.listenEditablePage(mockPageAsset);
+
+            expect(initUVE).toHaveBeenCalledWith(mockPageAsset);
+            expect(updateNavigation).toHaveBeenCalledWith('/test-page');
+            expect(createUVESubscription).toHaveBeenCalledWith(
+                UVEEventType.CONTENT_CHANGES,
+                expect.any(Function)
+            );
+            expect(result).toBeTruthy();
+        });
+
+        it('should return observable with the initial page asset when UVE state is false', () => {
+            (getUVEState as jest.Mock).mockReturnValue(false);
+            let result: DotCMSEditablePage | null = null;
+
+            service.listenEditablePage(mockPageAsset).subscribe((res) => {
+                result = res;
+            });
+
+            expect(initUVE).not.toHaveBeenCalled();
+            expect(updateNavigation).not.toHaveBeenCalled();
+            expect(createUVESubscription).not.toHaveBeenCalled();
+            expect(result).toEqual(mockPageAsset);
+        });
+
+        it('should emit updated page asset when UVE event occurs', () => {
+            let capturedCallback = (_payload: DotCMSEditablePage): void => {
+                // Empty default implementation
+            };
+
+            (createUVESubscription as jest.Mock).mockImplementation((eventType, callback) => {
+                capturedCallback = callback;
+
+                return { unsubscribe: unsubscribeMock };
+            });
+
+            const emittedValues: Array<DotCMSEditablePage | null> = [];
+
+            service.listenEditablePage(mockPageAsset).subscribe((value) => {
+                emittedValues.push(value);
+            });
+
+            capturedCallback(mockUpdatedPageAsset);
+
+            expect(emittedValues.length).toBe(1);
+            expect(emittedValues[0]).toEqual(mockUpdatedPageAsset);
+        });
+
+        it('should handle undefined page asset', () => {
+            service.listenEditablePage();
+
+            expect(initUVE).toHaveBeenCalled();
+            expect(updateNavigation).toHaveBeenCalledWith('/');
+        });
+    });
+
+    describe('unsubscribeEditablePage', () => {
+        it('should call unsubscribe and reset the page asset', () => {
+            service.listenEditablePage(mockPageAsset);
+            let finalValue: DotCMSEditablePage | null = mockPageAsset;
+
+            const subscription = service.listenEditablePage().subscribe((value) => {
+                finalValue = value;
+            });
+
+            service.unsubscribeEditablePage();
+
+            expect(unsubscribeMock).toHaveBeenCalled();
+            expect(finalValue).toBeNull();
+
+            subscription.unsubscribe();
+        });
+
+        it('should handle being called without prior listen', () => {
+            expect(() => service.unsubscribeEditablePage()).not.toThrow();
+        });
+    });
+});

--- a/core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.spec.ts
+++ b/core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.spec.ts
@@ -58,7 +58,7 @@ describe('DotCMSEditablePageService', () => {
         it('should initialize UVE and setup subscriptions', () => {
             (getUVEState as jest.Mock).mockReturnValue(true);
 
-            const result = service.listenEditablePage(mockPageAsset);
+            const result = service.listen(mockPageAsset);
 
             expect(initUVE).toHaveBeenCalledWith(mockPageAsset);
             expect(updateNavigation).toHaveBeenCalledWith('/test-page');
@@ -73,7 +73,7 @@ describe('DotCMSEditablePageService', () => {
             (getUVEState as jest.Mock).mockReturnValue(false);
             let result: DotCMSEditablePage | null = null;
 
-            service.listenEditablePage(mockPageAsset).subscribe((res) => {
+            service.listen(mockPageAsset).subscribe((res) => {
                 result = res;
             });
 
@@ -96,7 +96,7 @@ describe('DotCMSEditablePageService', () => {
 
             const emittedValues: Array<DotCMSEditablePage | null> = [];
 
-            service.listenEditablePage(mockPageAsset).subscribe((value) => {
+            service.listen(mockPageAsset).subscribe((value) => {
                 emittedValues.push(value);
             });
 
@@ -107,32 +107,10 @@ describe('DotCMSEditablePageService', () => {
         });
 
         it('should handle undefined page asset', () => {
-            service.listenEditablePage();
+            service.listen();
 
             expect(initUVE).toHaveBeenCalled();
             expect(updateNavigation).toHaveBeenCalledWith('/');
-        });
-    });
-
-    describe('unsubscribeEditablePage', () => {
-        it('should call unsubscribe and reset the page asset', () => {
-            service.listenEditablePage(mockPageAsset);
-            let finalValue: DotCMSEditablePage | null = mockPageAsset;
-
-            const subscription = service.listenEditablePage().subscribe((value) => {
-                finalValue = value;
-            });
-
-            service.unsubscribeEditablePage();
-
-            expect(unsubscribeMock).toHaveBeenCalled();
-            expect(finalValue).toBeNull();
-
-            subscription.unsubscribe();
-        });
-
-        it('should handle being called without prior listen', () => {
-            expect(() => service.unsubscribeEditablePage()).not.toThrow();
         });
     });
 });

--- a/core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.ts
+++ b/core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.ts
@@ -46,12 +46,15 @@ export class DotCMSEditablePageService {
      * const page = await client.page.get('/');
      *
      * // Listen for changes
-     * this.editablePageService.listenEditablePage(page).subscribe(updatedPage => {
+     * const subscription = this.editablePageService.listen(page).subscribe(updatedPage => {
      *   if (updatedPage) {
      *     // Handle updated page data
      *     console.log('Page updated:', updatedPage);
      *   }
      * });
+     *
+     * // When done listening, unsubscribe
+     * subscription.unsubscribe();
      * ```
      *
      * @param pageAsset Optional initial page data

--- a/core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.ts
+++ b/core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.ts
@@ -1,0 +1,49 @@
+import { Observable, of, Subject } from 'rxjs';
+
+import { Injectable } from '@angular/core';
+
+import { updateNavigation } from '@dotcms/client';
+import { UVEEventType, DotCMSEditablePage, UVEUnsubscribeFunction } from '@dotcms/types';
+import { createUVESubscription, getUVEState, initUVE } from '@dotcms/uve';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class DotCMSEditablePageService {
+    #pageAssetSubject = new Subject<DotCMSEditablePage | null>();
+    #pageAsset$ = this.#pageAssetSubject.asObservable();
+
+    #uveUnsubscribe: UVEUnsubscribeFunction | null = null;
+
+    listenEditablePage(pageAsset?: DotCMSEditablePage): Observable<DotCMSEditablePage | null> {
+        if (!getUVEState()) {
+            return of(pageAsset || null);
+        }
+
+        const pageURI = pageAsset?.page?.pageURI ?? '/';
+
+        initUVE(pageAsset);
+        updateNavigation(pageURI);
+
+        this.#uveUnsubscribe = this.#listenUVEChanges();
+
+        return this.#pageAsset$;
+    }
+
+    #listenUVEChanges() {
+        const { unsubscribe } = createUVESubscription(UVEEventType.CONTENT_CHANGES, (payload) => {
+            this.#pageAssetSubject.next(payload);
+        });
+
+        return unsubscribe;
+    }
+
+    unsubscribeEditablePage() {
+        if (this.#uveUnsubscribe) {
+            this.#uveUnsubscribe();
+            this.#uveUnsubscribe = null;
+        }
+
+        this.#pageAssetSubject.next(null);
+    }
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/76b3f9d9-4a0f-44a5-912f-efe6c7cafb67


Proposed API

```
// angular.component.ts
  pageAsset: DotCMSPageAsset;
  dotEditablePageService = inject(DotCMSEditablePageService)

  async ngOnInit() {
this.dotEditablePageService.listenEditablePage(this.pageAsset).subscribe((res) => {
        if (res) {
          this.pageAsset = res as DotCMSPageAsset;
        }
      })
  }
```


This pull request introduces updates to the `ContentletComponent` to support enhanced container data handling and adds a new `DotCMSEditablePageService` for managing editable page interactions. Key changes include replacing the `container` input with `containerData` in `ContentletComponent`, updating related tests, and implementing a new service for managing UVE state and subscriptions.

### Updates to `ContentletComponent`:

* Replaced the `container` input with `containerData` in `ContentletComponent` to include additional container metadata such as `identifier`, `acceptTypes`, `maxContentlets`, and `uuid`. (`[[1]](diffhunk://#diff-541ec0ec3088e794f87a01868ff38ee017461a2390d4af1d6762b19b46d4b42eL52-R52)`, `[[2]](diffhunk://#diff-541ec0ec3088e794f87a01868ff38ee017461a2390d4af1d6762b19b46d4b42eL70-R70)`, `[[3]](diffhunk://#diff-541ec0ec3088e794f87a01868ff38ee017461a2390d4af1d6762b19b46d4b42eL91-R91)`)
* Updated the template in `container.component.ts` to use the `containerData` input instead of `container`. (`[core-web/libs/sdk/angular/next/components/dotcms-layout-body/components/container/container.component.tsL45-R45](diffhunk://#diff-f1e3151fad2bca3c1b8d9da03367789892480c2e77f95fe553606d30c41f4fc1L45-R45)`)
* Modified the test suite for `ContentletComponent` to reflect the new `containerData` input and ensure all attributes, including `data-dot-container`, are correctly set. (`[[1]](diffhunk://#diff-59efd8542c845e7b0f478d80e16344aa469a106bb531616bdf94b7bd46c8c687L60-R65)`, `[[2]](diffhunk://#diff-59efd8542c845e7b0f478d80e16344aa469a106bb531616bdf94b7bd46c8c687R91)`)

### Introduction of `DotCMSEditablePageService`:

* Created a new `DotCMSEditablePageService` to manage editable page interactions, including initializing UVE, handling UVE events, and managing subscriptions. (`[core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.tsR1-R49](diffhunk://#diff-08ba5e2ca6377757a25ae71539af956c5b47f9f6b918a74bdca06a1e23b7438dR1-R49)`)
* Added a comprehensive test suite for `DotCMSEditablePageService` to validate UVE initialization, event handling, and subscription management. (`[core-web/libs/sdk/angular/next/services/dotcms-editable-page.service.spec.tsR1-R138](diffhunk://#diff-9e99be6093c44be0c1ff531e7f2eee75185a56c63cd07e9ec60b8db26d98ccf4R1-R138)`)

### Other Changes:

* Updated imports in `contentlet.component.ts` to include the new `EditableContainerData` type from `@dotcms/types`. (`[core-web/libs/sdk/angular/next/components/dotcms-layout-body/components/contentlet/contentlet.component.tsL15-R15](diffhunk://#diff-541ec0ec3088e794f87a01868ff38ee017461a2390d4af1d6762b19b46d4b42eL15-R15)`)
* Exported the `DotCMSEditablePageService` in the `public_api.ts` file to make it available for use across the application. (`[core-web/libs/sdk/angular/next/public_api.tsR10-R11](diffhunk://#diff-f89360dc6b26b79932dbb3befec078807da2e0071d63b56c5dba9606c405665cR10-R11)`)

This PR fixes: #31210