### PR TITLE
Issue 32186 experiments variants not indexing

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -537,8 +537,10 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
 
         Logger.info(this,
-                "Indexing: " + parentContenlet.getIdentifier() + " : " + parentContenlet.getTitle()
-                        + ", includeDependencies: " + includeDependencies +
+                "Indexing: ContentletIdentifier:" + parentContenlet.getIdentifier() + " " +
+                        "ContentletInode: " + parentContenlet.getInode() + " " +
+                        "ContentletTitle: " + parentContenlet.getTitle() + " " +
+                        ", includeDependencies: " + includeDependencies +
                         ", policy: " + parentContenlet.getIndexPolicy());
 
         final List<Contentlet> contentToIndex = includeDependencies

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1376,29 +1376,48 @@ public class ESContentletAPIImpl implements ContentletAPI {
     public List<Contentlet> search(String luceneQuery, int limit, int offset, String sortBy,
             User user, boolean respectFrontendRoles, int requiredPermission)
             throws DotDataException, DotSecurityException {
+        Logger.debug(this, "search - search: " + luceneQuery);
+        Logger.debug(this, "search - limit: " + limit);
+        Logger.debug(this, "search - offset: " + offset);
+        Logger.debug(this, "search - sortBy: " + sortBy);
+        Logger.debug(this, "search - user: " + user);
+        Logger.debug(this, "search - respectFrontendRoles: " + respectFrontendRoles);
+        Logger.debug(this, "search - requiredPermission: " + requiredPermission);
+
         PaginatedArrayList<Contentlet> contents = new PaginatedArrayList<>();
         ArrayList<String> inodes = new ArrayList<>();
 
         PaginatedArrayList<ContentletSearch> list = (PaginatedArrayList) searchIndex(luceneQuery,
                 limit, offset, sortBy, user, respectFrontendRoles);
         contents.setTotalResults(list.getTotalResults());
+        Logger.debug(this, "search - list size: " + contents.getTotalResults());
         for (ContentletSearch conwrap : list) {
-
             inodes.add(conwrap.getInode());
+            Logger.debug(this, "search - inode Added: " + conwrap.getInode());
         }
 
+        Logger.debug(this, "search - inodes: " + inodes);
         List<Contentlet> contentlets = findContentlets(inodes);
+        Logger.debug(this, "search - contentlets size: " + contentlets.size());
+        Logger.debug(this, "search - contentlets: " + contentlets);
         Map<String, Contentlet> map = new HashMap<>(contentlets.size());
         for (Contentlet contentlet : contentlets) {
+            Logger.debug(this, "search - contentlet: " + contentlet);
+            Logger.debug(this, "search - contentlet inode: " + contentlet.getInode());
             map.put(contentlet.getInode(), contentlet);
+            Logger.debug(this, "search - map size: " + map.size());
         }
+        Logger.debug(this, "search - map: " + map);
         for (String inode : inodes) {
+            Logger.debug(this, "search - inode: " + inode);
             if (map.get(inode) != null) {
+                Logger.debug(this, "search - map.get(inode): " + map.get(inode));
                 contents.add(map.get(inode));
+                Logger.debug(this, "search - contents size: " + contents.size());
             }
         }
+        Logger.debug(this, "search - contents: " + contents);
         return contents;
-
     }
 
     @Override
@@ -1485,14 +1504,22 @@ public class ESContentletAPIImpl implements ContentletAPI {
             throws DotDataException, DotStateException,
             DotSecurityException {
 
+        Logger.debug(this, "Experiments - getAllContentByVariants: " + Arrays.toString(variantNames));
+
         final String queryWithoutParenthesis = Arrays.stream(variantNames)
                 .map((variant) -> "variant:" + variant)
                 .collect(Collectors.joining(" OR "));
 
         final String query = "+(" + queryWithoutParenthesis + ")";
 
-        return search(query, -1, 0, null,
+        Logger.debug(this, "Experiments - getAllContentByVariants: query: " + query);
+
+        final List<Contentlet> search = search(query, -1, 0, null,
                 user, respectFrontendRoles);
+
+        Logger.debug(this, "Experiments - getAllContentByVariants: search: " + search);
+
+        return search;
     }
 
     @Override
@@ -4889,6 +4916,10 @@ public class ESContentletAPIImpl implements ContentletAPI {
             try {
                 publish(contentlet, user, respectFrontendRoles);
             } catch (DotContentletStateException e) {
+                stateError = true;
+            } catch (Exception e){
+                Logger.debug(this.getClass(),
+                        "Unable to publish one contentlet because ",e);
                 stateError = true;
             }
         }

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsAPIImpl.java
@@ -818,14 +818,19 @@ public class ExperimentsAPIImpl implements ExperimentsAPI, EventSubscriber<Syste
             final boolean generateNewRunId)
             throws DotSecurityException, DotDataException {
 
+        Logger.debug(this, "Starting experiment with id: " + persistedExperiment.id().get() +", by User: " + user.getUserId() + ", and generating new runId: " + generateNewRunId);
         final Experiment experimentToSave = generateNewRunId
                 ? Experiment.builder().from(persistedExperiment).runningIds(getRunningIds(persistedExperiment)).build()
                 : persistedExperiment;
 
         final Experiment running = save(experimentToSave, user);
+        Logger.debug(this, "Experiment with id: " + running.id().get() + " has been saved");
         cleanRunningExperimentsCache();
+        Logger.debug(this, "Running experiments cache has been cleaned");
         publishExperimentPage(running, user);
+        Logger.debug(this, "Experiment page has been published");
         publishContentOnExperimentVariants(user, running);
+        Logger.debug(this, "Experiment content has been published");
 
         SecurityLogger.logInfo(
                 this.getClass(),
@@ -860,13 +865,35 @@ public class ExperimentsAPIImpl implements ExperimentsAPI, EventSubscriber<Syste
             final Experiment runningExperiment)
             throws DotDataException, DotSecurityException {
 
-        final List<Contentlet> contentByVariants = contentletAPI.getAllContentByVariants(user, false,
-                runningExperiment.trafficProportion().variants().stream()
-                        .map(ExperimentVariant::id).filter(id -> !id.equals(DEFAULT_VARIANT.name()))
-                        .toArray(String[]::new)).stream()
-                        .filter((contentlet -> Try.of(contentlet::isWorking)
-                                .getOrElse(false))).collect(Collectors.toList());
+        final List<String> variantIds = new ArrayList<>();
+        final SortedSet<ExperimentVariant> variants = runningExperiment.trafficProportion().variants();
+        Logger.debug(this,"Variants: " + variants);
+        for (final ExperimentVariant variant : variants) {
+            if (!variant.id().equals(DEFAULT_VARIANT.name())) {
+                variantIds.add(variant.id());
+                Logger.debug(this,"Added Variant Id: " + variant.id());
+            }
+        }
 
+        final String[] variantIdArray = variantIds.toArray(new String[0]);
+
+        final List<Contentlet> allVariants = contentletAPI.getAllContentByVariants(user, false, variantIdArray);
+        Logger.debug(this,"All Variants: " + allVariants);
+
+        final List<Contentlet> contentByVariants = new ArrayList<>();
+        for (final Contentlet contentlet : allVariants) {
+            boolean isWorking = false;
+            try {
+                isWorking = contentlet.isWorking();
+            } catch (Exception e) {
+                Logger.debug(this,"Error getting isWorking for contentlet: " + contentlet.getIdentifier());
+            }
+            if (isWorking) {
+                contentByVariants.add(contentlet);
+                Logger.debug(this,"Added Variant Id: " + contentlet.getIdentifier());
+            }
+        }
+        Logger.debug(this,"Variants That Will Be Published: " + contentByVariants);
         contentletAPI.publish(contentByVariants, user, false);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -40,6 +40,7 @@ import com.dotmarketing.portlets.contentlet.business.DotContentletStateException
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
+import com.dotmarketing.portlets.contentlet.model.IndexPolicy;
 import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI;
 import com.dotmarketing.portlets.htmlpageasset.business.render.HTMLPageAssetNotFoundException;
 import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
@@ -338,6 +339,7 @@ public class PageResourceHelper implements Serializable {
         final Contentlet checkout = APILocator.getContentletAPI()
                 .checkout(pageInode, user, false);
         checkout.setVariantId(currentVariantId);
+        checkout.setIndexPolicy(IndexPolicy.FORCE);
         final Contentlet checkin = APILocator.getContentletAPI()
                 .checkin(checkout, user, false);
 


### PR DESCRIPTION
This pull request introduces several logging enhancements and minor functional updates across multiple classes to improve debugging and ensure better traceability of operations. The most notable changes include adding detailed debug logs to key methods, refining error handling during content publishing, and enforcing index policies in content versioning.

### Logging Enhancements:
* Added extensive debug logging in `search` to trace query parameters, intermediate results, and final outputs in `ESContentletAPIImpl.java`.
* Introduced debug logs in `getAllContentByVariants` to log variant queries and search results in `ESContentletAPIImpl.java`.
* Enhanced logging in `publishContentOnExperimentVariants` to log variant processing and publishing details in `ExperimentsAPIImpl.java`.
* Added debug logs to track the lifecycle of experiments, including saving, cache cleaning, and content publishing in `innerStart` of `ExperimentsAPIImpl.java`.

### Functional Updates:
* Improved error handling in the `publish` method by catching generic exceptions and logging the issue in `ESContentletAPIImpl.java`.
* Enforced `IndexPolicy.FORCE` during content version creation to ensure consistent indexing in `PageResourceHelper.java`.

### Minor Update:
* Added an import for `IndexPolicy` in `PageResourceHelper.java` to support the new indexing functionality.

This PR fixes: #32186