### PR TITLE
fix(push publishing) #32423 : [Push Publishing] : Error when pushing Advanced Templates

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/CategoryFullHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/CategoryFullHandler.java
@@ -12,6 +12,7 @@ package com.dotcms.enterprise.publishing.remote.handler;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.publishing.remote.bundler.CategoryFullBundler;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.pusher.wrapper.CategoryWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
 import com.dotcms.publisher.util.PushCategoryUtil;
@@ -53,7 +54,7 @@ public class CategoryFullHandler implements IHandler {
     private final CategoryAPI categoryAPI = APILocator.getCategoryAPI();
     private final UserAPI     userAPI     = APILocator.getUserAPI();
     private PushCategoryUtil pushCategoryUtil;
-    private PublisherConfig config;
+    private final PublisherConfig config;
     private int categoryHandledCounter = 0;
 
     public CategoryFullHandler(PublisherConfig config) {
@@ -116,7 +117,7 @@ public class CategoryFullHandler implements IHandler {
             	handleCategory(null, topLevel.getCategory());
             	
                 // try with children
-                if (null != topLevel.getChildren() && topLevel.getChildren().size() > 0) {
+                if (null != topLevel.getChildren() && !topLevel.getChildren().isEmpty()) {
 
                     for (final String inode : topLevel.getChildren()) {
                         childCategoryInode = inode;
@@ -129,7 +130,7 @@ public class CategoryFullHandler implements IHandler {
             PushPublishLogger.log(getClass(), "Categories published", config.getId());
         } catch (final Exception e) {
             final String errorMsg = String.format("An error occurred when publishing Category Inode '%s', Parent " +
-                    "Inode '%s': %s", childCategoryInode, topLevelCategoryInode, e.getMessage());
+                    "Inode '%s': %s", childCategoryInode, topLevelCategoryInode, ExceptionUtil.getErrorMessage(e));
             Logger.error(this, errorMsg, e);
             throw new DotPublishingException(errorMsg, e);
         }
@@ -146,7 +147,7 @@ public class CategoryFullHandler implements IHandler {
         handleCategory(parent.getCategory(), wrapper.getCategory());
 
         // the category has children
-        if (null != wrapper.getChildren() && wrapper.getChildren().size() > 0) {
+        if (null != wrapper.getChildren() && !wrapper.getChildren().isEmpty()) {
 
             for (final String inode : wrapper.getChildren()) {
 
@@ -182,4 +183,5 @@ public class CategoryFullHandler implements IHandler {
                 "delete from tree where parent not in (select inode from category) and relation_type = 'child' ");
         db.loadResult();
     }
+
 }

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/CategoryHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/CategoryHandler.java
@@ -12,6 +12,7 @@ package com.dotcms.enterprise.publishing.remote.handler;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.CategoryBundler;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.pusher.wrapper.CategoryWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
 import com.dotcms.publisher.util.PushCategoryUtil;
@@ -174,7 +175,7 @@ public class CategoryHandler implements IHandler {
             }
         } catch (final Exception e) {
             final String errorMsg = String.format("An error occurred when publishing Category Inode '%s', children [ " +
-                    "%s ]: %s", categoryInode, categoryChildren, e.getMessage());
+                    "%s ]: %s", categoryInode, categoryChildren, ExceptionUtil.getErrorMessage(e));
             Logger.error(this, errorMsg, e);
             throw new DotPublishingException(errorMsg, e);
         }

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentHandler.java
@@ -20,6 +20,7 @@ import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.ContentBundler;
 import com.dotcms.enterprise.publishing.remote.bundler.HostBundler;
 import com.dotcms.enterprise.publishing.remote.handler.HandlerUtil.HandlerType;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.bundle.bean.Bundle;
 import com.dotcms.publisher.bundle.business.BundleAPI;
 import com.dotcms.publisher.pusher.PushPublisherConfig;
@@ -28,7 +29,6 @@ import com.dotcms.publisher.receiver.handler.IHandler;
 import com.dotcms.publishing.DotPublishingException;
 import com.dotcms.publishing.FilterDescriptor;
 import com.dotcms.publishing.PublisherConfig;
-import com.dotcms.publishing.PublisherFilter;
 import com.dotcms.rendering.velocity.services.PageLoader;
 import com.dotcms.repackage.com.google.common.base.Strings;
 import com.dotcms.storage.FileMetadataAPI;
@@ -101,7 +101,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -216,16 +215,13 @@ public class ContentHandler implements IHandler {
 		}
 	}
 
-
-
 	private boolean ignoreContent(Contentlet contentlet){
 
 		// if a host does not exist on target, skip content
 		Host localHost = Try.of(()->APILocator.getHostAPI().find(contentlet.getHost(), APILocator.systemUser(), false)).getOrNull();
-		return UtilMethods.isEmpty(()->localHost.getIdentifier());
+		return UtilMethods.isEmpty(localHost::getIdentifier);
 
 	}
-
 
 	/**
 	 * Reads the information of the contentlets contained in the bundle and
@@ -249,7 +245,7 @@ public class ContentHandler implements IHandler {
 		}
 	    final User systemUser = userAPI.getSystemUser();
         File workingOn=null;
-        Contentlet content = null;
+        Contentlet content;
 		ContentWrapper wrapper = null;
 		final Collection<File> contents = contentsIn.stream().filter(File::isFile).collect(Collectors.toList());
 		final Collection<String> alreadyDeleted = new HashSet<>();
@@ -259,13 +255,12 @@ public class ContentHandler implements IHandler {
 			final Set<Pair<String,Long>> pushedIdsToIgnore = new HashSet<>();
             for (final File contentFile : contents) {
                 workingOn=contentFile;
-                content = null;
 
                 try(final InputStream input = Files.newInputStream(contentFile.toPath())){
                     wrapper = (ContentWrapper) xstream.fromXML(input);
                 }
                 //This is to check if the contentType exists in the receiver, to improve logs
-				//If the ContentType does not exists will throw a NotFoundInDBException
+				//If the ContentType does not exist, this method will throw a NotFoundInDBException
 				APILocator.getContentTypeAPI(systemUser).find(wrapper.getContent().getContentTypeId());
 
 				if (Host.SYSTEM_HOST.equalsIgnoreCase(wrapper.getContent().getIdentifier())) {
@@ -298,12 +293,10 @@ public class ContentHandler implements IHandler {
                     content.getMap().remove(PAGE_FRIENDLY_NAME_FIELD_VAR.toLowerCase());
                 }
 
-
-				// if a host does not exist on target, skip content
+				// if a Site does not exist on target, skip content
 				if(ignoreContent(content)){
-					Contentlet finalContent = content;
-					Logger.warn(this.getClass(), "Ignoring contentlet:" + content.getIdentifier() + " | " + Try.of(
-                            finalContent::getTitle).getOrElse("unknown")  + " . Unable to find referenced host id:" + content.getHost());
+                    Logger.warn(this.getClass(), "Ignoring contentlet: " + content.getIdentifier() + " | " + Try.of(
+                            content::getTitle).getOrElse("unknown")  + " . Unable to find referenced Site: " + content.getHost());
 					continue;
 				}
 
@@ -365,7 +358,7 @@ public class ContentHandler implements IHandler {
 								+ " , inode: " + contentInode + " , language: " + languageId);
 					}
 				} catch (final FileAssetValidationException e1){
-                    Logger.error(ContentHandler.class, "Content id ["+content.getIdentifier()+"] could not be processed because of missing binary file. Error: "+e1.getMessage(),e1);
+                    Logger.error(ContentHandler.class, "Content id ["+content.getIdentifier()+"] could not be processed because of missing binary file. Error: "+ ExceptionUtil.getErrorMessage(e1), e1);
 				}
             }
 			workingOn = null;
@@ -392,8 +385,8 @@ public class ContentHandler implements IHandler {
 					// if a host does not exist on target, skip content
 					if(ignoreContent(content)){
 						Contentlet finalContent = content;
-						Logger.warn(this.getClass(), "Ignoring contentlet:" + content.getIdentifier() + " | " + Try.of(
-                                finalContent::getTitle).getOrElse("unknown")  + " . Unable to find referenced host id:" + content.getHost());
+						Logger.warn(this.getClass(), "Ignoring contentlet: " + content.getIdentifier() + " | " + Try.of(
+                                finalContent::getTitle).getOrElse("unknown")  + " . Unable to find referenced Site: " + content.getHost());
 						continue;
 					}
 
@@ -478,7 +471,7 @@ public class ContentHandler implements IHandler {
 					addRelatedContentsToInfoToRemove(content, wrapper.getInfo());
 
                     // saving a contentletVersionInfo might do an implicit publish. Need to know in order to clean up properly
-                    boolean implicitPublish = false;
+                    boolean implicitPublish;
                     if (updateExisting) {
                         // Updating an existing content. Just read the local content version info to
                         // publish or not publish the content
@@ -518,7 +511,7 @@ public class ContentHandler implements IHandler {
                         Logger.debug(this, ()-> "*********************** live inode is null");
                     } else {
 						if(Logger.isDebugEnabled(getClass())){
-                          //This might generate a DotStateException if we're copying a brand new instance that doesnt have a version on the receiver
+                          //This might generate a DotStateException if we're copying a brand-new instance that doesn't have a version on the receiver
 						  Logger.debug(this,
 								  () -> "*********************** content " + contentId
 										+ " is live? " + isLiveContentlet);
@@ -583,7 +576,7 @@ public class ContentHandler implements IHandler {
 			final String errorMsg = String.format("An error occurred when processing Contentlet in '%s' with ID '%s': '%s'",
 					workingOn,
 					(UtilMethods.isSet(wrapper) && UtilMethods.isSet(wrapper.getContent()) ? wrapper.getContent().getIdentifier() : "(empty)"),
-					e.getMessage());
+					ExceptionUtil.getErrorMessage(e));
 			Logger.error(this.getClass(), errorMsg, e);
 			throw new DotPublishingException(errorMsg, e);
 		}
@@ -625,9 +618,9 @@ public class ContentHandler implements IHandler {
 					String.format("Error trying to push content with ID '%s' / version info '%s': %s",
 							content.getIdentifier(),
 							info,
-							e.getMessage())
+							ExceptionUtil.getErrorMessage(e))
 			);
-			Logger.debug(ContentHandler.class, e, () -> e.getMessage());
+			Logger.debug(ContentHandler.class, e, () -> ExceptionUtil.getErrorMessage(e));
 		}
 	}
 
@@ -676,7 +669,7 @@ public class ContentHandler implements IHandler {
 					// Check for folders with same path
 					List<Identifier> folders = identifierAPI.findByURIPattern(
 							"folder", fullPageUrl, true, h);
-					if (folders.size() > 0) {
+					if (!folders.isEmpty()) {
 						throw new DotDataException(
 								"Conflict between HTML page and Folder. Page with identifier : '"
 										+ contentPage.getIdentifier() + "' "
@@ -854,7 +847,7 @@ public class ContentHandler implements IHandler {
 					invalidateMultiTreeCache(contentId);
 				} catch (final DotDataException e) {
 					Logger.debug(this, () -> String.format("Failed to flush cache for Contentlet '%s': %s", contentId,
-							e.getMessage()));
+							ExceptionUtil.getErrorMessage(e)));
 				}
 			}
 		} );
@@ -1041,7 +1034,7 @@ public class ContentHandler implements IHandler {
 						.searchIndex(luceneQuery.toString(), limit, offset, sortBy,
 								systemUser, !RESPECT_FRONTEND_ROLES);
 
-				if (null != contentlets && contentlets.size() > 0) {
+				if (null != contentlets && !contentlets.isEmpty()) {
 					// A contentlet with different Identifier but same unique value has been found. Update the local
                     // one WITHOUT CHANGING the local Identifier and Inode
 					final Contentlet matchingContent =
@@ -1087,7 +1080,7 @@ public class ContentHandler implements IHandler {
 		}
         return String.format("Lucene query [ %s ] matched existing content with ID '%s' / inode '%s' in ES Index, but" +
                 " it was not found via API. Unique fields: %s", luceneQuery, matchedContent.getIdentifier(),
-                matchedContent.getInode(), fieldsInfo.toString());
+                matchedContent.getInode(), fieldsInfo);
     }
 
 	/**
@@ -1322,10 +1315,9 @@ public class ContentHandler implements IHandler {
      * Delete the Trees related to this given contentlet, this is in order to add the new published Trees (Relationships and categories)
      *
      * @param contentlet whose tree will be deleted
-     * @throws DotPublishingException
      */
 	@WrapInTransaction
-	private void cleanTrees ( Contentlet contentlet ) throws DotPublishingException {
+	private void cleanTrees ( Contentlet contentlet ) {
 		if(LicenseUtil.getLevel() < LicenseLevel.PROFESSIONAL.level)
 			throw new RuntimeException("need an enterprise pro license to run this");
 		try{
@@ -1335,8 +1327,8 @@ public class ContentHandler implements IHandler {
 			TreeFactory.deleteTreesByParentById(contentlet.getIdentifier());
 			HibernateUtil.flush();
 		}catch (Exception e) {
-			Logger.error(this, "Cleaning trees for Contentlet '" + contentlet.getIdentifier() + "' has failed: " + e
-					.getMessage(), e);
+			Logger.error(this, "Cleaning trees for Contentlet '" + contentlet.getIdentifier() + "' has failed: " +
+					ExceptionUtil.getErrorMessage(e), e);
 		}
 	}
 
@@ -1369,7 +1361,7 @@ public class ContentHandler implements IHandler {
 			} catch (final Exception e) {
 				Logger.debug(this,
 						"Unable to use received user from sender. Using 'system' User instead. "
-							+ "UserId [" + modUserId + "]. Error message: " + e.getMessage());
+							+ "UserId [" + modUserId + "]. Error message: " + ExceptionUtil.getErrorMessage(e));
 				//On errors also lets use the System User and allow the process to continue
 				modUserId = APILocator.getUserAPI().getSystemUser().getUserId();
 			}

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentWorkflowHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ContentWorkflowHandler.java
@@ -12,6 +12,7 @@ package com.dotcms.enterprise.publishing.remote.handler;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.ContentBundler;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.pusher.wrapper.PushContentWorkflowWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
 import com.dotcms.publishing.DotPublishingException;
@@ -192,7 +193,7 @@ public class ContentWorkflowHandler implements IHandler {
         } catch (final Exception ex) {
             final String errorMsg = String.format("An error occurred when processing Workflow Task in '%s' with Title: %s And ID '%s': %s",
                     workingOn, (null == workflowTask ? "(empty)" : workflowTask.getTitle()), (null == workflowTask ? "(empty)" :
-                            workflowTask.getId()), ex.getMessage());
+                            workflowTask.getId()), ExceptionUtil.getErrorMessage(ex));
             Logger.error(this.getClass(), errorMsg, ex);
             throw new DotPublishingException(errorMsg, ex);
         } finally {

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ExperimentHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/ExperimentHandler.java
@@ -10,55 +10,27 @@
 package com.dotcms.enterprise.publishing.remote.handler;
 
 import com.dotcms.business.WrapInTransaction;
-import com.dotcms.contenttype.exception.NotFoundInDbException;
-import com.dotcms.contenttype.model.field.Field;
-import com.dotcms.contenttype.model.field.FieldVariable;
-import com.dotcms.contenttype.model.field.RelationshipField;
-import com.dotcms.contenttype.model.field.RelationshipFieldBuilder;
-import com.dotcms.contenttype.model.type.ContentType;
-import com.dotcms.contenttype.transform.contenttype.StructureTransformer;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
-import com.dotcms.enterprise.publishing.remote.bundler.ContentTypeBundler;
 import com.dotcms.enterprise.publishing.remote.bundler.ExperimentBundler;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.experiments.business.ExperimentsAPI;
 import com.dotcms.experiments.model.AbstractExperiment.Status;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.experiments.model.Scheduling;
-import com.dotcms.publisher.pusher.wrapper.ContentTypeWrapper;
 import com.dotcms.publisher.pusher.wrapper.ExperimentWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
 import com.dotcms.publishing.BundlerUtil;
 import com.dotcms.publishing.DotPublishingException;
 import com.dotcms.publishing.PublisherConfig;
 import com.dotcms.publishing.PublisherConfig.Operation;
-import com.dotcms.repackage.com.google.common.collect.ImmutableList;
-import com.dotcms.workflow.helper.SystemActionMappingsHandlerMerger;
-import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.DotStateException;
-import com.dotmarketing.business.PermissionAPI;
-import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.portlets.folders.model.Folder;
-import com.dotmarketing.portlets.workflows.model.SystemActionWorkflowActionMapping;
-import com.dotmarketing.portlets.workflows.model.WorkflowScheme;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.PushPublishLogger;
-import com.dotmarketing.util.PushPublishLogger.PushPublishAction;
-import com.dotmarketing.util.PushPublishLogger.PushPublishHandler;
-import com.dotmarketing.util.UtilMethods;
-import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
+
 import java.io.File;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * This handler class is part of the Push Publishing mechanism that deals with Experiments-related information inside a
@@ -160,9 +132,9 @@ public class ExperimentHandler implements IHandler {
 				}
 			}
     	} catch (final Exception e) {
-			final String errorMsg = String.format("An error occurred when processing Experiment in '%s' with Id '%s': %s",
-					workingOn, experiment.name(),
-							experiment.id().orElseThrow(), e.getMessage());
+			final String errorMsg = String.format("An error occurred when processing Experiment in '%s' with Name '%s' [%s]: %s",
+					workingOn, null != experiment ? experiment.name() : "- null -",
+						null != experiment ? experiment.id().orElseThrow() : "- null -", ExceptionUtil.getErrorMessage(e));
 			Logger.error(this.getClass(), errorMsg, e);
 			throw new DotPublishingException(errorMsg, e);
     	}

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/FolderHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/FolderHandler.java
@@ -12,6 +12,7 @@ package com.dotcms.enterprise.publishing.remote.handler;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.FolderBundler;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.pusher.PushPublisherConfig;
 import com.dotcms.publisher.pusher.wrapper.FolderWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
@@ -41,6 +42,7 @@ import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import com.thoughtworks.xstream.XStream;
 import io.vavr.control.Try;
+import org.apache.commons.beanutils.BeanUtils;
 
 import java.io.File;
 import java.io.InputStream;
@@ -50,7 +52,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import org.apache.commons.beanutils.BeanUtils;
 
 /**
  * This handler class is part of the Push Publishing mechanism that deals with Folder-related information inside a
@@ -63,10 +64,11 @@ import org.apache.commons.beanutils.BeanUtils;
  * @since Mar 7, 2013
  */
 public class FolderHandler implements IHandler {
-	private FolderAPI fAPI = APILocator.getFolderAPI();
-	private IdentifierAPI iAPI = APILocator.getIdentifierAPI();
-	private UserAPI uAPI = APILocator.getUserAPI();
-	private PublisherConfig config;
+
+	private final FolderAPI fAPI = APILocator.getFolderAPI();
+	private final IdentifierAPI iAPI = APILocator.getIdentifierAPI();
+	private final UserAPI uAPI = APILocator.getUserAPI();
+	private final PublisherConfig config;
 
 	public FolderHandler(PublisherConfig config) {
 		this.config = config;
@@ -111,13 +113,12 @@ public class FolderHandler implements IHandler {
 				Logger.debug(getClass(), "SYSTEM FOLDER CANNOT BE DELETED");
 			} else {
                 final String errorMsg = String.format("Folder '%s' [%s] could not be deleted: %s", (null == folder ?
-                        "(null)" : folder.getPath()), (null == folder ? "(null)" : folder.getInode()), e.getMessage());
+                        "(null)" : folder.getPath()), (null == folder ? "(null)" : folder.getInode()), ExceptionUtil.getErrorMessage(e));
                 Logger.error(this.getClass(), errorMsg, e);
                 throw new DotPublishingException(errorMsg, e);
 			}
 		}
 	}
