### PR TITLE
fix(static push): Fix uppercase extension when static push publishing error

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/bundlers/FileAssetBundler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/bundlers/FileAssetBundler.java
@@ -371,7 +371,7 @@ public class FileAssetBundler implements IBundler {
 		else {
 		    //only write if changed
 			if(!output.exists(filePath) || output.lastModified(filePath) != cal.getTimeInMillis()){
-				File oldAsset = new File(APILocator.getFileAssetAPI().getRealAssetPath(fileAssetWrapper.getAsset().getInode(), fileAssetWrapper.getAsset().getUnderlyingFileName()));
+				File oldAsset = new File(APILocator.getFileAssetAPI().getRealAssetPathIgnoreExtensionCase(fileAssetWrapper.getAsset().getInode(), fileAssetWrapper.getAsset().getUnderlyingFileName()));
 				if(output.exists(filePath)) {
 					output.delete(filePath);
 				}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPI.java
@@ -273,8 +273,22 @@ public interface FileAssetAPI {
 	 */
 	public String getRealAssetPath(String inode);
 
+	/**
+	 * Returns the file on the filesystem that backup the fileAsset
+	 * @param inode
+	 * @param fileName generally speaking this method is expected to be called using the Underlying File Name property
+	 * e.g.   getRealAssetPath(inode, fileAsset.getUnderlyingFileName())
+	 * @return
+	 */
 	String getRealAssetPath(String inode, String fileName);
 
+	/**
+	 * This method returns the file on the filesystem that backup the fileAsset ignoring the case of the extension
+	 *
+	 * @param inode
+	 * @param fileName
+	 * @return the real path of the asset
+	 */
 	String getRealAssetPathIgnoreExtensionCase(String inode, String fileName);
 	
 	/**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPI.java
@@ -273,7 +273,9 @@ public interface FileAssetAPI {
 	 */
 	public String getRealAssetPath(String inode);
 
-	String getRealAssetPath(String inode, String fileName); 
+	String getRealAssetPath(String inode, String fileName);
+
+	String getRealAssetPathIgnoreExtensionCase(String inode, String fileName);
 	
 	/**
      * This method returns the relative path for assets

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
@@ -639,6 +639,13 @@ public class FileAssetAPIImpl implements FileAssetAPI {
 
     }
 
+	/**
+	 * Returns the file on the filesystem that backup the fileAsset ignoring the case of the extension
+	 * @param inode
+	 * @param fileName generally speaking this method is expected to be called using the Underlying File Name property
+	 * e.g.   getRealAssetPath(inode, fileAsset.getUnderlyingFileName())
+	 * @return
+	 */
 	@Override
 	public String getRealAssetPathIgnoreExtensionCase(String inode, String fileName) {
 		String extension = UtilMethods.getFileExtensionIgnoreCase(fileName);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
@@ -639,6 +639,13 @@ public class FileAssetAPIImpl implements FileAssetAPI {
 
     }
 
+	@Override
+	public String getRealAssetPathIgnoreExtensionCase(String inode, String fileName) {
+		String extension = UtilMethods.getFileExtensionIgnoreCase(fileName);
+		String fileNameWOExtenstion  =  UtilMethods.getFileName(fileName);
+		return getRealAssetPath(inode, fileNameWOExtenstion, extension);
+	}
+
 	/**
 	 * This method returns the relative path for assets
      *

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAssetAPIImpl.java
@@ -643,7 +643,7 @@ public class FileAssetAPIImpl implements FileAssetAPI {
 	 * Returns the file on the filesystem that backup the fileAsset ignoring the case of the extension
 	 * @param inode
 	 * @param fileName generally speaking this method is expected to be called using the Underlying File Name property
-	 * e.g.   getRealAssetPath(inode, fileAsset.getUnderlyingFileName())
+	 * e.g.   getRealAssetPathIgnoreExtensionCase(inode, fileAsset.getUnderlyingFileName())
 	 * @return
 	 */
 	@Override

--- a/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
@@ -1050,7 +1050,7 @@ public class UtilMethods {
     }
 
     /**
-     * This method returns the extension of the file ignoring the case of the extension
+     * This method returns the extension of the file 
      * */
     public static String getFileExtension(String fileName) {
     	String result = "";

--- a/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
@@ -24,6 +24,7 @@ import com.dotmarketing.portlets.links.model.LinkVersionInfo;
 import com.dotmarketing.portlets.templates.model.TemplateVersionInfo;
 import com.liferay.portal.model.Company;
 import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.index.Term;
@@ -1048,26 +1049,31 @@ public class UtilMethods {
         return sb.toString();
     }
 
-    public static String getFileExtension(String x) {
-    	String r = "";
+    /**
+     * This method returns the extension of the file ignoring the case of the extension
+     * */
+    public static String getFileExtension(String fileName) {
+    	String result = "";
         try {
-            if (x.lastIndexOf(".") != -1) {
-                return x.substring(x.lastIndexOf(".") + 1).toLowerCase();
+            if (fileName.lastIndexOf(StringPool.PERIOD) != -1) {
+                return fileName.substring(fileName.lastIndexOf(StringPool.PERIOD) + 1).toLowerCase();
             } else {
-                return r;
+                return result;
             }
         } catch (Exception e) {
             return "ukn";
         }
     }
-
-    public static String getFileExtensionIgnoreCase(String x){
-        String r = "";
+    /**
+     * This method returns the extension of the file ignoring the case of the extension
+     * */
+    public static String getFileExtensionIgnoreCase(String fileName){
+        String result = "";
         try {
-            if (x.lastIndexOf(".") != -1) {
-                return x.substring(x.lastIndexOf(".") + 1);
+            if (fileName.lastIndexOf(StringPool.PERIOD) != -1) {
+                return fileName.substring(fileName.lastIndexOf(StringPool.PERIOD) + 1);
             } else {
-                return r;
+                return result;
             }
         } catch (Exception e) {
             return "ukn";

--- a/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
@@ -1061,6 +1061,19 @@ public class UtilMethods {
         }
     }
 
+    public static String getFileExtensionIgnoreCase(String x){
+        String r = "";
+        try {
+            if (x.lastIndexOf(".") != -1) {
+                return x.substring(x.lastIndexOf(".") + 1);
+            } else {
+                return r;
+            }
+        } catch (Exception e) {
+            return "ukn";
+        }
+    }
+
     public static String getFileName(String x) {
         try {
             if (x.lastIndexOf("/") > -1 || x.lastIndexOf("\\") > -1) {

--- a/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/remote/StaticPushPublishBundleGeneratorTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/remote/StaticPushPublishBundleGeneratorTest.java
@@ -14,6 +14,7 @@ import com.dotcms.datagen.FolderDataGen;
 import com.dotcms.datagen.HTMLPageDataGen;
 import com.dotcms.datagen.TemplateDataGen;
 import com.dotcms.enterprise.publishing.bundlers.FileAssetBundler;
+import com.dotcms.enterprise.publishing.bundlers.FileAssetWrapper;
 import com.dotcms.enterprise.publishing.bundlers.HTMLPageAsContentBundler;
 import com.dotcms.enterprise.publishing.remote.StaticPushPublishBundleGeneratorTest.TestCase.Condition;
 import com.dotcms.enterprise.publishing.staticpublishing.StaticPublisher;
@@ -22,14 +23,14 @@ import com.dotcms.publisher.business.PublishAuditAPI;
 import com.dotcms.publisher.business.PublishQueueElement;
 import com.dotcms.publisher.business.PublisherAPI;
 import com.dotcms.publisher.pusher.PushPublisherConfig;
+import com.dotcms.publisher.receiver.BundlePublisher;
 import com.dotcms.publisher.util.PublisherUtil;
-import com.dotcms.publishing.BundlerStatus;
-import com.dotcms.publishing.BundlerUtil;
-import com.dotcms.publishing.IBundler;
-import com.dotcms.publishing.Publisher;
+import com.dotcms.publishing.*;
 import com.dotcms.publishing.PublisherConfig.Operation;
+import com.dotcms.publishing.output.BundleOutput;
 import com.dotcms.publishing.output.DirectoryBundleOutput;
 import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
@@ -224,14 +225,15 @@ public class StaticPushPublishBundleGeneratorTest extends IntegrationTestBase {
 
     }
 
+    /**
+     * Given Scenario: A FileAsset with an uppercase extension is created and published
+     * Expected Result: It should be possible to generate a bundle with the file asset without errors
+     */
     @Test
-    public void Test_Static_Publish_Bundle_Generate1()
+    public void Test_Static_Publish_File_With_Uppercase_Extension()
             throws Exception {
 
-        Contentlet contentlet = null;
-
-        Logger.info(StaticPushPublishBundleGeneratorTest.class, "Testing FileAssetBundler");
-        contentlet = FileAssetDataGen.createFileAsset(folder, "example", ".PNG");
+        Contentlet contentlet = FileAssetDataGen.createFileAsset(folder, "example", ".PNG");
         ContentletDataGen.publish(contentlet);
 
 

--- a/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/remote/StaticPushPublishBundleGeneratorTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/remote/StaticPushPublishBundleGeneratorTest.java
@@ -224,6 +224,36 @@ public class StaticPushPublishBundleGeneratorTest extends IntegrationTestBase {
 
     }
 
+    @Test
+    public void Test_Static_Publish_Bundle_Generate1()
+            throws Exception {
+
+        Contentlet contentlet = null;
+
+        Logger.info(StaticPushPublishBundleGeneratorTest.class, "Testing FileAssetBundler");
+        contentlet = FileAssetDataGen.createFileAsset(folder, "example", ".PNG");
+        ContentletDataGen.publish(contentlet);
+
+
+        final String contentletIdentifier = contentlet.getIdentifier();
+
+        final User systemUser = APILocator.getUserAPI().getSystemUser();
+
+        //Create bundle with DefaultFilter
+        final Bundle bundleWithDefaultFilter = createBundle(
+                "TestBundle" + System.currentTimeMillis(), false, defaultFilterKey);
+        //Add assets to the bundle
+
+        final List<String> identifiers = ImmutableList.of(contentletIdentifier);
+        final PublisherAPI publisherAPI = PublisherAPI.getInstance();
+        publisherAPI.saveBundleAssets(identifiers, bundleWithDefaultFilter.getId(), systemUser);
+
+
+        generateBundle(systemUser, bundleWithDefaultFilter.getId(), FileAssetBundler.class, null, null);
+
+
+    }
+
     private static BundlerStatus generateBundle(final User user, final String bundleId, Class<? extends IBundler> bundleGenerator, final String includePatterns, final String excludePatterns) throws Exception{
         final PushPublisherConfig publisherConfig = new PushPublisherConfig();
         final PublisherAPI publisherAPI = PublisherAPI.getInstance();


### PR DESCRIPTION
The method that was retrieving the file was not considering a case in where the extension is uppercase, so a new function  
`getRealAssetPathIgnoreExtensionCase` was created that retrieves the file without transforming the extension to lower case 

This PR fixes: #31792