### PR TITLE
chore: #32269 Update the parent pom to empty_20250528.

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,7 +76,7 @@
         <docker.jacoco.skip>true</docker.jacoco.skip>
         <!-- starter -->
         <starter.download.folder>${project.build.directory}/starter</starter.download.folder>
-        <starter.deploy.version>empty_20241105</starter.deploy.version>
+        <starter.deploy.version>empty_20250528</starter.deploy.version>
         <starter.deploy.filename>starter.zip</starter.deploy.filename>
         <starter.run.version>${starter.deploy.version}</starter.run.version>
         <starter.run.filename>starter-${starter.run.version}.zip</starter.run.filename>


### PR DESCRIPTION
### Proposed Changes

This pull request updates the `starter.deploy.version` property in the `parent/pom.xml` file to reflect a new deployment version.

* [`parent/pom.xml`](diffhunk://#diff-b5a06276719e759fe07dfe6f75d781be5f83d2215179d82bdb195ad035348214L79-R79): Updated the `starter.deploy.version` from `empty_20241105` to `empty_20250528` to align with the new deployment version.

### Related Issue
#32269 