-
 
 	private void handleFolders(Collection<File> folders) throws DotPublishingException, DotDataException{
 	    if(LicenseUtil.getLevel() < LicenseLevel.PROFESSIONAL.level) {
@@ -130,6 +131,7 @@ public class FolderHandler implements IHandler {
 		Identifier folderId=null;
 		Host host = null;
         File workingOn = null;
+		Folder folder = new Folder();
 		try{
 	        XStream xstream = XStreamHandler.newXStreamInstance();
 	        //Handle folders
@@ -142,7 +144,7 @@ public class FolderHandler implements IHandler {
                      folderWrapper = (FolderWrapper) xstream.fromXML(input);
                 }
 
-	        	final Folder folder = folderWrapper.getFolder();
+	        	folder = folderWrapper.getFolder();
 				if (folder.isSystemFolder()) {
 					continue;
 				}
@@ -158,9 +160,9 @@ public class FolderHandler implements IHandler {
 
 	        	//Check Host if exists otherwise create
 	        	Host localHost = APILocator.getHostAPI().find(host.getIdentifier(), systemUser, false);
-				if(UtilMethods.isEmpty(()->localHost.getIdentifier())){
-					Logger.warn(FolderHandler.class, "Unable to publish folder:" + folderName + ". Unable to find referenced host id:" + folder.getHostId());
-					Logger.warn(FolderHandler.class, "Make sure the host exists with the id:" + folder.getHostId() + " before pushing the folder or run the integrity checker before pushing.");
+				if(UtilMethods.isEmpty(localHost::getIdentifier)){
+					Logger.warn(FolderHandler.class, "Unable to publish folder: " + folderName + ". Unable to find referenced Site: " + folder.getHostId());
+					Logger.warn(FolderHandler.class, "Make sure the Site exists with the id: " + folder.getHostId() + " before pushing the folder or run the integrity checker before pushing.");
 					continue;
 
 				}
@@ -295,7 +297,7 @@ public class FolderHandler implements IHandler {
 	        }
     	} catch (final Exception e) {
             final String errorMsg = String.format("An error occurred when processing Folder in '%s': %s", workingOn,
-                    e.getMessage());
+                    ExceptionUtil.getErrorMessage(e));
             Logger.error(this.getClass(), errorMsg);
 			Logger.error(this, "-- Local Folder: " + (UtilMethods.isSet(temp) ? temp : "- object is null -"));
 			if(UtilMethods.isSet(temp) && UtilMethods.isSet(folderName)) {

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/LinkHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/LinkHandler.java
@@ -13,6 +13,7 @@ import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.LinkBundler;
 import com.dotcms.enterprise.publishing.remote.handler.HandlerUtil.HandlerType;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.pusher.PushPublisherConfig;
 import com.dotcms.publisher.pusher.wrapper.LinkWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
@@ -57,9 +58,10 @@ import java.util.List;
  * @since Mar 7, 2013
  */
 public class LinkHandler implements IHandler {
-	private UserAPI uAPI = APILocator.getUserAPI();
-	private List<String> infoToRemove = new ArrayList<>();
-	private PublisherConfig config;
+
+	private final UserAPI uAPI = APILocator.getUserAPI();
+	private final List<String> infoToRemove = new ArrayList<>();
+	private final PublisherConfig config;
 
 	public LinkHandler(PublisherConfig config) {
 		this.config = config;
@@ -80,15 +82,15 @@ public class LinkHandler implements IHandler {
 		handleLinks(templates);
 	}
 
-	private void deleteLink(Link link) throws DotPublishingException, DotDataException{
+	private void deleteLink(Link link) {
 		try {
 			Link l = APILocator.getMenuLinkAPI().find(link.getInode(), APILocator.getUserAPI().getSystemUser(), false);
 			if(l!=null && InodeUtils.isSet(l.getInode())){
 				APILocator.getMenuLinkAPI().delete(link, APILocator.getUserAPI().getSystemUser(), false);
 			}
 		} catch (final Exception e) {
-            Logger.error(this, String.format("An error occurred when deleting Link '%s' [%s]: %s", (null == link ? "" +
-                    "(null)" : link.getTitle()), (null == link ? "(null)" : link.getIdentifier()), e.getMessage()), e);
+            Logger.error(this, String.format("An error occurred when deleting Link '%s' [%s]: %s",
+					(null == link ? "(null)" : link.getTitle()), (null == link ? "(null)" : link.getIdentifier()), ExceptionUtil.getErrorMessage(e)), e);
         }
 	}
 
@@ -179,14 +181,15 @@ public class LinkHandler implements IHandler {
 	            }
 	        } catch (final Exception e) {
                 throw new DotPublishingException(String.format("An error occurred when removing Version Info with ID " +
-                        "'%s' from cache: %s", identToRemove, e.getMessage()), e);
+                        "'%s' from cache: %s", identToRemove, ExceptionUtil.getErrorMessage(e)), e);
             }
     	} catch (final Exception e) {
-            final String errorMsg = String.format("An error occurred when processing Link in '%s' with ID '%s': %s",
+            final String errorMsg = String.format("An error occurred when processing Link in '%s' with title '%s' [%s]: %s",
                     workingOn, (null == linkToPublish ? "(empty)" : linkToPublish.getTitle()), (null == linkToPublish
-                            ? "(empty)" : linkToPublish.getIdentifier()), e.getMessage());
+                            ? "(empty)" : linkToPublish.getIdentifier()), ExceptionUtil.getErrorMessage(e));
             Logger.error(this.getClass(), errorMsg, e);
             throw new DotPublishingException(errorMsg, e);
     	}
     }
+
 }

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/RelationshipHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/RelationshipHandler.java
@@ -12,6 +12,7 @@ package com.dotcms.enterprise.publishing.remote.handler;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.RelationshipBundler;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.pusher.wrapper.RelationshipWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
 import com.dotcms.publishing.DotPublishingException;
@@ -28,6 +29,7 @@ import com.dotmarketing.util.PushPublishLogger.PushPublishHandler;
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.util.FileUtil;
 import com.thoughtworks.xstream.XStream;
+
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -48,7 +50,7 @@ import java.util.Collection;
  */
 public class RelationshipHandler implements IHandler {
 
-	private PublisherConfig config;
+	private final PublisherConfig config;
 
 	public RelationshipHandler(PublisherConfig config) {
 		this.config = config;
@@ -121,10 +123,10 @@ public class RelationshipHandler implements IHandler {
 				}
 			}
 		} catch (final Exception e) {
-            final String errorMsg = String.format("An error occurred when processing Relationship in '%s' with ID " +
-                    "'%s': %s", workingOn, (null == relationshipToPublish ? "(empty)" : relationshipToPublish
+            final String errorMsg = String.format("An error occurred when processing Relationship in '%s' with type value " +
+                    "'%s' [%s]: %s", workingOn, (null == relationshipToPublish ? "(empty)" : relationshipToPublish
                     .getRelationTypeValue()), (null == relationshipToPublish ? "(empty)" : relationshipToPublish
-                    .getInode()), e.getMessage());
+                    .getInode()), ExceptionUtil.getErrorMessage(e));
             Logger.error(this.getClass(), errorMsg, e);
             throw new DotPublishingException(errorMsg, e);
 		}

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/UserHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/UserHandler.java
@@ -12,6 +12,7 @@ package com.dotcms.enterprise.publishing.remote.handler;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.UserBundler;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.pusher.PushPublisherConfig;
 import com.dotcms.publisher.pusher.wrapper.UserWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
@@ -32,6 +33,7 @@ import com.liferay.portal.model.Company;
 import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import com.thoughtworks.xstream.XStream;
+
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -52,7 +54,7 @@ import java.util.Collection;
  */
 public class UserHandler implements IHandler {
 
-    private PublisherConfig config;
+    private final PublisherConfig config;
 
     public UserHandler ( PublisherConfig config ) {
         this.config = config;
@@ -149,9 +151,9 @@ public class UserHandler implements IHandler {
 
             }
         } catch (final Exception e) {
-            final String errorMsg = String.format("An error occurred when processing User in '%s' with ID '%s': %s",
+            final String errorMsg = String.format("An error occurred when processing User in '%s' with email '%s' [%s]: %s",
                     workingOn, (null == user ? "(empty)" : user.getEmailAddress()), (null == user ? "(empty)" : user
-                            .getUserId()), e.getMessage());
+                            .getUserId()), ExceptionUtil.getErrorMessage(e));
             Logger.error(this.getClass(), errorMsg, e);
             throw new DotPublishingException(errorMsg, e);
         }

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/VariantHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/VariantHandler.java
@@ -13,8 +13,7 @@ import com.dotcms.business.WrapInTransaction;
 import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.VariantBundler;
-import com.dotcms.experiments.model.Experiment;
-import com.dotcms.publisher.pusher.wrapper.ExperimentWrapper;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.pusher.wrapper.VariantWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
 import com.dotcms.publishing.BundlerUtil;
@@ -24,9 +23,9 @@ import com.dotcms.publishing.PublisherConfig.Operation;
 import com.dotcms.variant.VariantAPI;
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Logger;
 import com.liferay.util.FileUtil;
+
 import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
@@ -106,8 +105,7 @@ public class VariantHandler implements IHandler {
 			}
     	} catch (final Exception e) {
 			final String errorMsg = String.format("An error occurred when processing Variant in '%s' with name '%s': %s",
-					workingOn, variant.name(),
-							variant.name(), e.getMessage());
+					workingOn, null != variant ? variant.name() : "- null -", ExceptionUtil.getErrorMessage(e));
 			Logger.error(this.getClass(), errorMsg, e);
 			throw new DotPublishingException(errorMsg, e);
     	}

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/WorkflowHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/WorkflowHandler.java
@@ -14,6 +14,7 @@ import com.dotcms.enterprise.LicenseUtil;
 import com.dotcms.enterprise.license.LicenseLevel;
 import com.dotcms.enterprise.publishing.remote.bundler.ContainerBundler;
 import com.dotcms.enterprise.publishing.remote.bundler.WorkflowBundler;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.publisher.pusher.wrapper.WorkflowWrapper;
 import com.dotcms.publisher.receiver.handler.IHandler;
 import com.dotcms.publishing.DotPublishingException;
