### PR TITLE
Update GitHub labels option is turned on by default

### DIFF
--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -26,7 +26,7 @@ on:
       update_github_labels:
         description: 'Update GitHub labels'
         type: boolean
-        default: false
+        default: true
         required: false
       notify_slack:
         description: 'Notify Slack'


### PR DESCRIPTION
### Proposed Changes
The flag to update GitHub labels is enabled by default. It makes the generation process easier

