### PR TITLE
Fixed color on roles selector

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users.jsp
@@ -50,6 +50,10 @@
 		padding:4px ;
 		color: rgb(85,85,85);
 	}
+
+	#userRolesSelect option:checked{
+		background: light-dark(rgb(206, 206, 206), rgb(84, 84, 84));
+	}
 	
 	.tokenDivClass{
 		background:#eeeeee;


### PR DESCRIPTION


https://github.com/user-attachments/assets/e7a9dbd9-5388-4554-8d5d-2b3ae8db607e


This pull request introduces a small visual enhancement to the user interface in the `view_users.jsp` file. Specifically, it adds a style rule to improve the appearance of selected options in the `#userRolesSelect` dropdown.

* [`dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users.jsp`](diffhunk://#diff-1b673eafaf482579d77a457632e9f8dd599e45ec32b65715555dee62ac5a6fb3R54-R57): Added a CSS rule to apply a light-dark background color to selected options in the `#userRolesSelect` dropdown.

This PR fixes: #32001