### PR TITLE
refactor(edit-content): add Language Variables to JSON Field, refactor to use DotEditContentMonacoEditorControl

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/resolvers/dot-template-create-edit.resolver.spec.ts
@@ -7,9 +7,12 @@ import { TestBed } from '@angular/core/testing';
 import { DotTemplatesService } from '@dotcms/app/api/services/dot-templates/dot-templates.service';
 import { DotRouterService } from '@dotcms/data-access';
 import { DotTemplate } from '@dotcms/dotcms-models';
-import { MockDotRouterService } from '@dotcms/utils-testing';
+import { MockDotRouterService, setupResizeObserverMock } from '@dotcms/utils-testing';
 
 import { DotTemplateCreateEditResolver } from './dot-template-create-edit.resolver';
+
+// Setup ResizeObserver mock
+setupResizeObserverMock();
 
 const templateMock: DotTemplate = {
     anonymous: false,

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
@@ -1,4 +1,5 @@
 import { describe } from '@jest/globals';
+import { MonacoEditorModule, MonacoEditorLoaderService } from '@materia-ui/ngx-monaco-editor';
 import { byTestId, createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { EditorComponent } from '@tinymce/tinymce-angular';
 import { MockComponent } from 'ng-mocks';
@@ -7,7 +8,7 @@ import { of } from 'rxjs';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Provider, signal, Type } from '@angular/core';
-import { ControlContainer, FormGroupDirective } from '@angular/forms';
+import { ControlContainer, FormGroupDirective, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { BlockEditorModule, DotBlockEditorComponent } from '@dotcms/block-editor';
@@ -18,7 +19,8 @@ import {
     DotMessageService,
     DotWorkflowActionsFireService
 } from '@dotcms/data-access';
-import { DotKeyValueComponent } from '@dotcms/ui';
+import { DotKeyValueComponent, DotLanguageVariableSelectorComponent } from '@dotcms/ui';
+import { monacoMock } from '@dotcms/utils-testing';
 
 import { DotEditContentFieldComponent } from './dot-edit-content-field.component';
 
@@ -42,6 +44,7 @@ import { DotEditContentTextFieldComponent } from '../../fields/dot-edit-content-
 import { DotEditContentWYSIWYGFieldComponent } from '../../fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component';
 import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
 import { DotEditContentService } from '../../services/dot-edit-content.service';
+import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component';
 import { DotEditContentStore } from '../../store/edit-content.store';
 import {
     BINARY_FIELD_CONTENTLET,
@@ -69,6 +72,9 @@ declare module '@tiptap/core' {
         };
     }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).monaco = monacoMock;
 
 // This holds the mapping between the field type and the component that should be used to render it.
 // We need to hold this record here, because for some reason the references just fall to undefined.
@@ -157,7 +163,15 @@ const FIELD_TYPES_COMPONENTS: Record<FIELD_TYPES, Type<unknown> | DotEditFieldTe
     },
     [FIELD_TYPES.JSON]: {
         component: DotEditContentJsonFieldComponent,
-        declarations: [MockComponent(DotEditContentJsonFieldComponent)]
+        imports: [ReactiveFormsModule, MonacoEditorModule],
+        providers: [
+            mockProvider(DotMessageDisplayService),
+            { provide: MonacoEditorLoaderService, useValue: { isMonacoLoaded$: of(true) } }
+        ],
+        declarations: [
+            MockComponent(DotLanguageVariableSelectorComponent),
+            MockComponent(DotEditContentMonacoEditorControlComponent)
+        ]
     },
     [FIELD_TYPES.KEY_VALUE]: {
         component: DotEditContentKeyValueComponent,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
@@ -1,3 +1,1 @@
-<ngx-monaco-editor
-    [formControlName]="contentTypeField().variable"
-    [options]="monacoEditorOptions()"></ngx-monaco-editor>
+<dot-edit-content-monaco-editor-control [field]="$field()" [forceLanguage]="languages.Json" />

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
@@ -1,1 +1,13 @@
-<dot-edit-content-monaco-editor-control [field]="$field()" [forceLanguage]="languages.Json" />
+<div class="dot-json-field__container flex flex-column gap-2">
+    <div class="dot-json-field__controls flex justify-content-end">
+        <dot-language-variable-selector
+            (onSelectLanguageVariable)="onSelectLanguageVariable($event)" />
+    </div>
+
+    <div class="dot-json-field__editor">
+        <dot-edit-content-monaco-editor-control
+            #monaco
+            [field]="$field()"
+            [forceLanguage]="languages.Json" />
+    </div>
+</div>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
@@ -1,12 +1,16 @@
-<div class="dot-json-field__container flex flex-column gap-2">
-    <div class="dot-json-field__controls flex justify-content-end">
+<div class="dot-json-field__container flex flex-column gap-2" data-testid="json-field-container">
+    <div
+        class="dot-json-field__controls flex justify-content-end"
+        data-testid="json-field-controls">
         <dot-language-variable-selector
+            data-testid="json-field-language-selector"
             (onSelectLanguageVariable)="onSelectLanguageVariable($event)" />
     </div>
 
-    <div class="dot-json-field__editor">
+    <div class="dot-json-field__editor" data-testid="json-field-editor">
         <dot-edit-content-monaco-editor-control
             #monaco
+            data-testid="json-field-monaco-editor"
             [field]="$field()"
             [forceLanguage]="languages.Json" />
     </div>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
@@ -1,4 +1,6 @@
-<div class="dot-json-field__container flex flex-column gap-2" data-testid="json-field-container">
+<div
+    class="dot-json-field__container flex flex-column gap-2 h-full w-full"
+    data-testid="json-field-container">
     <div
         class="dot-json-field__controls flex justify-content-end"
         data-testid="json-field-controls">

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.scss
@@ -9,11 +9,11 @@
     resize: vertical;
 }
 
