### PR TITLE
implementation (edit content): Enable “Revert” link to disable new content editor and reload old editor modal #32123

### DIFF
--- a/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.spec.ts
@@ -212,6 +212,29 @@ describe('DotContentletService', () => {
         req.flush({ entity: [contenttypeA, contentTypeB] });
     });
 
+    it('should update the content type ', (done) => {
+        const id = 'test-id-123';
+        const payload = { title: 'Updated Content Type', description: 'Updated description' };
+        const contentTypeExpected: DotCMSContentType = {
+            ...dotcmsContentTypeBasicMock,
+            id,
+            title: payload.title,
+            description: payload.description
+        };
+
+        dotContentTypeService
+            .updateContentType(id, payload)
+            .subscribe((contentType: DotCMSContentType) => {
+                expect(contentType).toEqual(contentTypeExpected);
+                done();
+            });
+
+        const req = httpMock.expectOne(`/api/v1/contenttype/id/${id}`);
+        expect(req.request.method).toBe('PUT');
+        expect(req.request.body).toEqual(payload);
+        req.flush({ entity: contentTypeExpected });
+    });
+
     afterEach(() => {
         httpMock.verify();
     });

--- a/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.ts
@@ -158,6 +158,23 @@ export class DotContentTypeService {
             .pipe(pluck('entity'));
     }
 
+    /**
+     * Updates a content type by its ID with the provided payload.
+     *
+     * This method allows updating any property of a content type by sending a partial or full payload.
+     * The payload should match the expected structure for the content type update API.
+     *
+     * @param id The unique identifier of the content type to update.
+     * @param payload The data to update the content type with. This can be a partial or full content type object.
+     * @returns Observable<DotCMSContentType> The updated content type.
+     * @memberof DotContentTypeService
+     */
+    updateContentType(id: string, payload: unknown): Observable<DotCMSContentType> {
+        return this.#httpClient
+            .put<{ entity: DotCMSContentType }>(`/api/v1/contenttype/id/${id}`, payload)
+            .pipe(pluck('entity'));
+    }
+
     private isRecentContentType(type: StructureTypeView): boolean {
         return type.name.startsWith('RECENT');
     }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.html
@@ -30,10 +30,8 @@
                             data-testId="edit-content-layout__beta-message-content">
                             {{ 'edit.content.layout.back.to.old.edit.content' | dm }}
                             <a
-                                [routerLink]="['/content-types-angular/edit', variable]"
-                                [queryParams]="{
-                                    'open-config': 'true'
-                                }"
+                                href="#"
+                                (click)="$event.preventDefault(); $store.disableNewContentEditor()"
                                 data-testId="edit-content-layout__beta-message-link">
                                 {{ 'edit.content.layout.back.to.old.edit.content.switch' | dm }}
                             </a>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.spec.ts
@@ -208,30 +208,6 @@ describe('EditContentLayoutComponent', () => {
                 expect(spectator.query(byTestId('edit-content-layout__beta-message'))).toBeFalsy();
             }));
 
