### PR TITLE
fix(graphql): block editor field for urlcontentmap is a json string instead of an object #31921 

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -107,7 +107,7 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
      *
      * @param hydratedMap the map to enrich
      */
-    private void enrichWithParsedRawFields(Map<String, Object> hydratedMap) {
+    private void enrichWithParsedRawFields(final Map<String, Object> hydratedMap) {
         final ObjectMapper objectMapper = new ObjectMapper();
         for (Map.Entry<String, Object> entry : new HashMap<>(hydratedMap).entrySet()) {
             final String mapKey = entry.getKey();

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -91,6 +91,8 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             HashMap<String,Object> result = new ObjectMapper().readValue(jsonWithRels.toString(), HashMap.class);
             hydratedMap.putAll(result);
 
+            enrichWithParsedRawFields(hydratedMap);
+
             return hydratedMap;
 
         } catch (Exception e) {
@@ -98,6 +100,35 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             throw e;
         }
     }
+
+    /**
+     * Detects *_raw fields in the hydrated map and parses them as JSON if a base key exists.
+     * Adds the parsed value under the base key only if it was already defined.
+     *
+     * @param hydratedMap the map to enrich
+     */
+    private void enrichWithParsedRawFields(Map<String, Object> hydratedMap) {
+        final ObjectMapper objectMapper = new ObjectMapper();
+        for (Map.Entry<String, Object> entry : new HashMap<>(hydratedMap).entrySet()) {
+            final String mapKey = entry.getKey();
+            final Object rawValue = entry.getValue();
+
+            if (mapKey.endsWith("_raw") && rawValue instanceof String) {
+                final String baseKey = mapKey.substring(0, mapKey.length() - 4);
+
+                if (hydratedMap.containsKey(baseKey)) {
+                    try {
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> parsed = objectMapper.readValue((String) rawValue, Map.class);
+                        hydratedMap.put(baseKey, parsed);
+                    } catch (Exception e) {
+                        Logger.warn(this, () -> "Error parsing JSON for '" + mapKey + "': " + e.getMessage());
+                    }
+                }
+            }
+        }
+    }
+
 
     private Object getRenderedFieldValue(final HttpServletRequest request,
             final HttpServletResponse response, final Contentlet contentlet,

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
@@ -60,6 +60,7 @@ import org.junit.runners.Suite.SuiteClasses;
         com.dotcms.uuid.shorty.ShortyIdApiTest.class,
         DotGraphQLHttpServletTest.class,
         com.dotcms.graphql.datafetcher.page.VanityURLFetcherTest.class,
+        com.dotcms.graphql.datafetcher.page.ContentMapDataFetcherTest.class,
         com.dotcms.graphql.datafetcher.page.RunningExperimentFetcherTest.class,
         com.dotcms.graphql.datafetcher.CategoryFieldDataFetcherTest.class,
         com.dotcms.rest.TagResourceIntegrationTest.class,

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
@@ -60,7 +60,6 @@ import org.junit.runners.Suite.SuiteClasses;
         com.dotcms.uuid.shorty.ShortyIdApiTest.class,
         DotGraphQLHttpServletTest.class,
         com.dotcms.graphql.datafetcher.page.VanityURLFetcherTest.class,
-        com.dotcms.graphql.datafetcher.page.ContentMapDataFetcherTest.class,
         com.dotcms.graphql.datafetcher.page.RunningExperimentFetcherTest.class,
         com.dotcms.graphql.datafetcher.CategoryFieldDataFetcherTest.class,
         com.dotcms.rest.TagResourceIntegrationTest.class,
@@ -89,7 +88,8 @@ import org.junit.runners.Suite.SuiteClasses;
         com.dotcms.content.elasticsearch.business.ESSiteSearchAPITest.class,
         com.dotcms.content.elasticsearch.business.ContentletIndexAPIImplTest.class,
         com.dotcms.content.elasticsearch.business.ES6UpgradeTest.class,
-        com.dotcms.content.elasticsearch.business.ESContentFactoryImplTest.class
+        com.dotcms.content.elasticsearch.business.ESContentFactoryImplTest.class,
+        com.dotcms.graphql.datafetcher.page.ContentMapDataFetcherTest.class
 })
 
 public class MainSuite1b {

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/page/ContentMapDataFetcherTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/page/ContentMapDataFetcherTest.java
@@ -1,0 +1,124 @@
+package com.dotcms.graphql.datafetcher.page;
+
+import static com.dotcms.datagen.TestDataUtils.getNewsLikeContentType;
+import static org.junit.Assert.*;
+
+import com.dotcms.datagen.TestDataUtils;
+import com.dotcms.graphql.DotGraphQLContext;
+import com.dotcms.graphql.datafetcher.ContentMapDataFetcher;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.UserAPI;
+import com.dotmarketing.portlets.contentlet.business.HostAPI;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.liferay.portal.model.User;
+import graphql.schema.DataFetchingEnvironment;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Map;
+
+/**
+ * Integration tests for {@link ContentMapDataFetcher}.
+ * <p>
+ * These tests verify that:
+ * - Raw fields (ending in "_raw") are preserved as strings
+ * - Corresponding base fields are replaced with parsed JSON if they exist
+ * - No new base fields are added unless explicitly present in the contentlet
+ */
+public class ContentMapDataFetcherTest {
+
+    private static UserAPI userAPI;
+    private static User user;
+    private static Language defaultLanguage;
+
+    /**
+     * Initializes the test environment including default user and language.
+     */
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+        userAPI = APILocator.getUserAPI();
+        user = userAPI.getSystemUser();
+        defaultLanguage = APILocator.getLanguageAPI().getDefaultLanguage();
+    }
+
+    /**
+     * Given a contentlet with both `blockEditor_raw` and `blockEditor`,
+     * When fetched through ContentMapDataFetcher,
+     * Then the base field is replaced with the parsed JSON object
+     */
+    @Test
+    @SuppressWarnings("unchecked") // safe cast after instanceof check
+    public void testMapIncludesRawAndParsedBlockEditor() throws Exception {
+        Contentlet contentlet = TestDataUtils.getNewsContent(true, defaultLanguage.getId(), getNewsLikeContentType().id());
+        String rawJson = "{\"type\":\"doc\",\"attrs\":{\"charCount\":4}}";
+        contentlet.setStringProperty("blockEditor_raw", rawJson);
+        contentlet.setStringProperty("blockEditor", "some string"); // base field pre-exists
+
+        var environment = Mockito.mock(DataFetchingEnvironment.class);
+        Mockito.when(environment.getContext()).thenReturn(
+                DotGraphQLContext.createServletContext().with(user).build()
+        );
+        Mockito.when(environment.getArgument("key")).thenReturn(null);
+        Mockito.when(environment.getArgument("depth")).thenReturn(0);
+        Mockito.when(environment.getArgument("render")).thenReturn(false);
+        Mockito.when(environment.getSource()).thenReturn(contentlet);
+
+        var fetcher = new ContentMapDataFetcher();
+        Object result = fetcher.get(environment);
+
+        assertNotNull(result);
+        assertTrue("Expected result to be a Map", result instanceof Map);
+
+        Map<String, Object> map = (Map<String, Object>) result;
+
+        assertTrue(map.containsKey("blockEditor_raw"));
+        assertTrue(map.get("blockEditor_raw") instanceof String);
+        assertEquals(rawJson, map.get("blockEditor_raw"));
+
+        assertTrue(map.containsKey("blockEditor"));
+        assertTrue(map.get("blockEditor") instanceof Map);
+
+        Map<String, Object> parsed = (Map<String, Object>) map.get("blockEditor");
+        assertEquals("doc", parsed.get("type"));
+        assertTrue(parsed.containsKey("attrs"));
+    }
+
+    /**
+     * Given a contentlet with only a `customField_raw`,
+     * When fetched through ContentMapDataFetcher,
+     * Then the base field `customField` should NOT be present in the result
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testRawFieldDoesNotAddMissingBaseField() throws Exception {
+        Contentlet contentlet = TestDataUtils.getNewsContent(true, defaultLanguage.getId(), getNewsLikeContentType().id());
+        String rawJson = "{\"foo\": \"bar\"}";
+        contentlet.setStringProperty("customField_raw", rawJson); // base field not set
+
+        var environment = Mockito.mock(DataFetchingEnvironment.class);
+        Mockito.when(environment.getContext()).thenReturn(
+                DotGraphQLContext.createServletContext().with(user).build()
+        );
+        Mockito.when(environment.getArgument("key")).thenReturn(null);
+        Mockito.when(environment.getArgument("depth")).thenReturn(0);
+        Mockito.when(environment.getArgument("render")).thenReturn(false);
+        Mockito.when(environment.getSource()).thenReturn(contentlet);
+
+        var fetcher = new ContentMapDataFetcher();
+        Object result = fetcher.get(environment);
+
+        assertNotNull(result);
+        assertTrue(result instanceof Map);
+
+        Map<String, Object> map = (Map<String, Object>) result;
+
+        assertTrue(map.containsKey("customField_raw"));
+        assertEquals(rawJson, map.get("customField_raw"));
+        assertFalse("Parsed base field should not be added", map.containsKey("customField"));
+    }
+}


### PR DESCRIPTION
### Proposed Changes

* Ensured that fields ending in `_raw` are parsed as JSON and injected as objects under their corresponding base key (e.g., `blockEditor`) — only when that base key already exists.
* Extracted parsing logic into a private method: `enrichWithParsedRawFields`.
* Added an integration test suite (`ContentMapDataFetcherTest`) that covers:
  * Correct parsing and replacement of `blockEditor` when `blockEditor_raw` is present.
  * Ensuring that fields like `customField_raw` do **not** inject `customField` if the base key was not defined.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (no sensitive processing; only structural parsing of contentlet fields)

### Additional Info

Fixes the issue where GraphQL was returning `blockEditor` as a raw JSON string instead of an object, while the REST API returned it correctly as an object.

This change brings consistency between REST and GraphQL responses for `_map` fields that rely on JSON string values (specifically block editor fields). It adheres to the original field contract by only enriching existing base keys, avoiding the introduction of unexpected fields in the response.


### Original
```
"blockEditor_raw": "{\"type\":\"doc\",\"attrs\":{\"charCount\":4,\"wordCount\":1,\"readingTime\":1},\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":null},\"content\":[{\"type\":\"text\",\"text\":\"test\"}]}]}",
"blockEditor": "{\"type\":\"doc\",\"attrs\":{\"charCount\":4,\"wordCount\":1,\"readingTime\":1},\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":null},\"content\":[{\"type\":\"text\",\"text\":\"test\"}]}]}"
```  

### Updatetd
```  
"blockEditor_raw": "{\"type\":\"doc\",\"attrs\":{\"charCount\":4,\"wordCount\":1,\"readingTime\":1},\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":null},\"content\":[{\"type\":\"text\",\"text\":\"test\"}]}]}",
"blockEditor": {
  "type": "doc",
  "attrs": {
    "charCount": 4,
    "wordCount": 1,
    "readingTime": 1
  },
  "content": [
    {
      "type": "paragraph",
      "attrs": {
        "textAlign": null
      },
      "content": [
        {
          "type": "text",
          "text": "test"
        }
      ]
    }
  ]
}
```


This PR fixes: #31921