### PR TITLE
fix(Unique Fields) #32260 : Unique field verification via DB must be case insensitive

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldCriteria.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldCriteria.java
@@ -1,9 +1,5 @@
 package com.dotcms.contenttype.business.uniquefields.extratable;
 
-
-import com.dotcms.api.APIProvider;
-import com.dotcms.content.elasticsearch.business.ESContentletAPIImpl;
-
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotmarketing.beans.Host;
@@ -26,10 +22,14 @@ import static com.dotcms.content.elasticsearch.business.ESContentletAPIImpl.UNIQ
  * <ul>
  *     <li>The ID of the Content Type it belongs to.</li>
  *     <li>The Velocity Var Name of the field.</li>
- *     <li>The unique value.</li>
  *     <li>The Language of the Contentlet using it.</li>
+ *     <li>The unique value, which is case-insensitive.</li>
  *     <li>The Site where the Contentlet lives.</li>
+ *     <li>The Identifiers of the Contentlets that can have the same unique value, for backwards
+ *     compatibility.</li>
  *     <li>The Variant that the Contentlet belongs to.</li>
+ *     <li>The value of the {@code uniquePerSite} Field Variable.</li>
+ *     <li>Whether the Contentlet is live or not.</li>
  * </ul>
  *
  * @author Freddy Rodriguez
@@ -46,16 +46,14 @@ public class UniqueFieldCriteria {
     public static final String VARIANT_ATTR = "variant";
     public static final String UNIQUE_PER_SITE_ATTR = "uniquePerSite";
     public static final String LIVE_ATTR = "live";
+
     private final ContentType contentType;
     private final Field field;
     private final Object value;
     private final Language language;
     private final Host site;
-
     private final String variantName;
-
-    private boolean isLive;
-
+    private final boolean isLive;
 
     public UniqueFieldCriteria(final Builder builder) {
         this.contentType = builder.contentType;
@@ -178,8 +176,19 @@ public class UniqueFieldCriteria {
             return this;
         }
 
+        /**
+         * Sets the value for the Unique Field in this builder. If the provided value is a String,
+         * it trims and converts it to lowercase before assigning it. For other types, the value is
+         * assigned as-is.
+         *
+         * @param value the value to set; can be of any object type
+         *
+         * @return the builder instance for method chaining
+         */
         public Builder setValue(final Object value) {
-            this.value = value;
+            this.value = (value instanceof String)
+                    ? ((String) value).trim().toLowerCase()
+                    : value;
             return this;
         }
 
@@ -210,6 +219,7 @@ public class UniqueFieldCriteria {
             this.isLive = live;
             return this;
         }
+
     }
 
 }

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/uniquefields/extratable/DBUniqueFieldValidationStrategyTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/uniquefields/extratable/DBUniqueFieldValidationStrategyTest.java
@@ -31,19 +31,15 @@ import org.junit.runner.RunWith;
 import javax.enterprise.context.ApplicationScoped;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static com.dotcms.content.elasticsearch.business.ESContentletAPIImpl.UNIQUE_PER_SITE_FIELD_VARIABLE_NAME;
-import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.CONTENTLET_IDS_ATTR;
 import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.CONTENT_TYPE_ID_ATTR;
 import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.FIELD_VALUE_ATTR;
 import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.FIELD_VARIABLE_NAME_ATTR;
 import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.LANGUAGE_ID_ATTR;
 import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.SITE_ID_ATTR;
-import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.UNIQUE_PER_SITE_ATTR;
 import static com.dotcms.util.CollectionsUtils.list;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.IDENTIFIER_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.INODE_KEY;
