### PR TITLE
fix(Apps): add error detail when exporting app config 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
@@ -185,7 +185,7 @@ describe('DotAppsService', () => {
                         return `attachment; filename=${fileName}`;
                     }
                     if (_header === 'error-message') {
-                        return null; 
+                        return null;
                     }
                     return null;
                 }

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
@@ -188,7 +188,7 @@ describe('DotAppsService', () => {
                     if (_header === 'error-message') {
                         return null;
                     }
-                    
+
                     return null;
                 }
             },

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
@@ -181,7 +181,13 @@ describe('DotAppsService', () => {
         const mockResponse = {
             headers: {
                 get: (_header: string) => {
-                    return `attachment; filename=${fileName}`;
+                    if (_header === 'content-disposition') {
+                        return `attachment; filename=${fileName}`;
+                    }
+                    if (_header === 'error-message') {
+                        return null; 
+                    }
+                    return null;
                 }
             },
             blob: () => {

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
@@ -184,9 +184,11 @@ describe('DotAppsService', () => {
                     if (_header === 'content-disposition') {
                         return `attachment; filename=${fileName}`;
                     }
+
                     if (_header === 'error-message') {
                         return null;
                     }
+                    
                     return null;
                 }
             },

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.ts
@@ -149,9 +149,8 @@ export class DotAppsService {
             body: JSON.stringify(conf)
         })
             .then((res: Response) => {
-
                 const message = res.headers.get('error-message');
-                if (message){
+                if (message) {
                     throw new Error(message);
                 }
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.ts
@@ -149,6 +149,12 @@ export class DotAppsService {
             body: JSON.stringify(conf)
         })
             .then((res: Response) => {
+
+                const message = res.headers.get('error-message');
+                if (message){
+                    throw new Error(message);
+                }
+
                 const key = 'filename=';
                 const contentDisposition = res.headers.get('content-disposition');
                 fileName = contentDisposition.slice(contentDisposition.indexOf(key) + key.length);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.ts
@@ -141,9 +141,10 @@ export class DotAppsImportExportDialogComponent implements OnChanges, OnDestroy 
                         .exportConfiguration(requestConfiguration)
                         .then((errorMsg: string) => {
                             if (errorMsg) {
-                                this.errorMessage = this.dotMessageService.get(
-                                    'apps.confirmation.export.error'
-                                ) + ': ' + errorMsg;
+                                this.errorMessage =
+                                    this.dotMessageService.get('apps.confirmation.export.error') +
+                                    ': ' +
+                                    errorMsg;
                             } else {
                                 this.closeExportDialog();
                             }

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-import-export-dialog/dot-apps-import-export-dialog.component.ts
@@ -143,7 +143,7 @@ export class DotAppsImportExportDialogComponent implements OnChanges, OnDestroy 
                             if (errorMsg) {
                                 this.errorMessage = this.dotMessageService.get(
                                     'apps.confirmation.export.error'
-                                );
+                                ) + ': ' + errorMsg;
                             } else {
                                 this.closeExportDialog();
                             }


### PR DESCRIPTION
**Problem**

A generic message was displayed when getting an error in the Apps export config tab. Also, it wasn't considering the case when the API that was requesting returned an error.

**Fix**

Added a check that validates if the response has an `error-message` as headers (this means that the API is returning an error) and if it has, then throw an error so it can be received correctly, and when received, display it.

<img width="417" alt="Captura de pantalla 2025-06-12 a la(s) 12 04 01 p  m" src="https://github.com/user-attachments/assets/e1ac14c4-a98f-44b2-adaf-91214e4c2f9c" />

This PR fixes: #31859