### PR TITLE
chore(examples): Removed searchparams from examples

### DIFF
--- a/examples/angular/src/app/services/editable-page.service.ts
+++ b/examples/angular/src/app/services/editable-page.service.ts
@@ -31,7 +31,7 @@ export class EditablePageService<T extends DotCMSExtendedPageResponse> {
      * @param route Optional override for the current route
      * @returns Observable that completes when initial page load is done
      */
-    initializePage(extraParams?: DotCMSPageRequestParams): Signal<PageState<T>> {
+    initializePage(extraParams: DotCMSPageRequestParams = {}): Signal<PageState<T>> {
         this.#setLoading();
 
         // Wait for the router to navigate to the page
@@ -52,17 +52,8 @@ export class EditablePageService<T extends DotCMSExtendedPageResponse> {
                     // If the path is empty, use the root path
                     const url = path || '/';
 
-                    // Get the query params from the current route, avoid passing mode to let the UVE handle it
-                    const { mode, ...queryParams } = this.#activatedRoute.snapshot.queryParams;
-
-                    // Combine the query params with the extra params
-                    const fullParams = {
-                        ...queryParams,
-                        ...extraParams
-                    };
-
                     // Fetch the page asset
-                    return this.#pageService.getPageAsset<T>(url, fullParams);
+                    return this.#pageService.getPageAsset<T>(url, extraParams);
                 })
             )
             .subscribe((response) => {

--- a/examples/nextjs/src/app/[[...slug]]/page.js
+++ b/examples/nextjs/src/app/[[...slug]]/page.js
@@ -3,11 +3,10 @@ import { Page } from "@/views/Page";
 import { getDotCMSPage } from "@/utils/getDotCMSPage";
 
 export async function generateMetadata(props) {
-    const searchParams = await props.searchParams;
     const params = await props.params;
     try {
         const path = params?.slug?.join('/') || '/';
-        const { pageAsset } = await getDotCMSPage(path, searchParams);
+        const { pageAsset } = await getDotCMSPage(path);
         const page = pageAsset.page;
         const title = page?.friendlyName || page?.title;
 
@@ -22,10 +21,9 @@ export async function generateMetadata(props) {
 }
 
 export default async function Home(props) {
-    const searchParams = await props.searchParams;
     const params = await props.params;
     const path = params?.slug?.join('/') || '/';
-    const pageContent = await getDotCMSPage(path, searchParams);
+    const pageContent = await getDotCMSPage(path);
 
     const vanityUrl = pageContent?.pageAsset?.vanityUrl;
     const action = vanityUrl?.action ?? 0;

--- a/examples/nextjs/src/app/blog/post/[[...slug]]/page.js
+++ b/examples/nextjs/src/app/blog/post/[[...slug]]/page.js
@@ -3,11 +3,10 @@ import { DetailPage } from "@/views/DetailPage";
 import { getDotCMSPage } from "@/utils/getDotCMSPage";
 
 export async function generateMetadata(props) {
-    const searchParams = await props.searchParams;
     const params = await props.params;
     try {
         const path = params.slug[0];
-        const { pageAsset } = await getDotCMSPage(`/blog/post/${path}`, searchParams);
+        const { pageAsset } = await getDotCMSPage(`/blog/post/${path}`);
         const urlContentMap = pageAsset?.urlContentMap;
         const title = urlContentMap?.title || 'Page not found';
         return {
@@ -22,9 +21,8 @@ export async function generateMetadata(props) {
 
 export default async function Home(props) {
     const params = await props.params;
-    const searchParams = await props.searchParams;
     const path = params.slug[0];
-    const pageContent = await getDotCMSPage(`/blog/post/${path}`, searchParams);
+    const pageContent = await getDotCMSPage(`/blog/post/${path}`);
 
     const vanityUrl = pageContent?.pageAsset?.vanityUrl;
     const action = vanityUrl?.action ?? 0;

--- a/examples/nextjs/src/utils/getDotCMSPage.js
+++ b/examples/nextjs/src/utils/getDotCMSPage.js
@@ -7,12 +7,9 @@ import {
     navigationQuery,
 } from "./queries";
 
-export const getDotCMSPage = cache(async (path, searchParams = {}) => {
-    // Avoid passing mode if you have a read only auth token
-    const { mode, ...params } = searchParams;
+export const getDotCMSPage = cache(async (path) => {
     try {
         const pageData = await dotCMSClient.page.get(path, {
-            ...params,
             graphql: {
                 content: {
                     blogs: blogQuery,


### PR DESCRIPTION
This pull request simplifies the handling of query parameters across Angular and Next.js applications by removing unnecessary logic and defaulting to cleaner parameter handling. The updates streamline the codebase and enhance maintainability by reducing redundancy.

### Angular Application Changes:
* Updated the `initializePage` method in `EditablePageService` to use a default empty object for `extraParams`, simplifying the parameter handling.
* Removed the merging of query parameters with `extraParams` in the page asset fetching logic, directly passing `extraParams` instead.

### Next.js Application Changes:
* Removed the use of `searchParams` in `generateMetadata` and `Home` functions across multiple files (`examples/nextjs/src/app/[[...slug]]/page.js` and `examples/nextjs/src/app/blog/post/[[...slug]]/page.js`), simplifying function calls to `getDotCMSPage`. ([examples/nextjs/src/app/[[...slug]]/page.jsL6-R9](diffhunk://#diff-ae32fed6c8c541fd820d195111a8c016ec33ecd22c5785374a4cb48e295c479bL6-R9), [examples/nextjs/src/app/[[...slug]]/page.jsL25-R26](diffhunk://#diff-ae32fed6c8c541fd820d195111a8c016ec33ecd22c5785374a4cb48e295c479bL25-R26), [examples/nextjs/src/app/blog/post/[[...slug]]/page.jsL6-R9](diffhunk://#diff-b407330cf92641b72b66d15e4c134e93224b6b10a9ededc2771705c259dab081L6-R9), [examples/nextjs/src/app/blog/post/[[...slug]]/page.jsL25-R25](diffhunk://#diff-b407330cf92641b72b66d15e4c134e93224b6b10a9ededc2771705c259dab081L25-R25))
* Updated the `getDotCMSPage` utility to remove the logic for excluding the `mode` parameter from `searchParams`, as it is no longer passed.