@@ -150,57 +146,53 @@ public class DBUniqueFieldValidationStrategyTest {
     }
 
     /**
-     * Method to test: {@link DBUniqueFieldValidationStrategy#validate(Contentlet, Field)}
-     * When: Called the method with a field with uniquePerSite set to true
-     * Should: Allow insert the same values in different Host
+     * <ul>
+     *     <li><b>Method to test:</b>
+     *     {@link DBUniqueFieldValidationStrategy#validate(Contentlet, Field)}</li>
+     *     <li><b>Given Scenario: </b>Create two Contentlets with the same unique value, but each
+     *     living under a different Site, and the {@code uniquePerSite} is set to {@code true}
+     *     .</li>
+     *     <li><b>Expected Result: </b>Even though both contents have the same unique value, they
+     *     live in different Sites. So, the creation must be successful.</li>
+     * </ul>
      */
     @Test
     public void insertWithUniquePerSiteSetToTrue() throws DotDataException, UniqueFieldValueDuplicatedException, DotSecurityException {
-        final Field uniqueField = new FieldDataGen().type(TextField.class).unique(true).next();
-        final ContentType contentType = new ContentTypeDataGen().field(uniqueField).nextPersisted();
+        // ╔══════════════════╗
+        // ║  Initialization  ║
+        // ╚══════════════════╝
+        final String uniqueValue = "UniqueValue" + System.currentTimeMillis();
+        final DBUniqueFieldValidationStrategy databaseUniqueFieldValidationStrategy =
+                new DBUniqueFieldValidationStrategy(uniqueFieldDataBaseUtil);
+
+        // ╔════════════════════════╗
+        // ║  Generating Test data  ║
+        // ╚════════════════════════╝
+        final ContentType contentType = new ContentTypeDataGen().nextPersisted();
+        Field uniqueField = new FieldDataGen()
+                .type(TextField.class)
+                .contentTypeId(contentType.id())
+                .unique(true)
+                .nextPersisted();
+        new FieldVariableDataGen()
+                .key(UNIQUE_PER_SITE_FIELD_VARIABLE_NAME)
+                .value(Boolean.toString(true))
+                .field(uniqueField)
+                .nextPersisted();
+        // Force retrieving the field variables as they're lazily loaded
+        uniqueField.fieldVariables();
+
         final Language language = new LanguageDataGen().nextPersisted();
         final Host site = new SiteDataGen().nextPersisted();
         final Host site_2 = new SiteDataGen().nextPersisted();
         final String uniqueFieldVariable = uniqueField.variable();
-        final String uniqueValue = "UniqueValue" + System.currentTimeMillis();
-
-        new FieldVariableDataGen()
-                .key(UNIQUE_PER_SITE_FIELD_VARIABLE_NAME)
-                .value("true")
-                .field(contentType.fields().stream()
-                        .filter(field -> Objects.equals(field.variable(), uniqueFieldVariable))
-                        .limit(1)
-                        .findFirst()
-                        .orElseThrow())
-                .nextPersisted();
-
-        final UniqueFieldCriteria uniqueFieldCriteria_1 = new UniqueFieldCriteria.Builder()
-                .setContentType(contentType)
-                .setField(uniqueField)
-                .setValue(uniqueValue)
-                .setLanguage(language)
-                .setSite(site)
-                .setVariantName(VariantAPI.DEFAULT_VARIANT.name())
-                .build();
-
         final Contentlet contentlet_1 = new ContentletDataGen(contentType)
                 .setProperty(uniqueFieldVariable, uniqueValue)
                 .host(site)
                 .languageId(language.getId())
                 .next();
 
-        final DBUniqueFieldValidationStrategy extraTableUniqueFieldValidationStrategy =
-                new DBUniqueFieldValidationStrategy(uniqueFieldDataBaseUtil);
-        extraTableUniqueFieldValidationStrategy.validate(contentlet_1, uniqueField);
-
-        final UniqueFieldCriteria uniqueFieldCriteria_2 = new UniqueFieldCriteria.Builder()
-                .setContentType(contentType)
-                .setField(uniqueField)
-                .setValue(uniqueValue)
-                .setLanguage(language)
-                .setSite(site_2)
-                .setVariantName(VariantAPI.DEFAULT_VARIANT.name())
-                .build();
+        databaseUniqueFieldValidationStrategy.validate(contentlet_1, uniqueField);
 
         final Contentlet contentlet_2 = new ContentletDataGen(contentType)
                 .setProperty(uniqueFieldVariable, uniqueValue)
@@ -208,26 +200,23 @@ public class DBUniqueFieldValidationStrategyTest {
                 .languageId(language.getId())
                 .next();
 
-        extraTableUniqueFieldValidationStrategy.validate(contentlet_2, uniqueField);
+        databaseUniqueFieldValidationStrategy.validate(contentlet_2, uniqueField);
 
+        // ╔══════════════╗
+        // ║  Assertions  ║
+        // ╚══════════════╝
         final List<Map<String, Object>> results = new DotConnect()
                 .setSQL("SELECT * FROM unique_fields WHERE supporting_values->>'" + CONTENT_TYPE_ID_ATTR + "' = ?")
                 .addParam(contentType.id())
                 .loadObjectResults();
+        assertEquals(String.format("There must be two Unique Field entries related to the test Content Type " +
+                "'%s'", contentType.variable()), 2, results.size());
 
-        assertEquals(2, results.size());
-
-        final UniqueFieldCriteria[] uniqueFieldCriteria = new UniqueFieldCriteria[]{uniqueFieldCriteria_1, uniqueFieldCriteria_2};
-        final Contentlet[] contentlets = new Contentlet[]{contentlet_1, contentlet_2};
         final Host[] sites = new Host[]{site, site_2};
-
         for (int i =0; i < results.size(); i++) {
-            Map<String, Object> result = results.get(i);
-            final Map<String, Object> mapExpected = new HashMap<>(uniqueFieldCriteria[i].toMap());
-            mapExpected.put(CONTENTLET_IDS_ATTR, list(contentlets[i].getIdentifier()));
-            mapExpected.put(UNIQUE_PER_SITE_ATTR, true);
-
-            final String valueToHash = contentType.id() + uniqueField.variable() + language.getId() + uniqueValue +
+            final Map<String, Object> result = results.get(i);
+            // Unique values are case-insensitive, so we convert it to lower case
+            final String valueToHash = contentType.id() + uniqueField.variable() + language.getId() + uniqueValue.toLowerCase() +
                     sites[i].getIdentifier();
             assertEquals(StringUtils.hashText(valueToHash), result.get("unique_key_val"));
         }


### PR DESCRIPTION
This pull request updates the `UniqueFieldCriteria` class to enhance functionality and improve code clarity. The most notable changes include updates to the `Builder` class for better data handling, and adjustments to the documentation for improved readability.

### Enhancement to `UniqueFieldCriteria` class:

* Updated the `Builder` class to preprocess string values by trimming and converting them to lowercase, ensuring case-insensitive handling of unique values.

### Documentation improvements:

* Updated the Javadoc for the `UniqueFieldCriteria` class to include new attributes and clarify the behavior of existing ones, such as the case-insensitivity of unique values and the addition of backward compatibility for contentlet identifiers.

### Code cleanup:

* Removed unused imports (`APIProvider` and `ESContentletAPIImpl`) to streamline the codebase.

This PR fixes: #32260