### PR TITLE
fix(ci): 32269 Adding checkout step to fix starter workflow.

### DIFF
--- a/.github/workflows/cicd_manual_publish-starter.yml
+++ b/.github/workflows/cicd_manual_publish-starter.yml
@@ -102,6 +102,10 @@ jobs:
       url: ${{ steps.deploy-artifacts.outputs.url }}
       pr_created: ${{ steps.create-pull-request.outcome == 'success' }}      
     steps:
+      - name: 'Checkout repository'
+        if: ${{ github.event.inputs.type == 'empty' && github.event.inputs.dry-run == 'false' }}
+        uses: actions/checkout@v4
+
       - uses: jfrog/setup-jfrog-cli@v4
         env:
           JF_URL: ${{ vars.ARTIFACTORY_URL }}


### PR DESCRIPTION
### Proposed Changes
This pull request introduces a new step to the CI/CD workflow for manual publishing in the `.github/workflows/cicd_manual_publish-starter.yml` file. The change ensures that the repository is checked out under specific conditions before proceeding with further steps.

**Workflow enhancements:**

* [`.github/workflows/cicd_manual_publish-starter.yml`](diffhunk://#diff-f4c2b208b6c5ad3659de07d2d4cbbf9681941aa9b9588cc68dc17ebc3a522ea9R105-R108): Added a new step named 'Checkout repository' to the `jobs` section. This step uses the `actions/checkout@v4` action and is conditionally executed when the `type` input is `'empty'` and the `dry-run` input is `'false'`.

### Fixes
#32269 

This PR fixes: #32269