### PR TITLE
#31485 adding addition info details to the user from SAML

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/SAMLHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/auth/providers/saml/v1/SAMLHelper.java
@@ -368,6 +368,12 @@ public class SAMLHelper {
             user.setFirstName(attributesBean.getFirstName());
             user.setLastName(attributesBean.getLastName());
 
+            if (Objects.nonNull(attributesBean.getAdditionalAttributes()) &&
+                    attributesBean.getAdditionalAttributes().size() > 0) {
+
+                user.setAdditionalInfo(attributesBean.getAdditionalAttributes());
+            }
+
             this.userAPI.save(user, systemUser, false);
             Logger.debug(this, ()-> "User with email '" + attributesBean.getEmail() + "' has been updated");
         } catch (Exception e) {
@@ -697,6 +703,12 @@ public class SAMLHelper {
             user.setCreateDate(new Date());
             user.setPassword(PublicEncryptionFactory.digestString(UUIDGenerator.generateUuid() + "/" + UUIDGenerator.generateUuid()));
             user.setPasswordEncrypted(true);
+
+            if (Objects.nonNull(attributesBean.getAdditionalAttributes()) &&
+                    attributesBean.getAdditionalAttributes().size() > 0) {
+
+                user.setAdditionalInfo(attributesBean.getAdditionalAttributes());
+            }
 
             this.userAPI.save(user, systemUser, false);
             Logger.debug(this, ()-> "User with NameID '" + nameID + "' and email '" +

--- a/dotCMS/src/main/java/com/dotcms/saml/Attributes.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/Attributes.java
@@ -4,6 +4,7 @@ import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
 
 import java.io.Serializable;
+import java.util.Map;
 
 /**
  * Encapsulates the attributes retrieve from the Saml Assertion
@@ -35,6 +36,8 @@ public class Attributes implements Serializable {
 	// SAML Session Index
 	private final String sessionIndex;
 
+	private final Map<String, Object> additionalAttributes;
+
 	private Attributes(final Builder builder) {
 
 		final String uuid = UUIDUtil.uuid();
@@ -45,6 +48,7 @@ public class Attributes implements Serializable {
 		this.roles        = builder.roles;
 		this.nameID       = builder.nameID;
 		this.sessionIndex = builder.sessionIndex;
+		this.additionalAttributes = builder.additionalAttributes;
 	}
 
 	public String getEmail()
@@ -81,10 +85,22 @@ public class Attributes implements Serializable {
 		return sessionIndex;
 	}
 
+	public Map<String, Object> getAdditionalAttributes() {
+		return additionalAttributes;
+	}
+
 	@Override
 	public String toString() {
-		return "AttributesBean{" + "nameID='" + nameID + '\'' + ", email='" + email + '\'' + ", lastName='" + lastName + '\''
-				+ ", firstName='" + firstName + '\'' + ", addRoles=" + addRoles + ", roles=" + roles + '}';
+		return "Attributes{" +
+				"email='" + email + '\'' +
+				", lastName='" + lastName + '\'' +
+				", firstName='" + firstName + '\'' +
+				", addRoles=" + addRoles +
+				", roles=" + roles +
+				", nameID=" + nameID +
+				", sessionIndex='" + sessionIndex + '\'' +
+				", additionalAttributes=" + additionalAttributes +
+				'}';
 	}
 
 	public static final class Builder {
@@ -95,6 +111,13 @@ public class Attributes implements Serializable {
 		Object roles     = null;
 		Object nameID    = null;
 		String sessionIndex;
+		Map<String, Object> additionalAttributes;
+
+		public Builder additionalAttributes(final Map<String, Object> additionalAttributes)
+		{
+			this.additionalAttributes = additionalAttributes;
+			return this;
+		}
 
 		public Builder email(final String email )
 		{

--- a/dotcms-integration/src/test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.io.Writer;
 import java.security.NoSuchAlgorithmException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -197,8 +198,13 @@ public class SAMLHelperTest extends IntegrationTestBase {
         final User nativeUser = new UserDataGen().active(true).lastName(nativeLastName).firstName(nativeFirstName)
                 .emailAddress(nativeEmailAddress).nextPersisted();
 
+        final Map<String, Object> additionalAttributes = new HashMap<>();
+
+        additionalAttributes.put("prop-key1", "prop-value1");
+        additionalAttributes.put("prop-key2", "prop-value2");
+
         final Attributes nativeUserAttributes = new Attributes.Builder().firstName(nativeFirstName + "Updated")
-                .lastName(nativeLastName).nameID(nativeUser.getUserId()).email(nativeEmailAddress).build();
+                .lastName(nativeLastName).nameID(nativeUser.getUserId()).email(nativeEmailAddress).additionalAttributes(additionalAttributes).build();
 
         // recover with SAML the native user
         final User recoveredNativeUser = samlHelper.resolveUser(nativeUserAttributes, identityProviderConfiguration);
@@ -208,6 +214,9 @@ public class SAMLHelperTest extends IntegrationTestBase {
         Assert.assertEquals (nativeUser.getEmailAddress(), recoveredNativeUser.getEmailAddress());
         Assert.assertNotEquals(nativeUser.getFirstName(),  recoveredNativeUser.getFirstName());
         Assert.assertEquals (nativeUser.getLastName(),     recoveredNativeUser.getLastName());
+        Assert.assertNotNull(recoveredNativeUser.getAdditionalInfo());
+        Assert.assertEquals ("The additional info prop1 is not right","prop-value1",     recoveredNativeUser.getAdditionalInfo().get("prop-key1"));
+        Assert.assertEquals ("The additional info prop1 is not right","prop-value2",     recoveredNativeUser.getAdditionalInfo().get("prop-key2"));
 
         // creates an user from saml
         final Attributes samlUserAttributes = new Attributes.Builder().firstName(samlFirstName)


### PR DESCRIPTION
Adding the support to add additional info to the user model from SAML

This PR fixes: #31485