### PR TITLE
#32332 POC to support custom attributes in analytics

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
@@ -191,6 +191,11 @@ cube('request', {
       type: `string`,
       primaryKey: true
     },
+    custom_0: { sql: 'custom_0', type: `string` },
+    custom_1: { sql: 'custom_1', type: `string` },
+    custom_2: { sql: 'custom_2', type: `string` },
+    custom_3: { sql: 'custom_3', type: `string` },
+    custom_4: { sql: 'custom_4', type: `string` },
     conHost: { sql: 'conhost', type: `string` },
     conHostName: { sql: 'conhostname', type: `string` },
     contentTypeName: { sql: 'object_contenttypename', type: `string` },

--- a/dotCMS/src/main/java/com/dotcms/analytics/content/ContentAnalyticsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/content/ContentAnalyticsAPIImpl.java
@@ -2,11 +2,15 @@ package com.dotcms.analytics.content;
 
 import com.dotcms.analytics.query.AnalyticsQuery;
 import com.dotcms.cube.CubeJSQuery;
+import com.dotcms.rest.api.v1.analytics.content.util.ContentAnalyticsUtil;
+import com.dotcms.util.JsonUtil;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Map;
 
 /**
  * Implementation class for the {@link ContentAnalyticsAPIImpl} interface.
@@ -41,8 +45,14 @@ public class ContentAnalyticsAPIImpl implements ContentAnalyticsAPI {
     @Override
     public ReportResponse runRawReport(final String cubeJsQueryJson, final User user) {
 
+        String translateQuery = cubeJsQueryJson;
+
+        for (Map.Entry<String, String> customMatch : ContentAnalyticsUtil.CUSTOM_MATCH.entrySet()) {
+            translateQuery = translateQuery.replaceAll(customMatch.getKey(), customMatch.getValue());
+        }
+
         Logger.debug(this, ()-> "Running the report for the raw json query: " + cubeJsQueryJson);
         // note: should check any permissions for an user.
-        return this.contentAnalyticsFactory.getRawReport(cubeJsQueryJson, user);
+        return this.contentAnalyticsFactory.getRawReport(translateQuery, user);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/cube/CubeJSClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cube/CubeJSClient.java
@@ -8,6 +8,7 @@ import com.dotcms.http.CircuitBreakerUrl;
 import com.dotcms.http.CircuitBreakerUrl.Method;
 import com.dotcms.http.CircuitBreakerUrl.Response;
 import com.dotcms.metrics.timing.TimeMetric;
+import com.dotcms.rest.api.v1.analytics.content.util.ContentAnalyticsUtil;
 import com.dotcms.system.event.local.model.EventSubscriber;
 import com.dotcms.util.DotPreconditions;
 import com.dotcms.util.JsonUtil;
@@ -114,8 +115,15 @@ public class CubeJSClient implements EventSubscriber<SystemTableUpdatedKeyEvent>
 
         try {
             final String responseAsString = response.getResponse();
-            final Map<String, Object> responseAsMap = UtilMethods.isSet(responseAsString) && !responseAsString.equals("[]") ?
-                    JsonUtil.getJsonFromString(responseAsString) : new HashMap<>();
+
+            String translateResponse = responseAsString;
+
+            for (Map.Entry<String, String> customMatch : ContentAnalyticsUtil.CUSTOM_MATCH.entrySet()) {
+                translateResponse = translateResponse.replaceAll(customMatch.getValue(), customMatch.getKey());
+            }
+
+            final Map<String, Object> responseAsMap = UtilMethods.isSet(translateResponse) && !translateResponse.equals("[]") ?
+                    JsonUtil.getJsonFromString(translateResponse) : new HashMap<>();
             final List<Map<String, Object>> data = (List<Map<String, Object>>) responseAsMap.get("data");
 
             return new CubeJSResultSetImpl(UtilMethods.isSet(data) ? data : Collections.emptyList());

--- a/dotCMS/src/main/java/com/dotcms/jitsu/EventLogRunnable.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/EventLogRunnable.java
@@ -133,7 +133,7 @@ public class EventLogRunnable implements Runnable {
 
         return Optional.ofNullable(
                         Try.of(postLog::doResponse)
-                                .onFailure(e -> Logger.warnAndDebug(EventLogRunnable.class, e.getMessage(), e))
+                                .onFailure(e -> Logger.info(EventLogRunnable.class, () -> e.getMessage()))
                                 .getOrElse(CircuitBreakerUrl.EMPTY_RESPONSE));
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/ContentAnalyticsResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/ContentAnalyticsResource.java
@@ -200,8 +200,10 @@ public class ContentAnalyticsResource {
         final User user = initDataObject.getUser();
         checkNotNull(cubeJsQueryJson, IllegalArgumentException.class, "The 'query' JSON data cannot be null");
         Logger.debug(this,  ()->"Querying content analytics data with the cube query json: " + cubeJsQueryJson);
+
         final ReportResponse reportResponse =
                 this.contentAnalyticsAPI.runRawReport(cubeJsQueryJson, user);
+
         return new ReportResponseEntityView(reportResponse.getResults().stream().map(ResultSetItem::getAll).collect(Collectors.toList()));
     }
 
@@ -341,6 +343,7 @@ public class ContentAnalyticsResource {
         Logger.debug(this,  ()->"Creating an user custom event with the payload: " + userEventPayload);
 
         ContentAnalyticsUtil.registerContentAnalyticsRestEvent(request, response, userEventPayload);
+
 
         return new ResponseEntityStringView("User event created successfully");
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
@@ -9,8 +9,21 @@ import com.dotcms.analytics.track.matchers.PagesAndUrlMapsRequestMatcher;
 import com.dotcms.analytics.track.matchers.RequestMatcher;
 import com.dotcms.analytics.track.matchers.UserCustomDefinedRequestMatcher;
 import com.dotcms.analytics.track.matchers.VanitiesRequestMatcher;
+import com.dotcms.jitsu.EventLogSubmitter;
+import com.dotcms.jitsu.EventsPayload;
+import com.dotcms.util.JsonUtil;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.web.WebAPILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.UUIDUtil;
+import com.dotmarketing.util.json.JSONObject;
+import com.liferay.portal.PortalException;
+import com.liferay.portal.SystemException;
+
+import java.io.IOException;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -20,7 +33,10 @@ import javax.servlet.http.HttpServletResponse;
 
 public class ContentAnalyticsUtil {
 
+    public static final Map<String, String> CUSTOM_MATCH = new HashMap<>();
+
     private static final UserCustomDefinedRequestMatcher USER_CUSTOM_DEFINED_REQUEST_MATCHER =  new UserCustomDefinedRequestMatcher();
+    private static final EventLogSubmitter SUBMITTER  = new EventLogSubmitter();;
 
     private static final Map<String, Supplier<RequestMatcher>> MATCHER_MAP = Map.of(
             EventType.FILE_REQUEST.getType(), FilesRequestMatcher::new,
@@ -32,18 +48,58 @@ public class ContentAnalyticsUtil {
     public static void registerContentAnalyticsRestEvent(HttpServletRequest request, HttpServletResponse response,
             Map<String, Serializable> userEventPayload) {
 
-        request.setAttribute("requestId", Objects.nonNull(request.getAttribute("requestId")) ? request.getAttribute("requestId") : UUIDUtil.uuid());
+        final String requestId = Objects.nonNull(request.getAttribute("requestId")) ?
+                (String) request.getAttribute("requestId") : UUIDUtil.uuid();
+        request.setAttribute("requestId", requestId);
 
         final Map<String, Serializable> userEventPayloadWithDefaults = new HashMap<>(
                 userEventPayload);
+
         userEventPayloadWithDefaults.put(Collector.EVENT_SOURCE, EventSource.REST_API.getName());
+
         if (!userEventPayloadWithDefaults.containsKey(Collector.EVENT_TYPE)){
             userEventPayloadWithDefaults.put(Collector.EVENT_TYPE,   userEventPayload.getOrDefault(Collector.EVENT_TYPE, EventType.CUSTOM_USER_EVENT.getType()));
         }
-        WebEventsCollectorServiceFactory.getInstance().getWebEventsCollectorService().fireCollectorsAndEmitEvent(
+
+        final String eventType = userEventPayloadWithDefaults.get(Collector.EVENT_TYPE).toString();
+
+        final Map<String, String> customAttributes = (Map<String, String>) userEventPayload.get("custom");
+        final Map<String, String> customAttributesTranslate = new HashMap<>();
+
+        for (Map.Entry<String, String> customAttribute : customAttributes.entrySet()) {
+            String match = CUSTOM_MATCH.get(customAttribute.getKey());
+
+            if (match == null) {
+
+                if (CUSTOM_MATCH.size() >= 10) {
+                    throw new IllegalArgumentException(
+                            String.format("Max limit of custom attributes to the event %s reach", eventType));
+                }
+
+                match = "custom_" + CUSTOM_MATCH.size();
+                CUSTOM_MATCH.put(customAttribute.getKey(), match);
+            }
+
+            customAttributesTranslate.put(match, customAttribute.getValue());
+        }
+
+        userEventPayload.remove("custom");
+        userEventPayload.putAll(customAttributesTranslate);
+        userEventPayload.put("url", "");
+        userEventPayload.put("request_id", requestId);
+
+        try {
+            final Host  host = WebAPILocator.getHostWebAPI().getCurrentHost(request);
+            SUBMITTER.logEvent(host, new NewEventsPayload((Map<String, Object>) (Map<?, ?>) userEventPayload));
+        } catch (DotDataException | DotSecurityException | PortalException | SystemException e) {
+            throw new RuntimeException(e);
+        }
+
+
+        /*WebEventsCollectorServiceFactory.getInstance().getWebEventsCollectorService().fireCollectorsAndEmitEvent(
                 request, response,
                 loadRequestMatcher(userEventPayload), userEventPayloadWithDefaults, fromPayload(
-                        userEventPayload));
+                        userEventPayload));*/
     }
 
     private static Map<String, Object> fromPayload(final Map<String, Serializable> userEventPayload) {
@@ -66,6 +122,26 @@ public class ContentAnalyticsUtil {
 
         String eventType = (String) userEventPayload.getOrDefault(Collector.EVENT_TYPE, EventType.CUSTOM_USER_EVENT.getType());
         return MATCHER_MAP.getOrDefault(eventType, () -> USER_CUSTOM_DEFINED_REQUEST_MATCHER).get();
+    }
+
+    private static class NewEventsPayload extends EventsPayload {
+
+        private Map<String, Object> payload;
+
+        public NewEventsPayload(Map<String, Object> payload) {
+            super(payload);
+            this.payload = payload;
+        }
+
+        public Iterable<EventPayload> payloads() {
+
+            try {
+                final JSONObject experimentJsonPayload = new JSONObject(JsonUtil.getJsonAsString(payload));
+                return Arrays.asList(new EventPayload(experimentJsonPayload));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
 }


### PR DESCRIPTION
**This is just a POC, really we are not going to merge this changes to main, but I created this PR to discuss about** 


it was test with the follow cases:

Inputs 1:
```

{
    "event_type": "my-custom-event",
    "sessionid": "2",
    "custom": {
        "name": "BBB",
        "type": "B"
    }
}
```

Inputs 2:
```

{
    "event_type": "my-custom-event-2",
    "sessionid": "1",
    "custom": {
        "another-custom": "yyy"
    }
}
```

Getting data:

Case 1: 

```

{
    "event_type": "my-custom-event-2",
    "sessionid": "1",
    "custom": {
        "another-custom": "yyy"
    }
}
```

Case 2:
```


{
   "dimensions":[
      "request.type"
   ],
      "measures":[
      "request.totalSessions"
   ],
      "filters":[
      {
         "member":"request.type",
         "operator":"equals",
         "values":[
            "A"
         ]
      }
   ]
}
```