### PR TITLE
fix(Content Types): Visual indication for variable value copied missing

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.html
@@ -1,12 +1,17 @@
 <button
+    #copyButton
     (click)="copyUrlToClipboard($event)"
     [class]="$clazz()"
     [label]="label()"
-    [pTooltip]="$tooltipText()"
+    [pTooltip]="tooltipContent"
     appendTo="body"
-    hideDelay="800"
+    hideDelay="1000"
     icon="pi pi-copy"
     pButton
     tooltipPosition="bottom"
     data-testid="copy-to-clipboard"
     type="button"></button>
+
+<ng-template #tooltipContent>
+    <span>{{ $tooltipText() }}</span>
+</ng-template>

--- a/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.html
@@ -5,7 +5,7 @@
     [label]="label()"
     [pTooltip]="tooltipContent"
     appendTo="body"
-    hideDelay="1000"
+    hideDelay="800"
     icon="pi pi-copy"
     pButton
     tooltipPosition="bottom"
@@ -13,5 +13,5 @@
     type="button"></button>
 
 <ng-template #tooltipContent>
-    <span>{{ $tooltipText() }}</span>
+    <span data-testid="tooltip-content">{{ $tooltipText() }}</span>
 </ng-template>

--- a/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.spec.ts
@@ -72,7 +72,7 @@ describe('DotCopyButtonComponent', () => {
         it('should have pTooltip attributes', () => {
             expect(button.attributes.appendTo).toEqual('body');
             expect(button.attributes.tooltipPosition).toEqual('bottom');
-            // expect(button.attributes.hideDelay).toEqual('800');
+            expect(button.attributes.hideDelay).toEqual('800');
         });
 
         it('should copy text to clipboard', () => {
@@ -99,7 +99,7 @@ describe('DotCopyButtonComponent', () => {
             nativeButton.dispatchEvent(new Event('mouseenter'));
             fixture.detectChanges();
 
-            tick(100); // Give time for tooltip to render
+            tick(100);
             fixture.detectChanges();
 
             const tooltipElement = document.querySelector('[data-testid="tooltip-content"]');
@@ -111,19 +111,16 @@ describe('DotCopyButtonComponent', () => {
         it('should show "Copied" in tooltip after clicking the button', fakeAsync(() => {
             const nativeButton = button.nativeElement;
 
-            // 1. Hover to show the tooltip
             nativeButton.dispatchEvent(new Event('mouseenter'));
             fixture.detectChanges();
-            tick(100); // Give time for tooltip to render
+            tick(100);
             fixture.detectChanges();
 
-            // 2. Click the button to trigger copy and update tooltip
             nativeButton.dispatchEvent(new Event('click'));
             fixture.detectChanges();
-            tick(100); // Give time for promise resolution and tooltip update
+            tick(100);
             fixture.detectChanges();
 
-            // 3. Assert tooltip content is "Copied"
             const tooltipElement = document.querySelector('[data-testid="tooltip-content"]');
             expect(tooltipElement).toBeTruthy();
             expect(tooltipElement.textContent.trim()).toBe('Copied');

--- a/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.ts
@@ -67,8 +67,13 @@ export class DotCopyButtonComponent {
 
         this.dotClipboardUtil
             .copy(this.copy())
-            .then(() => this.$tempTooltipText.set(this.dotMessageService.get('Copied')))
-            .catch(() => this.$tempTooltipText.set('Error'))
-            .finally(() => setTimeout(() => this.$tempTooltipText.set(''), 1000));
+            .then(() => {
+                this.$tempTooltipText.set(this.dotMessageService.get('Copied'));
+                setTimeout(() => this.$tempTooltipText.set(''), 1000);
+            })
+            .catch((error) => {
+                this.$tempTooltipText.set('Error');
+                console.error('[DotCopyButtonComponent] Error copying to clipboard: ', error);
+            });
     }
 }

--- a/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-copy-button/dot-copy-button.component.ts
@@ -67,15 +67,8 @@ export class DotCopyButtonComponent {
 
         this.dotClipboardUtil
             .copy(this.copy())
-            .then(() => {
-                this.$tempTooltipText.set(this.dotMessageService.get('Copied'));
-
-                setTimeout(() => {
-                    this.$tempTooltipText.set('');
-                }, 1000);
-            })
-            .catch(() => {
-                this.$tempTooltipText.set('Error');
-            });
+            .then(() => this.$tempTooltipText.set(this.dotMessageService.get('Copied')))
+            .catch(() => this.$tempTooltipText.set('Error'))
+            .finally(() => setTimeout(() => this.$tempTooltipText.set(''), 1000));
     }
 }


### PR DESCRIPTION
### Video

https://github.com/user-attachments/assets/66b8a7e5-5ce5-455c-b8b6-f89550cb9dac


This PR fixes: #32550