### PR TITLE
fix(templates) : Add containers included by dotParse directive to template

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotCacheDirective.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotCacheDirective.java
@@ -1,5 +1,6 @@
 package com.dotcms.rendering.velocity.directive;
 
+import com.dotcms.rendering.velocity.util.VelocityUtil;
 import com.dotmarketing.util.Logger;
 import java.io.IOException;
 import java.io.Serializable;
@@ -7,6 +8,8 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
+
+import org.apache.velocity.context.Context;
 import org.apache.velocity.context.InternalContextAdapter;
 import org.apache.velocity.exception.MethodInvocationException;
 import org.apache.velocity.exception.ParseErrorException;
@@ -20,6 +23,8 @@ import com.dotmarketing.util.PageMode;
 import io.vavr.control.Try;
 
 public class DotCacheDirective extends Directive {
+
+    public static final String DONT_USE_DIRECTIVE_CACHE = "_dotDontUseDirectiveCache";
 
     private static final long serialVersionUID = 1L;
 
@@ -39,7 +44,7 @@ public class DotCacheDirective extends Directive {
 
 
         HttpServletRequest request = (HttpServletRequest) context.get("request");
-        boolean shouldCache = shouldCache(request);
+        boolean shouldCache = shouldCache(context, request);
         boolean refreshCache = refreshCache(request);
 
         int ttl = 0;
@@ -82,8 +87,11 @@ public class DotCacheDirective extends Directive {
     }
 
 
-    boolean shouldCache(HttpServletRequest request) {
+    boolean shouldCache(final Context context, HttpServletRequest request) {
         if (request == null) {
+            return false;
+        }
+        if (VelocityUtil.getDontUseDirectiveCache(context)) {
             return false;
         }
         if ("no".equals(request.getParameter(getName())) || "no".equals(request.getAttribute(getName()))) {

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotParse.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotParse.java
@@ -201,8 +201,9 @@ public class DotParse extends DotDirective {
      *
      * @param render    Template content after render
      * @param arguments
+     * @param context
      */
-    void afterRender(final String render, String[] arguments) {
+    void afterRender(final String render, String[] arguments, Context context) {
         if (arguments.length > 1) {
             try {
                 int ttl = Integer.parseInt(arguments[1]);

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/ParseContainer.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/ParseContainer.java
@@ -1,28 +1,28 @@
 package com.dotcms.rendering.velocity.directive;
 
 import com.dotmarketing.beans.MultiTree;
-import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.portlets.templates.design.bean.ContainerUUID;
-import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
-import com.dotmarketing.util.VelocityUtil;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.velocity.context.Context;
-import org.apache.velocity.context.InternalContextAdapter;
-import org.apache.velocity.exception.TemplateInitException;
-import org.apache.velocity.runtime.RuntimeServices;
-import org.apache.velocity.runtime.parser.node.Node;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
+
 /**
  * Could includes a container by id (long or shorty) or a path (with or without host "without will use the current host").
  */
 public class ParseContainer extends DotDirective {
 
-	public  static final String PARSE_CONTAINER_UUID_PREFIX = "dotParser_";
-	public  static final String DEFAULT_UUID_VALUE = MultiTree.LEGACY_RELATION_TYPE;
+	public static final String PARSE_CONTAINER_UUID_PREFIX = "dotParser_";
+	public static final String DEFAULT_UUID_VALUE = MultiTree.LEGACY_RELATION_TYPE;
+	public static final String DOT_TEMPLATE_CONTAINER_IDS = "_dotTemplateContainerIds";
+	public static final String DONT_LOAD_CONTAINERS = "_dotDontLoadContainers";
+
 	private static final long serialVersionUID     = 1L;
 
 	public static String getDotParserContainerUUID(final String uniqueId) {
@@ -42,9 +42,73 @@ public class ParseContainer extends DotDirective {
 		return "parseContainer";
 	}
 
-	public void init(RuntimeServices rs, InternalContextAdapter context, Node node) throws TemplateInitException {
-		super.init(rs, context, node);
+	/**
+	 * Returns if the template should be loaded and rendered based on the context,
+	 * by checking the DONT_LOAD_CONTAINERS flag.
+	 *
+	 * @param context The context in which the directive is executed
+	 * @param arguments The arguments passed to the directive,
+	 * @return true if the template should be loaded and rendered, else otherwise.
+	 */
+	@Override
+	boolean shouldLoadAndRenderTemplate(final Context context, final String[] arguments) {
+		return !getDontLoadContainers(context);
+	}
 
+	/**
+	 * Stores the list of container IDs collected during the rendering process.
+	 *
+	 * @param render    The rendered output (not used in this method)
+	 * @param arguments The arguments passed to the directive,
+	 *                  where the first argument is expected to be the container identifier
+	 *                  and the second argument is expected to be the container UUID
+	 *                  (if not present, the default UUID value is used).
+	 * @param context   The context in which the directive is executed,
+	 */
+	@Override
+	public void afterRender(final String render, final String[] arguments, final Context context) {
+
+		final Collection<Pair<String,String>> containerIds = getContainerIdsFromContext(context);
+
+		if (arguments.length > 0 && UtilMethods.isSet(arguments[0])) {
+			final String containerId = arguments[0];
+			final String parserContainerUUID = arguments.length > 1 && UtilMethods.isSet(arguments[1]) ?
+				arguments[1] : DEFAULT_UUID_VALUE;
+			containerIds.add(Pair.of(containerId, parserContainerUUID));
+		}
+	}
+
+	/**
+	 * Safely retrieves the containerIds from the context.
+	 * @param context The context containing the stored containerIds
+	 * @return The list of containerIds if found and properly typed,
+	 * otherwise initializes a new list and stores it in the context.
+	 */
+	@SuppressWarnings("unchecked")
+	private Collection<Pair<String, String>> getContainerIdsFromContext(final Context context) {
+		final Object value = context.get(DOT_TEMPLATE_CONTAINER_IDS);
+		if (value instanceof Collection<?>) {
+			return (Collection<Pair<String, String>>) value;
+		} else {
+			Collection<Pair<String, String>> emptyList = new ArrayList<>();
+			context.put(DOT_TEMPLATE_CONTAINER_IDS, emptyList);
+			return emptyList;
+		}
+	}
+
+	/**
+	 * Get the value of the DONT_LOAD_CONTAINERS flag from the context.
+	 * @param context the internal context adapter
+	 * @return true if containers should not be loaded, false otherwise
+	 */
+	private boolean getDontLoadContainers(final Context context) {
+		final Object dontLoadContainersObj = context.get(ParseContainer.DONT_LOAD_CONTAINERS);
+		if (dontLoadContainersObj instanceof Boolean) {
+			return (Boolean) dontLoadContainersObj;
+		} else if (dontLoadContainersObj instanceof String) {
+			return Boolean.parseBoolean((String) dontLoadContainersObj);
+		}
+		return false;
 	}
 
 	@Override

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/util/VelocityUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/util/VelocityUtil.java
@@ -6,6 +6,7 @@ import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.mock.request.FakeHttpRequest;
 import com.dotcms.mock.response.BaseResponse;
+import com.dotcms.rendering.velocity.directive.DotCacheDirective;
 import com.dotcms.rendering.velocity.viewtools.VelocityRequestWrapper;
 import com.dotcms.rendering.velocity.viewtools.content.ContentMap;
 import com.dotcms.rendering.velocity.viewtools.content.ContentTool;
@@ -41,6 +42,7 @@ import org.apache.velocity.Template;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
 import org.apache.velocity.context.Context;
+import org.apache.velocity.context.InternalContextAdapter;
 import org.apache.velocity.exception.ParseErrorException;
 import org.apache.velocity.exception.ResourceNotFoundException;
 import org.apache.velocity.tools.view.ToolboxManager;
@@ -578,6 +580,25 @@ public class VelocityUtil {
 
 		Logger.debug(VelocityUtil.class, String.format("Velocity ROOT path found: %s", velocityRootPath));
 		return velocityRootPath;
+	}
+
+	/**
+	 * Gets the value of the DONT_USE_DIRECTIVE_CACHE from the context.
+	 * If the value is a Boolean, it returns it as is.
+	 * If the value is a String, it parses it to a Boolean.
+	 * If the value is not set or not a Boolean or String, it returns false.
+	 *
+	 * @param context The context from which to retrieve the value.
+	 * @return true if the directive cache should not be used, false otherwise.
+	 */
+	public static boolean getDontUseDirectiveCache(Context context) {
+		final Object dontCacheObj = context.get(DotCacheDirective.DONT_USE_DIRECTIVE_CACHE);
+		if (dontCacheObj instanceof Boolean) {
+			return (Boolean) dontCacheObj;
+		} else if (dontCacheObj instanceof String) {
+			return Boolean.parseBoolean((String) dontCacheObj);
+		}
+		return false;
 	}
 
 

--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
@@ -1232,7 +1232,7 @@ dojo.declare(
 
                 // Select button functionality
                 var selected = function (scope, content) {
-                    if (this.useRelateContentOnSelect) {
+                    if (scope.useRelateContentOnSelect) {
                         scope._doRelateContent(content);
                     } else {
                         scope._onContentSelected(content);
@@ -1322,6 +1322,7 @@ dojo.declare(
                     );
                     if (selectButton.onclick == undefined) {
                         selectButton.onclick = dojo.hitch(this, function (event) {
+                            event.stopPropagation();
                             selected(this, asset);
                         });
                     }


### PR DESCRIPTION
Closes #31790

### Proposed Changes
This pull request introduces changes to the directive execution in Velocity in order to get all the containers included in a template body, included containers in a separate file processed with the dotParse directive. These are the specific changes:
* A new flag `_dotDontUseDirectiveCache` is used to disable caching while getting the containers on the template.
* The `shouldLoadAndRenderTemplate` method has been added to the `DotDirective` class to allow subclasses to disable template files from being loaded.
* Also a new flag `_dotDontLoadContainers` is used to disable containers from being loaded because we are only interested in getting the container identifiers when checking the template. The `ParseContainer` class overwrites the `shouldLoadAndRenderTemplate` method to implement this behaviour.
* The `afterRender` method has been updated in the `ParseCotainer` class to collect container IDs  in the `_dotTemplateContainerIds` variable. 
* The `getContainerUUIDFromHTML` method from the `TemplateFactoryImpl`  class has been refactored to parse the Velocity code and to use Velocity context for extracting container UUIDs, replacing the previous line-by-line parsing approach.

### Minor UI fixes:
* **ContentSelector.js**: Fixed an issue where the `selectButton` click event did not stop propagation, ensuring proper event handling. This stop propagation was removed by the fix for the issue #31601, but the problem is that causes the event being handled by both the button click handler and by the row click handler. With this new fix, the appropriate `scope` variable is used to check the value of `useRelateContentOnSelect` flag in the `selected` function to check if the dialog is being used to relate content.

### Checklist
- [x] Tests

This PR fixes: #31790