### PR TITLE
fix(deployment): Issue 32209 cicd build fails due to incorrect nodejs version.

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -59,8 +59,8 @@ runs:
       run: |
         echo "::group::Adding node and yarn to the PATH env"
         BASE_PATH=${{ github.workspace }}/installs
-        ls -R $BASE_PATH
-        echo "PATH=$PATH:${BASE_PATH}/node/:${BASE_PATH}/node/yarn/dist/bin" >> $GITHUB_ENV
+        ls -Rla ${BASE_PATH}/node
+        echo "PATH=${BASE_PATH}/node:${BASE_PATH}/node/yarn/dist/bin:$PATH" >> $GITHUB_ENV
         echo "::endgroup::"
       shell: bash
 


### PR DESCRIPTION
## Proposed Changes

* This pull request includes a minor update to the `.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml` file. The change improves the debugging output and adjusts the order of the `PATH` environment variable update.

* [`.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml`](diffhunk://#diff-b47e2bc3507c79547b7f53206919f60585f49479fa09c01ee9ab15eb6bb4c068L62-R63): Updated the `run` script to use `ls -Rla` for more detailed directory listings and reordered the `PATH` modification to ensure the new paths are prioritized.

## Fixes
#32209

This PR fixes: #32209