### PR TITLE
fix(core): Adding back support of Bring Back Version feature in Container's portlet

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
@@ -33,10 +33,7 @@ const PORTLETS_ANGULAR: Route[] = [
         loadChildren: () =>
             import('@dotcms/app/portlets/dot-containers/dot-containers.module').then(
                 (m) => m.DotContainersModule
-            ),
-        data: {
-            reuseRoute: false
-        }
+            )
     },
     {
         path: 'categories',

--- a/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/app-routing.module.ts
@@ -33,7 +33,10 @@ const PORTLETS_ANGULAR: Route[] = [
         loadChildren: () =>
             import('@dotcms/app/portlets/dot-containers/dot-containers.module').then(
                 (m) => m.DotContainersModule
-            )
+            ),
+        data: {
+            reuseRoute: false
+        }
     },
     {
         path: 'categories',

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.html
@@ -1,3 +1,6 @@
 <dot-portlet-box>
-    <dot-iframe [src]="historyUrl" data-testId="historyIframe"></dot-iframe>
+    <dot-iframe
+        [src]="historyUrl"
+        data-testId="historyIframe"
+        (custom)="onCustomEvent($event)"></dot-iframe>
 </dot-portlet-box>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.html
@@ -1,6 +1,3 @@
 <dot-portlet-box>
-    <dot-iframe
-        [src]="historyUrl"
-        data-testId="historyIframe"
-        (custom)="onCustomEvent($event)"></dot-iframe>
+    <dot-iframe [src]="historyUrl" data-testId="historyIframe" (custom)="onCustomEvent($event)" />
 </dot-portlet-box>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.spec.ts
@@ -1,8 +1,18 @@
-import { Component, DebugElement, ElementRef, Input, ViewChild } from '@angular/core';
+import {
+    Component,
+    DebugElement,
+    ElementRef,
+    EventEmitter,
+    Input,
+    Output,
+    ViewChild
+} from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
+import { DotRouterService } from '@dotcms/data-access';
+import { MockDotRouterService } from '@dotcms/utils-testing';
 
 import { DotContainerHistoryComponent } from './dot-container-history.component';
 
@@ -12,6 +22,7 @@ import { DotContainerHistoryComponent } from './dot-container-history.component'
 })
 export class IframeMockComponent {
     @Input() src: string;
+    @Output() custom: EventEmitter<CustomEvent> = new EventEmitter();
     @ViewChild('iframeElement') iframeElement: ElementRef;
 }
 
@@ -29,11 +40,18 @@ describe('ContainerHistoryComponent', () => {
     let hostComponent: DotTestHostComponent;
     let fixture: ComponentFixture<DotTestHostComponent>;
     let de: DebugElement;
+    let dotRouterService: DotRouterService;
 
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             declarations: [DotContainerHistoryComponent, IframeMockComponent, DotTestHostComponent],
-            imports: [DotPortletBoxModule]
+            imports: [DotPortletBoxModule],
+            providers: [
+                {
+                    provide: DotRouterService,
+                    useValue: new MockDotRouterService()
+                }
+            ]
         }).compileComponents();
 
         fixture = TestBed.createComponent(DotTestHostComponent);