@@ -46,6 +47,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import com.thoughtworks.xstream.XStream;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -83,7 +85,7 @@ public class WorkflowHandler implements IHandler {
             this.systemUser = this.userAPI.getSystemUser();
         } catch (DotDataException e) {
 
-            Logger.fatal(ContainerBundler.class, e.getMessage(), e);
+            Logger.fatal(ContainerBundler.class, ExceptionUtil.getErrorMessage(e), e);
         }
     }
 
@@ -131,7 +133,7 @@ public class WorkflowHandler implements IHandler {
 
         } catch (final Exception e) {
             final String errorMsg = String.format("An error occurred when processing Workflow in '%s': %s",
-                    workingOn, e.getMessage());
+                    workingOn, ExceptionUtil.getErrorMessage(e));
             Logger.error(this.getClass(), errorMsg, e);
             throw new DotPublishingException(errorMsg, e);
         }


### PR DESCRIPTION
### Main Code Change Only this is required in LTSs
* In here: [[1]](https://github.com/dotCMS/core/pull/32429/files#diff-1e5a19fcdfdbe883752308cb7adf42231e860dff8300edf8b20c66f8b2b0fd39R200) , if the `isDrawed()` method from Template being pushed returns `true`, call the `TemplateAPI.saveAndUpdateLayout` method. Otherwise, call the `TemplateAPI.saveTemplate` method instead, which is the one that must be used to Advanced Templates.

### Proposed Changes
This pull request introduces several improvements and fixes across multiple handler classes in the `dotCMS` codebase. The most notable changes include replacing direct exception message retrieval with `ExceptionUtil.getErrorMessage` for better error handling, refactoring conditional checks for improved readability, and removing redundant or unnecessary code. Below is a categorized summary of the most important changes:

### Error Handling Improvements:
* Replaced `e.getMessage()` with `ExceptionUtil.getErrorMessage(e)` in error messages across `CategoryFullHandler`, `CategoryHandler`, `ContainerHandler`, and `ContentHandler` to provide more robust and consistent error reporting. [[1]](diffhunk://#diff-a0f977f665e0decb1e5c6023846a90108353aaf16d458eafe3e554872f62a5e2L132-R133) [[2]](diffhunk://#diff-edd255f3b77a3ded6d4b8ae486abb2331dffcb19e269a16a9ac12b3888d72385L177-R178) [[3]](diffhunk://#diff-4baceb4a87a390bdce6285584b9894071839d03a1ee67d764f49616cda883773L93-R94) [[4]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL586-R579)

### Code Simplification and Refactoring:
* Replaced `size() > 0` checks with `!isEmpty()` for better readability in `CategoryFullHandler` and `ContainerHandler`. [[1]](diffhunk://#diff-a0f977f665e0decb1e5c6023846a90108353aaf16d458eafe3e554872f62a5e2L119-R120) [[2]](diffhunk://#diff-a0f977f665e0decb1e5c6023846a90108353aaf16d458eafe3e554872f62a5e2L149-R150)
* Removed redundant variable initialization and streamlined code in `ContentHandler`. [[1]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL252-R248) [[2]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL481-R474)

### Consistency and Clarity:
* Updated log messages to use "Site" instead of "host" for clarity in `ContentHandler`. [[1]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL301-R299) [[2]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL396-R389)
* Improved comments for better understanding of the code's behavior, such as clarifying the behavior of exceptions and implicit publishing. [[1]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL262-R263) [[2]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL521-R514)

### Bug Fixes:
* Fixed a potential issue in `ContainerHandler` by removing an unnecessary `throws` clause from the `deleteContainer` method, as exceptions are already handled within the method.

### Miscellaneous Cleanup:
* Removed unused imports and redundant lines of code in `ContentHandler`. [[1]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL31) [[2]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL104) [[3]](diffhunk://#diff-39e5f35ab504d57b9244a02e68aae5395e59ea83fa525875137f76fb967279beL219-L229)

This PR fixes: #32423