### PR TITLE
feat(Telemetry) #32066 : Turn Telemetry on by default

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/MetricStatsCollector.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/MetricStatsCollector.java
@@ -10,7 +10,6 @@ import com.dotcms.telemetry.collectors.ai.TotalEmbeddingsIndexesMetricType;
 import com.dotcms.telemetry.collectors.ai.TotalSitesUsingDotaiMetricType;
 import com.dotcms.telemetry.collectors.ai.TotalSitesWithAutoIndexContentConfigMetricType;
 import com.dotcms.telemetry.collectors.api.ApiMetricAPI;
-import com.dotcms.telemetry.collectors.api.ApiMetricTypes;
 import com.dotcms.telemetry.collectors.container.TotalFileContainersInLivePageDatabaseMetricType;
 import com.dotcms.telemetry.collectors.container.TotalFileContainersInLiveTemplatesDatabaseMetricType;
 import com.dotcms.telemetry.collectors.container.TotalFileContainersInWorkingPageDatabaseMetricType;
@@ -266,9 +265,6 @@ public final class MetricStatsCollector {
         metricStatsCollectors.add(new CountExperimentsWithExitRateGoalMetricType());
         metricStatsCollectors.add(new CountExperimentsWithBounceRateGoalMetricType());
         metricStatsCollectors.add(new CountExperimentsEditedInThePast30DaysMetricType());
-
-        // api ones
-        metricStatsCollectors.addAll(ApiMetricTypes.INSTANCE.get());
     }
 
     public static MetricsSnapshot getStatsAndCleanUp() {

--- a/osgi-base/system-bundles/pom.xml
+++ b/osgi-base/system-bundles/pom.xml
@@ -58,19 +58,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>com.dotcms.core.plugins</groupId>
-            <artifactId>com.dotcms.telemetry</artifactId>
-            <version>24.08.08</version>
-            <scope>provided</scope>
-
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
### Proposed Changes
* Turn Telemetry on by default.
* Remove unnecessary code that is meant to be replaced by the new Content Analytics.
* Remove the legacy Telemetry JAR from Felix.

This PR fixes: #32066