-            // it('should call $store.disableNewContentEditor and prevent default when beta message link is clicked', fakeAsync(() => {
-            //     spectator.detectChanges();
-            //     tick();
-
-            //     const link = spectator.query(byTestId('edit-content-layout__beta-message-link')) as HTMLAnchorElement;
-            //     expect(link).toBeTruthy();
-
-            //     // Spy on the store method
-            //     const disableNewContentEditorSpy = jest.spyOn(store, 'disableNewContentEditor');
-
-            //     // Create a fake event with preventDefault
-            //     const event = new MouseEvent('click');
-            //     Object.defineProperty(event, 'preventDefault', { value: jest.fn() });
-
-            //     // Dispatch the event
-            //     link.dispatchEvent(event);
-
-            //     expect(event.preventDefault).toHaveBeenCalled();
-            //     expect(disableNewContentEditorSpy).toHaveBeenCalled();
-
-            //     // Flush any remaining timers
-            //     tick(1000); // or just tick() or flush() if available
-            // }));
-
             it('should have correct link to old editor', async () => {
                 // Initialize the content type
                 dotContentTypeService.getContentType.mockReturnValue(of(CONTENT_TYPE_MOCK));

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.spec.ts
@@ -132,6 +132,8 @@ describe('EditContentLayoutComponent', () => {
             activeSidebarTab: 0,
             isBetaMessageVisible: true
         });
+
+        dotContentTypeService.updateContentType.mockReturnValue(of(CONTENT_TYPE_MOCK));
     });
 
     it('should have p-confirmDialog component', () => {
@@ -206,6 +208,30 @@ describe('EditContentLayoutComponent', () => {
                 expect(spectator.query(byTestId('edit-content-layout__beta-message'))).toBeFalsy();
             }));
 
+            // it('should call $store.disableNewContentEditor and prevent default when beta message link is clicked', fakeAsync(() => {
+            //     spectator.detectChanges();
+            //     tick();
+
+            //     const link = spectator.query(byTestId('edit-content-layout__beta-message-link')) as HTMLAnchorElement;
+            //     expect(link).toBeTruthy();
+
+            //     // Spy on the store method
+            //     const disableNewContentEditorSpy = jest.spyOn(store, 'disableNewContentEditor');
+
+            //     // Create a fake event with preventDefault
+            //     const event = new MouseEvent('click');
+            //     Object.defineProperty(event, 'preventDefault', { value: jest.fn() });
+
+            //     // Dispatch the event
+            //     link.dispatchEvent(event);
+
+            //     expect(event.preventDefault).toHaveBeenCalled();
+            //     expect(disableNewContentEditorSpy).toHaveBeenCalled();
+
+            //     // Flush any remaining timers
+            //     tick(1000); // or just tick() or flush() if available
+            // }));
+
             it('should have correct link to old editor', async () => {
                 // Initialize the content type
                 dotContentTypeService.getContentType.mockReturnValue(of(CONTENT_TYPE_MOCK));
@@ -218,9 +244,22 @@ describe('EditContentLayoutComponent', () => {
                 await spectator.fixture.whenStable();
                 spectator.detectChanges();
 
-                expect(
-                    spectator.query(byTestId('edit-content-layout__beta-message-link'))
-                ).toExist();
+                // Create a fake event with preventDefault
+                const event = new MouseEvent('click');
+                Object.defineProperty(event, 'preventDefault', { value: jest.fn() });
+
+                // Spy on the store method
+                const disableNewContentEditorSpy = jest.spyOn(store, 'disableNewContentEditor');
+
+                const link = spectator.query(
+                    byTestId('edit-content-layout__beta-message-link')
+                ) as HTMLAnchorElement;
+
+                // Dispatch the event
+                link.dispatchEvent(event);
+
+                expect(event.preventDefault).toHaveBeenCalled();
+                expect(disableNewContentEditorSpy).toHaveBeenCalled();
             });
         });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, inject, model } from '@angular/core';
-import { RouterLink } from '@angular/router';
 
 import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
@@ -34,7 +33,6 @@ import { DotEditContentSidebarComponent } from '../dot-edit-content-sidebar/dot-
         ButtonModule,
         ToastModule,
         MessagesModule,
-        RouterLink,
         DotEditContentFormComponent,
         DotEditContentSidebarComponent,
         ConfirmDialogModule

--- a/core-web/libs/edit-content/src/lib/store/features/content/content.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/content/content.feature.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { createServiceFactory, SpectatorService, SpyObject } from '@ngneat/spectator/jest';
-import { signalStore, withState } from '@ngrx/signals';
+import { signalStore, withState, patchState } from '@ngrx/signals';
 import { of, throwError } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
@@ -384,6 +384,35 @@ describe('ContentFeature', () => {
             tick();
 
             expect(store.initialContentletState()).toBe('reset');
+        }));
+    });
+
+    describe('disableNewContentEditor', () => {
+        const mockContentlet = {
+            inode: '123',
+            stInode: 'st-123',
+            contentType: 'testContentType'
+        } as any;
+
+        beforeEach(() => {
+            // Set up the store to have a contentlet
+            patchState(store, { contentlet: mockContentlet });
+        });
+
+        it('should call updateContentType and navigate to legacy edit page on success', fakeAsync(() => {
+            contentTypeService.updateContentType.mockReturnValue(of(CONTENT_TYPE_MOCK));
+
+            store.disableNewContentEditor();
+            tick();
+
+            expect(contentTypeService.updateContentType).toHaveBeenCalledWith('st-123', {
+                clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
+                name: 'testContentType',
+                metadata: {
+                    CONTENT_EDITOR2_ENABLED: false
+                }
+            });
+            expect(router.navigate).toHaveBeenCalledWith(['/c/content/', '123']);
         }));
     });
 });

