### PR TITLE
chore(actions): Updated gh action to publish sdks

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -1,17 +1,18 @@
-# Note: The versions of the SDK libraries will be incremented in the NPM registry,
-# but they will not be updated in the codebase itself through this process.
-# This simplification avoids automatic pull requests and all the considerations
-# necessary due to protections on the main branch, as well as the lengthy execution
-# process that would be required to ultimately publish the libraries.
+# Note: This action publishes stable versions of the SDK libraries to NPM.
+# 
+# DUAL PUBLISHING BEHAVIOR:
+# LATEST TAG:
+# - If current version contains "alpha" or "beta" -> publishes 1.0.0
+# - If stable version exists -> only publishes on explicit version-type (patch/minor/major/custom)
+# - Auto mode with stable version -> skips latest publishing
 #
-# This is a temporary solution until we determine the most appropriate pattern
-# to handle the lifecycle of each module that needs to be released individually
-# (e.g., dotCLI and the SDKs).
+# NEXT TAG:
+# - Always publishes with "-next.X" suffix where X increments
+# - If transitioning from prerelease -> publishes {latest_version}-next.1
+# - If stable version -> publishes {current_or_new_version}-next.{incremented_patch}
 #
-# Additionally, the example projects should point to the 'next' tag to ensure
-# that version updates do not impact their functionality due to version inconsistency.
-name: 'SDK Publish NPM Packages'
-description: 'Publish the dotCMS SDK libs on NPM registry.'
+name: 'SDK Publish NPM Packages - Stable'
+description: 'Publish stable versions of the dotCMS SDK libs on NPM registry.'
 inputs:
   ref:
     description: 'Branch to build from'
@@ -21,19 +22,36 @@ inputs:
     description: 'NPM token'
     required: true
   npm-package-tag:
-    description: 'Package tag'
+    description: 'Package tag for stable releases'
     required: false
-    default: 'beta'
+    default: 'latest'
+  version-type:
+    description: 'Version type: auto (default), patch, minor, major, or custom. Auto means no increment unless transitioning from prerelease to 1.0.0'
+    required: false
+    default: 'auto'
+  custom-version:
+    description: 'Custom version to set (e.g., 1.3.4, 2.1.0). Only used when version-type is "custom". Must be valid semver format.'
+    required: false
+    default: ''
   github-token:
     description: 'GitHub Token'
     required: true
 outputs:
   npm-package-version:
-    description: 'SDK libs - NPM package version'
+    description: 'SDK libs - NPM package version for latest tag'
     value: ${{ steps.next_version.outputs.next_version }}
-  published:
-    description: 'SDK libs - Published'
-    value: ${{ steps.deployment_status.outputs.published }}
+  npm-package-version-next:
+    description: 'SDK libs - NPM package version for next tag'
+    value: ${{ steps.next_version.outputs.next_version_next }}
+  published-latest:
+    description: 'SDK libs - Published to latest tag'
+    value: ${{ steps.deployment_status.outputs.published_latest }}
+  published-next:
+    description: 'SDK libs - Published to next tag'
+    value: ${{ steps.deployment_status.outputs.published_next }}
+  version-type-used:
+    description: 'Type of version increment that was applied'
+    value: ${{ steps.next_version.outputs.version_type_used }}
 runs:
   using: "composite"
   steps:
@@ -68,15 +86,61 @@ runs:
       id: current_version
       run: |
         echo "::group::Get current version"
-        # This should be empty on the first run. Setting the NEXT_VERSION to 0.0.1-beta.1
-        CURRENT_VERSION=$(npm view @dotcms/client dist-tags --json | jq -r '.beta')
-
-        if [ -z "$CURRENT_VERSION" ] || [ "$CURRENT_VERSION" = "null" ]; then
-          CURRENT_VERSION="0.0.1-beta.0"
+        
+        # Get the current stable version from the latest tag
+        CURRENT_STABLE=$(npm view @dotcms/client dist-tags --json 2>/dev/null | jq -r '.latest // empty')
+        
+        # Get the current beta version for reference
+        CURRENT_BETA=$(npm view @dotcms/client dist-tags --json 2>/dev/null | jq -r '.beta // empty')
+        
+        # Get the current next version
+        CURRENT_NEXT=$(npm view @dotcms/client dist-tags --json 2>/dev/null | jq -r '.next // empty')
+        
+        # Determine the current version to use as base
+        if [ -n "$CURRENT_STABLE" ] && [ "$CURRENT_STABLE" != "null" ]; then
+          CURRENT_VERSION="$CURRENT_STABLE"
+          VERSION_SOURCE="stable"
+        elif [ -n "$CURRENT_BETA" ] && [ "$CURRENT_BETA" != "null" ]; then
+          CURRENT_VERSION="$CURRENT_BETA"
+          VERSION_SOURCE="beta"
+        else
+          CURRENT_VERSION="0.0.0"
+          VERSION_SOURCE="none"
         fi
 
