### PR TITLE
fix(content-search): fixed content search by title

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
@@ -366,7 +366,6 @@ dojo.declare(
 
             var fieldVelocityVarName = field['fieldVelocityVarName'];
             var fieldContentlet = field['fieldContentlet'];
-            this.structureVelVar = field['fieldStructureVarName'];
             var value = '';
 
             var type = field['fieldFieldType'];


### PR DESCRIPTION
Closes #31969

### Proposed Changes
* This pull request includes a small change to the `ContentSelector.js` file. The change removes the assignment of the `structureVelVar` property in the `_renderSearchField` method, because it was already set in `_structureDetailsCallback` method after a content type is selected in the search window.
* This assignment removal also avoids setting `structureVelVar` to undefined when `field['fieldStructureVarName']` is not set, that was causing this issue.

This PR fixes: #31969