### PR TITLE
chore(uve): Fix Today button interaction with calendar picker on Published UVE mode

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.spec.ts
@@ -741,6 +741,15 @@ describe('DotUveToolbarComponent', () => {
                 });
             });
 
+            it('should change the date to today when button "Today" is clicked', () => {
+                const calendar = spectator.query('p-calendar');
+
+                spectator.triggerEventHandler('p-calendar', 'click', new Event('click'));
+
+                expect(calendar.getAttribute('ng-reflect-model')).toBeDefined();
+                expect(new Date(calendar.getAttribute('ng-reflect-model'))).toEqual(new Date());
+            });
+
             it('should track event on date when date is selected', () => {
                 const spyTrackUVECalendarChange = jest.spyOn(
                     baseUVEState,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/dot-uve-toolbar.component.ts
@@ -11,8 +11,7 @@ import {
     Output,
     viewChild,
     Signal,
-    signal,
-    untracked
+    signal
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
@@ -120,7 +119,7 @@ export class DotUveToolbarComponent {
 
     protected readonly $pageParams = this.#store.pageParams;
     protected readonly $previewDate = computed<Date>(() => {
-        const publishDate = untracked(() => this.$pageParams().publishDate);
+        const publishDate = this.$pageParams().publishDate;
 
         const previewDate = publishDate ? new Date(publishDate) : new Date();
 


### PR DESCRIPTION
This pull request introduces a new test case for the `DotUveToolbarComponent` and simplifies the component's code by removing unused imports and eliminating the use of `untracked` in a computed property. Below is a summary of the most important changes:

### New Test Case Addition:
* Added a test to verify that clicking the "Today" button updates the calendar date to today's date in `dot-uve-toolbar.component.spec.ts`.

### Code Simplification:
* Removed the unused `untracked` import from `@angular/core` in `dot-uve-toolbar.component.ts`.
* Simplified the `$previewDate` computed property by directly accessing `publishDate` from `$pageParams`, removing the use of `untracked`.

This PR fixes: #32144