### PR TITLE
chore(relate-content-modal): Move selection checkbox to first column

### DIFF
--- a/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
+++ b/dotCMS/src/main/webapp/html/js/dotcms/dijit/form/ContentSelector.js
@@ -1174,6 +1174,16 @@ dojo.declare(
             //Filling Headers
             var row = table.insertRow(table.rows.length);
 
+            // Add checkbox/select column header FIRST
+            var cell = row.insertCell(row.cells.length);
+            cell.setAttribute('class', 'beta');
+            cell.setAttribute('className', 'beta');
+            if (this.multiple == 'true') {
+                cell.innerHTML = '<b>Select</b>';
+            } else {
+                cell.innerHTML = '<b></b>'; // Empty for single select
+            }
+
             var cell = row.insertCell(row.cells.length);
             cell.setAttribute('class', 'beta');
             cell.setAttribute('className', 'beta');
@@ -1194,11 +1204,6 @@ dojo.declare(
             cell.setAttribute('style', 'min-width:120px;');
             cell.innerHTML =
                 '<b>' + this.availableLanguages[0]['title'] + '</b>';
-
-            var cell = row.insertCell(row.cells.length);
-            cell.setAttribute('class', 'beta');
-            cell.setAttribute('className', 'beta');
-            cell.setAttribute('width', '5%');
 
             var style = document.createElement('style');
             style.type = 'text/css';
@@ -1251,6 +1256,15 @@ dojo.declare(
                     }
                 }
 
+                // Add checkbox/select button cell FIRST
+                var cell = row.insertCell(row.cells.length);
+                cell.setAttribute('id', i);
+                if (this.multiple == 'true') {
+                    cell.innerHTML = this._checkButton(cellData);
+                } else {
+                    cell.innerHTML = this._selectButton(cellData);
+                }
+
                 var cell = row.insertCell(row.cells.length);
                 var iconName = this._getIconName(cellData['__type__']);
                 var hasTitleImage = cellData.hasTitleImage === 'true';
@@ -1301,14 +1315,6 @@ dojo.declare(
                             this.availableLanguages[l]['countryCode'] +
                             ')';
                     }
-                }
-
-                var cell = row.insertCell(row.cells.length);
-                cell.setAttribute('id', i);
-                if (this.multiple == 'true') {
-                    cell.innerHTML = this._checkButton(cellData);
-                } else {
-                    cell.innerHTML = this._selectButton(cellData);
                 }
             }
 


### PR DESCRIPTION
### Proposed Changes
Move selection checkbox column to leftmost position in the Relate Content modal table (ContentSelector.js)

### Checklist
- Local testing confirmed checkboxes now appear on left side and are always visible

### Additional Info

Issue Reference: Fixes #32288
Technical Details:
Modified _fillResultsTable function in ContentSelector.js
Moved checkbox column insertion from last position to first position

### Screenshots
Original 
<img width="1662" alt="Screenshot 2025-06-06 at 11 21 02 AM" src="https://github.com/user-attachments/assets/caf090eb-2431-4403-8aee-fecb14f23f56" />

Updated 

<img width="1667" alt="Screenshot 2025-06-06 at 11 21 14 AM" src="https://github.com/user-attachments/assets/b3368d78-18fa-4cbf-bb4b-5fab1c1ada76" />


This PR fixes: #32288