### PR TITLE
feat(JobQueue): Improve swagger documentation #30939

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobParamsSchema.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobParamsSchema.java
@@ -1,0 +1,46 @@
+package com.dotcms.rest.api.v1.job;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.ws.rs.FormParam;
+
+@Schema(description = "Schema for multipart job queue parameters.")
+public class JobParamsSchema {
+
+    @FormParam("file")
+    @Schema(
+            description = "The file to be processed by the job.",
+            type = "string",
+            format = "binary"
+    )
+    private String file;
+
+    @FormParam("params")
+    @Schema(
+            description = "JSON string with job-specific parameters.",
+            type = "string",
+            example = "{\n" +
+                    "  \"sourceUrl\": \"https://example.com/image.jpeg\",\n" +
+                    "  \"width\": 320,\n" +
+                    "  \"height\": 240,\n" +
+                    "}"
+    )
+    private String params;
+
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public String getParams() {
+        return params;
+    }
+
+    public void setParams(String params) {
+        this.params = params;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueDocs.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueDocs.java
@@ -1,0 +1,19 @@
+package com.dotcms.rest.api.v1.job;
+
+public class JobQueueDocs {
+
+    public static final String FORM_FIELD_DOC =
+            "This endpoint accepts a `multipart/form-data` request with two fields:\n\n" +
+                    "| **Field** | **Type** | **Required** | **Description** |\n" +
+                    "|-----------|----------|--------------|-----------------|\n" +
+                    "| `file`    | File     | ❌ No        | The file to be processed by the queue.|\n" +
+                    "| `form`    | String   | ❌ No        | A JSON string containing job-specific parameters.|\n\n" +
+                    "**Example `form` value:**\n\n" +
+                    "```json\n" +
+                    "{\n" +
+                    "  \"sourceUrl\": \"https://example.com/image.jpeg\",\n" +
+                    "  \"width\": 320,\n" +
+                    "  \"height\": 240,\n" +
+                    "}\n" +
+                    "```";
+}


### PR DESCRIPTION
### FIXME IMPORTANT: 

As we have 2 endpoints POST at `/{queueName}` one for json and other for multipart, only one of them is being rendered at swagger playground. We have to consolidate both in a single endpoint that has enough logic to identify which contentType is being passed and make the proper call to `JobQueueHelper.createJob()` method. (I didn't have time to finish that)

---

This pull request introduces a new schema and documentation for handling multipart job queue parameters in the API. The most important changes include the addition of a `JobParamsSchema` class to define the structure of the job parameters and a `JobQueueDocs` class to provide documentation for the API endpoint.

### Additions to API schema and documentation:

* [`dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobParamsSchema.java`](diffhunk://#diff-948cf1a3843b79cf0b8bf6de2f8d86cd96b9e6c3d8905f7649fe061c2568d98fR1-R46): Added a new class, `JobParamsSchema`, to define the schema for multipart job queue parameters. This includes fields for a file (`file`) and job-specific parameters (`params`), along with their respective getters and setters.

* [`dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueDocs.java`](diffhunk://#diff-8c562471b62a91702ff765f40a3c4e9779518a9761dfd019f2b17b123f7cd240R1-R19): Added a new class, `JobQueueDocs`, to provide documentation for the API endpoint. This includes details about the `multipart/form-data` fields (`file` and `form`) and an example JSON for the `form` field.

![image](https://github.com/user-attachments/assets/b9c43af0-9ba3-455b-9acc-9cb5d90c9db2)
