### PR TITLE
fix: Unable to upload image when Content Search portlet was not available for the user

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/FileBrowserDialog.js
@@ -523,6 +523,7 @@ dojo.declare("dotcms.dijit.FileBrowserDialog", [dijit._Widget, dijit._Templated]
 		var addFilePorletURL = "/c/portal/layout?p_l_id=" + this._getRequestParameter('p_l_id') +
 			"&p_p_id=" + this._getRequestParameter('p_p_id') +
 			"&referer=/html/blank.jsp" +
+			"&angularCurrentPortlet=" + this._getRequestParameter("angularCurrentPortlet") +
 			"&p_p_action=1&p_p_state=maximized&p_p_mode=view&struts_action=/ext/files/upload_multiple&cmd=edit&in_frame=true&parent=" + this.currentFolder.id;
 		this.addAFileIFrame.src = addFilePorletURL;
 		this.addFileDialog.show();


### PR DESCRIPTION
**Problem**
The data sent to the backend had the portlet name as "content" representing the Content Search portlet, and as the user didn't have access to it, it was failing and throwing a permissions error
 
**Fix**
Add the property `angularCurrentPortlet` to the data sent to the backend, representing the correct portlet in which the user is standing, this way the backend is going to handle the portlet and return a correct result, without permissions issues 

This PR fixes: #29324