### PR TITLE
feat: Automate LICENSE Change Date update during releases

### DIFF
--- a/.github/actions/update-license-date.sh
+++ b/.github/actions/update-license-date.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Script to update the LICENSE file Change Date line with current date
+# Format: "Change Date:     Four years from Month DD, YYYY"
+
+LICENSE_FILE="../LICENSE"
+
+# Get current date in the required format (e.g., "June 01, 2025")
+CURRENT_DATE=$(date "+%B %d, %Y")
+
+# Find the line containing "Change Date:" and extract the current date
+CURRENT_LINE=$(grep "^Change Date:" "$LICENSE_FILE")
+
+if [ -z "$CURRENT_LINE" ]; then
+    echo "Error: Could not find 'Change Date:' line in LICENSE file"
+    exit 1
+fi
+
+# Extract the date from the current line (everything after "Four years from ")
+CURRENT_DATE_IN_FILE=$(echo "$CURRENT_LINE" | sed 's/.*Four years from //')
+
+# Check if the date needs to be updated
+if [ "$CURRENT_DATE_IN_FILE" = "$CURRENT_DATE" ]; then
+    echo "LICENSE file already has the current date: $CURRENT_DATE"
+    echo "No update needed."
+    exit 0
+fi
+
+echo "Updating LICENSE file Change Date from '$CURRENT_DATE_IN_FILE' to '$CURRENT_DATE'"
+
+# Create the new line with the current date
+NEW_LINE="Change Date:     Four years from $CURRENT_DATE"
+
+# Update the file using sed to replace the line that starts with "Change Date:"
+sed -i.bak "s/^Change Date:.*/Change Date:     Four years from $CURRENT_DATE/" "$LICENSE_FILE"
+
+if [ $? -eq 0 ]; then
+    echo "Successfully updated LICENSE file"
+    echo "Backup created as ${LICENSE_FILE}.bak"
+else
+    echo "Error updating LICENSE file"
+    exit 1
+fi

--- a/.github/actions/update-license-date.sh
+++ b/.github/actions/update-license-date.sh
@@ -3,7 +3,14 @@
 # Script to update the LICENSE file Change Date line with current date
 # Format: "Change Date:     Four years from Month DD, YYYY"
 
-LICENSE_FILE="../LICENSE"
+# Find the git repository root directory
+REPO_ROOT=$(git rev-parse --show-toplevel)
+if [ $? -ne 0 ]; then
+    echo "Error: Not in a git repository"
+    exit 1
+fi
+
+LICENSE_FILE="${REPO_ROOT}/LICENSE"
 
 # Get current date in the required format (e.g., "June 01, 2025")
 CURRENT_DATE=$(date "+%B %d, %Y")

--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -118,6 +118,16 @@ jobs:
           
           git add .mvn/maven.config
           
+          # Update LICENSE file Change Date
+          chmod +x .github/actions/update-license-date.sh
+          .github/actions/update-license-date.sh
+          
+          # Add LICENSE file if it was modified
+          if ! git diff --quiet HEAD -- LICENSE; then
+            echo "LICENSE file was updated, adding to commit"
+            git add LICENSE
+          fi
+          
           git status
           git commit -a -m "🏁 Publishing release version [${release_version}]"
           git push origin ${release_branch}


### PR DESCRIPTION
## Summary
- Automates the update of the LICENSE file Change Date during the release process
- Ensures BSL license conversion date is properly maintained with each release

## Changes
- **New script**: `.github/actions/update-license-date.sh` - Updates LICENSE file Change Date to current date
- **Workflow integration**: Modified `legacy-release_maven-release-process.yml` to run the script during release preparation
- **Smart updates**: Only updates the LICENSE file if the date is different from current date

## Details
The Business Source License requires updating the "Change Date" with each release. This automation:

1. **Runs during release preparation** - Integrated into the existing maven release workflow
2. **Finds the Change Date line** - Uses grep to locate the line regardless of position in file
3. **Compares dates** - Only updates if current date differs from what's in the file
4. **Proper formatting** - Maintains the exact format: "Change Date: Four years from Month DD, YYYY"
5. **Includes in release commit** - The updated LICENSE file becomes part of the release commit

## Test plan
- [x] Script correctly identifies and updates Change Date line in LICENSE file
- [x] Script handles case where date is already current (no unnecessary updates)
- [x] Script is properly integrated into release workflow
- [x] Follows existing project conventions for script placement in `.github/actions/`

## Related Issue
Closes #31844

🤖 Generated with [Claude Code](https://claude.ai/code)