--- a/core-web/libs/edit-content/src/lib/store/features/content/content.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/content/content.feature.spec.ts
@@ -400,19 +400,54 @@ describe('ContentFeature', () => {
         });
 
         it('should call updateContentType and navigate to legacy edit page on success', fakeAsync(() => {
-            contentTypeService.updateContentType.mockReturnValue(of(CONTENT_TYPE_MOCK));
+            // Arrange
+            const workflow1 = {
+                archived: false,
+                creationDate: new Date(),
+                defaultScheme: false,
+                description: 'desc',
+                entryActionId: null,
+                id: 'workflow-1',
+                mandatory: false,
+                modDate: new Date(),
+                name: 'Workflow 1',
+                system: false
+            };
+            const workflow2 = {
+                archived: false,
+                creationDate: new Date(),
+                defaultScheme: false,
+                description: 'desc2',
+                entryActionId: null,
+                id: 'workflow-2',
+                mandatory: false,
+                modDate: new Date(),
+                name: 'Workflow 2',
+                system: false
+            };
+            const contentType = {
+                ...CONTENT_TYPE_MOCK,
+                id: 'st-123',
+                workflows: [workflow1, workflow2],
+                metadata: { foo: 'bar', CONTENT_EDITOR2_ENABLED: true }
+            };
+            patchState(store, { contentType });
+            contentTypeService.updateContentType.mockReturnValue(of(contentType));
 
+            // Act
             store.disableNewContentEditor();
             tick();
 
+            // Assert
             expect(contentTypeService.updateContentType).toHaveBeenCalledWith('st-123', {
-                clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
-                name: 'testContentType',
+                ...contentType,
                 metadata: {
+                    ...contentType.metadata,
                     CONTENT_EDITOR2_ENABLED: false
-                }
+                },
+                workflow: contentType.workflows.map((w: any) => w.id)
             });
-            expect(router.navigate).toHaveBeenCalledWith(['/c/content/', '123']);
+            expect(router.navigate).toHaveBeenCalledWith([`/c/content/`, '123']);
         }));
     });
 });

--- a/core-web/libs/edit-content/src/lib/store/features/content/content.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/content/content.feature.ts
@@ -294,27 +294,30 @@ export function withContent() {
                         switchMap(() => {
                             // Access the contentlet from the store and its id before calling the API
                             const contentlet = store.contentlet();
-                            const stInode = contentlet?.stInode;
+                            const contentType = store.contentType();
 
                             const payload = {
-                                clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
-                                name: contentlet?.contentType,
+                                ...contentType,
                                 metadata: {
+                                    ...contentType.metadata,
                                     CONTENT_EDITOR2_ENABLED: false
-                                }
+                                },
+                                workflow: contentType.workflows.map((workflow) => workflow.id) // The Content Types endpoint returns workflows (plural) but receive workflow (singular)
                             };
 
-                            return dotContentTypeService.updateContentType(stInode, payload).pipe(
-                                tapResponse({
-                                    next: () => {
-                                        // Redirect to legacy edit content page
-                                        router.navigate([`/c/content/`, contentlet.inode]);
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        dotHttpErrorManagerService.handle(error);
-                                    }
-                                })
-                            );
+                            return dotContentTypeService
+                                .updateContentType(contentType.id, payload)
+                                .pipe(
+                                    tapResponse({
+                                        next: () => {
+                                            // Redirect to legacy edit content page
+                                            router.navigate([`/c/content/`, contentlet.inode]);
+                                        },
+                                        error: (error: HttpErrorResponse) => {
+                                            dotHttpErrorManagerService.handle(error);
+                                        }
+                                    })
+                                );
                         })
                     )
                 )

--- a/core-web/libs/edit-content/src/lib/store/features/content/content.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/content/content.feature.ts
@@ -280,6 +280,43 @@ export function withContent() {
                             );
                         })
                     )
+                ),
+
+                /**
+                 * Disables the new content editor for the current content type by updating the CONTENT_EDITOR2_ENABLED flag to false in the content type's metadata.
+                 *
+                 * This method retrieves the current contentlet from the store, constructs the appropriate payload, and calls the content type update API.
+                 * On success, it redirects the user to the legacy edit content page for the content type with the configuration panel open.
+                 * On error, it displays an error message using the DotHttpErrorManagerService.
+                 */
+                disableNewContentEditor: rxMethod<void>(
+                    pipe(
+                        switchMap(() => {
+                            // Access the contentlet from the store and its id before calling the API
+                            const contentlet = store.contentlet();
+                            const stInode = contentlet?.stInode;
+
+                            const payload = {
+                                clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
+                                name: contentlet?.contentType,
+                                metadata: {
+                                    CONTENT_EDITOR2_ENABLED: false
+                                }
+                            };
+
+                            return dotContentTypeService.updateContentType(stInode, payload).pipe(
+                                tapResponse({
+                                    next: () => {
+                                        // Redirect to legacy edit content page
+                                        router.navigate([`/c/content/`, contentlet.inode]);
+                                    },
+                                    error: (error: HttpErrorResponse) => {
+                                        dotHttpErrorManagerService.handle(error);
+                                    }
+                                })
+                            );
+                        })
+                    )
                 )
             })
         )


### PR DESCRIPTION
### Proposed Changes
* Enable “Revert” link to disable new content editor and reload old editor modal

### Screenshots

https://github.com/user-attachments/assets/382b59bc-8889-41c1-99c9-0ff06f7bab2d


This PR fixes: #32123