-        echo "Current version: $CURRENT_VERSION"
+        echo "Current stable version: ${CURRENT_STABLE:-'none'}"
+        echo "Current beta version: ${CURRENT_BETA:-'none'}"
+        echo "Current next version: ${CURRENT_NEXT:-'none'}"
+        echo "Using version: $CURRENT_VERSION (source: $VERSION_SOURCE)"
+        
         echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        echo "version_source=$VERSION_SOURCE" >> $GITHUB_OUTPUT
+        echo "current_stable=$CURRENT_STABLE" >> $GITHUB_OUTPUT
+        echo "current_next=$CURRENT_NEXT" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 'Validate custom version'
+      if: ${{ inputs.version-type == 'custom' }}
+      env:
+        CUSTOM_VERSION: ${{ inputs.custom-version }}
+      run: |
+        echo "::group::Validate custom version"
+        
+        if [ -z "$CUSTOM_VERSION" ]; then
+          echo "::error::Custom version cannot be empty when version-type is 'custom'"
+          echo "Please provide a valid semantic version (e.g., 1.3.4, 2.0.0, 1.2.1)"
+          exit 1
+        fi
+        
+        # Validate semantic version format (major.minor.patch)
+        if [[ ! "$CUSTOM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::Invalid custom version format: '$CUSTOM_VERSION'"
+          echo "Version must follow semantic versioning format: major.minor.patch (e.g., 1.3.4)"
+          exit 1
+        fi
+        
+        echo "✅ Custom version '$CUSTOM_VERSION' is valid"
         echo "::endgroup::"
       shell: bash
 
@@ -84,29 +148,230 @@ runs:
       id: next_version
       env:
        CURRENT_VERSION: ${{ steps.current_version.outputs.current_version }}
+       VERSION_SOURCE: ${{ steps.current_version.outputs.version_source }}
+       CURRENT_STABLE: ${{ steps.current_version.outputs.current_stable }}
+       CURRENT_NEXT: ${{ steps.current_version.outputs.current_next }}
+       VERSION_TYPE: ${{ inputs.version-type }}
+       CUSTOM_VERSION: ${{ inputs.custom-version }}
       run: |
         echo "::group::Calculate next version"
-        VERSION_PARTS=(${CURRENT_VERSION//./ })
-        BASE_VERSION="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
-        BETA_PART=${VERSION_PARTS[3]#*-}
-        BETA_NUMBER=${BETA_PART#*.}
-        NEW_BETA_NUMBER=$((BETA_NUMBER + 1))
-        NEXT_VERSION="${BASE_VERSION}.${NEW_BETA_NUMBER}"
-        echo "Next version: $NEXT_VERSION"
-        echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
-        echo "::endgroup::"
+        
+        echo "Current version: $CURRENT_VERSION"
+        echo "Version source: $VERSION_SOURCE"
+        echo "Current next: $CURRENT_NEXT"
+        echo "Requested version type: $VERSION_TYPE"
+        if [ "$VERSION_TYPE" = "custom" ]; then
+          echo "Custom version requested: $CUSTOM_VERSION"
+        fi
+        echo ""
+        
+        # Function to check if version contains alpha or beta
+        is_prerelease_version() {
+          [[ "$1" == *"alpha"* ]] || [[ "$1" == *"beta"* ]]
+        }
+        
+        # Function to get next patch number for "next" tag
+        get_next_patch_number() {
+          local base_version="$1"
+          local current_next="$2"
+          
+          if [ -z "$current_next" ] || [ "$current_next" = "null" ]; then
+            echo "1"
+            return
+          fi
+          
+          # Extract the base version from current next (remove -next.X)
+          local current_base=$(echo "$current_next" | sed 's/-next\.[0-9]*$//')
+          
+          if [ "$current_base" = "$base_version" ]; then
+            # Same base version, increment the patch number
+            local current_patch=$(echo "$current_next" | sed 's/.*-next\.//')
+            echo "$((current_patch + 1))"
+          else
+            # Different base version, start from 1
+            echo "1"
+          fi
+        }
+        
+        # Function to compare versions (returns 0 if v1 >= v2, 1 if v1 < v2)
+        version_compare() {
+          local v1="$1"
+          local v2="$2"
+          
+          IFS='.' read -ra V1_PARTS <<< "$v1"
+          IFS='.' read -ra V2_PARTS <<< "$v2"
+          
+          for i in 0 1 2; do
+            local p1=${V1_PARTS[i]:-0}
+            local p2=${V2_PARTS[i]:-0}
+            
+            if [ "$p1" -gt "$p2" ]; then
+              return 0  # v1 > v2
+            elif [ "$p1" -lt "$p2" ]; then
+              return 1  # v1 < v2
+            fi
+          done
+          
+          return 0  # v1 == v2
+        }
+        
+        # Calculate LATEST version
+        if [ "$VERSION_TYPE" = "custom" ]; then
+          # Custom version specified
+          NEXT_VERSION="$CUSTOM_VERSION"
+          VERSION_TYPE_USED="custom"
+          
+          # Check if custom version is valid relative to current version
+          if [ "$VERSION_SOURCE" = "stable" ] && [ -n "$CURRENT_STABLE" ]; then
+            if version_compare "$CURRENT_STABLE" "$CUSTOM_VERSION"; then
+              echo "::warning::Custom version $CUSTOM_VERSION is not greater than current stable version $CURRENT_STABLE"
+              echo "This will still be published, but consider if this is intentional."
+            fi
+          fi
+          
+          echo "Using custom version: $CUSTOM_VERSION"
+          
+        elif [ "$VERSION_SOURCE" = "none" ] || [ "$CURRENT_VERSION" = "0.0.0" ]; then
+          # No version exists, start with 1.0.0
+          NEXT_VERSION="1.0.0"
+          VERSION_TYPE_USED="initial"
+          echo "No existing version found, setting initial version to 1.0.0"
+          
+        elif is_prerelease_version "$CURRENT_VERSION"; then
+          # Current version is alpha or beta, transition to 1.0.0 stable
+          NEXT_VERSION="1.0.0"
+          VERSION_TYPE_USED="prerelease-to-stable"
+          echo "Transitioning from prerelease version ($CURRENT_VERSION) to stable 1.0.0"
+          
+        elif [ "$VERSION_SOURCE" = "stable" ] && [ -n "$CURRENT_STABLE" ]; then
+          # We have a stable version, apply versioning logic
+          IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_STABLE"
+          MAJOR=${VERSION_PARTS[0]:-1}
+          MINOR=${VERSION_PARTS[1]:-0}
+          PATCH=${VERSION_PARTS[2]:-0}
+          
+          case "$VERSION_TYPE" in
+            "major")
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              VERSION_TYPE_USED="major"
+              echo "Manual major version increment requested"
+              ;;
+            "minor")
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              VERSION_TYPE_USED="minor"
+              echo "Manual minor version increment requested"
+              ;;
+            "patch")
+              PATCH=$((PATCH + 1))
+              VERSION_TYPE_USED="patch"
+              echo "Manual patch version increment requested"
+              ;;
+            "auto"|*)
+              # Auto mode: keep current version (no increment)
+              VERSION_TYPE_USED="auto-no-increment"
+              echo "Auto mode: keeping current stable version (no increment)"
+              ;;
+          esac
+          
+          NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+        else
+          # Fallback case
+          NEXT_VERSION="1.0.0"
+          VERSION_TYPE_USED="fallback"
+          echo "Fallback: setting version to 1.0.0"
+        fi
 
+        # Calculate NEXT version (always generated)
+        if [ "$VERSION_TYPE_USED" = "auto-no-increment" ]; then
+          # For auto mode, use current stable version as base for next
+          NEXT_BASE_VERSION="$CURRENT_STABLE"
+        else
+          # Use the calculated next version as base
+          NEXT_BASE_VERSION="$NEXT_VERSION"
+        fi
+        
+        NEXT_PATCH_NUMBER=$(get_next_patch_number "$NEXT_BASE_VERSION" "$CURRENT_NEXT")
+        NEXT_VERSION_NEXT="${NEXT_BASE_VERSION}-next.${NEXT_PATCH_NUMBER}"
+
+        echo ""
+        echo "=== VERSION CALCULATION RESULT ==="
+        echo "Previous version: $CURRENT_VERSION"
+        echo "Next version (latest): $NEXT_VERSION"
+        echo "Next version (next): $NEXT_VERSION_NEXT"
+        echo "Version type used: $VERSION_TYPE_USED"
+        echo "=================================="
+        
+        echo "next_version=$NEXT_VERSION" >> $GITHUB_OUTPUT
+        echo "next_version_next=$NEXT_VERSION_NEXT" >> $GITHUB_OUTPUT
+        echo "version_type_used=$VERSION_TYPE_USED" >> $GITHUB_OUTPUT
+        echo "::endgroup::"
+      shell: bash
+
+    - name: 'Validate version increment'
+      id: validate_version
+      env:
+        CURRENT_VERSION: ${{ steps.current_version.outputs.current_version }}
+        NEXT_VERSION: ${{ steps.next_version.outputs.next_version }}
+        NEXT_VERSION_NEXT: ${{ steps.next_version.outputs.next_version_next }}
+        VERSION_TYPE_USED: ${{ steps.next_version.outputs.version_type_used }}
+      run: |
+        echo "::group::Validate version increment"
+        echo "Validation summary:"
+        echo "  Current: $CURRENT_VERSION"
+        echo "  Next (latest): $NEXT_VERSION"
+        echo "  Next (next): $NEXT_VERSION_NEXT"
+        echo "  Type: $VERSION_TYPE_USED"
+        
+        # Basic validation - ensure we have valid semver
+        if [[ ! "$NEXT_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::error::Invalid version format for latest: $NEXT_VERSION"
+          exit 1
+        fi
+        
+        if [[ ! "$NEXT_VERSION_NEXT" =~ ^[0-9]+\.[0-9]+\.[0-9]+-next\.[0-9]+$ ]]; then
+          echo "::error::Invalid version format for next: $NEXT_VERSION_NEXT"
+          exit 1
+        fi
+        
+        # Determine what should be published
+        if [ "$CURRENT_VERSION" = "$NEXT_VERSION" ] && [ "$VERSION_TYPE_USED" = "auto-no-increment" ]; then
+          echo "🚫 No version change detected for latest tag (${CURRENT_VERSION} → ${NEXT_VERSION})"
+          echo "   Skipping latest publishing since version-type is 'auto' and no increment is needed."
+          SHOULD_PUBLISH_LATEST="false"
+        else
+          echo "✅ Version will be updated for latest tag (${CURRENT_VERSION} → ${NEXT_VERSION})"
+          SHOULD_PUBLISH_LATEST="true"
+        fi
+        
+        # Always publish to next tag
+        SHOULD_PUBLISH_NEXT="true"
+        echo "✅ Version will be published to next tag: ${NEXT_VERSION_NEXT}"
+        
+        echo "should_publish_latest=$SHOULD_PUBLISH_LATEST" >> $GITHUB_OUTPUT
+        echo "should_publish_next=$SHOULD_PUBLISH_NEXT" >> $GITHUB_OUTPUT
+        
+        echo "✅ Version validation passed"
+        echo "::endgroup::"
       shell: bash
 
     - name: 'Printing versions'
       working-directory: ${{ github.workspace }}/core-web/libs/sdk/
       env:
        NEXT_VERSION: ${{ steps.next_version.outputs.next_version }}
+       NEXT_VERSION_NEXT: ${{ steps.next_version.outputs.next_version_next }}
        CURRENT_VERSION: ${{ steps.current_version.outputs.current_version }}
+       VERSION_TYPE_USED: ${{ steps.next_version.outputs.version_type_used }}
+       SHOULD_PUBLISH_LATEST: ${{ steps.validate_version.outputs.should_publish_latest }}
+       SHOULD_PUBLISH_NEXT: ${{ steps.validate_version.outputs.should_publish_next }}
       run: |
-        echo "::group::Update versions"
+        echo "::group::Version update summary"
         echo "Current version: $CURRENT_VERSION"
-        echo "Next version: $NEXT_VERSION"
+        echo "Next version (latest): $NEXT_VERSION (publish: $SHOULD_PUBLISH_LATEST)"
+        echo "Next version (next): $NEXT_VERSION_NEXT (publish: $SHOULD_PUBLISH_NEXT)"
+        echo "Update type: $VERSION_TYPE_USED"
         echo "::endgroup::"
       shell: bash
 
@@ -114,9 +379,13 @@ runs:
       working-directory: ${{ github.workspace }}/core-web/libs/sdk/
       env:
         NEXT_VERSION: ${{ steps.next_version.outputs.next_version }}
+        NEXT_VERSION_NEXT: ${{ steps.next_version.outputs.next_version_next }}
         EXAMPLES_PATH: ${{ github.workspace }}/examples
+        SHOULD_PUBLISH_LATEST: ${{ steps.validate_version.outputs.should_publish_latest }}
       run: |
-        echo "Updating version to $NEXT_VERSION"
+        echo "Preparing versions:"
+        echo "  Latest: $NEXT_VERSION (will publish: $SHOULD_PUBLISH_LATEST)"
+        echo "  Next: $NEXT_VERSION_NEXT (will publish: $SHOULD_PUBLISH_NEXT)"
 
         # Function to update the version in package.json using jq
         update_version() {
@@ -126,9 +395,9 @@ runs:
 
           if [ -f "$package_json_path" ]; then
             jq --arg new_version "$new_version" '.version = $new_version' "$package_json_path" > tmp.$$.json && mv tmp.$$.json "$package_json_path"
-            echo "Updated version in $package_json_path to $new_version"
+            echo "✅ Updated version in $package_json_path to $new_version"
           else
-            echo "::warn::Warning: No package.json found in $pkg_dir"
+            echo "::warning::No package.json found in $pkg_dir"
           fi
         }
 
@@ -141,14 +410,10 @@ runs:
           if [ -f "$package_json_path" ]; then
             for dep in "${sdk_packages[@]}"; do
               if jq -e ".peerDependencies[\"@dotcms/$dep\"]" "$package_json_path" >/dev/null; then
-                jq --arg new_version "$new_version" ".peerDependencies[\"@dotcms/$dep\"] = \$new_version" "$package_json_path" > tmp.$$.json && mv tmp.$$.json "$package_json_path"
-                echo "::debug::Updated peerDependency @dotcms/$dep in $package_json_path to $new_version"
-              else
-                echo "::debug::PeerDependency @dotcms/$dep not found in $package_json_path, skipping update."
+                jq --arg new_version "^$new_version" ".peerDependencies[\"@dotcms/$dep\"] = \$new_version" "$package_json_path" > tmp.$$.json && mv tmp.$$.json "$package_json_path"
+                echo "  ↳ Updated peerDependency @dotcms/$dep to ^$new_version"
               fi
             done
-          else
-            echo "::warn::Warning: No package.json found in $pkg_dir"
           fi
         }
 
@@ -159,41 +424,59 @@ runs:
           local package_json_path="$example_dir/package.json"
 
           if [ -f "$package_json_path" ]; then
+            local updated=false
             for dep in "${sdk_packages[@]}"; do
               if jq -e ".dependencies[\"@dotcms/$dep\"]" "$package_json_path" >/dev/null; then
-                jq --arg sdk_name "@dotcms/$dep" --arg new_version "$new_version" \
+                jq --arg sdk_name "@dotcms/$dep" --arg new_version "^$new_version" \
                 '.dependencies[$sdk_name] = $new_version' \
                 "$package_json_path" > tmp.$$.json && mv tmp.$$.json "$package_json_path"
-                echo "::debug::Updated dependency @dotcms/$dep in $package_json_path to $new_version"
-              else
-                echo "::debug::Dependency @dotcms/$dep not found in $package_json_path, skipping update."
+                updated=true
               fi
             done
-          else
-            echo "::warn::Warning: No package.json found in $example_dir"
+            if [ "$updated" = true ]; then
+              echo "✅ Updated dependencies in $package_json_path"
+            fi
           fi
         }
 
         # Detect all SDK packages dynamically in the libs/sdk directory
         sdk_packages=($(find . -maxdepth 1 -type d -exec basename {} \; | grep -v "^\.$"))
 
+        echo "Found SDK packages: ${sdk_packages[*]}"
+        echo ""
+
+        # We'll use the latest version for package.json updates (even if not publishing to latest)
+        # This ensures consistency in the build artifacts
+        VERSION_FOR_PACKAGES="$NEXT_VERSION"
+        
         # Step 1: Update the version in each SDK package
+        echo "📦 Updating SDK package versions to $VERSION_FOR_PACKAGES..."
         for sdk in "${sdk_packages[@]}"; do
-          update_version "$sdk" "$NEXT_VERSION"
+          update_version "$sdk" "$VERSION_FOR_PACKAGES"
         done
+        echo ""
 
         # Step 2: Update peerDependencies in each SDK package
+        echo "🔗 Updating SDK peer dependencies..."
         for sdk in "${sdk_packages[@]}"; do
-          update_peer_dependencies "$sdk" "$NEXT_VERSION"
+          update_peer_dependencies "$sdk" "$VERSION_FOR_PACKAGES"
         done
+        echo ""
 
         # Step 3: Update dependencies in example projects
-        example_packages=$(find $EXAMPLES_PATH -name "package.json" -not -path "*/node_modules/*")
+        echo "📚 Updating example project dependencies..."
+        example_packages=$(find $EXAMPLES_PATH -name "package.json" -not -path "*/node_modules/*" 2>/dev/null || echo "")
 
-        for package_json_path in $example_packages; do
-          example_dir=$(dirname "$package_json_path")
-          update_dependencies_in_examples "$example_dir" "$NEXT_VERSION"
-        done
+        if [ -n "$example_packages" ]; then
+          for package_json_path in $example_packages; do
+            example_dir=$(dirname "$package_json_path")
+            update_dependencies_in_examples "$example_dir" "$VERSION_FOR_PACKAGES"
+          done
+        else
+          echo "No example packages found"
+        fi
+        echo ""
+        echo "✅ All version updates completed successfully"
       shell: bash
 
     - name: 'Printing SDK packages configuration'
@@ -203,14 +486,22 @@ runs:
       run: |
         print_packages() {
           cd $1
-          ls -ls | awk '{ print$10 }' | grep -v '^$' | while read a; do echo -e "${a}:\n" && cat ./${a}/package.json && echo -e "\n"; done
+          ls -ls | awk '{ print$10 }' | grep -v '^$' | while read a; do 
+            if [ -f "./${a}/package.json" ]; then
+              echo -e "${a}:"
+              cat "./${a}/package.json" | jq '.name, .version'
+              echo ""
+            fi
+          done
         }
-        echo "::group::Printing SDK and Example packages"
+        echo "::group::SDK and Example packages configuration"
         echo "SDK libs:"
         print_packages "$SDK_LIBS_PATH"
         echo ""
-        echo "Examples:"
-        print_packages "$EXAMPLES_PATH"
+        if [ -d "$EXAMPLES_PATH" ]; then
+          echo "Examples:"
+          print_packages "$EXAMPLES_PATH"
+        fi
         echo "::endgroup::"
       shell: bash
 
@@ -233,25 +524,79 @@ runs:
       working-directory: ${{ github.workspace }}/core-web/dist/libs/sdk/
       env:
         NEXT_VERSION: ${{ steps.next_version.outputs.next_version }}
+        NEXT_VERSION_NEXT: ${{ steps.next_version.outputs.next_version_next }}
         NPM_AUTH_TOKEN: ${{ inputs.npm-token }}
-        NPM_TAG: ${{ inputs.npm-package-tag }}
+        NPM_TAG_LATEST: ${{ inputs.npm-package-tag }}
+        VERSION_TYPE_USED: ${{ steps.next_version.outputs.version_type_used }}
+        SHOULD_PUBLISH_LATEST: ${{ steps.validate_version.outputs.should_publish_latest }}
+        SHOULD_PUBLISH_NEXT: ${{ steps.validate_version.outputs.should_publish_next }}
       run: |
         echo "::group::Publishing SDK packages"
+        echo "Publishing plan:"
+        echo "  Latest tag ($NPM_TAG_LATEST): $NEXT_VERSION (publish: $SHOULD_PUBLISH_LATEST)"
+        echo "  Next tag: $NEXT_VERSION_NEXT (publish: $SHOULD_PUBLISH_NEXT)"
+        echo "  Version type: $VERSION_TYPE_USED"
+        echo ""
+        
+        # Set up NPM authentication
+        echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
+        
         sdks=$(ls)
+        PUBLISH_LATEST_SUCCESS=true
+        PUBLISH_NEXT_SUCCESS=true
+        
         for sdk in $sdks; do
-          echo "Publishing SDK lib [${sdk}]"
-          cd $sdk && echo "$(pwd)"
-          echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
-          npm publish --access public --tag $NPM_TAG
-          npm dist-tag add @dotcms/${sdk}@${NEXT_VERSION} next
+          echo "📦 Processing @dotcms/${sdk}..."
+          cd $sdk && echo "  Working directory: $(pwd)"
+          
+          # Publish to latest tag if needed
+          if [ "$SHOULD_PUBLISH_LATEST" = "true" ]; then
+            echo "  🚀 Publishing to latest tag: @dotcms/${sdk}@${NEXT_VERSION}"
+            if npm publish --access public --tag $NPM_TAG_LATEST; then
+              echo "  ✅ Successfully published to latest tag"
+            else
+              echo "  ❌ Failed to publish to latest tag"
+              PUBLISH_LATEST_SUCCESS=false
+            fi
+          else
+            echo "  ⏭️ Skipping latest tag publishing (no version change)"
+          fi
+          
+          # Always publish to next tag
+          if [ "$SHOULD_PUBLISH_NEXT" = "true" ]; then
+            echo "  🚀 Publishing to next tag: @dotcms/${sdk}@${NEXT_VERSION_NEXT}"
+            
+            # Temporarily update package.json version for next publication
+            jq --arg next_version "$NEXT_VERSION_NEXT" '.version = $next_version' package.json > tmp.$$.json && mv tmp.$$.json package.json
+            
+            if npm publish --access public --tag next; then
+              echo "  ✅ Successfully published to next tag"
+            else
+              echo "  ❌ Failed to publish to next tag"
+              PUBLISH_NEXT_SUCCESS=false
+            fi
+          fi
+          
           cd ..
+          echo ""
         done
+        
+        # Final status
+        if [ "$PUBLISH_LATEST_SUCCESS" = "true" ] && [ "$PUBLISH_NEXT_SUCCESS" = "true" ]; then
+          echo "🎉 All SDK packages published successfully!"
+        else
+          echo "❌ Some publications failed"
+          exit 1
+        fi
         echo "::endgroup::"
       shell: bash
 
     - name: 'Set output'
       id: deployment_status
-      if: success()
+      env:
+        SHOULD_PUBLISH_LATEST: ${{ steps.validate_version.outputs.should_publish_latest }}
+        SHOULD_PUBLISH_NEXT: ${{ steps.validate_version.outputs.should_publish_next }}
       run: |
-        echo "published=true" >> $GITHUB_OUTPUT
+        echo "published_latest=$SHOULD_PUBLISH_LATEST" >> $GITHUB_OUTPUT
+        echo "published_next=$SHOULD_PUBLISH_NEXT" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -38,8 +38,8 @@ inputs:
     required: true
 outputs:
   npm-package-version:
-    description: 'SDK libs - NPM package version for latest tag'
-    value: ${{ steps.next_version.outputs.next_version }}
+    description: 'SDK libs - NPM package version (formatted for notifications)'
+    value: ${{ steps.deployment_status.outputs.npm_package_version }}
   npm-package-version-next:
     description: 'SDK libs - NPM package version for next tag'
     value: ${{ steps.next_version.outputs.next_version_next }}
@@ -49,6 +49,9 @@ outputs:
   published-next:
     description: 'SDK libs - Published to next tag'
     value: ${{ steps.deployment_status.outputs.published_next }}
+  published:
+    description: 'SDK libs - Published (backward compatibility - true if any tag published)'
+    value: ${{ steps.deployment_status.outputs.published }}
   version-type-used:
     description: 'Type of version increment that was applied'
     value: ${{ steps.next_version.outputs.version_type_used }}
@@ -615,6 +618,38 @@ runs:
       env:
         ACTUAL_PUBLISHED_LATEST: ${{ steps.publish_packages.outputs.actual_published_latest }}
         ACTUAL_PUBLISHED_NEXT: ${{ steps.publish_packages.outputs.actual_published_next }}
+        NEXT_VERSION: ${{ steps.next_version.outputs.next_version }}
+        NEXT_VERSION_NEXT: ${{ steps.next_version.outputs.next_version_next }}
       run: |
         echo "published_latest=$ACTUAL_PUBLISHED_LATEST" >> $GITHUB_OUTPUT
         echo "published_next=$ACTUAL_PUBLISHED_NEXT" >> $GITHUB_OUTPUT
+        
+        # Backward compatibility: published is true if either latest or next was published
+        if [ "$ACTUAL_PUBLISHED_LATEST" = "true" ] || [ "$ACTUAL_PUBLISHED_NEXT" = "true" ]; then
+          PUBLISHED="true"
+        else
+          PUBLISHED="false"
+        fi
+        echo "published=$PUBLISHED" >> $GITHUB_OUTPUT
+        
+        # Create npm-package-version output that works with existing message template
+        # Template expects: [ `${{ outputs.npm-package-version }}` ]
+        if [ "$ACTUAL_PUBLISHED_LATEST" = "true" ] && [ "$ACTUAL_PUBLISHED_NEXT" = "true" ]; then
+          # Both published - format to work with existing [ `...` ] template
+          NPM_PACKAGE_VERSION="${NEXT_VERSION}\` ] (latest) and [ \`${NEXT_VERSION_NEXT}\` ] (next"
+        elif [ "$ACTUAL_PUBLISHED_LATEST" = "true" ]; then
+          # Only latest published
+          NPM_PACKAGE_VERSION="$NEXT_VERSION"
+        elif [ "$ACTUAL_PUBLISHED_NEXT" = "true" ]; then
+          # Only next published
+          NPM_PACKAGE_VERSION="$NEXT_VERSION_NEXT"
+        else
+          # Nothing published (shouldn't happen if we reach this step)
+          NPM_PACKAGE_VERSION="No versions published"
+        fi
+        echo "npm_package_version=$NPM_PACKAGE_VERSION" >> $GITHUB_OUTPUT
+        
+        echo "✅ Outputs set:"
+        echo "  published: $PUBLISHED"
+        echo "  npm_package_version: $NPM_PACKAGE_VERSION"
+      shell: bash

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -521,6 +521,7 @@ runs:
       shell: bash
 
     - name: 'Publishing sdk into NPM registry'
+      id: publish_packages
       working-directory: ${{ github.workspace }}/core-web/dist/libs/sdk/
       env:
         NEXT_VERSION: ${{ steps.next_version.outputs.next_version }}
@@ -595,15 +596,19 @@ runs:
           echo "❌ Some publications failed"
           exit 1
         fi
+        
+        # At the end of the publishing step, set the actual results
+        echo "actual_published_latest=$PUBLISH_LATEST_SUCCESS" >> $GITHUB_OUTPUT
+        echo "actual_published_next=$PUBLISH_NEXT_SUCCESS" >> $GITHUB_OUTPUT
         echo "::endgroup::"
       shell: bash
 
     - name: 'Set output'
       id: deployment_status
+      if: success()
       env:
-        SHOULD_PUBLISH_LATEST: ${{ steps.validate_version.outputs.should_publish_latest }}
-        SHOULD_PUBLISH_NEXT: ${{ steps.validate_version.outputs.should_publish_next }}
+        ACTUAL_PUBLISHED_LATEST: ${{ steps.publish_packages.outputs.actual_published_latest }}
+        ACTUAL_PUBLISHED_NEXT: ${{ steps.publish_packages.outputs.actual_published_next }}
       run: |
-        echo "published_latest=$SHOULD_PUBLISH_LATEST" >> $GITHUB_OUTPUT
-        echo "published_next=$SHOULD_PUBLISH_NEXT" >> $GITHUB_OUTPUT
-      shell: bash
+        echo "published_latest=$ACTUAL_PUBLISHED_LATEST" >> $GITHUB_OUTPUT
+        echo "published_next=$ACTUAL_PUBLISHED_NEXT" >> $GITHUB_OUTPUT

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -186,7 +186,13 @@ runs:
           if [ "$current_base" = "$base_version" ]; then
             # Same base version, increment the patch number
             local current_patch=$(echo "$current_next" | sed 's/.*-next\.//')
-            echo "$((current_patch + 1))"
+            # Validate that current_patch is numeric to prevent arithmetic errors
+            if [[ "$current_patch" =~ ^[0-9]+$ ]]; then
+              echo "$((current_patch + 1))"
+            else
+              # If patch number is not numeric (malformed), treat as different base version
+              echo "1"
+            fi
           else
             # Different base version, start from 1
             echo "1"

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -549,6 +549,9 @@ runs:
           echo "📦 Processing @dotcms/${sdk}..."
           cd $sdk && echo "  Working directory: $(pwd)"
           
+          # Save original version before any modifications
+          ORIGINAL_VERSION=$(jq -r '.version' package.json)
+          
           # Publish to latest tag if needed
           if [ "$SHOULD_PUBLISH_LATEST" = "true" ]; then
             echo "  🚀 Publishing to latest tag: @dotcms/${sdk}@${NEXT_VERSION}"
@@ -575,6 +578,10 @@ runs:
               echo "  ❌ Failed to publish to next tag"
               PUBLISH_NEXT_SUCCESS=false
             fi
+            
+            # IMPORTANT: Revert package.json back to original stable version
+            jq --arg original_version "$ORIGINAL_VERSION" '.version = $original_version' package.json > tmp.$$.json && mv tmp.$$.json package.json
+            echo "  ↩️ Reverted package.json version back to $ORIGINAL_VERSION"
           fi
           
           cd ..

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -632,19 +632,19 @@ runs:
         fi
         echo "published=$PUBLISHED" >> $GITHUB_OUTPUT
         
-        # Create npm-package-version output that works with existing message template
-        # Template expects: [ `${{ outputs.npm-package-version }}` ]
+        # Create npm-package-version output with clean formatting
+        # Template will wrap with: [ `${{ outputs.npm-package-version }}` ]
         if [ "$ACTUAL_PUBLISHED_LATEST" = "true" ] && [ "$ACTUAL_PUBLISHED_NEXT" = "true" ]; then
-          # Both published - format to work with existing [ `...` ] template
-          NPM_PACKAGE_VERSION="${NEXT_VERSION}\` ] (latest) and [ \`${NEXT_VERSION_NEXT}\` ] (next"
+          # Both published - clean dual format
+          NPM_PACKAGE_VERSION="${NEXT_VERSION} (latest) and ${NEXT_VERSION_NEXT} (next)"
         elif [ "$ACTUAL_PUBLISHED_LATEST" = "true" ]; then
           # Only latest published
-          NPM_PACKAGE_VERSION="$NEXT_VERSION"
+          NPM_PACKAGE_VERSION="${NEXT_VERSION} (latest)"
         elif [ "$ACTUAL_PUBLISHED_NEXT" = "true" ]; then
           # Only next published
-          NPM_PACKAGE_VERSION="$NEXT_VERSION_NEXT"
+          NPM_PACKAGE_VERSION="${NEXT_VERSION_NEXT} (next)"
         else
-          # Nothing published (shouldn't happen if we reach this step)
+          # Nothing published
           NPM_PACKAGE_VERSION="No versions published"
         fi
         echo "npm_package_version=$NPM_PACKAGE_VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This PR introduces a major enhancement to the SDK publishing action, implementing dual publishing with comprehensive version control and enhanced logging capabilities.

Key Changes
1. Dual Publishing Strategy
Before: Single publication to latest tag only
After: Simultaneous publication to both `latest` and `next` tags

2. Enhanced Version Control Logic
Before: Auto mode always incremented patch version
After: Auto mode only publishes when transitioning from prerelease, otherwise skips latest publication,

3. Next Tag Publishing
New: Always publishes to next tag with format {version}-next.{patch} (Angular style)
Smart Incrementing: Tracks and increments next tag patch numbers automatically

4. Comprehensive Logging
Enhanced: Detailed console output with visual summaries, step-by-step calculations, and publishing status
Improved: Clear indicators for what will/won't be published and why

📋 Publishing Behavior Examples:

1. Scenario 1: Alpha/Beta to Stable

Current State:
  latest: ❌ none
  beta: 1.2.3-alpha.1
  next: ❌ none

Action: version-type: auto (default)

Result:
  ✅ latest: 1.0.0 (PUBLISHED)
  ✅ next: 1.0.0-next.1 (PUBLISHED)

Reason: First stable release from prerelease

2. Stable version with auto mode
Current State:
  latest: 1.0.0
  next: 1.0.0-next.1

Action: version-type: auto (default)

Result:
  🚫 latest: 1.0.0 (NOT PUBLISHED - no version change)
  ✅ next: 1.0.0-next.2 (PUBLISHED)

Reason: Auto mode doesn't increment stable versions


This PR fixes: #32327