### PR TITLE
chore(uve): Fixed save contentlets from palette content-types

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -644,6 +644,18 @@ describe('EditEmaEditorComponent', () => {
 
                 it('should open a dialog and save after backend emit', (done) => {
                     spectator.detectChanges();
+
+                    const graphQlSpy = jest.spyOn(store, 'graphql');
+
+                    graphQlSpy.mockReturnValue({
+                        query: `query {
+                            pageAsset {
+                                identifier
+                            }
+                        }`,
+                        variables: {}
+                    });
+
                     const dialog = spectator.debugElement.query(
                         By.css('[data-testId="ema-dialog"]')
                     );
@@ -696,6 +708,17 @@ describe('EditEmaEditorComponent', () => {
                     );
 
                     spectator.detectComponentChanges();
+
+                    const graphQlSpy = jest.spyOn(store, 'graphql');
+
+                    graphQlSpy.mockReturnValue({
+                        query: `query {
+                            pageAsset {
+                                identifier
+                            }
+                        }`,
+                        variables: {}
+                    });
 
                     const dialog = spectator.debugElement.query(
                         By.css("[data-testId='ema-dialog']")

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -645,17 +645,6 @@ describe('EditEmaEditorComponent', () => {
                 it('should open a dialog and save after backend emit', (done) => {
                     spectator.detectChanges();
 
-                    const graphQlSpy = jest.spyOn(store, 'graphql');
-
-                    graphQlSpy.mockReturnValue({
-                        query: `query {
-                            pageAsset {
-                                identifier
-                            }
-                        }`,
-                        variables: {}
-                    });
-
                     const dialog = spectator.debugElement.query(
                         By.css('[data-testId="ema-dialog"]')
                     );
@@ -708,17 +697,6 @@ describe('EditEmaEditorComponent', () => {
                     );
 
                     spectator.detectComponentChanges();
-
-                    const graphQlSpy = jest.spyOn(store, 'graphql');
-
-                    graphQlSpy.mockReturnValue({
-                        query: `query {
-                            pageAsset {
-                                identifier
-                            }
-                        }`,
-                        variables: {}
-                    });
 
                     const dialog = spectator.debugElement.query(
                         By.css("[data-testId='ema-dialog']")

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -734,17 +734,22 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
 
                 const graphql = this.uveStore.graphql();
 
-                if (!actionPayload && graphql) {
-                    this.uveStore.reloadCurrentPage();
-
-                    return;
-                } else if (clientAction === CLIENT_ACTIONS.EDIT_CONTENTLET) {
+                if (clientAction === CLIENT_ACTIONS.EDIT_CONTENTLET) {
                     this.contentWindow?.postMessage(
                         {
                             name: __DOTCMS_UVE_EVENT__.UVE_RELOAD_PAGE
                         },
                         this.host
                     );
+                    if (graphql) {
+                        return;
+                    }
+                }
+
+                if (!actionPayload) {
+                    this.uveStore.reloadCurrentPage();
+
+                    return;
                 }
 
                 const { pageContainers, didInsert } = insertContentletInContainer({

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -732,7 +732,11 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
                     return;
                 }
 
-                const graphql = this.uveStore.graphql();
+                if (!actionPayload) {
+                    this.uveStore.reloadCurrentPage();
+
+                    return;
+                }
 
                 if (clientAction === CLIENT_ACTIONS.EDIT_CONTENTLET) {
                     this.contentWindow?.postMessage(
@@ -741,15 +745,6 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
                         },
                         this.host
                     );
-                    if (graphql) {
-                        return;
-                    }
-                }
-
-                if (!actionPayload) {
-                    this.uveStore.reloadCurrentPage();
-
-                    return;
                 }
 
                 const { pageContainers, didInsert } = insertContentletInContainer({

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -734,7 +734,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy {
 
                 const graphql = this.uveStore.graphql();
 
-                if (!actionPayload || graphql) {
+                if (!actionPayload && graphql) {
                     this.uveStore.reloadCurrentPage();
 
                     return;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
@@ -212,6 +212,12 @@ export interface EditEmaDialogState {
     status: DialogStatus;
     url: string;
     type: DialogType;
+    /**
+     * Represent the action payload of the dialog, with the edited contentlet or the new contentlet
+     * that is being created, both inside PageAsset.
+     *
+     * Can be null when the dialog is opened outside of PageAsset, like from the Content API.
+     */
     actionPayload?: ActionPayload;
     form: DialogForm;
     clientAction: CLIENT_ACTIONS;


### PR DESCRIPTION
https://github.com/user-attachments/assets/28e4e6d8-48ab-4e4b-85ac-7d48c68640c6

Issue: Previously, we used a conditional check that, due to how it was written, didn’t properly handle the expected case:

`if (!actionPayload || graphql)
`

In this condition, the evaluation wasn’t based on a strict boolean check, but rather on the truthiness of the graphql object. As a result, in headless mode—where graphql always had a value—the condition would always evaluate as true.

This caused the current content to always be "reloaded," and the request to save the new contentlet was never actually made.

Now, a preliminary evaluation is performed without needing to combine actionPayload and graphql in a single condition. All tests are still passing, and after manual testing, no issues were found as a result of this change.

This PR fixes: #32512