### PR TITLE
chore(examples): Remove searchparams from query in uve examples

### DIFF
--- a/examples/angular/src/app/services/editable-page.service.ts
+++ b/examples/angular/src/app/services/editable-page.service.ts
@@ -25,11 +25,19 @@ export class EditablePageService<T extends DotCMSExtendedPageResponse> {
         status: 'idle'
     });
 
+
     /**
-     * Initialize page loading for the current route
-     * Call this method from a component's ngOnInit
-     * @param route Optional override for the current route
-     * @returns Observable that completes when initial page load is done
+     * Initializes the page by loading and managing page content based on the current route.
+     * This method:
+     * 1. Sets initial loading state
+     * 2. Listens for route changes
+     * 3. Fetches page content for the current URL
+     * 4. Handles vanity URLs and redirects
+     * 5. Manages UVE (Universal Visual Editor) integration
+     * 6. Updates page state based on responses
+     *
+     * @param {DotCMSPageRequestParams} extraParams - Additional parameters to include in the page request
+     * @returns {Signal<PageState<T>>} A signal containing the current page state
      */
     initializePage(extraParams: DotCMSPageRequestParams = {}): Signal<PageState<T>> {
         this.#setLoading();

--- a/examples/angular/src/app/services/editable-page.service.ts
+++ b/examples/angular/src/app/services/editable-page.service.ts
@@ -31,7 +31,7 @@ export class EditablePageService<T extends DotCMSExtendedPageResponse> {
      * @param route Optional override for the current route
      * @returns Observable that completes when initial page load is done
      */
-    initializePage(extraParams?: DotCMSPageRequestParams): Signal<PageState<T>> {
+    initializePage(extraParams: DotCMSPageRequestParams = {}): Signal<PageState<T>> {
         this.#setLoading();
 
         // Wait for the router to navigate to the page
@@ -52,17 +52,8 @@ export class EditablePageService<T extends DotCMSExtendedPageResponse> {
                     // If the path is empty, use the root path
                     const url = path || '/';
 
-                    // Get the query params from the current route, avoid passing mode to let the UVE handle it
-                    const { mode, ...queryParams } = this.#activatedRoute.snapshot.queryParams;
-
-                    // Combine the query params with the extra params
-                    const fullParams = {
-                        ...queryParams,
-                        ...extraParams
-                    };
-
                     // Fetch the page asset
-                    return this.#pageService.getPageAsset<T>(url, fullParams);
+                    return this.#pageService.getPageAsset<T>(url, extraParams);
                 })
             )
             .subscribe((response) => {

--- a/examples/nextjs/src/app/[[...slug]]/page.js
+++ b/examples/nextjs/src/app/[[...slug]]/page.js
@@ -3,11 +3,10 @@ import { Page } from "@/views/Page";
 import { getDotCMSPage } from "@/utils/getDotCMSPage";
 
 export async function generateMetadata(props) {
-    const searchParams = await props.searchParams;
     const params = await props.params;
     try {
         const path = params?.slug?.join('/') || '/';
-        const { pageAsset } = await getDotCMSPage(path, searchParams);
+        const { pageAsset } = await getDotCMSPage(path);
         const page = pageAsset.page;
         const title = page?.friendlyName || page?.title;
 
@@ -22,10 +21,9 @@ export async function generateMetadata(props) {
 }
 
 export default async function Home(props) {
-    const searchParams = await props.searchParams;
     const params = await props.params;
     const path = params?.slug?.join('/') || '/';
-    const pageContent = await getDotCMSPage(path, searchParams);
+    const pageContent = await getDotCMSPage(path);
 
     const vanityUrl = pageContent?.pageAsset?.vanityUrl;
     const action = vanityUrl?.action ?? 0;

--- a/examples/nextjs/src/app/blog/post/[[...slug]]/page.js
+++ b/examples/nextjs/src/app/blog/post/[[...slug]]/page.js
@@ -3,11 +3,10 @@ import { DetailPage } from "@/views/DetailPage";
 import { getDotCMSPage } from "@/utils/getDotCMSPage";
 
 export async function generateMetadata(props) {
-    const searchParams = await props.searchParams;
     const params = await props.params;
     try {
         const path = params.slug[0];
-        const { pageAsset } = await getDotCMSPage(`/blog/post/${path}`, searchParams);
+        const { pageAsset } = await getDotCMSPage(`/blog/post/${path}`);
         const urlContentMap = pageAsset?.urlContentMap;
         const title = urlContentMap?.title || 'Page not found';
         return {
@@ -22,9 +21,8 @@ export async function generateMetadata(props) {
 
 export default async function Home(props) {
     const params = await props.params;
-    const searchParams = await props.searchParams;
     const path = params.slug[0];
-    const pageContent = await getDotCMSPage(`/blog/post/${path}`, searchParams);
+    const pageContent = await getDotCMSPage(`/blog/post/${path}`);
 
     const vanityUrl = pageContent?.pageAsset?.vanityUrl;
     const action = vanityUrl?.action ?? 0;

--- a/examples/nextjs/src/utils/getDotCMSPage.js
+++ b/examples/nextjs/src/utils/getDotCMSPage.js
@@ -7,12 +7,9 @@ import {
     navigationQuery,
 } from "./queries";
 
-export const getDotCMSPage = cache(async (path, searchParams = {}) => {
-    // Avoid passing mode if you have a read only auth token
-    const { mode, ...params } = searchParams;
+export const getDotCMSPage = cache(async (path) => {
     try {
         const pageData = await dotCMSClient.page.get(path, {
-            ...params,
             graphql: {
                 content: {
                     blogs: blogQuery,


### PR DESCRIPTION
This pull request simplifies the handling of query parameters in both Angular and Next.js applications by removing unnecessary query parameter merging logic and standardizing the `getDotCMSPage` function. The most important changes include defaulting `extraParams` to an empty object in Angular, removing query parameter destructuring, and updating Next.js components to reflect this streamlined approach.

### Angular Changes:
* `initializePage` method in `EditablePageService`: Updated the `extraParams` parameter to default to an empty object, simplifying its usage. Removed the merging of query parameters with `extraParams` and instead passed `extraParams` directly to the `getPageAsset` method. (`examples/angular/src/app/services/editable-page.service.ts`, [[1]](diffhunk://#diff-fba6f4546b16e21264012741bda034f42c7170f5b25febd7d5e83663addd8a59L34-R34) [[2]](diffhunk://#diff-fba6f4546b16e21264012741bda034f42c7170f5b25febd7d5e83663addd8a59L55-R56)

### Next.js Changes:
* `getDotCMSPage` function: Simplified the function by removing the destructuring of `searchParams` and directly passing the `path` parameter to the `dotCMSClient.page.get` method. (`examples/nextjs/src/utils/getDotCMSPage.js`, [examples/nextjs/src/utils/getDotCMSPage.jsL10-L15](diffhunk://#diff-94df90f4a07f9cfacdffe3aebe9b3d2b0ea1ddc0efc6fa8dbb8466ab56c7a0e7L10-L15))
* `generateMetadata` and `Home` functions in `[[...slug]]/page.js`: Removed the usage of `searchParams` and updated calls to `getDotCMSPage` to only pass the `path` parameter. (`examples/nextjs/src/app/[[...slug]]/page.js`, [examples/nextjs/src/app/[[...slug]]/page.jsL6-R9](diffhunk://#diff-ae32fed6c8c541fd820d195111a8c016ec33ecd22c5785374a4cb48e295c479bL6-R9), [examples/nextjs/src/app/[[...slug]]/page.jsL25-R26](diffhunk://#diff-ae32fed6c8c541fd820d195111a8c016ec33ecd22c5785374a4cb48e295c479bL25-R26))
* `generateMetadata` and `Home` functions in `blog/post/[[...slug]]/page.js`: Similarly removed `searchParams` and updated calls to `getDotCMSPage` to align with the simplified function. (`examples/nextjs/src/app/blog/post/[[...slug]]/page.js`, [examples/nextjs/src/app/blog/post/[[...slug]]/page.jsL6-R9](diffhunk://#diff-b407330cf92641b72b66d15e4c134e93224b6b10a9ededc2771705c259dab081L6-R9), [examples/nextjs/src/app/blog/post/[[...slug]]/page.jsL25-R25](diffhunk://#diff-b407330cf92641b72b66d15e4c134e93224b6b10a9ededc2771705c259dab081L25-R25))

This PR fixes: #32444