### PR TITLE
feat(angular): Introduce provideDotCMSClient for Angular SDK

### DIFF
--- a/core-web/libs/sdk/angular/README.md
+++ b/core-web/libs/sdk/angular/README.md
@@ -80,33 +80,46 @@ For detailed instructions, please refer to the [dotCMS API Documentation - Read-
 npm install @dotcms/angular@next @dotcms/uve@next @dotcms/client@next @dotcms/types@next @tinymce/tinymce-angular
 ```
 
-### dotCMS Client Configuration
+## Configuration
+
+The recommended way to configure the DotCMS client in your Angular application is to use the `provideDotCMSClient` function in your `app.config.ts`:
 
 ```typescript
-import { createDotCMSClient } from '@dotcms/client/next';
-import { InjectionToken } from '@angular/core';
-
-export type DotCMSClient = ReturnType<typeof createDotCMSClient>;
-
-const dotCMSClient: DotCMSClient = createDotCMSClient({
-    dotcmsUrl: 'https://your-dotcms-instance.com',
-    authToken: 'your-auth-token', // Optional for public content
-    siteId: 'your-site-id' // Optional site identifier/name
-});
-
-export const DOTCMS_CLIENT_TOKEN = new InjectionToken<DotCMSClient>('DOTCMS_CLIENT');
+import { ApplicationConfig } from '@angular/core';
+import { provideDotCMSClient } from '@dotcms/angular/next'; // Or '@dotcms/angular' depending on your setup
+import { environment } from './environments/environment'; // Assuming your environment variables are here
 
 export const appConfig: ApplicationConfig = {
-    providers: [
-        {
-            provide: DOTCMS_CLIENT_TOKEN,
-            useValue: dotCMSClient
-        }
-    ]
+  providers: [
+    provideDotCMSClient({
+      dotcmsUrl: environment.dotcmsUrl,
+      authToken: environment.authToken, // Optional: if you need to use an auth token
+      siteId: environment.siteId // Optional: if you need to specify a site ID
+    })
+  ]
 };
 ```
 
-This configuration makes the dotCMS client service available throughout your Angular application, allowing you to inject it wherever needed. For more details on how Angular's InjectionToken works, you can refer to the [Angular InjectionToken documentation](https://angular.dev/api/core/InjectionToken).
+Then, you can inject the `DotCMSClient` into your components or services:
+
+```typescript
+import { Component, inject } from '@angular/core';
+import { DotCMSClient } from '@dotcms/angular/next'; // Or '@dotcms/angular'
+
+@Component({
+  selector: 'app-my-component',
+  template: `<!-- Your component template -->`
+})
+export class MyComponent {
+  private dotcmsClient = inject(DotCMSClient);
+
+  constructor() {
+    // You can now use this.dotcmsClient.client to access the DotCMS SDK
+    // For example: this.dotcmsClient.client.page.get('/about-us')
+    // .then(page => console.log(page));
+  }
+}
+```
 
 ### Proxy Configuration for Static Assets
 

--- a/core-web/libs/sdk/angular/next/providers/dotcms-client/dotcms-client.provider.spec.ts
+++ b/core-web/libs/sdk/angular/next/providers/dotcms-client/dotcms-client.provider.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core';
+import { provideDotCMSClient } from './dotcms-client.provider';
+import { DotCMSClientService } from '../../services/dotcms-client.service';
+import { DotCMSClientConfig } from '@dotcms/client/next';
+
+describe('provideDotCMSClient', () => {
+  const testConfig: DotCMSClientConfig = {
+    dotcmsUrl: 'https://demo.dotcms.com',
+    siteId: 'default'
+  };
+
+  it('should provide DotCMSClientService with the given config', () => {
+    TestBed.configureTestingModule({
+      providers: [provideDotCMSClient(testConfig)]
+    });
+
+    const clientService = TestBed.inject(DotCMSClientService);
+    expect(clientService).toBeTruthy();
+    expect(clientService.client).toBeTruthy();
+    expect(clientService.client.config.dotcmsUrl).toBe('https://demo.dotcms.com');
+    expect(clientService.client.config.siteId).toBe('default');
+  });
+
+  it('should allow injecting DotCMSClientService using inject()', () => {
+    TestBed.configureTestingModule({
+      providers: [provideDotCMSClient(testConfig)]
+    });
+
+    const clientService = inject(DotCMSClientService);
+    expect(clientService).toBeTruthy();
+    expect(clientService.client).toBeTruthy();
+    expect(clientService.client.config.dotcmsUrl).toBe('https://demo.dotcms.com');
+  });
+});

--- a/core-web/libs/sdk/angular/next/providers/dotcms-client/dotcms-client.provider.ts
+++ b/core-web/libs/sdk/angular/next/providers/dotcms-client/dotcms-client.provider.ts
@@ -1,0 +1,13 @@
+import { makeEnvironmentProviders, EnvironmentProviders } from '@angular/core';
+import { DotCMSClientConfig }
+from '@dotcms/client/next';
+import { DotCMSClientService } from '../../services/dotcms-client.service';
+
+export function provideDotCMSClient(config: DotCMSClientConfig): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: DotCMSClientService,
+      useValue: new DotCMSClientService(config)
+    }
+  ]);
+}

--- a/core-web/libs/sdk/angular/next/public_api.ts
+++ b/core-web/libs/sdk/angular/next/public_api.ts
@@ -9,3 +9,6 @@ export { DotCMSBlockEditorRendererComponent } from './components/dotcms-block-ed
 export { DotCMSLayoutBodyComponent } from './components/dotcms-layout-body/dotcms-layout-body.component';
 
 export { DotCMSEditablePageService } from './services/dotcms-editable-page.service';
+
+export { DotCMSClientService as DotCMSClient } from './services/dotcms-client.service';
+export { provideDotCMSClient } from './providers/dotcms-client/dotcms-client.provider';

--- a/core-web/libs/sdk/angular/next/services/dotcms-client.service.spec.ts
+++ b/core-web/libs/sdk/angular/next/services/dotcms-client.service.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed } from '@angular/core/testing';
+import { DotCMSClientService } from './dotcms-client.service';
+import { DotCMSClientConfig } from '@dotcms/client/next';
+
+describe('DotCMSClientService', () => {
+  const mockConfig: DotCMSClientConfig = {
+    dotcmsUrl: 'http://localhost:8080',
+    siteId: 'test-site'
+  };
+
+  it('should be created with a valid config', () => {
+    const service = new DotCMSClientService(mockConfig);
+    expect(service).toBeTruthy();
+    expect(service.client).toBeTruthy();
+  });
+
+  it('should expose the dotcms client instance', () => {
+    const service = new DotCMSClientService(mockConfig);
+    expect(service.client.config.dotcmsUrl).toBe('http://localhost:8080');
+    expect(service.client.config.siteId).toBe('test-site');
+  });
+});

--- a/core-web/libs/sdk/angular/next/services/dotcms-client.service.ts
+++ b/core-web/libs/sdk/angular/next/services/dotcms-client.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { createDotCMSClient, DotCMSClientConfig, DotCMSClient } from '@dotcms/client/next';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DotCMSClientService {
+  public client: DotCMSClient;
+
+  constructor(config: DotCMSClientConfig) {
+    this.client = createDotCMSClient(config);
+  }
+}


### PR DESCRIPTION
Introduces a new `provideDotCMSClient` function for the @dotcms/angular package, simplifying the DotCMS client configuration in Angular applications. This change aligns with modern Angular practices using environment providers.

Key changes:
- Added `DotCMSClientService` to wrap the `@dotcms/client`.
- Created `provideDotCMSClient` using `makeEnvironmentProviders` for easy setup in `app.config.ts`.
- The `DotCMSClientService` (aliased as `DotCMSClient`) can now be directly injected into components and services using `inject(DotCMSClient)`.
- Updated `README.md` to reflect the new recommended configuration method.
- Added unit tests for the new service and provider.

This change makes setting up the DotCMS client more idiomatic for Angular developers and improves code clarity.

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
