### PR TITLE
chore(block-editor): Replaced custom dotPlaceholder with official Placeholder

### DIFF
--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
@@ -25,6 +25,7 @@ import CharacterCount, { CharacterCountStorage } from '@tiptap/extension-charact
 import { Level } from '@tiptap/extension-heading';
 import { Highlight } from '@tiptap/extension-highlight';
 import { Link } from '@tiptap/extension-link';
+import Placeholder from '@tiptap/extension-placeholder';
 import { Subscript } from '@tiptap/extension-subscript';
 import { Superscript } from '@tiptap/extension-superscript';
 import { TableRow } from '@tiptap/extension-table-row';
@@ -63,7 +64,7 @@ import {
     FreezeScroll,
     IndentExtension
 } from '../../extensions';
-import { DotPlaceholder } from '../../extensions/dot-placeholder/dot-placeholder-plugin';
+import { DotCMSPlusButton } from '../../extensions/dot-plus-button/dot-plus-button.plugin';
 import { AIContentNode, ContentletBlock, ImageNode, LoaderNode, VideoNode } from '../../nodes';
 import {
     DotMarketingConfigService,
@@ -434,7 +435,6 @@ export class DotBlockEditorComponent implements OnInit, OnDestroy, ControlValueA
                 contentletIdentifier: this.contentletIdentifier
             }),
             DotComands,
-            DotPlaceholder.configure({ placeholder: 'Type "/" for commands' }),
             Youtube.configure({
                 height: 300,
                 width: 400,
@@ -459,7 +459,17 @@ export class DotBlockEditorComponent implements OnInit, OnDestroy, ControlValueA
             FreezeScroll,
             CharacterCount,
             AssetUploader(this.#injector, this.viewContainerRef),
-            IndentExtension
+            IndentExtension,
+            Placeholder.configure({
+                placeholder: 'Start writing or type / to choose a block',
+                emptyEditorClass: 'is-editor-empty',
+                emptyNodeClass: 'is-empty'
+            }),
+            DotCMSPlusButton.configure({
+                showOnlyWhenEditable: true,
+                showOnlyCurrent: true,
+                includeChildren: false
+            })
         ];
 
         if (isAIPluginInstalled) {

--- a/core-web/package.json
+++ b/core-web/package.json
@@ -82,6 +82,7 @@
         "@tiptap/extension-highlight": "^2.14.0",
         "@tiptap/extension-image": "^2.14.0",
         "@tiptap/extension-link": "^2.14.0",
+        "@tiptap/extension-placeholder": "^2.23.0",
         "@tiptap/extension-subscript": "^2.14.0",
         "@tiptap/extension-superscript": "^2.14.0",
         "@tiptap/extension-table": "^2.14.0",

--- a/core-web/yarn.lock
+++ b/core-web/yarn.lock
@@ -6032,6 +6032,11 @@
   resolved "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.14.0.tgz"
   integrity sha512-bsQesVpgvDS2e+wr2fp59QO7rWRp2FqcJvBafwXS3Br9U5Mx3eFYryx4wC7cUnhlhUwX5pmaoA7zISgV9dZDgg==
 
+"@tiptap/extension-placeholder@^2.23.0":
+  version "2.23.0"
+  resolved "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-2.23.0.tgz#30474158b2c0d633fd8d2313b8e25c527803dd52"
+  integrity sha512-I5RQk0qn6nj7l7z4mWKIxjO2nluvKsm00W2CbC75b4YcScBfsMInHQdjN2s+W8xuF0zquhwVITxA+Bmn4zynqg==
+
 "@tiptap/extension-strike@^2.14.0":
   version "2.14.0"
   resolved "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.14.0.tgz"
@@ -22037,7 +22042,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -22054,6 +22059,15 @@ string-width@^1.0.1:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
@@ -22165,7 +22179,7 @@ stringify-package@^1.0.0, stringify-package@^1.0.1:
   resolved "https://registry.npmjs.org/stringify-package/-/stringify-package-1.0.1.tgz"
   integrity sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg==
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22192,6 +22206,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -24278,7 +24299,7 @@ worker-farm@^1.6.0, worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -24300,6 +24321,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION


https://github.com/user-attachments/assets/36401348-0a51-43be-bc8a-36fc6aa2a3fb




This pull request refactors the placeholder functionality in the block editor by replacing the `DotPlaceholder` extension with a new `DotCMSPlusButton` extension. The changes include updating the placeholder behavior, improving the user experience with a "plus" button for adding blocks, and modifying dependencies accordingly.

### Placeholder and Plus Button Refactor:
* Replaced the `DotPlaceholder` extension with `DotCMSPlusButton`, which introduces a "plus" button for adding blocks instead of using placeholder text. The new extension is configurable with options such as `showOnlyWhenEditable`, `showOnlyCurrent`, and `includeChildren`. (`core-web/libs/block-editor/src/lib/extensions/dot-plus-button/dot-plus-button.plugin.ts`) [[1]](diffhunk://#diff-77f12fdd87c8cf5382ab3d6747b850b40c6706e7418f093ab24fa0e5208f3a52L7-R7) [[2]](diffhunk://#diff-77f12fdd87c8cf5382ab3d6747b850b40c6706e7418f093ab24fa0e5208f3a52L60-L67)
* Removed placeholder-specific configurations such as `emptyEditorClass`, `emptyNodeClass`, and `placeholder` from the editor setup. The new `DotCMSPlusButton` focuses on block-level interactions instead. (`core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts`) [[1]](diffhunk://#diff-266eab162f8661e695c3e40956692fa3696fbd4e8cd3e0352ea9e01f90b13609L437) [[2]](diffhunk://#diff-266eab162f8661e695c3e40956692fa3696fbd4e8cd3e0352ea9e01f90b13609L462-R472)

### Dependency Updates:
* Added the `@tiptap/extension-placeholder` dependency to support the new placeholder functionality. (`core-web/package.json`)

### Code Cleanup:
* Removed unused methods and properties from the old `DotPlaceholder` implementation, such as `toTitleCase` and placeholder-related decorations. (`core-web/libs/block-editor/src/lib/extensions/dot-plus-button/dot-plus-button.plugin.ts`) [[1]](diffhunk://#diff-77f12fdd87c8cf5382ab3d6747b850b40c6706e7418f093ab24fa0e5208f3a52L21-L26) [[2]](diffhunk://#diff-77f12fdd87c8cf5382ab3d6747b850b40c6706e7418f093ab24fa0e5208f3a52L77-L125)

### File Renaming:
* Renamed the file `dot-placeholder-plugin.ts` to `dot-plus-button.plugin.ts` to reflect the new functionality.

This PR fixes: #32396