### PR TITLE
chore: add nx.clean option to maven build

### DIFF
--- a/core-web/pom.xml
+++ b/core-web/pom.xml
@@ -30,6 +30,7 @@
         <git.origin.branch>origin/main</git.origin.branch>
         <nx.affected.options>--base=${git.origin.branch} --head=HEAD</nx.affected.options>
         <pretty.quick.options>--branch=${git.origin.branch}</pretty.quick.options>
+        <skip.nx.reset.execution>true</skip.nx.reset.execution>
     </properties>
 
     <dependencies>
@@ -195,6 +196,18 @@
                             <arguments>run nx run-many -t test --exclude='tag:skip:test'</arguments>
                         </configuration>
                     </execution>
+
+                    <execution>
+                        <id>nx-reset</id>
+                        <goals>
+                            <goal>yarn</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <arguments>exec nx reset</arguments>
+                            <skip>${skip.nx.reset.execution}</skip>
+                        </configuration>
+                    </execution>
                 </executions>
 
             </plugin>
@@ -303,6 +316,18 @@
                 <yarn.install.cmd>--frozen-lockfile --prefer-offline</yarn.install.cmd>
             </properties>
             <build/>
+        </profile>
+
+        <profile>
+            <id>do-nx-reset</id>
+            <activation>
+                <property>
+                    <name>nx.reset</name>
+                </property>
+            </activation>
+            <properties>
+                <skip.nx.reset.execution>false</skip.nx.reset.execution>
+            </properties>
         </profile>
 
         <profile>

--- a/justfile
+++ b/justfile
@@ -46,6 +46,18 @@ build-quicker:
 build-prod:
     ./mvnw -DskipTests clean install -Pprod
 
+# Builds core-web module
+build-core-web:
+    ./mvnw clean install -pl :dotcms-core-web -am -DskipTests
+
+# Builds core-web module with Nx cache reset
+build-core-web-reset-nx:
+    ./mvnw clean install -pl :dotcms-core-web -am -DskipTests -Dnx.reset
+
+# Builds core-web module with Nx cache reset
+build-test-core-web:
+    ./mvnw clean install -pl :dotcms-core-web -am
+
 # Runs a comprehensive test suite including core integration and postman tests, suitable for final validation
 build-test-full:
     ./mvnw clean install -Dcoreit.test.skip=false -Dpostman.test.skip=false -Dkarate.test.skip=false


### PR DESCRIPTION
- Add the -Dnx.reset option in maven to run a full nx reset before any build in case there are issues
- Add examples in justfile


When the option is passed when the core-web module is run with verify target or higher you will get

```
[INFO] --- frontend:1.12.1:yarn (config yarn registry) @ dotcms-core-web ---
[INFO] Running 'yarn config set registry https://dotcms-npm.b-cdn.net' in /Users/stevebolton/git/core-baseline/core-web
[INFO] yarn config v1.22.19
[INFO] warning ../../package.json: No license field
[INFO] success Set "registry" to "https://dotcms-npm.b-cdn.net".
[INFO] Done in 0.03s.
[INFO] 
[INFO] --- frontend:1.12.1:yarn (nx-reset) @ dotcms-core-web ---
[INFO] Running 'yarn exec nx reset' in /Users/stevebolton/git/core-baseline/core-web
[INFO] yarn exec v1.22.19
[INFO] warning ../../package.json: No license field
[INFO] 
[INFO]  NX   Resetting the Nx cache and stopping the daemon.
[INFO] 
[INFO] 
[INFO] 
[INFO]  NX   Successfully reset the Nx workspace.
[INFO] 
[INFO] Done in 1.00s.

```


This PR fixes: #32264