@@ -41,6 +59,8 @@ describe('ContainerHistoryComponent', () => {
         hostComponent = fixture.componentInstance;
         hostComponent.containerId = '123';
         fixture.detectChanges();
+
+        dotRouterService = TestBed.inject(DotRouterService);
     });
 
     it('should create', () => {
@@ -55,6 +75,25 @@ describe('ContainerHistoryComponent', () => {
             expect(permissions.componentInstance.src).toBe(
                 '/html/containers/push_history.jsp?containerId=123&popup=true'
             );
+        });
+    });
+
+    describe('onCustomEvent', () => {
+        it('should call the service method when dotDialog emits custom output', () => {
+            const historyIframe: IframeMockComponent = de.query(
+                By.css('[data-testId="historyIframe"]')
+            ).componentInstance;
+
+            const customEvent = new CustomEvent('custom', {
+                detail: {
+                    data: { id: '456' },
+                    name: 'bring-back-version'
+                }
+            });
+
+            historyIframe.custom.emit(customEvent);
+
+            expect(dotRouterService.goToEditContainer).toHaveBeenCalledWith('456');
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.spec.ts
@@ -5,6 +5,8 @@ import { By } from '@angular/platform-browser';
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
 
 import { DotContainerHistoryComponent } from './dot-container-history.component';
+import { DotRouterService } from '@dotcms/data-access';
+import { MockDotRouterService } from '@dotcms/utils-testing';
 
 @Component({
     selector: 'dot-iframe',
@@ -33,7 +35,8 @@ describe('ContainerHistoryComponent', () => {
     beforeEach(async () => {
         await TestBed.configureTestingModule({
             declarations: [DotContainerHistoryComponent, IframeMockComponent, DotTestHostComponent],
-            imports: [DotPortletBoxModule]
+            imports: [DotPortletBoxModule],
+            providers: [{ provide: DotRouterService, useClass: MockDotRouterService }]
         }).compileComponents();
 
         fixture = TestBed.createComponent(DotTestHostComponent);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.spec.ts
@@ -3,10 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { DotPortletBoxModule } from '@components/dot-portlet-base/components/dot-portlet-box/dot-portlet-box.module';
-
-import { DotContainerHistoryComponent } from './dot-container-history.component';
 import { DotRouterService } from '@dotcms/data-access';
 import { MockDotRouterService } from '@dotcms/utils-testing';
+
+import { DotContainerHistoryComponent } from './dot-container-history.component';
 
 @Component({
     selector: 'dot-iframe',

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-history/dot-container-history.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, OnChanges, ViewChild } from '@angular/core';
+import { Component, inject, Input, OnChanges, ViewChild } from '@angular/core';
 
 import { IframeComponent } from '@components/_common/iframe/iframe-component';
+import { DotRouterService } from '@dotcms/data-access';
 
 @Component({
     selector: 'dot-container-history',
@@ -10,12 +11,22 @@ import { IframeComponent } from '@components/_common/iframe/iframe-component';
 export class DotContainerHistoryComponent implements OnChanges {
     @Input() containerId: string;
     @ViewChild('historyIframe') historyIframe: IframeComponent;
-    historyUrl = '/html/containers/push_history.jsp';
+
+    protected historyUrl = '/html/containers/push_history.jsp';
+    private readonly dotRouterService = inject(DotRouterService);
 
     ngOnChanges(): void {
         this.historyUrl = `/html/containers/push_history.jsp?containerId=${this.containerId}&popup=true`;
         if (this.historyIframe) {
             this.historyIframe.iframeElement.nativeElement.contentWindow.location.reload();
+        }
+    }
+
+    onCustomEvent($event: CustomEvent): void {
+        const { data, name } = $event.detail;
+
+        if (name === 'bring-back-version') {
+            this.dotRouterService.goToEditContainer(data.id);
         }
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-containers-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-containers-routing.module.ts
@@ -24,7 +24,8 @@ const routes: Routes = [
             ),
         resolve: {
             container: DotContainerEditResolver
-        }
+        },
+        runGuardsAndResolvers: 'always'
     }
 ];
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-containers-routing.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-containers-routing.module.ts
@@ -25,6 +25,9 @@ const routes: Routes = [
         resolve: {
             container: DotContainerEditResolver
         },
+        data: {
+            reuseRoute: false
+        },
         runGuardsAndResolvers: 'always'
     }
 ];

--- a/core-web/libs/utils-testing/src/lib/dot-router-service.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-router-service.mock.ts
@@ -67,6 +67,7 @@ export class MockDotRouterService {
     goToEditTemplate = jasmine.createSpy('goToEditTemplate');
     allowRouteDeactivation = jasmine.createSpy('allowRouteDeactivation');
     forbidRouteDeactivation = jasmine.createSpy('forbidRouteDeactivation');
+    goToEditContainer = jasmine.createSpy('goToEditContainer');
     isEditPage() {
         /* */
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/container/ContainerResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/container/ContainerResource.java
@@ -740,36 +740,39 @@ public class ContainerResource implements Serializable {
                 () -> "Updating container. Request payload is : " + JsonUtil.getJsonStringFromObject(
                         containerForm));
 
-            container.setInode(StringPool.BLANK);
-            container.setCode(containerForm.getCode());
-            container.setMaxContentlets(containerForm.getMaxContentlets());
-            container.setNotes(containerForm.getNotes());
-            container.setPreLoop(containerForm.getPreLoop());
-            container.setPostLoop(containerForm.getPostLoop());
-            container.setSortContentletsBy(containerForm.getSortContentletsBy());
-            container.setStaticify(containerForm.isStaticify());
-            container.setUseDiv(containerForm.isUseDiv());
-            container.setFriendlyName(containerForm.getFriendlyName());
-            container.setModDate(new Date());
-            container.setModUser(user.getUserId());
-            container.setOwner(user.getUserId());
-            container.setShowOnMenu(containerForm.isShowOnMenu());
-            container.setTitle(containerForm.getTitle());
+        Container newContainerVersion = new Container();
+        newContainerVersion.setIdentifier(containerForm.getIdentifier());
+        newContainerVersion.setCode(containerForm.getCode());
+        newContainerVersion.setMaxContentlets(containerForm.getMaxContentlets());
+        newContainerVersion.setNotes(containerForm.getNotes());
+        newContainerVersion.setPreLoop(containerForm.getPreLoop());
+        newContainerVersion.setPostLoop(containerForm.getPostLoop());
+        newContainerVersion.setSortContentletsBy(containerForm.getSortContentletsBy());
+        newContainerVersion.setStaticify(containerForm.isStaticify());
+        newContainerVersion.setUseDiv(containerForm.isUseDiv());
+        newContainerVersion.setFriendlyName(containerForm.getFriendlyName());
+        newContainerVersion.setModDate(new Date());
+        newContainerVersion.setModUser(user.getUserId());
+        newContainerVersion.setOwner(user.getUserId());
+        newContainerVersion.setShowOnMenu(containerForm.isShowOnMenu());
+        newContainerVersion.setTitle(containerForm.getTitle());
 
-            if (containerForm.getMaxContentlets() == 0) {
-                container.setCode(containerForm.getCode());
-            }
+        if (containerForm.getMaxContentlets() == 0) {
+            newContainerVersion.setCode(containerForm.getCode());
+        }
 
-            this.containerAPI.save(container, containerForm.getContainerStructures(), host, user,
-                    pageMode.respectAnonPerms);
+        newContainerVersion.setLuceneQuery(container.getLuceneQuery());
+
+        this.containerAPI.save(newContainerVersion, containerForm.getContainerStructures(), host, user,
+                pageMode.respectAnonPerms);
 
         ActivityLogger.logInfo(this.getClass(),
                 "Update Container: " + containerForm.getIdentifier(),
                 getInfoMessage(user,
-                        MessageConstants.SAVED + container.getTitle()),
+                        MessageConstants.SAVED + newContainerVersion.getTitle()),
                 host.getHostname());
 
-        return Response.ok(new ResponseEntityView(new ContainerView(container))).build();
+        return Response.ok(new ResponseEntityView(new ContainerView(newContainerVersion))).build();
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerCacheImpl.java
@@ -30,10 +30,8 @@ public class ContainerCacheImpl extends ContainerCache {
       return container;
     }
 
-    key = primaryGroup + key;
-
     // Add the key to the cache
-    cache.put(key, container, primaryGroup);
+    cache.put(primaryGroup + key, container, primaryGroup);
 
     return container;
   }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/containers/business/ContainerFactoryImpl.java
@@ -89,7 +89,7 @@ public class ContainerFactoryImpl implements ContainerFactory {
 			container = TransformerLocator.createContainerTransformer(containerResults).findFirst();
 
 			if(container != null && container.getInode() != null) {
-				containerCache.add(inode, container);
+				containerCache.add(container.getInode(), container);
 			}
 		}
 

--- a/dotCMS/src/main/webapp/html/containers/push_history.jsp
+++ b/dotCMS/src/main/webapp/html/containers/push_history.jsp
@@ -18,7 +18,7 @@
     final String containerId = httpServletRequest.getParameter("containerId");
     Container container =  APILocator.getContainerAPI().getWorkingContainerById(containerId, user, true);
     request.setAttribute(com.dotmarketing.util.WebKeys.VERSIONS_INODE_EDIT, container);
-    request.setAttribute("hideBringBack", true);
+    request.setAttribute("hideBringBack", false);
 %>
 	<%@ include file="/html/portlet/ext/common/edit_versions_inc.jsp" %>
 
@@ -43,4 +43,37 @@
 		});
 		document.dispatchEvent(customEvent);
 	}
+
+    let isBringBack = false;
+    function bringBackTemplateVersion(inode){
+        if(!isBringBack && confirm('<%=UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "folder.replace.container.working.version"))%>')){
+            setIsBringBack(true);
+            fetch(`/api/v1/versionables/${inode}/_bringback`, {
+                method: 'PUT'
+            })
+            .then(response => response.json())
+            .then(({ entity }) => {
+                const customEvent = document.createEvent('CustomEvent');
+                customEvent.initCustomEvent('ng-event', false, false, {
+                    name: 'bring-back-version',
+                    data: {
+                        id: entity.versionId,
+                        inode: entity.inode,
+                        type: 'container'
+                    }
+                })
+                document.dispatchEvent(customEvent);
+            })
+            .catch((error) => {
+                console.error('Error bringing back version: ', error);
+            })
+            .finally(() => setIsBringBack(false));
+        }
+    }
+
+    function setIsBringBack(isBringBack){
+        const element = document.querySelector("[data-messageId='bring-back-message']");
+        element.style.display = isBringBack ? 'flex' : 'none';
+        isBringBack = isBringBack
+    }
 </script>

--- a/dotCMS/src/main/webapp/html/containers/push_history.jsp
+++ b/dotCMS/src/main/webapp/html/containers/push_history.jsp
@@ -45,15 +45,19 @@
 	}
 
     let isBringBack = false;
+    const message = '<%=UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "folder.replace.container.working.version"))%>'
     function bringBackTemplateVersion(inode){
-        if(!isBringBack && confirm('<%=UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "folder.replace.container.working.version"))%>')){
+        if(!isBringBack && confirm(message)){
+
             setIsBringBack(true);
+
             fetch(`/api/v1/versionables/${inode}/_bringback`, {
                 method: 'PUT'
             })
             .then(response => response.json())
             .then(({ entity }) => {
                 const customEvent = document.createEvent('CustomEvent');
+
                 customEvent.initCustomEvent('ng-event', false, false, {
                     name: 'bring-back-version',
                     data: {
@@ -62,12 +66,20 @@
                         type: 'container'
                     }
                 })
+
                 document.dispatchEvent(customEvent);
+
+
+
             })
             .catch((error) => {
                 console.error('Error bringing back version: ', error);
             })
-            .finally(() => setIsBringBack(false));
+            .finally(() => {
+                setIsBringBack(false)
+                // Redirect in the top window
+                window.top.location.href = `/dotAdmin/#/containers`;
+            });
         }
     }
 

--- a/dotCMS/src/main/webapp/html/containers/push_history.jsp
+++ b/dotCMS/src/main/webapp/html/containers/push_history.jsp
@@ -46,7 +46,7 @@
 
     let isBringBack = false;
     const message = '<%=UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "folder.replace.container.working.version"))%>'
-    function bringBackTemplateVersion(inode){
+    function bringBackVersion(inode){
         if(!isBringBack && confirm(message)){
 
             setIsBringBack(true);

--- a/dotCMS/src/main/webapp/html/containers/push_history.jsp
+++ b/dotCMS/src/main/webapp/html/containers/push_history.jsp
@@ -56,10 +56,9 @@
             })
             .then(response => response.json())
             .then(({ entity }) => {
-                const customEvent = document.createEvent('CustomEvent');
-
-                customEvent.initCustomEvent('ng-event', false, false, {
-                    name: 'bring-back-version',
+				const customEvent = document.createEvent('CustomEvent');
+				customEvent.initCustomEvent('ng-event', false, false, {
+					name: 'bring-back-version',
                     data: {
                         id: entity.versionId,
                         inode: entity.inode,
@@ -68,18 +67,11 @@
                 })
 
                 document.dispatchEvent(customEvent);
-
-
-
             })
             .catch((error) => {
                 console.error('Error bringing back version: ', error);
             })
-            .finally(() => {
-                setIsBringBack(false)
-                // Redirect in the top window
-                window.top.location.href = `/dotAdmin/#/containers`;
-            });
+            .finally(() => setIsBringBack(false));
         }
     }
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/common/edit_versions_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/common/edit_versions_inc.jsp
@@ -149,7 +149,7 @@
 						<a  href="javascript: deleteVersion('<%= vinode%>');"><%= LanguageUtil.get(pageContext, "Delete") %></a>
 					<% } %>
 					<% if(!hideBringBack) { %>
-						 - <a  href="javascript: bringBackTemplateVersion('<%= vinode %>');"><%= LanguageUtil.get(pageContext, "Bring-Back") %></a>
+						 - <a  href="javascript: bringBackVersion('<%= vinode %>');"><%= LanguageUtil.get(pageContext, "Bring-Back") %></a>
 					<%}%>
 				<% } %>
 			<% } else { %>

--- a/dotCMS/src/main/webapp/html/templates/push_history.jsp
+++ b/dotCMS/src/main/webapp/html/templates/push_history.jsp
@@ -45,7 +45,7 @@
 	}
 
 	let isBringBack = false;
-	function bringBackTemplateVersion(inode){
+	function bringBackVersion(inode){
 		if(!isBringBack && confirm('<%=UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "folder.replace.template.working.version"))%>')){
 			setIsBringBack(true);
 			fetch(`/api/v1/versionables/${inode}/_bringback`, {


### PR DESCRIPTION
### Proposed Changes
* The Bring Back version feature was removed from containers after a refactor made [here](https://github.com/dotCMS/core/issues/19087). These changes add it back. The functionality was removed in 2021.
* An additional fix was included in the `ContainerResource.update()`. The logic was making changes in the object in the cache instead of using a new container instance, which was messing up the cache
* The `bringBackTemplateVersion` method was renamed to `bringBackVersion` as it is used by templates and containers too.

### Video


https://github.com/user-attachments/assets/1df72de1-af65-432c-bedc-37ab18e4a22d



Refs: #32127 

This PR fixes: #32127