### PR TITLE
fix(graphql) map attribute failure for contentlets within page variants in graphql #32384 

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -68,15 +68,6 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             }
 
             final User user = ((DotGraphQLContext) environment.getContext()).getUser();
-
-            final DotTransformerBuilder transformerBuilder = new DotTransformerBuilder();
-
-            if(UtilMethods.isSet(render) && render) {
-                transformerBuilder.hydratedContentMapTransformer(RENDER_FIELDS);
-            } else {
-                render = false;
-                transformerBuilder.hydratedContentMapTransformer();
-            }
             // Resolve hydrated contentlet map with optional variant handling
             Map<String, Object> hydratedMap = getHydratedMapWithVariantFallback(request, user, contentlet, render);
             final JSONObject contentMapInJSON = new JSONObject();

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -160,6 +160,8 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             final Contentlet contentlet,
             final boolean render
     ) {
+        // Create a defensive copy to avoid modifying the original contentlet
+        final Contentlet contentletCopy = new Contentlet(contentlet.getMap());
         final Object variantAttr = request.getAttribute(VariantAPI.VARIANT_KEY);
 
         // Set variantId only if explicitly requested
@@ -169,25 +171,25 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             // Avoid fallback loop if DEFAULT is already being used
             assert VariantAPI.DEFAULT_VARIANT.name() != null;
             if (VariantAPI.DEFAULT_VARIANT.name().equals(variantName)) {
-                contentlet.setVariantId(variantName);
-                return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
+                contentletCopy.setVariantId(variantName);
+                return ContentletUtil.getContentPrintableMap(user, contentletCopy, false, render);
             }
 
             try {
-                contentlet.setVariantId(variantName);
-                return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
+                contentletCopy.setVariantId(variantName);
+                return ContentletUtil.getContentPrintableMap(user, contentletCopy, false, render);
             } catch (DotStateException e) {
                 Logger.debug(this, () -> String.format(
                         "Variant '%s' not found for contentlet '%s'. Falling back to DEFAULT variant.",
-                        variantName, contentlet.getIdentifier()
+                        variantName, contentletCopy.getIdentifier()
                 ));
 
-                contentlet.setVariantId(VariantAPI.DEFAULT_VARIANT.name());
-                return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
+                contentletCopy.setVariantId(VariantAPI.DEFAULT_VARIANT.name());
+                return ContentletUtil.getContentPrintableMap(user, contentletCopy, false, render);
             }
         }
 
         // No variantAttr: implicitly uses DEFAULT variant
-        return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
+        return ContentletUtil.getContentPrintableMap(user, contentletCopy, false, render);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -3,9 +3,11 @@ package com.dotcms.graphql.datafetcher;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.graphql.DotGraphQLContext;
 import com.dotcms.rest.ContentHelper;
+import com.dotcms.variant.VariantAPI;
+import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.portlets.contentlet.transform.DotContentletTransformer;
 import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
+import com.dotmarketing.portlets.contentlet.util.ContentletUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.json.JSONObject;
@@ -75,10 +77,8 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
                 render = false;
                 transformerBuilder.hydratedContentMapTransformer();
             }
-
-            final DotContentletTransformer myTransformer = transformerBuilder.content(contentlet).build();
-
-            final Map<String, Object> hydratedMap =  myTransformer.toMaps().get(0);
+            // Resolve hydrated contentlet map with optional variant handling
+            Map<String, Object> hydratedMap = getHydratedMapWithVariantFallback(request, user, contentlet, render);
             final JSONObject contentMapInJSON = new JSONObject();
 
             // this only adds relationships to any json. We would need to return them with the transformations already
@@ -131,16 +131,72 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
 
 
     private Object getRenderedFieldValue(final HttpServletRequest request,
-            final HttpServletResponse response, final Contentlet contentlet,
-            final String key) {
+                                         final HttpServletResponse response, final Contentlet contentlet,
+                                         final String key) {
         final Field field = Try.of(()-> contentlet.getContentType().fields()
                 .stream().filter((myField)->myField.variable().equals(key)).collect(
-                Collectors.toList()).get(0)).getOrNull();
+                        Collectors.toList()).get(0)).getOrNull();
 
         if(!isFieldRenderable(field)) {
             return contentlet.get(key);
         }
 
         return renderFieldValue(request, response, (String) contentlet.get(key), contentlet, field.variable());