-ngx-monaco-editor {
+dot-edit-content-monaco-editor-control {
     border-radius: $border-radius-md;
-    border: $field-border-size solid $color-palette-gray-400;
     display: block;
     height: 100%;
+    min-height: 9.375rem;
     overflow: auto;
     width: 100%;
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.scss
@@ -9,6 +9,22 @@
     resize: vertical;
 }
 
+.dot-json-field {
+    &__container {
+        height: 100%;
+        width: 100%;
+    }
+
+    &__controls {
+        padding: $spacing-1 0;
+    }
+
+    &__editor {
+        flex: 1;
+        height: calc(100% - 3rem);
+    }
+}
+
 dot-edit-content-monaco-editor-control {
     border-radius: $border-radius-md;
     display: block;

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.scss
@@ -14,15 +14,6 @@
         height: 100%;
         width: 100%;
     }
-
-    &__controls {
-        padding: $spacing-1 0;
-    }
-
-    &__editor {
-        flex: 1;
-        height: calc(100% - 3rem);
-    }
 }
 
 dot-edit-content-monaco-editor-control {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.scss
@@ -9,13 +9,6 @@
     resize: vertical;
 }
 
-.dot-json-field {
-    &__container {
-        height: 100%;
-        width: 100%;
-    }
-}
-
 dot-edit-content-monaco-editor-control {
     border-radius: $border-radius-md;
     display: block;

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.spec.ts
@@ -2,7 +2,9 @@ import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { DotLanguageVariableSelectorComponent } from '@dotcms/ui';
 
 import { DotEditContentJsonFieldComponent } from './dot-edit-content-json-field.component';
 
@@ -16,7 +18,10 @@ describe('DotEditContentJsonFieldComponent', () => {
     const createComponent = createComponentFactory({
         component: DotEditContentJsonFieldComponent,
         imports: [ReactiveFormsModule],
-        declarations: [MockComponent(DotEditContentMonacoEditorControlComponent)],
+        declarations: [
+            MockComponent(DotEditContentMonacoEditorControlComponent),
+            MockComponent(DotLanguageVariableSelectorComponent)
+        ],
         detectChanges: false
     });
 
@@ -31,6 +36,11 @@ describe('DotEditContentJsonFieldComponent', () => {
         expect(editorComponent).not.toBeNull();
     });
 
+    it('should render the DotLanguageVariableSelectorComponent', () => {
+        const selectorComponent = spectator.query(DotLanguageVariableSelectorComponent);
+        expect(selectorComponent).not.toBeNull();
+    });
+
     it('should pass the field to the editor component', () => {
         const editorComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
         expect(editorComponent.$field()).toEqual(JSON_FIELD_MOCK);
@@ -39,5 +49,17 @@ describe('DotEditContentJsonFieldComponent', () => {
     it('should force the language to be JSON', () => {
         const editorComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
         expect(editorComponent.$forcedLanguage()).toEqual(AvailableLanguageMonaco.Json);
+    });
+
+    it('should insert language variable when selected', () => {
+        const monacoComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
+        const insertSpy = jest.spyOn(monacoComponent, 'insertContent');
+        const languageVar = '$text.get("message.key")';
+
+        // Trigger language variable selection
+        const languageSelector = spectator.query(DotLanguageVariableSelectorComponent);
+        languageSelector.onSelectLanguageVariable.emit(languageVar);
+
+        expect(insertSpy).toHaveBeenCalledWith(languageVar);
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.spec.ts
@@ -1,65 +1,86 @@
-import { Spectator } from '@ngneat/spectator';
-import { createComponentFactory } from '@ngneat/spectator/jest';
-import { MockComponent } from 'ng-mocks';
+import { byTestId, createComponentFactory, Spectator } from '@ngneat/spectator/jest';
 
-import { ReactiveFormsModule } from '@angular/forms';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ControlContainer, FormGroupDirective } from '@angular/forms';
 
 import { DotLanguageVariableSelectorComponent } from '@dotcms/ui';
+import { monacoMock } from '@dotcms/utils-testing';
 
 import { DotEditContentJsonFieldComponent } from './dot-edit-content-json-field.component';
 
 import { AvailableLanguageMonaco } from '../../models/dot-edit-content-field.constant';
 import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component';
-import { JSON_FIELD_MOCK } from '../../utils/mocks';
+import { JSON_FIELD_MOCK, createFormGroupDirectiveMock } from '../../utils/mocks';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).monaco = monacoMock;
 
 describe('DotEditContentJsonFieldComponent', () => {
     let spectator: Spectator<DotEditContentJsonFieldComponent>;
+    let component: DotEditContentJsonFieldComponent;
 
     const createComponent = createComponentFactory({
         component: DotEditContentJsonFieldComponent,
-        imports: [ReactiveFormsModule],
-        declarations: [
-            MockComponent(DotEditContentMonacoEditorControlComponent),
-            MockComponent(DotLanguageVariableSelectorComponent)
+        componentMocks: [
+            DotLanguageVariableSelectorComponent,
+            DotEditContentMonacoEditorControlComponent
         ],
-        detectChanges: false
+        componentViewProviders: [
+            {
+                provide: ControlContainer,
+                useValue: createFormGroupDirectiveMock()
+            }
+        ],
+        providers: [FormGroupDirective, provideHttpClient(), provideHttpClientTesting()]
     });
 
     beforeEach(() => {
-        spectator = createComponent();
+        // Limpiar cualquier llamada anterior a los mocks
+        jest.clearAllMocks();
+
+        spectator = createComponent({
+            detectChanges: false
+        });
         spectator.setInput('field', JSON_FIELD_MOCK);
-        spectator.detectComponentChanges();
+        spectator.detectChanges();
+
+        component = spectator.component;
     });
 
-    it('should render the DotEditContentMonacoEditorControl component', () => {
-        const editorComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
-        expect(editorComponent).not.toBeNull();
+    it('should render the component container', () => {
+        expect(spectator.query(byTestId('json-field-container'))).toBeTruthy();
     });
 
-    it('should render the DotLanguageVariableSelectorComponent', () => {
-        const selectorComponent = spectator.query(DotLanguageVariableSelectorComponent);
-        expect(selectorComponent).not.toBeNull();
+    it('should render the language variable selector', () => {
+        const languageVariableSelector = spectator.query(DotLanguageVariableSelectorComponent);
+        expect(languageVariableSelector).toBeTruthy();
     });
 
-    it('should pass the field to the editor component', () => {
-        const editorComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
-        expect(editorComponent.$field()).toEqual(JSON_FIELD_MOCK);
+    it('should render the editor container', () => {
+        expect(spectator.query(byTestId('json-field-editor'))).toBeTruthy();
     });
 
-    it('should force the language to be JSON', () => {
-        const editorComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
-        expect(editorComponent.$forcedLanguage()).toEqual(AvailableLanguageMonaco.Json);
+    it('should render the monaco editor component', () => {
+        const monacoEditor = spectator.query(DotEditContentMonacoEditorControlComponent);
+        expect(monacoEditor).toBeTruthy();
     });
 
-    it('should insert language variable when selected', () => {
-        const monacoComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
-        const insertSpy = jest.spyOn(monacoComponent, 'insertContent');
-        const languageVar = '$text.get("message.key")';
+    it('should pass JSON as forced language to monaco editor', () => {
+        const monacoEditor = spectator.query(DotEditContentMonacoEditorControlComponent);
+        expect(monacoEditor.$forcedLanguage()).toBe(AvailableLanguageMonaco.Json);
+    });
 
-        // Trigger language variable selection
-        const languageSelector = spectator.query(DotLanguageVariableSelectorComponent);
-        languageSelector.onSelectLanguageVariable.emit(languageVar);
+    it('should call insertLanguageVariableInMonaco when language variable is selected', () => {
+        // Mock the insertLanguageVariableInMonaco private method
+        const insertLanguageVariableInMonacoMock = jest.fn();
+        component['insertLanguageVariableInMonaco'] = insertLanguageVariableInMonacoMock;
 
-        expect(insertSpy).toHaveBeenCalledWith(languageVar);
+        // Trigger onSelectLanguageVariable with a test variable
+        const testVariable = 'test_variable';
+        component.onSelectLanguageVariable(testVariable);
+
+        // Verify the mocked method was called with the correct variable
+        expect(insertLanguageVariableInMonacoMock).toHaveBeenCalledWith(testVariable);
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.spec.ts
@@ -1,75 +1,43 @@
-import { MonacoEditorComponent, MonacoEditorModule } from '@materia-ui/ngx-monaco-editor';
 import { Spectator } from '@ngneat/spectator';
 import { createComponentFactory } from '@ngneat/spectator/jest';
 import { MockComponent } from 'ng-mocks';
 
-import {
-    ControlContainer,
-    FormControl,
-    FormGroup,
-    FormGroupDirective,
-    FormsModule,
-    ReactiveFormsModule
-} from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
-import {
-    DEFAULT_JSON_FIELD_EDITOR_CONFIG,
-    DotEditContentJsonFieldComponent
-} from './dot-edit-content-json-field.component';
+import { DotEditContentJsonFieldComponent } from './dot-edit-content-json-field.component';
 
-import { createFormGroupDirectiveMock, JSON_FIELD_MOCK } from '../../utils/mocks';
+import { AvailableLanguageMonaco } from '../../models/dot-edit-content-field.constant';
+import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component';
+import { JSON_FIELD_MOCK } from '../../utils/mocks';
 
 describe('DotEditContentJsonFieldComponent', () => {
-    describe('test with value', () => {
-        let spectator: Spectator<DotEditContentJsonFieldComponent>;
-        let controlContainer: ControlContainer;
+    let spectator: Spectator<DotEditContentJsonFieldComponent>;
 
-        const FAKE_FORM_GROUP = new FormGroup({
-            json: new FormControl("{ 'test': 'test' }")
-        });
+    const createComponent = createComponentFactory({
+        component: DotEditContentJsonFieldComponent,
+        imports: [ReactiveFormsModule],
+        declarations: [MockComponent(DotEditContentMonacoEditorControlComponent)],
+        detectChanges: false
+    });
 
-        const createComponent = createComponentFactory({
-            component: DotEditContentJsonFieldComponent,
-            imports: [FormsModule, ReactiveFormsModule, MonacoEditorModule],
-            declarations: [MockComponent(MonacoEditorComponent)],
-            componentViewProviders: [
-                {
-                    provide: ControlContainer,
-                    useValue: createFormGroupDirectiveMock(FAKE_FORM_GROUP)
-                }
-            ],
-            providers: [FormGroupDirective],
-            detectChanges: false
-        });
+    beforeEach(() => {
+        spectator = createComponent();
+        spectator.setInput('field', JSON_FIELD_MOCK);
+        spectator.detectComponentChanges();
+    });
 
-        beforeEach(() => {
-            spectator = createComponent();
-            controlContainer = spectator.inject(ControlContainer, true);
-            spectator.setInput('field', JSON_FIELD_MOCK);
-            spectator.detectComponentChanges();
-        });
+    it('should render the DotEditContentMonacoEditorControl component', () => {
+        const editorComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
+        expect(editorComponent).not.toBeNull();
+    });
 
-        it('should render the Monoaco Editor with Current Value', () => {
-            const monacoEditorComponent = spectator.query(MonacoEditorComponent);
-            expect(monacoEditorComponent).not.toBeNull();
-        });
+    it('should pass the field to the editor component', () => {
+        const editorComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
+        expect(editorComponent.$field()).toEqual(JSON_FIELD_MOCK);
+    });
 
-        it('should have the form Variable as a FormControlName', () => {
-            const element = spectator.query('ngx-monaco-editor');
-            expect(element.getAttribute('ng-reflect-name')).toBe(JSON_FIELD_MOCK.variable);
-        });
-
-        it('should have the right editor options', () => {
-            const monacoEditorComponent = spectator.query(MonacoEditorComponent);
-            expect(monacoEditorComponent.options).toEqual(DEFAULT_JSON_FIELD_EDITOR_CONFIG);
-        });
-
-        it('should called markForCheck when the value changes', () => {
-            const spy = jest.spyOn(spectator.component['cd'], 'markForCheck');
-
-            controlContainer.control.get(JSON_FIELD_MOCK.variable).setValue('{ "test": "test" }');
-
-            expect(spy).toHaveBeenCalled();
-        });
+    it('should force the language to be JSON', () => {
+        const editorComponent = spectator.query(DotEditContentMonacoEditorControlComponent);
+        expect(editorComponent.$forcedLanguage()).toEqual(AvailableLanguageMonaco.Json);
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
@@ -1,95 +1,31 @@
-import { MonacoEditorConstructionOptions, MonacoEditorModule } from '@materia-ui/ngx-monaco-editor';
-import { Subject } from 'rxjs';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
 
-import { JsonPipe } from '@angular/common';
-import {
-    ChangeDetectionStrategy,
-    ChangeDetectorRef,
-    Component,
-    computed,
-    inject,
-    Input,
-    OnDestroy,
-    OnInit,
-    signal,
-    Signal
-} from '@angular/core';
-import { ControlContainer, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
 
-import { takeUntil } from 'rxjs/operators';
+import { AvailableLanguageMonaco } from '../../models/dot-edit-content-field.constant';
+import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component';
 
-import { DotCMSContentTypeField, DotCMSContentTypeFieldVariable } from '@dotcms/dotcms-models';
-
-import { DEFAULT_MONACO_CONFIG } from '../../models/dot-edit-content-field.constant';
-import { getFieldVariablesParsed, stringToJson } from '../../utils/functions.util';
-
-export const DEFAULT_JSON_FIELD_EDITOR_CONFIG: MonacoEditorConstructionOptions = {
-    ...DEFAULT_MONACO_CONFIG,
-    language: 'json'
-};
-
+/**
+ * JSON field editor component that uses Monaco Editor for JSON content editing.
+ * Uses DotEditContentMonacoEditorControl for editor functionality with JSON language forced.
+ */
 @Component({
     selector: 'dot-edit-content-json-field',
     standalone: true,
-    imports: [FormsModule, ReactiveFormsModule, MonacoEditorModule, JsonPipe],
+    imports: [ReactiveFormsModule, DotEditContentMonacoEditorControlComponent],
     templateUrl: './dot-edit-content-json-field.component.html',
     styleUrls: ['./dot-edit-content-json-field.component.scss'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    viewProviders: [
-        {
-            provide: ControlContainer,
-            useFactory: () => inject(ControlContainer, { skipSelf: true })
-        }
-    ]
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DotEditContentJsonFieldComponent implements OnInit, OnDestroy {
-    contentTypeField = signal<DotCMSContentTypeField>({} as DotCMSContentTypeField);
-    // Monaco options
-    monacoEditorOptions: Signal<MonacoEditorConstructionOptions> = computed(() => {
-        return {
-            ...DEFAULT_JSON_FIELD_EDITOR_CONFIG,
-            ...this.parseCustomMonacoOptions(this.contentTypeField().fieldVariables)
-        };
-    });
-    private readonly cd = inject(ChangeDetectorRef);
-    private readonly controlContainer = inject(ControlContainer);
-    private readonly destroy$: Subject<boolean> = new Subject<boolean>();
-
-    @Input({ required: true })
-    set field(contentTypeField: DotCMSContentTypeField) {
-        this.contentTypeField.set(contentTypeField);
-    }
-
-    ngOnInit(): void {
-        const form = this.controlContainer.control;
-        const control = form.get(this.contentTypeField().variable);
-
-        /*
-         * This is a workaround to force the change detection to run when the value of the control changes.
-         * This is needed because the Monaco Editor does not play well with the change detection strategy of the component.
-         */
-        control.valueChanges.pipe(takeUntil(this.destroy$)).subscribe(() => this.cd.markForCheck());
-    }
-
-    ngOnDestroy(): void {
-        this.destroy$.next(true);
-        this.destroy$.complete();
-    }
+export class DotEditContentJsonFieldComponent {
+    /**
+     * Input field DotCMSContentTypeField
+     */
+    $field = input.required<DotCMSContentTypeField>({ alias: 'field' });
 
     /**
-     * Parses the custom Monaco options for a given field of a DotCMSContentTypeField.
-     *
-     * @returns {Record<string, string>} Returns the parsed custom Monaco options as a key-value pair object.
-     * @private
-     * @param fieldVariables
+     * Available languages for Monaco editor
      */
-    private parseCustomMonacoOptions(
-        fieldVariables: DotCMSContentTypeFieldVariable[]
-    ): Record<string, string> {
-        const { monacoOptions } = getFieldVariablesParsed<{ monacoOptions: string }>(
-            fieldVariables
-        );
-
-        return stringToJson(monacoOptions);
-    }
+    protected readonly languages = AvailableLanguageMonaco;
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
@@ -28,7 +28,9 @@ export class DotEditContentJsonFieldComponent {
     /**
      * Input field DotCMSContentTypeField
      */
-    $field = input.required<DotCMSContentTypeField>({ alias: 'field' });
+    $field = input<DotCMSContentTypeField | null>(null, {
+        alias: 'field'
+    });
 
     /**
      * Reference to the Monaco editor component

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
@@ -1,7 +1,8 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, viewChild } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
+import { DotLanguageVariableSelectorComponent } from '@dotcms/ui';
 
 import { AvailableLanguageMonaco } from '../../models/dot-edit-content-field.constant';
 import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component';
@@ -9,11 +10,16 @@ import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edi
 /**
  * JSON field editor component that uses Monaco Editor for JSON content editing.
  * Uses DotEditContentMonacoEditorControl for editor functionality with JSON language forced.
+ * Supports language variable insertion through DotLanguageVariableSelectorComponent.
  */
 @Component({
     selector: 'dot-edit-content-json-field',
     standalone: true,
-    imports: [ReactiveFormsModule, DotEditContentMonacoEditorControlComponent],
+    imports: [
+        ReactiveFormsModule,
+        DotEditContentMonacoEditorControlComponent,
+        DotLanguageVariableSelectorComponent
+    ],
     templateUrl: './dot-edit-content-json-field.component.html',
     styleUrls: ['./dot-edit-content-json-field.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -25,7 +31,38 @@ export class DotEditContentJsonFieldComponent {
     $field = input.required<DotCMSContentTypeField>({ alias: 'field' });
 
     /**
+     * Reference to the Monaco editor component
+     */
+    private readonly $monacoComponent =
+        viewChild<DotEditContentMonacoEditorControlComponent>('monaco');
+
+    /**
      * Available languages for Monaco editor
      */
     protected readonly languages = AvailableLanguageMonaco;
+
+    /**
+     * Handler for language variable selection
+     * Inserts the selected language variable at current cursor position in Monaco editor
+     *
+     * @param languageVariable - The parsed language variable string to insert
+     */
+    onSelectLanguageVariable(languageVariable: string): void {
+        this.insertLanguageVariableInMonaco(languageVariable);
+    }
+
+    /**
+     * Insert language variable at current cursor position in Monaco editor
+     *
+     * @param languageVariable - The parsed language variable string to insert
+     * @private
+     */
+    private insertLanguageVariableInMonaco(languageVariable: string): void {
+        const monaco = this.$monacoComponent();
+        if (monaco) {
+            monaco.insertContent(languageVariable);
+        } else {
+            console.warn('Monaco component is not available');
+        }
+    }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.ts
@@ -36,7 +36,7 @@ export class DotEditContentJsonFieldComponent {
      * Reference to the Monaco editor component
      */
     private readonly $monacoComponent =
-        viewChild<DotEditContentMonacoEditorControlComponent>('monaco');
+        viewChild.required<DotEditContentMonacoEditorControlComponent>('monaco');
 
     /**
      * Available languages for Monaco editor

--- a/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.constant.ts
+++ b/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.constant.ts
@@ -28,7 +28,8 @@ export enum AvailableLanguageMonaco {
     Javascript = 'javascript',
     Markdown = 'markdown',
     Html = 'html',
-    Velocity = 'velocity'
+    Velocity = 'velocity',
+    Json = 'json'
 }
 
 /**

--- a/core-web/libs/edit-content/src/lib/shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component.spec.ts
@@ -7,11 +7,12 @@ import { monacoMock } from '@dotcms/utils-testing';
 
 import { DotEditContentMonacoEditorControlComponent } from './dot-edit-content-monaco-editor-control.component';
 
-import {
-    DEFAULT_MONACO_LANGUAGE,
-    DEFAULT_WYSIWYG_FIELD_MONACO_CONFIG
-} from '../../fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.constant';
 import { WYSIWYG_MOCK } from '../../fields/dot-edit-content-wysiwyg-field/mocks/dot-edit-content-wysiwyg-field.mock';
+import {
+    AvailableLanguageMonaco,
+    DEFAULT_MONACO_LANGUAGE,
+    DEFAULT_MONACO_CONFIG
+} from '../../models/dot-edit-content-field.constant';
 import { createFormGroupDirectiveMock } from '../../utils/mocks';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -48,7 +49,7 @@ describe('DotEditContentMonacoEditorControlComponent', () => {
 
     it('should generate correct Monaco options', async () => {
         const expectedOptions = {
-            ...DEFAULT_WYSIWYG_FIELD_MONACO_CONFIG,
+            ...DEFAULT_MONACO_CONFIG,
             theme: 'vs',
             language: 'plaintext' // due the auto detect language is plaintext
         };
@@ -60,6 +61,26 @@ describe('DotEditContentMonacoEditorControlComponent', () => {
         spectator.detectChanges();
 
         expect(component.$monacoOptions()).toEqual(expectedOptions);
+    });
+
+    it('should use forcedLanguage when provided', () => {
+        // Set the forced language
+        spectator.setInput('forceLanguage', AvailableLanguageMonaco.Javascript);
+
+        // Check if monaco options includes the forced language
+        const options = component.$monacoOptions();
+        expect(options.language).toBe(AvailableLanguageMonaco.Javascript);
+    });
+
+    it('should override auto-detected language when forcedLanguage is provided', () => {
+        // First test auto-detection - expecting plaintext instead of DEFAULT_MONACO_LANGUAGE
+        expect(component.$language()).toBe('plaintext');
+
+        // Now set forced language
+        spectator.setInput('forceLanguage', AvailableLanguageMonaco.Velocity);
+
+        // Verify that the monaco options uses the forced language
+        expect(component.$monacoOptions().language).toBe(AvailableLanguageMonaco.Velocity);
     });
 
     it('should parse custom props from field variables', () => {
@@ -76,7 +97,7 @@ describe('DotEditContentMonacoEditorControlComponent', () => {
         spectator.setInput('field', fieldWithVariables);
 
         const expectedOptions = {
-            ...DEFAULT_WYSIWYG_FIELD_MONACO_CONFIG,
+            ...DEFAULT_MONACO_CONFIG,
             ...customProps,
             language: 'plaintext' // due the auto detect language is plaintext
         };

--- a/core-web/libs/edit-content/src/lib/shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component.ts
+++ b/core-web/libs/edit-content/src/lib/shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component.ts
@@ -89,6 +89,12 @@ export class DotEditContentMonacoEditorControlComponent implements OnDestroy, On
     $field = input.required<DotCMSContentTypeField>({ alias: 'field' });
 
     /**
+     * Input property to force a specific language for the Monaco editor.
+     * If provided, this overrides the automatic language detection.
+     */
+    $forcedLanguage = input<AvailableLanguageMonaco | null>(null, { alias: 'forceLanguage' });
+
+    /**
      * A computed property that retrieves and parses custom Monaco properties that comes from
      * Field Variable with the name `monacoOptions`
      *
@@ -117,7 +123,7 @@ export class DotEditContentMonacoEditorControlComponent implements OnDestroy, On
         return {
             ...DEFAULT_MONACO_CONFIG,
             ...this.$customPropsContentField(),
-            language: this.$language()
+            language: this.$forcedLanguage() || this.$language()
         };
     });
 
@@ -290,6 +296,13 @@ export class DotEditContentMonacoEditorControlComponent implements OnDestroy, On
      * Detects the language of the content in the Monaco editor and sets the appropriate language.
      */
     private detectLanguage() {
+        // Skip language detection if a forced language is provided
+        if (this.$forcedLanguage()) {
+            this.setLanguage(this.$forcedLanguage());
+
+            return;
+        }
+
         const content = this.#editor.getValue().trim();
 
         if (!content) {

--- a/core-web/libs/utils-testing/src/index.ts
+++ b/core-web/libs/utils-testing/src/index.ts
@@ -49,3 +49,4 @@ export * from './lib/push-publish.mock';
 export * from './lib/dot-license-service.mock';
 export * from './lib/monaco-editor.mock';
 export * from './lib/dot-site.mock';
+export * from './lib/resize-observer.mock';

--- a/core-web/libs/utils-testing/src/lib/monaco-editor.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/monaco-editor.mock.ts
@@ -8,7 +8,7 @@ export const monacoMock = {
             }),
             getValue: () => '',
             setValue: (value: string) => {
-                console.log(`Editor value set to: ${value}`);
+                //
             },
             getModel: () => ({
                 uri: {
@@ -16,15 +16,14 @@ export const monacoMock = {
                 }
             }),
             updateOptions: (options: object) => {
-                console.log('Editor options updated:', options);
+                //
             },
             onDidChangeModelDecorations: (callback: () => void) => {
-                console.log('Model decorations changed');
                 callback();
 
                 return {
                     dispose: () => {
-                        console.log('Listener disposed');
+                        //
                     }
                 };
             },
@@ -36,17 +35,17 @@ export const monacoMock = {
                 dispose: () => {}
             }),
             layout: (dimension?: { width: number; height: number }) => {
-                console.log('Editor layout updated:', dimension);
+                //
             },
             getPosition: () => ({
                 lineNumber: 1,
                 column: 1
             }),
             setPosition: (position: { lineNumber: number; column: number }) => {
-                console.log('Editor position set to:', position);
+                //
             },
             revealLine: (lineNumber: number) => {
-                console.log('Revealing line:', lineNumber);
+                //
             }
         }),
         setModelLanguage: () => {},
@@ -55,7 +54,7 @@ export const monacoMock = {
         }),
         setTheme: () => {},
         getModelMarkers: (model: object) => {
-            console.log('Getting model markers for model:', model);
+            //
 
             return [
                 {

--- a/core-web/libs/utils-testing/src/lib/resize-observer.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/resize-observer.mock.ts
@@ -2,9 +2,15 @@
  * Mock implementation of ResizeObserver for testing environments
  */
 export class MockResizeObserver {
-    observe() {}
-    unobserve() {}
-    disconnect() {}
+    observe() {
+        // do nothing
+    }
+    unobserve() {
+        // do nothing
+    }
+    disconnect() {
+        // do nothing
+    }
 }
 
 /**
@@ -12,4 +18,4 @@ export class MockResizeObserver {
  */
 export function setupResizeObserverMock(): void {
     window.ResizeObserver = MockResizeObserver;
-} 
+}

--- a/core-web/libs/utils-testing/src/lib/resize-observer.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/resize-observer.mock.ts
@@ -1,0 +1,15 @@
+/**
+ * Mock implementation of ResizeObserver for testing environments
+ */
+export class MockResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+
+/**
+ * Sets up the ResizeObserver mock globally for testing
+ */
+export function setupResizeObserverMock(): void {
+    window.ResizeObserver = MockResizeObserver;
+} 

--- a/core-web/yarn.lock
+++ b/core-web/yarn.lock
@@ -10760,7 +10760,7 @@ debug@^3.1.0, debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==
@@ -14234,7 +14234,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
@@ -16454,11 +16454,6 @@ lodash-es@^4.17.21:
   resolved "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha512-bSYo8Pc/f0qAkr8fPJydpJjtrHiSynYfYBjtANIgXv5xEf1WlTC63dIDlgu0s9dmTvzRu1+JJTxcIAHe+sH0FQ==
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -16467,32 +16462,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha512-2wlI0JRAGX8WEf4Gm1p/mv/SZ+jLijpj0jyaE/AXeuQphzCgD8ZQW4oSpoN8JAopujOFGU3KMuq7qfHBWlGpjQ==
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha512-S8dUjWr7SUT/X6TBIQ/OYoCHo1Stu1ZRy6uMUSKqzFnZp5G5RyQizSm6kvxD2Ewyy6AVfMg4AToeZzKfF99T5w==
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha512-ev5SP+iFpZOugyab/DEUQxUeZP5qyciVTlgQ1f4Vlw7VUcCD8fVnyIqVUEIaoFH9zjAqdgi69KiofzvVmda/ZQ==
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA==
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha512-RrL9VxMEPyDMHOd9uFbvMe8X55X16/cGM5IgOKgRElQZutpX89iS6vwl64duTV1/16w5JY7tuFNXqoekmh1EmA==
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -16573,11 +16546,6 @@ lodash.once@^4.0.0, lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha512-L4/arjjuq4noiUJpt3yS6KIKDtJwNe2fIYgMqyYYKoeIfV1iEqvPwhCx23o+R9dzouGihDAPN1dTIRWa7zk8tw==
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
@@ -22443,7 +22411,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22460,6 +22428,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
@@ -22571,7 +22548,7 @@ stringify-package@^1.0.0, stringify-package@^1.0.1:
   resolved "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz#e5aa3643e7f74d0f28628b72f3dad5cecfc3ba85"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22598,6 +22575,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -24699,7 +24683,7 @@ worker-farm@^1.6.0, worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24729,6 +24713,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This commit refactors the DotEditContentJsonFieldComponent to utilize the new DotEditContentMonacoEditorControl for JSON editing. Key changes include:

- Updated the HTML template to replace ngx-monaco-editor with dot-edit-content-monaco-editor-control.
- Adjusted SCSS styles to accommodate the new editor control.
- Modified the component's TypeScript file to remove unnecessary imports and streamline the code.
- Enhanced the test suite to validate the integration of the new editor control and its properties.

This change improves the maintainability and functionality of the JSON field editor.

### Changes:
This pull request introduces significant updates to the JSON field editor component and its integration with the Monaco editor. The changes focus on enhancing functionality, improving test coverage, and refactoring the codebase for better maintainability. Key updates include replacing the direct usage of `ngx-monaco-editor` with a custom wrapper component, adding support for forcing specific languages in the Monaco editor, and improving the test structure for the JSON field editor.

### JSON Field Editor Enhancements:
* Replaced the `ngx-monaco-editor` with a custom wrapper component, `DotEditContentMonacoEditorControlComponent`, to provide more control over the editor's behavior and customization. [[1]](diffhunk://#diff-b8aa90bf87b74a086b7d91cd7a45b06022453dba3f26a7fd751a7fd2aacb2f42L1-R17) [[2]](diffhunk://#diff-cb3c5e92c52c399050b6321834f69fe6125ce05b964f3fdd5425d7ae0e623026L1-R68)
* Introduced a language variable selector (`DotLanguageVariableSelectorComponent`) for inserting language variables into the JSON editor. [[1]](diffhunk://#diff-b8aa90bf87b74a086b7d91cd7a45b06022453dba3f26a7fd751a7fd2aacb2f42L1-R17) [[2]](diffhunk://#diff-cb3c5e92c52c399050b6321834f69fe6125ce05b964f3fdd5425d7ae0e623026L1-R68)
* Added support for forcing specific languages in the Monaco editor using the new `$forcedLanguage` input property. [[1]](diffhunk://#diff-c1909062ea002433d379181fe62a87bf3b509cfac047b67debda6576920f5b07R91-R96) [[2]](diffhunk://#diff-a5d0c8034761266780cde3f0981d0b7575af0f8e45fa756fabf8d14509f11b68R66-R85)

### Test and Mock Updates:
* Updated test cases for the JSON field editor to validate the rendering of new components (`DotLanguageVariableSelectorComponent`, `DotEditContentMonacoEditorControlComponent`) and their interactions.
* Added new test cases for the Monaco editor wrapper component to ensure the correct application of forced languages and custom properties. [[1]](diffhunk://#diff-a5d0c8034761266780cde3f0981d0b7575af0f8e45fa756fabf8d14509f11b68R66-R85) [[2]](diffhunk://#diff-a5d0c8034761266780cde3f0981d0b7575af0f8e45fa756fabf8d14509f11b68L79-R100)

### Styling and Layout Improvements:
* Refactored the JSON field editor's layout to include separate containers for controls and the editor, improving the UI structure and maintainability.

### Codebase Refactoring:
* Removed redundant imports and dependencies related to `ngx-monaco-editor` and replaced them with the custom wrapper component. [[1]](diffhunk://#diff-cb3c5e92c52c399050b6321834f69fe6125ce05b964f3fdd5425d7ae0e623026L1-R68) [[2]](diffhunk://#diff-7de4eab63be6786869cc64142ef14ec11998fe5d7aa9bfd3c9a38979ebbd5216L1-R84)
* Added a new `Json` option to the `AvailableLanguageMonaco` enum for explicit JSON language support.

These changes collectively improve the functionality, usability, and maintainability of the JSON field editor component.


### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![CleanShot 2025-05-07 at 10 18 00@2x](https://github.com/user-attachments/assets/645c5332-1a7a-4e7e-8622-c7e3edd0a0b4)


This PR fixes: #31985