### PR TITLE
task(logging): do not spit noise into logs when using API key:

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/auth/providers/jwt/beans/JWToken.java
+++ b/dotCMS/src/main/java/com/dotcms/auth/providers/jwt/beans/JWToken.java
@@ -71,7 +71,9 @@ public interface JWToken extends Serializable {
     default Optional<User> getActiveUser() {
         String subjectString = getUserId();
 
-        String userIdString = Try.of(()-> PublicEncryptionFactory.decryptString(subjectString)).onFailure(e-> Logger.warnAndDebug(JWToken.class,"Subject Not Encrypted:" + e,e)).getOrElse(subjectString);
+        String userIdString = (this instanceof ApiToken)
+                ? subjectString
+                : Try.of(()-> PublicEncryptionFactory.decryptString(subjectString)).onFailure(e-> Logger.warnAndDebug(JWToken.class,"Subject Not Encrypted:" + e,e)).getOrElse(subjectString);
         User user = Try.of(() -> APILocator.getUserAPI().loadUserById(userIdString)).getOrNull();
         if (user != null && user.isActive()) {
             return Optional.of(user);

--- a/dotCMS/src/main/java/com/dotcms/auth/providers/jwt/beans/JWToken.java
+++ b/dotCMS/src/main/java/com/dotcms/auth/providers/jwt/beans/JWToken.java
@@ -73,7 +73,7 @@ public interface JWToken extends Serializable {
 
         String userIdString = (this instanceof ApiToken)
                 ? subjectString
-                : Try.of(()-> PublicEncryptionFactory.decryptString(subjectString)).onFailure(e-> Logger.warnAndDebug(JWToken.class,"Subject Not Encrypted:" + e,e)).getOrElse(subjectString);
+                : Try.of(()-> PublicEncryptionFactory.decryptString(subjectString)).onFailure(e-> Logger.debug(JWToken.class,"Subject Not Encrypted:" + e,e)).getOrElse(subjectString);
         User user = Try.of(() -> APILocator.getUserAPI().loadUserById(userIdString)).getOrNull();
         if (user != null && user.isActive()) {
             return Optional.of(user);


### PR DESCRIPTION
This pull request introduces a change to the `JWToken` interface to handle a specific case for `ApiToken` instances when retrieving the active user. The update ensures that the `subjectString` is used directly for `ApiToken` instances, bypassing decryption.

Most importantly - this pr stops the unnecessary log messages when using an API key to access dotCMS.


### Key change:
* Updated the `getActiveUser` method in `JWToken` to check if the current instance is of type `ApiToken`. If so, it directly uses the `subjectString` without attempting decryption, improving compatibility and avoiding unnecessary decryption for `ApiToken` instances. (`[dotCMS/src/main/java/com/dotcms/auth/providers/jwt/beans/JWToken.javaL74-R76](diffhunk://#diff-9e1faef3f8c5f2b7d61c08596157ffcfd27185c34be59a2916175507e8a97f54L74-R76)`)

This PR fixes: #31415