### PR TITLE
chore(uve): Removed filter on UVE query params

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -32,13 +32,13 @@ import { EditEmaNavigationBarComponent } from './components/edit-ema-navigation-
 import { DotEmaDialogComponent } from '../components/dot-ema-dialog/dot-ema-dialog.component';
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
 import { DotPageApiService } from '../services/dot-page-api.service';
+import { PERSONA_KEY } from '../shared/consts';
 import { NG_CUSTOM_EVENTS } from '../shared/enums';
 import { DialogAction, DotPageAssetParams } from '../shared/models';
 import { UVEStore } from '../store/dot-uve.store';
 import { DotUveViewParams } from '../store/models';
 import {
     checkClientHostAccess,
-    getAllowedPageParams,
     getTargetUrl,
     normalizeQueryParams,
     sanitizeURL,
@@ -205,7 +205,7 @@ export class DotEmaShellComponent implements OnInit {
         const allowedDevURLs = uveConfig?.options?.allowedDevURLs;
 
         // Clone queryParams to avoid mutation errors
-        const params = getAllowedPageParams(queryParams);
+        const params = { ...queryParams };
         const validHost = checkClientHostAccess(params.clientHost, allowedDevURLs);
 
         //Sanitize the url
@@ -231,10 +231,11 @@ export class DotEmaShellComponent implements OnInit {
         }
 
         if (queryParams['personaId']) {
-            params['com.dotmarketing.persona.id'] = queryParams['personaId'];
+            params[PERSONA_KEY] = queryParams['personaId'];
+            delete params['personaId'];
         }
 
-        return params;
+        return params as DotPageAssetParams;
     }
 
     #getViewParams(uveMode: UVE_MODE): DotUveViewParams {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
@@ -23,6 +23,8 @@ export interface DotPageApiParams {
     experimentId?: string;
     clientHost?: string;
     publishDate?: string;
+    // We need this to allow any other query param to be passed by the user
+    [x: string]: any;
 }
 
 export enum DotPageAssetKeys {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
@@ -24,6 +24,7 @@ export interface DotPageApiParams {
     clientHost?: string;
     publishDate?: string;
     // We need this to allow any other query param to be passed by the user
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [x: string]: any;
 }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/load/withLoad.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/load/withLoad.ts
@@ -15,12 +15,7 @@ import { DEFAULT_VARIANT_ID } from '@dotcms/dotcms-models';
 import { DotPageApiService } from '../../../services/dot-page-api.service';
 import { UVE_STATUS } from '../../../shared/enums';
 import { DotPageAssetParams } from '../../../shared/models';
-import {
-    computeCanEditPage,
-    computePageIsLocked,
-    getAllowedPageParams,
-    isForwardOrPage
-} from '../../../utils';
+import { computeCanEditPage, computePageIsLocked, isForwardOrPage } from '../../../utils';
 import { UVEState } from '../../models';
 import { withClient } from '../client/withClient';
 import { withWorkflow } from '../workflow/withWorkflow';
@@ -87,10 +82,8 @@ export function withLoad() {
                             });
                         }),
                         switchMap((pageParams) => {
-                            const allowedParams = getAllowedPageParams(pageParams);
-
                             return forkJoin({
-                                pageAsset: dotPageApiService.get(allowedParams).pipe(
+                                pageAsset: dotPageApiService.get(pageParams).pipe(
                                     // This logic should be handled in the Shell component using an effect
                                     switchMap((pageAsset) => {
                                         const { vanityUrl } = pageAsset;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/load/withLoad.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/load/withLoad.ts
@@ -88,6 +88,7 @@ export function withLoad() {
                         }),
                         switchMap((pageParams) => {
                             const allowedParams = getAllowedPageParams(pageParams);
+
                             return forkJoin({
                                 pageAsset: dotPageApiService.get(allowedParams).pipe(
                                     // This logic should be handled in the Shell component using an effect

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/load/withLoad.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/load/withLoad.ts
@@ -15,7 +15,12 @@ import { DEFAULT_VARIANT_ID } from '@dotcms/dotcms-models';
 import { DotPageApiService } from '../../../services/dot-page-api.service';
 import { UVE_STATUS } from '../../../shared/enums';
 import { DotPageAssetParams } from '../../../shared/models';
-import { computeCanEditPage, computePageIsLocked, isForwardOrPage } from '../../../utils';
+import {
+    computeCanEditPage,
+    computePageIsLocked,
+    getAllowedPageParams,
+    isForwardOrPage
+} from '../../../utils';
 import { UVEState } from '../../models';
 import { withClient } from '../client/withClient';
 import { withWorkflow } from '../workflow/withWorkflow';
@@ -82,8 +87,9 @@ export function withLoad() {
                             });
                         }),
                         switchMap((pageParams) => {
+                            const allowedParams = getAllowedPageParams(pageParams);
                             return forkJoin({
-                                pageAsset: dotPageApiService.get(pageParams).pipe(
+                                pageAsset: dotPageApiService.get(allowedParams).pipe(
                                     // This logic should be handled in the Shell component using an effect
                                     switchMap((pageAsset) => {
                                         const { vanityUrl } = pageAsset;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -1,5 +1,3 @@
-import { Params } from '@angular/router';
-
 import { CurrentUser } from '@dotcms/dotcms-js';
 import {
     DEFAULT_VARIANT_ID,
@@ -18,7 +16,7 @@ import {
 } from '@dotcms/types';
 
 import { EmaDragItem } from '../edit-ema-editor/components/ema-page-dropzone/types';
-import { DotPageAssetKeys, DotPageApiParams } from '../services/dot-page-api.service';
+import { DotPageApiParams } from '../services/dot-page-api.service';
 import {
     BASE_IFRAME_MEASURE_UNIT,
     COMMON_ERRORS,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -661,25 +661,6 @@ export const checkClientHostAccess = (
 };
 
 /**
- * Retrieve the page params from the router query params
- *
- * @export
- * @param {Params} params
- * @return {*}  {DotPageApiParams}
- */
-export function getAllowedPageParams(params: Params): DotPageAssetParams {
-    const allowedParams: DotPageAssetKeys[] = Object.values(DotPageAssetKeys);
-
-    return Object.keys(params)
-        .filter((key) => key && allowedParams.includes(key as DotPageAssetKeys))
-        .reduce((obj, key) => {
-            obj[key] = params[key];
-
-            return obj;
-        }, {}) as DotPageAssetParams;
-}
-
-/**
  * Determines the target URL for navigation.
  *
  * If `urlContentMap` is present and contains a `URL_MAP_FOR_CONTENT`, it will be used.

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -20,7 +20,6 @@ import {
     createFullURL,
     getDragItemData,
     createReorderMenuURL,
-    getAllowedPageParams,
     getOrientation,
     getWrapperMeasures,
     normalizeQueryParams
@@ -751,53 +750,6 @@ describe('utils functions', () => {
             expect(result).toEqual(
                 'http://localhost/c/portal/layout?p_l_id=2df9f117-b140-44bf-93d7-5b10a36fb7f9&p_p_id=site-browser&p_p_action=1&p_p_state=maximized&_site_browser_struts_action=%2Fext%2Ffolders%2Forder_menu&startLevel=1&depth=1&pagePath=123&hostId=456'
             );
-        });
-    });
-
-    describe('getAllowedPageParams', () => {
-        it('should filter and return only allowed page params', () => {
-            const expected = {
-                url: 'some-url',
-                mode: UVE_MODE.EDIT,
-                depth: '2',
-                clientHost: 'localhost',
-                variantName: 'variant',
-                language_id: '1',
-                experimentId: 'exp123',
-                [PERSONA_KEY]: 'persona123'
-            } as DotPageApiParams;
-
-            const params: Params = {
-                ...expected,
-                invalidParam: 'invalid'
-            };
-
-            const result = getAllowedPageParams(params);
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should return an empty object if no allowed params are present', () => {
-            const params: Params = {
-                invalidParam1: 'invalid1',
-                invalidParam2: 'invalid2'
-            };
-
-            const expected = {} as DotPageApiParams;
-
-            const result = getAllowedPageParams(params);
-
-            expect(result).toEqual(expected);
-        });
-
-        it('should return an empty object if params is empty', () => {
-            const params: Params = {};
-
-            const expected = {} as DotPageApiParams;
-
-            const result = getAllowedPageParams(params);
-
-            expect(result).toEqual(expected);
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -1,5 +1,3 @@
-import { Params } from '@angular/router';
-
 import { CurrentUser } from '@dotcms/dotcms-js';
 import { DotContainer, DotDevice, DotExperiment, DotExperimentStatus } from '@dotcms/dotcms-models';
 import { DotCMSPage, DotCMSViewAsPersona, UVE_MODE } from '@dotcms/types';
@@ -25,7 +23,6 @@ import {
     normalizeQueryParams
 } from '.';
 
-import { DotPageApiParams } from '../services/dot-page-api.service';
 import { DEFAULT_PERSONA, PERSONA_KEY } from '../shared/consts';
 import { dotPageContainerStructureMock } from '../shared/mocks';
 import { ContentletDragPayload, ContentTypeDragPayload } from '../shared/models';


### PR DESCRIPTION

https://github.com/user-attachments/assets/937d82f4-3baa-49af-ac7c-c39d9468382c

This pull request refactors the handling of query parameters in the `DotEmaShellComponent` and removes the `getAllowedPageParams` utility function. The changes simplify the codebase, improve maintainability, and ensure better alignment with TypeScript type safety.

### Refactoring query parameter handling:

* Replaced the `getAllowedPageParams` function with a direct spread operator approach to clone and modify query parameters in `DotEmaShellComponent`. This eliminates the need for filtering allowed parameters manually. (`dot-ema-shell.component.ts`: [[1]](diffhunk://#diff-677330662fea6dadc7e48fd8455ec2a6fe60d624c7ed1f01f0a3e985aacd05c6L208-R208) [[2]](diffhunk://#diff-677330662fea6dadc7e48fd8455ec2a6fe60d624c7ed1f01f0a3e985aacd05c6L234-R238)
* Introduced the `PERSONA_KEY` constant for consistent usage of the `personaId` parameter key, replacing hardcoded strings. (`dot-ema-shell.component.ts`: [[1]](diffhunk://#diff-677330662fea6dadc7e48fd8455ec2a6fe60d624c7ed1f01f0a3e985aacd05c6R35-L41) [[2]](diffhunk://#diff-677330662fea6dadc7e48fd8455ec2a6fe60d624c7ed1f01f0a3e985aacd05c6L234-R238)

### Code cleanup and removal of unused functionality:

* Removed the `getAllowedPageParams` utility function and its associated imports and tests, as it is no longer necessary. (`index.ts`: [[1]](diffhunk://#diff-2fd4d225bb33327848da73766ec5efbe037e3aed1a1e51a50c19f6a2be8cdb80L663-L681) [[2]](diffhunk://#diff-2fd4d225bb33327848da73766ec5efbe037e3aed1a1e51a50c19f6a2be8cdb80L1-L2) [[3]](diffhunk://#diff-2fd4d225bb33327848da73766ec5efbe037e3aed1a1e51a50c19f6a2be8cdb80L21-R19); `utils.spec.ts`: [[4]](diffhunk://#diff-6b95047786d13d69ebdcb642c6d382bc35784a2ada53f95d1908119ab08dfb91L1-L2) [[5]](diffhunk://#diff-6b95047786d13d69ebdcb642c6d382bc35784a2ada53f95d1908119ab08dfb91L23-L29) [[6]](diffhunk://#diff-6b95047786d13d69ebdcb642c6d382bc35784a2ada53f95d1908119ab08dfb91L757-L803)

### TypeScript improvements:

* Updated the `DotPageApiParams` interface to allow dynamic query parameters using an index signature, ensuring flexibility for additional parameters. (`dot-page-api.service.ts`: [core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.tsR26-R28](diffhunk://#diff-9acb0e7dc2619395c49047164381778d2b6d6c41f58b30aa3cd6a798044007c6R26-R28))

This PR fixes: #32224