### PR TITLE
feat(edit-content): Enhance category field with disabled state handling

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
@@ -151,6 +151,7 @@
         @defer (on immediate) {
             <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-category-field
+                [formControlName]="field.variable"
                 [attr.data-testId]="'field-' + field.variable"
                 [contentlet]="contentlet"
                 [field]="field" />

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.html
@@ -2,11 +2,12 @@
     @for (category of $categoriesToShow(); track category.key) {
         <p-chip
             [pTooltip]="category.path || category.value"
-            [removable]="true"
             [label]="category.value"
             tooltipPosition="top"
-            styleClass="p-chip-sm"
-            (onRemove)="remove.emit(category.key)">
+            [removable]="true"
+            [styleClass]="$disabled() ? 'p-chip-sm p-chip-disabled' : 'p-chip-sm'"
+            [class.p-chip-disabled]="$disabled()"
+            (onRemove)="onRemove(category.key)">
             <ng-template pTemplate="removeicon">
                 <i class="pi pi-times"></i>
             </ng-template>
@@ -16,6 +17,7 @@
         <button
             (click)="toogleShowAll()"
             [label]="$btnLabel()"
+            [disabled]="$disabled()"
             class="p-button-sm p-button-text p-button-secondary"
             data-testId="show-btn"
             pButton></button>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.html
@@ -6,7 +6,6 @@
             tooltipPosition="top"
             [removable]="true"
             [styleClass]="$disabled() ? 'p-chip-sm p-chip-disabled' : 'p-chip-sm'"
-            [class.p-chip-disabled]="$disabled()"
             (onRemove)="onRemove(category.key)">
             <ng-template pTemplate="removeicon">
                 <i class="pi pi-times"></i>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.ts
@@ -31,7 +31,8 @@ import { DotCategoryFieldKeyValueObj } from '../../models/dot-category-field.mod
     templateUrl: './dot-category-field-chips.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
-        class: 'dot-category-field__categories'
+        class: 'dot-category-field__categories',
+        '[class.dot-category-field__categories--disabled]': '$disabled()'
     }
 })
 export class DotCategoryFieldChipsComponent {
@@ -53,6 +54,12 @@ export class DotCategoryFieldChipsComponent {
      * @memberof DotCategoryFieldChipsComponent
      */
     $categories = input<DotCategoryFieldKeyValueObj[]>([], { alias: 'categories' });
+    /**
+     * Represents whether the component is disabled.
+     *
+     * @memberof DotCategoryFieldChipsComponent
+     */
+    $disabled = input<boolean>(false, { alias: 'disabled' });
     /**
      * Represents the variable 'label' which is of type 'string'.
      *
@@ -121,6 +128,24 @@ export class DotCategoryFieldChipsComponent {
      * @memberof DotCategoryFieldChipsComponent
      */
     toogleShowAll(): void {
+        if (this.$disabled()) {
+            return;
+        }
+
         this.$showAll.update((showAll) => !showAll);
+    }
+
+    /**
+     * Handles the remove action for a category chip.
+     *
+     * @param {string} key - The key of the category to remove
+     * @memberof DotCategoryFieldChipsComponent
+     */
+    onRemove(key: string): void {
+        if (this.$disabled()) {
+            return;
+        }
+
+        this.remove.emit(key);
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.html
@@ -2,6 +2,7 @@
     <dot-category-field-chips
         data-testId="category-chip-list"
         [categories]="store.selected()"
+        [disabled]="$isDisabled()"
         (remove)="store.removeRootSelected($event)" />
 }
 
@@ -9,7 +10,7 @@
     <button
         type="button"
         (click)="openCategoriesDialog()"
-        [disabled]="store.isDialogOpen()"
+        [disabled]="store.isDialogOpen() || $isDisabled()"
         [label]="'edit.content.category-field.show-categories-dialog' | dm"
         class="p-button-sm p-button-text p-button-secondary"
         data-testId="show-dialog-btn"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.scss
@@ -9,6 +9,15 @@
         border-bottom: none;
         padding: $spacing-1;
     }
+
+    &.dot-category-field__container--disabled {
+        .dot-category-field__categories,
+        .dot-category-field__select {
+            border-color: $color-palette-gray-200;
+            background: $color-palette-gray-100;
+            color: $color-palette-gray-500;
+        }
+    }
 }
 
 .dot-category-field__categories,
