### PR TITLE
bug(quartz): unneeded sync call to quartz fails when saving a field

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FieldAPIImpl.java
@@ -163,8 +163,6 @@ public class FieldAPIImpl implements FieldAPI {
             throw new DotDataValidationException("ContentTypeId needs to be set to save the Field");
         }
 
-        QuartzUtils.validateFieldReferences(field);
-
         ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(user);
         ContentType type = contentTypeAPI.find(field.contentTypeId());
         permissionAPI.checkPermission(type, PermissionLevel.EDIT_PERMISSIONS, user);

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/QuartzUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/QuartzUtils.java
@@ -883,42 +883,7 @@ public class QuartzUtils {
 
 	}
 
-	/**
-	 *  Checks if the CleanUpFieldReferencesJob is running for a field with the same name, if so, throws an exception
-	 * */
-	public static void validateFieldReferences(Field field) throws DotDataException{
-		try {
 
-			List<JobExecutionContext> currentlyExecutingJobs = new ArrayList<>();
-			currentlyExecutingJobs.addAll(QuartzUtils.getScheduler().getCurrentlyExecutingJobs());
-
-			JobDetail existingJobDetail = QuartzUtils.getScheduler().getJobDetail("CleanUpFieldReferencesJob", "CleanUpFieldReferencesJob_Group");
-
-			if (existingJobDetail != null) {
-				for (JobExecutionContext jec : currentlyExecutingJobs) {
-
-					final JobDetail runningJobDetail = jec.getJobDetail();
-					//if there is a CleanUpFieldReferencesJob running
-					if (existingJobDetail.equals(runningJobDetail) || isSameJob(existingJobDetail, runningJobDetail)) {
-						JobDataMap jobDataMap = runningJobDetail.getJobDataMap();
-						Map<String, Map<String,Object>> jobDetail = (Map<String, Map<String, Object>>) jobDataMap.get("trigger_job_detail");
-						//checks on the running jobs if there is any job with a field with the same name
-						boolean doesFieldExists =  jobDetail.values()
-								.stream()
-								.filter(value -> value.get("field") != null)
-								.map(filteredField -> ((Field) filteredField.get("field")).name())
-								.anyMatch(fieldName -> fieldName.equals(field.name()));
-
-						if (doesFieldExists) {
-							throw new DotDataException("Field variable '" + field.name() + "' cannot be recreated while the CleanUpFieldReferencesJob is running. Please wait until finish");
-						}
-					}
-				}
-			}
-		} catch (SchedulerException e){
-			throw new DotDataException(e);
-		}
-	}
 
 
 


### PR DESCRIPTION
ref: #32121

This pull request removes the `validateFieldReferences` method from `QuartzUtils` and its usage in `FieldAPIImpl`. The change simplifies the codebase by eliminating a method that checks for running jobs related to field references, which may no longer be necessary.

### Codebase simplification:

* [`dotCMS/src/main/java/com/dotcms/contenttype/business/FieldAPIImpl.java`](diffhunk://#diff-dc5a462cb1d56bf3e5a45ca74183ddd3c44d53fc4f27bb3e70f0a1b5d6756f68L166-L167): Removed the call to `QuartzUtils.validateFieldReferences(field)` in the `save` method, simplifying the field-saving logic.
* [`dotCMS/src/main/java/com/dotmarketing/quartz/QuartzUtils.java`](diffhunk://#diff-3b97fc7f012d18dfe3c6ce31dbd43a9a549847555a0d4b0d75bb1d89bc376ff5L886-L921): Completely removed the `validateFieldReferences` method, which previously checked for running `CleanUpFieldReferencesJob` instances to prevent field recreation during job execution.

This PR fixes: #32121