### PR TITLE
Fix(block-editor) : Fixed removedAtttribute method on velocity request wrapper

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/mock/request/MockAttributeRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/mock/request/MockAttributeRequest.java
@@ -45,4 +45,9 @@ public class MockAttributeRequest extends HttpServletRequestWrapper implements M
         attributes.put(name, o);
     }
 
+    @Override
+    public void removeAttribute(String name) {
+        attributes.remove(name);
+    }
+
 }

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/VelocityRequestWrapper.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/VelocityRequestWrapper.java
@@ -94,8 +94,11 @@ public class VelocityRequestWrapper extends javax.servlet.http.HttpServletReques
     }
 
     @Override
-    public void removeAttribute(String arg0) {
-        // do nothing
+    public void removeAttribute(String key) {
+        if (SET_VALUE_BLACKLIST.contains(key)) {
+            return;
+        }
+        super.removeAttribute(key);
     }
 
     @Override

--- a/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/VelocityRequestWrapperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/VelocityRequestWrapperTest.java
@@ -1,0 +1,140 @@
+package com.dotcms.rendering.velocity.viewtools;
+
+import com.dotcms.UnitTestBase;
+import com.dotmarketing.util.Config;
+import com.liferay.portal.util.WebKeys;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link VelocityRequestWrapper} class.
+ * Tests the setAttribute and removeAttribute methods with blacklisted and non-blacklisted attributes.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class VelocityRequestWrapperTest extends UnitTestBase {
+
+    @Mock
+    private HttpServletRequest mockRequest;
+
+    private boolean originalConfigValue;
+
+    /**
+     * Sets up the test environment by configuring the VELOCITY_PREVENT_SETTING_USER_ID property to true.
+     */
+    @Before
+    public void setUp() {
+        // Store original config value to restore after test
+        originalConfigValue = Config.getBooleanProperty("VELOCITY_PREVENT_SETTING_USER_ID", true);
+        Config.setProperty("VELOCITY_PREVENT_SETTING_USER_ID", true);
+    }
+
+    /**
+     * Tears down the test environment by restoring the original config value.
+     */
+    @After
+    public void tearDown() {
+        // Restore original config value
+        Config.setProperty("VELOCITY_PREVENT_SETTING_USER_ID", originalConfigValue);
+    }
+
+    /**
+     * Tests that the VelocityRequestWrapper correctly prevents setting blacklisted attributes.
+     * Specifically, it checks that USER_ID attributes is not set.
+     */
+    @Test
+    public void testSetAttribute_withBlacklistedUserIdAttribute_shouldNotSetAttribute() {
+        final VelocityRequestWrapper wrapper = VelocityRequestWrapper.wrapVelocityRequest(mockRequest);
+        
+        // When: setting a blacklisted attribute (USER_ID)
+        wrapper.setAttribute(WebKeys.USER_ID, "testUserId");
+        
+        // Then: setAttribute should not be called on the wrapped request
+        verify(mockRequest, never()).setAttribute(WebKeys.USER_ID, "testUserId");
+    }
+
+    /**
+     * Tests that the VelocityRequestWrapper correctly prevents setting blacklisted attributes.
+     * Specifically, it checks that USER attribute is not set.
+     */
+    @Test
+    public void testSetAttribute_withBlacklistedUserAttribute_shouldNotSetAttribute() {
+        final VelocityRequestWrapper wrapper = VelocityRequestWrapper.wrapVelocityRequest(mockRequest);
+        
+        // When: setting a blacklisted attribute (USER)
+        wrapper.setAttribute(WebKeys.USER, "testUser");
+        
+        // Then: setAttribute should not be called on the wrapped request
+        verify(mockRequest, never()).setAttribute(WebKeys.USER, "testUser");
+    }
+
+    /**
+     * Tests that the VelocityRequestWrapper allows setting non-blacklisted attributes.
+     * Specifically, it checks that a custom attribute is set correctly.
+     */
+    @Test
+    public void testSetAttribute_withNonBlacklistedAttribute_shouldSetAttribute() {
+        final VelocityRequestWrapper wrapper = VelocityRequestWrapper.wrapVelocityRequest(mockRequest);
+        final String testKey = "testAttribute";
+        final String testValue = "testValue";
+        
+        // When: setting a non-blacklisted attribute
+        wrapper.setAttribute(testKey, testValue);
+        
+        // Then: setAttribute should be called on the wrapped request
+        verify(mockRequest, times(1)).setAttribute(testKey, testValue);
+    }
+
+    /**
+     * Tests that the VelocityRequestWrapper correctly prevents removing blacklisted attributes.
+     * Specifically, it checks that USER_ID attribute is not removed.
+     */
+    @Test
+    public void testRemoveAttribute_withBlacklistedUserIdAttribute_shouldNotRemoveAttribute() {
+        final VelocityRequestWrapper wrapper = VelocityRequestWrapper.wrapVelocityRequest(mockRequest);
+        
+        // When: removing a blacklisted attribute (USER_ID)
+        wrapper.removeAttribute(WebKeys.USER_ID);
+        
+        // Then: removeAttribute should not be called on the wrapped request
+        verify(mockRequest, never()).removeAttribute(WebKeys.USER_ID);
+    }
+
+    /**
+     * Tests that the VelocityRequestWrapper correctly prevents removing blacklisted attributes.
+     * Specifically, it checks that USER attribute is not removed.
+     */
+    @Test
+    public void testRemoveAttribute_withBlacklistedUserAttribute_shouldNotRemoveAttribute() {
+        final VelocityRequestWrapper wrapper = VelocityRequestWrapper.wrapVelocityRequest(mockRequest);
+        
+        // When: removing a blacklisted attribute (USER)
+        wrapper.removeAttribute(WebKeys.USER);
+        
+        // Then: removeAttribute should not be called on the wrapped request
+        verify(mockRequest, never()).removeAttribute(WebKeys.USER);
+    }
+
+    /**
+     * Tests that the VelocityRequestWrapper allows removing non-blacklisted attributes.
+     * Specifically, it checks that a custom attribute is removed correctly.
+     */
+    @Test
+    public void testRemoveAttribute_withNonBlacklistedAttribute_shouldRemoveAttribute() {
+        final VelocityRequestWrapper wrapper = VelocityRequestWrapper.wrapVelocityRequest(mockRequest);
+        final String testKey = "testAttribute";
+        
+        // When: removing a non-blacklisted attribute
+        wrapper.removeAttribute(testKey);
+        
+        // Then: removeAttribute should be called on the wrapped request
+        verify(mockRequest, times(1)).removeAttribute(testKey);
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/VelocityRequestWrapperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/VelocityRequestWrapperTest.java
@@ -3,8 +3,8 @@ package com.dotcms.rendering.velocity.viewtools;
 import com.dotcms.UnitTestBase;
 import com.dotmarketing.util.Config;
 import com.liferay.portal.util.WebKeys;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -24,23 +24,23 @@ public class VelocityRequestWrapperTest extends UnitTestBase {
     @Mock
     private HttpServletRequest mockRequest;
 
-    private boolean originalConfigValue;
+    private static boolean originalConfigValue;
 
     /**
-     * Sets up the test environment by configuring the VELOCITY_PREVENT_SETTING_USER_ID property to true.
+     * Sets up the config property before class loading to ensure SET_VALUE_BLACKLIST is initialized correctly.
      */
-    @Before
-    public void setUp() {
-        // Store original config value to restore after test
+    @BeforeClass
+    public static void setUpClass() {
+        // Store original config value to restore after all tests
         originalConfigValue = Config.getBooleanProperty("VELOCITY_PREVENT_SETTING_USER_ID", true);
         Config.setProperty("VELOCITY_PREVENT_SETTING_USER_ID", true);
     }
 
     /**
-     * Tears down the test environment by restoring the original config value.
+     * Restores the original config value after all tests complete.
      */
-    @After
-    public void tearDown() {
+    @AfterClass
+    public static void tearDownClass() {
         // Restore original config value
         Config.setProperty("VELOCITY_PREVENT_SETTING_USER_ID", originalConfigValue);
     }

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/StoryBlockAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/StoryBlockAPITest.java
@@ -10,14 +10,11 @@ import com.dotcms.contenttype.model.field.*;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.datagen.*;
 import com.dotcms.mock.request.MockAttributeRequest;
-import com.dotcms.mock.request.MockHttpRequestIntegrationTest;
-import com.dotcms.mock.response.MockHttpResponse;
-import com.dotcms.rendering.velocity.viewtools.content.util.ContentUtils;
+import com.dotcms.rendering.velocity.viewtools.VelocityRequestWrapper;
 import com.dotcms.util.CollectionsUtils;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.util.JsonUtil;
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.db.LocalTransaction;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
@@ -29,24 +26,22 @@ import com.dotmarketing.util.WebKeys;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.liferay.util.StringPool;
 import com.tngtech.java.junit.dataprovider.DataProvider;
-import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import io.vavr.control.Try;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static com.dotcms.util.CollectionsUtils.list;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -435,7 +430,7 @@ public class StoryBlockAPITest extends IntegrationTestBase {
         assertNotNull(contentletIdList);
         assertTrue(contentletIdList.isEmpty());
     }
-    
+
     @Test
     public void test_get_refreshStoryBlockValueReferences_with_bad_content_value()  {
     
@@ -466,6 +461,143 @@ public class StoryBlockAPITest extends IntegrationTestBase {
         StoryBlockReferenceResult result = APILocator.getStoryBlockAPI().refreshStoryBlockValueReferences(newStoryBlockJson1, "xxx");
         assertNotNull(result);
         assertFalse(result.isRefreshed());
+
+    }
+
+    /**
+     * Method to test: {@link StoryBlockAPI#refreshReferences(Contentlet)}
+     * Given Scenario: This will create 2 block contents, adds a rich content to each block content and retrieve the json.
+     * ExpectedResult: The new json will contain the rich text data map for each block content.
+     */
+    @Test
+    public void test_refresh_references_multiple_blocks()
+            throws DotDataException, DotSecurityException, JsonProcessingException, IOException {
+
+        ContentType storyBlockType = null;
+
+        final HttpServletRequest oldThreadRequest = HttpServletRequestThreadLocal.INSTANCE.getRequest();
+        final HttpServletResponse oldThreadResponse = HttpServletResponseThreadLocal.INSTANCE.getResponse();
+
+        try {
+            // 1) get the default language
+            final Language defaultLanguage = APILocator.getLanguageAPI().getDefaultLanguage();
+
+            // 2) create 2 rich text contentlets with some initial values
+            final ContentType contentTypeRichText = APILocator.getContentTypeAPI(APILocator.systemUser()).find("webPageContent");
+            final Contentlet richTextContentlet1 = new ContentletDataGen(contentTypeRichText)
+                    .languageId(defaultLanguage.getId())
+                    .setProperty("title","Title1")
+                    .setProperty("body", TestDataUtils.BLOCK_EDITOR_DUMMY_CONTENT)
+                    .nextPersistedAndPublish();
+            final Contentlet richTextContentlet2 = new ContentletDataGen(contentTypeRichText)
+                    .languageId(defaultLanguage.getId())
+                    .setProperty("title","Title2")
+                    .setProperty("body", TestDataUtils.BLOCK_EDITOR_DUMMY_CONTENT)
+                    .nextPersistedAndPublish();
+
+            // 3) create a StoryBlockField and a ContentType with it
+            final Field storyBlockField = new FieldDataGen()
+                    .type(StoryBlockField.class)
+                    .name("StoryBlockTestField")
+                    .velocityVarName("storyBlockTestField")
+                    .next();
+            storyBlockType = new ContentTypeDataGen().field(storyBlockField).nextPersisted();
+
+            // 4) create first block content with first rich content
+            final Contentlet firstBlockContentlet = new ContentletDataGen(storyBlockType)
+                    .languageId(defaultLanguage.getId())
+                    .nextPersisted();
+            final Contentlet firstBlockCheckout = ContentletDataGen.checkout(firstBlockContentlet);
+            setBlockEditorField(firstBlockCheckout, storyBlockField, richTextContentlet1);
+            final Contentlet firstBlockComplete = APILocator.getContentletAPI().checkin(
+                    firstBlockCheckout, APILocator.systemUser(), false);
+            ContentletDataGen.publish(firstBlockComplete);
+
+            // 5) create second block content with second rich content
+            final Contentlet secondBlockContentlet = new ContentletDataGen(storyBlockType)
+                    .languageId(defaultLanguage.getId())
+                    .nextPersisted();
+            final Contentlet secondBlockCheckout = ContentletDataGen.checkout(secondBlockContentlet);
+            setBlockEditorField(secondBlockCheckout, storyBlockField, richTextContentlet2);
+            final Contentlet secondBlockComplete = APILocator.getContentletAPI().checkin(
+                    secondBlockCheckout, APILocator.systemUser(), false);
+            ContentletDataGen.publish(secondBlockComplete);
+
+            // 6) now we have 2 block contents, each one with a rich content, we are going to refresh the references
+            final HttpServletRequest attrRequest = new MockAttributeRequest(mock(HttpServletRequest.class));
+            attrRequest.setAttribute("USER", APILocator.systemUser());
+            attrRequest.setAttribute(WebKeys.PAGE_MODE_PARAMETER, PageMode.LIVE);
+            attrRequest.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, "1");
+
+            final HttpServletRequest request = VelocityRequestWrapper.wrapVelocityRequest(attrRequest);
+            HttpServletRequestThreadLocal.INSTANCE.setRequest(request);
+
+            final HttpServletResponse response = mock(HttpServletResponse.class);
+            HttpServletResponseThreadLocal.INSTANCE.setResponse(response);
+
+            // 7) verify first rich content
+            final Contentlet firstBlockPublished = APILocator.getContentletAPI().find(
+                    firstBlockComplete.getInode(), APILocator.systemUser(), false);
+            assertNotNull(firstBlockPublished);
+
+            final Map<?, ?> firstDataMap = getDataMap(firstBlockPublished, storyBlockField.variable());
+            assertNotNull(firstDataMap);
+
+            assertEquals(richTextContentlet1.getIdentifier(), firstDataMap.get("identifier"));
+            assertEquals(richTextContentlet1.getStringProperty("title"), firstDataMap.get("title"));
+
+            // 8) verify second rich content
+            final Contentlet secondBlockPublished = APILocator.getContentletAPI().find(
+                    secondBlockComplete.getInode(), APILocator.systemUser(), false);
+            assertNotNull(secondBlockPublished);
+
+            final Map<?, ?> secondDataMap = getDataMap(secondBlockPublished, storyBlockField.variable());
+            assertNotNull(secondDataMap);
+
+            assertEquals(richTextContentlet2.getIdentifier(), secondDataMap.get("identifier"));
+            assertEquals(richTextContentlet2.getStringProperty("title"), secondDataMap.get("title"));
+
+        } finally {
+            HttpServletRequestThreadLocal.INSTANCE.setRequest(oldThreadRequest);
+            HttpServletResponseThreadLocal.INSTANCE.setResponse(oldThreadResponse);
+            if (storyBlockType != null) {
+                ContentTypeDataGen.remove(storyBlockType);
+            }
+        }
+    }
+
+    /**
+     * Helper method to get the data map from the first Contentlet that is referenced in a StoryBlockField.
+     * @param storyBlockContentlet The Contentlet that contains the StoryBlockField.
+     * @param storyBlockField The StoryBlockField variable name.
+     * @return A map containing the data from the referenced Contentlet, or null if not found.
+     */
+    private Map<?, ?> getDataMap(final Contentlet storyBlockContentlet, final String storyBlockField)
+            throws JsonProcessingException {
+
+        if (storyBlockContentlet == null || storyBlockField == null) return null;
+
+        final Object storyBlockValue = storyBlockContentlet.getStringProperty(storyBlockField);
+        if (storyBlockValue == null) return null;
+
+        final Map<String, Object> blockEditorMap =
+                APILocator.getStoryBlockAPI().toMap(storyBlockValue);
+        if (blockEditorMap == null || blockEditorMap.isEmpty()) return null;
+
+        final List<?> contentsMap = (List<?>) blockEditorMap.get(StoryBlockAPI.CONTENT_KEY);
+        if (contentsMap == null || contentsMap.isEmpty()) return null;
+
+        final Optional<?> firstContentletMap = contentsMap.stream()
+                .filter(contentMap -> "dotContent".equals(
+                    ((Map<?,?>)contentMap).get("type")))
+                .findFirst();
+        if (firstContentletMap.isEmpty()) return null;
+
+        final Map<?, ?> contentletMap = (Map<?, ?>) firstContentletMap.get();
+        final Map<?, ?> attrsMap = (Map<?, ?>) contentletMap.get(StoryBlockAPI.ATTRS_KEY);
+        if (attrsMap == null) return null;
+
+        return (Map<?, ?>) attrsMap.get(StoryBlockAPI.DATA_KEY);
 
     }
 


### PR DESCRIPTION
Closes #32522

### Proposed Changes
* This pull request updates the `removeAttribute` method from the `VelocityRequestWrapper` class to prevent the removal of attributes listed in the `SET_VALUE_BLACKLIST`. If an attribute is blacklisted, the method now exits without invoking the superclass method, otherwise the attribute is removed.
* Added a new test suite in `VelocityRequestWrapperTest` to verify the behavior of `setAttribute` and `removeAttribute` methods: ensures blacklisted attributes cannot be set or removed and confirms that non-blacklisted attributes can be set and removed as expected.
* With the attribute removal working as expected, the `refreshBlockEditorDataMap` method from the `StoryBlockAPIImpl`
will work as expected in these lines:
https://github.com/dotCMS/core/blob/484527afeea886a39d45473227d3340a7427dd20/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java#L451-L453
That attribute is removed to signal that there are no recursion levels when refreshing the data map for a contentlet referenced from a block editor field. When it wasn't removed, content referenced from the second block editor field wasn't refreshed as expected.

### Checklist
- [x] Tests

This PR fixes: #32522