### PR TITLE
Restore Contributing section environment setup links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ dotCMS is licensed under the terms of the BSL 1.1 license and all features are f
 
 GitHub pull requests are the preferred method to contribute code to dotCMS. Before any pull requests can be accepted, an automated tool will ask you to agree to the [dotCMS Contributor's Agreement](https://gist.github.com/wezell/85ef45298c48494b90d92755b583acb3). 
 
+-  [How to set up my front-end environment?](dotFrontendOnboarding.md) - Useful if you want to propose changes under the core-web directory
+-  [How to set up my back-end environment?](dotBackendOnboarding.md) - Useful if you want to propose changes in Java classes, jsp files and anything under the [dotCMS](dotCMS) or [tools](tools) directories 
+
 ## Requirements
 
 For a complete list of requirements, see [this page](http://www.dotcms.com/docs/latest/dotcms-technology-requirements).


### PR DESCRIPTION
## Summary
- Restore the front-end and back-end environment setup links that were removed in commit ff4f11ccd0b9d6fea667326f1517d38620dedcd8
- These links help new contributors understand how to set up their development environment properly

## Test plan
- [x] Verify README.md displays the Contributing section with both environment setup links
- [x] Check that the links point to the correct documentation files

🤖 Generated with [Claude Code](https://claude.ai/code)