@@ -22,6 +31,12 @@
 .dot-category-field__categories {
     gap: $spacing-1;
     border-radius: $border-radius-md $border-radius-md 0 0;
+
+    &--disabled {
+        border-color: $color-palette-gray-200;
+        background: $color-palette-gray-100;
+        color: $color-palette-gray-500;
+    }
 }
 
 .dot-category-field__select {
@@ -29,4 +44,16 @@
     border-radius: $border-radius-md;
     padding: 0 $spacing-0;
     justify-content: flex-end;
+}
+
+// Disabled chips styling
+:host ::ng-deep {
+    .p-chip-disabled {
+        background-color: $color-palette-gray-200 !important;
+        color: $color-palette-gray-500 !important;
+
+        .p-chip-remove-icon {
+            color: $color-palette-gray-500 !important;
+        }
+    }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
@@ -3,12 +3,14 @@ import {
     Component,
     computed,
     effect,
+    forwardRef,
     inject,
     Injector,
     input,
-    OnInit
+    OnInit,
+    signal
 } from '@angular/core';
-import { ControlContainer, FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
 
@@ -43,19 +45,21 @@ import { CategoryFieldStore } from './store/content-category-field.store';
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         '[class.dot-category-field__container--has-categories]': '$hasSelectedCategories()',
-        '[class.dot-category-field__container]': '!$hasSelectedCategories()'
+        '[class.dot-category-field__container]': '!$hasSelectedCategories()',
+        '[class.dot-category-field__container--disabled]': '$isDisabled()'
     },
-    viewProviders: [
+    providers: [
+        CategoriesService,
+        CategoryFieldStore,
         {
-            provide: ControlContainer,
-            useFactory: () => inject(ControlContainer, { skipSelf: true })
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: forwardRef(() => DotEditContentCategoryFieldComponent),
+            multi: true
         }
-    ],
-    providers: [CategoriesService, CategoryFieldStore]
+    ]
 })
