### PR TITLE
chore(sdk-analytics): Update peer dependency for @dotcms/uve to 'next' in package.json

### DIFF
--- a/core-web/libs/sdk/analytics/package.json
+++ b/core-web/libs/sdk/analytics/package.json
@@ -24,7 +24,7 @@
     },
     "peerDependencies": {
         "react": "19.1.0",
-        "@dotcms/uve": "*"
+        "@dotcms/uve": "next"
     },
     "devDependencies": {
         "@testing-library/jest-dom": "^6.1.6",


### PR DESCRIPTION
This pull request updates the `peerDependencies` in the `core-web/libs/sdk/analytics/package.json` file to specify a more explicit version for `@dotcms/uve`.

Dependency update:

* Changed the version of the `@dotcms/uve` peer dependency from a wildcard (`*`) to `next`, ensuring a more controlled versioning strategy.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #32458