### PR TITLE
fix(graphql): fix issue where content types with Collection in the name

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/graphql/util/TypeUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/util/TypeUtil.java
@@ -125,12 +125,14 @@ public class TypeUtil {
         return builder.build();
     }
 
+    final static String COLLECTION="Collection";
+
     public static String collectionizedName(final String typeName) {
-        return typeName + "Collection";
+        return typeName + COLLECTION;
     }
 
     public static String singularizeCollectionName(final String collectionName) {
-        return collectionName.replaceAll("Collection", "");
+        return collectionName.endsWith(COLLECTION) ? collectionName.substring(0,collectionName.lastIndexOf(COLLECTION)) : collectionName;
     }
 
     public static String singularizeBaseTypeCollectionName(final String baseTypeCollectionName) {

--- a/dotCMS/src/test/java/com/dotcms/graphql/util/TypeUtilTest.java
+++ b/dotCMS/src/test/java/com/dotcms/graphql/util/TypeUtilTest.java
@@ -1,0 +1,65 @@
+package com.dotcms.graphql.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class TypeUtilTest {
+
+
+
+    @Test
+    void testCollectionizedName() {
+        // Basic functionality
+        assertEquals("TestCollection", TypeUtil.collectionizedName("Test"));
+
+        // With empty string
+        assertEquals("Collection", TypeUtil.collectionizedName(""));
+
+        // Already has Collection suffix
+        assertEquals("TestCollectionCollection", TypeUtil.collectionizedName("TestCollection"));
+    }
+
+    @Test
+    void testSingularizeCollectionName() {
+        // Basic functionality
+        assertEquals("Test", TypeUtil.singularizeCollectionName("TestCollection"));
+
+        // Without Collection suffix
+        assertEquals("Test", TypeUtil.singularizeCollectionName("Test"));
+
+        // Collection in the middle
+        assertEquals("TestCollectionSuffix", TypeUtil.singularizeCollectionName("TestCollectionSuffix"));
+
+        // Collection in the middle and End
+        assertEquals("TestCollectionSuffix", TypeUtil.singularizeCollectionName("TestCollectionSuffixCollection"));
+
+
+        // Multiple Collections, only removes from end
+        assertEquals("TestCollection", TypeUtil.singularizeCollectionName("TestCollectionCollection"));
+
+        // Empty string
+        assertEquals("", TypeUtil.singularizeCollectionName(""));
+    }
+
+    @Test
+    void testSingularizeBaseTypeCollectionName() {
+        // Both Collection and BaseType
+        assertEquals("Test", TypeUtil.singularizeBaseTypeCollectionName("TestBaseTypeCollection"));
+
+        // Only Collection suffix
+        assertEquals("Test", TypeUtil.singularizeBaseTypeCollectionName("TestCollection"));
+
+        // Only BaseType
+        assertEquals("Test", TypeUtil.singularizeBaseTypeCollectionName("TestBaseType"));
+
+        // Multiple BaseType occurrences
+        assertEquals("TestTest", TypeUtil.singularizeBaseTypeCollectionName("TestBaseTypeTestBaseType"));
+
+        // Neither Collection nor BaseType
+        assertEquals("Test", TypeUtil.singularizeBaseTypeCollectionName("Test"));
+
+        // Empty string
+        assertEquals("", TypeUtil.singularizeBaseTypeCollectionName(""));
+    }
+}


### PR DESCRIPTION
This pull request introduces a constant for the "Collection" string in `TypeUtil` to improve maintainability and adds comprehensive unit tests for its methods to ensure correctness. The changes enhance code readability and robustness.

### Code improvements:
* [`dotCMS/src/main/java/com/dotcms/graphql/util/TypeUtil.java`](diffhunk://#diff-b81500a068d7284b7576cc4c9e886ad3266d129ecfa072c6115551112edef8fdR128-R135): Introduced a `COLLECTION` constant to replace the hardcoded "Collection" string in the `collectionizedName` and `singularizeCollectionName` methods, improving maintainability and reducing potential errors.

### Testing enhancements:
* [`dotCMS/src/test/java/com/dotcms/graphql/util/TypeUtilTest.java`](diffhunk://#diff-9f4561c3a9170e5e7b2e180e4d26e7a739fd9c1256c8d3efa5d16147e5720749R1-R65): Added a new test class `TypeUtilTest` with unit tests for the `collectionizedName`, `singularizeCollectionName`, and `singularizeBaseTypeCollectionName` methods. These tests cover various edge cases, such as empty strings, multiple suffixes, and strings without the "Collection" suffix, ensuring the methods behave as expected.
ref: #32159
### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #32159