### PR TITLE
chore: #32269 Update the parent pom to empty_20250528

### DIFF
--- a/dotCMS/src/main/docker/original/Dockerfile
+++ b/dotCMS/src/main/docker/original/Dockerfile
@@ -60,11 +60,13 @@ RUN apt update && \
 
 # Install PostgreSQL client and pg_dump
 RUN apt update && \
-    apt install -y --no-install-recommends postgresql-common && \
-    /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && \
+    apt install -y --no-install-recommends wget gnupg2 lsb-release && \
+    echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt update && \
     apt install -y --no-install-recommends postgresql-client-16 && \
-    apt purge -y postgresql-common gnupg && \
     /usr/bin/pg_dump --version || exit 1 && \
+    apt purge -y wget gnupg2 lsb-release && \
     rm -rf /var/lib/apt/lists/*
 
 ARG USER_UID="65001"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,7 +76,7 @@
         <docker.jacoco.skip>true</docker.jacoco.skip>
         <!-- starter -->
         <starter.download.folder>${project.build.directory}/starter</starter.download.folder>
-        <starter.deploy.version>empty_20241105</starter.deploy.version>
+        <starter.deploy.version>empty_20250528</starter.deploy.version>
         <starter.deploy.filename>starter.zip</starter.deploy.filename>
         <starter.run.version>${starter.deploy.version}</starter.run.version>
         <starter.run.filename>starter-${starter.run.version}.zip</starter.run.filename>


### PR DESCRIPTION
### Proposed Changes

This pull request updates the `parent/pom.xml` file to change the `starter.deploy.version` property to a new version.

* [`parent/pom.xml`](diffhunk://#diff-b5a06276719e759fe07dfe6f75d781be5f83d2215179d82bdb195ad035348214L79-R79): Updated the `starter.deploy.version` from `empty_20241105` to `empty_20250528` to reflect the new deployment version.

### Related Issue
#32269 

This PR fixes: #32269