### PR TITLE
feat(content analytics) #32539 : Create new dedicated Content Analytics App

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
@@ -1,8 +1,8 @@
 package com.dotcms.analytics.app;
 
-import com.dotcms.analytics.model.AnalyticsProperties;
-import com.dotcms.analytics.model.AnalyticsKey;
 import com.dotcms.analytics.model.AnalyticsAppProperty;
+import com.dotcms.analytics.model.AnalyticsKey;
+import com.dotcms.analytics.model.AnalyticsProperties;
 import com.dotcms.security.apps.AppDescriptor;
 import com.dotcms.security.apps.AppSecrets;
 import com.dotcms.security.apps.AppsAPI;
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-
 /**
  * Holds configuration for Analytics App from secrets.
  *
@@ -31,7 +30,7 @@ import java.util.stream.Stream;
  */
 public class AnalyticsApp {
 
-    public static final String ANALYTICS_APP_KEY = "dotAnalytics-config";
+    public static final String ANALYTICS_APP_KEY = "dotExperiments-config";
     public static final String ANALYTICS_APP_CONFIG_URL_KEY = "analytics.app.config.url";
     public static final String ANALYTICS_APP_WRITE_URL_KEY = "analytics.app.write.url";
     public static final String ANALYTICS_APP_READ_URL_KEY = "analytics.app.read.url";

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
@@ -3,51 +3,60 @@ package com.dotcms.rest.api.v1.analytics.content.util;
 import com.dotcms.analytics.track.collectors.Collector;
 import com.dotcms.analytics.track.collectors.EventSource;
 import com.dotcms.analytics.track.collectors.EventType;
-import com.dotcms.analytics.track.matchers.FilesRequestMatcher;
-import com.dotcms.analytics.track.matchers.PagesAndUrlMapsRequestMatcher;
-import com.dotcms.analytics.track.matchers.RequestMatcher;
-import com.dotcms.analytics.track.matchers.UserCustomDefinedRequestMatcher;
-import com.dotcms.analytics.track.matchers.VanitiesRequestMatcher;
 import com.dotcms.jitsu.EventLogSubmitter;
 import com.dotcms.jitsu.ValidAnalyticsEventPayload;
 import com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes;
 import com.dotcms.jitsu.validators.AnalyticsValidatorUtil;
+import com.dotcms.security.apps.AppSecrets;
+import com.dotcms.security.apps.AppsAPI;
+import com.dotcms.security.apps.Secret;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.json.JSONArray;
 import com.dotmarketing.util.json.JSONObject;
 import com.liferay.portal.PortalException;
 import com.liferay.portal.SystemException;
+import io.vavr.Lazy;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Supplier;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
-import static com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes.*;
+import static com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes.REFERER_ATTRIBUTE_NAME;
+import static com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes.URL_ATTRIBUTE_NAME;
+import static com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes.USER_AGENT_ATTRIBUTE_NAME;
 
+/**
+ *
+ * @author Jonathan Sanchez
+ * @since Mar 12th, 2025
+ */
 public class ContentAnalyticsUtil {
 
-    private static final AnalyticsValidatorUtil analyticsValidatorUtil = AnalyticsValidatorUtil.INSTANCE;
+    private static final Lazy<String> SITE_KEY_FORMAT = Lazy.of(() -> Config.getStringProperty("CONTENT_ANALYTICS_SITE_KEY_FORMAT", "DOT.%s.%s"));
+    private static final String SAMPLE_CA_JS_CONFIG = "const analyticsConfig = {\n" +
+                "\tsiteKey: '%s',\n" +
+                "\tserver: '%s'\n" +
+            "}";
+
+    private static final AnalyticsValidatorUtil analyticsValidatorUtil =  AnalyticsValidatorUtil.INSTANCE;
 
     private static final EventLogSubmitter SUBMITTER  = new EventLogSubmitter();
-    private static final UserCustomDefinedRequestMatcher USER_CUSTOM_DEFINED_REQUEST_MATCHER =  new UserCustomDefinedRequestMatcher();
 
-    private static final Map<String, Supplier<RequestMatcher>> MATCHER_MAP = Map.of(
-            EventType.FILE_REQUEST.getType(), FilesRequestMatcher::new,
-            EventType.PAGE_REQUEST.getType(), PagesAndUrlMapsRequestMatcher::new,
-            EventType.URL_MAP.getType(), PagesAndUrlMapsRequestMatcher::new,
-            EventType.VANITY_REQUEST.getType(), VanitiesRequestMatcher::new
-    );
+    public static final String CONTENT_ANALYTICS_APP_KEY = "dotContentAnalytics-config";
 
     public static AnalyticsEventsResult registerContentAnalyticsRestEvent(
             final HttpServletRequest request,
@@ -165,26 +174,70 @@ public class ContentAnalyticsUtil {
         }
     }
 
-    private static Map<String, Object> fromPayload(final Map<String, Serializable> userEventPayload) {
-        final Map<String, Object> baseContextMap = new HashMap<>();
-
-        if (userEventPayload.containsKey("url")) {
-
-            baseContextMap.put("uri", userEventPayload.get("url"));
-        }
-
-        if (userEventPayload.containsKey("doc_path")) {
-
-            baseContextMap.put("uri", userEventPayload.get("doc_path"));
-        }
-
-        return baseContextMap;
+    /**
+     * Exposes a sample basic JavaScript configuration object that customers can copy and paste to
+     * configure their code to send Analytics Events to our infrastructure.
+     *
+     * @param site The {@link Host} that the configuration belongs to.
+     *
+     * @return The sample JavaScript configuration.
+     */
+    public static String getSiteJSConfig(final Host site) throws DotDataException, DotSecurityException {
+        final String siteKey = getSiteKey(site);
+        return String.format(SAMPLE_CA_JS_CONFIG, siteKey, "https://" + site.getHostname());
     }
 
-    private static RequestMatcher loadRequestMatcher(final Map<String, Serializable> userEventPayload) {
+    /**
+     * Returns the authentication key for a specific Site. If the user has NOT provided a custom
+     * key, then dotCMS will generate one for them.
+     *
+     * @param site The {@link Host} that the configuration belongs to.
+     *
+     * @return The Site Key.
+     *
+     * @throws DotDataException     An error occurred when updating the App's secrets.
+     * @throws DotSecurityException A permission error occurred when reading/saving App data.
+     */
+    public static String getSiteKey(final Host site) throws DotDataException, DotSecurityException {
+        final AppsAPI appsAPI = APILocator.getAppsAPI();
+        final Optional<AppSecrets> optionalAppSecrets = appsAPI.getSecrets(CONTENT_ANALYTICS_APP_KEY, false, site, APILocator.systemUser());
+        if (optionalAppSecrets.isPresent()) {
+            final Set<Map.Entry<String, Secret>> appParams = optionalAppSecrets.get().getSecrets().entrySet();
+            final Optional<String> optSiteKey = appParams.stream()
+                    .filter(entry -> "siteKey".equals(entry.getKey()))
+                    .map(entry -> entry.getValue().getString())
+                    .findFirst();
+            if (optSiteKey.isPresent() && !optSiteKey.get().isEmpty()) {
+                return optSiteKey.get();
+            }
+        }
+        // The App config or Site Key doesn't exist, let's create it
+        final String siteKey = generateInternalSiteKey(site.getIdentifier());
+        final AppSecrets.Builder builder = new AppSecrets.Builder();
+        builder.withKey(CONTENT_ANALYTICS_APP_KEY);
+        optionalAppSecrets
+                .map(appSecrets -> appSecrets.getSecrets().entrySet())
+                .orElse(Set.of())
+                .forEach(entry -> builder.withSecret(entry.getKey(), entry.getValue()));
+        builder.withSecret("siteKey", siteKey);
+        final AppSecrets secrets = builder.build();
+        appsAPI.saveSecrets(secrets, site, APILocator.systemUser());
+        return siteKey;
+    }
 
-        String eventType = (String) userEventPayload.getOrDefault(Collector.EVENT_TYPE, EventType.CUSTOM_USER_EVENT.getType());
-        return MATCHER_MAP.getOrDefault(eventType, () -> USER_CUSTOM_DEFINED_REQUEST_MATCHER).get();
+    /**
+     * Generates the encrypted site key that will be used by JavaScript code in HTML Pages to send
+     * Analytics Events to our infrastructure. This allows us to provide customers with a secure
+     * token that must be passed down to our REST Endpoint in order to varify that the request is
+     * coming from a valid source.
+     *
+     * @param siteId The Identifier of the Site that the Content Analytics configuration belongs
+     *               to.
+     *
+     * @return The Encrypted Site Key
+     */
+    private static String generateInternalSiteKey(final String siteId) {
+        return String.format(SITE_KEY_FORMAT.get(), siteId, KeyGenerator.generateSiteKey());
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/KeyGenerator.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/KeyGenerator.java
@@ -1,0 +1,39 @@
+package com.dotcms.rest.api.v1.analytics.content.util;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+/**
+ * Utility class for generating random keys. This is used for generating secure authentication keys
+ * for Sites in the Content Analytics app. This implementation uses the {@link SecureRandom} class,
+ * which is Java’s cryptographically strong random number generator (CSPRNG) that provides enough
+ * randomness for attackers to be unable to predict the generated key.
+ *
+ * @author Jose Castro
+ * @since Jul 2nd, 2025
+ */
+public class KeyGenerator {
+
+    // Number of bytes to generate to get at least 25 Base64 characters, which roughly translates
+    // to ~150 bits of entropy: 18 bytes ≈ 24 Base64 characters (no padding)
+    private static final int RAW_BYTES_LENGTH = 18;
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    /**
+     * Generates a secure authentication key that can be used to authentication purposes.
+     *
+     * @return The generated key.
+     */
+    public static String generateSiteKey() {
+        final byte[] randomBytes = new byte[RAW_BYTES_LENGTH];
+        RANDOM.nextBytes(randomBytes);
+        // Use URL-safe Base64 encoding and strip padding
+        final String encoded = Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+        // Trim or pad to exactly 25 characters if needed
+        return encoded.length() >= 25
+                ? encoded.substring(0, 25)
+                : String.format("%-25s", encoded).replace(' ', 'X'); // pad with 'X' if necessary
+    }
+
+}

--- a/dotCMS/src/main/resources/apps/dotContentAnalytics-config.yml
+++ b/dotCMS/src/main/resources/apps/dotContentAnalytics-config.yml
@@ -1,0 +1,20 @@
+name: "Content Analytics"
+iconUrl: "https://static.dotcms.com/assets/icons/apps/analytics.png"
+allowExtraParameters: false
+description: "Content Analytics allow developers to track user interactions across all Sites in dotCMS."
+
+params:
+  siteKey:
+    value: ""
+    hidden: false
+    type: "STRING"
+    label: "Site Key"
+    hint: "The Site Key is required in all requests that send Events to the Content Analytics Service."
+    required: false
+  buttonParam:
+    hidden: false
+    type: "BUTTON"
+    label: "Generate Site Key"
+    hint: "Generates the Site Key (if not set yet) and the basic JavaScript configuration required to enable Content Analytics in your pages."
+    required: false
+    value: "/api/v1/analytics/content/siteconfig/$siteId"

--- a/dotCMS/src/main/resources/apps/dotExperiments-config.yml
+++ b/dotCMS/src/main/resources/apps/dotExperiments-config.yml
@@ -1,7 +1,7 @@
-name: "Analytics Integration - DEPRECATED"
+name: "Experiments"
 iconUrl: "https://static.dotcms.com/assets/icons/apps/analytics.png"
 allowExtraParameters: false
-description: "This App has been deprecated. Please migrate all its configuration to the new Experiments App."
+description: "Experiments provide the ability to, given a Client Id and Client Secret, resolve an access token to be injected across all the analytics services included the resolving of the Analytics Key (Id)."
 
 params:
   clientId:

--- a/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "2bf1306b-f3ed-40b4-9119-6b6e2d67ea55",
+		"_postman_id": "0a546c78-d414-42af-96c7-b0fbdef59bd0",
 		"name": "Content Analytics",
 		"description": "Performs simple data validation for the Content Analytics REST Endpoint. It's very important to notice that, for the time being, the CICD instance does not start up any of the additional third-party tools required to actually run the Content Analytics feature.\n\nThis means that these test do not deal with retrieveing or saving data at all. It verifies that important/required information is present.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "30436704"
+		"_exporter_id": "5403727"
 	},
 	"item": [
 		{
@@ -406,682 +406,1023 @@
 			"name": "Events",
 			"item": [
 				{
-					"name": "No Query Form on Event",
-					"event": [
+					"name": "Validations",
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"HTTP Status code must be 400\", function () {",
-									"    pm.response.to.have.status(400);",
-									"});",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
+							"name": "No Query Form on Event",
+							"event": [
 								{
-									"key": "token",
-									"value": "{{jwt}}",
-									"type": "string"
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
 								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/analytics/content/event",
-							"host": [
-								"{{serverURL}}"
 							],
-							"path": [
-								"api",
-								"v1",
-								"analytics",
-								"content",
-								"event"
-							]
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{jwt}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/event",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"event"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Unsupported Media Type Event",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"// Validate the response status is 415",
+											"pm.test(\"Response status is 415\", function () {",
+											"    pm.response.to.have.status(415);",
+											"});",
+											"",
+											"// Validate that the response body contains the 'message' property and it is not empty",
+											"pm.test(\"Response should have an error message\", function () {",
+											"    const responseBody = pm.response.json();",
+											"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
+											"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disabledSystemHeaders": {
+									"content-type": true
+								}
+							},
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/x-www-form-urlencoded",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"query\": {}\n}\n",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/event",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"event"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "site_key is required",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Response sould be right\", function () {",
+											"    const responseBody = pm.response.json();",
+											"",
+											"    pm.expect(responseBody).to.not.have.property(\"failed\");",
+											"    pm.expect(responseBody).to.not.have.property(\"success\");",
+											"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
+											"",
+											"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
+											"    pm.expect(responseBody.errors.length).to.be.eq(1);",
+											"",
+											"    pm.expect(responseBody.errors[0]).to.not.have.property(\"eventIndex\");",
+											"",
+											"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[0].field).to.be.eq(\"context.site_key\");",
+											"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: context.site_key\");",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{jwt}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"context\": {\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"page_view\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/event",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"event"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "events is required",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Response sould be right\", function () {",
+											"    const responseBody = pm.response.json();",
+											"",
+											"    pm.expect(responseBody).to.not.have.property(\"failed\");",
+											"    pm.expect(responseBody).to.not.have.property(\"success\");",
+											"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
+											"",
+											"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
+											"    pm.expect(responseBody.errors.length).to.be.eq(1);",
+											"",
+											"    pm.expect(responseBody.errors[0]).to.not.have.property(\"eventIndex\");",
+											"",
+											"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[0].field).to.be.eq(\"events\");",
+											"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: events\");",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{jwt}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/event",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"event"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "session_id is required",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Response sould be right\", function () {",
+											"    const responseBody = pm.response.json();",
+											"",
+											"    pm.expect(responseBody).to.not.have.property(\"failed\");",
+											"    pm.expect(responseBody).to.not.have.property(\"success\");",
+											"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
+											"",
+											"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
+											"    pm.expect(responseBody.errors.length).to.be.eq(1);",
+											"",
+											"    pm.expect(responseBody.errors[0]).to.not.have.property(\"eventIndex\");",
+											"",
+											"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[0].field).to.be.eq(\"context.session_id\");",
+											"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: context.session_id\");",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{jwt}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/event",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"event"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "user_id is required",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Response sould be right\", function () {",
+											"    const responseBody = pm.response.json();",
+											"",
+											"    pm.expect(responseBody).to.not.have.property(\"failed\");",
+											"    pm.expect(responseBody).to.not.have.property(\"success\");",
+											"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
+											"",
+											"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
+											"    pm.expect(responseBody.errors.length).to.be.eq(1);",
+											"",
+											"    pm.expect(responseBody.errors[0]).to.not.have.property(\"eventIndex\");",
+											"",
+											"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[0].field).to.be.eq(\"context.user_id\");",
+											"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: context.user_id\");",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{jwt}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\"\n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/event",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"event"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "event_type is required",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Response sould be right\", function () {",
+											"    const responseBody = pm.response.json();",
+											"",
+											"    pm.expect(responseBody.failed).to.be.eq(2);",
+											"    pm.expect(responseBody.success).to.be.eq(0);",
+											"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
+											"",
+											"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
+											"    pm.expect(responseBody.errors.length).to.be.eq(2);",
+											"",
+											"    pm.expect(responseBody.errors[0].eventIndex).to.be.eq(0);",
+											"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[0].field).to.be.eq(\"events[0].event_type\");",
+											"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: event_type\");",
+											"",
+											"    pm.expect(responseBody.errors[1].eventIndex).to.be.eq(1);",
+											"    pm.expect(responseBody.errors[1].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[1].field).to.be.eq(\"events[1].event_type\");",
+											"    pm.expect(responseBody.errors[1].message).to.be.eq(\"Required field is missing: event_type\");",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{jwt}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/event",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"event"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "pageview required fields",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Response sould be right\", function () {",
+											"    const responseBody = pm.response.json();",
+											"",
+											"    pm.expect(responseBody.failed).to.be.eq(6);",
+											"    pm.expect(responseBody.success).to.be.eq(0);",
+											"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
+											"",
+											"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
+											"    pm.expect(responseBody.errors.length).to.be.eq(8);",
+											"",
+											"    pm.expect(responseBody.errors[0].eventIndex).to.be.eq(0);",
+											"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[0].field).to.be.eq(\"events[0].local_time\");",
+											"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: local_time\");",
+											"",
+											"    pm.expect(responseBody.errors[1].eventIndex).to.be.eq(0);",
+											"    pm.expect(responseBody.errors[1].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[1].field).to.be.eq(\"events[0].data.page.url\");",
+											"    pm.expect(responseBody.errors[1].message).to.be.eq(\"Required field is missing: data.page.url\");",
+											"",
+											"    pm.expect(responseBody.errors[2].eventIndex).to.be.eq(1);",
+											"    pm.expect(responseBody.errors[2].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[2].field).to.be.eq(\"events[1].data.page.doc_encoding\");",
+											"    pm.expect(responseBody.errors[2].message).to.be.eq(\"Required field is missing: data.page.doc_encoding\");",
+											"",
+											"    pm.expect(responseBody.errors[3].eventIndex).to.be.eq(2);",
+											"    pm.expect(responseBody.errors[3].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[3].field).to.be.eq(\"events[2].data.page.title\");",
+											"    pm.expect(responseBody.errors[3].message).to.be.eq(\"Required field is missing: data.page.title\");",
+											"",
+											"    pm.expect(responseBody.errors[4].eventIndex).to.be.eq(3);",
+											"    pm.expect(responseBody.errors[4].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[4].field).to.be.eq(\"events[3].data.device.screen_resolution\");",
+											"    pm.expect(responseBody.errors[4].message).to.be.eq(\"Required field is missing: data.device.screen_resolution\");",
+											"",
+											"    pm.expect(responseBody.errors[5].eventIndex).to.be.eq(4);",
+											"    pm.expect(responseBody.errors[5].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[5].field).to.be.eq(\"events[4].data.device.language\");",
+											"    pm.expect(responseBody.errors[5].message).to.be.eq(\"Required field is missing: data.device.language\");",
+											"",
+											"    pm.expect(responseBody.errors[6].eventIndex).to.be.eq(5);",
+											"    pm.expect(responseBody.errors[6].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[6].field).to.be.eq(\"events[5].data.device.viewport_height\");",
+											"    pm.expect(responseBody.errors[6].message).to.be.eq(\"Required field is missing: data.device.viewport_height\");",
+											"",
+											"    pm.expect(responseBody.errors[7].eventIndex).to.be.eq(5);",
+											"    pm.expect(responseBody.errors[7].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
+											"    pm.expect(responseBody.errors[7].field).to.be.eq(\"events[5].data.device.viewport_width\");",
+											"    pm.expect(responseBody.errors[7].message).to.be.eq(\"Required field is missing: data.device.viewport_width\");",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/event",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"event"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "pageview extra attributes",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be 400\", function () {",
+											"    pm.response.to.have.status(400);",
+											"});",
+											"",
+											"pm.test(\"Response sould be right\", function () {",
+											"    const responseBody = pm.response.json();",
+											"",
+											"    pm.expect(responseBody.failed).to.be.eq(1);",
+											"    pm.expect(responseBody.success).to.be.eq(0);",
+											"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
+											"",
+											"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
+											"    pm.expect(responseBody.errors.length).to.be.eq(4);",
+											"",
+											"    pm.expect(responseBody.errors[0].eventIndex).to.be.eq(0);",
+											"    pm.expect(responseBody.errors[0].code).to.be.eq(\"UNKNOWN_FIELD\");",
+											"    pm.expect(responseBody.errors[0].field).to.be.eq(\"events[0].data.page.extra\");",
+											"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Unknown field 'data.page.extra'\");",
+											"",
+											"    pm.expect(responseBody.errors[1].eventIndex).to.be.eq(0);",
+											"    pm.expect(responseBody.errors[1].code).to.be.eq(\"UNKNOWN_FIELD\");",
+											"    pm.expect(responseBody.errors[1].field).to.be.eq(\"events[0].data.device.extra\");",
+											"    pm.expect(responseBody.errors[1].message).to.be.eq(\"Unknown field 'data.device.extra'\");",
+											"",
+											"    pm.expect(responseBody.errors[2].eventIndex).to.be.eq(0);",
+											"    pm.expect(responseBody.errors[2].code).to.be.eq(\"UNKNOWN_FIELD\");",
+											"    pm.expect(responseBody.errors[2].field).to.be.eq(\"events[0].data.utm.extra\");",
+											"    pm.expect(responseBody.errors[2].message).to.be.eq(\"Unknown field 'data.utm.extra'\");",
+											"",
+											"    pm.expect(responseBody.errors[3].eventIndex).to.be.eq(0);",
+											"    pm.expect(responseBody.errors[3].code).to.be.eq(\"UNKNOWN_FIELD\");",
+											"    pm.expect(responseBody.errors[3].field).to.be.eq(\"events[0].data.extra\");",
+											"    pm.expect(responseBody.errors[3].message).to.be.eq(\"Unknown field 'data.extra'\");",
+											"});"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"auth": {
+									"type": "basic",
+									"basic": [
+										{
+											"key": "username",
+											"value": "admin@dotcms.com",
+											"type": "string"
+										},
+										{
+											"key": "password",
+											"value": "admin",
+											"type": "string"
+										}
+									]
+								},
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"extra\": \"extra\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\",\n                    \"extra\": \"extra\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\",\n                    \"extra\": \"extra\"\n                },\n                \"extra\": \"extra\"\n            }\n        }\n    ]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/event",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"event"
+									]
+								}
+							},
+							"response": []
 						}
-					},
-					"response": []
+					]
 				},
 				{
-					"name": "Unsupported Media Type Event",
-					"event": [
+					"name": "App Configuration",
+					"item": [
 						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"// Validate the response status is 415",
-									"pm.test(\"Response status is 415\", function () {",
-									"    pm.response.to.have.status(415);",
-									"});",
-									"",
-									"// Validate that the response body contains the 'message' property and it is not empty",
-									"pm.test(\"Response should have an error message\", function () {",
-									"    const responseBody = pm.response.json();",
-									"    pm.expect(responseBody).to.have.property('message').that.is.not.empty;",
-									"    pm.expect(responseBody.message).to.equal('HTTP 415 Unsupported Media Type');",
-									"});",
-									""
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"protocolProfileBehavior": {
-						"disabledSystemHeaders": {
-							"content-type": true
-						}
-					},
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/x-www-form-urlencoded",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"query\": {}\n}\n",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/analytics/content/event",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"analytics",
-								"content",
-								"event"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "site_key is required",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"HTTP Status code must be 400\", function () {",
-									"    pm.response.to.have.status(400);",
-									"});",
-									"",
-									"pm.test(\"Response sould be right\", function () {",
-									"    const responseBody = pm.response.json();",
-									"",
-									"    pm.expect(responseBody).to.not.have.property(\"failed\");",
-									"    pm.expect(responseBody).to.not.have.property(\"success\");",
-									"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
-									"",
-									"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
-									"    pm.expect(responseBody.errors.length).to.be.eq(1);",
-									"",
-									"    pm.expect(responseBody.errors[0]).to.not.have.property(\"eventIndex\");",
-									"",
-									"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[0].field).to.be.eq(\"context.site_key\");",
-									"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: context.site_key\");",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
+							"name": "Create test Site",
+							"event": [
 								{
-									"key": "token",
-									"value": "{{jwt}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"context\": {\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"page_view\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/analytics/content/event",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"analytics",
-								"content",
-								"event"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "events is required",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"HTTP Status code must be 400\", function () {",
-									"    pm.response.to.have.status(400);",
-									"});",
-									"",
-									"pm.test(\"Response sould be right\", function () {",
-									"    const responseBody = pm.response.json();",
-									"",
-									"    pm.expect(responseBody).to.not.have.property(\"failed\");",
-									"    pm.expect(responseBody).to.not.have.property(\"success\");",
-									"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
-									"",
-									"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
-									"    pm.expect(responseBody.errors.length).to.be.eq(1);",
-									"",
-									"    pm.expect(responseBody.errors[0]).to.not.have.property(\"eventIndex\");",
-									"",
-									"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[0].field).to.be.eq(\"events\");",
-									"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: events\");",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{jwt}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/analytics/content/event",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"analytics",
-								"content",
-								"event"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "session_id is required",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"HTTP Status code must be 400\", function () {",
-									"    pm.response.to.have.status(400);",
-									"});",
-									"",
-									"pm.test(\"Response sould be right\", function () {",
-									"    const responseBody = pm.response.json();",
-									"",
-									"    pm.expect(responseBody).to.not.have.property(\"failed\");",
-									"    pm.expect(responseBody).to.not.have.property(\"success\");",
-									"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
-									"",
-									"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
-									"    pm.expect(responseBody.errors.length).to.be.eq(1);",
-									"",
-									"    pm.expect(responseBody.errors[0]).to.not.have.property(\"eventIndex\");",
-									"",
-									"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[0].field).to.be.eq(\"context.session_id\");",
-									"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: context.session_id\");",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{jwt}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/analytics/content/event",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"analytics",
-								"content",
-								"event"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "user_id is required",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"HTTP Status code must be 400\", function () {",
-									"    pm.response.to.have.status(400);",
-									"});",
-									"",
-									"pm.test(\"Response sould be right\", function () {",
-									"    const responseBody = pm.response.json();",
-									"",
-									"    pm.expect(responseBody).to.not.have.property(\"failed\");",
-									"    pm.expect(responseBody).to.not.have.property(\"success\");",
-									"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
-									"",
-									"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
-									"    pm.expect(responseBody.errors.length).to.be.eq(1);",
-									"",
-									"    pm.expect(responseBody.errors[0]).to.not.have.property(\"eventIndex\");",
-									"",
-									"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[0].field).to.be.eq(\"context.user_id\");",
-									"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: context.user_id\");",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{jwt}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\"\n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/analytics/content/event",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"analytics",
-								"content",
-								"event"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "event_type is required",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"HTTP Status code must be 400\", function () {",
-									"    pm.response.to.have.status(400);",
-									"});",
-									"",
-									"pm.test(\"Response sould be right\", function () {",
-									"    const responseBody = pm.response.json();",
-									"",
-									"    pm.expect(responseBody.failed).to.be.eq(2);",
-									"    pm.expect(responseBody.success).to.be.eq(0);",
-									"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
-									"",
-									"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
-									"    pm.expect(responseBody.errors.length).to.be.eq(2);",
-									"",
-									"    pm.expect(responseBody.errors[0].eventIndex).to.be.eq(0);",
-									"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[0].field).to.be.eq(\"events[0].event_type\");",
-									"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: event_type\");",
-									"",
-									"    pm.expect(responseBody.errors[1].eventIndex).to.be.eq(1);",
-									"    pm.expect(responseBody.errors[1].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[1].field).to.be.eq(\"events[1].event_type\");",
-									"    pm.expect(responseBody.errors[1].message).to.be.eq(\"Required field is missing: event_type\");",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "bearer",
-							"bearer": [
-								{
-									"key": "token",
-									"value": "{{jwt}}",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/analytics/content/event",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"analytics",
-								"content",
-								"event"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "pageview required fields",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"HTTP Status code must be 400\", function () {",
-									"    pm.response.to.have.status(400);",
-									"});",
-									"",
-									"pm.test(\"Response sould be right\", function () {",
-									"    const responseBody = pm.response.json();",
-									"",
-									"    pm.expect(responseBody.failed).to.be.eq(6);",
-									"    pm.expect(responseBody.success).to.be.eq(0);",
-									"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
-									"",
-									"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
-									"    pm.expect(responseBody.errors.length).to.be.eq(8);",
-									"",
-									"    pm.expect(responseBody.errors[0].eventIndex).to.be.eq(0);",
-									"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[0].field).to.be.eq(\"events[0].local_time\");",
-									"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Required field is missing: local_time\");",
-									"",
-									"    pm.expect(responseBody.errors[1].eventIndex).to.be.eq(0);",
-									"    pm.expect(responseBody.errors[1].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[1].field).to.be.eq(\"events[0].data.page.url\");",
-									"    pm.expect(responseBody.errors[1].message).to.be.eq(\"Required field is missing: data.page.url\");",
-									"",
-									"    pm.expect(responseBody.errors[2].eventIndex).to.be.eq(1);",
-									"    pm.expect(responseBody.errors[2].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[2].field).to.be.eq(\"events[1].data.page.doc_encoding\");",
-									"    pm.expect(responseBody.errors[2].message).to.be.eq(\"Required field is missing: data.page.doc_encoding\");",
-									"",
-									"    pm.expect(responseBody.errors[3].eventIndex).to.be.eq(2);",
-									"    pm.expect(responseBody.errors[3].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[3].field).to.be.eq(\"events[2].data.page.title\");",
-									"    pm.expect(responseBody.errors[3].message).to.be.eq(\"Required field is missing: data.page.title\");",
-									"",
-									"    pm.expect(responseBody.errors[4].eventIndex).to.be.eq(3);",
-									"    pm.expect(responseBody.errors[4].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[4].field).to.be.eq(\"events[3].data.device.screen_resolution\");",
-									"    pm.expect(responseBody.errors[4].message).to.be.eq(\"Required field is missing: data.device.screen_resolution\");",
-									"",
-									"    pm.expect(responseBody.errors[5].eventIndex).to.be.eq(4);",
-									"    pm.expect(responseBody.errors[5].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[5].field).to.be.eq(\"events[4].data.device.language\");",
-									"    pm.expect(responseBody.errors[5].message).to.be.eq(\"Required field is missing: data.device.language\");",
-									"",
-									"    pm.expect(responseBody.errors[6].eventIndex).to.be.eq(5);",
-									"    pm.expect(responseBody.errors[6].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[6].field).to.be.eq(\"events[5].data.device.viewport_height\");",
-									"    pm.expect(responseBody.errors[6].message).to.be.eq(\"Required field is missing: data.device.viewport_height\");",
-									"",
-									"    pm.expect(responseBody.errors[7].eventIndex).to.be.eq(5);",
-									"    pm.expect(responseBody.errors[7].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-									"    pm.expect(responseBody.errors[7].field).to.be.eq(\"events[5].data.device.viewport_width\");",
-									"    pm.expect(responseBody.errors[7].message).to.be.eq(\"Required field is missing: data.device.viewport_width\");",
-									"});"
-								],
-								"type": "text/javascript",
-								"packages": {}
-							}
-						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Check test Site information\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    const siteName = pm.collectionVariables.get(\"siteName\");",
+											"    pm.expect(jsonData.entity.siteName).to.equal(siteName, \"The created Site has a different expected name\");",
+											"    pm.collectionVariables.set(\"siteId\", jsonData.entity.identifier);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
 								},
 								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"siteName\", \"www.mytestsitewithcontentanalytics.com\");"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
 								}
-							]
+							],
+							"request": {
+								"method": "POST",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"siteName\": \"{{siteName}}\"\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/site",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"site"
+									]
+								},
+								"description": "## API Endpoint: Create Site\n\nThis endpoint allows users to create a new site by sending a POST request to the server. The request requires a JSON payload that includes the name of the site to be created.\n\n### Request\n\n- **Method**: POST\n    \n- **URL**: `{{serverURL}}/api/v1/site`\n    \n- **Content-Type**: application/json\n    \n\n#### Request Body\n\nThe request body must be in JSON format and include the following parameter:\n\n- `siteName` (string): The name of the site that you want to create.\n    \n\n**Example Request Body:**\n\n``` json\n{\n  \"siteName\": \"{{siteName}}\"\n}\n\n ```\n\n### Response\n\nUpon a successful request, the server responds with a status code of `200` and a JSON object containing the details of the created site.\n\n#### Response Structure\n\n- **entity**: An object containing the details of the site.\n    \n    - `addThis`: (null) Placeholder for additional configuration.\n        \n    - `aliases`: (null) Placeholder for site aliases.\n        \n    - `archived`: (boolean) Indicates if the site is archived.\n        \n    - `default`: (boolean) Indicates if this is the default site.\n        \n    - `description`: (null) Placeholder for site description.\n        \n    - `embeddedDashboard`: (null) Placeholder for embedded dashboard settings.\n        \n    - `googleAnalytics`: (null) Placeholder for Google Analytics settings.\n        \n    - `googleMap`: (null) Placeholder for Google Map settings.\n        \n    - `identifier`: (string) Unique identifier for the site.\n        \n    - `inode`: (string) Internal node identifier.\n        \n    - `keywords`: (null) Placeholder for site keywords.\n        \n    - `languageId`: (integer) Language identifier.\n        \n    - `live`: (boolean) Indicates if the site is live.\n        \n    - `locked`: (boolean) Indicates if the site is locked.\n        \n    - `modDate`: (integer) Modification date timestamp.\n        \n    - `modUser`: (string) User who last modified the site.\n        \n    - `proxyUrlForEditMode`: (null) Placeholder for proxy URL in edit mode.\n        \n    - `runDashboard`: (boolean) Indicates if the dashboard should run.\n        \n    - `siteName`: (string) The name of the site.\n        \n    - `siteThumbnail`: (string) URL for the site thumbnail.\n        \n    - `systemHost`: (boolean) Indicates if this is a system host.\n        \n    - `tagStorage`: (string) Placeholder for tag storage.\n        \n    - `variables`: (array) Array of variables associated with the site.\n        \n    - `working`: (boolean) Indicates if the site is in a working state.\n        \n- **errors**: (array) An array that will contain any errors encountered during the request. In this case, it is empty.\n    \n- **i18nMessagesMap**: (object) An object for internationalization messages, which is empty in this response.\n    \n- **messages**: (array) An array for any messages returned by the server, which is also empty.\n    \n- **pagination**: (null) Placeholder for pagination details, if applicable.\n    \n- **permissions**: (array) An array for permissions related to the site, which is empty.\n    \n\nThis endpoint is essential for managing site creation and ensures that the necessary parameters are provided to successfully create a new site."
+							},
+							"response": []
 						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        }\n    ]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
+						{
+							"name": "Get Site Configuration - System Host",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify expected data in response body\", function () {",
+											"    pm.expect(pm.response.text()).to.contain(\"siteKey: 'DOT.SYSTEM_HOST.\", \"Returned 'siteKey' attribute doesn't have the expected value\");",
+											"    pm.expect(pm.response.text()).to.contain(\"server: 'https://System Host\", \"Returned 'server' attribute doesn't have the expected value\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
 								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{jwt}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/siteconfig/SYSTEM_HOST",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"siteconfig",
+										"SYSTEM_HOST"
+									]
+								},
+								"description": "## Endpoint: Get CA Authentication Object for System Host Configuration\n\nThis endpoint retrieves the system host configuration from the server. It is a simple HTTP GET request that does not require any additional parameters or headers.\n\n### Request\n\n- **Method**: GET\n    \n- **URL**: `{{serverURL}}/api/v1/analytics/content/siteconfig/SYSTEM_HOST`\n    \n\n### Request Parameters\n\nThere are no request parameters for this endpoint.\n\n### Request Headers\n\nNo specific headers are required for this request.\n\n### Response\n\n- **Status Code**: 200 OK\n    \n- **Content-Type**: text/plain\n    \n\n### Response Body\n\nThe response body will be empty (`{}`) if the request is successful.\n\n### Possible Response Codes\n\n- **200 OK**: The request was successful, and the system host configuration is returned (or an empty response).\n    \n- **4xx**: Client errors indicating issues with the request.\n    \n- **5xx**: Server errors indicating issues on the server side.\n    \n\n### Notes\n\nThis endpoint is primarily used for retrieving the current system host configuration settings. Ensure that the server is running and accessible to get a successful response."
+							},
+							"response": []
+						},
+						{
+							"name": "Get Site Configuration - Test Site",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify expected data in response body\", function () {",
+											"    const siteId = pm.collectionVariables.get(\"siteId\");",
+											"    const siteName = pm.collectionVariables.get(\"siteName\");",
+											"    pm.expect(pm.response.text()).to.contain(\"siteKey: 'DOT.\" + siteId + \".\", \"Returned 'siteKey' attribute doesn't have the expected value\");",
+											"    pm.expect(pm.response.text()).to.contain(\"server: 'https://\" + siteName + \"'\", \"Returned 'server' attribute doesn't have the expected value\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{jwt}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/siteconfig/{{siteId}}",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"siteconfig",
+										"{{siteId}}"
+									]
+								},
+								"description": "## Endpoint: Get CA Authentication Object for Test Site Configuration\n\nThis endpoint retrieves the Test Site configuration from the server. It is a simple HTTP GET request that does not require any additional parameters or headers.\n\n### Request\n\n- **Method**: GET\n    \n- **URL**: `{{serverURL}}/api/v1/analytics/content/siteconfig/{{siteId}}`\n    \n\n### Request Parameters\n\nThere are no request parameters for this endpoint.\n\n### Request Headers\n\nNo specific headers are required for this request.\n\n### Response\n\n- **Status Code**: 200 OK\n    \n- **Content-Type**: text/plain\n    \n\n### Response Body\n\nThe response body will be empty (`{}`) if the request is successful.\n\n### Possible Response Codes\n\n- **200 OK**: The request was successful, and the Test Site configuration is returned (or an empty response).\n    \n- **4xx**: Client errors indicating issues with the request.\n    \n- **5xx**: Server errors indicating issues on the server side.\n    \n\n### Notes\n\nThis endpoint is primarily used for retrieving the current Test Site configuration settings. Ensure that the server is running and accessible to get a successful response."
+							},
+							"response": []
+						},
+						{
+							"name": "Save User-Defined Site Key",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Check that response is correct\", function () {",
+											"    const jsonData = pm.response.json();",
+											"    pm.expect(jsonData.entity).to.equal(\"Ok\", \"The value of the 'entity' attribute is not the expected one\");",
+											"    pm.expect(jsonData.errors.length).to.equal(0, \"An error occurred when saving the App secret\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											"pm.collectionVariables.set(\"customKeyValue\", \"custom-key-value\");"
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{ \n\t  \"siteKey\": {\n\t\t \"value\": \"{{customKeyValue}}\"\n      }\n}\n"
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/apps/{{key}}/{{siteId}}",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"apps",
+										"{{key}}",
+										"{{siteId}}"
+									]
+								},
+								"description": "## HTTP POST Request to Save Content Analytics App Secrets\n\n### Endpoint\n\n`POST {{serverURL}}/api/v1/apps/{{key}}/{{siteId}}`\n\n### Request Parameters\n\n- **Request Body** (Raw JSON):\n    \n    - `siteKey` (object): Contains the following property:\n        \n        - `value` (string): The custom key value to identify the site.\n            \n\n### Expected Response\n\n- **Status Code**: `200 OK`\n    \n- **Content-Type**: `application/json`\n    \n- **Response Body**:\n    \n    - `entity` (string): Represents the entity returned.\n        \n    - `errors` (array): A list of any errors encountered during the request.\n        \n    - `i18nMessagesMap` (object): A map for internationalization messages.\n        \n    - `messages` (array): A list of messages related to the request.\n        \n    - `pagination` (null): Indicates if there is any pagination data.\n        \n    - `permissions` (array): A list of permissions associated with the request.\n        \n\nThis request is designed to save Content Analytics App data using the provided app key and site ID."
+							},
+							"response": []
+						},
+						{
+							"name": "Get Site Configuration With Custom Key",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"HTTP Status code must be successful\", function () {",
+											"    pm.response.to.have.status(200);",
+											"});",
+											"",
+											"pm.test(\"Verify expected data in response body\", function () {",
+											"    const customKeyValue = pm.collectionVariables.get(\"customKeyValue\");",
+											"    const siteName = pm.collectionVariables.get(\"siteName\");",
+											"    pm.expect(pm.response.text()).to.contain(\"siteKey: '\" + customKeyValue + \"'\", \"Returned 'siteKey' attribute doesn't have the expected value\");",
+											"    pm.expect(pm.response.text()).to.contain(\"server: 'https://\" + siteName + \"'\", \"Returned 'server' attribute doesn't have the expected value\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"auth": {
+									"type": "bearer",
+									"bearer": [
+										{
+											"key": "token",
+											"value": "{{jwt}}",
+											"type": "string"
+										}
+									]
+								},
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/analytics/content/siteconfig/{{siteId}}",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"analytics",
+										"content",
+										"siteconfig",
+										"{{siteId}}"
+									]
+								},
+								"description": "## Endpoint: Get CA Authentication Object for Test Site Configuration with Custom Site Key\n\nThis endpoint retrieves the Test Site configuration from the server. It is a simple HTTP GET request that does not require any additional parameters or headers.\n\n### Request\n\n- **Method**: GET\n    \n- **URL**: `{{serverURL}}/api/v1/analytics/content/siteconfig/{{siteId}}`\n    \n\n### Request Parameters\n\nThere are no request parameters for this endpoint.\n\n### Request Headers\n\nNo specific headers are required for this request.\n\n### Response\n\n- **Status Code**: 200 OK\n    \n- **Content-Type**: text/plain\n    \n\n### Response Body\n\nThe response body will be empty (`{}`) if the request is successful.\n\n### Possible Response Codes\n\n- **200 OK**: The request was successful, and the Test Site configuration is returned (or an empty response).\n    \n- **4xx**: Client errors indicating issues with the request.\n    \n- **5xx**: Server errors indicating issues on the server side.\n    \n\n### Notes\n\nThis endpoint is primarily used for retrieving the current Test Site configuration settings. Ensure that the server is running and accessible to get a successful response."
+							},
+							"response": []
+						}
+					],
+					"description": "Verifies that the different configuration parameters in the **Content Analytics** App are evaluated and/or generated correctly.",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.collectionVariables.set(\"key\", \"dotContentAnalytics-config\")"
+								]
 							}
 						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/analytics/content/event",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"analytics",
