### PR TITLE
fix(DotCMSEditableText): To listen props changes

### DIFF
--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSEditableText/DotCMSEditableText.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSEditableText/DotCMSEditableText.tsx
@@ -47,13 +47,17 @@ export function DotCMSEditableText({
     const [content, setContent] = useState(contentlet?.[fieldName] || '');
 
     useEffect(() => {
+        setContent(contentlet?.[fieldName] || '');
+    }, [fieldName, contentlet]);
+
+    useEffect(() => {
         const state = getUVEState();
 
         setInitEditor(state?.mode === UVE_MODE.EDIT && !!state?.dotCMSHost?.length);
 
         if (!contentlet || !fieldName) {
             console.error(
-                'DotCMSEditableText: contentlet or fieldName is missing',
+                '[DotCMSEditableText]: contentlet or fieldName is missing',
                 'Ensure that all needed props are passed to view and edit the content'
             );
 
@@ -61,14 +65,14 @@ export function DotCMSEditableText({
         }
 
         if (state && state.mode !== UVE_MODE.EDIT) {
-            console.warn('DotCMSEditableText: TinyMCE is not available in the current mode');
+            console.warn('[DotCMSEditableText]: TinyMCE is not available in the current mode');
 
             return;
         }
 
         if (!state?.dotCMSHost) {
             console.warn(
-                'The `dotCMSHost` parameter is not defined. Check that the UVE is sending the correct parameters.'
+                '[DotCMSEditableText]: The `dotCMSHost` parameter is not defined. Check that the UVE is sending the correct parameters.'
             );
 
             return;
@@ -77,10 +81,8 @@ export function DotCMSEditableText({
         const createURL = new URL(__TINYMCE_PATH_ON_DOTCMS__, state.dotCMSHost);
         setScriptSrc(createURL.toString());
 
-        const content = contentlet?.[fieldName] || '';
         editorRef.current?.setContent(content, { format });
-        setContent(content);
-    }, [format, fieldName, contentlet]);
+    }, [format, fieldName, contentlet, content]);
 
     useEffect(() => {
         if (getUVEState()?.mode !== UVE_MODE.EDIT) {


### PR DESCRIPTION
This pull request enhances the `DotCMSEditableText` component and its associated tests, focusing on improving content handling, logging clarity, and test coverage. The most significant updates include adding a `useEffect` hook to synchronize content changes, refining log messages for better readability, and introducing new tests for dynamic updates to contentlet and fieldName.

### Component Enhancements:
* [`core-web/libs/sdk/react/src/lib/next/components/DotCMSEditableText/DotCMSEditableText.tsx`](diffhunk://#diff-a9f5ce3b51841e32f21318ae90f875b8a8926768c19cd34d147aec96f8cdd049R49-R75): Added a `useEffect` hook to update the `content` state whenever `contentlet` or `fieldName` changes, ensuring the component reflects dynamic updates. Also refined log messages to include a consistent prefix for better debugging. [[1]](diffhunk://#diff-a9f5ce3b51841e32f21318ae90f875b8a8926768c19cd34d147aec96f8cdd049R49-R75) [[2]](diffhunk://#diff-a9f5ce3b51841e32f21318ae90f875b8a8926768c19cd34d147aec96f8cdd049L80-R85)

### Test Enhancements:
* `core-web/libs/sdk/react/src/lib/next/__test__/components/DotCMSEditableText.test.tsx`: 
  - Introduced a mock UVE state (`MOCK_UVE_STATE`) to simplify test setup.
  - Updated existing tests to use the refined log messages with consistent prefixes. [[1]](diffhunk://#diff-57b2eed240a2c3e88240ae0b1144d12c95f4e723418550f53519e64cab253c13L86-R92) [[2]](diffhunk://#diff-57b2eed240a2c3e88240ae0b1144d12c95f4e723418550f53519e64cab253c13L104-R110) [[3]](diffhunk://#diff-57b2eed240a2c3e88240ae0b1144d12c95f4e723418550f53519e64cab253c13L122-R128) [[4]](diffhunk://#diff-57b2eed240a2c3e88240ae0b1144d12c95f4e723418550f53519e64cab253c13L139-R145)
  - Added new tests to verify that the component updates its HTML correctly when `contentlet` or `fieldName` changes dynamically.


### Videos

#### NextJS

https://github.com/user-attachments/assets/c97840dd-2f1f-4b49-b4c0-edbee0b84ebf

#### Angular


https://github.com/user-attachments/assets/ca38079d-389f-43c3-8bce-47fee1189df7





This PR fixes: #32218