+    }
+
+    /**
+     * Attempts to retrieve a hydrated contentlet map, respecting an explicitly requested variant if present.
+     * <p>
+     * Behavior:
+     * <ul>
+     *   <li>If a variant is explicitly provided via {@link VariantAPI#VARIANT_KEY} in the request,
+     *       it is set on the contentlet.</li>
+     *   <li>If the variant is {@code DEFAULT}, no fallback is performed on error.</li>
+     *   <li>If no variant is provided, the contentlet will implicitly use the {@code DEFAULT} variant.</li>
+     *   <li>If a variant is set and fails to resolve (e.g., the contentlet has no version for it),
+     *       a fallback attempt is made using the {@code DEFAULT} variant.</li>
+     * </ul>
+     *
+     * @param request    the current HTTP request, used to extract the variant key if provided
+     * @param user       the user requesting the content, used for permissions and rendering
+     * @param contentlet the contentlet to hydrate
+     * @param render     whether renderable fields should be velocity-rendered
+     * @return a hydrated content map including field values (rendered if requested)
+     */
+    private Map<String, Object> getHydratedMapWithVariantFallback(
+            final HttpServletRequest request,
+            final User user,
+            final Contentlet contentlet,
+            final boolean render
+    ) {
+        final Object variantAttr = request.getAttribute(VariantAPI.VARIANT_KEY);
+
+        // Set variantId only if explicitly requested
+        if (UtilMethods.isSet(variantAttr)) {
+            final String variantName = variantAttr.toString();
+
+            // Avoid fallback loop if DEFAULT is already being used
+            assert VariantAPI.DEFAULT_VARIANT.name() != null;
+            if (VariantAPI.DEFAULT_VARIANT.name().equals(variantName)) {
+                contentlet.setVariantId(variantName);
+                return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
+            }
+
+            try {
+                contentlet.setVariantId(variantName);
+                return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
+            } catch (DotStateException e) {
+                Logger.debug(this, () -> String.format(
+                        "Variant '%s' not found for contentlet '%s'. Falling back to DEFAULT variant.",
+                        variantName, contentlet.getIdentifier()
+                ));
+
+                contentlet.setVariantId(VariantAPI.DEFAULT_VARIANT.name());
+                return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
+            }
+        }
+
+        // No variantAttr: implicitly uses DEFAULT variant
+        return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -48,7 +48,8 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             final Contentlet contentlet = environment.getSource();
             final String key = environment.getArgument("key");
             final int depth = environment.getArgument("depth");
-            Boolean render = environment.getArgument("render");
+            Boolean renderArg = environment.getArgument("render");
+            boolean render = Boolean.TRUE.equals(renderArg);
 
             final HttpServletRequest request = ((DotGraphQLContext) environment.getContext())
                     .getHttpServletRequest();
@@ -59,7 +60,7 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             Logger.debug(this, ()-> "Fetching content map for contentlet: " + contentlet.getIdentifier());
             if(UtilMethods.isSet(key)) {
                 Object fieldValue;
-                if(UtilMethods.isSet(render) && render) {
+                if(render) {
                     fieldValue = getRenderedFieldValue(request, response, contentlet, key);
                 } else {
                     fieldValue = contentlet.get(key);
@@ -69,14 +70,6 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
 
             final User user = ((DotGraphQLContext) environment.getContext()).getUser();
 
-            final DotTransformerBuilder transformerBuilder = new DotTransformerBuilder();
-
-            if(UtilMethods.isSet(render) && render) {
-                transformerBuilder.hydratedContentMapTransformer(RENDER_FIELDS);
-            } else {
-                render = false;
-                transformerBuilder.hydratedContentMapTransformer();
-            }
             // Resolve hydrated contentlet map with optional variant handling
             Map<String, Object> hydratedMap = getHydratedMapWithVariantFallback(request, user, contentlet, render);
             final JSONObject contentMapInJSON = new JSONObject();
@@ -84,7 +77,7 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             // this only adds relationships to any json. We would need to return them with the transformations already
 
             final JSONObject jsonWithRels = ContentHelper.getInstance().addRelationshipsToJSON(request, response,
-                    render.toString(), user, depth, false, contentlet,
+                    Boolean.toString(render), user, depth, false, contentlet,
                     contentMapInJSON, null, 1, true, false,
                     true);
 

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -6,7 +6,6 @@ import com.dotcms.rest.ContentHelper;
 import com.dotcms.variant.VariantAPI;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
-import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
 import com.dotmarketing.portlets.contentlet.util.ContentletUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
@@ -26,7 +25,6 @@ import java.util.stream.Collectors;
 
 import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.isFieldRenderable;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.RenderFieldStrategy.renderFieldValue;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.RENDER_FIELDS;
 
 /**
  * {@link DataFetcher} that fetches the data when the special <code>_map<code/> GraphQL Field is requested.

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -3,11 +3,9 @@ package com.dotcms.graphql.datafetcher;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.graphql.DotGraphQLContext;
 import com.dotcms.rest.ContentHelper;
-import com.dotcms.variant.VariantAPI;
-import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.transform.DotContentletTransformer;
 import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
-import com.dotmarketing.portlets.contentlet.util.ContentletUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.json.JSONObject;
@@ -77,8 +75,10 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
                 render = false;
                 transformerBuilder.hydratedContentMapTransformer();
             }
-            // Resolve hydrated contentlet map with optional variant handling
-            Map<String, Object> hydratedMap = getHydratedMapWithVariantFallback(request, user, contentlet, render);
+
+            final DotContentletTransformer myTransformer = transformerBuilder.content(contentlet).build();
+
+            final Map<String, Object> hydratedMap =  myTransformer.toMaps().get(0);
             final JSONObject contentMapInJSON = new JSONObject();
 
             // this only adds relationships to any json. We would need to return them with the transformations already
@@ -142,61 +142,5 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
         }
 
         return renderFieldValue(request, response, (String) contentlet.get(key), contentlet, field.variable());
-    }
-
-    /**
-     * Attempts to retrieve a hydrated contentlet map, respecting an explicitly requested variant if present.
-     * <p>
-     * Behavior:
-     * <ul>
-     *   <li>If a variant is explicitly provided via {@link VariantAPI#VARIANT_KEY} in the request,
-     *       it is set on the contentlet.</li>
-     *   <li>If the variant is {@code DEFAULT}, no fallback is performed on error.</li>
-     *   <li>If no variant is provided, the contentlet will implicitly use the {@code DEFAULT} variant.</li>
-     *   <li>If a variant is set and fails to resolve (e.g., the contentlet has no version for it),
-     *       a fallback attempt is made using the {@code DEFAULT} variant.</li>
-     * </ul>
-     *
-     * @param request    the current HTTP request, used to extract the variant key if provided
-     * @param user       the user requesting the content, used for permissions and rendering
-     * @param contentlet the contentlet to hydrate
-     * @param render     whether renderable fields should be velocity-rendered
-     * @return a hydrated content map including field values (rendered if requested)
-     */
-    private Map<String, Object> getHydratedMapWithVariantFallback(
-            final HttpServletRequest request,
-            final User user,
-            final Contentlet contentlet,
-            final boolean render
-    ) {
-        final Object variantAttr = request.getAttribute(VariantAPI.VARIANT_KEY);
-
-        // Set variantId only if explicitly requested
-        if (UtilMethods.isSet(variantAttr)) {
-            final String variantName = variantAttr.toString();
-
-            // Avoid fallback loop if DEFAULT is already being used
-            assert VariantAPI.DEFAULT_VARIANT.name() != null;
-            if (VariantAPI.DEFAULT_VARIANT.name().equals(variantName)) {
-                contentlet.setVariantId(variantName);
-                return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
-            }
-
-            try {
-                contentlet.setVariantId(variantName);
-                return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
-            } catch (DotStateException e) {
-                Logger.debug(this, () -> String.format(
-                        "Variant '%s' not found for contentlet '%s'. Falling back to DEFAULT variant.",
-                        variantName, contentlet.getIdentifier()
-                ));
-
-                contentlet.setVariantId(VariantAPI.DEFAULT_VARIANT.name());
-                return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
-            }
-        }
-
-        // No variantAttr: implicitly uses DEFAULT variant
-        return ContentletUtil.getContentPrintableMap(user, contentlet, false, render);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -68,6 +68,15 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             }
 
             final User user = ((DotGraphQLContext) environment.getContext()).getUser();
+
+            final DotTransformerBuilder transformerBuilder = new DotTransformerBuilder();
+
+            if(UtilMethods.isSet(render) && render) {
+                transformerBuilder.hydratedContentMapTransformer(RENDER_FIELDS);
+            } else {
+                render = false;
+                transformerBuilder.hydratedContentMapTransformer();
+            }
             // Resolve hydrated contentlet map with optional variant handling
             Map<String, Object> hydratedMap = getHydratedMapWithVariantFallback(request, user, contentlet, render);
             final JSONObject contentMapInJSON = new JSONObject();

--- a/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/datafetcher/ContentMapDataFetcher.java
@@ -48,8 +48,8 @@ public class ContentMapDataFetcher implements DataFetcher<Object> {
             final Contentlet contentlet = environment.getSource();
             final String key = environment.getArgument("key");
             final int depth = environment.getArgument("depth");
-            Boolean renderArg = environment.getArgument("render");
-            boolean render = Boolean.TRUE.equals(renderArg);
+            final Boolean renderArg = environment.getArgument("render");
+            final boolean render = Boolean.TRUE.equals(renderArg);
 
             final HttpServletRequest request = ((DotGraphQLContext) environment.getContext())
                     .getHttpServletRequest();

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/page/ContentMapDataFetcherTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/page/ContentMapDataFetcherTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.model.User;
 import graphql.schema.DataFetchingEnvironment;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/page/ContentMapDataFetcherTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/page/ContentMapDataFetcherTest.java
@@ -18,7 +18,6 @@ import com.liferay.portal.model.User;
 import graphql.schema.DataFetchingEnvironment;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/page/ContentMapDataFetcherTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/graphql/datafetcher/page/ContentMapDataFetcherTest.java
@@ -2,15 +2,16 @@ package com.dotcms.graphql.datafetcher.page;
 
 import static com.dotcms.datagen.TestDataUtils.getNewsLikeContentType;
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.dotcms.datagen.TestDataUtils;
 import com.dotcms.graphql.DotGraphQLContext;
 import com.dotcms.graphql.datafetcher.ContentMapDataFetcher;
 import com.dotcms.util.IntegrationTestInitService;
-import com.dotmarketing.beans.Host;
+import com.dotcms.variant.VariantAPI;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.UserAPI;
-import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.liferay.portal.model.User;
@@ -19,6 +20,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
 
 /**
@@ -59,14 +62,20 @@ public class ContentMapDataFetcherTest {
         contentlet.setStringProperty("blockEditor_raw", rawJson);
         contentlet.setStringProperty("blockEditor", "some string"); // base field pre-exists
 
-        var environment = Mockito.mock(DataFetchingEnvironment.class);
-        Mockito.when(environment.getContext()).thenReturn(
-                DotGraphQLContext.createServletContext().with(user).build()
-        );
-        Mockito.when(environment.getArgument("key")).thenReturn(null);
-        Mockito.when(environment.getArgument("depth")).thenReturn(0);
-        Mockito.when(environment.getArgument("render")).thenReturn(false);
-        Mockito.when(environment.getSource()).thenReturn(contentlet);
+        var environment = mock(DataFetchingEnvironment.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        DotGraphQLContext context = mock(DotGraphQLContext.class);
+        when(context.getHttpServletRequest()).thenReturn(request);
+        when(context.getHttpServletResponse()).thenReturn(response);
+        when(context.getUser()).thenReturn(user);
+
+        when(environment.getContext()).thenReturn(context);
+        when(environment.getArgument("key")).thenReturn(null);
+        when(environment.getArgument("depth")).thenReturn(0);
+        when(environment.getArgument("render")).thenReturn(false);
+        when(environment.getSource()).thenReturn(contentlet);
 
         var fetcher = new ContentMapDataFetcher();
         Object result = fetcher.get(environment);
@@ -100,14 +109,20 @@ public class ContentMapDataFetcherTest {
         String rawJson = "{\"foo\": \"bar\"}";
         contentlet.setStringProperty("customField_raw", rawJson); // base field not set
 
-        var environment = Mockito.mock(DataFetchingEnvironment.class);
-        Mockito.when(environment.getContext()).thenReturn(
-                DotGraphQLContext.createServletContext().with(user).build()
-        );
-        Mockito.when(environment.getArgument("key")).thenReturn(null);
-        Mockito.when(environment.getArgument("depth")).thenReturn(0);
-        Mockito.when(environment.getArgument("render")).thenReturn(false);
-        Mockito.when(environment.getSource()).thenReturn(contentlet);
+        var environment = mock(DataFetchingEnvironment.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        DotGraphQLContext context = mock(DotGraphQLContext.class);
+        when(context.getHttpServletRequest()).thenReturn(request);
+        when(context.getHttpServletResponse()).thenReturn(response);
+        when(context.getUser()).thenReturn(user);
+
+        when(environment.getContext()).thenReturn(context);
+        when(environment.getArgument("key")).thenReturn(null);
+        when(environment.getArgument("depth")).thenReturn(0);
+        when(environment.getArgument("render")).thenReturn(false);
+        when(environment.getSource()).thenReturn(contentlet);
 
         var fetcher = new ContentMapDataFetcher();
         Object result = fetcher.get(environment);
@@ -121,4 +136,130 @@ public class ContentMapDataFetcherTest {
         assertEquals(rawJson, map.get("customField_raw"));
         assertFalse("Parsed base field should not be added", map.containsKey("customField"));
     }
+
+    /**
+     * Verifies that when no variant is set in the request,
+     * the contentlet is hydrated using the default variant implicitly.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void returnsMapWhenVariantAttributeIsNull() throws Exception {
+        // Mock request with no variant attribute
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getAttribute(VariantAPI.VARIANT_KEY)).thenReturn(null);
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        // Mock GraphQL context
+        DotGraphQLContext context = mock(DotGraphQLContext.class);
+        when(context.getHttpServletRequest()).thenReturn(request);
+        when(context.getHttpServletResponse()).thenReturn(response);
+        when(context.getUser()).thenReturn(user);
+
+        // Mock GraphQL environment
+        DataFetchingEnvironment environment = mock(DataFetchingEnvironment.class);
+        when(environment.getContext()).thenReturn(context);
+        when(environment.getArgument("key")).thenReturn(null);
+        when(environment.getArgument("depth")).thenReturn(0);
+        when(environment.getArgument("render")).thenReturn(false);
+
+        // Valid contentlet with default variant data
+        Contentlet contentlet = TestDataUtils.getNewsContent(true, defaultLanguage.getId(), getNewsLikeContentType().id());
+        when(environment.getSource()).thenReturn(contentlet);
+
+        // Execute data fetcher
+        ContentMapDataFetcher fetcher = new ContentMapDataFetcher();
+        Object result = fetcher.get(environment);
+
+        // Validate response
+        assertNotNull(result);
+        assertTrue(result instanceof Map);
+
+        Map<String, Object> map = (Map<String, Object>) result;
+        assertFalse("Hydrated map should not be empty", map.isEmpty());
+    }
+
+    /**
+     * Verifies that when the DEFAULT variant is explicitly set in the request,
+     * the contentlet is hydrated successfully and no fallback occurs.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void returnsMapWhenVariantIsDefault() throws Exception {
+        // Mock request explicitly setting the DEFAULT variant
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getAttribute(VariantAPI.VARIANT_KEY)).thenReturn(VariantAPI.DEFAULT_VARIANT.name());
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        // Mock context and environment
+        DotGraphQLContext context = mock(DotGraphQLContext.class);
+        when(context.getHttpServletRequest()).thenReturn(request);
+        when(context.getHttpServletResponse()).thenReturn(response);
+        when(context.getUser()).thenReturn(user);
+
+        DataFetchingEnvironment environment = mock(DataFetchingEnvironment.class);
+        when(environment.getContext()).thenReturn(context);
+        when(environment.getArgument("key")).thenReturn(null);
+        when(environment.getArgument("depth")).thenReturn(0);
+        when(environment.getArgument("render")).thenReturn(false);
+
+        // Valid contentlet with data in DEFAULT variant
+        Contentlet contentlet = TestDataUtils.getNewsContent(true, defaultLanguage.getId(), getNewsLikeContentType().id());
+        when(environment.getSource()).thenReturn(contentlet);
+
+        // Execute data fetcher
+        ContentMapDataFetcher fetcher = new ContentMapDataFetcher();
+        Object result = fetcher.get(environment);
+
+        // Validate
+        assertNotNull(result);
+        assertTrue(result instanceof Map);
+
+        Map<String, Object> map = (Map<String, Object>) result;
+        assertFalse("Hydrated map should not be empty", map.isEmpty());
+    }
+
+    /**
+     * Verifies that when a non-existent variant is set in the request,
+     * the fetcher falls back to the DEFAULT variant and still returns content.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void fallsBackToDefaultWhenVariantFails() throws Exception {
+        // Mock request with a non-existent variant
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getAttribute(VariantAPI.VARIANT_KEY)).thenReturn("non-existent-variant");
+
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        // Mock context and environment
+        DotGraphQLContext context = mock(DotGraphQLContext.class);
+        when(context.getHttpServletRequest()).thenReturn(request);
+        when(context.getHttpServletResponse()).thenReturn(response);
+        when(context.getUser()).thenReturn(user);
+
+        DataFetchingEnvironment environment = mock(DataFetchingEnvironment.class);
+        when(environment.getContext()).thenReturn(context);
+        when(environment.getArgument("key")).thenReturn(null);
+        when(environment.getArgument("depth")).thenReturn(0);
+        when(environment.getArgument("render")).thenReturn(false);
+
+        // Valid contentlet that only exists under DEFAULT variant
+        Contentlet contentlet = TestDataUtils.getNewsContent(true, defaultLanguage.getId(), getNewsLikeContentType().id());
+        contentlet.setVariantId("non-existent-variant");
+        when(environment.getSource()).thenReturn(contentlet);
+
+        // Execute data fetcher
+        ContentMapDataFetcher fetcher = new ContentMapDataFetcher();
+        Object result = fetcher.get(environment);
+
+        // Validate
+        assertNotNull(result);
+        assertTrue(result instanceof Map);
+
+        Map<String, Object> map = (Map<String, Object>) result;
+        assertFalse("Hydrated map should not be empty even after fallback", map.isEmpty());
+    }
+
 }


### PR DESCRIPTION
### Proposed Changes
* Added a new private method `getHydratedMapWithVariantFallback` in `ContentMapDataFetcher` to handle content hydration with explicit or implicit variant resolution. The method includes fallback logic to the `DEFAULT` variant when a requested variant is unavailable.
* Replaced the direct usage of `DotContentletTransformer` with the new `getHydratedMapWithVariantFallback` method in the `get` method, improving content hydration flexibility.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated  

### Additional Info
This improves the correctness and maintainability of variant resolution logic in `_map` queries and ensures coverage for edge cases in contentlet hydration across variants.

### Screenshots
![image](https://github.com/user-attachments/assets/e87c5418-468c-46df-91a2-da416c5b8c7a)

This PR fixes: #32384