### PR TITLE
fix(sessions): Only store IntegrityChecker enum in session:

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/IntegrityResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/IntegrityResource.java
@@ -1054,7 +1054,7 @@ public class IntegrityResource {
      * @param integrityDataRequestID
      */
     private void addThreadToSession ( HttpSession session, Thread thread, String endpointId, String integrityDataRequestID ) {
-        session.setAttribute( "integrityThread_" + endpointId, thread );
+        session.setAttribute( "integrityThread_" + endpointId, ProcessStatus.PROCESSING );
         session.setAttribute( "integrityDataRequest_" + endpointId, integrityDataRequestID );
     }
 


### PR DESCRIPTION
This pull request introduces changes to improve session handling and enforce serialization checks in the `SwitchSiteListener` class, as well as updates to session attribute management in the `IntegrityResource` class. The most important changes include adding a mechanism to validate session object serialization, logging warnings for non-serializable objects, and modifying how session attributes are stored.

### Session Handling Improvements in `SwitchSiteListener`:

* **Serialization Check for Session Attributes**:
  - Added a `checkSerializable` method to validate if session objects are serializable. If an object is not serializable, a warning is logged, or an exception is thrown based on the `THROW_WHEN_SESSION_NOT_SERIALIZABLE` configuration. (`SwitchSiteListener.java`, [dotCMS/src/main/java/com/dotcms/listeners/SwitchSiteListener.javaR32-R55](diffhunk://#diff-b42d244f4bf97775fd70eef4c238efefcc8bdcf964790012d54c96c9110bf415R32-R55))
  - Integrated the `checkSerializable` method into the `attributeAdded` and `attributeReplaced` methods to ensure serialization checks are performed when session attributes are modified. (`SwitchSiteListener.java`, [dotCMS/src/main/java/com/dotcms/listeners/SwitchSiteListener.javaR73](diffhunk://#diff-b42d244f4bf97775fd70eef4c238efefcc8bdcf964790012d54c96c9110bf415R73))

* **Lazy Initialization for Configuration**:
  - Introduced a `Lazy` field to fetch the `THROW_WHEN_SESSION_NOT_SERIALIZABLE` configuration property only when needed, improving efficiency. (`SwitchSiteListener.java`, [dotCMS/src/main/java/com/dotcms/listeners/SwitchSiteListener.javaR32-R55](diffhunk://#diff-b42d244f4bf97775fd70eef4c238efefcc8bdcf964790012d54c96c9110bf415R32-R55))

### Session Attribute Management in `IntegrityResource`:

* **Update to Session Attribute Storage**:
  - Replaced the storage of `Thread` objects in session attributes with a `ProcessStatus.PROCESSING` enum value to avoid potential serialization issues and improve clarity. (`IntegrityResource.java`, [dotCMS/src/main/java/com/dotcms/rest/IntegrityResource.javaL1057-R1057](diffhunk://#diff-c5ecbdb61ea4e7398ed519980900dd7f4cdb4d122a990e75db09b3a9f93ed87cL1057-R1057))

This PR fixes: #32131