### PR TITLE
fix(glowroot) fixes the TMP directory for glowroot so that it always exists

### DIFF
--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -176,7 +176,7 @@ add_glowroot_agent() {
           fi
           CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.conf.dir=$GLOWROOT_CONF_DIR"
           # We may want to modify these defaults
-          CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.tmp.dir=${GLOWROOT_TMP_DIR:=$CATALINA_TMPDIR}"
+          CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.tmp.dir=${GLOWROOT_TMP_DIR:=/tmp}"
           # Only used if when not using a collector
           CATALINA_OPTS="$CATALINA_OPTS -Dglowroot.data.dir=${GLOWROOT_DATA_DIR:=$GLOWROOT_SHARED_FOLDER/data}"
 


### PR DESCRIPTION
Sets glowroot tmp dir to /tmp


ref: #32183

This PR fixes: #32183