-								"content",
-								"event"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "pageview extra attributes",
-					"event": [
 						{
 							"listen": "test",
 							"script": {
-								"exec": [
-									"pm.test(\"HTTP Status code must be 400\", function () {",
-									"    pm.response.to.have.status(400);",
-									"});",
-									"",
-									"pm.test(\"Response sould be right\", function () {",
-									"    const responseBody = pm.response.json();",
-									"",
-									"    pm.expect(responseBody.failed).to.be.eq(1);",
-									"    pm.expect(responseBody.success).to.be.eq(0);",
-									"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
-									"",
-									"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
-									"    pm.expect(responseBody.errors.length).to.be.eq(4);",
-									"",
-									"    pm.expect(responseBody.errors[0].eventIndex).to.be.eq(0);",
-									"    pm.expect(responseBody.errors[0].code).to.be.eq(\"UNKNOWN_FIELD\");",
-									"    pm.expect(responseBody.errors[0].field).to.be.eq(\"events[0].data.page.extra\");",
-									"    pm.expect(responseBody.errors[0].message).to.be.eq(\"Unknown field 'data.page.extra'\");",
-									"",
-									"    pm.expect(responseBody.errors[1].eventIndex).to.be.eq(0);",
-									"    pm.expect(responseBody.errors[1].code).to.be.eq(\"UNKNOWN_FIELD\");",
-									"    pm.expect(responseBody.errors[1].field).to.be.eq(\"events[0].data.device.extra\");",
-									"    pm.expect(responseBody.errors[1].message).to.be.eq(\"Unknown field 'data.device.extra'\");",
-									"",
-									"    pm.expect(responseBody.errors[2].eventIndex).to.be.eq(0);",
-									"    pm.expect(responseBody.errors[2].code).to.be.eq(\"UNKNOWN_FIELD\");",
-									"    pm.expect(responseBody.errors[2].field).to.be.eq(\"events[0].data.utm.extra\");",
-									"    pm.expect(responseBody.errors[2].message).to.be.eq(\"Unknown field 'data.utm.extra'\");",
-									"",
-									"    pm.expect(responseBody.errors[3].eventIndex).to.be.eq(0);",
-									"    pm.expect(responseBody.errors[3].code).to.be.eq(\"UNKNOWN_FIELD\");",
-									"    pm.expect(responseBody.errors[3].field).to.be.eq(\"events[0].data.extra\");",
-									"    pm.expect(responseBody.errors[3].message).to.be.eq(\"Unknown field 'data.extra'\");",
-									"});"
-								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"exec": [
+									""
+								]
 							}
 						}
-					],
-					"request": {
-						"auth": {
-							"type": "basic",
-							"basic": [
-								{
-									"key": "username",
-									"value": "admin@dotcms.com",
-									"type": "string"
-								},
-								{
-									"key": "password",
-									"value": "admin",
-									"type": "string"
-								}
-							]
-						},
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"context\": {\n        \"site_key\": \"xyz\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"extra\": \"extra\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\",\n                    \"extra\": \"extra\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\",\n                    \"extra\": \"extra\"\n                },\n                \"extra\": \"extra\"\n            }\n        }\n    ]\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{serverURL}}/api/v1/analytics/content/event",
-							"host": [
-								"{{serverURL}}"
-							],
-							"path": [
-								"api",
-								"v1",
-								"analytics",
-								"content",
-								"event"
-							]
-						}
-					},
-					"response": []
+					]
 				}
 			]
 		}


### PR DESCRIPTION
### Proposed Changes
* We're creating a dedicated App named `Content Analytics` that will hold every specific configuration we have for tracking events. The previous `Analytics Integration` App has been renamed `Experiments` as its name and App Key were very similar, and we wanted to avoid confusion from both customers and us developers. Any existing configuration will be manually migrated by Support.
* A new REST Endpoint has been created which has two potential results:
  * If the customer defines its own `Site Key`, the endpoint will return the expected JavaScript configuration that developers can copy and paste to authenticate to our Content Analytics service in their code.
  * If the customer doesn't define a key, dotCMS will generate a secure Site Key for them, and the same JavaScript configuration will be returned.

This PR fixes: #32539