### PR TITLE
fix(UVE): Make computed be updated everytime the page asset changes

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1006,7 +1006,6 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
             [CLIENT_ACTIONS.CLIENT_READY]: (devConfig) => {
                 const isClientReady = this.uveStore.isClientReady();
 
-                // console.log('isClientReady', isClientReady);
                 if (isClientReady) {
                     return;
                 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.spec.ts
@@ -182,6 +182,28 @@ describe('withEditor', () => {
                 );
             });
 
+            // There is an issue with Signal Store when you try to spy on a signal called from a computed property
+            // Unskip this when this discussion is resolved: https://github.com/ngrx/platform/discussions/4627
+            describe.skip('pageAPIResponse dependency', () => {
+                it('should call pageAPIResponse when it is a headless page', () => {
+                    const spy = jest.spyOn(store, 'pageAPIResponse');
+                    patchState(store, { isTraditionalPage: false });
+                    store.$iframeURL();
+
+                    expect(spy).toHaveBeenCalled();
+                });
+
+                it('should call pageAPIResponse when it is a traditional page', () => {
+                    const spy = jest.spyOn(store, 'pageAPIResponse');
+
+                    patchState(store, { isTraditionalPage: true });
+
+                    store.$iframeURL();
+
+                    expect(spy).toHaveBeenCalled();
+                });
+            });
+
             it('should be an instance of String in src when the page is traditional', () => {
                 patchState(store, {
                     pageAPIResponse: MOCK_RESPONSE_VTL,


### PR DESCRIPTION
This pull request makes several updates to the `EditEmaEditorComponent` and `withEditor` functions to clean up the code and improve maintainability. The changes include removing commented-out code, optimizing computed dependencies, and refining iframe URL generation logic.

### Code cleanup:

* Removed a commented-out `console.log` statement from the `EditEmaEditorComponent` to declutter the code and improve readability. (`core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts`)

### Optimization of computed dependencies:

* Updated the `$reloadEditorContent` computed property in `withEditor` to directly use `store.isTraditionalPage()` instead of wrapping it with `untracked`, simplifying the dependency logic. (`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts`)

### Improvements to iframe URL generation:

* Added comments and logic in the `$iframeURL` computed property to explicitly import `pageAPIResponse()` for dependency tracking, ensuring updates occur when the API response changes. This adjustment improves future maintainability and aligns with planned UVE improvements. (`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts`)
* Refined the `$iframeURL` logic by removing outdated comments and consolidating the `vanityURL` and `params.url` handling, ensuring cleaner and more maintainable code. (`core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/editor/withEditor.ts`)

### Video

https://github.com/user-attachments/assets/6af1dc01-f1ab-4e0a-90fa-e54e644fdff4


This PR fixes: #32139