### PR TITLE
fix(tomcat): maxHttpHeaderSize configuration

### DIFF
--- a/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
+++ b/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
@@ -30,6 +30,7 @@
         noCompressionStrongETag="${CMS_NOCOMPRESSIONSTRONGETAG:-false}"
         compressionMinSize="${CMS_COMPRESSION_MIN_SIZE:-128}"
         useSendfile="${CMS_USE_SENDFILE:-false}"
+        maxHttpHeaderSize="${CMS_MAX_HTTP_HEADER_SIZE:-8192}"
     />
 
     <!-- HTTP Connector from upstream proxy
@@ -51,6 +52,7 @@
         noCompressionStrongETag="${CMS_NOCOMPRESSIONSTRONGETAG:-false}"
         compressionMinSize="${CMS_COMPRESSION_MIN_SIZE:-128}"
         useSendfile="${CMS_USE_SENDFILE:-false}"
+        maxHttpHeaderSize="${CMS_MAX_HTTP_HEADER_SIZE:-8192}"
     />
 
     <!-- HTTPS (SSL) Connector from upstream proxy
@@ -73,6 +75,7 @@
         noCompressionStrongETag="${CMS_NOCOMPRESSIONSTRONGETAG:-false}"
         compressionMinSize="${CMS_COMPRESSION_MIN_SIZE:-128}"
         useSendfile="${CMS_USE_SENDFILE:-false}"
+        maxHttpHeaderSize="${CMS_MAX_HTTP_HEADER_SIZE:-8192}"
     />
 
 
@@ -98,6 +101,7 @@
         noCompressionStrongETag="${CMS_NOCOMPRESSIONSTRONGETAG:-false}"
         compressionMinSize="${CMS_COMPRESSION_MIN_SIZE:-128}"
         useSendfile="${CMS_USE_SENDFILE:-false}"
+        maxHttpHeaderSize="${CMS_MAX_HTTP_HEADER_SIZE:-8192}"
         SSLEnabled="${CMS_SSL_ENABLED:-true}"
         SSLCertificateFile="${CMS_SSL_CERTIFICATE_FILE:-/data/shared/assets/certs/local.dotcms.site.pem}"
         SSLCertificateKeyFile="${CMS_SSL_CERTIFICATE_KEY_FILE:-/data/shared/assets/certs/local.dotcms.site-key.pem}"


### PR DESCRIPTION
This pull request updates the `server.xml` configuration file for Tomcat to include a new property, `maxHttpHeaderSize`, across multiple HTTP and HTTPS connectors. This property is set to a default value of 8192 bytes, with the ability to override it using the `CMS_MAX_HTTP_HEADER_SIZE` environment variable.

Key changes to `server.xml`:

* Added `maxHttpHeaderSize="${CMS_MAX_HTTP_HEADER_SIZE:-8192}"` to the HTTP connector configuration.
* Added `maxHttpHeaderSize="${CMS_MAX_HTTP_HEADER_SIZE:-8192}"` to the HTTPS connector configuration. [[1]](diffhunk://#diff-fc87979ef3adacc48c4fb30be5275119e5023899f83079295169cf5195e9de19R55) [[2]](diffhunk://#diff-fc87979ef3adacc48c4fb30be5275119e5023899f83079295169cf5195e9de19R78) [[3]](diffhunk://#diff-fc87979ef3adacc48c4fb30be5275119e5023899f83079295169cf5195e9de19R104)

This PR fixes: #20515