-export class DotEditContentCategoryFieldComponent implements OnInit {
+export class DotEditContentCategoryFieldComponent implements OnInit, ControlValueAccessor {
     readonly store = inject(CategoryFieldStore);
-    readonly #form = inject(ControlContainer).control as FormGroup;
     readonly #injector = inject(Injector);
 
     /**
@@ -68,6 +72,16 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
      * @description DotCMSContentlet input representing a DotCMS contentlet.
      */
     contentlet = input.required<DotCMSContentlet>();
+
+    // ControlValueAccessor callbacks
+    private onChange: (value: string[]) => void = () => {
+        // Callback will be set by registerOnChange
+    };
+    private onTouched: () => void = () => {
+        // Callback will be set by registerOnTouched
+    };
+    protected $isDisabled = signal(false);
+
     /**
      * The `$hasConfirmedCategories` variable is a computed property that returns a boolean value.
      *
@@ -76,43 +90,95 @@ export class DotEditContentCategoryFieldComponent implements OnInit {
     $hasSelectedCategories = computed(() => this.store.selected().length > 0);
 
     /**
-     * Getter to retrieve the category field control.
-     *
-     * @return {FormControl} The category field control.
-     */
-    get categoryFieldControl(): FormControl {
-        return this.#form.get(this.store.fieldVariableName()) as FormControl;
-    }
-    /**
      * Initialize the component.
      *
      * @memberof DotEditContentCategoryFieldComponent
      */
     ngOnInit(): void {
+        // Initialize the store with field information only
+        // The contentlet data will come through ControlValueAccessor's writeValue
         this.store.load({
             field: this.field(),
             contentlet: this.contentlet()
         });
+
+        // Effect to sync selected categories with form control
         effect(
             () => {
                 const categoryValues = this.store.selected();
+                const inodes = categoryValues?.map((category) => category.inode) ?? [];
 
-                if (this.categoryFieldControl) {
-                    const inodes = categoryValues?.map((category) => category.inode) ?? [];
-                    this.categoryFieldControl.setValue(inodes);
-                }
+                // Notify form control of value change
+                this.onChange(inodes);
             },
             {
                 injector: this.#injector
             }
         );
     }
+
     /**
      * Open the categories dialog.
      *
      * @memberof DotEditContentCategoryFieldComponent
      */
     openCategoriesDialog(): void {
+        if (this.$isDisabled()) {
+            return;
+        }
+
         this.store.openDialog();
+        this.onTouched();
+    }
+
+    // ControlValueAccessor implementation
+
+    /**
+     * Sets the value in the component when the form control value changes.
+     * This method is called by Angular's forms system.
+     *
+     * @param value - Array of category inode strings
+     */
+    writeValue(value: string[]): void {
+        if (!value) {
+            this.store.setSelectedFromInodes([]);
+
+            return;
+        }
+
+        if (!Array.isArray(value)) {
+            return;
+        }
+
+        // Update store with the new value
+        this.store.setSelectedFromInodes(value);
+    }
+
+    /**
+     * Registers a callback function that is called when the control's value changes in the UI.
+     *
+     * @param fn - The callback function to register
+     */
+    registerOnChange(fn: (value: string[]) => void): void {
+        this.onChange = fn;
+    }
+
+    /**
+     * Registers a callback function that is called when the control is marked as touched in the UI.
+     *
+     * @param fn - The callback function to register
+     */
+    registerOnTouched(fn: () => void): void {
+        this.onTouched = fn;
+    }
+
+    /**
+     * Sets the disabled state of the component.
+     * This method is called by Angular when the form control's disabled state changes.
+     *
+     * @param isDisabled - Whether the component should be disabled
+     */
+    setDisabledState(isDisabled: boolean): void {
+        this.$isDisabled.set(isDisabled);
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.ts
@@ -131,8 +131,6 @@ export class DotEditContentCategoryFieldComponent implements OnInit, ControlValu
         this.onTouched();
     }
 
-    // ControlValueAccessor implementation
-
     /**
      * Sets the value in the component when the form control value changes.
      * This method is called by Angular's forms system.

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
@@ -1,7 +1,7 @@
 import { tapResponse } from '@ngrx/operators';
 import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { pipe } from 'rxjs';
+import { EMPTY, pipe } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { computed, inject } from '@angular/core';
@@ -323,7 +323,7 @@ export const CategoryFieldStore = signalStore(
                                 state: ComponentStatus.LOADED
                             });
 
-                            return [];
+                            return EMPTY;
                         }
 
                         return categoryService.getSelectedHierarchy(inodes).pipe(

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/store/content-category-field.store.ts
@@ -21,16 +21,16 @@ import { CategoriesService } from '../services/categories.service';
 import {
     addSelected,
     checkIfClickedIsLastItem,
+    checkIfClickedIsLoaded,
     clearCategoriesAfterIndex,
     clearParentPathAfterIndex,
+    getMenuItemsFromKeyParentPath,
     getSelectedFromContentlet,
     removeEmptyArrays,
     removeItemByKey,
     transformCategories,
     transformToSelectedObject,
-    updateChecked,
-    getMenuItemsFromKeyParentPath,
-    checkIfClickedIsLoaded
+    updateChecked
 } from '../utils/category-field.utils';
 
 export type CategoryFieldState = {
@@ -306,6 +306,47 @@ export const CategoryFieldStore = signalStore(
 
                 patchState(store, { selected });
             },
+
+            /**
+             * Sets the selected categories from an array of inodes.
+             * This method is used by ControlValueAccessor to initialize the component.
+             *
+             * @param {string[]} inodes - Array of category inodes to set as selected
+             */
+            setSelectedFromInodes: rxMethod<string[]>(
+                pipe(
+                    tap(() => patchState(store, { state: ComponentStatus.LOADING })),
+                    switchMap((inodes) => {
+                        if (!inodes || inodes.length === 0) {
+                            patchState(store, {
+                                selected: [],
+                                state: ComponentStatus.LOADED
+                            });
+
+                            return [];
+                        }
+
+                        return categoryService.getSelectedHierarchy(inodes).pipe(
+                            tapResponse({
+                                next: (categoryWithParentPath) => {
+                                    const selected =
+                                        transformToSelectedObject(categoryWithParentPath);
+                                    patchState(store, {
+                                        selected,
+                                        state: ComponentStatus.LOADED
+                                    });
+                                },
+                                error: (error: HttpErrorResponse) => {
+                                    patchState(store, {
+                                        state: ComponentStatus.ERROR
+                                    });
+                                    dotHttpErrorManagerService.handle(error);
+                                }
+                            })
+                        );
+                    })
+                )
+            ),
 
             /**
              * Resets the store to its initial state.


### PR DESCRIPTION
### Proposed Changes
- Added a disabled state to the dot-edit-content-category-field component, allowing for better user experience when the field is not editable.
- Updated the template and styles to reflect the disabled state visually.
- Implemented ControlValueAccessor methods to manage form control integration, ensuring proper value handling when disabled.
- Enhanced the dot-category-field-chips component to respect the disabled state, preventing user interactions when the field is not active.
- Improved overall accessibility and usability of the category field components.

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots

https://github.com/user-attachments/assets/d4aaeb4b-b83a-4391-9af0-c564887a55c3



This PR fixes: #31498