### PR TITLE
fix(uve): Support Containers added to Themes

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
@@ -58,6 +58,9 @@ export interface PageContainer {
     identifier: string;
     uuid: string;
     contentletsId: string[];
+    acceptTypes?: string;
+    maxContentlets?: number;
+    variantId?: string;
 }
 
 export interface ContainerPayload {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -72,6 +72,21 @@ export function insertContentletInContainer(action: ActionPayload): {
 
     const { pageContainers, container, personaTag, newContentletId } = action;
 
+    const containerIsOnPageResponse = pageContainers.find((pageContainer) =>
+        areContainersEquals(pageContainer, container)
+    );
+
+    // We had a case where users are using the #parseContainer macro to hard code containers on their themes
+    // This case was not taken into account when we moved to design templates, so the container is not getting indexed on the PageAPI until we add some content
+    // That means, we have to trust the data we got from our SDK when we are adding a contentlet to a container and add the container to the pageContainers array if it's not there
+    // https://github.com/dotCMS/core/issues/31790#issuecomment-2945998795
+    if (!containerIsOnPageResponse) {
+        pageContainers.push({
+            ...container,
+            contentletsId: [...container.contentletsId]
+        });
+    }
+
     const newPageContainers = pageContainers.map((pageContainer) => {
         if (
             areContainersEquals(pageContainer, container) &&
@@ -106,6 +121,21 @@ export function deleteContentletFromContainer(action: ActionPayload): {
     const { pageContainers, container, contentlet, personaTag } = action;
 
     let contentletsId = [];
+
+    const containerIsOnPageResponse = pageContainers.find((pageContainer) =>
+        areContainersEquals(pageContainer, container)
+    );
+
+    // We had a case where users are using the #parseContainer macro to hard code containers on their themes
+    // This case was not taken into account when we moved to design templates, so the container is not getting indexed on the PageAPI until we add some content
+    // That means, we have to trust the data we got from our SDK when we are adding a contentlet to a container and add the container to the pageContainers array if it's not there
+    // https://github.com/dotCMS/core/issues/31790#issuecomment-2945998795
+    if (!containerIsOnPageResponse) {
+        pageContainers.push({
+            ...container,
+            contentletsId: [...container.contentletsId]
+        });
+    }
 
     const newPageContainers = pageContainers.map((currentContainer) => {
         if (areContainersEquals(currentContainer, container)) {
@@ -169,6 +199,21 @@ function insertPositionedContentletInContainer(payload: ActionPayload): {
 
     const { pageContainers, container, contentlet, personaTag, newContentletId, position } =
         payload;
+
+    const containerIsOnPageResponse = pageContainers.find((pageContainer) =>
+        areContainersEquals(pageContainer, container)
+    );
+
+    // We had a case where users are using the #parseContainer macro to hard code containers on their themes
+    // This case was not taken into account when we moved to design templates, so the container is not getting indexed on the PageAPI until we add some content
+    // That means, we have to trust the data we got from our SDK when we are adding a contentlet to a container and add the container to the pageContainers array if it's not there
+    // https://github.com/dotCMS/core/issues/31790#issuecomment-2945998795
+    if (!containerIsOnPageResponse) {
+        pageContainers.push({
+            ...container,
+            contentletsId: [...container.contentletsId]
+        });
+    }
 
     const newPageContainers = pageContainers.map((pageContainer) => {
         if (

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -83,7 +83,7 @@ export function insertContentletInContainer(action: ActionPayload): {
     if (!containerIsOnPageResponse) {
         pageContainers.push({
             ...container,
-            contentletsId: [...container.contentletsId]
+            contentletsId: [...(container.contentletsId ?? [])]
         });
     }
 
@@ -133,7 +133,7 @@ export function deleteContentletFromContainer(action: ActionPayload): {
     if (!containerIsOnPageResponse) {
         pageContainers.push({
             ...container,
-            contentletsId: [...container.contentletsId]
+            contentletsId: [...(container.contentletsId ?? [])]
         });
     }
 
@@ -211,7 +211,7 @@ function insertPositionedContentletInContainer(payload: ActionPayload): {
     if (!containerIsOnPageResponse) {
         pageContainers.push({
             ...container,
-            contentletsId: [...container.contentletsId]
+            contentletsId: [...(container.contentletsId ?? [])]
         });
     }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -154,6 +154,51 @@ describe('utils functions', () => {
                 contentletsId: ['test']
             });
         });
+
+        it('should add container to pageContainers if it does not exist - issue #31790', () => {
+            // Current page with no containers
+            const pageContainers = [];
+
+            // Container where we want to delete the contentlet
+            const container = {
+                identifier: 'test',
+                uuid: 'test',
+                contentletsId: ['test'],
+                maxContentlets: 1,
+                acceptTypes: 'test',
+                variantId: '1'
+            };
+
+            // Contentlet to delete
+            const contentlet = {
+                identifier: 'test',
+                inode: 'test',
+                title: 'test',
+                contentType: 'test'
+            };
+
+            const result = deleteContentletFromContainer({
+                pageContainers,
+                container,
+                contentlet,
+                pageId: 'test',
+                language_id: 'test',
+                personaTag: 'persona-tag'
+            });
+
+            expect(result.pageContainers).toEqual([
+                {
+                    acceptTypes: 'test',
+                    maxContentlets: 1,
+                    variantId: '1',
+                    identifier: 'test',
+                    uuid: 'test',
+                    contentletsId: [],
+                    personaTag: 'persona-tag'
+                }
+            ]);
+            expect(result.contentletsId).toEqual([]);
+        });
     });
 
     describe('insert contentlet in container', () => {
@@ -302,6 +347,103 @@ describe('utils functions', () => {
                         identifier: 'test',
                         uuid: 'test',
                         contentletsId: ['test']
+                    }
+                ]
+            });
+        });
+
+        it('should add container to pageContainers if it does not exist - issue #31790', () => {
+            // Current page with no containers
+            const pageContainers = [];
+
+            // Container where we want to insert the contentlet
+            const container = {
+                identifier: 'test',
+                uuid: 'test',
+                contentletsId: [],
+                maxContentlets: 1,
+                acceptTypes: 'test',
+                variantId: '1'
+            };
+
+            // Contentlet position mark
+            const contentlet = {
+                identifier: 'contentlet-id',
+                inode: 'contentlet-inode',
+                title: 'test',
+                contentType: 'test'
+            };
+
+            const result = insertContentletInContainer({
+                pageContainers,
+                container,
+                contentlet,
+                pageId: 'page-id',
+                language_id: '1',
+                newContentletId: 'new-contentlet-id',
+                personaTag: 'persona-tag'
+            });
+
+            expect(result).toEqual({
+                didInsert: true,
+                pageContainers: [
+                    {
+                        identifier: 'test',
+                        uuid: 'test',
+                        contentletsId: ['new-contentlet-id'],
+                        personaTag: 'persona-tag',
+                        acceptTypes: 'test',
+                        maxContentlets: 1,
+                        variantId: '1'
+                    }
+                ]
+            });
+        });
+
+        it('should add container to pageContainers and insert in specific position - issue #31790', () => {
+            // Current page with no containers
+            const pageContainers = [];
+
+            // Container where we want to insert the contentlet
+            const container = {
+                identifier: 'test',
+                uuid: 'test',
+                contentletsId: ['test123'],
+                maxContentlets: 1,
+                acceptTypes: 'test',
+                variantId: '1'
+            };
+
+            // Contentlet to insert
+            const contentlet = {
+                identifier: 'test123',
+                inode: 'test',
+                title: 'test',
+                contentType: 'test'
+            };
+
+            const result = insertContentletInContainer({
+                pageContainers,
+                container,
+                contentlet,
+                pageId: 'test',
+                language_id: 'test',
+                position: 'after',
+                newContentletId: '000',
+                personaTag: 'persona-tag'
+            });
+
+            expect(result).toEqual({
+                didInsert: true,
+                pageContainers: [
+                    {
+                        identifier: 'test',
+                        uuid: 'test',
+                        contentletsId: ['test123', '000'],
+                        personaTag: 'persona-tag',
+                        acceptTypes: 'test',
+                        maxContentlets: 1,
+                        variantId: '1'
                     }
                 ]
             });


### PR DESCRIPTION
This pull request introduces enhancements to the container management logic in the `edit-ema` portlet, addressing edge cases where containers are hardcoded in themes but not indexed in the `PageAPI`. Additionally, it improves type definitions and adds comprehensive test cases to validate the new behavior.

### Enhancements to container management logic:
* Updated `insertContentletInContainer`, `deleteContentletFromContainer`, and `insertPositionedContentletInContainer` functions to handle cases where containers are hardcoded in themes but not indexed in the `PageAPI`. These functions now check if the container exists in `pageContainers` and add it if missing. [[1]](diffhunk://#diff-2fd4d225bb33327848da73766ec5efbe037e3aed1a1e51a50c19f6a2be8cdb80R75-R89) [[2]](diffhunk://#diff-2fd4d225bb33327848da73766ec5efbe037e3aed1a1e51a50c19f6a2be8cdb80R125-R139) [[3]](diffhunk://#diff-2fd4d225bb33327848da73766ec5efbe037e3aed1a1e51a50c19f6a2be8cdb80R203-R217)

### Type definition improvements:
* Added optional properties `acceptTypes`, `maxContentlets`, and `variantId` to the `PageContainer` interface in `shared/models.ts`. These properties provide additional configuration options for containers.

### Test coverage improvements:
* Added test cases to validate the behavior of `deleteContentletFromContainer`, `insertContentletInContainer`, and `insertPositionedContentletInContainer` when containers are missing from `pageContainers`. These tests ensure that containers are correctly added and contentlets are managed as expected. [[1]](diffhunk://#diff-6b95047786d13d69ebdcb642c6d382bc35784a2ada53f95d1908119ab08dfb91R157-R201) [[2]](diffhunk://#diff-6b95047786d13d69ebdcb642c6d382bc35784a2ada53f95d1908119ab08dfb91R354-R450)

This PR fixes: #31790