### PR TITLE
chore(docs): Add build time opanapi.yaml creation (#32606)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,6 @@
 package-lock.json -diff
 *.bat             text eol=crlf
 *.cmd             text eol=crlf
+
+# Generated OpenAPI file - always use "ours" and let pre-commit hook regenerate
+dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml merge=ours

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -16,7 +16,7 @@
         <flatten.mode>bom</flatten.mode>
         <aws-java-sdk.version>1.12.488</aws-java-sdk.version>
         <twelvemonkeys.version>3.10.1</twelvemonkeys.version>
-        <swagger.version>2.2.0</swagger.version>
+        <swagger.version>2.2.34</swagger.version>
         <bytebuddy.version>1.14.15</bytebuddy.version>
         <batik.version>1.17</batik.version>
         <bouncy-castle.version>1.70</bouncy-castle.version>

--- a/core-web/.husky/pre-commit
+++ b/core-web/.husky/pre-commit
@@ -22,7 +22,7 @@ print_color() {
 
 # Source husky script
 . "$(dirname "$0")/_/husky.sh" || {
-    print_color "$RED" "Failed to source husky.sh"
+    print_color "$RED" "❌ Failed to source husky.sh"
     exit 1
 }
 
@@ -33,13 +33,13 @@ root_dir="$(git rev-parse --show-toplevel)"
 setup_nvm() {
     # Check if nvm is already installed
     if [ -s "$NVM_DIR/nvm.sh" ]; then
-        print_color "$GREEN" "nvm is already installed."
+        print_color "$GREEN" "✅ nvm is already installed."
     else
-        print_color "$YELLOW" "Installing nvm..."
+        print_color "$YELLOW" "📦 Installing nvm..."
         # Use the project's Node.js to download and run the nvm install script
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 
-        print_color "$GREEN" "nvm installed successfully."
+        print_color "$GREEN" "✅ nvm installed successfully."
     fi
 
     # Source nvm
@@ -48,24 +48,24 @@ setup_nvm() {
 
     # Ensure the correct Node.js version is used
     if [ -f "$root_dir/.nvmrc" ]; then
-        print_color "$BLUE" "Using Node.js version specified in .nvmrc"
+        print_color "$BLUE" "📋 Using Node.js version specified in .nvmrc"
 
         nvm install
     else
-        print_color "$YELLOW" "No .nvmrc found. Using default Node.js version."
+        print_color "$YELLOW" "⚠️ No .nvmrc found. Using default Node.js version."
         nvm use default
     fi
 }
 
 check_sdk_client_affected() {
     local affected_projects=$(npx nx show projects --affected)
-    printf "Affected projects: %s\n" "$affected_projects"
+    print_color "$BLUE" "📋 Affected projects: $affected_projects"
 
     # Build sdk-client if affected
     if echo "$affected_projects" | grep -q "sdk-uve"; then
-        printf "Building sdk-client\n"
+        print_color "$BLUE" "🔨 Building sdk-client"
         if ! yarn nx run sdk-uve:build:js; then
-            print_color "$RED" "Failed to build sdk-client"
+            print_color "$RED" "❌ Failed to build sdk-client"
             has_errors=true
         fi
     fi
@@ -75,13 +75,13 @@ check_sdk_client_affected() {
     # Check if the file exists, then delete it
     if [ -f "$file_to_remove" ]; then
         rm "$file_to_remove"
-        printf "Removed %s\n" "$file_to_remove"
+        print_color "$GREEN" "🗑️ Removed ${file_to_remove}"
     else
-        printf "%s does not exist\n" "$file_to_remove"
+        print_color "$BLUE" "ℹ️ ${file_to_remove} does not exist"
     fi
 
     if ! git add "${root_dir}/dotCMS/src/main/webapp/ext/uve/dot-uve.js"; then
-        print_color "$RED" "Failed to stage computed dot-uve.js"
+        print_color "$RED" "❌ Failed to stage computed dot-uve.js"
         exit 1
     fi
 }
@@ -92,18 +92,18 @@ check_sdkman() {
     # Check if sdkman-init.sh exists and is readable
     if [ -s "$SDKMAN_INIT" ]; then
         source "$SDKMAN_INIT" # Source sdkman to make sdk command available
-        print_color "$GREEN" "SDKMAN! sourced from $SDKMAN_INIT"
+        print_color "$GREEN" "✅ SDKMAN! sourced from $SDKMAN_INIT"
 
         # Optionally check if sdk command is available
         if command -v sdk >/dev/null 2>&1; then
-            print_color "$GREEN" "SDKMAN! is installed and functional."
+            print_color "$GREEN" "✅ SDKMAN! is installed and functional."
         else
-            print_color "$RED" "SDKMAN! command is not available. Please check the installation."
+            print_color "$RED" "❌ SDKMAN! command is not available. Please check the installation."
             exit 1
         fi
     else
-        print_color "$RED" "SDKMAN! not found at $SDKMAN_INIT. Please install SDKMAN! first."
-        print_color "$RED" "You can install this and other required utilities from https://github.com/dotCMS/dotcms-utilities"
+        print_color "$RED" "❌ SDKMAN! not found at $SDKMAN_INIT. Please install SDKMAN! first."
+        print_color "$RED" "💡 You can install this and other required utilities from https://github.com/dotCMS/dotcms-utilities"
         exit 1
     fi
 }
@@ -118,12 +118,12 @@ perform_frontend_fixes() {
 
     # Check if yarn.lock is present
     if ! yarn install; then
-        print_color "$RED" "Failed to install dependencies with yarn install"
-        print_color "$YELLOW" "Please run 'yarn install' to update the lockfile and make sure you commit this with any package.json changes."
+        print_color "$RED" "❌ Failed to install dependencies with yarn install"
+        print_color "$YELLOW" "💡 Please run 'yarn install' to update the lockfile and make sure you commit this with any package.json changes."
         has_errors=true
         return 1
     else
-        printf "Completed yarn install adding yarn.lock if it was modified\n"
+        print_color "$GREEN" "✅ Completed yarn install adding yarn.lock if it was modified"
         git add "${root_dir}/core-web/yarn.lock"
     fi
 
@@ -153,14 +153,14 @@ perform_frontend_fixes() {
 
         if [ ${#unmatched_files[@]} -ne 0 ]; then
             printf "===================================\n"
-            print_color "$YELLOW" "Warning: The following unrelated files in the affected modules should be linted and/or formatted"
+            print_color "$YELLOW" "⚠️ Warning: The following unrelated files in the affected modules should be linted and/or formatted"
             printf "\n"
             for file in "${unmatched_files[@]}"; do
                 printf "    %s\n" "${file}"
                 git restore "${file}"
             done
             printf "\n"
-            print_color "$YELLOW" "You can fix these files by running the following commands:"
+            print_color "$YELLOW" "💡 You can fix these files by running the following commands:"
             printf "nx affected -t lint --exclude='tag:skip:lint' --fix=true\n"
             printf "nx format:write;\n"
         fi
@@ -169,7 +169,7 @@ perform_frontend_fixes() {
 
 restore_untracked_files() {
     if [ "$backup_untracked" = true ] && [ -n "${untracked_files}" ] && [ "$(ls -A "${temp_dir}")" ]; then
-        printf "Restoring untracked files...\n"
+        print_color "$BLUE" "🔄 Restoring untracked files..."
         # Copy each file back from the temporary directory while maintaining the directory structure
         find "${temp_dir}" -type f -exec sh -c '
             for file do
@@ -207,20 +207,112 @@ cd "${root_dir}" || exit 1
 
 check_sdkman
 
-printf "Setting up Java\n"
+print_color "$BLUE" "☕ Setting up Java environment..."
 sdk env install
-printf "Initializing Maven, Node, and Yarn versions\n"
+print_color "$BLUE" "🔧 Initializing Maven, Node, and Yarn versions..."
 # Output maven and java versions
 ./mvnw --version
 
-# Run a base validate on maven to ensure that the correct version of node and yarn are installed
-if ! ./mvnw validate -pl :dotcms-core --am -q; then
-    print_color "$RED" "Failed to run './mvnw validate -pl :dotcms-core --am'"
-    print_color "$YELLOW" "Please run the following command to see the detailed output:"
-    printf "./mvnw validate -pl :dotcms-core --am\n"
-    exit 1
+# Function to check if Maven is needed at all
+needs_maven() {
+    local staged_files=$(git diff --cached --name-only)
+
+    # Check if there are any non-core-web files or core-web/pom.xml
+    if echo "$staged_files" | grep -v "^core-web/" > /dev/null 2>&1; then
+        return 0  # Non-core-web files changed, Maven needed
+    fi
+
+    # Check if core-web/pom.xml is changed
+    if echo "$staged_files" | grep -E "^core-web/pom\.xml$" > /dev/null 2>&1; then
+        return 0  # core-web/pom.xml changed, Maven needed
+    fi
+
+    return 1  # Only core-web files (excluding pom.xml) changed, no Maven needed
+}
+
+# Function to check if OpenAPI generation is needed
+needs_openapi_compile() {
+    local openapi_file="${root_dir}/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml"
+    local staged_files=$(git diff --cached --name-only)
+
+    # Check if any REST API related files are staged
+    local rest_files_changed=false
+
+    # Check for changes in OpenAPI configuration files
+    if echo "$staged_files" | grep -E "(DotRestApplication\.java)" > /dev/null 2>&1; then
+        rest_files_changed=true
+    fi
+
+    # Check for changes in any @Path annotated files
+    if echo "$staged_files" | grep -E "\.java$" > /dev/null 2>&1; then
+        # Check if any staged Java files contain REST annotations
+        local java_files=$(echo "$staged_files" | grep "\.java$")
+        for file in $java_files; do
+            if [ -f "${root_dir}/${file}" ] && grep -E "@Path|@GET|@POST|@PUT|@DELETE|@OpenAPIDefinition|@Tag|@Operation" "${root_dir}/${file}" > /dev/null 2>&1; then
+                rest_files_changed=true
+                break
+            fi
+        done
+    fi
+
+    # If no REST files changed, no compile needed
+    if [ "$rest_files_changed" = false ]; then
+        return 1
+    fi
+
+    # If OpenAPI file doesn't exist, compile is needed
+    if [ ! -f "$openapi_file" ]; then
+        return 0
+    fi
+
+    # If REST files changed, compile is needed
+    return 0
+}
+
+print_color "$BLUE" "🔍 Analyzing staged files to determine required build steps..."
+
+# Check if Maven is needed at all
+if needs_maven; then
+    # Maven is needed, determine if we need compile or just validate
+    if needs_openapi_compile; then
+        print_color "$YELLOW" "🔄 REST API files detected - running compile to update OpenAPI specification"
+        if ! ./mvnw compile -pl :dotcms-core --am -q; then
+            print_color "$RED" "❌ Failed to run './mvnw compile -pl :dotcms-core --am'"
+            print_color "$YELLOW" "💡 Please run the following command to see the detailed output:"
+            printf "./mvnw compile -pl :dotcms-core --am\n"
+            exit 1
+        else
+            print_color "$GREEN" "✅ Completed Maven compile with OpenAPI generation"
+            # Stage the updated OpenAPI file if it was regenerated
+            if [ -f "${root_dir}/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml" ]; then
+                git add "${root_dir}/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml"
+                print_color "$GREEN" "📋 Updated OpenAPI specification staged for commit"
+            fi
+        fi
+    else
+        print_color "$GREEN" "⚡ No REST API changes detected - running validation only"
+        # Run lightweight validation to ensure Maven/Node/Yarn are available
+        if ! ./mvnw validate -pl :dotcms-core --am -q; then
+            print_color "$RED" "❌ Failed to run './mvnw validate -pl :dotcms-core --am'"
+            print_color "$YELLOW" "💡 Please run the following command to see the detailed output:"
+            printf "./mvnw validate -pl :dotcms-core --am\n"
+            exit 1
+        else
+            print_color "$GREEN" "✅ Completed Maven validation"
+        fi
+    fi
 else
-    printf "Completed Maven init\n"
+    print_color "$GREEN" "🚀 Only core-web files changed (excluding pom.xml) - skipping Maven entirely"
+    # Still need to setup basic paths for Node/Yarn, but skip Maven validation
+    # Create minimal node/yarn setup without Maven
+    if [ ! -d "${root_dir}/installs/node" ]; then
+        print_color "$YELLOW" "📦 Node.js not found in project directory. Running minimal Maven setup..."
+        # Run minimal Maven setup only to get Node/Yarn installed
+        if ! ./mvnw validate -pl :dotcms-core --am -q; then
+            print_color "$RED" "❌ Failed to run './mvnw validate -pl :dotcms-core --am'"
+            exit 1
+        fi
+    fi
 fi
 
 # Update PATH to include project-specific Node.js and Yarn
@@ -228,8 +320,8 @@ export PATH="${root_dir}/installs/node:${root_dir}/installs/node/yarn/dist/bin:$
 
 # Verify that node and yarn are accessible
 if ! command -v node > /dev/null 2>&1 || ! command -v yarn > /dev/null 2>&1; then
-    print_color "$RED" "Error: Node.js or Yarn not found in the project directory."
-    print_color "$YELLOW" "Please ensure they are installed in ${root_dir}/installs/node"
+    print_color "$RED" "❌ Error: Node.js or Yarn not found in the project directory."
+    print_color "$YELLOW" "💡 Please ensure they are installed in ${root_dir}/installs/node"
     exit 1
 fi
 
@@ -238,8 +330,8 @@ fi
 setup_nvm
 
 # Log the versions being used
-printf "Using Node version: %s\n" "$(node --version)"
-printf "Using Yarn version: %s\n" "$(yarn --version)"
+print_color "$BLUE" "📋 Using Node version: $(node --version)"
+print_color "$BLUE" "📋 Using Yarn version: $(yarn --version)"
 
 core_web_dir="${root_dir}/core-web"
 cd "${core_web_dir}" || exit 1
@@ -263,16 +355,16 @@ printf "%s\n" "${core_web_files_staged}"
 if [ "$backup_untracked" = true ] && [ -n "${untracked_files}" ]; then
     temp_dir=$(mktemp -d)
     if [ ! -d "${temp_dir}" ]; then
-        print_color "$RED" "Failed to create temporary directory."
+        print_color "$RED" "❌ Failed to create temporary directory."
         exit 1
     fi
-    printf "Created temporary directory %s\n" "${temp_dir}"
+    print_color "$BLUE" "📁 Created temporary directory ${temp_dir}"
 
     for file in $untracked_files; do
         if echo "${staged_files}" | grep -q "^${file}$"; then
             mkdir -p "${temp_dir}/$(dirname "${file}")"  # Ensure the directory structure exists in the temp directory
             cp "${root_dir}/${file}" "${temp_dir}/${file}"  # Copy the file to the temp directory, preserving the directory structure
-            printf "Backing up %s to %s\n" "${file}" "${temp_dir}/${file}"
+            print_color "$BLUE" "💾 Backing up ${file}"
             # Restore the original file state in the repo, removing unstaged changes
             git restore "${root_dir}/${file}"  # Using relative path relative to current directory
         fi
@@ -287,7 +379,7 @@ if [ "$backup_untracked" = true ] && [ -n "${untracked_files}" ]; then
             fi
     done
 
-    printf "Backed up workspace to %s\n" "${temp_dir}"
+    print_color "$GREEN" "✅ Backed up workspace to ${temp_dir}"
 fi
 
 # Run fixes on staged files
@@ -313,9 +405,9 @@ cd "${original_pwd}" || exit 1  # Exit if the directory does not exist
 
 # Final check before exiting
 if [ "$has_errors" = true ]; then
-    print_color "$RED" "Checks failed. Force commit with --no-verify option if bypass required."
+    print_color "$RED" "❌ Checks failed. Force commit with --no-verify option if bypass required."
     exit 1  # Change the exit code to reflect that an error occurred
 else
-    print_color "$GREEN" "Commit checks completed successfully."
+    print_color "$GREEN" "🎉 Commit checks completed successfully."
     exit 0  # No errors, exit normally
 fi

--- a/core-web/.husky/pre-commit
+++ b/core-web/.husky/pre-commit
@@ -246,13 +246,31 @@ needs_openapi_compile() {
     # Check for changes in any @Path annotated files
     if echo "$staged_files" | grep -E "\.java$" > /dev/null 2>&1; then
         # Check if any staged Java files contain REST annotations
-        local java_files=$(echo "$staged_files" | grep "\.java$")
-        for file in $java_files; do
-            if [ -f "${root_dir}/${file}" ] && grep -E "@Path|@GET|@POST|@PUT|@DELETE|@OpenAPIDefinition|@Tag|@Operation" "${root_dir}/${file}" > /dev/null 2>&1; then
-                rest_files_changed=true
-                break
+        # Use macOS-compatible approach to handle files with spaces and special characters
+        local java_files_list
+        java_files_list=$(echo "$staged_files" | grep "\.java$")
+        
+        # Use a more portable approach for iterating over filenames
+        local IFS=$'\n'
+        for file in $java_files_list; do
+            # Check if file exists (for modified files) or if it's a deleted file containing REST annotations
+            if [ -f "${root_dir}/${file}" ]; then
+                # File exists, check for REST annotations
+                if grep -E "@Path|@GET|@POST|@PUT|@DELETE|@OpenAPIDefinition|@Tag|@Operation" "${root_dir}/${file}" > /dev/null 2>&1; then
+                    rest_files_changed=true
+                    break
+                fi
+            else
+                # File was deleted, check git show for REST annotations in the deleted content
+                if git show "HEAD:${file}" 2>/dev/null | grep -E "@Path|@GET|@POST|@PUT|@DELETE|@OpenAPIDefinition|@Tag|@Operation" > /dev/null 2>&1; then
+                    rest_files_changed=true
+                    break
+                fi
             fi
         done
+        
+        # Restore IFS to default
+        unset IFS
     fi
 
     # If no REST files changed, no compile needed

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -1968,6 +1968,39 @@
                     </execution>
                 </executions>
             </plugin>
+            
+            <!-- OpenAPI/Swagger documentation generation -->
+            <plugin>
+                <groupId>io.swagger.core.v3</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <configuration>
+                    <outputFileName>openapi</outputFileName>
+                    <!--<outputPath>${project.build.directory}/generated-resources/openapi</outputPath>-->
+                    <outputPath>${project.basedir}/src/main/webapp/WEB-INF/openapi</outputPath>
+                    <outputFormat>YAML</outputFormat>
+                    <prettyPrint>true</prettyPrint>
+                    <!-- Enable sorting for consistent output -->
+                    <sortOutput>true</sortOutput>
+                    <!-- Scan all dotCMS packages to extract @OpenAPIDefinition -->
+                    <resourcePackages>
+                        <package>com.dotcms.rest.config</package>
+                        <package>com.dotcms.rest</package>
+                        <package>com.dotcms.contenttype.model.field</package>
+                        <package>com.dotcms.rendering.js</package>
+                        <package>com.dotcms.ai.rest</package>
+                        <package>com.dotcms.health</package>
+                    </resourcePackages>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-openapi</id>
+                        <goals>
+                            <goal>resolve</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -8073,6 +8073,7 @@ paths:
       responses:
         default:
           content:
+            application/javascript: {}
             application/json: {}
           description: default response
       tags:

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -1,0 +1,25423 @@
+openapi: 3.0.1
+info:
+  title: dotCMS REST API
+  version: "3"
+servers:
+- description: dotCMS Server
+  url: /
+tags:
+- description: AI-powered content generation and analysis endpoints
+  name: AI
+- description: Content type field definitions and configuration
+  name: Content Type Field
+- description: JavaScript execution and server-side scripting
+  name: JavaScript
+- description: Content bundle management and deployment
+  name: Bundle
+- description: Data integrity checking and conflict resolution
+  name: Data Integrity
+- description: Content type definitions and schema management
+  name: Content Type
+- description: Content tagging and labeling
+  name: Tags
+- description: Endpoints that perform operations related to validating accessibility
+    in content.
+  name: Accessibility Checker
+- description: This REST Endpoint exposes information related to how dotCMS content
+    is accessed and interacted with by users.
+  name: Content Analytics
+- description: System announcements and notifications
+  name: Announcements
+- description: Third-party application integration and configuration
+  name: Apps
+- description: Endpoints that handle operations related to API tokens
+  externalDocs:
+    description: Additional API token information
+    url: https://www.dotcms.com/docs/latest/rest-api-authentication#APIToken
+  name: API Token
+- description: Endpoints that perform operations related to user authentication
+  externalDocs:
+    description: Additional Authentication API information
+    url: https://www.dotcms.com/docs/latest/rest-api-authentication
+  name: Authentication
+- description: File and folder browser tree operations
+  name: Browser Tree
+- description: Content categorization and taxonomy
+  name: Categories
+- description: Endpoints for managing Container objects and their content
+  name: Containers
+- description: Endpoints for managing content and contentlets
+  name: Content
+- description: Endpoints for managing folder structure and organization
+  name: Folders
+- description: Form management and processing
+  name: Forms
+- description: Health management and monitoring endpoints for administrative dashboards
+  name: Health
+- description: Elasticsearch index management and operations
+  name: Search Index
+- description: Endpoints for managing background jobs and job queues
+  name: Job Queue
+- description: System maintenance and administration operations
+  name: Maintenance
+- description: Endpoints that operate on pages
+  externalDocs:
+    description: Additional Page API information
+    url: https://www.dotcms.com/docs/latest/page-rest-api-layout-as-a-service-laas
+  name: Page
+- description: Content relationship management
+  name: Relationships
+- description: Endpoints for managing sites (hosts) and their configuration
+  name: Sites
+- description: System configuration and company settings
+  name: System Configuration
+- description: Cache provider management and operations
+  name: Cache Management
+- description: System logging configuration and management
+  name: System Logging
+- description: System monitoring and health checks
+  name: System Monitoring
+- description: Permission management and access control
+  name: Permissions
+- description: User role and permission management
+  name: Roles
+- description: Endpoints for managing page templates and layouts
+  name: Templates
+- description: "Endpoints for managing user accounts, authentication, and user-related\
+    \ operations"
+  name: Users
+- description: Endpoints for managing content variants
+  name: Variants
+- description: Endpoints that perform operations related to workflows.
+  externalDocs:
+    description: Additional Workflow API information
+    url: https://www.dotcms.com/docs/latest/workflow-rest-api
+  name: Workflow
+- description: System administration and management tools
+  name: Administration
+- description: Cluster nodes and distributed system management
+  name: Cluster Management
+- description: Content delivery and rendering
+  name: Content Delivery
+- description: Content reporting and analytics
+  name: Content Report
+- description: Publishing environment management and configuration
+  name: Environment
+- description: A/B testing and experimentation
+  name: Experiment
+- description: File asset management and download operations
+  name: File Assets
+- description: Language management and localization
+  name: Internationalization
+- description: License management and validation
+  name: License
+- description: Site navigation and menu management
+  name: Navigation
+- description: User notifications and alerts management
+  name: Notifications
+- description: OSGi plugin management and dynamic deployment
+  name: OSGi Plugins
+- description: Content personalization and persona management
+  name: Personalization
+- description: Portlet management and administration
+  name: Portlets
+- description: Content publishing and deployment operations
+  name: Publishing
+- description: Business rules and conditional logic management
+  name: Rules Engine
+- description: SAML SSO authentication and integration
+  name: SAML Authentication
+- description: Content search and query operations
+  name: Search
+- description: Storage providers and data replication management
+  name: System Storage
+- description: Temporary file upload and management operations
+  name: Temporary Files
+- description: Widget development and rendering
+  name: Widgets
+paths:
+  /auditPublishing/get/{bundleId}:
+    get:
+      operationId: get_2
+      parameters:
+      - in: path
+        name: bundleId
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/xml: {}
+          description: default response
+      tags:
+      - Publishing
+  /bundle:
+    post:
+      operationId: uploadBundleAsync
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/_download/{bundleId}:
+    get:
+      operationId: downloadBundle
+      parameters:
+      - in: path
+        name: bundleId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/_generate:
+    post:
+      operationId: generateBundle
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GenerateBundleForm"
+      responses:
+        default:
+          content:
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/all:
+    delete:
+      operationId: deleteAll
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/all/fail:
+    delete:
+      operationId: deleteAllFail
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/all/success:
+    delete:
+      operationId: deleteAllSuccess
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/deleteenvironmentpushhistory/{params}:
+    get:
+      operationId: deleteEnvironmentPushHistory
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/deletepushhistory/{params}:
+    get:
+      operationId: deletePushHistory
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/getunsendbundles/{params}:
+    get:
+      operationId: getUnsendBundles
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/ids:
+    delete:
+      operationId: deleteBundlesByIdentifiers
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/DeleteBundlesByIdentifierForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/olderthan/{olderThan}:
+    delete:
+      operationId: deleteBundlesOlderThan
+      parameters:
+      - in: path
+        name: olderThan
+        required: true
+        schema:
+          type: string
+          format: date-time
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/sync:
+    post:
+      operationId: uploadBundleSync
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/updatebundle/{params}:
+    get:
+      operationId: updateBundle
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/{bundleId}/assets:
+    get:
+      operationId: getPublishQueueElements
+      parameters:
+      - in: path
+        name: bundleId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          format: int32
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundle/{bundleId}/manifest:
+    get:
+      operationId: downloadManifest
+      parameters:
+      - in: path
+        name: bundleId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Bundle
+  /bundlePublisher/publish:
+    post:
+      operationId: publish
+      parameters:
+      - in: query
+        name: type
+        schema:
+          type: string
+      - in: query
+        name: callback
+        schema:
+          type: string
+      - in: query
+        name: FORCE_PUSH
+        schema:
+          type: boolean
+      - in: query
+        name: filterkey
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Bundle
+  /cluster/getESConfigProperties/{params}:
+    get:
+      operationId: getESConfigProperties
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Cluster Management
+  /cluster/getNodesStatus/{params}:
+    get:
+      operationId: getNodesInfo
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Cluster Management
+  /cluster/licenseRepoStatus:
+    get:
+      operationId: getLicenseRepoStatus
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Cluster Management
+  /cluster/remove/{params}:
+    post:
+      operationId: removeFromCluster
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Cluster Management
+  /cluster/test:
+    get:
+      operationId: testCluster
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Cluster Management
+  /config/deleteEndpoint:
+    post:
+      deprecated: true
+      operationId: deleteEndpoint
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                callback:
+                  type: string
+                endPoint:
+                  type: string
+                password:
+                  type: string
+                type:
+                  type: string
+                user:
+                  type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+  /config/deleteEnvironment:
+    post:
+      operationId: deleteEnvironment
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                callback:
+                  type: string
+                environment:
+                  type: string
+                password:
+                  type: string
+                type:
+                  type: string
+                user:
+                  type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+  /config/regenerateKey:
+    post:
+      operationId: regenerateKey
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+  /config/saveCompanyAuthTypeInfo:
+    post:
+      operationId: saveCompanyAuthTypeInfo
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                authType:
+                  type: string
+                password:
+                  type: string
+                user:
+                  type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+  /config/saveCompanyBasicInfo:
+    post:
+      operationId: saveCompanyBasicInfo
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                city:
+                  type: string
+                emailAddress:
+                  type: string
+                homeURL:
+                  type: string
+                mx:
+                  type: string
+                password:
+                  type: string
+                portalURL:
+                  type: string
+                size:
+                  type: string
+                state:
+                  type: string
+                street:
+                  type: string
+                type:
+                  type: string
+                user:
+                  type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+  /config/saveCompanyLocaleInfo:
+    post:
+      operationId: saveCompanyLocaleInfo
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                languageId:
+                  type: string
+                password:
+                  type: string
+                timeZoneId:
+                  type: string
+                user:
+                  type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+  /config/saveCompanyLogo:
+    post:
+      deprecated: true
+      operationId: saveCompanyLogo
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                logoFile:
+                  $ref: "#/components/schemas/FormDataContentDisposition"
+                password:
+                  type: string
+                user:
+                  type: string
+      responses:
+        default:
+          content:
+            text/html: {}
+          description: default response
+      tags:
+      - System Configuration
+  /content/_search:
+    post:
+      operationId: search
+      parameters:
+      - in: query
+        name: rememberQuery
+        schema:
+          type: boolean
+          default: false
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SearchForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Content Delivery
+  /content/canLock/{params}:
+    put:
+      deprecated: true
+      operationId: canLockContent
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Content Delivery
+  /content/indexcount/{query}:
+    get:
+      operationId: indexCount_1
+      parameters:
+      - in: path
+        name: query
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: callback
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            text/plain: {}
+          description: default response
+      tags:
+      - Content Delivery
+  /content/indexsearch/{query}/sortby/{sortby}/limit/{limit}/offset/{offset}:
+    get:
+      operationId: indexSearch
+      parameters:
+      - in: path
+        name: query
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: sortby
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: limit
+        required: true
+        schema:
+          type: integer
+          format: int32
+      - in: path
+        name: offset
+        required: true
+        schema:
+          type: integer
+          format: int32
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: callback
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Content Delivery
+  /content/lock/{params}:
+    put:
+      deprecated: true
+      operationId: lockContent
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Content Delivery
+  /content/unlock/{params}:
+    put:
+      deprecated: true
+      operationId: unlockContent
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Content Delivery
+  /content/{params}:
+    get:
+      operationId: getContent
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Content Delivery
+    post:
+      deprecated: true
+      operationId: singlePOST
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Content Delivery
+    put:
+      deprecated: true
+      operationId: singlePUT
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Content Delivery
+  /environment:
+    get:
+      operationId: loadAllEnvironments
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityEnvironmentsView"
+          description: Collection of environments.
+      summary: Returns the environments
+      tags:
+      - Environment
+    post:
+      operationId: create_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/EnvironmentForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityEnvironmentView"
+          description: If creation is successfully.
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: If the environment already exits
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenException"
+          description: "If the user is not an admin or access to the configuration\
+            \ layout or does have permission, it will return a 403."
+      summary: Creates an environment
+      tags:
+      - Environment
+  /environment/loadenvironments/{params}:
+    get:
+      operationId: loadEnvironments
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Environment
+  /environment/{id}:
+    delete:
+      operationId: delete_4
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+          description: If deletion is successfully environment.
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenException"
+          description: "If the user is not an admin or access to the configuration\
+            \ layout or does have permission, it will return a 403."
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DoesNotExistException"
+          description: If the environment does not exits
+      summary: Deletes an environment
+      tags:
+      - Environment
+    put:
+      operationId: update_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/EnvironmentForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityEnvironmentView"
+          description: If update is success.
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: If the environment already exits
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenException"
+          description: "If the user is not an admin or access to the configuration\
+            \ layout or does have permission, it will return a 403."
+      summary: Updates an environment
+      tags:
+      - Environment
+  /es/layout/{params}:
+    get:
+      operationId: getLayout_3
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/html: {}
+          description: default response
+      tags:
+      - Search
+  /es/raw:
+    get:
+      operationId: searchRawGet
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search
+    post:
+      operationId: searchRaw
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search
+  /es/search:
+    get:
+      operationId: search_2
+      parameters:
+      - in: query
+        name: depth
+        schema:
+          type: string
+      - in: query
+        name: live
+        schema:
+          type: boolean
+      - in: query
+        name: allCategoriesInfo
+        schema:
+          type: boolean
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search
+    post:
+      operationId: searchPost
+      parameters:
+      - in: query
+        name: depth
+        schema:
+          type: string
+      - in: query
+        name: live
+        schema:
+          type: boolean
+      - in: query
+        name: allCategoriesInfo
+        schema:
+          type: boolean
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search
+  /integrity/_fixconflictsfromremote:
+    post:
+      operationId: fixConflictsFromRemote
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                DATA_TO_FIX:
+                  type: object
+                TYPE:
+                  type: string
+      responses:
+        default:
+          content:
+            text/plain: {}
+          description: default response
+      tags:
+      - Data Integrity
+  /integrity/_generateintegritydata:
+    post:
+      operationId: generateIntegrityData
+      responses:
+        default:
+          content:
+            text/plain: {}
+          description: default response
+      tags:
+      - Data Integrity
+  /integrity/checkIntegrityProcessStatus/{params}:
+    get:
+      operationId: checkIntegrityProcessStatus
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Data Integrity
+  /integrity/checkintegrity/{params}:
+    get:
+      operationId: checkIntegrity
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Data Integrity
+  /integrity/discardconflicts/{params}:
+    get:
+      operationId: discardConflicts
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Data Integrity
+  /integrity/fixconflicts/{params}:
+    get:
+      operationId: fixConflicts
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Data Integrity
+  /integrity/getIntegrityResult/{params}:
+    get:
+      operationId: getIntegrityResult
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Data Integrity
+  /integrity/{requestId}/integrityData:
+    get:
+      operationId: getIntegrityData
+      parameters:
+      - in: path
+        name: requestId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/zip: {}
+          description: default response
+      tags:
+      - Data Integrity
+  /js/dynamic:
+    get:
+      operationId: dynamicGet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    post:
+      operationId: dynamicPost
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    put:
+      operationId: dynamicPut
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+  /js/dynamic/{pathParam}:
+    delete:
+      operationId: dynamicDelete
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    get:
+      operationId: dynamicGet_1
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    patch:
+      operationId: dynamicPatch
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    post:
+      operationId: dynamicPost_1
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    put:
+      operationId: dynamicPut_1
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+  /js/{folder}:
+    delete:
+      operationId: delete_1
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    get:
+      operationId: get
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    patch:
+      operationId: patchMultipart
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    post:
+      operationId: postMultipart
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    put:
+      operationId: putMultipart
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+  /js/{folder}/{pathParam}:
+    delete:
+      operationId: delete_2
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    get:
+      operationId: get_1
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    patch:
+      operationId: patchMultipart_1
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    post:
+      operationId: postMultipart_1
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+    put:
+      operationId: putMultipart_1
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - JavaScript
+  /license/all/{params}:
+    get:
+      operationId: getAll
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - License
+  /license/applyLicense:
+    post:
+      operationId: applyLicense
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: licenseText
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - License
+  /license/delete/{params}:
+    delete:
+      operationId: delete_5
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - License
+  /license/free/{params}:
+    post:
+      operationId: freeLicense
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - License
+  /license/pick/{params}:
+    post:
+      operationId: pickLicense
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - License
+  /license/requestCode/{params}:
+    post:
+      operationId: requestLicense
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - License
+  /license/resetLicense/{params}:
+    post:
+      operationId: resetLicense
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - License
+  /license/upload/{params}:
+    post:
+      operationId: putZipFile
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  $ref: "#/components/schemas/FormDataContentDisposition"
+                return:
+                  type: string
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - License
+  /osgi:
+    post:
+      deprecated: true
+      operationId: updateBundles
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - OSGi Plugins
+  /osgi/_processExports/{bundle}:
+    get:
+      deprecated: true
+      operationId: processBundle
+      parameters:
+      - in: path
+        name: bundle
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - OSGi Plugins
+  /osgi/getInstalledBundles/{params}:
+    get:
+      deprecated: true
+      operationId: getInstalledBundles
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - OSGi Plugins
+  /personas/layout/{params}:
+    get:
+      operationId: getLayout_4
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/html: {}
+          description: default response
+      tags:
+      - Personalization
+  /personas/sites/{id}:
+    get:
+      operationId: list_15
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/Persona"
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/Persona"
+          description: default response
+      tags:
+      - Personalization
+  /portlet/layout/{params}:
+    get:
+      operationId: getLayout
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/html: {}
+          description: default response
+      tags:
+      - Portlets
+  /portlet/{params}:
+    get:
+      operationId: layoutGet
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/html: {}
+          description: default response
+      tags:
+      - Portlets
+    post:
+      operationId: layoutPost
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/html: {}
+          description: default response
+      tags:
+      - Portlets
+  /restexample/layout/{params}:
+    get:
+      operationId: getLayout_1
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/html: {}
+          description: default response
+      tags:
+      - Administration
+  /restexample/test/{params}:
+    get:
+      operationId: loadJson
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Administration
+  /role/loadbyid/{params}:
+    get:
+      operationId: loadById
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+  /role/loadbyname/{params}:
+    get:
+      operationId: loadByName
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+  /role/loadchildren/{params}:
+    get:
+      operationId: loadChildren
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+  /rulesengine/layout/{params}:
+    get:
+      operationId: getLayout_2
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/html: {}
+          description: default response
+      tags:
+      - Rules Engine
+  /structure/{path}:
+    get:
+      operationId: getStructuresWithWYSIWYGFields
+      parameters:
+      - in: path
+        name: path
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: callback
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type
+  /testResource/testGet/{params}:
+    get:
+      operationId: getDocumentCount
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+  /testResource/testPost:
+    post:
+      operationId: saveTest
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                callback:
+                  type: string
+                param1:
+                  type: string
+                param2:
+                  type: string
+                password:
+                  type: string
+                type:
+                  type: string
+                user:
+                  type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+  /user/getloggedinuser/{params}:
+    get:
+      deprecated: true
+      operationId: getLoggedInUser
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Users
+  /util/encodeQueryParamValue/{params}:
+    get:
+      operationId: getLoggedInUser_1
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Administration
+  /v1/achecker/_validate:
+    post:
+      description: Validates the given content against the one or more Accessibility
+        Guidelines.
+      operationId: postValidateContent
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+              properties:
+                empty:
+                  type: boolean
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example: |-
+                {
+                    "entity": {
+                        "errors": [
+                            {
+                                "check": {
+                                    "check_id": 98,
+                                    "confidence": 2,
+                                    "confidenceEnum": "POTENTIAL",
+                                    "decision_fail": "Not all abbreviations are marked with the <code>abbr</code> element.",
+                                    "decision_pass": "All abbreviations are marked with the <code>abbr</code> element.",
+                                    "description": "If <code>body</code> element content is greater than 10 characters (English) this error will be generated.",
+                                    "err": "Abbreviations may not be marked with <code>abbr</code> element.",
+                                    "func": "return (BasicFunctions::getPlainTextLength() <= 10);",
+                                    "how_to_repair": "",
+                                    "html_tag": "body",
+                                    "lang": "en",
+                                    "long_description": null,
+                                    "name": "Abbreviations must be marked with <code>abbr</code> element.",
+                                    "note": "",
+                                    "open_to_public": 1,
+                                    "question": "Are there any abbreviations in the document that are not marked with the <code>abbr</code> element?",
+                                    "rationale": "_RATIONALE_98",
+                                    "repair_example": "",
+                                    "search_str": null,
+                                    "test_expected_result": "1. All abbreviations are expected to be marked with a valid <code>abbr</code> element.",
+                                    "test_failed_result": "1. Mark all abbreviations with a valid <code>abbr</code> element.",
+                                    "test_procedure": "1. Check the document for any text abbreviations.\\n2. If an abbreviation is found, check if it is properly marked with the <code>abbr</code> element.",
+                                    "user_id": 0
+                                },
+                                "col_number": 110,
+                                "cssCode": null,
+                                "htmlCode": "<body> Adventure travel done right  Wherever you want to go, whatever you want to get into, we’ve go...",
+                                "image": null,
+                                "imageAlt": null,
+                                "line_number": 0,
+                                "success": false
+                            },
+                            ...
+                            ...
+                        ],
+                        "lang": "en",
+                        "results": [
+                            {
+                                "check": {
+                                    "check_id": 29,
+                                    "confidence": 0,
+                                    "confidenceEnum": "KNOWN",
+                                    "decision_fail": "",
+                                    "decision_pass": "",
+                                    "description": "Each document must contain a valid <code>doctype</code> declaration.",
+                                    "err": "<code>doctype</code> declaration missing.",
+                                    "func": "return (BasicFunctions::getNumOfTagInWholeContent(\\\"doctype\\\") > 0);",
+                                    "how_to_repair": "Add a valid <code>doctype</code> declaration to the document.",
+                                    "html_tag": "html",
+                                    "lang": "en",
+                                    "long_description": null,
+                                    "name": "HTML content has a valid <code>doctype</code> declaration.",
+                                    "note": "",
+                                    "open_to_public": 1,
+                                    "question": "",
+                                    "rationale": "",
+                                    "repair_example": "",
+                                    "search_str": null,
+                                    "test_expected_result": "1. HTML content has a valid <code>doctype</code> declaration.",
+                                    "test_failed_result": "1. Add a valid <code>doctype</code> declaration to the document.",
+                                    "test_procedure": "1. Check for the presence of a <code>doctype</code> declaration at the start of the document.\\n2. Check the content of the <code>doctype</code> declaration.",
+                                    "user_id": 0
+                                },
+                                "col_number": 110,
+                                "cssCode": null,
+                                "htmlCode": "<html lang=\"en\" xml:lang=\"en\">     <body> Adventure travel done right  Wherever you want to go, what...",
+                                "image": null,
+                                "imageAlt": null,
+                                "line_number": 0,
+                                "success": true
+                            },
+                            ...
+                            ...
+                        ]
+                    },
+                    "errors": [],
+                    "i18nMessagesMap": {},
+                    "messages": [],
+                    "pagination": null,
+                    "permissions": []
+                }
+          description: Content validated successfully
+        "400":
+          description: Bad Request
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Validates content
+      tags:
+      - Accessibility Checker
+  /v1/achecker/guidelines:
+    get:
+      description: Returns the list of available Accessibility Guidelines that are
+        used to validate content.
+      operationId: getAccessibilityGuidelines
+      responses:
+        "200":
+          content:
+            application/json: {}
+          description: Guideline list retrieved successfully
+        "500":
+          description: Internal Server Error
+      summary: Retrieves Accessibility Guidelines
+      tags:
+      - Accessibility Checker
+  /v1/ai/completions:
+    post:
+      description: Creates AI-powered content summaries and completions based on provided
+        prompts. Supports both streaming and non-streaming responses.
+      operationId: summarizeFromContent
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CompletionsForm"
+        description: Completion form with prompt and configuration
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Completion generated successfully
+        "400":
+          description: Bad request - Missing or invalid prompt
+        "401":
+          description: Unauthorized - User not authenticated
+        "500":
+          description: Internal server error
+      summary: Generate AI completions from content
+      tags:
+      - AI
+  /v1/ai/completions/config:
+    get:
+      description: "Retrieves the current AI service configuration including available\
+        \ models, API settings, and host-specific configurations."
+      operationId: getAiConfig
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: Configuration retrieved successfully
+        "401":
+          description: Unauthorized - User not authenticated
+        "500":
+          description: Internal server error
+      summary: Get AI service configuration
+      tags:
+      - AI
+  /v1/ai/completions/rawPrompt:
+    post:
+      description: Processes raw prompts directly through the AI service without content
+        preprocessing. Supports both streaming and non-streaming responses.
+      operationId: rawPrompt
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CompletionsForm"
+        description: Completion form with raw prompt and configuration
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Raw completion generated successfully
+        "400":
+          description: Bad request - Missing or invalid prompt
+        "401":
+          description: Unauthorized - User not authenticated
+        "500":
+          description: Internal server error
+      summary: Generate AI completions from raw prompt
+      tags:
+      - AI
+  /v1/ai/embeddings:
+    delete:
+      operationId: delete
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+              properties:
+                asMap:
+                  type: object
+                  additionalProperties:
+                    type: object
+                empty:
+                  type: boolean
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+    post:
+      operationId: embed
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/EmbeddingsForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/embeddings/count:
+    get:
+      operationId: count_1
+      parameters:
+      - in: query
+        name: site
+        schema:
+          type: string
+      - in: query
+        name: contentType
+        schema:
+          type: string
+      - in: query
+        name: indexName
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
+      - in: query
+        name: identifier
+        schema:
+          type: string
+      - in: query
+        name: inode
+        schema:
+          type: string
+      - in: query
+        name: fieldVar
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+    post:
+      operationId: count
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CompletionsForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/embeddings/db:
+    delete:
+      operationId: dropAndRecreateTables
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+              properties:
+                asMap:
+                  type: object
+                  additionalProperties:
+                    type: object
+                empty:
+                  type: boolean
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/embeddings/indexCount:
+    get:
+      operationId: indexCount
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/embeddings/test:
+    get:
+      operationId: textResource
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/image/generate:
+    get:
+      operationId: indexByInode_1
+      parameters:
+      - in: query
+        name: prompt
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+    post:
+      operationId: handleImageRequest
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/AIImageRequestDTO"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/image/test:
+    get:
+      operationId: indexByInode
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/search:
+    get:
+      operationId: searchByGet
+      parameters:
+      - in: query
+        name: query
+        schema:
+          type: string
+      - in: query
+        name: searchLimit
+        schema:
+          type: integer
+          format: int32
+          default: 1000
+      - in: query
+        name: searchOffset
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - in: query
+        name: site
+        schema:
+          type: string
+      - in: query
+        name: contentType
+        schema:
+          type: string
+      - in: query
+        name: indexName
+        schema:
+          type: string
+          default: default
+      - in: query
+        name: threshold
+        schema:
+          type: number
+          format: float
+          default: 0.5
+      - in: query
+        name: stream
+        schema:
+          type: boolean
+          default: false
+      - in: query
+        name: responseLength
+        schema:
+          type: integer
+          format: int32
+          default: 1024
+      - in: query
+        name: operator
+        schema:
+          type: string
+          default: <=>
+      - in: query
+        name: language
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - AI
+    post:
+      operationId: searchByPost
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CompletionsForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/search/related:
+    get:
+      operationId: relatedByGet
+      parameters:
+      - in: query
+        name: language
+        schema:
+          type: integer
+          format: int64
+      - in: query
+        name: identifier
+        schema:
+          type: string
+      - in: query
+        name: inode
+        schema:
+          type: string
+      - in: query
+        name: indexName
+        schema:
+          type: string
+      - in: query
+        name: fieldVar
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+    post:
+      operationId: relatedByPost
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+              properties:
+                asMap:
+                  type: object
+                  additionalProperties:
+                    type: object
+                empty:
+                  type: boolean
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/search/test:
+    get:
+      operationId: testResponse
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/ai/text/generate:
+    get:
+      operationId: doGet
+      parameters:
+      - in: query
+        name: prompt
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+    post:
+      operationId: doPost
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CompletionsForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - AI
+  /v1/analytics/content:
+    post:
+      description: "Returns information of specific dotCMS objects whose health and\
+        \ engagement data is tracked, using Path Parameters instead of a CubeJS JSON\
+        \ query. This helps abstract the complexity of the underlying JSON format\
+        \ for users that need an easier way to query for specific data."
+      operationId: postContentAnalyticsSimpleQuery
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                measures: request.count request.totalSessions
+                dimensions: request.host request.whatAmI request.url
+                timeDimensions: request.createdAt:day:Last month
+                filters: "request.totalRequest gt 0:request.whatAmI contains PAGE,FILE"
+                order: request.count asc:request.createdAt asc
+                limit: 15
+                offset: 0
+          description: Content Analytics data being queried
+        "400":
+          description: Bad Request
+        "401":
+          description: Unauthorized
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Returns Content Analytics data
+      tags:
+      - Content Analytics
+  /v1/analytics/content/_query:
+    post:
+      description: Returns information of specific dotCMS objects whose health and
+        engagement data is tracked. This method takes a specific less verbose JSON
+        format to query the data.
+      operationId: postContentAnalyticsQuery
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QueryForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                query:
+                  measures:
+                  - request.count
+                  order: request.count DESC
+                  dimensions:
+                  - request.url
+                  - request.pageId
+                  - request.pageTitle
+                  filters: "request.whatAmI = ['PAGE']"
+                  limit: 100
+                  offset: 1
+          description: Content Analytics data being queried
+        "400":
+          description: Bad Request
+        "403":
+          description: Forbidden
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Retrieve Content Analytics data
+      tags:
+      - Content Analytics
+  /v1/analytics/content/_query/cube:
+    post:
+      description: "Returns information of specific dotCMS objects whose health and\
+        \ engagement data is tracked, using a CubeJS JSON query."
+      operationId: postContentAnalyticsQuery_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                dimensions:
+                - Events.experiment
+                - Events.variant
+          description: Content Analytics data being queried
+        "400":
+          description: Bad Request
+        "401":
+          description: Unauthorized
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Retrieve Content Analytics data
+      tags:
+      - Content Analytics
+  /v1/analytics/content/event:
+    post:
+      description: receives a custom event payload and fires the event to the collectors
+      operationId: fireUserCustomEvent
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        "200":
+          content:
+            application/json:
+              example: TBD
+          description: If the event was created successfully
+        "400":
+          description: Bad Request
+        "403":
+          description: Forbidden
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Fire an user custom event.
+      tags:
+      - Content Analytics
+  /v1/analytics/content/siteconfig/{siteId}:
+    get:
+      description: Returns the expected JS configuration object that must be used
+        for client-side JS code to send custom Events
+      operationId: getSiteConfig
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: The Site configuration was returned successfully
+        "400":
+          description: Bad Request
+        "403":
+          description: Forbidden
+        "404":
+          description: Site ID in path is not present
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Site Configuration
+      tags:
+      - Content Analytics
+  /v1/announcements:
+    get:
+      operationId: announcements
+      parameters:
+      - in: query
+        name: refreshCache
+        schema:
+          type: boolean
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          format: int32
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewListAnnouncement"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewListAnnouncement"
+          description: default response
+      tags:
+      - Announcements
+  /v1/apitoken:
+    post:
+      description: |-
+        Issues an API token to an authorized user account.
+
+        Returns an object representing the issued token.
+      operationId: postIssueApiToken
+      requestBody:
+        content:
+          application/json:
+            example:
+              userId: string
+              expirationSeconds: 0
+              network: string
+              claims:
+                label: string
+              shouldBeAdmin: false
+            schema:
+              $ref: "#/components/schemas/ApiTokenForm"
+        description: |
+          This method requires a POST body of a JSON object containing the following properties.
+
+          | Property        | Value     | Description                                   |
+          |-----------------|-----------|-----------------------------------------------|
+          | `userId`             | String    | **Required.** ID of user attempting receiving |
+          | `expirationSeconds`  | Integer    | **Required.** TTL of token in seconds. |
+          | `network`            | String    | Network mask in which token is valid. Defaults to `0.0.0.0/0`, or any local network.  |
+          | `claims`             | Object    | Contains `label` property. |
+          | `claims.label`       | String    | Sets a user-defined name for token. |
+          | `shouldBeAdmin`      | Boolean   | If `true`, the call only succeeds if the token is being issued to an admin account. Defaults to `false` if omitted. |
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  jwt: string
+                  token:
+                    allowNetwork: 0.0.0.0/0
+                    claims:
+                      label: string
+                    expired: false
+                    expiresDate: 0
+                    id: string
+                    issueDate: 0
+                    issuer: string
+                    modificationDate: 0
+                    notBeforeDate: false
+                    requestingIp: string
+                    requestingUserId: string
+                    revoked: false
+                    revokedDate: 0
+                    subject: string
+                    tokenType: string
+                    userId: string
+                    valid: true
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: Token successfully issued to user
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid user
+        "403":
+          description: Forbidden
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Unexpected server error
+      summary: Issues an API token
+      tags:
+      - API Token
+  /v1/apitoken/remote:
+    put:
+      description: |-
+        This endpoint takes as part of its payload authentication credentials for a user account on a remote dotCMS instance. It returns a token object that can be used to permit remote operation according to the role and permissions of the authenticated account.
+
+        This is used, for example, in configuring a [push publishing](https://www.dotcms.com/docs/latest/push-publishing) endpoint.
+
+        Usable only by administrators.
+      operationId: putGetRemoteToken
+      requestBody:
+        content:
+          application/json:
+            example:
+              token:
+                network: 0.0.0.0/0
+                expirationSeconds: "1000"
+                claims:
+                  label: Example
+              remote:
+                host: dotcms-receiver.local
+                port: "8082"
+                protocol: http
+              auth:
+                login: admin@dotcms.com
+                password: YWRtaW4=
+            schema:
+              $ref: "#/components/schemas/RemoteAPITokenForm"
+        description: |
+          PUT body consists of a JSON object containing three properties: `token`, concerning the token's direct properties; `remote`, defining the remote host, and `auth`, specifying remote user authentication.
+
+          Each of these three top-level properties is itself an object containing further properties, listed fully below:
+
+          | Properties                 | Value   | Description                                                            |
+          |----------------------------|---------|------------------------------------------------------------------------|
+          | `token.network`            | String  | Network mask in which the token is active.                             |
+          | `token.expirationSeconds`  | String  | Seconds until the token expires.                                       |
+          | `token.claims`             | Object  | Object containing the property `label`, defined below.                 |
+          | `token.claims.label`       | String  | The name of the token generated.                                       |
+          |             |   |  |
+          | `remote.host`              | String  | Remote host for which to generate a token.                             |
+          | `remote.port`              | String  | Port number for the remote host.                                       |
+          | `remote.protocol`          | String  | Web protocol used to connect to the remote host.                       |
+          |             |   |  |
+          | `auth.login`               | String  | Email of account from which the remote token will derive permissions.  |
+          | `auth.password`            | String  | A string representing a base64-encoded password.                       |
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  jwt: string
+                  token:
+                    allowNetwork: 0.0.0.0/0
+                    claims:
+                      label: string
+                    expired: false
+                    expiresDate: 0
+                    id: string
+                    issueDate: 0
+                    issuer: string
+                    modificationDate: 0
+                    notBeforeDate: false
+                    requestingIp: string
+                    requestingUserId: string
+                    revoked: false
+                    revokedDate: 0
+                    subject: string
+                    tokenType: string
+                    userId: string
+                    valid: true
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                permissions: []
+          description: Remote token generated successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid user
+        "403":
+          description: Forbidden
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Unexpected server error
+      summary: Generates a remote API token
+      tags:
+      - API Token
+  /v1/apitoken/{tokenId}:
+    delete:
+      description: |-
+        Deletes an API token by identifier. May be performed on either active, expired, or revoked.
+
+        Returned entity contains the property `deleted`, the value of which is the deleted token object.
+      operationId: deleteApiTokenById
+      parameters:
+      - description: Identifier of API token to be deleted.
+        in: path
+        name: tokenId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  deleted:
+                    allowNetwork: null
+                    claims:
+                      label: string
+                    expired: false
+                    expiresDate: 1822623941000
+                    id: string
+                    issueDate: 1728061510000
+                    issuer: string
+                    modificationDate: 1728069870000
+                    notBeforeDate: false
+                    requestingIp: string
+                    requestingUserId: string
+                    revoked: true
+                    revokedDate: 1728069870000
+                    subject: string
+                    tokenType: string
+                    userId: string
+                    valid: false
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: Token successfully deleted
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid user
+        "404":
+          description: Token not found
+        "500":
+          description: Unexpected server error
+      summary: Deletes an API token
+      tags:
+      - API Token
+  /v1/apitoken/{tokenId}/jwt:
+    get:
+      description: Returns a JSON web token. This overwrites the JWT value associated
+        with the specified token object.
+      operationId: getGetJwtFromApiToken
+      parameters:
+      - description: Identifier of API token to receive a new JWT.
+        in: path
+        name: tokenId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  jwt: string
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: JSON web token successfully created
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid user
+        "403":
+          description: Forbidden
+        "404":
+          description: Token not found
+        "500":
+          description: Unexpected server error
+      summary: Generates a new JWT for an existing token
+      tags:
+      - API Token
+  /v1/apitoken/{tokenId}/revoke:
+    put:
+      description: |-
+        Revokes a token by its identifier.
+
+         Returned entity contains the property `revoked`, whose value is an object representing the revoked token.
+      operationId: putRevokeTokenById
+      parameters:
+      - description: Identifier of API token to be revoked
+        in: path
+        name: tokenId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  revoked:
+                    allowNetwork: null
+                    claims:
+                      label: string
+                    expired: false
+                    expiresDate: 1822623941000
+                    id: string
+                    issueDate: 1728061510000
+                    issuer: string
+                    modificationDate: 1728069870000
+                    notBeforeDate: false
+                    requestingIp: string
+                    requestingUserId: string
+                    revoked: true
+                    revokedDate: 1728069870000
+                    subject: string
+                    tokenType: string
+                    userId: string
+                    valid: false
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: Token revoked successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid user
+        "403":
+          description: Forbidden
+        "404":
+          description: Token not found
+        "500":
+          description: Unexpected server error
+      summary: Revokes an API token
+      tags:
+      - API Token
+  /v1/apitoken/{userId}/tokens:
+    get:
+      description: |+
+        Accepts a user identifier and returns a list of API tokens associated with that user.
+
+        The returned list may optionally include or exclude tokens that have been revoked.
+
+      operationId: getApiTokensByUserId
+      parameters:
+      - description: Identifier of user to check for tokens.
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+      - description: Determines whether revoked tokens are shown. Defaults to `false`
+          if omitted.
+        in: query
+        name: showRevoked
+        schema:
+          type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  tokens:
+                  - allowNetwork: null
+                    claims:
+                      label: string
+                    expired: false
+                    expiresDate: 1822623941000
+                    id: string
+                    issueDate: 1728061510000
+                    issuer: string
+                    modificationDate: 1728061510000
+                    notBeforeDate: false
+                    requestingIp: string
+                    requestingUserId: string
+                    revoked: false
+                    revokedDate: null
+                    subject: string
+                    tokenType: string
+                    userId: string
+                    valid: true
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: User's API tokens successfully retrieved
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid user
+        "403":
+          description: Forbidden
+        "404":
+          description: Invalid user
+        "500":
+          description: Unexpected server error
+      summary: Retrieves API tokens based on a user ID
+      tags:
+      - API Token
+  /v1/appconfiguration:
+    get:
+      operationId: list_7
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+  /v1/apps:
+    delete:
+      operationId: deleteIndividualAppSecret
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/DeleteSecretForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+    get:
+      operationId: listAvailableApps
+      parameters:
+      - in: query
+        name: filter
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+    post:
+      operationId: createApp
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+  /v1/apps/export:
+    post:
+      operationId: exportSecrets
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ExportSecretForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Apps
+  /v1/apps/import:
+    post:
+      operationId: importSecrets
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+  /v1/apps/{key}:
+    delete:
+      operationId: deleteApp
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: removeDescriptor
+        schema:
+          type: boolean
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+    get:
+      operationId: getAppByKey
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+  /v1/apps/{key}/{siteId}:
+    delete:
+      operationId: deleteAllAppSecrets
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+    get:
+      operationId: getAppDetail
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+    post:
+      operationId: createAppSecrets
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SecretForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+    put:
+      operationId: updateAppIndividualSecret
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SecretForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+  /v1/assets:
+    post:
+      operationId: getAssetsInfo
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/AssetInfoRequestForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Web Assets
+    put:
+      operationId: saveUpdateAsset
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                assetPath:
+                  type: string
+                detail:
+                  $ref: "#/components/schemas/FileUploadDetail"
+                file:
+                  $ref: "#/components/schemas/FormDataContentDisposition"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Web Assets
+  /v1/assets/_archive:
+    post:
+      operationId: archiveAsset
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/AssetInfoRequestForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Web Assets
+  /v1/assets/_delete:
+    post:
+      operationId: deleteAsset
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/AssetInfoRequestForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Web Assets
+  /v1/assets/_download:
+    post:
+      operationId: download
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/AssetsRequestForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Web Assets
+  /v1/assets/folders/_delete:
+    post:
+      operationId: deleteFolder
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/AssetInfoRequestForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Web Assets
+  /v1/authentication:
+    post:
+      description: |+
+        Takes a user's login ID and password and checks them against the user rolls.
+
+        If the user is found and authenticated, a session is created.
+
+        Otherwise the system will return an 'authentication failed' message.
+
+      operationId: postAuthentication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthenticationForm"
+        description: |
+          This method takes a user's credentials and language preferences to authenticate them.
+
+          Requires a POST body consisting of a JSON object containing the following properties:
+
+          | **Property** | **Value** | **Description**                               |
+          |--------------|-----------|-----------------------------------------------|
+          | `userId`     | String    | **Required.** ID of user attempting to log in |
+          | `password`   | String    | User password                                 |
+          | `language`   | String    | Preferred language for user                   |
+          | `country`    | String    | Country where user is located                 |
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityUserMapView"
+          description: User authentication successful
+        "401":
+          description: User not authenticated
+        "403":
+          description: Forbidden request
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Unexpected error
+      summary: Verifies user or application authentication
+      tags:
+      - Authentication
+  /v1/authentication/logInUser:
+    get:
+      description: |+
+        Provides information about any users that are currently in a session.
+
+        This retrieved data will be formatted into a JSON response body.
+
+      operationId: getLogInUser
+      responses:
+        "200":
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityUserView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityUserView"
+          description: User data successfully collected
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized request
+        "404":
+          description: User not found
+      summary: Retrieves user data
+      tags:
+      - Authentication
+  /v1/browser:
+    post:
+      operationId: getFolderContent
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/BrowserQueryForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Browser Tree
+  /v1/browser/selectedfolder:
+    get:
+      operationId: getSelectFolder
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Browser Tree
+    put:
+      operationId: selectFolder
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/OpenFolderForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Browser Tree
+  /v1/browsertree/sitename/{sitename}/uri:
+    get:
+      deprecated: true
+      operationId: loadAssetsUnder
+      parameters:
+      - in: path
+        name: sitename
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Browser Tree
+  /v1/browsertree/sitename/{sitename}/uri/{uri}:
+    get:
+      deprecated: true
+      operationId: loadAssetsUnder_1
+      parameters:
+      - in: path
+        name: sitename
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: uri
+        required: true
+        schema:
+          type: string
+          pattern: .+
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Browser Tree
+  /v1/caches/provider/{provider}/flush:
+    delete:
+      operationId: flushAll
+      parameters:
+      - in: path
+        name: provider
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Cache Management
+  /v1/caches/provider/{provider}/flush/{group}:
+    delete:
+      operationId: flushGroup
+      parameters:
+      - in: path
+        name: provider
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: group
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Cache Management
+  /v1/caches/provider/{provider}/flush/{group}/{id}:
+    delete:
+      operationId: flushObject
+      parameters:
+      - in: path
+        name: provider
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: group
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Cache Management
+  /v1/caches/provider/{provider}/keys/{group}:
+    get:
+      operationId: getKeys
+      parameters:
+      - in: path
+        name: provider
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: group
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Cache Management
+  /v1/caches/provider/{provider}/object/{group}/{id}:
+    get:
+      operationId: showObject
+      parameters:
+      - in: path
+        name: provider
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: group
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Cache Management
+  /v1/caches/provider/{provider}/objects/{group}:
+    get:
+      operationId: showObjects
+      parameters:
+      - in: path
+        name: provider
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: group
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Cache Management
+  /v1/caches/provider/{provider}/{group}:
+    get:
+      operationId: showProviders_1
+      parameters:
+      - in: path
+        name: provider
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: group
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Cache Management
+  /v1/caches/providers/{group}:
+    get:
+      operationId: showProviders
+      parameters:
+      - in: path
+        name: group
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Cache Management
+  /v1/categories:
+    delete:
+      operationId: delete_7
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Categories
+    get:
+      operationId: getCategories
+      parameters:
+      - in: query
+        name: filter
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: orderby
+        schema:
+          type: string
+          default: category_name
+      - in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+      - in: query
+        name: showChildrenCount
+        schema:
+          type: boolean
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Categories
+    post:
+      operationId: saveNew
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CategoryForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Categories
+    put:
+      operationId: save_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CategoryForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Categories
+  /v1/categories/_export:
+    get:
+      operationId: export
+      parameters:
+      - in: query
+        name: contextInode
+        schema:
+          type: string
+      - in: query
+        name: filter
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            text/csv: {}
+          description: default response
+      tags:
+      - Categories
+  /v1/categories/_import:
+    post:
+      operationId: importCategories
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Categories
+  /v1/categories/_sort:
+    put:
+      operationId: save
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CategoryEditForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Categories
+  /v1/categories/children:
+    get:
+      operationId: getChildren
+      parameters:
+      - in: query
+        name: filter
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: orderby
+        schema:
+          type: string
+          default: category_name
+      - in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+      - in: query
+        name: inode
+        schema:
+          type: string
+      - in: query
+        name: showChildrenCount
+        schema:
+          type: boolean
+      - in: query
+        name: allLevels
+        schema:
+          type: boolean
+      - in: query
+        name: parentList
+        schema:
+          type: boolean
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Categories
+  /v1/categories/hierarchy:
+    post:
+      description: Response with the list of parents for a specific set of categories.
+        If any of the categoriesdoes not exists then it is just ignored
+      operationId: getSchemes
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CategoryKeysForm"
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HierarchyShortCategoriesResponseView"
+          description: default response
+      summary: Get the List of Parents from  set of categories
+      tags:
+      - Categories
+  /v1/categories/{idOrKey}:
+    get:
+      operationId: getCategoryByIdOrKey
+      parameters:
+      - in: path
+        name: idOrKey
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: showChildrenCount
+        schema:
+          type: boolean
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Categories
+  /v1/changePassword:
+    post:
+      operationId: resetPassword
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ResetPasswordForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Authentication
+  /v1/configuration:
+    get:
+      operationId: list_8
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+    put:
+      operationId: set
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - System Configuration
+  /v1/configuration/_validateCompanyEmail:
+    post:
+      operationId: validateEmail
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CompanyEmailForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+  /v1/configuration/config:
+    get:
+      operationId: getConfigVariables
+      parameters:
+      - in: query
+        name: keys
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System Configuration
+  /v1/containers:
+    delete:
+      operationId: delete_8
+      parameters:
+      - in: query
+        name: containerId
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+    get:
+      description: Returns a list of Container objects based on filtering and pagination
+        parameters. Containers are layout components that define how content is displayed
+        on pages.
+      operationId: getContainers
+      parameters:
+      - description: Filter containers by title pattern
+        in: query
+        name: filter
+        schema:
+          type: string
+      - description: Page number for pagination (starting from 1)
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - description: Number of items per page
+        in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+      - description: Field to order results by
+        in: query
+        name: orderby
+        schema:
+          type: string
+          default: title
+      - description: "Sort direction: ASC or DESC"
+        in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+      - description: Filter containers by host ID
+        in: query
+        name: host
+        schema:
+          type: string
+      - description: Include system containers in results
+        in: query
+        name: system
+        schema:
+          type: boolean
+      - description: Include archived containers in results
+        in: query
+        name: archive
+        schema:
+          type: boolean
+      - description: Filter containers by content type ID or variable name
+        in: query
+        name: content_type
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Containers retrieved successfully
+        "400":
+          description: Bad request - Invalid parameters
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "500":
+          description: Internal server error
+      summary: Retrieves a paginated list of Containers
+      tags:
+      - Containers
+    post:
+      description: Creates and publishes a new container with the provided configuration.
+        The container will be saved as both working and live versions.
+      operationId: saveContainer
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ContainerForm"
+        description: "Container configuration data including title, code, content\
+          \ type structures, and display settings"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Container created successfully
+        "400":
+          description: Bad request - Invalid container data
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks create permissions
+        "500":
+          description: Internal server error
+      summary: Creates a new container
+      tags:
+      - Containers
+    put:
+      description: Updates a container's working version with the provided configuration.
+        The container must exist and the user must have edit permissions.
+      operationId: updateContainer
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ContainerForm"
+        description: Updated container configuration data including identifier and
+          modified properties
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Container updated successfully
+        "400":
+          description: Bad request - Invalid container data
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks edit permissions
+        "404":
+          description: Container not found
+        "500":
+          description: Internal server error
+      summary: Updates an existing container
+      tags:
+      - Containers
+  /v1/containers/_archive:
+    put:
+      operationId: archive
+      parameters:
+      - in: query
+        name: containerId
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/_bulkarchive:
+    put:
+      operationId: bulkArchive
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/_bulkdelete:
+    delete:
+      operationId: bulkDelete
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/_bulkpublish:
+    put:
+      operationId: bulkPublish
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/_bulkunarchive:
+    put:
+      operationId: bulkUnarchive
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/_bulkunpublish:
+    put:
+      operationId: bulkUnpublish
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/_publish:
+    put:
+      description: Makes a container live by publishing it. The container must exist
+        and the user must have publish permissions.
+      operationId: publishContainer
+      parameters:
+      - description: Container identifier to publish
+        in: query
+        name: containerId
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Container published successfully
+        "400":
+          description: Bad request - Container ID is required
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks publish permissions
+        "404":
+          description: Container not found
+        "500":
+          description: Internal server error
+      summary: Publishes a container
+      tags:
+      - Containers
+  /v1/containers/_unarchive:
+    put:
+      operationId: unarchive
+      parameters:
+      - in: query
+        name: containerId
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/_unpublish:
+    put:
+      description: Removes a container from live status by unpublishing it. The container
+        must exist and the user must have unpublish permissions.
+      operationId: unpublishContainer
+      parameters:
+      - description: Container identifier to unpublish
+        in: query
+        name: containerId
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Container unpublished successfully
+        "400":
+          description: Bad request - Container ID is required
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks unpublish permissions
+        "404":
+          description: Container not found
+        "500":
+          description: Internal server error
+      summary: Unpublishes a container
+      tags:
+      - Containers
+  /v1/containers/content/{contentletId}:
+    get:
+      operationId: containerContentByQueryParam
+      parameters:
+      - in: query
+        name: containerId
+        schema:
+          type: string
+      - in: query
+        name: pageInode
+        schema:
+          type: string
+      - in: path
+        name: contentletId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/delete/{containerId}/content/{contentletId}/uid/{uid}:
+    delete:
+      description: Removes a specific contentlet from a container at a particular
+        position. This affects the container's content layout and rendering.
+      operationId: removeContentletFromContainer
+      parameters:
+      - description: Container identifier
+        in: path
+        name: containerId
+        required: true
+        schema:
+          type: string
+      - description: Contentlet identifier
+        in: path
+        name: contentletId
+        required: true
+        schema:
+          type: string
+      - description: Order position of the content
+        in: query
+        name: order
+        schema:
+          type: integer
+          format: int64
+      - description: Unique identifier for the content instance
+        in: path
+        name: uid
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Content removed successfully
+        "400":
+          description: Bad request - Invalid parameters
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "404":
+          description: "Container, content, or UID not found"
+        "500":
+          description: Internal server error
+      summary: Removes content from a container
+      tags:
+      - Containers
+  /v1/containers/form/{formId}:
+    get:
+      operationId: containerFormByQueryParam
+      parameters:
+      - in: query
+        name: containerId
+        schema:
+          type: string
+      - in: path
+        name: formId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/live:
+    get:
+      description: Returns the live (published) version of a container. Optionally
+        includes associated content type information.
+      operationId: getLiveContainer
+      parameters:
+      - description: Container identifier
+        in: query
+        name: containerId
+        schema:
+          type: string
+      - description: Include associated content type information
+        in: query
+        name: includeContentType
+        schema:
+          type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Live container retrieved successfully
+        "400":
+          description: Bad request - Invalid container ID
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "404":
+          description: Live container not found
+        "500":
+          description: Internal server error
+      summary: Retrieves a live container by ID
+      tags:
+      - Containers
+  /v1/containers/working:
+    get:
+      description: Returns the working (draft) version of a container. Optionally
+        includes associated content type information.
+      operationId: getWorkingContainer
+      parameters:
+      - description: Container identifier
+        in: query
+        name: containerId
+        schema:
+          type: string
+      - description: Include associated content type information
+        in: query
+        name: includeContentType
+        schema:
+          type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Working container retrieved successfully
+        "400":
+          description: Bad request - Invalid container ID
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "404":
+          description: Working container not found
+        "500":
+          description: Internal server error
+      summary: Retrieves a working container by ID
+      tags:
+      - Containers
+  /v1/containers/{containerId}/content/{contentletId}:
+    get:
+      operationId: containerContent
+      parameters:
+      - in: path
+        name: containerId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: contentletId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: pageInode
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Containers
+  /v1/containers/{containerId}/form/{formId}:
+    get:
+      description: Returns HTML content for a form rendered within the specified container.
+        This is used to display forms with container styling and layout.
+      operationId: containerForm
+      parameters:
+      - description: Container identifier (UUID or path)
+        in: path
+        name: containerId
+        required: true
+        schema:
+          type: string
+      - description: Form identifier
+        in: path
+        name: formId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Form rendered successfully
+        "400":
+          description: Bad request - Invalid container or form ID
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "404":
+          description: Container or form not found
+        "500":
+          description: Internal server error
+      summary: Renders a form within a container
+      tags:
+      - Containers
+  /v1/containers/{id}/_copy:
+    post:
+      operationId: copy
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityContainerView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityContainerView"
+          description: default response
+      tags:
+      - Containers
+  /v1/content/_canlock/{inodeOrIdentifier}:
+    get:
+      description: Checks if the contentlet specified by its inode or identifier can
+        be locked by the current user.
+      operationId: canLockContent_1
+      parameters:
+      - in: path
+        name: inodeOrIdentifier
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Successfully retrieved lock status
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "500":
+          description: Internal Server Error
+      summary: Check if a contentlet can be locked
+      tags:
+      - Content
+  /v1/content/_draft:
+    put:
+      description: Creates or updates a draft version of a contentlet without triggering
+        workflow. Drafts allow content editors to save work in progress without publishing.
+      operationId: saveDraft
+      parameters:
+      - description: Content inode for existing content
+        in: query
+        name: inode
+        schema:
+          type: string
+      - description: Content identifier for existing content
+        in: query
+        name: identifier
+        schema:
+          type: string
+      - description: "Index policy (DEFER_UNTIL_PUBLISH, FORCE, WAIT_FOR)"
+        in: query
+        name: indexPolicy
+        schema:
+          type: string
+      - description: Language ID for content localization
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ContentForm"
+        description: Content data and field values
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityContentletView"
+          description: Draft saved successfully
+        "400":
+          description: Bad request - Invalid content data
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks write permissions
+        "404":
+          description: Content not found
+        "500":
+          description: Internal server error
+      summary: Saves a content draft
+      tags:
+      - Content
+  /v1/content/_import:
+    get:
+      description: Fetches a paginated list of all content import jobs regardless
+        of state. Results can be paginated using query parameters.
+      operationId: getContentImportJobs
+      parameters:
+      - description: Page number to retrieve (1-based indexing).
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - description: Number of records per page.
+        in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of content import
+            jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves content import jobs
+      tags:
+      - Content Import
+      - Content
+    post:
+      description: Creates and enqueues a new content import job. Requires a CSV file
+        and a JSON string representing import parameters.
+      operationId: importContent
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/ContentImportParamsSchema"
+        description: |-
+          This endpoint accepts a `multipart/form-data` request with two fields:
+
+          | **Field** | **Type** | **Required** | **Description** |
+          |-----------|----------|--------------|-----------------|
+          | `file`    | File     | ✅ Yes        | The CSV file to import. Must contain content rows and match the expected structure for the content type. |
+          | `form`    | String   | ✅ Yes        | A JSON string containing the import parameters. See structure below. |
+
+          **`form` field structure:**
+
+          | **Property**         | **Type**   | **Required** | **Default** | **Description** |
+          |----------------------|------------|--------------|-------------|-----------------|
+          | `contentType`        | String     | ✅ Yes        | –           | Content Type variable or ID to import data into. |
+          | `language`           | String     | ❌ No         | Default language | Language code (e.g., `en-US`) or language ID. |
+          | `workflowActionId`   | String     | ✅ Yes        | –           | Workflow Action UUID to apply to imported content. |
+          | `fields`             | String[]   | ❌ No         | –           | List of field variables or IDs used as keys for content updates. |
+          | `stopOnError`        | Boolean    | ❌ No         | `false`     | Whether to stop import on first validation error. |
+          | `commitGranularity`  | Integer    | ❌ No         | `100`       | Number of rows to commit in each transaction batch. |
+
+          **Example `form` value:**
+
+          ```json
+          {
+            "contentType": "webPageContent",
+            "language": "en-US",
+            "workflowActionId": "b9d89c80-3d88-4311-8365-187323c96436",
+            "fields": ["title"],
+            "stopOnError": false,
+            "commitGranularity": 100
+          }
+          ```
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobStatusView"
+          description: Content import job successfully created and enqueued.
+        "400":
+          description: "Bad Request: Invalid parameters or malformed request (e.g.,\
+            \ missing file, invalid JSON in 'form', file not CSV)."
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions for content\
+            \ import or workflow action."
+        "404":
+          description: "Not Found: Specified Content Type or Language could not be\
+            \ found."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred during\
+            \ job creation or processing."
+      summary: Imports content from a CSV file
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/_validate:
+    post:
+      description: "Creates and enqueues a content import job in preview mode. This\
+        \ validates the CSV data against the specified Content Type, language, and\
+        \ workflow action without actually importing content."
+      operationId: validateContentImport
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/ContentImportParamsSchema"
+        description: |-
+          This endpoint accepts a `multipart/form-data` request with two fields:
+
+          | **Field** | **Type** | **Required** | **Description** |
+          |-----------|----------|--------------|-----------------|
+          | `file`    | File     | ✅ Yes        | The CSV file to import. Must contain content rows and match the expected structure for the content type. |
+          | `form`    | String   | ✅ Yes        | A JSON string containing the import parameters. See structure below. |
+
+          **`form` field structure:**
+
+          | **Property**         | **Type**   | **Required** | **Default** | **Description** |
+          |----------------------|------------|--------------|-------------|-----------------|
+          | `contentType`        | String     | ✅ Yes        | –           | Content Type variable or ID to import data into. |
+          | `language`           | String     | ❌ No         | Default language | Language code (e.g., `en-US`) or language ID. |
+          | `workflowActionId`   | String     | ✅ Yes        | –           | Workflow Action UUID to apply to imported content. |
+          | `fields`             | String[]   | ❌ No         | –           | List of field variables or IDs used as keys for content updates. |
+          | `stopOnError`        | Boolean    | ❌ No         | `false`     | Whether to stop import on first validation error. |
+          | `commitGranularity`  | Integer    | ❌ No         | `100`       | Number of rows to commit in each transaction batch. |
+
+          **Example `form` value:**
+
+          ```json
+          {
+            "contentType": "webPageContent",
+            "language": "en-US",
+            "workflowActionId": "b9d89c80-3d88-4311-8365-187323c96436",
+            "fields": ["title"],
+            "stopOnError": false,
+            "commitGranularity": 100
+          }
+          ```
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  jobId: e6d9bae8-657b-4e2f-8524-c0222db66355
+                  statusUrl: http://localhost:8080/api/v1/_import/e6d9bae8-657b-4e2f-8524-c0222db66355
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobStatusView"
+          description: Content import validation job successfully created and enqueued.
+        "400":
+          description: "Bad Request: Invalid parameters or malformed request (e.g.,\
+            \ missing file, invalid JSON in 'form', file not CSV)."
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions for validation\
+            \ or workflow action."
+        "404":
+          description: "Not Found: Specified Content Type or Language could not be\
+            \ found."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred during\
+            \ job creation or processing."
+      summary: Validates content import from a CSV file
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/abandoned:
+    get:
+      description: Fetches a paginated list of abandoned content import jobs (jobs
+        with state ABANDONED). Results can be paginated using query parameters.
+      operationId: getAbandonedContentImportJobs
+      parameters:
+      - description: Page number to retrieve (1-based indexing).
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - description: Number of records per page.
+        in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of abandoned content
+            import jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves abandoned content import jobs
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/active:
+    get:
+      description: "Fetches a paginated list of active content import jobs (jobs with\
+        \ state NEW, PROCESSING, or WAITING). Results can be paginated using query\
+        \ parameters."
+      operationId: getActiveContentImportJobs
+      parameters:
+      - description: Page number to retrieve (1-based indexing).
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - description: Number of records per page.
+        in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of active content
+            import jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves active content import jobs
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/canceled:
+    get:
+      description: Fetches a paginated list of canceled content import jobs (jobs
+        with state CANCELED). Results can be paginated using query parameters.
+      operationId: getCanceledContentImportJobs
+      parameters:
+      - description: Page number to retrieve (1-based indexing).
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - description: Number of records per page.
+        in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of canceled content
+            import jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves canceled content import jobs
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/completed:
+    get:
+      description: Fetches a paginated list of completed content import jobs (jobs
+        with state COMPLETED). Results can be paginated using query parameters.
+      operationId: getCompletedContentImportJobs
+      parameters:
+      - description: Page number to retrieve (1-based indexing).
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - description: Number of records per page.
+        in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of completed content
+            import jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves completed content import jobs
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/failed:
+    get:
+      description: Fetches a paginated list of failed content import jobs (jobs with
+        state FAILED). Results can be paginated using query parameters.
+      operationId: getFailedContentImportJobs
+      parameters:
+      - description: Page number to retrieve (1-based indexing).
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - description: Number of records per page.
+        in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of failed content
+            import jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves failed content import jobs
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/successful:
+    get:
+      description: Fetches a paginated list of successful content import jobs (jobs
+        with state COMPLETED and successful result). Results can be paginated using
+        query parameters.
+      operationId: getSuccessfulContentImportJobs
+      parameters:
+      - description: Page number to retrieve (1-based indexing).
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - description: Number of records per page.
+        in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of successful content
+            import jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves successful content import jobs
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/{jobId}:
+    get:
+      description: Fetches the detailed current status of a specific content import
+        job identified by its ID.
+      operationId: getJobStatus
+      parameters:
+      - description: The unique identifier (UUID) of the job whose status is to be
+          retrieved.
+        in: path
+        name: jobId
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: e6d9bae8-657b-4e2f-8524-c0222db66355
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobView"
+          description: Successfully retrieved job status. The entity contains detailed
+            information about the job.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have permissions to view the specified\
+            \ job."
+        "404":
+          description: "Not Found: Job with the specified ID could not be found."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving the job status."
+      summary: Retrieves the status of a content import job
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/{jobId}/cancel:
+    post:
+      description: Requests cancellation of a specific content import job identified
+        by its ID. Note that cancellation is asynchronous and may not be immediate.
+      operationId: cancelContentImportJob
+      parameters:
+      - description: The unique identifier (UUID) of the job to be cancelled.
+        in: path
+        name: jobId
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: e6d9bae8-657b-4e2f-8524-c0222db66355
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity: Cancellation request successfully sent to job e6d9bae8-657b-4e2f-8524-c0222db66355
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Cancellation request successfully sent to the job.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have permissions to cancel the specified\
+            \ job."
+        "404":
+          description: "Not Found: Job with the specified ID could not be found or\
+            \ is already completed/cancelled."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ attempting to cancel the job."
+      summary: Cancel a content import job
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_import/{jobId}/monitor:
+    get:
+      description: "Establishes a Server-Sent Events (SSE) connection to monitor the\
+        \ progress of a specific content import job in real-time. This endpoint will\
+        \ continuously send updates as the job progresses, including status changes\
+        \ and completion information."
+      operationId: monitorContentImportJobs
+      parameters:
+      - description: The unique identifier (UUID) of the job whose status is to be
+          retrieved.
+        in: path
+        name: jobId
+        required: true
+        schema:
+          type: string
+          format: uuid
+          example: e6d9bae8-657b-4e2f-8524-c0222db66355
+      responses:
+        "200":
+          content:
+            text/event-stream:
+              schema:
+                $ref: "#/components/schemas/EventOutput"
+          description: Server-Sent Events stream established successfully. Events
+            will be sent as the job progresses.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have permissions to monitor the specified\
+            \ job."
+        "404":
+          description: "Not Found: Job with the specified ID could not be found."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ establishing the monitoring connection."
+      summary: Monitor a content import job in real-time
+      tags:
+      - Content Import
+      - Content
+  /v1/content/_lock/{inodeOrIdentifier}:
+    put:
+      description: "If the user is allowed to lock the contentlet specified by its\
+        \ inode or identifier, the contentlet will be locked."
+      operationId: lockContent_1
+      parameters:
+      - in: path
+        name: inodeOrIdentifier
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityMapView"
+          description: Successfully locked contentlet
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "500":
+          description: Internal Server Error
+      summary: Lock a given contentlet by the current user
+      tags:
+      - Content
+  /v1/content/_unlock/{inodeOrIdentifier}:
+    put:
+      description: "If the user is allowed to unlock the contentlet specified by its\
+        \ inode or identifier, the contentlet will be unlocked."
+      operationId: unlockContent_1
+      parameters:
+      - in: path
+        name: inodeOrIdentifier
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityMapView"
+          description: Successfully unlocked contentlet
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "500":
+          description: Internal Server Error
+      summary: Unlock a given contentlet by the current user
+      tags:
+      - Content
+  /v1/content/fileassets/{inode}/resourcelink:
+    get:
+      operationId: findResourceLink_1
+      parameters:
+      - in: path
+        name: inode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json;charset=UTF-8: {}
+          description: default response
+      tags:
+      - File Assets
+  /v1/content/related:
+    post:
+      operationId: pullRelated
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/PullRelatedForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+        "400":
+          description: Contentlet does not have a relationship field
+        "404":
+          description: Contentlet not found
+      summary: Pull Related Content
+      tags:
+      - Content
+  /v1/content/resourcelinks:
+    get:
+      operationId: findResourceLinks
+      parameters:
+      - in: query
+        name: inode
+        schema:
+          type: string
+      - in: query
+        name: identifier
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      responses:
+        default:
+          content:
+            application/json;charset=UTF-8: {}
+          description: default response
+      tags:
+      - Content
+  /v1/content/resourcelinks/field/{field}:
+    get:
+      operationId: findResourceLink
+      parameters:
+      - in: path
+        name: field
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: inode
+        schema:
+          type: string
+      - in: query
+        name: identifier
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      responses:
+        default:
+          content:
+            application/json;charset=UTF-8: {}
+          description: default response
+      tags:
+      - Content
+  /v1/content/search:
+    post:
+      description: "Abstracts the generation of the required Lucene query to look\
+        \ for user searchable fields in a Content Type, and returns the expected results."
+      operationId: search_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ContentSearchForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchView"
+          description: The query has been executed. It's possible that no contents
+            matched the search criteria.
+        "400":
+          description: Bad request. Malformed JSON body
+        "401":
+          description: "Invalid User, or not logged in"
+        "403":
+          description: Forbidden
+        "500":
+          description: Internal Server Error
+      summary: Retrieves content from the dotCMS repository
+      tags:
+      - Content
+  /v1/content/versions:
+    get:
+      operationId: findVersions
+      parameters:
+      - in: query
+        name: inodes
+        schema:
+          type: string
+      - in: query
+        name: identifier
+        schema:
+          type: string
+      - in: query
+        name: groupByLang
+        schema:
+          type: string
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          format: int32
+      responses:
+        default:
+          content:
+            application/json;charset=UTF-8: {}
+          description: default response
+      tags:
+      - Content
+  /v1/content/versions/{inode}:
+    get:
+      operationId: findByInode
+      parameters:
+      - in: path
+        name: inode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json;charset=UTF-8: {}
+          description: default response
+      tags:
+      - Content
+  /v1/content/{identifier}/languages:
+    get:
+      operationId: checkContentLanguageVersions
+      parameters:
+      - in: path
+        name: identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewListExistingLanguagesForContentletView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewListExistingLanguagesForContentletView"
+          description: default response
+      tags:
+      - Content
+  /v1/content/{identifier}/references/count:
+    get:
+      operationId: getAllContentletReferencesCount
+      parameters:
+      - in: path
+        name: identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityCountView"
+          description: default response
+      tags:
+      - Content
+  /v1/content/{inodeOrIdentifier}:
+    get:
+      description: "Returns a single contentlet based on its identifier or inode.\
+        \ This is the primary endpoint for fetching content data with support for\
+        \ language, variants, and relationship depth."
+      operationId: getContent_2
+      parameters:
+      - description: Contentlet identifier or inode
+        in: path
+        name: inodeOrIdentifier
+        required: true
+        schema:
+          type: string
+      - description: Language ID for content localization
+        in: query
+        name: language
+        schema:
+          type: string
+          default: ""
+      - description: Variant name for A/B testing
+        in: query
+        name: variantName
+        schema:
+          type: string
+          default: DEFAULT
+      - description: Relationship depth to include (-1 for no relationships)
+        in: query
+        name: depth
+        schema:
+          type: integer
+          format: int32
+          default: -1
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Contentlet retrieved successfully
+        "400":
+          description: Bad request - Invalid identifier format
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks read permissions
+        "404":
+          description: Contentlet not found
+        "500":
+          description: Internal server error
+      summary: Retrieves a contentlet by identifier or inode
+      tags:
+      - Content
+  /v1/content/{inodeOrIdentifier}/references:
+    get:
+      operationId: getContentletReferences
+      parameters:
+      - in: path
+        name: inodeOrIdentifier
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: language
+        schema:
+          type: string
+          default: ""
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewListContentReferenceView"
+          description: default response
+      tags:
+      - Content
+  /v1/contentrelationships/{params}:
+    get:
+      deprecated: true
+      operationId: getContent_1
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Content
+  /v1/contentreport/folder/{folder}:
+    get:
+      operationId: getFolderContentReport
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: query
+        name: site
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: orderby
+        schema:
+          type: string
+          default: upper(name)
+      - in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ContentReportView"
+          description: "Content Report for the specified Folder ID/path, or an empty\
+            \ list if either the Folder doesn't exist, or no content is found."
+      summary: "Generates a report of the different Content Types living under a Folder,\
+        \ and the number of content items for each type"
+      tags:
+      - Content Report
+  /v1/contentreport/site/{site}:
+    get:
+      operationId: getSiteContentReport
+      parameters:
+      - in: path
+        name: site
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: orderby
+        schema:
+          type: string
+          default: upper(name)
+      - in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseSiteVariablesEntityView"
+          description: "Content Report for the specified Site ID/Key, or an empty\
+            \ list if either the Site doesn't exist, or no content is found."
+      summary: "Generates a report of the different Content Types living under a Site,\
+        \ and the number of content items for each type"
+      tags:
+      - Content Report
+  /v1/contenttype:
+    get:
+      description: Returns a list of content type objects based on the filtering criteria.
+      operationId: getContentType
+      parameters:
+      - description: String to filter/search for specific content types; leave blank
+          to return all.
+        in: query
+        name: filter
+        schema:
+          type: string
+      - description: |-
+          Page number in response pagination.
+
+          Default: `1`
+        in: query
+        name: page
+        schema:
+          type: integer
+          format: int64
+      - description: |-
+          Number of results per page for pagination.
+
+          Default: `10`
+        in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int64
+      - description: |-
+          Column(s) to sort the results. Multiple columns can be combined in a comma-separated list. Column names can also be set within a SQL string function, such as `upper()`.
+
+          Some possible values:
+
+          `name`, `velocity_var_name`, `mod_date`, `sort_order`
+
+          `description`, `structuretype`, `category`, `inode`
+        in: query
+        name: orderby
+        schema:
+          type: string
+          default: upper(name)
+      - description: "Sort direction: choose between ascending or descending."
+        in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+          enum:
+          - ASC
+          - DESC
+      - description: "Variable name of [base content type](https://www.dotcms.com/docs/latest/base-content-types)."
+        in: query
+        name: type
+        schema:
+          type: string
+          enum:
+          - ANY
+          - CONTENT
+          - WIDGET
+          - FORM
+          - FILEASSET
+          - HTMLPAGE
+          - PERSONA
+          - VANITY_URL
+          - KEY_VALUE
+          - DOTASSET
+      - description: Filter by site identifier.
+        in: query
+        name: host
+        schema:
+          type: string
+      - description: "Multi-site filter: Takes comma-separated list of site identifiers\
+          \ or keys."
+        in: query
+        name: sites
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                - baseType: string
+                  clazz: string
+                  defaultType: true
+                  description: string
+                  fixed: true
+                  folder: string
+                  folderPath: string
+                  host: string
+                  iDate: 0
+                  icon: string
+                  id: string
+                  layout: []
+                  metadata: {}
+                  modDate: 0
+                  multilingualable: true
+                  nEntries: 0
+                  name: string
+                  siteName: string
+                  sortOrder: 0
+                  system: true
+                  variable: string
+                  versionable: true
+                  workflows: []
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination:
+                  currentPage: 0
+                  perPage: 0
+                  totalEntries: 0
+                permissions: []
+          description: Content types retrieved successfully
+        "403":
+          description: Forbidden
+        "500":
+          description: Internal Server Error
+      summary: Retrieves a list of content types
+      tags:
+      - Content Type
+    post:
+      description: |-
+        Creates one or more content types specified in the JSON payload.
+
+         Returns a list entity containing the created content type objects.
+      operationId: postContentTypeCreate
+      requestBody:
+        content:
+          application/json:
+            example:
+            - clazz: com.dotcms.contenttype.model.type.ImmutableSimpleContentType
+              defaultType: false
+              name: The Content Type 1
+              description: THE DESCRIPTION
+              host: 48190c8c-42c4-46af-8d1a-0cd5db894797
+              owner: dotcms.org.1
+              variable: TheContentType1
+              fixed: false
+              system: false
+              folder: SYSTEM_FOLDER
+              systemActionMappings:
+                NEW: ceca71a0-deee-4999-bd47-b01baa1bcfc8
+                PUBLISH: ceca71a0-deee-4999-bd47-b01baa1bcfc8
+              workflow:
+              - d61a59e1-a49c-46f2-a929-db2b4bfa88b2
+            - clazz: com.dotcms.contenttype.model.type.ImmutableSimpleContentType
+              defaultType: false
+              name: The Content Type 2
+              description: THE DESCRIPTION
+              host: 48190c8c-42c4-46af-8d1a-0cd5db894797
+              owner: dotcms.org.1
+              variable: TheContentType2
+              fixed: false
+              system: false
+              folder: SYSTEM_FOLDER
+              workflow:
+              - d61a59e1-a49c-46f2-a929-db2b4bfa88b2
+            schema:
+              $ref: "#/components/schemas/ContentTypeForm"
+        description: |-
+          Payload may consist of a single content type JSON object, or a list containing multiple content type objects.
+
+          Objects require `clazz` and `name` properties at minimum.
+
+          May optionally include the following special properties:
+
+          | Property | Value | Description |
+          |-|-|-|
+          | `systemActionMappings` | JSON Object | Maps [Default Workflow Actions](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) (as keys) to workflow action identifiers (as values) for this content type.|
+          | `workflow` | List of Strings | A list of identifiers of workflow schemes to be associated with the content type.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                - baseType: string
+                  clazz: string
+                  defaultType: true
+                  description: string
+                  fields: []
+                  fixed: true
+                  folder: string
+                  folderPath: string
+                  host: string
+                  iDate: 0
+                  icon: string
+                  id: string
+                  layout: []
+                  metadata: {}
+                  modDate: 0
+                  multilingualable: true
+                  name: string
+                  owner: string
+                  siteName: string
+                  sortOrder: 0
+                  system: true
+                  systemActionMappings: {}
+                  variable: string
+                  versionable: true
+                  workflows: []
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: Content type(s) created successfully
+        "400":
+          description: Bad Request
+        "403":
+          description: Forbidden
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Creates one or more content types
+      tags:
+      - Content Type
+  /v1/contenttype/_filter:
+    post:
+      description: "Returns the list of content type objects that match the specified\
+        \ filter, with optional pagination criteria."
+      operationId: postContentTypeFilter
+      requestBody:
+        content:
+          application/json:
+            example:
+              filter:
+                query: ""
+                types: "Blog,Activity"
+              page: 1
+              perPage: 10
+              orderBy: name
+              direction: ASC
+            schema:
+              $ref: "#/components/schemas/FilteredContentTypesForm"
+        description: |-
+          Requires POST body consisting of a JSON object with the following properties:
+
+          | Property |  Type  | Description |
+          |----------|--------|-------------|
+          | `filter`   | JSON Object | Contains two properties: <table><tr><td>`query`</td><td>A simple query returning full or partial matches.</td></tr><tr><td>`types`</td><td>A comma-separated list of specific content type variables.</td></tr></table> |
+          | `page` | Integer | Which page of results to show. Defaults to `1`. |
+          | `perPage`   | Integer | Number of results to display per page. Defaults to `10`. |
+          | `orderBy`   | String | Sorting parameter: `name` (default), `velocity_var_name`, `mod_date`, or `sort_order`. |
+          | `direction`   | String | `ASC` (default) or `DESC` for ascending or descending. |
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                - baseType: string
+                  clazz: string
+                  defaultType: true
+                  description: string
+                  fixed: false
+                  folder: string
+                  folderPath: string
+                  host: string
+                  iDate: 0
+                  icon: string
+                  id: string
+                  layout: []
+                  metadata: {}
+                  modDate: 0
+                  multilingualable: true
+                  nEntries: 0
+                  name: string
+                  siteName: string
+                  sortOrder: 0
+                  system: true
+                  variable: string
+                  versionable: true
+                  workflows: []
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination:
+                  currentPage: 0
+                  perPage: 0
+                  totalEntries: 0
+                permissions: []
+          description: Content types filtered successfully
+        "400":
+          description: Bad Request
+        "403":
+          description: Forbidden
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Filters content types
+      tags:
+      - Content Type
+  /v1/contenttype/basetypes:
+    get:
+      description: Returns a list of base content types.
+      operationId: getContentTypeBaseTypes
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                - label: string
+                  name: string
+                  types: null
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: Base content types retrieved successfully
+        "500":
+          description: Internal Server Error
+      summary: Retrieves base content types
+      tags:
+      - Content Type
+  /v1/contenttype/id/{idOrVar}:
+    delete:
+      description: |-
+        Deletes the content type based on the provided ID or Velocity variable name.
+
+        Returns JSON string containing the identifier of the deleted content type.
+      operationId: deleteContentType
+      parameters:
+      - description: The ID or Velocity variable name of the content type to delete.
+        in: path
+        name: idOrVar
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity: "{\"deleted\":\"string\"}"
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: Content type deleted successfully
+        "403":
+          description: Forbidden
+        "404":
+          description: Content type not found
+        "500":
+          description: Internal Server Error
+      summary: Deletes a content type
+      tags:
+      - Content Type
+    get:
+      description: Returns one content type based on the provided ID or Velocity variable
+        name.
+      operationId: getContentTypeIdVar
+      parameters:
+      - description: |-
+          The ID or Velocity variable name of the content type to retrieve.
+
+          Example: `htmlpageasset` (Default page content type)
+        in: path
+        name: idOrVar
+        required: true
+        schema:
+          type: string
+      - description: The language ID for localization.
+        in: query
+        name: languageId
+        schema:
+          type: integer
+          format: int64
+      - description: Determines whether live versions of language variables are used
+          in the returned object.
+        in: query
+        name: live
+        schema:
+          type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                - baseType: string
+                  clazz: string
+                  defaultType: true
+                  description: string
+                  fields: []
+                  fixed: false
+                  folder: string
+                  folderPath: string
+                  host: string
+                  iDate: 0
+                  icon: string
+                  id: string
+                  layout: []
+                  metadata: {}
+                  modDate: 0
+                  multilingualable: true
+                  name: string
+                  siteName: string
+                  sortOrder: 0
+                  system: true
+                  variable: string
+                  systemActionMappings: {}
+                  versionable: true
+                  workflows: []
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination:
+                  currentPage: 0
+                  perPage: 0
+                  totalEntries: 0
+                permissions: []
+          description: Content type retrieved successfully
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      summary: Retrieves a single content type
+      tags:
+      - Content Type
+    put:
+      description: |-
+        Updates the content type based on the given ID or Velocity variable name.
+
+        Returns a copy of the updated content type object.
+
+        > **Caution:** When updating a content type, any editable fields omitted from the request body will be removed from the content type. To update selected properties without deleting others,submit the full JSON entity with the desired items edited.
+      operationId: putContentTypeUpdate
+      parameters:
+      - description: |-
+          The ID or Velocity variable name of the content type to update.
+
+          Example value: `htmlpageasset` (Default page content type)
+        in: path
+        name: idOrVar
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              clazz: com.dotcms.contenttype.model.type.ImmutableSimpleContentType
+              defaultType: false
+              id: 39fecdb0-46cc-40a9-a056-f2e1a80ea78c
+              name: The Content Type 2
+              description: THE DESCRIPTION 2
+              host: 48190c8c-42c4-46af-8d1a-0cd5db894797
+              owner: dotcms.org.1
+              variable: TheContentType1
+              fixed: false
+              system: false
+              folder: SYSTEM_FOLDER
+              workflow:
+              - d61a59e1-a49c-46f2-a929-db2b4bfa88b2
+            schema:
+              $ref: "#/components/schemas/ContentTypeForm"
+        description: |-
+          The minimum required properties for a successful update are `clazz`, `id`, and `name`.
+
+          May also optionally include the following special properties:
+
+          | Property | Value | Description |
+          |-|-|-|
+          | `systemActionMappings` | JSON Object | Maps [Default Workflow Actions](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) (as keys) to workflow action identifiers (as values) for this content type.|
+          | `workflow` | List of Strings | A list of identifiers of workflow schemes to be associated with the content type.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  baseType: string
+                  clazz: string
+                  defaultType: true
+                  fields: []
+                  fixed: true
+                  folder: string
+                  folderPath: string
+                  host: string
+                  iDate: 0
+                  icon: string
+                  id: string
+                  layout: []
+                  metadata: {}
+                  modDate: 0
+                  multilingualable: true
+                  name: string
+                  siteName: string
+                  sortOrder: 0
+                  system: true
+                  systemActionMappings: {}
+                  variable: string
+                  versionable: true
+                  workflows: []
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: Content type updated successfully
+        "400":
+          description: Bad Request
+        "403":
+          description: Forbidden
+        "404":
+          description: Not Found
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Updates a content type
+      tags:
+      - Content Type
+  /v1/contenttype/{baseVariableName}/_copy:
+    post:
+      description: |-
+        Creates a new content type by copying an existing one.
+
+        Returns resulting content type.
+      operationId: postContentTypeCopy
+      parameters:
+      - description: |-
+          The variable name of the content type to copy.
+
+          Example value: `htmlpageasset` (Default page content type)
+        in: path
+        name: baseVariableName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              name: Copied Content Type Name
+              variable: copiedContentTypeVar
+              folder: SYSTEM_FOLDER
+              host: 8a7d5e23-da1e-420a-b4f0-471e7da8ea2d
+              icon: event_note
+            schema:
+              $ref: "#/components/schemas/CopyContentTypeForm"
+        description: |-
+          Requires POST body consisting of a JSON object with the following properties:
+
+          | Property |  Type  | Description |
+          |----------|--------|-------------|
+          | `name`   | String | **Required.** Name of new content type |
+          | `variable` | String | System variable of new content type |
+          | `folder`   | String | Folder in which new content type will live |
+          | `host`   | String | Site or host to which the new content type will belong |
+          | `icon`   | String | System icon to represent content type |
+
+          Values not specified default to values of the original content type.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                errors:
+                - errorCode: string
+                  message: string
+                  fieldName: string
+                entity:
+                  baseType: string
+                  clazz: string
+                  defaultType: true
+                  description: string
+                  fields: []
+                  fixed: true
+                  folder: string
+                  folderPath: string
+                  host: string
+                  iDate: 0
+                  icon: string
+                  id: string
+                  layout: []
+                  metadata: {}
+                  modDate: 0
+                  multilingualable: true
+                  name: string1
+                  siteName: string
+                  sortOrder: 0
+                  system: true
+                  systemActionMappings: {}
+                  variable: string
+                  versionable: true
+                  workflows: []
+                messages:
+                - message: string
+                i18nMessagesMap:
+                  additionalProp1: string
+                  additionalProp2: string
+                  additionalProp3: string
+                permissions:
+                - string
+                pagination:
+                  currentPage: 0
+                  perPage: 0
+                  totalEntries: 0
+          description: Content type copied successfully
+        "400":
+          description: Bad Request
+        "403":
+          description: Forbidden
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Copies a content type
+      tags:
+      - Content Type
+  /v1/contenttype/{typeId}/fields:
+    delete:
+      deprecated: true
+      operationId: deleteFields
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    get:
+      deprecated: true
+      operationId: getContentTypeFields
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    post:
+      deprecated: true
+      operationId: createContentTypeField
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    put:
+      deprecated: true
+      operationId: updateFields
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v1/contenttype/{typeId}/fields/id/{fieldId}:
+    delete:
+      deprecated: true
+      operationId: deleteContentTypeFieldById
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    get:
+      deprecated: true
+      operationId: getContentTypeFieldById
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    put:
+      deprecated: true
+      operationId: updateContentTypeFieldById
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v1/contenttype/{typeId}/fields/id/{fieldId}/variables:
+    get:
+      operationId: getFieldVariablesByFieldId
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    post:
+      operationId: createFieldVariableByFieldId
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v1/contenttype/{typeId}/fields/id/{fieldId}/variables/id/{fieldVarId}:
+    delete:
+      operationId: deleteFieldVariableByFieldId
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVarId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    get:
+      operationId: getFieldVariableByFieldId
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVarId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    put:
+      operationId: updateFieldVariableByFieldId
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVarId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v1/contenttype/{typeId}/fields/var/{fieldVar}:
+    delete:
+      deprecated: true
+      operationId: deleteContentTypeFieldByVar
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    get:
+      deprecated: true
+      operationId: getContentTypeFieldByVar
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    put:
+      deprecated: true
+      operationId: updateContentTypeFieldByVar
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v1/contenttype/{typeId}/fields/var/{fieldVar}/variables:
+    get:
+      operationId: getFieldVariablesByFieldVar
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    post:
+      operationId: createFieldVariableByFieldVar
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v1/contenttype/{typeId}/fields/var/{fieldVar}/variables/id/{fieldVarId}:
+    delete:
+      operationId: deleteFieldVariableByFieldVar
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVarId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    get:
+      operationId: getFieldVariableByFieldVar
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVarId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    put:
+      operationId: updateFieldVariableByFieldVar
+      parameters:
+      - in: path
+        name: typeId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVarId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v1/ema:
+    get:
+      operationId: getDetails
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Apps
+  /v1/environments/endpoints:
+    get:
+      operationId: getEndpoints
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityEndpointsView"
+          description: Collection of environments.
+      summary: Returns the endpoints
+      tags:
+      - Environment
+    post:
+      operationId: create
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/EndpointForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityEndpointView"
+          description: If creation is successfully.
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: If the endpoint already exits
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenException"
+          description: "If the user is not an admin or access to the configuration\
+            \ layout or does have permission, it will return a 403."
+      summary: Creates an endpoint
+      tags:
+      - Environment
+  /v1/environments/endpoints/environment/{environmentId}:
+    get:
+      operationId: getEndpointsByEnvironmentId
+      parameters:
+      - in: path
+        name: environmentId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityEndpointsView"
+          description: Collection of environments.
+      summary: Returns the endpoints
+      tags:
+      - Environment
+  /v1/environments/endpoints/{endpointId}:
+    get:
+      operationId: getEndpoint
+      parameters:
+      - in: path
+        name: endpointId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityEndpointView"
+          description: Collection of environments.
+      summary: Returns the endpoint by id
+      tags:
+      - Environment
+  /v1/environments/endpoints/{id}:
+    delete:
+      operationId: delete_3
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+          description: If deletion is successfully endpoint.
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenException"
+          description: "If the user is not an admin or access to the configuration\
+            \ layout or does have permission, it will return a 403."
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DoesNotExistException"
+          description: If the endpoint does not exits
+      summary: Deletes an endpoint
+      tags:
+      - Environment
+    put:
+      operationId: update
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/EndpointForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityEndpointView"
+          description: If update is success.
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: If the environment already exits
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ForbiddenException"
+          description: "If the user is not an admin or access to the configuration\
+            \ layout or does have permission, it will return a 403."
+      summary: Updates an endpoint
+      tags:
+      - Environment
+  /v1/esindex:
+    get:
+      operationId: getIndexStatus
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/activate/{params}:
+    put:
+      deprecated: true
+      operationId: activateIndex
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/active/{params}:
+    get:
+      deprecated: true
+      operationId: getActive
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/plain: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/cache:
+    delete:
+      operationId: flushIndiciesCache
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/clear/{params}:
+    put:
+      deprecated: true
+      operationId: clearIndex
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/close/{params}:
+    put:
+      deprecated: true
+      operationId: closeIndex
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/cluster:
+    get:
+      operationId: getClusterStats
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/create/{params}:
+    put:
+      deprecated: true
+      operationId: createIndex
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/plain: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/deactivate/{params}:
+    put:
+      deprecated: true
+      operationId: deactivateIndex
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/failed:
+    delete:
+      operationId: deleteFailedRecords
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+    get:
+      operationId: downloadRemainingRecordsAsCsv
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/indexlist/{params}:
+    get:
+      operationId: indexList
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/open/{params}:
+    put:
+      deprecated: true
+      operationId: openIndex
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/optimize:
+    post:
+      operationId: optimizeIndices
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/reindex:
+    delete:
+      operationId: stopReindexation
+      parameters:
+      - in: query
+        name: switch
+        schema:
+          type: boolean
+          default: true
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+    get:
+      operationId: getReindexationProgress
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+    post:
+      operationId: startReindex
+      parameters:
+      - in: query
+        name: shards
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: contentType
+        schema:
+          type: string
+          default: DOTALL
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/esindex/{indexName}:
+    delete:
+      operationId: deleteIndex
+      parameters:
+      - in: path
+        name: indexName
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+    put:
+      operationId: modIndex
+      parameters:
+      - in: path
+        name: indexName
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: query
+        name: action
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Search Index
+  /v1/experiments:
+    get:
+      operationId: list_1
+      parameters:
+      - in: query
+        name: pageId
+        schema:
+          type: string
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: status
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - RUNNING
+            - SCHEDULED
+            - ENDED
+            - DRAFT
+            - ARCHIVED
+          uniqueItems: true
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityExperimentView"
+          description: default response
+      tags:
+      - Experiment
+    post:
+      operationId: create_2
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ExperimentForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/health:
+    get:
+      operationId: healthcheck
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/isUserIncluded:
+    post:
+      operationId: isUserIncluded
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExcludedExperimentListForm"
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityExperimentSelectedView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/scheduled/{experimentId}/_cancel:
+    post:
+      operationId: cancel
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{experimentId}:
+    delete:
+      operationId: delete_9
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewString"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewString"
+          description: default response
+      tags:
+      - Experiment
+    patch:
+      operationId: update_2
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ExperimentForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{experimentId}/_archive:
+    put:
+      operationId: archive_1
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{experimentId}/_end:
+    post:
+      operationId: end
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{experimentId}/_start:
+    post:
+      operationId: start
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{experimentId}/goals/primary:
+    delete:
+      operationId: deleteGoal
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{experimentId}/targetingConditions/{id}:
+    delete:
+      operationId: deleteTargetingCondition
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{experimentId}/variants:
+    post:
+      operationId: addVariant
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddVariantForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{experimentId}/variants/{name}:
+    delete:
+      operationId: deleteVariant
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+    put:
+      operationId: updateVariant
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/javascript:
+            schema:
+              $ref: "#/components/schemas/ExperimentVariantForm"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExperimentVariantForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{experimentId}/variants/{name}/_promote:
+    put:
+      operationId: promoteVariant
+      parameters:
+      - in: path
+        name: experimentId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: name
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/javascript:
+            schema:
+              $ref: "#/components/schemas/ExperimentVariantForm"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExperimentVariantForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{id}:
+    get:
+      operationId: get_3
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySingleExperimentView"
+          description: default response
+      tags:
+      - Experiment
+  /v1/experiments/{id}/results:
+    get:
+      operationId: getResult
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityExperimentResults"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityExperimentResults"
+          description: default response
+      tags:
+      - Experiment
+  /v1/fieldTypes:
+    get:
+      operationId: getFieldTypes
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v1/folder/byPath:
+    post:
+      operationId: findSubFoldersByPath
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SearchByPathForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Folders
+  /v1/folder/createfolders/{siteName}:
+    post:
+      operationId: createFolders
+      parameters:
+      - in: path
+        name: siteName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Folders
+  /v1/folder/siteId/{siteId}/path/{path}:
+    get:
+      operationId: loadFolderAndSubFoldersByPath
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: path
+        required: true
+        schema:
+          type: string
+          pattern: .+
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Folders
+  /v1/folder/sitename/{siteName}/uri/{uri}:
+    get:
+      operationId: loadFolderByURI
+      parameters:
+      - in: path
+        name: siteName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: uri
+        required: true
+        schema:
+          type: string
+          pattern: .+
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Folders
+  /v1/folder/{folderId}:
+    get:
+      operationId: findFolderById
+      parameters:
+      - in: path
+        name: folderId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Folders
+  /v1/folder/{id}/file-browser-selected:
+    put:
+      operationId: selectFolder_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Folders
+  /v1/folder/{siteName}:
+    delete:
+      operationId: deleteFolders
+      parameters:
+      - in: path
+        name: siteName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Folders
+  /v1/forgotpassword:
+    post:
+      operationId: forgotPassword
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ForgotPasswordForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Authentication
+  /v1/form/{idOrVar}/successCallback:
+    get:
+      operationId: getSuccessCallbackFunction
+      parameters:
+      - in: path
+        name: idOrVar
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+          description: default response
+      tags:
+      - Forms
+  /v1/health:
+    get:
+      description: Returns comprehensive health status including all registered health
+        checks. Authentication requirements are controlled by the health.detailed.authentication.required
+        configuration property.
+      operationId: getOverallHealth
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Successfully retrieved overall health status
+        "403":
+          description: Forbidden - Authentication required
+        "500":
+          description: Internal Server Error
+      summary: Get overall health status
+      tags:
+      - Health
+  /v1/health/check/{checkName}:
+    get:
+      description: Returns the result of a specific health check identified by name.
+        Useful for monitoring individual components or debugging specific health issues.
+      operationId: getHealthCheck
+      parameters:
+      - description: Name of the health check to retrieve
+        in: path
+        name: checkName
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Successfully retrieved health check result
+        "403":
+          description: Forbidden - Authentication required
+        "404":
+          description: Health check not found
+        "500":
+          description: Internal Server Error
+      summary: Get specific health check result
+      tags:
+      - Health
+  /v1/health/checks:
+    get:
+      description: Returns a list of all registered health check names. Useful for
+        discovering available health checks and building monitoring interfaces.
+      operationId: getHealthCheckNames
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Successfully retrieved health check names
+        "403":
+          description: Forbidden - Authentication required
+        "500":
+          description: Internal Server Error
+      summary: Get all health check names
+      tags:
+      - Health
+  /v1/health/liveness:
+    get:
+      description: Returns liveness health checks suitable for application dashboards.
+        This endpoint provides detailed JSON information about critical system components
+        required for the application to be considered alive.
+      operationId: getLivenessHealth
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Successfully retrieved liveness health status
+        "403":
+          description: Forbidden - Authentication required
+        "500":
+          description: Internal Server Error
+      summary: Get liveness health status
+      tags:
+      - Health
+  /v1/health/readiness:
+    get:
+      description: Returns readiness health checks to determine if the application
+        is ready to receive traffic. This endpoint provides detailed JSON information
+        about system components required for the application to be considered ready
+        to serve requests.
+      operationId: getReadinessHealth
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Successfully retrieved readiness health status
+        "500":
+          description: Internal Server Error
+      summary: Get readiness health status
+      tags:
+      - Health
+  /v1/health/refresh:
+    post:
+      description: "Triggers an immediate refresh of all registered health checks,\
+        \ bypassing any caching mechanisms. Useful for getting up-to-date health status\
+        \ after configuration changes or system maintenance."
+      operationId: refreshHealthChecks
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Successfully triggered health checks refresh
+        "403":
+          description: Forbidden - Authentication required
+        "500":
+          description: Internal Server Error
+      summary: Force refresh all health checks
+      tags:
+      - Health
+  /v1/health/refresh/{checkName}:
+    post:
+      description: "Triggers an immediate refresh of a specific health check identified\
+        \ by name, bypassing any caching mechanisms. Useful for testing individual\
+        \ components or getting up-to-date status after targeted maintenance."
+      operationId: refreshHealthCheck
+      parameters:
+      - description: Name of the health check to refresh
+        in: path
+        name: checkName
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Successfully refreshed the health check
+        "403":
+          description: Forbidden - Authentication required
+        "404":
+          description: Health check not found
+        "500":
+          description: Internal Server Error
+      summary: Force refresh a specific health check
+      tags:
+      - Health
+  /v1/health/status:
+    get:
+      description: Returns a simple boolean summary of system health status with alive
+        and ready flags. Provides a quick overview of system health without detailed
+        check information.
+      operationId: getSystemStatus
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Successfully retrieved system status summary
+        "403":
+          description: Forbidden - Authentication required
+        "500":
+          description: Internal Server Error
+      summary: Get system status summary
+      tags:
+      - Health
+  /v1/jobs:
+    get:
+      operationId: listJobs
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jobs/abandoned:
+    get:
+      operationId: abandonedJobs
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jobs/active:
+    get:
+      operationId: activeJobs
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jobs/canceled:
+    get:
+      operationId: canceledJobs
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jobs/completed:
+    get:
+      operationId: completedJobs
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jobs/failed:
+    get:
+      operationId: failedJobs
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jobs/queues:
+    get:
+      description: Returns a list of all available job queue names that can be used
+        for submitting jobs.
+      operationId: getQueues
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Queues retrieved successfully
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "500":
+          description: Internal server error
+      summary: Retrieves available job queues
+      tags:
+      - Job Queue
+  /v1/jobs/successful:
+    get:
+      operationId: successfulJobs
+      parameters:
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jobs/{jobId}/cancel:
+    post:
+      operationId: cancelJob
+      parameters:
+      - in: path
+        name: jobId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewString"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jobs/{jobId}/monitor:
+    get:
+      operationId: monitorJob
+      parameters:
+      - in: path
+        name: jobId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            text/event-stream:
+              schema:
+                $ref: "#/components/schemas/EventOutput"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jobs/{jobId}/status:
+    get:
+      description: "Returns detailed status information for a specific job including\
+        \ progress, state, and results."
+      operationId: getJobStatus_1
+      parameters:
+      - description: Unique identifier of the job
+        in: path
+        name: jobId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Job status retrieved successfully
+        "400":
+          description: Bad request - Invalid job ID
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "404":
+          description: Job not found
+        "500":
+          description: Internal server error
+      summary: Retrieves job status information
+      tags:
+      - Job Queue
+  /v1/jobs/{queueName}:
+    post:
+      description: Creates and queues a new background job with JSON parameters. Returns
+        the job ID and initial status information.
+      operationId: createJobWithJson
+      parameters:
+      - description: Name of the job queue to submit to
+        in: path
+        name: queueName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+        description: Job parameters as JSON key-value pairs
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobStatusView"
+          description: Job created successfully
+        "400":
+          description: Bad request - Invalid job parameters or queue name
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "500":
+          description: Internal server error
+      summary: Creates a new job with JSON parameters
+      tags:
+      - Job Queue
+  /v1/jobs/{queueName}/active:
+    get:
+      operationId: activeJobs_1
+      parameters:
+      - in: path
+        name: queueName
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      - in: query
+        name: pageSize
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
+          description: default response
+      tags:
+      - Job Queue
+  /v1/jvm:
+    get:
+      operationId: getJvmInfo
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Administration
+  /v1/languages:
+    get:
+      operationId: list_2
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/RestLanguage"
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/RestLanguage"
+          description: default response
+      tags:
+      - Internationalization
+  /v1/languages/i18n:
+    post:
+      operationId: getMessages
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/I18NForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v1/logger:
+    get:
+      operationId: getLoggers
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System Logging
+    put:
+      operationId: changeLoggerLevel
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ChangeLoggerForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System Logging
+  /v1/logger/{loggerName}:
+    get:
+      operationId: getLogger
+      parameters:
+      - in: path
+        name: loggerName
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System Logging
+  /v1/loginform:
+    post:
+      operationId: loginForm
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/I18NForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Authentication
+  /v1/logout:
+    get:
+      operationId: logout
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Authentication
+  /v1/logs/{fileName}/_tail:
+    get:
+      operationId: getLogs
+      parameters:
+      - in: path
+        name: fileName
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: linesBack
+        schema:
+          type: integer
+          format: int32
+      responses:
+        default:
+          content:
+            text/event-stream:
+              schema:
+                $ref: "#/components/schemas/EventOutput"
+          description: default response
+      tags:
+      - TailLog
+  /v1/maintenance/_downloadAssets:
+    get:
+      operationId: downloadAssets
+      parameters:
+      - in: query
+        name: oldAssets
+        schema:
+          type: boolean
+          default: true
+      - in: query
+        name: maxSize
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Maintenance
+  /v1/maintenance/_downloadDb:
+    get:
+      operationId: downloadDb
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Maintenance
+  /v1/maintenance/_downloadLog/{fileName}:
+    get:
+      operationId: downloadLogFile
+      parameters:
+      - in: path
+        name: fileName
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Maintenance
+  /v1/maintenance/_downloadStarter:
+    get:
+      operationId: downloadStarter
+      parameters:
+      - in: query
+        name: maxSize
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Maintenance
+  /v1/maintenance/_downloadStarterWithAssets:
+    get:
+      operationId: downloadStarterWithAssets
+      parameters:
+      - in: query
+        name: oldAssets
+        schema:
+          type: boolean
+          default: true
+      - in: query
+        name: maxSize
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Maintenance
+  /v1/maintenance/_pgDumpAvailable:
+    get:
+      operationId: isPgDumpAvailable
+      responses:
+        default:
+          content:
+            text/plain: {}
+          description: default response
+      tags:
+      - Maintenance
+  /v1/maintenance/_shutdown:
+    delete:
+      operationId: shutdown
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Maintenance
+  /v1/maintenance/_shutdownCluster:
+    delete:
+      operationId: shutdownCluster
+      parameters:
+      - in: query
+        name: rollingDelay
+        schema:
+          type: integer
+          format: int32
+          default: 60
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Maintenance
+  /v1/menu:
+    get:
+      operationId: getMenus
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Navigation
+  /v1/nav/{uri}:
+    get:
+      operationId: loadJson_1
+      parameters:
+      - in: path
+        name: uri
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: query
+        name: depth
+        schema:
+          type: string
+      - in: query
+        name: languageId
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Navigation
+  /v1/notification/delete:
+    put:
+      operationId: delete_10
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/DeleteForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Notifications
+  /v1/notification/getNewNotificationsCount:
+    get:
+      operationId: getNewNotificationsCount
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Notifications
+  /v1/notification/getNotifications/{params}:
+    get:
+      operationId: getNotifications
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: header
+        name: Range
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Notifications
+  /v1/notification/id/{id}:
+    delete:
+      operationId: delete_11
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Notifications
+  /v1/notification/markAsRead:
+    put:
+      operationId: markAsRead
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Notifications
+  /v1/osgi:
+    get:
+      operationId: getInstalledBundles_1
+      parameters:
+      - in: query
+        name: ignoresystembundles
+        schema:
+          type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBundleListView"
+      summary: Returns a list of all bundles installed
+      tags:
+      - OSGi Plugins
+    post:
+      operationId: uploadBundles
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+        "403":
+          description: Can not access the upload folder or invalid OSGI Upload request
+      summary: Upload bundles to the OSGI framework
+      tags:
+      - OSGi Plugins
+  /v1/osgi/_processExports/{bundle}:
+    get:
+      operationId: processBundle_1
+      parameters:
+      - in: path
+        name: bundle
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+      summary: Process exports
+      tags:
+      - OSGi Plugins
+  /v1/osgi/_restart:
+    put:
+      operationId: restart
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+      summary: restarts the OSGI framework
+      tags:
+      - OSGi Plugins
+  /v1/osgi/available-plugins:
+    get:
+      operationId: getAvailablePlugis
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityListView"
+      summary: get available plugins
+      tags:
+      - OSGi Plugins
+  /v1/osgi/dotsystem:
+    get:
+      operationId: getSystemInstalledBundles
+      parameters:
+      - in: query
+        name: ignoresystembundles
+        schema:
+          type: boolean
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBundleListView"
+      summary: Returns the dot system list of all bundles installed
+      tags:
+      - OSGi Plugins
+  /v1/osgi/extra-packages:
+    get:
+      operationId: getExtraPackages
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+      summary: get extra packages
+      tags:
+      - OSGi Plugins
+    put:
+      operationId: modifyExtraPackages
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/ExtraPackagesForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+      summary: modify extra packages
+      tags:
+      - OSGi Plugins
+  /v1/osgi/jar/{jar}:
+    delete:
+      operationId: undeploy
+      parameters:
+      - in: path
+        name: jar
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+        "400":
+          description: Can not stop system bundle
+        "404":
+          description: Bundle not found
+      summary: Undeploys bundle
+      tags:
+      - OSGi Plugins
+  /v1/osgi/jar/{jar}/_deploy:
+    put:
+      operationId: deploy
+      parameters:
+      - in: path
+        name: jar
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+        "400":
+          description: Error loading OSGI Bundle
+        "404":
+          description: Bundle not found
+      summary: deploys bundle
+      tags:
+      - OSGi Plugins
+  /v1/osgi/jar/{jar}/_start:
+    put:
+      operationId: start_1
+      parameters:
+      - in: path
+        name: jar
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+        "400":
+          description: Can not stop system bundle
+        "404":
+          description: Bundle not found
+      summary: starts bundle
+      tags:
+      - OSGi Plugins
+  /v1/osgi/jar/{jar}/_stop:
+    put:
+      operationId: stop
+      parameters:
+      - in: path
+        name: jar
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+        "400":
+          description: Can not stop system bundle
+        "404":
+          description: Bundle not found
+      summary: stops bundle
+      tags:
+      - OSGi Plugins
+  /v1/page/_check-permission:
+    post:
+      operationId: checkPagePermission
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/PageCheckPermissionForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+          description: default response
+      tags:
+      - Page
+  /v1/page/actions:
+    post:
+      operationId: findAvailableActions
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/FindAvailableActionsForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityPageWorkflowActionsView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityPageWorkflowActionsView"
+          description: default response
+      tags:
+      - Page
+  /v1/page/copyContent:
+    put:
+      operationId: copyContent
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CopyContentletForm"
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewMapStringObject"
+          description: default response
+      tags:
+      - Page
+  /v1/page/json/{uri}:
+    get:
+      operationId: loadJson_2
+      parameters:
+      - in: path
+        name: uri
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: query
+        name: mode
+        schema:
+          type: string
+      - in: query
+        name: com.dotmarketing.persona.id
+        schema:
+          type: string
+      - in: query
+        name: language_id
+        schema:
+          type: string
+      - in: query
+        name: device_inode
+        schema:
+          type: string
+      - in: query
+        name: publishDate
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Page
+  /v1/page/layout:
+    post:
+      description: Handles saving of a page template using provided data. Method processes
+        the request and returns HTTP response indicating a complete save operation.
+      operationId: postPageLayout
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PageForm"
+        description: "POST body consists of a JSON object containing one property\
+          \ called 'PageForm', which contains a template layout for the page"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Page template saved successfully
+        "400":
+          description: Bad request or data exception
+        "404":
+          description: Page not found
+      summary: Saves a page template
+      tags:
+      - Page
+  /v1/page/render/{uri}:
+    get:
+      operationId: render
+      parameters:
+      - in: path
+        name: uri
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: query
+        name: mode
+        schema:
+          type: string
+      - in: query
+        name: com.dotmarketing.persona.id
+        schema:
+          type: string
+      - in: query
+        name: language_id
+        schema:
+          type: string
+      - in: query
+        name: device_inode
+        schema:
+          type: string
+      - in: query
+        name: publishDate
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Page
+  /v1/page/renderHTML/{uri}:
+    get:
+      operationId: renderHTMLOnly
+      parameters:
+      - in: path
+        name: uri
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: query
+        name: mode
+        schema:
+          type: string
+          default: LIVE_ADMIN
+      responses:
+        default:
+          content:
+            application/html: {}
+            application/javascript: {}
+          description: default response
+      tags:
+      - Page
+  /v1/page/search:
+    get:
+      operationId: searchPage
+      parameters:
+      - in: query
+        name: path
+        schema:
+          type: string
+      - in: query
+        name: live
+        schema:
+          type: boolean
+      - in: query
+        name: onlyLiveSites
+        schema:
+          type: boolean
+      responses:
+        default:
+          content:
+            application/html: {}
+            application/javascript: {}
+          description: default response
+      tags:
+      - Page
+  /v1/page/types:
+    get:
+      operationId: getPageTypes
+      parameters:
+      - in: query
+        name: filter
+        schema:
+          type: string
+          default: ""
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: orderby
+        schema:
+          type: string
+          default: UPPER(name)
+      - in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Page
+  /v1/page/{pageId}/_deepcopy:
+    put:
+      operationId: deepCopyPage
+      parameters:
+      - in: path
+        name: pageId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewMapStringObject"
+          description: default response
+      tags:
+      - Page
+  /v1/page/{pageId}/content:
+    post:
+      operationId: addContent
+      parameters:
+      - in: path
+        name: pageId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: variantName
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PageContainerForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Page
+  /v1/page/{pageId}/content/tree:
+    get:
+      operationId: getContentTree
+      parameters:
+      - in: path
+        name: pageId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewListMulitreeView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewListMulitreeView"
+          description: default response
+      tags:
+      - Page
+  /v1/page/{pageId}/languages:
+    get:
+      deprecated: true
+      operationId: checkPageLanguageVersions
+      parameters:
+      - in: path
+        name: pageId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Page
+  /v1/page/{pageId}/layout:
+    post:
+      description: |+
+        Takes a saved template and links it to an HTML page.
+
+        Any pages with a template already linked will update with the new link.
+
+        Otherwise a new template will be created without making any changes to previous templates.
+
+        Returns the rendered page.
+
+      operationId: postPageLayoutHTMLLink
+      parameters:
+      - description: ID for the page will link to
+        in: path
+        name: pageId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: variantName
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PageForm"
+        description: "POST body consists of a JSON object containing one property\
+          \ called 'PageForm', which contains information about the layout of a page's\
+          \ template "
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Page template linked to HTML and saved successfully
+        "400":
+          description: Bad request or data exception
+        "404":
+          description: Page not found
+      summary: Links template and page
+      tags:
+      - Page
+  /v1/page/{pageId}/personas:
+    get:
+      operationId: getPersonalizedPersonasOnPage
+      parameters:
+      - in: query
+        name: filter
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: orderby
+        schema:
+          type: string
+          default: title
+      - in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+      - in: query
+        name: hostId
+        schema:
+          type: string
+      - in: path
+        name: pageId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: respectFrontEndRoles
+        schema:
+          type: boolean
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Page
+  /v1/page/{pageId}/render/versions:
+    get:
+      operationId: getHtmlVersionsPage
+      parameters:
+      - in: path
+        name: pageId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: langId
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Page
+  /v1/permissions/_bycontent:
+    get:
+      operationId: getByContentlet
+      parameters:
+      - in: query
+        name: contentletId
+        schema:
+          type: string
+      - in: query
+        name: type
+        schema:
+          type: string
+          default: READ
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityPermissionView"
+        "403":
+          description: If not admin user
+      summary: Get permission for a Contentlet
+      tags:
+      - Permissions
+  /v1/permissions/_bycontent/_groupbytype:
+    get:
+      operationId: getByContentletGroupByType
+      parameters:
+      - in: query
+        name: contentletId
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityPermissionView"
+        "403":
+          description: If not admin user
+      summary: Get permissions roles group by type for a Contentlet
+      tags:
+      - Permissions
+  /v1/permissions/_bypermissiontype:
+    get:
+      operationId: getPermissionsByPermissionType
+      parameters:
+      - in: query
+        name: userid
+        schema:
+          type: string
+      - in: query
+        name: permission
+        schema:
+          type: string
+      - in: query
+        name: permissiontype
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Permissions
+  /v1/personalization/pagepersonas:
+    post:
+      operationId: personalizePageContainers
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/PersonalizationPersonaPageForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Personalization
+  /v1/personalization/pagepersonas/page/{pageId}/personalization/{personalization}:
+    delete:
+      operationId: personalizePageContainers_1
+      parameters:
+      - in: path
+        name: pageId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: personalization
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Personalization
+  /v1/personas:
+    get:
+      operationId: list_3
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/RestPersona"
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/RestPersona"
+          description: default response
+      tags:
+      - Personalization
+  /v1/personas/{id}:
+    get:
+      operationId: self
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/RestPersona"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestPersona"
+          description: default response
+      tags:
+      - Personalization
+  /v1/portlet/_actionurl/{contentTypeVariable}:
+    get:
+      operationId: getCreateContentURL
+      parameters:
+      - in: path
+        name: contentTypeVariable
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: language_id
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Portlets
+  /v1/portlet/custom:
+    post:
+      operationId: saveNew_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomPortletForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Portlets
+    put:
+      operationId: updatePortlet
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomPortletForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Portlets
+  /v1/portlet/custom/{portletId}:
+    delete:
+      operationId: deleteCustomPortlet
+      parameters:
+      - in: path
+        name: portletId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Portlets
+  /v1/portlet/custom/{portletId}/_addtolayout/{layoutId}:
+    put:
+      operationId: addContentPortletToLayout
+      parameters:
+      - in: path
+        name: portletId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: layoutId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Portlets
+  /v1/portlet/portletId/{portletId}:
+    delete:
+      operationId: deletePersonalPortlet
+      parameters:
+      - in: path
+        name: portletId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Portlets
+  /v1/portlet/portletId/{portletId}/roleId/{roleId}:
+    delete:
+      operationId: deletePortletForRole
+      parameters:
+      - in: path
+        name: portletId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: roleId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Portlets
+  /v1/portlet/{portletId}:
+    get:
+      operationId: findPortlet
+      parameters:
+      - in: path
+        name: portletId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Portlets
+  /v1/portlet/{portletId}/_doesuserhaveaccess:
+    get:
+      operationId: doesUserHaveAccessToPortlet
+      parameters:
+      - in: path
+        name: portletId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Portlets
+  /v1/publishqueue:
+    delete:
+      operationId: deleteAssetsByIdentifiers
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/DeletePPQueueElementsByIdentifierForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Publishing
+  /v1/pushpublish/filters:
+    get:
+      operationId: getFilters
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Publishing
+    post:
+      operationId: saveFromForm
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/FilterDescriptorForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Publishing
+    put:
+      operationId: updateFromForm
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/FilterDescriptorForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Publishing
+  /v1/pushpublish/filters/{filterKey}:
+    delete:
+      operationId: deleteFilter
+      parameters:
+      - in: path
+        name: filterKey
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Publishing
+    get:
+      operationId: getFilter
+      parameters:
+      - in: path
+        name: filterKey
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Publishing
+  /v1/redis:
+    put:
+      operationId: set_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SetForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+  /v1/redis/echo/{message}:
+    get:
+      operationId: echo
+      parameters:
+      - in: path
+        name: message
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+  /v1/redis/hash:
+    put:
+      operationId: setHash
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SetHashForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+  /v1/redis/hash/{key}:
+    delete:
+      operationId: deleteHash
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+    get:
+      operationId: getHash
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+  /v1/redis/incr/{key}:
+    get:
+      operationId: getIncrement
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+    put:
+      operationId: incrementAsync
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+  /v1/redis/ping:
+    get:
+      operationId: ping
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+  /v1/redis/{key}:
+    delete:
+      operationId: delete_13
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+    get:
+      operationId: get_5
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System
+  /v1/relationships:
+    get:
+      operationId: getOneSidedRelationships
+      parameters:
+      - in: query
+        name: contentTypeId
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Relationships
+  /v1/relationships/cardinalities:
+    get:
+      operationId: getCardinality
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Relationships
+  /v1/roles:
+    get:
+      operationId: loadRootRoles
+      parameters:
+      - in: query
+        name: loadChildrenRoles
+        schema:
+          type: boolean
+          default: true
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+    post:
+      operationId: addNewRole
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/RoleForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+  /v1/roles/_search:
+    get:
+      operationId: searchRoles
+      parameters:
+      - description: Value to filter by role name
+        in: query
+        name: searchName
+        schema:
+          type: string
+          default: ""
+      - description: Value to filter by role key
+        in: query
+        name: searchKey
+        schema:
+          type: string
+          default: ""
+      - description: Value for specific role id
+        in: query
+        name: roleId
+        schema:
+          type: string
+          default: ""
+      - description: Offset on pagination
+        in: query
+        name: start
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - description: Size on pagination
+        in: query
+        name: count
+        schema:
+          type: integer
+          format: int32
+          default: 20
+      - description: Set false if do not want to include user rules
+        in: query
+        name: includeUserRoles
+        schema:
+          type: boolean
+          default: true
+      - description: Set to true if want to include the workflow roles
+        in: query
+        name: includeWorkflowRoles
+        schema:
+          type: boolean
+          default: false
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySmallRoleView"
+      summary: Search Roles
+      tags:
+      - Roles
+  /v1/roles/checkuserroles/userid/{userId}/roleids/{roleIds}:
+    get:
+      operationId: checkRoles
+      parameters:
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: roleIds
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+  /v1/roles/layouts:
+    delete:
+      operationId: deleteRoleLayouts
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/RoleLayoutForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+    get:
+      operationId: getAllLayouts
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+    post:
+      operationId: saveRoleLayouts
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/RoleLayoutForm"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+  /v1/roles/{roleId}/layouts:
+    get:
+      operationId: findRoleLayouts
+      parameters:
+      - in: path
+        name: roleId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+  /v1/roles/{roleid}:
+    get:
+      operationId: loadRoleByRoleId
+      parameters:
+      - in: path
+        name: roleid
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: loadChildrenRoles
+        schema:
+          type: boolean
+          default: true
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+  /v1/roles/{roleid}/rolehierarchyanduserroles:
+    get:
+      operationId: loadUsersAndRolesByRoleId
+      parameters:
+      - in: path
+        name: roleid
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: roleHierarchyForAssign
+        schema:
+          type: boolean
+          default: false
+      - in: query
+        name: name
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Roles
+  /v1/site:
+    get:
+      operationId: sites
+      parameters:
+      - in: query
+        name: filter
+        schema:
+          type: string
+      - in: query
+        name: archive
+        schema:
+          type: boolean
+      - in: query
+        name: live
+        schema:
+          type: boolean
+      - in: query
+        name: system
+        schema:
+          type: boolean
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+    post:
+      operationId: createNewSite
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SiteForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+    put:
+      operationId: updateSite
+      parameters:
+      - in: query
+        name: id
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SiteForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/_byname:
+    post:
+      operationId: findHostByName
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SearchSiteByNameForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/_copy:
+    put:
+      operationId: copySite
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/CopySiteForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/currentSite:
+    get:
+      operationId: currentSite
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/defaultSite:
+    get:
+      operationId: defaultSite
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/switch:
+    put:
+      operationId: switchSite
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/switch/{id}:
+    put:
+      operationId: switchSite_1
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/thumbnails:
+    get:
+      operationId: findAllSiteThumbnails
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/variable:
+    put:
+      operationId: saveSiteVariable
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/SiteVariableForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseHostVariableEntityView"
+        "400":
+          description: When a required value is not sent
+      summary: Save a Site Variable
+      tags:
+      - Sites
+  /v1/site/variable/{siteId}:
+    get:
+      operationId: getSiteVariables
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseSiteVariablesEntityView"
+        "404":
+          description: When the site id does not exists
+      summary: Retrieve the Site Variables for a site
+      tags:
+      - Sites
+  /v1/site/{siteId}:
+    delete:
+      operationId: deleteSite
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+    get:
+      operationId: findHostByIdentifier
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/{siteId}/_archive:
+    put:
+      operationId: archiveSite
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/{siteId}/_makedefault:
+    put:
+      operationId: makeDefault
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/{siteId}/_publish:
+    put:
+      operationId: publishSite
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/{siteId}/_unarchive:
+    put:
+      operationId: unarchiveSite
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/{siteId}/_unpublish:
+    put:
+      operationId: unpublishSite
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/site/{siteId}/setup_progress:
+    get:
+      operationId: getSiteSetupProgress
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Sites
+  /v1/sites/{siteId}/ruleengine/actions:
+    post:
+      operationId: add_1
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestRuleAction"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/actions/{actionId}:
+    delete:
+      operationId: remove_1
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+    get:
+      operationId: self_2
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/RestRuleAction"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestRuleAction"
+          description: default response
+      tags:
+      - Rules Engine
+    put:
+      operationId: update_4
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestRuleAction"
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestRuleAction"
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/conditions:
+    post:
+      operationId: add_3
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestCondition"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/conditions/{conditionId}:
+    delete:
+      operationId: remove_3
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: conditionId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Rules Engine
+    get:
+      operationId: self_4
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: conditionId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+    put:
+      operationId: update_6
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: conditionId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestCondition"
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestCondition"
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/conditions/{conditionId}/conditionValues:
+    get:
+      operationId: list_6
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: conditionId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+    post:
+      operationId: add_4
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: conditionId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestConditionValue"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/conditions/{conditionId}/conditionValues/{valueId}:
+    delete:
+      operationId: remove_4
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: conditionId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: valueId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Rules Engine
+    get:
+      operationId: self_5
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: conditionId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: valueId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+    put:
+      operationId: update_7
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: conditionId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: valueId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestConditionValue"
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestConditionValue"
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/rules:
+    get:
+      operationId: list_4
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/RestRule"
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/RestRule"
+          description: default response
+      tags:
+      - Rules Engine
+    post:
+      operationId: add
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestRule"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/rules/{ruleId}:
+    delete:
+      operationId: remove
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: ruleId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Rules Engine
+    get:
+      operationId: self_1
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: ruleId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/RestRule"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestRule"
+          description: default response
+      tags:
+      - Rules Engine
+    put:
+      operationId: update_3
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: ruleId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestRule"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/RestRule"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestRule"
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/rules/{ruleId}/conditionGroups:
+    get:
+      operationId: list_5
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: ruleId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+    post:
+      operationId: add_2
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: ruleId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestConditionGroup"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/rules/{ruleId}/conditionGroups/{conditionGroupId}:
+    delete:
+      operationId: remove_2
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: ruleId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: conditionGroupId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            '*/*': {}
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/sites/{siteId}/ruleengine/rules/{ruleId}/conditionGroups/{groupId}:
+    get:
+      operationId: self_3
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: ruleId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: groupId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestConditionGroup"
+          description: default response
+      tags:
+      - Rules Engine
+    put:
+      operationId: update_5
+      parameters:
+      - in: path
+        name: siteId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: ruleId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: groupId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RestConditionGroup"
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestConditionGroup"
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/storages/chain/_replicate/{from}/to/{to}:
+    get:
+      operationId: replicateStorages
+      parameters:
+      - in: path
+        name: from
+        required: true
+        schema:
+          type: string
+          enum:
+          - FILE_SYSTEM
+          - DB
+          - S3
+          - MEMORY
+          - DEFAULT_CHAIN
+          - CHAIN1
+          - CHAIN2
+          - CHAIN3
+      - in: path
+        name: to
+        required: true
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              matrixParameters:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+              path:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System Storage
+  /v1/storages/hello:
+    get:
+      operationId: hello
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - System Storage
+  /v1/system-table:
+    get:
+      operationId: getAll_1
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewMapStringString"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewMapStringString"
+          description: default response
+      tags:
+      - System Configuration
+    post:
+      operationId: save_2
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/KeyValueForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: default response
+      tags:
+      - System Configuration
+    put:
+      operationId: update_8
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/KeyValueForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: default response
+      tags:
+      - System Configuration
+  /v1/system-table/_delete:
+    delete:
+      operationId: deleteWithKey
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: default response
+      tags:
+      - System Configuration
+  /v1/system-table/{key}:
+    delete:
+      operationId: delete_12
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: default response
+      tags:
+      - System Configuration
+    get:
+      operationId: get_4
+      parameters:
+      - in: path
+        name: key
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: default response
+      tags:
+      - System Configuration
+  /v1/system/i18n/{lang}/{rsrc}:
+    get:
+      operationId: list_9
+      parameters:
+      - in: path
+        name: lang
+        required: true
+        schema:
+          type: string
+          pattern: "[\\w]{2,3}(?:-?[\\w]{2})?"
+      - in: path
+        name: rsrc
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v1/system/request-draining-test/long-request:
+    get:
+      operationId: longRunningRequest
+      parameters:
+      - in: query
+        name: duration
+        schema:
+          type: integer
+          format: int64
+          default: 5000
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewMapStringObject"
+          description: default response
+  /v1/system/request-draining-test/simulate-active-requests:
+    get:
+      operationId: simulateActiveRequests
+      parameters:
+      - in: query
+        name: count
+        schema:
+          type: integer
+          format: int32
+          default: 1
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewMapStringObject"
+          description: default response
+  /v1/system/request-draining-test/status:
+    get:
+      operationId: getShutdownStatus
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewMapStringObject"
+          description: default response
+  /v1/system/ruleengine/actionlets:
+    get:
+      operationId: list_10
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/system/ruleengine/conditionlets:
+    get:
+      operationId: list_11
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Rules Engine
+  /v1/tags:
+    get:
+      deprecated: true
+      operationId: list
+      parameters:
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: siteId
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/RestTag"
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/RestTag"
+          description: default response
+      tags:
+      - Tags
+    post:
+      deprecated: true
+      operationId: addTag
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/TagForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Tags
+    put:
+      deprecated: true
+      operationId: updateTag
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/UpdateTagForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Tags
+  /v1/tags/import:
+    post:
+      deprecated: true
+      operationId: importTags
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Tags
+  /v1/tags/inode/{inode}:
+    delete:
+      deprecated: true
+      operationId: deleteTagInodesByInode
+      parameters:
+      - in: path
+        name: inode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Tags
+    get:
+      deprecated: true
+      operationId: findTagsByInode
+      parameters:
+      - in: path
+        name: inode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Tags
+  /v1/tags/tag/{nameOrId}/inode/{inode}:
+    put:
+      deprecated: true
+      operationId: linkTagsAndInode
+      parameters:
+      - in: path
+        name: nameOrId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: inode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Tags
+  /v1/tags/user/{userId}:
+    get:
+      deprecated: true
+      operationId: getTagsByUserId
+      parameters:
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Tags
+  /v1/tags/{nameOrId}:
+    get:
+      deprecated: true
+      operationId: getTagsByNameOrId
+      parameters:
+      - in: path
+        name: nameOrId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Tags
+  /v1/tags/{tagId}:
+    delete:
+      deprecated: true
+      operationId: delete_6
+      parameters:
+      - in: path
+        name: tagId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Tags
+  /v1/temp:
+    post:
+      operationId: uploadTempResourceMulti
+      parameters:
+      - in: query
+        name: maxFileLength
+        schema:
+          type: string
+          default: "-1"
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/octet-stream: {}
+          description: default response
+      tags:
+      - Temporary Files
+  /v1/temp/byUrl:
+    post:
+      operationId: copyTempFromUrl
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RemoteUrlForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Temporary Files
+  /v1/templates:
+    delete:
+      operationId: delete_14
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+    get:
+      operationId: list_12
+      parameters:
+      - in: query
+        name: filter
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+          default: 40
+      - in: query
+        name: orderby
+        schema:
+          type: string
+          default: mod_date
+      - in: query
+        name: direction
+        schema:
+          type: string
+          default: DESC
+      - in: query
+        name: host
+        schema:
+          type: string
+      - in: query
+        name: archive
+        schema:
+          type: boolean
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+    post:
+      operationId: saveNew_2
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/TemplateForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+    put:
+      operationId: save_3
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/TemplateForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/_archive:
+    put:
+      operationId: archive_2
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/_publish:
+    put:
+      operationId: publish_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/_savepublish:
+    put:
+      operationId: saveAndPublish
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/TemplateForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/_unarchive:
+    put:
+      operationId: unarchive_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/_unpublish:
+    put:
+      operationId: unpublish
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/draft:
+    put:
+      operationId: saveDraft_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/TemplateForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/image:
+    post:
+      operationId: fetchTemplateImage
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TemplateImageForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/{templateId}/_copy:
+    put:
+      operationId: copy_1
+      parameters:
+      - in: path
+        name: templateId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/{templateId}/live:
+    get:
+      operationId: getLiveById
+      parameters:
+      - in: path
+        name: templateId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/templates/{templateId}/working:
+    get:
+      operationId: getWorkingById
+      parameters:
+      - in: path
+        name: templateId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/themes:
+    get:
+      operationId: findThemes
+      parameters:
+      - in: query
+        name: hostId
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+          default: -1
+      - in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+      - in: query
+        name: searchParam
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/themes/id/{id}:
+    get:
+      operationId: findThemeById
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Templates
+  /v1/toolgroups/{layoutId}/_addtouser:
+    put:
+      operationId: addToolGroupToUser
+      parameters:
+      - in: path
+        name: layoutId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: userid
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Administration
+  /v1/toolgroups/{layoutId}/_removefromuser:
+    put:
+      operationId: deleteToolGroupFromUser
+      parameters:
+      - in: path
+        name: layoutId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: userid
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Administration
+  /v1/toolgroups/{layoutId}/_userHasLayout:
+    get:
+      operationId: userHasLayout
+      parameters:
+      - in: path
+        name: layoutId
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: userid
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Administration
+  /v1/upgradetask:
+    post:
+      operationId: upgrade
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/UpgradeTaskForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Maintenance
+  /v1/users:
+    post:
+      operationId: create_3
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/UserForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Users
+    put:
+      operationId: udpate
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/UserForm"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseSiteVariablesEntityView"
+          description: If success returns a map with the user + user id.
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseSiteVariablesEntityView"
+          description: If the user information is not valid
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseSiteVariablesEntityView"
+          description: "If the user is not an admin or access to the role + user layouts\
+            \ or does have permission, it will return a 403."
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseSiteVariablesEntityView"
+          description: If the user to update does not exist
+      summary: Update an existing user.
+      tags:
+      - Users
+  /v1/users/activate/{userId}:
+    patch:
+      operationId: active
+      parameters:
+      - description: "Identifier of an user.\n\nExample value: `b9d89c80-3d88-4311-8365-187323c96436` "
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserMapEntityView"
+          description: If success returns a map with the user + user id.
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserMapEntityView"
+          description: If the user information is not valid
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserMapEntityView"
+          description: "If the user is not an admin or access to the role + user layouts\
+            \ or does have permission, it will return a 403."
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserMapEntityView"
+          description: If the user to update does not exist
+      summary: Active an existing user.
+      tags:
+      - Users
+  /v1/users/current:
+    get:
+      operationId: self_6
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/RestUser"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RestUser"
+          description: default response
+      tags:
+      - Users
+    put:
+      operationId: updateCurrent
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/UpdateCurrentUserForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Users
+  /v1/users/deactivate/{userId}:
+    patch:
+      operationId: deactivate
+      parameters:
+      - description: "Identifier of an user.\n\nExample value: `b9d89c80-3d88-4311-8365-187323c96436` "
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserMapEntityView"
+          description: If success returns a map with the user + user id.
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserMapEntityView"
+          description: If the user information is not valid
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserMapEntityView"
+          description: "If the user is not an admin or access to the role + user layouts\
+            \ or does have permission, it will return a 403."
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserMapEntityView"
+          description: If the user to update does not exist
+      summary: Deactivate an existing user.
+      tags:
+      - Users
+  /v1/users/filter:
+    get:
+      operationId: filter
+      parameters:
+      - in: query
+        name: query
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+          default: 0
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+          default: 40
+      - in: query
+        name: orderby
+        schema:
+          type: string
+      - in: query
+        name: direction
+        schema:
+          type: string
+          default: ASC
+      - in: query
+        name: includeanonymous
+        schema:
+          type: boolean
+      - in: query
+        name: includedefault
+        schema:
+          type: boolean
+      - in: query
+        name: assetinode
+        schema:
+          type: string
+      - in: query
+        name: permission
+        schema:
+          type: integer
+          format: int32
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Users
+  /v1/users/loginAsData:
+    get:
+      operationId: loginAsData
+      parameters:
+      - in: query
+        name: filter
+        schema:
+          type: string
+      - in: query
+        name: page
+        schema:
+          type: integer
+          format: int32
+      - in: query
+        name: per_page
+        schema:
+          type: integer
+          format: int32
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Users
+  /v1/users/loginas:
+    post:
+      operationId: loginAs
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/LoginAsForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Users
+  /v1/users/logoutas:
+    put:
+      operationId: logoutAs
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Users
+  /v1/users/{userId}:
+    delete:
+      operationId: delete_15
+      parameters:
+      - description: "Identifier of an user.\n\nExample value: `b9d89c80-3d88-4311-8365-187323c96436` "
+        in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+      - description: "Identifier of an user.\n\nExample value: `b9d89c80-3d88-4311-8365-187323c96436` "
+        in: query
+        name: replacementUserId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserDeletedEntityView"
+          description: If success returns a map with the user + user id.
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserDeletedEntityView"
+          description: If the user information is not valid
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserDeletedEntityView"
+          description: "If the user is not an admin or access to the role + user layouts\
+            \ or does have permission, it will return a 403."
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseUserDeletedEntityView"
+          description: If the user to update does not exist
+      summary: Deletes an existing user.
+      tags:
+      - Users
+  /v1/variants:
+    post:
+      description: Creates a new content variant with the specified name and description.
+        Variants allow for A/B testing and personalization of content.
+      operationId: addVariant_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/VariantForm"
+        description: Variant configuration including name and description
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityVariantView"
+          description: Variant created successfully
+        "400":
+          description: Bad request - Invalid variant data or variant already exists
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "500":
+          description: Internal server error
+      summary: Creates a new content variant
+      tags:
+      - Variants
+  /v1/variants/{variantName}/_promote:
+    put:
+      description: Promotes a content variant to replace the default content version.
+        This action makes the variant content live for all users.
+      operationId: promoteVariant_1
+      parameters:
+      - description: Name of the variant to promote
+        in: path
+        name: variantName
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: Variant promoted successfully
+        "400":
+          description: Bad request - Invalid variant name
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks required permissions
+        "404":
+          description: Variant not found
+        "500":
+          description: Internal server error
+      summary: Promotes a variant to become the default
+      tags:
+      - Variants
+  /v1/versionables/{versionableInodeOrIdentifier}:
+    get:
+      operationId: findVersionable
+      parameters:
+      - in: path
+        name: versionableInodeOrIdentifier
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Variants
+  /v1/versionables/{versionableInode}:
+    delete:
+      operationId: deleteVersion
+      parameters:
+      - in: path
+        name: versionableInode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Variants
+  /v1/versionables/{versionableInode}/_bringback:
+    put:
+      operationId: bringBack
+      parameters:
+      - in: path
+        name: versionableInode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Variants
+  /v1/workflow/actionlets:
+    get:
+      description: "Returns a list of all workflow actionlets — a.k.a. [workflow sub-actions](https://www.dotcms.com/docs/latest/workflow-sub-actions).\
+        \ The returned list is complete and does not use pagination."
+      operationId: getWorkflowActionlets
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionletsView"
+          description: Workflow actionlets returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find all workflow actionlets
+      tags:
+      - Workflow
+  /v1/workflow/actionlets/{actionletId}:
+    delete:
+      description: |+
+        Removes an [actionlet](https://www.dotcms.com/docs/latest/workflow-sub-actions), or sub-action, from a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions). This deletes only the actionlet's binding to the action utilizing it, and leaves the actionlet category intact.
+
+        To find the identifier, you can call `GET /workflow/actions/{actionId}/actionlets`.
+
+        Returns "Ok" on success.
+
+      operationId: deleteWorkflowActionletFromAction
+      parameters:
+      - description: Identifier of the actionlet to delete.
+        in: path
+        name: actionletId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Workflow actionlet deleted from action successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Remove an actionlet from a workflow action
+      tags:
+      - Workflow
+  /v1/workflow/actions:
+    post:
+      description: "Creates or updates a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ from the properties specified in the payload. Returns the created workflow\
+        \ action."
+      operationId: postActionsByWorkflowActionForm
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowActionForm"
+        description: |+
+          Body consists of a JSON object containing a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) form. This includes the following properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `actionId` | String | The identifier of the workflow action to be updated. If left blank, a new workflow action will be created. |
+          | `schemeId` | String | The [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes) under which the action will be created. |
+          | `stepId` | String |  The [workflow step](https://www.dotcms.com/docs/latest/managing-workflows#Steps) with which to associate the action. |
+          | `actionName` | String | The name of the workflow action. Multiple actions of the same name can coexist with different identifiers.  |
+          | `whoCanUse` | List of Strings | A list of identifiers representing [users](https://www.dotcms.com/docs/latest/user-management), [role keys](https://www.dotcms.com/docs/latest/adding-roles), or [other user categories](https://www.dotcms.com/docs/latest/managing-workflows#ActionWho) allowed to use this action. This list can be empty. |
+          | `actionIcon` | String | The icon to associate with the action. Example: `workflowIcon`.  |
+          | `actionCommentable` | Boolean | Whether this action supports comments.  |
+          | `showOn` | List of Strings | List defining under which of the eight valid [workflow states](https://www.dotcms.com/docs/latest/managing-workflows#ActionShow) the action is visible. States must be specified uppercase, such as `NEW` or `LOCKED`. There is no single state for ALL; each state must be listed. |
+          | `actionNextStep` | String | The identifier of the step to enter after performing the action; `currentstep` is also a valid value. |
+          | `actionNextAssign` | String | A user identifier or role key (such as `CMS Anonymous`) to serve as the  default entry in the assignment dropdown. |
+          | `actionCondition` | String | [Custom Velocity code](https://www.dotcms.com/docs/latest/managing-workflows#ActionAssign) to be executed along with the action. |
+          | `actionAssignable` | Boolean | Whether this action can be assigned.  |
+          | `actionRoleHierarchyForAssign` | Boolean | If true, non-administrators cannot assign tasks to administrators.  |
+          | `metadata` | Object | Additional metadata to include in the action definition. |
+
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionView"
+          description: Workflow action created successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Creates/saves a workflow action
+      tags:
+      - Workflow
+  /v1/workflow/actions/default/fire/{systemAction}:
+    patch:
+      description: |-
+        Assigns values to the specified fields across multiple [contentlets](https://www.dotcms.com/docs/latest/content#Contentlets) simultaneously.
+
+        Can use a [Lucene query](https://www.dotcms.com/docs/latest/content-search-syntax#Lucene) in its body to select all resulting content items.
+
+        Returns a list of resultant contentlet maps, each with an additional  `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.
+      operationId: patchFireMergeSystemAction
+      parameters:
+      - description: Inode of the target content.
+        in: query
+        name: inode
+        schema:
+          type: string
+      - description: Identifier of target content.
+        in: query
+        name: identifier
+        schema:
+          type: string
+      - description: Language version of target content.
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      - description: Numeric offset for query results; useful for paginating.
+        in: query
+        name: offset
+        schema:
+          type: integer
+          format: int64
+      - description: Default system action.
+        in: path
+        name: systemAction
+        required: true
+        schema:
+          type: string
+          enum:
+          - NEW
+          - EDIT
+          - PUBLISH
+          - UNPUBLISH
+          - ARCHIVE
+          - UNARCHIVE
+          - DELETE
+          - DESTROY
+      requestBody:
+        content:
+          application/json:
+            example:
+              comments: Publish an existing Generic content
+              query: +contentType:webPageContent AND title:testcontent
+              contentlet:
+                title: TestContentNowWithCaps
+            schema:
+              $ref: "#/components/schemas/FireActionForm"
+        description: |+
+          Optional body consists of a JSON object containing various properties, some of which are specific to certain actionlets.
+
+          The full list of properties that may be used with this form is as follows:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `query` | String | A Lucene query that can target multiple contentlets for editing. Example: `+contentType:htmlpageasset` for all dotCMS pages. |
+          | `contentlet` | Object | An alternate way of specifying the target contentlet. If no identifier or inode is included via parameter, either one could instead be included in the body as a property of this object. |
+          | `comments` | String | Comments that will appear in the [workflow tasks](https://www.dotcms.com/docs/latest/workflow-tasks) tool with the execution of this workflow action. |
+          | `individualPermissions` | Object | Allows setting granular permissions associated with the target. The object properties are the [system names of permissions](https://www.dotcms.com/docs/latest/user-permissions#Permissions), such as READ, PUBLISH, EDIT, etc. Their respective values are a list of user or role identifiers that should be granted the permission in question. Example: `"READ": ["9ad24203-ae6a-4e5e-aa10-a8c38fd11f17","MyRole"]` |
+          | `assign` | String | The identifier of a user or role to next receive the workflow task assignment. |
+          | `pathToMove` | String | If the workflow action includes the Move actionlet, this property will specify the target path. This path must include a host, such as `//default/testfolder`, `//demo.dotcms.com/application`, etc. |
+          | `whereToSend` | String | For the [push publishing](push-publishing) actionlet; sets the push-publishing environment to receive the target content. Must be specified as an environment identifier. [Learn how to find environment IDs here.](https://www.dotcms.com/docs/latest/push-publishing-endpoints#EnvironmentIds) |
+          | `iWantTo` | String | For the push publishing actionlet; this can be set to one of three values: <ul style="line-height:2rem;"><li>`publish` for push publish;</li><li>`expire` for remove;</li><li>`publishexpire` for push remove.</li></ul> These are further configurable with the properties below that specify publishing and expiration dates, times, etc. |
+          | `publishDate` | String | For the push publishing actionlet; specifies a date to push the content. Format: `yyyy-MM-dd`.  |
+          | `publishTime` | String | For the push publishing actionlet; specifies a time to push the content. Format: `hh-mm`. |
+          | `expireDate` | String | For the push publishing actionlet; specifies a date to remove the content. Format: `yyyy-MM-dd`.  |
+          | `expireTime` | String | For the push publishing actionlet; specifies a time to remove the content. Format: `hh-mm`.  |
+          | `neverExpire` | Boolean | For the push publishing actionlet; a value of `true` invalidates the expiration time/date. |
+          | `filterKey` | String | For the push publishing actionlet; specifies a [push publishing filter](https://www.dotcms.com/docs/latest/push-publishing-filters) key, should the workflow action call for such. To retrieve a full list of push publishing filters and their keys, use `GET /v1/pushpublish/filters`. |
+          | `timezoneId` | String | For the push publishing actionlet; specifies the time zone to which the indicated times belong. Uses the [tz database](https://www.iana.org/time-zones). For a list of values, see [the database directly](https://data.iana.org/time-zones/tz-link.html) or refer to [the Wikipedia entry listing tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). |
+
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              example:
+                entity:
+                  results:
+                  - c2701eced2b59f0bbd55b3d9667878ce:
+                      AUTO_ASSIGN_WORKFLOW: false
+                      archived: false
+                      baseType: string
+                      body: string
+                      body_raw: string
+                      contentType: string
+                      creationDate: 1725051866540
+                      folder: string
+                      hasLiveVersion: false
+                      hasTitleImage: false
+                      host: string
+                      hostName: string
+                      identifier: c2701eced2b59f0bbd55b3d9667878ce
+                      inode: string
+                      languageId: 1
+                      live: false
+                      locked: false
+                      modDate: 1727438483022
+                      modUser: string
+                      modUserName: string
+                      owner: string
+                      ownerName: string
+                      publishDate: 1727438483051
+                      publishUser: string
+                      publishUserName: string
+                      sortOrder: 0
+                      stInode: string
+                      title: string
+                      titleImage: string
+                      url: string
+                      working: false
+                  summary:
+                    affected: 1
+                    failCount: 0
+                    successCount: 1
+                    time: 45
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                permissions: []
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Contentlet(s) modified successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content Type not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Modify specific fields on multiple contentlets
+      tags:
+      - Workflow
+    post:
+      description: |-
+        Fire a [default system action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) by name on multiple target contentlets.
+
+        Returns a list of resultant contentlet maps, each with an additional  `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.
+      operationId: postFireSystemActionByNameMulti
+      parameters:
+      - description: Default system action.
+        in: path
+        name: systemAction
+        required: true
+        schema:
+          type: string
+          enum:
+          - NEW
+          - EDIT
+          - PUBLISH
+          - UNPUBLISH
+          - ARCHIVE
+          - UNARCHIVE
+          - DELETE
+          - DESTROY
+      requestBody:
+        content:
+          application/json:
+            example:
+              contentlet:
+              - identifier: d684c0a9abeeeceea8b9a7e32fc272ae
+              - identifier: c2701eced2b59f0bbd55b3d9667878ce
+              comments: test comment
+            schema:
+              $ref: "#/components/schemas/FireMultipleActionForm"
+        description: |+
+          Optional body consists of a JSON object containing various properties, some of which are specific to certain actionlets.
+
+          The full list of properties that may be used with this form is as follows:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `contentlet` | List of Objects | Multiple contentlet objects to serve as the target of the selected default system action; requires, at minimum, an identifier in each. |
+          | `comments` | String | Comments that will appear in the [workflow tasks](https://www.dotcms.com/docs/latest/workflow-tasks) tool with the execution of this workflow action. |
+          | `assign` | String | The identifier of a user or role to next receive the workflow task assignment. |
+          | `whereToSend` | String | For the [push publishing](push-publishing) actionlet; sets the push-publishing environment to receive the target content. Must be specified as an environment identifier. [Learn how to find environment IDs here.](https://www.dotcms.com/docs/latest/push-publishing-endpoints#EnvironmentIds) |
+          | `iWantTo` | String | For the push publishing actionlet; this can be set to one of three values: <ul style="line-height:2rem;"><li>`publish` for push publish;</li><li>`expire` for remove;</li><li>`publishexpire` for push remove.</li></ul> These are further configurable with the properties below that specify publishing and expiration dates, times, etc. |
+          | `publishDate` | String | For the push publishing actionlet; specifies a date to push the content. Format: `yyyy-MM-dd`.  |
+          | `publishTime` | String | For the push publishing actionlet; specifies a time to push the content. Format: `hh-mm`. |
+          | `expireDate` | String | For the push publishing actionlet; specifies a date to remove the content. Format: `yyyy-MM-dd`.  |
+          | `expireTime` | String | For the push publishing actionlet; specifies a time to remove the content. Format: `hh-mm`.  |
+          | `neverExpire` | Boolean | For the push publishing actionlet; a value of `true` invalidates the expiration time/date. |
+          | `filterKey` | String | For the push publishing actionlet; specifies a [push publishing filter](https://www.dotcms.com/docs/latest/push-publishing-filters) key, should the workflow action call for such. To retrieve a full list of push publishing filters and their keys, use `GET /v1/pushpublish/filters`. |
+          | `timezoneId` | String | For the push publishing actionlet; specifies the time zone to which the indicated times belong. Uses the [tz database](https://www.iana.org/time-zones). For a list of values, see [the database directly](https://data.iana.org/time-zones/tz-link.html) or refer to [the Wikipedia entry listing tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). |
+
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              example:
+                entity:
+                  results:
+                  - c2701eced2b59f0bbd55b3d9667878ce:
+                      AUTO_ASSIGN_WORKFLOW: false
+                      archived: false
+                      baseType: string
+                      body: string
+                      body_raw: string
+                      contentType: string
+                      creationDate: 1725051866540
+                      folder: string
+                      hasLiveVersion: false
+                      hasTitleImage: false
+                      host: string
+                      hostName: string
+                      identifier: c2701eced2b59f0bbd55b3d9667878ce
+                      inode: string
+                      languageId: 1
+                      live: false
+                      locked: false
+                      modDate: 1727438483022
+                      modUser: string
+                      modUserName: string
+                      owner: string
+                      ownerName: string
+                      publishDate: 1727438483051
+                      publishUser: string
+                      publishUserName: string
+                      sortOrder: 0
+                      stInode: string
+                      title: string
+                      titleImage: string
+                      url: string
+                      working: false
+                  summary:
+                    affected: 1
+                    failCount: 0
+                    successCount: 1
+                    time: 45
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                permissions: []
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Fired action successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Fire system action by name over multiple contentlets
+      tags:
+      - Workflow
+    put:
+      description: |-
+        Fire a [default system action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) by name on a target contentlet.
+
+        Returns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.
+      operationId: putFireDefaultSystemAction
+      parameters:
+      - description: Inode of the target content.
+        in: query
+        name: inode
+        schema:
+          type: string
+      - description: Identifier of target content.
+        in: query
+        name: identifier
+        schema:
+          type: string
+      - description: |+
+          Determines how target content is indexed.
+
+          | Value | Description |
+          |-------|-------------|
+          | `DEFER` | Content will be indexed asynchronously, outside of the current process. Valid content will finish the method in process and be returned before the content becomes visible in the index. This is the default index policy; it is resource-friendly and well-suited to batch processing. |
+          | `WAIT_FOR` | The API call will not return from the content check process until the content has been indexed. Ensures content is promptly available for searching. |
+          | `FORCE` | Forces Elasticsearch to index the content **immediately**.<br>**Caution:** Using this value may cause system performance issues; it is not recommended for general use, though may be useful for testing purposes. |
+
+        in: query
+        name: indexPolicy
+        schema:
+          type: string
+          enum:
+          - DEFER
+          - WAIT_FOR
+          - FORCE
+      - description: Language version of target content.
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      - description: Variant name
+        in: query
+        name: variantName
+        schema:
+          type: string
+          default: DEFAULT
+      - description: Default system action.
+        in: path
+        name: systemAction
+        required: true
+        schema:
+          type: string
+          enum:
+          - NEW
+          - EDIT
+          - PUBLISH
+          - UNPUBLISH
+          - ARCHIVE
+          - UNARCHIVE
+          - DELETE
+          - DESTROY
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FireActionByNameForm"
+        description: |+
+          Optional body consists of a JSON object containing a FireActionByNameForm object — a form that appears in similar functions, as well, but implemented with minor differences across methods. As such, some properties are unused.
+
+          The full list of properties that may be used with this form is as follows:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `actionName` | String | Not used in this method. |
+          | `contentlet` | Object | An alternate way of specifying the target contentlet. If no identifier or inode is included via parameter, either one could instead be included in the body as a property of this object. |
+          | `comments` | String | Comments that will appear in the [workflow tasks](https://www.dotcms.com/docs/latest/workflow-tasks) tool with the execution of this workflow action. |
+          | `individualPermissions` | Object | Allows setting granular permissions associated with the target. The object properties are the [system names of permissions](https://www.dotcms.com/docs/latest/user-permissions#Permissions), such as READ, PUBLISH, EDIT, etc. Their respective values are a list of user or role identifiers that should be granted the permission in question. Example: `"READ": ["9ad24203-ae6a-4e5e-aa10-a8c38fd11f17","MyRole"]` |
+          | `assign` | String | The identifier of a user or role to next receive the workflow task assignment. |
+          | `pathToMove` | String | If the workflow action includes the Move actionlet, this property will specify the target path. This path must include a host, such as `//default/testfolder`, `//demo.dotcms.com/application`, etc. |
+          | `query` | String | Not used in this method. |
+          | `whereToSend` | String | For the [push publishing](push-publishing) actionlet; sets the push-publishing environment to receive the target content. Must be specified as an environment identifier. [Learn how to find environment IDs here.](https://www.dotcms.com/docs/latest/push-publishing-endpoints#EnvironmentIds) |
+          | `iWantTo` | String | For the push publishing actionlet; this can be set to one of three values: <ul style="line-height:2rem;"><li>`publish` for push publish;</li><li>`expire` for remove;</li><li>`publishexpire` for push remove.</li></ul> These are further configurable with the properties below that specify publishing and expiration dates, times, etc. |
+          | `publishDate` | String | For the push publishing actionlet; specifies a date to push the content. Format: `yyyy-MM-dd`.  |
+          | `publishTime` | String | For the push publishing actionlet; specifies a time to push the content. Format: `hh-mm`. |
+          | `expireDate` | String | For the push publishing actionlet; specifies a date to remove the content. Format: `yyyy-MM-dd`.  |
+          | `expireTime` | String | For the push publishing actionlet; specifies a time to remove the content. Format: `hh-mm`.  |
+          | `neverExpire` | Boolean | For the push publishing actionlet; a value of `true` invalidates the expiration time/date. |
+          | `filterKey` | String | For the push publishing actionlet; specifies a [push publishing filter](https://www.dotcms.com/docs/latest/push-publishing-filters) key, should the workflow action call for such. To retrieve a full list of push publishing filters and their keys, use `GET /v1/pushpublish/filters`. |
+          | `timezoneId` | String | For the push publishing actionlet; specifies the time zone to which the indicated times belong. Uses the [tz database](https://www.iana.org/time-zones). For a list of values, see [the database directly](https://data.iana.org/time-zones/tz-link.html) or refer to [the Wikipedia entry listing tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). |
+
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Fired action successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Fire system action by name
+      tags:
+      - Workflow
+  /v1/workflow/actions/default/firemultipart/{systemAction}:
+    put:
+      description: |-
+        (**Construction notice:** Still needs request body documentation. Coming soon!)
+
+        Fires a default [system action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) on target contentlet. Uses a multipart form to transmit its data.
+
+        Returns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.
+      operationId: putFireActionByIdMultipart
+      parameters:
+      - description: Inode of the target content.
+        in: query
+        name: inode
+        schema:
+          type: string
+      - description: Identifier of target content.
+        in: query
+        name: identifier
+        schema:
+          type: string
+      - description: |+
+          Determines how target content is indexed.
+
+          | Value | Description |
+          |-------|-------------|
+          | `DEFER` | Content will be indexed asynchronously, outside of the current process. Valid content will finish the method in process and be returned before the content becomes visible in the index. This is the default index policy; it is resource-friendly and well-suited to batch processing. |
+          | `WAIT_FOR` | The API call will not return from the content check process until the content has been indexed. Ensures content is promptly available for searching. |
+          | `FORCE` | Forces Elasticsearch to index the content **immediately**.<br>**Caution:** Using this value may cause system performance issues; it is not recommended for general use, though may be useful for testing purposes. |
+
+        in: query
+        name: indexPolicy
+        schema:
+          type: string
+          enum:
+          - DEFER
+          - WAIT_FOR
+          - FORCE
+      - description: Language version of target content.
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      - description: Default system action.
+        in: path
+        name: systemAction
+        required: true
+        schema:
+          type: string
+          enum:
+          - NEW
+          - EDIT
+          - PUBLISH
+          - UNPUBLISH
+          - ARCHIVE
+          - UNARCHIVE
+          - DELETE
+          - DESTROY
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Fired action successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Fire action by ID (multipart form) 🚧
+      tags:
+      - Workflow
+  /v1/workflow/actions/fire:
+    put:
+      description: |-
+        Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by name, on a target contentlet.
+
+        Returns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.
+      operationId: putFireActionByName
+      parameters:
+      - description: Inode of the target content.
+        in: query
+        name: inode
+        schema:
+          type: string
+      - description: Identifier of target content.
+        in: query
+        name: identifier
+        schema:
+          type: string
+      - description: |+
+          Determines how target content is indexed.
+
+          | Value | Description |
+          |-------|-------------|
+          | `DEFER` | Content will be indexed asynchronously, outside of the current process. Valid content will finish the method in process and be returned before the content becomes visible in the index. This is the default index policy; it is resource-friendly and well-suited to batch processing. |
+          | `WAIT_FOR` | The API call will not return from the content check process until the content has been indexed. Ensures content is promptly available for searching. |
+          | `FORCE` | Forces Elasticsearch to index the content **immediately**.<br>**Caution:** Using this value may cause system performance issues; it is not recommended for general use, though may be useful for testing purposes. |
+
+        in: query
+        name: indexPolicy
+        schema:
+          type: string
+          enum:
+          - DEFER
+          - WAIT_FOR
+          - FORCE
+      - description: Language version of target content.
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FireActionByNameForm"
+        description: |+
+          Body consists of a JSON object containing at minimum the `actionName` property, specifying a workflow action to fire.
+
+          The full list of properties that may be used with this form is as follows:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `actionName` | String | The name of the workflow action to perform. |
+          | `contentlet` | Object | An alternate way of specifying the target contentlet. If no identifier or inode is included via parameter, either one could instead be included in the body as a property of this object. |
+          | `comments` | String | Comments that will appear in the [workflow tasks](https://www.dotcms.com/docs/latest/workflow-tasks) tool with the execution of this workflow action. |
+          | `individualPermissions` | Object | Allows setting granular permissions associated with the target. The object properties are the [system names of permissions](https://www.dotcms.com/docs/latest/user-permissions#Permissions), such as READ, PUBLISH, EDIT, etc. Their respective values are a list of user or role identifiers that should be granted the permission in question. Example: `"READ": ["9ad24203-ae6a-4e5e-aa10-a8c38fd11f17","MyRole"]` |
+          | `assign` | String | The identifier of a user or role to next receive the workflow task assignment. |
+          | `pathToMove` | String | If the workflow action includes the Move actionlet, this property will specify the target path. This path must include a host, such as `//default/testfolder`, `//demo.dotcms.com/application`, etc. |
+          | `query` | String | Not used in this method. |
+          | `whereToSend` | String | For the [push publishing](push-publishing) actionlet; sets the push-publishing environment to receive the target content. Must be specified as an environment identifier. [Learn how to find environment IDs here.](https://www.dotcms.com/docs/latest/push-publishing-endpoints#EnvironmentIds) |
+          | `iWantTo` | String | For the push publishing actionlet; this can be set to one of three values: <ul style="line-height:2rem;"><li>`publish` for push publish;</li><li>`expire` for remove;</li><li>`publishexpire` for push remove.</li></ul> These are further configurable with the properties below that specify publishing and expiration dates, times, etc. |
+          | `publishDate` | String | For the push publishing actionlet; specifies a date to push the content. Format: `yyyy-MM-dd`.  |
+          | `publishTime` | String | For the push publishing actionlet; specifies a time to push the content. Format: `hh-mm`. |
+          | `expireDate` | String | For the push publishing actionlet; specifies a date to remove the content. Format: `yyyy-MM-dd`.  |
+          | `expireTime` | String | For the push publishing actionlet; specifies a time to remove the content. Format: `hh-mm`.  |
+          | `neverExpire` | Boolean | For the push publishing actionlet; a value of `true` invalidates the expiration time/date. |
+          | `filterKey` | String | For the push publishing actionlet; specifies a [push publishing filter](https://www.dotcms.com/docs/latest/push-publishing-filters) key, should the workflow action call for such. To retrieve a full list of push publishing filters and their keys, use `GET /v1/pushpublish/filters`. |
+          | `timezoneId` | String | For the push publishing actionlet; specifies the time zone to which the indicated times belong. Uses the [tz database](https://www.iana.org/time-zones). For a list of values, see [the database directly](https://data.iana.org/time-zones/tz-link.html) or refer to [the Wikipedia entry listing tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). |
+
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Fired action successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Fire workflow action by name
+      tags:
+      - Workflow
+  /v1/workflow/actions/firemultipart:
+    put:
+      description: |-
+        (**Construction notice:** Still needs request body documentation. Coming soon!)
+
+        Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by name, on a target contentlet. Uses a multipart form to transmit its data.
+
+        Returns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.
+      operationId: putFireActionByNameMultipart
+      parameters:
+      - description: Inode of the target content.
+        in: query
+        name: inode
+        schema:
+          type: string
+      - description: Identifier of target content.
+        in: query
+        name: identifier
+        schema:
+          type: string
+      - description: |+
+          Determines how target content is indexed.
+
+          | Value | Description |
+          |-------|-------------|
+          | `DEFER` | Content will be indexed asynchronously, outside of the current process. Valid content will finish the method in process and be returned before the content becomes visible in the index. This is the default index policy; it is resource-friendly and well-suited to batch processing. |
+          | `WAIT_FOR` | The API call will not return from the content check process until the content has been indexed. Ensures content is promptly available for searching. |
+          | `FORCE` | Forces Elasticsearch to index the content **immediately**.<br>**Caution:** Using this value may cause system performance issues; it is not recommended for general use, though may be useful for testing purposes. |
+
+        in: query
+        name: indexPolicy
+        schema:
+          type: string
+          enum:
+          - DEFER
+          - WAIT_FOR
+          - FORCE
+      - description: Language version of target content.
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+        description: Multipart form. More details to follow.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Fired action successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Fire action by name (multipart form) 🚧
+      tags:
+      - Workflow
+  /v1/workflow/actions/separator:
+    post:
+      description: "Creates a [workflow action] separator(https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ from the properties specified in the payload. Returns the created workflow\
+        \ action."
+      operationId: addSeparatorAction
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowActionSeparatorForm"
+        description: |-
+          Body consists of a JSON object containing a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) form. This includes the following properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `schemeId` | String | The [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes) under which the action will be created. |
+          | `stepId` | String |  The [workflow step](https://www.dotcms.com/docs/latest
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkflowAction"
+          description: Workflow action created successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Creates workflow action separator
+      tags:
+      - Workflow
+  /v1/workflow/actions/{actionId}:
+    delete:
+      description: |+
+        Deletes a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) from all [steps](https://www.dotcms.com/docs/latest/managing-workflows#Steps) in which it appears.
+
+        Returns "Ok" on success.
+
+      operationId: deleteWorkflowActionByActionId
+      parameters:
+      - description: Identifier of the workflow action to delete.
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Workflow action deleted successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Delete a workflow action
+      tags:
+      - Workflow
+    get:
+      description: "Returns a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ object."
+      operationId: getWorkflowActionByActionId
+      parameters:
+      - description: |-
+          Identifier of the workflow action to return.
+
+          Example value: `b9d89c80-3d88-4311-8365-187323c96436` (Default system workflow "Publish" action)
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionView"
+          description: Action returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find action by ID
+      tags:
+      - Workflow
+    put:
+      description: |+
+        Updates a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) based on the payload properties.
+
+        Returns updated workflow action.
+
+      operationId: putSaveActionsByWorkflowActionForm
+      parameters:
+      - description: |-
+          Identifier of workflow action to update.
+
+          Example value: `b9d89c80-3d88-4311-8365-187323c96436` (Default system workflow "Publish" action)
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowActionForm"
+        description: |+
+          Body consists of a JSON object containing the same form data as used above in `POST /v1/workflow/actions`. However, this endpoint uses the form's properties differently, as noted below:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `schemeId` | String | The [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes) under which the action will be created. |
+          | `actionName` | String | The name of the workflow action. Multiple actions of the same name can coexist with different identifiers.  |
+          | `whoCanUse` | List of Strings | A list of identifiers representing [users](https://www.dotcms.com/docs/latest/user-management), [role keys](https://www.dotcms.com/docs/latest/adding-roles), or [other user categories](https://www.dotcms.com/docs/latest/managing-workflows#ActionWho) allowed to use this action. This list can be empty. |
+          | `actionIcon` | String | The icon to associate with the action. Example: `workflowIcon`.  |
+          | `actionCommentable` | Boolean | Whether this action supports comments.  |
+          | `showOn` | List of Strings | List defining under which of the eight valid [workflow states](https://www.dotcms.com/docs/latest/managing-workflows#ActionShow) the action is visible. States must be specified uppercase, such as `NEW` or `LOCKED`. There is no single state for ALL; each state must be listed. |
+          | `actionNextStep` | String | The identifier of the step to enter after performing the action; `currentstep` is also a valid value. |
+          | `actionNextAssign` | String | A user identifier or role key (such as `CMS Anonymous`) to serve as the  default entry in the assignment dropdown. |
+          | `actionCondition` | String | [Custom Velocity code](https://www.dotcms.com/docs/latest/managing-workflows#ActionAssign) to be executed along with the action. |
+          | `actionAssignable` | Boolean | Whether this action can be assigned.  |
+          | `actionRoleHierarchyForAssign` | Boolean | If true, non-administrators cannot assign tasks to administrators.  |
+          | `metadata` | Object | Optional. Additional metadata to include in the action definition. |
+          | `actionId` | String | Omit; not used in this endpoint. |
+          | `stepId` | String | Omit; not used in this endpoint. |
+
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionView"
+          description: Updated workflow action successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Update an existing workflow action
+      tags:
+      - Workflow
+  /v1/workflow/actions/{actionId}/actionlets:
+    get:
+      description: "Returns a list of the workflow actionlets — a.k.a. [workflow sub-actions](https://www.dotcms.com/docs/latest/workflow-sub-actions)\
+        \ — associated with a specified workflow action."
+      operationId: getWorkflowActionletsByActionId
+      parameters:
+      - description: |-
+          Identifier of workflow action to examine for actionlets.
+
+          Example value: `b9d89c80-3d88-4311-8365-187323c96436` (Default system workflow "Publish" action)
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                - actionId: string
+                  actionlet:
+                    actionClass: string
+                    howTo: string
+                    localizedHowto: string
+                    localizedName: string
+                    name: string
+                    nextStep: null
+                    parameters:
+                    - displayName: string
+                      key: string
+                      defaultValue: string
+                      required: true
+                  clazz: string
+                  id: string
+                  name: string
+                  order: 0
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionClassesView"
+          description: Workflow actionlets returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find workflow actionlets by workflow action
+      tags:
+      - Workflow
+    post:
+      description: |-
+        Adds an actionlet — a.k.a. a [workflow sub-action](https://www.dotcms.com/docs/latest/workflow-sub-actions) — to a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions).
+
+        Returns "Ok" on success.
+      operationId: postAddActionletToActionById
+      parameters:
+      - description: |-
+          Identifier of workflow action to receive actionlet.
+
+          Example value: `b9d89c80-3d88-4311-8365-187323c96436` (Default system workflow "Publish" action)
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowActionletActionForm"
+        description: |+
+          Body consists of a JSON object containing a workflow action form. This includes the following properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `actionletClass` | String | The class of the actionlet to be assigned.<br><br>Example: `com.dotcms.rendering.js.JsScriptActionlet` |
+          | `order` | Integer | The position of the actionlet within the action's sequence. |
+          | `parameters` | Object | Further parameters and properties are conveyed here, depending on the particulars of the selected actionlet.<br><br>For a complete list of possible parameters, refer to the various keys listed in `GET /workflow/actionlets`. |
+
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                errors:
+                - errorCode: string
+                  message: string
+                  fieldName: string
+                entity: Ok
+                messages:
+                - message: string
+                i18nMessagesMap:
+                  additionalProp1: string
+                  additionalProp2: string
+                  additionalProp3: string
+                permissions:
+                - string
+                pagination:
+                  currentPage: 0
+                  perPage: 0
+                  totalEntries: 0
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Workflow actionlet assigned successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Adds an actionlet to a workflow action
+      tags:
+      - Workflow
+  /v1/workflow/actions/{actionId}/condition:
+    get:
+      description: |-
+        Returns a string representing the "condition" on the selected action.
+
+        More specifically: if the workflow action has anything in its [Custom Code](https://www.dotcms.com/docs/latest/custom-workflow-actions) field, the result is evaluated as Velocity, and the output is returned.
+      operationId: getWorkflowConditionByActionId
+      parameters:
+      - description: |-
+          Identifier of a workflow action to check for condition.
+
+          Example value: `b9d89c80-3d88-4311-8365-187323c96436` (Default system workflow "Publish" action)
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Condition returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find condition by action ID
+      tags:
+      - Workflow
+  /v1/workflow/actions/{actionId}/fire:
+    put:
+      description: |-
+        Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by identifier, on a target contentlet.
+
+        Returns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.
+      operationId: putFireActionById
+      parameters:
+      - description: |-
+          Identifier of a workflow action.
+
+          Example value: `b9d89c80-3d88-4311-8365-187323c96436` (Default system workflow "Publish" action)
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      - description: Inode of the target content.
+        in: query
+        name: inode
+        schema:
+          type: string
+      - description: Identifier of target content.
+        in: query
+        name: identifier
+        schema:
+          type: string
+      - description: |+
+          Determines how target content is indexed.
+
+          | Value | Description |
+          |-------|-------------|
+          | `DEFER` | Content will be indexed asynchronously, outside of the current process. Valid content will finish the method in process and be returned before the content becomes visible in the index. This is the default index policy; it is resource-friendly and well-suited to batch processing. |
+          | `WAIT_FOR` | The API call will not return from the content check process until the content has been indexed. Ensures content is promptly available for searching. |
+          | `FORCE` | Forces Elasticsearch to index the content **immediately**.<br>**Caution:** Using this value may cause system performance issues; it is not recommended for general use, though may be useful for testing purposes. |
+
+        in: query
+        name: indexPolicy
+        schema:
+          type: string
+          enum:
+          - DEFER
+          - WAIT_FOR
+          - FORCE
+      - description: Language version of target content.
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FireActionForm"
+        description: |+
+          Optional body consists of a JSON object containing various properties, some of which are specific to certain actionlets.
+
+          The full list of properties that may be used with this form is as follows:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `contentlet` | Object | An alternate way of specifying the target contentlet. If no identifier or inode is included via parameter, either one could instead be included in the body as a property of this object. |
+          | `comments` | String | Comments that will appear in the [workflow tasks](https://www.dotcms.com/docs/latest/workflow-tasks) tool with the execution of this workflow action. |
+          | `individualPermissions` | Object | Allows setting granular permissions associated with the target. The object properties are the [system names of permissions](https://www.dotcms.com/docs/latest/user-permissions#Permissions), such as READ, PUBLISH, EDIT, etc. Their respective values are a list of user or role identifiers that should be granted the permission in question. Example: `"READ": ["9ad24203-ae6a-4e5e-aa10-a8c38fd11f17","MyRole"]` |
+          | `assign` | String | The identifier of a user or role to next receive the workflow task assignment. |
+          | `pathToMove` | String | If the workflow action includes the Move actionlet, this property will specify the target path. This path must include a host, such as `//default/testfolder`, `//demo.dotcms.com/application`, etc. |
+          | `query` | String | Not used in this method. |
+          | `whereToSend` | String | For the [push publishing](push-publishing) actionlet; sets the push-publishing environment to receive the target content. Must be specified as an environment identifier. [Learn how to find environment IDs here.](https://www.dotcms.com/docs/latest/push-publishing-endpoints#EnvironmentIds) |
+          | `iWantTo` | String | For the push publishing actionlet; this can be set to one of three values: <ul style="line-height:2rem;"><li>`publish` for push publish;</li><li>`expire` for remove;</li><li>`publishexpire` for push remove.</li></ul> These are further configurable with the properties below that specify publishing and expiration dates, times, etc. |
+          | `publishDate` | String | For the push publishing actionlet; specifies a date to push the content. Format: `yyyy-MM-dd`.  |
+          | `publishTime` | String | For the push publishing actionlet; specifies a time to push the content. Format: `hh-mm`. |
+          | `expireDate` | String | For the push publishing actionlet; specifies a date to remove the content. Format: `yyyy-MM-dd`.  |
+          | `expireTime` | String | For the push publishing actionlet; specifies a time to remove the content. Format: `hh-mm`.  |
+          | `neverExpire` | Boolean | For the push publishing actionlet; a value of `true` invalidates the expiration time/date. |
+          | `filterKey` | String | For the push publishing actionlet; specifies a [push publishing filter](https://www.dotcms.com/docs/latest/push-publishing-filters) key, should the workflow action call for such. To retrieve a full list of push publishing filters and their keys, use `GET /v1/pushpublish/filters`. |
+          | `timezoneId` | String | For the push publishing actionlet; specifies the time zone to which the indicated times belong. Uses the [tz database](https://www.iana.org/time-zones). For a list of values, see [the database directly](https://data.iana.org/time-zones/tz-link.html) or refer to [the Wikipedia entry listing tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones). |
+
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Fired action successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Fire action by ID
+      tags:
+      - Workflow
+  /v1/workflow/actions/{actionId}/firemultipart:
+    put:
+      description: |-
+        (**Construction notice:** Still needs request body documentation. Coming soon!)
+
+        Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by identifier, on a target contentlet. Uses a multipart form to transmit its data.
+
+        Returns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.
+      operationId: putFireActionByIdMultipart_1
+      parameters:
+      - description: |-
+          Identifier of a workflow action.
+
+          Example value: `b9d89c80-3d88-4311-8365-187323c96436` (Default system workflow "Publish" action)
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      - description: Inode of the target content.
+        in: query
+        name: inode
+        schema:
+          type: string
+      - description: Identifier of target content.
+        in: query
+        name: identifier
+        schema:
+          type: string
+      - description: |+
+          Determines how target content is indexed.
+
+          | Value | Description |
+          |-------|-------------|
+          | `DEFER` | Content will be indexed asynchronously, outside of the current process. Valid content will finish the method in process and be returned before the content becomes visible in the index. This is the default index policy; it is resource-friendly and well-suited to batch processing. |
+          | `WAIT_FOR` | The API call will not return from the content check process until the content has been indexed. Ensures content is promptly available for searching. |
+          | `FORCE` | Forces Elasticsearch to index the content **immediately**.<br>**Caution:** Using this value may cause system performance issues; it is not recommended for general use, though may be useful for testing purposes. |
+
+        in: query
+        name: indexPolicy
+        schema:
+          type: string
+          enum:
+          - DEFER
+          - WAIT_FOR
+          - FORCE
+      - description: Language version of target content.
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+        description: Multipart form. More details to follow.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Fired action successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Fire action by ID (multipart form) 🚧
+      tags:
+      - Workflow
+  /v1/workflow/contentlet/actions/_bulkfire:
+    post:
+      description: "This operation allows you to specify a multiple content items\
+        \ (either by query or a list of identifiers), a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ to perform on them, and additional parameters as needed by the selected\
+        \ action."
+      operationId: postBulkActionsFire
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FireBulkActionsForm"
+        description: |-
+          Body consists of a JSON object with the following possible properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `contentletIds` | List of Strings | A list of individual contentlet identifiers. |
+          | `query` | String | [Lucene query](https://www.dotcms.com/docs/latest/content-search-syntax#Lucene); uses all matching contentlets. |
+          | `workflowActionId` | String | The identifier of the workflow action to be performed on the selected content. |
+          | `additionalParams` | Object | Further parameters and properties are conveyed here, depending on the particulars of the selected action.<br><br>For a complete list of possible parameters, refer to the various keys listed in `GET /workflow/actionlets`. |
+
+          If both `contentletIds` and `query` properties are present, the operation will perform the selected action on all contentlets indicated in both. Note that this will lead to the workflow action being performed on the same contentlet twice, if it appears in both.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventOutput"
+          description: Success
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Perform workflow actions on bulk content
+      tags:
+      - Workflow
+  /v1/workflow/contentlet/actions/bulk:
+    post:
+      description: "Returns a list of bulk actions available for [contentlets](https://www.dotcms.com/docs/latest/content#Contentlets)\
+        \ either by identifiers or by query, as specified in the body."
+      operationId: postBulkActions
+      requestBody:
+        content:
+          application/json:
+            example:
+              contentletIds:
+              - 651a4dc8-2124-45d8-8bd2-d8e68ad358a8
+              - f8d60f79-e006-42e0-894f-5d3488b796f6
+              query: +contentType:*
+            schema:
+              $ref: "#/components/schemas/BulkActionForm"
+        description: |-
+          Body consists of a JSON object with either of the following properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `contentletIds` | List of Strings | A list of individual contentlet identifiers. |
+          | `query` | String | [Lucene query](https://www.dotcms.com/docs/latest/content-search-syntax#Lucene); uses all matching contentlets. |
+
+          If both properties are present, the operation will use the list of identifiers and disregard the query.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBulkActionView"
+          description: Zero or more bulk actions returned successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Finds available bulk workflow actions for content
+      tags:
+      - Workflow
+  /v1/workflow/contentlet/actions/bulk/fire:
+    put:
+      description: "This operation allows you to specify a multiple content items\
+        \ (either by query or a list of identifiers), a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ to perform on them, and additional parameters as needed by the selected\
+        \ action."
+      operationId: putBulkActionsFire
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FireBulkActionsForm"
+        description: |-
+          Body consists of a JSON object with the following possible properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `contentletIds` | List of Strings | A list of individual contentlet identifiers. |
+          | `query` | String | [Lucene query](https://www.dotcms.com/docs/latest/content-search-syntax#Lucene); uses all matching contentlets. |
+          | `workflowActionId` | String | The identifier of the workflow action to be performed on the selected content. |
+          | `additionalParams` | Object | Further parameters and properties are conveyed here, depending on the particulars of the selected action.<br><br>For a complete list of possible parameters, refer to the various keys listed in `GET /workflow/actionlets`. |
+
+          If both `contentletIds` and `query` properties are present, the operation will use the query and disregard the identifier list.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBulkActionsResultView"
+          description: Success
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Perform workflow actions on bulk content
+      tags:
+      - Workflow
+  /v1/workflow/contentlet/{inode}/actions:
+    get:
+      description: "Returns a list of [workflow actions](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ associated with a [contentlet](https://www.dotcms.com/docs/latest/content#Contentlets)\
+        \ specified by inode."
+      operationId: getWorkflowActionsByContentletInode
+      parameters:
+      - description: |+
+          Inode of contentlet to examine for workflow actions.
+
+        in: path
+        name: inode
+        required: true
+        schema:
+          type: string
+      - description: |-
+          *Optional.* Case-insensitive parameter indicating how results are to be displayed.
+
+          In listing mode, all associated actions are returned; in editing mode (the default), it returns only the actions accessible to the contentlet's current workflow step.
+        in: query
+        name: renderMode
+        schema:
+          type: string
+          default: EDITING
+          enum:
+          - EDITING
+          - LISTING
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionsView"
+          description: Scheme(s) returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Contentlet not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Finds workflow actions by content inode
+      tags:
+      - Workflow
+  /v1/workflow/contenttypes/{contentTypeVarOrId}/system/actions:
+    get:
+      description: "Returns a list of [default system actions](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions)\
+        \ associated with a specified [content type](https://www.dotcms.com/docs/latest/content-types)."
+      operationId: getSystemActionMappingsByContentType
+      parameters:
+      - description: |-
+          The ID or Velocity variable of the content type to inspectfor default system action bindings.
+
+          Example value: `htmlpageasset` (Default page content type)
+        in: path
+        name: contentTypeVarOrId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySystemActionWorkflowActionMappings"
+          description: Action(s) returned successfully from content type
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content Type not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find default system actions mapped to a content type
+      tags:
+      - Workflow
+  /v1/workflow/defaultactions/contenttype/{contentTypeId}:
+    get:
+      description: "Returns a list of actions that may be used as a [default action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions)\
+        \ for a specified [content type](https://www.dotcms.com/docs/latest/content-types),\
+        \ along with their associated [workflow schemes](https://www.dotcms.com/docs/latest/managing-workflows#Schemes)."
+      operationId: getDefaultActionsByContentTypeId
+      parameters:
+      - description: |-
+          Identifier or variable of content type to examine for actions.
+
+          Example ID: `c541abb1-69b3-4bc5-8430-5e09e5239cc8` (Default page content type)
+
+          Example Variable: `htmlpageasset` (Default page content type)
+        in: path
+        name: contentTypeId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityDefaultWorkflowActionsView"
+          description: Default action(s) returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content type not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find possible default actions by content type
+      tags:
+      - Workflow
+  /v1/workflow/defaultactions/schemes:
+    get:
+      description: "Returns a list of actions that are eligible to be used as a [default\
+        \ action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions)\
+        \ for one or more [workflow schemes](https://www.dotcms.com/docs/latest/managing-workflows#Schemes)."
+      operationId: getDefaultActionsBySchemeIds
+      parameters:
+      - description: Comma-separated list of workflow scheme identifiers.
+        in: query
+        name: ids
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityDefaultWorkflowActionsView"
+          description: Action(s) returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find possible default actions by scheme(s)
+      tags:
+      - Workflow
+  /v1/workflow/initialactions/contenttype/{contentTypeId}:
+    get:
+      description: "Returns a list of available actions of the initial/first step(s)\
+        \ of the workflow scheme(s) associated with a [content type](https://www.dotcms.com/docs/latest/content-types)."
+      operationId: getInitialActionsByContentTypeId
+      parameters:
+      - description: |-
+          Identifier or variable of content type to examine for initial actions.
+
+          Example ID: `c541abb1-69b3-4bc5-8430-5e09e5239cc8` (Default page content type)
+
+          Example Variable: `htmlpageasset` (Default page content type)
+        in: path
+        name: contentTypeId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityDefaultWorkflowActionsView"
+          description: Initial action(s) returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content type not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find initial actions by content type
+      tags:
+      - Workflow
+  /v1/workflow/reorder/step/{stepId}/order/{order}:
+    put:
+      description: |+
+        Updates a [workflow step](https://www.dotcms.com/docs/latest/managing-workflows#Steps)'s order within a [scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes) by assigning it a numeric order.
+
+        Returns "Ok" on success.
+
+      operationId: putReorderWorkflowStepsInScheme
+      parameters:
+      - description: |-
+          Identifier of the step to reorder.
+
+          Example: `ee24a4cb-2d15-4c98-b1bd-6327126451f3` (Default system workflow Draft step)
+        in: path
+        name: stepId
+        required: true
+        schema:
+          type: string
+      - description: "Integer indicating the step's position in the order, with `0`\
+          \ as the first. All other steps numbers are adjusted accordingly, leaving\
+          \ no gaps."
+        in: path
+        name: order
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Workflow step reordered successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Change the order of steps within a scheme
+      tags:
+      - Workflow
+  /v1/workflow/reorder/steps/{stepId}/actions/{actionId}:
+    put:
+      description: |+
+        Updates a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions)'s order within a [step](https://www.dotcms.com/docs/latest/managing-workflows#Steps) by assigning it a numeric order.
+
+        Returns "Ok" on success.
+
+      operationId: putReorderWorkflowActionsInStep
+      parameters:
+      - description: Identifier of the step containing the action.
+        in: path
+        name: stepId
+        required: true
+        schema:
+          type: string
+      - description: Identifier of the action to reorder.
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowReorderWorkflowActionStepForm"
+        description: "Body consists of a JSON object containing the single property\
+          \ `order`, which is assigned an integer value."
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Updated workflow action successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow step or action not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Change the order of actions within a workflow step
+      tags:
+      - Workflow
+  /v1/workflow/schemes:
+    get:
+      description: Returns workflow schemes. Can be filtered by content type and/or
+        live status through optional query parameters.
+      operationId: getWorkflowSchemes
+      parameters:
+      - description: |-
+          Optional filter parameter that takes a content type identifier and returns all [workflow schemes](https://www.dotcms.com/docs/latest/managing-workflows#Schemes) associated with that type.
+
+          Leave blank to return all workflow schemes.
+
+          Example value: `c541abb1-69b3-4bc5-8430-5e09e5239cc8` (Default page content type)
+        in: query
+        name: contentTypeId
+        schema:
+          type: string
+      - description: "If `true`, includes archived schemes in response."
+        in: query
+        name: showArchived
+        schema:
+          type: boolean
+          default: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowSchemesView"
+          description: Scheme(s) returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow scheme not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find workflow schemes
+      tags:
+      - Workflow
+    post:
+      description: |-
+        Create a [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes).
+
+         Returns created workflow scheme on success.
+      operationId: postSaveScheme_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowSchemeForm"
+        description: |
+          The request body consists of the following three properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `schemeName` | String | The workflow scheme's name. |
+          | `schemeDescription` | String | A description of the scheme. |
+          | `schemeArchived` | Boolean | If `true`, the scheme will be created in an archived state. |
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowSchemeView"
+          description: Copied workflow scheme successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Create a workflow scheme
+      tags:
+      - Workflow
+  /v1/workflow/schemes/actions/{systemAction}:
+    post:
+      description: "Returns a list of [workflow actions](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ associated with [workflow schemes](https://www.dotcms.com/docs/latest/managing-workflows#Schemes),\
+        \ further filtered by [default system actions](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions)."
+      operationId: postFindActionsBySchemesAndSystemAction
+      parameters:
+      - description: Default system action.
+        in: path
+        name: systemAction
+        required: true
+        schema:
+          type: string
+          enum:
+          - NEW
+          - EDIT
+          - PUBLISH
+          - UNPUBLISH
+          - ARCHIVE
+          - UNARCHIVE
+          - DELETE
+          - DESTROY
+      requestBody:
+        content:
+          application/json:
+            example:
+              schemes:
+              - d61a59e1-a49c-46f2-a929-db2b4bfa88b2
+            schema:
+              $ref: "#/components/schemas/WorkflowSchemesForm"
+        description: "Body consists of a JSON object containing a single property\
+          \ called `schemes`, which contains a list of workflow scheme identifier\
+          \ strings."
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionsView"
+          description: Workflow action(s) returned successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Finds workflow actions by schemes and system action
+      tags:
+      - Workflow
+  /v1/workflow/schemes/import:
+    post:
+      description: |-
+        Import a [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes).
+
+        Returns "OK" on success.
+      operationId: postImportScheme
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowSchemeImportObjectForm"
+        description: "Body consists of a JSON object containing two properties: \n\
+          \n| Property | Type | Description |\n|-|-|-|\n| `workflowObject` | Object\
+          \ | An entire scheme along with steps and actions, such as received from\
+          \ the corresponding export method. |\n| `permissions` | List of Objects\
+          \ | A list of permission objects, such as received from the corresponding\
+          \ export method. |\n\nThe simplest way to perform an import is to pass the\
+          \ full value of the `entity` property returned by the corresponding Workflow\
+          \ Scheme Export endpoint as the data payload."
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Imported workflow scheme successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Import a workflow scheme
+      tags:
+      - Workflow
+  /v1/workflow/schemes/schemescontenttypes/{contentTypeId}:
+    get:
+      description: |-
+        Fetches [workflow schemes](https://www.dotcms.com/docs/latest/managing-workflows#Schemes)  associated with a content type by its identifier. Returns an entity containing two properties:
+
+        | Property | Description |
+        |----------|-------------|
+        | `contentTypeSchemes` | A list of schemes associated with the specified content type. |
+        | `schemes` | A list of non-archived schemes, irrespective of relation to the content type. |
+      operationId: getWorkflowSchemesByContentTypeId
+      parameters:
+      - description: |-
+          Identifier of content type to examine for workflow schemes.
+
+          Example value: `c541abb1-69b3-4bc5-8430-5e09e5239cc8` (Default page content type)
+        in: path
+        name: contentTypeId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SchemesAndSchemesContentTypeView"
+          description: Scheme(s) returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Content type ID not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find workflow schemes by content type id
+      tags:
+      - Workflow
+  /v1/workflow/schemes/{schemeIdOrVariable}/export:
+    get:
+      description: |-
+        Export a [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes).
+
+        Returns the full workflow scheme, along with steps, actions, permissions, etc., on success.
+      operationId: getExportScheme
+      parameters:
+      - description: Identifier or variable name of the workflow scheme to export.
+        in: path
+        name: schemeIdOrVariable
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  permissions:
+                  - bitPermission: false
+                    id: 0
+                    individualPermission: true
+                    inode: string
+                    permission: 0
+                    roleId: string
+                    type: string
+                  workflowObject:
+                    actionClassParams:
+                    - actionClassId: string
+                      id: null
+                      key: string
+                      value: null
+                    actionClasses:
+                    - actionId: string
+                      actionlet:
+                        actionClass: string
+                        howTo: string
+                        localizedHowto: string
+                        localizedName: string
+                        name: string
+                        nextStep: null
+                        parameters:
+                        - defaultValue: ""
+                          displayName: string
+                          key: string
+                          required: false
+                      clazz: string
+                      id: string
+                      name: string
+                      order: 0
+                    actionSteps:
+                    - actionId: string
+                      actionOrder: "0"
+                      stepId: string
+                    actions:
+                    - assignable: false
+                      commentable: false
+                      condition: ""
+                      icon: string
+                      id: string
+                      metadata: null
+                      name: string
+                      nextAssign: string
+                      nextStep: string
+                      nextStepCurrentStep: true
+                      order: 0
+                      owner: null
+                      roleHierarchyForAssign: false
+                      schemeId: string
+                      showOn: []
+                    schemeSystemActionWorkflowActionMappings:
+                    - identifier: string
+                      owner:
+                        archived: false
+                        creationDate: 1723806880187
+                        defaultScheme: false
+                        description: string
+                        entryActionId: null
+                        id: string
+                        mandatory: false
+                        modDate: 1723796816309
+                        name: string
+                        system: false
+                        variableName: string
+                      systemAction: string
+                      workflowAction:
+                        assignable: false
+                        commentable: false
+                        condition: ""
+                        icon: string
+                        id: string
+                        metadata: null
+                        name: string
+                        nextAssign: string
+                        nextStep: string
+                        nextStepCurrentStep: true
+                        order: 0
+                        owner: null
+                        roleHierarchyForAssign: false
+                        schemeId: string
+                        showOn: []
+                      ownerContentType: false
+                      ownerScheme: true
+                    schemes:
+                    - archived: false
+                      creationDate: 1723806880187
+                      defaultScheme: false
+                      description: string
+                      entryActionId: null
+                      id: string
+                      mandatory: false
+                      modDate: 1723796816309
+                      name: string
+                      system: false
+                      variableName: string
+                    steps:
+                    - creationDate: 1723806894533
+                      enableEscalation: false
+                      escalationAction: null
+                      escalationTime: 0
+                      id: string
+                      myOrder: 0
+                      name: string
+                      resolved: false
+                      schemeId: string
+                    version: string
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+              schema:
+                $ref: "#/components/schemas/ResponseEntityView"
+          description: Exported workflow scheme successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow scheme not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Export a workflow scheme
+      tags:
+      - Workflow
+  /v1/workflow/schemes/{schemeId}:
+    delete:
+      description: |-
+        Deletes a [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes)
+
+        Scheme must already be in an archived state.
+
+        Returns deleted workflow scheme on success.
+      operationId: deleteWorkflowSchemeById
+      parameters:
+      - description: Identifier of workflow scheme to delete.
+        in: path
+        name: schemeId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowSchemeView"
+          description: Workflow scheme deleted successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow scheme not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Delete a workflow scheme
+      tags:
+      - Workflow
+    put:
+      description: |-
+        Updates a [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes).
+
+        Returns updated scheme on success.
+      operationId: putUpdateWorkflowScheme
+      parameters:
+      - description: |-
+          Identifier of workflow scheme.
+
+          Example value: `d61a59e1-a49c-46f2-a929-db2b4bfa88b2` (Default system workflow)
+        in: path
+        name: schemeId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowSchemeForm"
+        description: |
+          The request body consists of the following three properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `schemeName` | String | The workflow scheme's name. |
+          | `schemeDescription` | String | A description of the scheme. |
+          | `schemeArchived` | Boolean | If `true`, the scheme will be be placed in an archived state. |
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Updated workflow scheme successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow scheme not found.
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Update a workflow scheme
+      tags:
+      - Workflow
+  /v1/workflow/schemes/{schemeId}/actions:
+    get:
+      description: "Returns a list of [workflow actions](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ associated with a specified [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes)."
+      operationId: getWorkflowActionsBySchemeId
+      parameters:
+      - description: |-
+          Identifier of workflow scheme.
+
+          Example value: `d61a59e1-a49c-46f2-a929-db2b4bfa88b2` (Default system workflow)
+        in: path
+        name: schemeId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionsView"
+          description: Actions returned successfully from workflow scheme
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow scheme not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find all actions in a workflow scheme
+      tags:
+      - Workflow
+  /v1/workflow/schemes/{schemeId}/copy:
+    post:
+      description: |-
+        Copy a [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes).
+
+         A name for the new scheme may be provided either by parameter or by POST body property; if no name is supplied, the name will be that of the copied workflow scheme with the current Unix epoch timestamp integer appended.
+
+        Returns copied workflow scheme on success.
+      operationId: postCopyScheme
+      parameters:
+      - description: |-
+          Identifier of workflow scheme.
+
+          Example value: `d61a59e1-a49c-46f2-a929-db2b4bfa88b2` (Default system workflow)
+        in: path
+        name: schemeId
+        required: true
+        schema:
+          type: string
+      - description: |-
+          Name of new scheme from copy.
+
+          Note: A name with a length less than 2 characters or greater than 100 may require renaming before certain actions, such as archiving, can be taken on it.
+        in: query
+        name: name
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowCopyForm"
+        description: |-
+          Body consists of a `name` property; an alternate way to supply the name of the new scheme, instead of parameter.
+
+           Name supplied this way must be at minimum 2 and at maximum 100 characters in length.
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowSchemeView"
+          description: Copied workflow scheme successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow scheme not found
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Copy a workflow scheme
+      tags:
+      - Workflow
+  /v1/workflow/schemes/{schemeId}/steps:
+    get:
+      description: "Returns a list of [steps](https://www.dotcms.com/docs/latest/managing-workflows#Steps)\
+        \ associated with a [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes)."
+      operationId: getWorkflowStepsBySchemeId
+      parameters:
+      - description: |-
+          Identifier of workflow scheme.
+
+          Example value: `d61a59e1-a49c-46f2-a929-db2b4bfa88b2` (Default system workflow)
+        in: path
+        name: schemeId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowStepsView"
+          description: Scheme(s) returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow scheme not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find steps by workflow scheme ID
+      tags:
+      - Workflow
+  /v1/workflow/schemes/{schemeId}/system/actions:
+    get:
+      description: "Returns a list of [default system actions](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions)\
+        \ associated with a specified [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes)."
+      operationId: getSystemActionMappingsBySchemeId
+      parameters:
+      - description: |-
+          Identifier of workflow scheme.
+
+          Example value: `d61a59e1-a49c-46f2-a929-db2b4bfa88b2` (Default system workflow)
+        in: path
+        name: schemeId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySystemActionWorkflowActionMappings"
+          description: Actions returned successfully from workflow scheme
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow scheme not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find default system actions mapped to a workflow scheme
+      tags:
+      - Workflow
+  /v1/workflow/status/{contentletInode}:
+    get:
+      description: |-
+        Checks the current workflow status of a contentlet by its [inode](https://www.dotcms.com/docs/latest/content-versions#IdentifiersInodes).
+
+        Returns an object containing the associated [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes), [workflow step](https://www.dotcms.com/docs/latest/managing-workflows#Steps), and [workflow task](https://www.dotcms.com/docs/latest/workflow-tasks) associated with the contentlet.
+      operationId: getContentWorkflowStatusByInode
+      parameters:
+      - description: |+
+          Inode of content version to inspect for workflow status.
+
+        in: path
+        name: contentletInode
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseContentletWorkflowStatusView"
+          description: Action(s) returned successfully
+        "400":
+          description: Bad Request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find workflow status of content
+      tags:
+      - Workflow
+  /v1/workflow/steps:
+    post:
+      description: |-
+        Creates a [workflow step](https://www.dotcms.com/docs/latest/managing-workflows#Steps).
+
+        Returns an object representing the step.
+      operationId: postAddWorkflowStep
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowStepAddForm"
+        description: |+
+          Body consists of a JSON object containing a workflow step update form. This includes the following properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `schemeId` | String | The identifier of the [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes) to which the step will be added. |
+          | `stepName` | String | The name of the workflow step. |
+          | `enableEscalation` | Boolean | Determines whether a step is capable of automatic escalation to the next step. (Read more about [schedule-enabled workflows](https://www.dotcms.com/docs/latest/schedule-enabled-workflow).) |
+          | `escalationAction` | String | The identifier of the workflow action to execute on automatic escalation. |
+          | `escalationTime` | String | The time, in seconds, before the workflow automatically escalates. |
+          | `stepResolved` | Boolean | If true, any content which enters this workflow step will be considered resolved.
+          Content in a resolved step will not appear in the workflow queues of any users.
+           |
+
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowStepView"
+          description: Created workflow step successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Add a new workflow step
+      tags:
+      - Workflow
+  /v1/workflow/steps/{stepId}:
+    delete:
+      description: |-
+        Deletes a [step](https://www.dotcms.com/docs/latest/managing-workflows#Steps) from a [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes).
+
+        Returns the deleted workflow step object.
+      operationId: deleteWorkflowStepById
+      parameters:
+      - description: Identifier of a workflow step to delete.
+        in: path
+        name: stepId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowStepView"
+          description: Workflow step deleted successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Delete a workflow step
+      tags:
+      - Workflow
+    get:
+      description: "Returns a [workflow step](https://www.dotcms.com/docs/latest/managing-workflows#Steps)\
+        \ by identifier."
+      operationId: getFindWorkflowStepById
+      parameters:
+      - description: |-
+          Identifier of the step to retrieve.
+
+          Example: `ee24a4cb-2d15-4c98-b1bd-6327126451f3` (Default system workflow Draft step)
+        in: path
+        name: stepId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowStepView"
+          description: Found workflow step successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow step not found.
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Retrieves a workflow step
+      tags:
+      - Workflow
+    put:
+      description: |-
+        Updates a [workflow step](https://www.dotcms.com/docs/latest/managing-workflows#Steps).
+
+        Returns an object representing the updated step.
+      operationId: putUpdateWorkflowStepById
+      parameters:
+      - description: |-
+          Identifier of the step to update.
+
+          Example: `ee24a4cb-2d15-4c98-b1bd-6327126451f3` (Default system workflow Draft step)
+        in: path
+        name: stepId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowStepUpdateForm"
+        description: |+
+          Body consists of a JSON object containing a workflow step update form. This includes the following properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `stepOrder` | Integer | The position of the step within the [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes), with `0` being the first. |
+          | `stepName` | String | The name of the workflow step. |
+          | `enableEscalation` | Boolean | Determines whether a step is capable of automatic escalation to the next step. (Read more about [schedule-enabled workflows](https://www.dotcms.com/docs/latest/schedule-enabled-workflow).) |
+          | `escalationAction` | String | The identifier of the workflow action to execute on automatic escalation. |
+          | `escalationTime` | String | The time, in seconds, before the workflow automatically escalates. |
+          | `stepResolved` | Boolean | If true, any content which enters this workflow step will be considered resolved.
+          Content in a resolved step will not appear in the workflow queues of any users.
+           |
+
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowStepView"
+          description: Updated workflow step successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Update an existing workflow step
+      tags:
+      - Workflow
+  /v1/workflow/steps/{stepId}/actions:
+    get:
+      description: "Returns a list of [workflow actions](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ associated with a specified [workflow step](https://www.dotcms.com/docs/latest/managing-workflows#Steps)."
+      operationId: getWorkflowActionsByStepId
+      parameters:
+      - description: |-
+          Identifier of a workflow step.
+
+          Example value: `ee24a4cb-2d15-4c98-b1bd-6327126451f3` (Default system workflow "Draft" step)
+        in: path
+        name: stepId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionsView"
+          description: Actions returned successfully from step
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow step not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find all actions in a workflow step
+      tags:
+      - Workflow
+    post:
+      description: "Assigns a single [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ to a [workflow step](https://www.dotcms.com/docs/latest/managing-workflows#Steps).\
+        \ Returns \"Ok\" on success."
+      operationId: postActionToStepById
+      parameters:
+      - description: |-
+          Identifier of a workflow step to receive a new action.
+
+          Example value: `ee24a4cb-2d15-4c98-b1bd-6327126451f3` (Default system workflow "Draft" step)
+        in: path
+        name: stepId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            example:
+              actionId: b9d89c80-3d88-4311-8365-187323c96436
+            schema:
+              $ref: "#/components/schemas/WorkflowActionStepForm"
+        description: |+
+          Body consists of a JSON object with a single property:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `actionId` | String | The identifier of the workflow action to assign to the step specified in the parameter. |
+
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                errors:
+                - errorCode: string
+                  message: string
+                  fieldName: string
+                entity: Ok
+                messages:
+                - message: string
+                i18nMessagesMap:
+                  additionalProp1: string
+                  additionalProp2: string
+                  additionalProp3: string
+                permissions:
+                - string
+                pagination:
+                  currentPage: 0
+                  perPage: 0
+                  totalEntries: 0
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Workflow action added to step successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Adds a workflow action to a workflow step
+      tags:
+      - Workflow
+  /v1/workflow/steps/{stepId}/actions/{actionId}:
+    delete:
+      description: |-
+        Deletes an [action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) from a single [workflow step](https://www.dotcms.com/docs/latest/managing-workflows#Steps).
+
+        Returns "Ok" on success.
+
+        If the action exists on other steps, removing it from one step will not delete the action outright.
+      operationId: deleteWorkflowActionFromStepByActionId
+      parameters:
+      - description: Identifier of the workflow action to remove.
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      - description: Identifier of the step containing the action.
+        in: path
+        name: stepId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Workflow action removed from step successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Remove a workflow action from a step
+      tags:
+      - Workflow
+    get:
+      description: "Returns a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions)\
+        \ if it exists within a specific [step](https://www.dotcms.com/docs/latest/managing-workflows#Steps)."
+      operationId: getWorkflowActionByStepActionId
+      parameters:
+      - description: |-
+          Identifier of a workflow step.
+
+          Example value: `ee24a4cb-2d15-4c98-b1bd-6327126451f3` (Default system workflow "Draft" step)
+        in: path
+        name: stepId
+        required: true
+        schema:
+          type: string
+      - description: |-
+          Identifier of a workflow action.
+
+          Example value: `b9d89c80-3d88-4311-8365-187323c96436` (Default system workflow "Publish" action)
+        in: path
+        name: actionId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowActionView"
+          description: Action returned successfully from step
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found within specified step
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find a workflow action within a step
+      tags:
+      - Workflow
+  /v1/workflow/system/actions:
+    put:
+      description: |-
+        This operation allows you to save a [default system action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) mapping. This requires:
+
+        1. Selecting a default system action to be mapped;
+        2. Specifying a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) to be performed when that system action is called;
+        3. Associating this mapping with either a [workflow scheme](https://www.dotcms.com/docs/latest/managing-workflows#Schemes) or a [content type](https://www.dotcms.com/docs/latest/content-types).
+
+        See the request body below for further details.
+      operationId: putSaveSystemActions
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowSystemActionForm"
+        description: |-
+          Body consists of a JSON object with the following properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `systemAction` | String | A default system action, such as `NEW` or `PUBLISH`. |
+          | `actionId` | String | The identifier of an action that will be performed by the specified system action. |
+          | `schemeId` | String | The identifier of a workflow scheme to be associated with the system action. |
+          | `contentTypeVariable` | String | The variable of a content type to be associated with the system action. Note that the content type must already have the schema assigned as one of its valid workflows in order to bind a system action from said schema. |
+
+          If both the `schemeId` and `contentTypeVariable` are specified, the scheme identifier takes precedence, and the content type variable is disregarded.
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBulkActionsResultView"
+          description: Success
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Save a default system action mapping
+      tags:
+      - Workflow
+  /v1/workflow/system/actions/{identifier}:
+    delete:
+      description: |-
+        Deletes a [default system action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) binding.
+
+        Returns the deleted system action object.
+
+        This method is minimally destructive, as it neither deletes a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), nor removes any system action category. Instead, it dissolves the association between the two, which can be re-established any time.
+
+        To find a suitable identifier, you can use `GET /system/actions/{workflowActionId}` and find it in the immediate `identifier` property of any of the objects returned in the entity.
+      operationId: deleteSystemActionByActionId
+      parameters:
+      - description: |-
+          Identifier of the system action mapping to delete.
+
+          Example value: `59995336-187e-442a-b398-04b9f137eabd` (Demo starter binding that maps `DELETE` system action to the "Destroy" workflow action for the Blog content type)
+        in: path
+        name: identifier
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySystemActionWorkflowActionMapping"
+          description: System action binding deleted successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Delete default system action binding by action id
+      tags:
+      - Workflow
+  /v1/workflow/system/actions/{workflowActionId}:
+    get:
+      description: "Returns a list of [default system actions](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions)\
+        \ associated with a specified [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions)."
+      operationId: getSystemActionsByActionId
+      parameters:
+      - description: |-
+          Identifier of the workflow action to return.
+
+          Example value: `b9d89c80-3d88-4311-8365-187323c96436` (Default system workflow "Publish" action)
+        in: path
+        name: workflowActionId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySystemActionWorkflowActionMappings"
+          description: Action(s) returned successfully
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "404":
+          description: Workflow action not found
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find default system actions by workflow action id
+      tags:
+      - Workflow
+  /v1/workflow/tasks/history/comments/{contentletIdentifier}:
+    get:
+      description: |-
+        Retrieve the workflow tasks comments of a contentlet by its [id](https://www.dotcms.com/docs/latest/content-versions#IdentifiersInodes).
+
+        Returns an object containing the associated [workflow history or comments]https://www2.dotcms.com/docs/latest/workflow-tasks, [workflow task]
+      operationId: getWorkflowTasksHistoryComments
+      parameters:
+      - description: |+
+          Id of content  to inspect for workflow tasks.
+
+        in: path
+        name: contentletIdentifier
+        required: true
+        schema:
+          type: string
+      - description: Language version of target content.
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowHistoryCommentsView"
+          description: Action(s) returned successfully
+        "400":
+          description: Bad Request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "500":
+          description: Internal Server Error
+      summary: Find workflow tasks history and comments of content
+      tags:
+      - Workflow
+  /v1/workflow/{contentletId}/comments:
+    post:
+      description: |-
+        Create a [workflow comment].
+
+         Returns created workflow comment on success.
+      operationId: postSaveScheme
+      parameters:
+      - description: Identifier of contentlet to add comment.
+        in: path
+        name: contentletId
+        required: true
+        schema:
+          type: string
+      - description: Language version of target content.
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkflowCommentForm"
+        description: |
+          The request body consists of the following three properties:
+
+          | Property | Type | Description |
+          |-|-|-|
+          | `comment` | String | The workflow comment. |
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityWorkflowCommentView"
+          description: Copied workflow comment successfully
+        "400":
+          description: Bad request
+        "401":
+          description: Invalid User
+        "403":
+          description: Forbidden
+        "406":
+          description: Not Acceptable
+        "415":
+          description: Unsupported Media Type
+        "500":
+          description: Internal Server Error
+      summary: Create a workflow comment
+      tags:
+      - Workflow
+  /v1/{a}:
+    get:
+      operationId: heavyCheck
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - System Monitoring
+  /v1/{a}/{a}:
+    get:
+      operationId: ready
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - System Monitoring
+  /v2/contenttype/{typeIdOrVarName}/fields:
+    delete:
+      deprecated: true
+      operationId: deleteFields_1
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              type: array
+              items:
+                type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    get:
+      deprecated: true
+      operationId: getContentTypeFields_1
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    post:
+      operationId: createContentTypeField_1
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    put:
+      deprecated: true
+      operationId: updateFields_1
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v2/contenttype/{typeIdOrVarName}/fields/id/{fieldId}:
+    delete:
+      operationId: deleteContentTypeFieldById_1
+      parameters:
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    get:
+      operationId: getContentTypeFieldById_1
+      parameters:
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    put:
+      operationId: updateContentTypeFieldById_1
+      parameters:
+      - in: path
+        name: fieldId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v2/contenttype/{typeIdOrVarName}/fields/var/{fieldVar}:
+    delete:
+      operationId: deleteContentTypeFieldByVar_1
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    get:
+      operationId: getContentTypeFieldByVar_1
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    put:
+      operationId: updateContentTypeFieldByVar_1
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: fieldVar
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v2/languages:
+    get:
+      operationId: list_13
+      parameters:
+      - in: query
+        name: contentInode
+        schema:
+          type: string
+      - in: query
+        name: countLangVars
+        schema:
+          type: boolean
+      responses:
+        default:
+          content:
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+    post:
+      operationId: saveLanguage
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/LanguageForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v2/languages/_getdefault:
+    get:
+      operationId: getDefaultLanguage
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewLanguage"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityViewLanguage"
+          description: default response
+      tags:
+      - Internationalization
+  /v2/languages/i18n:
+    post:
+      operationId: getMessages_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/I18NForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v2/languages/id/{languageid}:
+    get:
+      operationId: get_8
+      parameters:
+      - in: path
+        name: languageid
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v2/languages/iso:
+    get:
+      operationId: getIsoLanguagesAndCountries
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v2/languages/variables:
+    get:
+      operationId: getVariables
+      parameters:
+      - in: query
+        name: renderNulls
+        schema:
+          type: boolean
+          default: true
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v2/languages/{languageId}:
+    delete:
+      operationId: deleteLanguage
+      parameters:
+      - in: path
+        name: languageId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+    put:
+      operationId: updateLanguage
+      parameters:
+      - in: path
+        name: languageId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/LanguageForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v2/languages/{languageTag}:
+    get:
+      operationId: getFromLanguageTag
+      parameters:
+      - in: path
+        name: languageTag
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: strict
+        schema:
+          type: boolean
+          default: false
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+    post:
+      operationId: saveFromLanguageTag
+      parameters:
+      - in: path
+        name: languageTag
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: strict
+        schema:
+          type: boolean
+          default: false
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v2/languages/{language}/_makedefault:
+    put:
+      operationId: makeDefault_1
+      parameters:
+      - in: path
+        name: language
+        required: true
+        schema:
+          type: integer
+          format: int64
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/MakeDefaultLangForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v2/languages/{language}/keys:
+    get:
+      operationId: getAllMessages
+      parameters:
+      - in: path
+        name: language
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Internationalization
+  /v2/tags:
+    get:
+      operationId: list_14
+      parameters:
+      - in: query
+        name: name
+        schema:
+          type: string
+      - in: query
+        name: siteId
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+          description: default response
+      tags:
+      - Tags
+    post:
+      operationId: addTag_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/TagForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+          description: default response
+      tags:
+      - Tags
+    put:
+      operationId: updateTag_1
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/UpdateTagForm"
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+          description: default response
+      tags:
+      - Tags
+  /v2/tags/import:
+    post:
+      operationId: importTags_1
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+          description: default response
+      tags:
+      - Tags
+  /v2/tags/inode/{inode}:
+    delete:
+      operationId: deleteTagInodesByInode_1
+      parameters:
+      - in: path
+        name: inode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+          description: default response
+      tags:
+      - Tags
+    get:
+      operationId: findTagsByInode_1
+      parameters:
+      - in: path
+        name: inode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagInodesMapView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagInodesMapView"
+          description: default response
+      tags:
+      - Tags
+  /v2/tags/tag/{nameOrId}/inode/{inode}:
+    put:
+      operationId: linkTagsAndInode_1
+      parameters:
+      - in: path
+        name: nameOrId
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: inode
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagInodesMapView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagInodesMapView"
+          description: default response
+      tags:
+      - Tags
+  /v2/tags/user/{userId}:
+    get:
+      operationId: getTagsByUserId_1
+      parameters:
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+          description: default response
+      tags:
+      - Tags
+  /v2/tags/{nameOrId}:
+    get:
+      operationId: getTagsByNameOrId_1
+      parameters:
+      - in: path
+        name: nameOrId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityTagMapView"
+          description: default response
+      tags:
+      - Tags
+  /v2/tags/{tagId}:
+    delete:
+      operationId: delete_18
+      parameters:
+      - in: path
+        name: tagId
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+          description: default response
+      tags:
+      - Tags
+  /v3/contenttype/{typeIdOrVarName}/fields:
+    delete:
+      operationId: deleteFields_2
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          '*/*':
+            schema:
+              $ref: "#/components/schemas/DeleteFieldsForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+    get:
+      operationId: getContentTypeFields_2
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v3/contenttype/{typeIdOrVarName}/fields/allfields:
+    get:
+      description: Returns the list of fields in a Content Type that meet the specified
+        criteria.
+      operationId: allfields
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: filter
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - REQUIRED
+            - USER_SEARCHABLE
+            - SYSTEM_INDEXED
+            - SHOW_IN_LIST
+            - UNIQUE
+          uniqueItems: true
+      requestBody:
+        content:
+          application/json:
+            examples:
+              filter:
+                description: filter
+                summary: Filter fields by one or more of the specified criteria
+                value: "REQUIRED,SYSTEM_INDEXED,UNIQUE,SHOW_IN_LIST,USER_SEARCHABLE"
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                - clazz: com.dotcms.contenttype.model.field.ImmutableTextField
+                  contentTypeId: 3b70f386cf65117a675f284eea928415
+                  dataType: TEXT
+                  dbColumn: text2
+                  defaultValue: null
+                  fixed: false
+                  forceIncludeInApi: false
+                  hint: null
+                  iDate: 1732992811000
+                  id: e39533a92ee05d8c083f7e6a1a5ee5e5
+                  indexed: true
+                  listed: false
+                  modDate: 1732992838000
+                  name: Description
+                  owner: null
+                  readOnly: false
+                  regexCheck: null
+                  relationType: null
+                  required: true
+                  searchable: false
+                  sortOrder: 3
+                  unique: true
+                  values: null
+                  variable: description
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+          description: Content type retrieved successfully
+        "400":
+          description: "Bad Request, when using invalid filter names"
+        "401":
+          description: Invalid User
+        "404":
+          description: Content Type was not found
+        "500":
+          description: Internal Server Error
+      summary: Returns filtered Content Type fields
+      tags:
+      - Content Type Field
+  /v3/contenttype/{typeIdOrVarName}/fields/move:
+    put:
+      operationId: moveFields
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MoveFieldsForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /v3/contenttype/{typeIdOrVarName}/fields/{id}:
+    put:
+      operationId: updateField
+      parameters:
+      - in: path
+        name: typeIdOrVarName
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateFieldForm"
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Content Type Field
+  /vtl/dynamic:
+    get:
+      operationId: dynamicGet_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    post:
+      operationId: dynamicPost_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    put:
+      operationId: dynamicPut_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+  /vtl/dynamic/{pathParam}:
+    delete:
+      operationId: dynamicDelete_1
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    get:
+      operationId: dynamicGet_3
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    patch:
+      operationId: dynamicPatch_1
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    post:
+      operationId: dynamicPost_3
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    put:
+      operationId: dynamicPut_3
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: string
+          text/plain:
+            schema:
+              type: string
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+  /vtl/{folder}:
+    delete:
+      operationId: delete_16
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    get:
+      operationId: get_6
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    patch:
+      operationId: patchMultipart_2
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    post:
+      operationId: postMultipart_2
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    put:
+      operationId: putMultipart_2
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+  /vtl/{folder}/{pathParam}:
+    delete:
+      operationId: delete_17
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    get:
+      operationId: get_7
+      parameters:
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties:
+                type: object
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    patch:
+      operationId: patchMultipart_3
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    post:
+      operationId: postMultipart_3
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+    put:
+      operationId: putMultipart_3
+      parameters:
+      - in: path
+        name: pathParam
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      - in: path
+        name: folder
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/FormDataMultiPart"
+      responses:
+        default:
+          content:
+            application/json: {}
+            application/xml: {}
+            text/plain: {}
+          description: default response
+      tags:
+      - Templates
+  /widget/{params}:
+    get:
+      operationId: getWidget
+      parameters:
+      - in: path
+        name: params
+        required: true
+        schema:
+          type: string
+          pattern: .*
+      responses:
+        default:
+          content:
+            text/plain; charset=UTF-8: {}
+          description: default response
+      tags:
+      - Widgets
+  /ws/v1/system/events:
+    get:
+      operationId: getEvents
+      parameters:
+      - in: query
+        name: lastcallback
+        schema:
+          type: integer
+          format: int64
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Administration
+  /ws/v1/system/syncevents:
+    get:
+      operationId: getSyncEvents
+      parameters:
+      - in: query
+        name: lastcallback
+        schema:
+          type: integer
+          format: int64
+      responses:
+        default:
+          content:
+            application/javascript: {}
+            application/json: {}
+          description: default response
+      tags:
+      - Administration
+components:
+  schemas:
+    AIImageRequestDTO:
+      type: object
+      properties:
+        model:
+          type: string
+        numberOfImages:
+          type: integer
+          format: int32
+        prompt:
+          type: string
+        size:
+          type: string
+    AccessibilityForm:
+      type: object
+      additionalProperties:
+        type: string
+      properties:
+        empty:
+          type: boolean
+    ActionFail:
+      type: object
+      properties:
+        errorMessage:
+          type: string
+        identifier:
+          type: string
+        inode:
+          type: string
+    ActionInputView:
+      type: object
+      properties:
+        body:
+          type: object
+          additionalProperties:
+            type: object
+        id:
+          type: string
+    AddVariantForm:
+      type: object
+      properties:
+        description:
+          type: string
+    AdditionalParamsBean:
+      type: object
+      properties:
+        additionalParamsMap:
+          type: object
+          additionalProperties:
+            type: object
+        assignComment:
+          $ref: "#/components/schemas/AssignCommentBean"
+        assignCommentBean:
+          $ref: "#/components/schemas/AssignCommentBean"
+        pushPublish:
+          $ref: "#/components/schemas/PushPublishBean"
+        pushPublishBean:
+          $ref: "#/components/schemas/PushPublishBean"
+    AnalyticsQuery:
+      type: object
+      properties:
+        dimensions:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+        filters:
+          type: string
+        limit:
+          type: integer
+          format: int64
+        measures:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+        offset:
+          type: integer
+          format: int64
+        order:
+          type: string
+        timeDimensions:
+          type: string
+    Announcement:
+      type: object
+      properties:
+        announcementDate:
+          type: string
+          format: date-time
+        announcementDateAsISO8601:
+          type: string
+        description:
+          type: string
+        identifier:
+          type: string
+        inode:
+          type: string
+        languageId:
+          type: string
+        modDate:
+          type: string
+          format: date-time
+        modDateAsISO8601:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+        url:
+          type: string
+    ApiTokenForm:
+      type: object
+      properties:
+        claims:
+          type: object
+          additionalProperties:
+            type: object
+        expirationSeconds:
+          type: integer
+          format: int32
+        network:
+          type: string
+        shouldBeAdmin:
+          type: boolean
+        userId:
+          type: string
+    AssetInfoRequestForm:
+      type: object
+      properties:
+        assetPath:
+          type: string
+    AssetsRequestForm:
+      type: object
+      properties:
+        assetPath:
+          type: string
+        language:
+          type: string
+        live:
+          type: boolean
+    AssignCommentBean:
+      type: object
+      properties:
+        assign:
+          type: string
+        comment:
+          type: string
+    AuthenticationForm:
+      type: object
+      properties:
+        backEndLogin:
+          type: boolean
+        country:
+          type: string
+        language:
+          type: string
+        password:
+          type: string
+        rememberMe:
+          type: boolean
+        userId:
+          type: string
+    BayesianResult:
+      type: object
+      properties:
+        differenceData:
+          $ref: "#/components/schemas/DifferenceData"
+        distributionPdfs:
+          $ref: "#/components/schemas/SampleGroup"
+        quantiles:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/QuantilePair"
+          properties:
+            empty:
+              type: boolean
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/VariantResult"
+          properties:
+            empty:
+              type: boolean
+            first:
+              $ref: "#/components/schemas/VariantResult"
+            last:
+              $ref: "#/components/schemas/VariantResult"
+        suggestedWinner:
+          type: string
+        value:
+          type: number
+          format: double
+    BinaryField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    Body:
+      type: object
+      properties:
+        rows:
+          type: array
+          items:
+            $ref: "#/components/schemas/TemplateLayoutRow"
+    BodyPart:
+      type: object
+      properties:
+        contentDisposition:
+          $ref: "#/components/schemas/ContentDisposition"
+        entity:
+          type: object
+        headers:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        mediaType:
+          type: object
+          properties:
+            parameters:
+              type: object
+              additionalProperties:
+                type: string
+            subtype:
+              type: string
+            type:
+              type: string
+            wildcardSubtype:
+              type: boolean
+            wildcardType:
+              type: boolean
+        messageBodyWorkers:
+          $ref: "#/components/schemas/MessageBodyWorkers"
+        parameterizedHeaders:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/ParameterizedHeader"
+        parent:
+          $ref: "#/components/schemas/MultiPart"
+        providers:
+          type: object
+    BodyView:
+      type: object
+      properties:
+        rows:
+          type: array
+          items:
+            $ref: "#/components/schemas/TemplateLayoutRowView"
+    BrowserQueryForm:
+      type: object
+      properties:
+        extensions:
+          type: array
+          items:
+            type: string
+        filter:
+          type: string
+        hostFolderId:
+          type: string
+        languageId:
+          type: integer
+          format: int64
+        maxResults:
+          type: integer
+          format: int32
+        mimeTypes:
+          type: array
+          items:
+            type: string
+        offset:
+          type: integer
+          format: int32
+        showArchived:
+          type: boolean
+        showDotAssets:
+          type: boolean
+        showFiles:
+          type: boolean
+        showFolders:
+          type: boolean
+        showLinks:
+          type: boolean
+        showPages:
+          type: boolean
+        showWorking:
+          type: boolean
+        sortBy:
+          type: string
+        sortByDesc:
+          type: boolean
+    BulkActionForm:
+      type: object
+      properties:
+        contentletIds:
+          type: array
+          items:
+            type: string
+        query:
+          type: string
+    BulkActionView:
+      type: object
+      properties:
+        schemes:
+          type: array
+          items:
+            $ref: "#/components/schemas/BulkWorkflowSchemeView"
+    BulkActionsResultView:
+      type: object
+      properties:
+        fails:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActionFail"
+        skippedCount:
+          type: integer
+          format: int64
+        successCount:
+          type: integer
+          format: int64
+    BulkWorkflowSchemeView:
+      type: object
+      properties:
+        scheme:
+          $ref: "#/components/schemas/WorkflowScheme"
+        steps:
+          type: array
+          items:
+            $ref: "#/components/schemas/BulkWorkflowStepView"
+    BulkWorkflowStepView:
+      type: object
+      properties:
+        actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/CountWorkflowAction"
+        step:
+          $ref: "#/components/schemas/CountWorkflowStep"
+    BundleMap:
+      type: object
+      properties:
+        bundleId:
+          type: integer
+          format: int64
+        jarFile:
+          type: string
+        location:
+          type: string
+        separator:
+          type: string
+        state:
+          type: integer
+          format: int32
+        symbolicName:
+          type: string
+        system:
+          type: boolean
+        version:
+          type: string
+    CategoryEditForm:
+      type: object
+      properties:
+        categoryData:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+        direction:
+          type: string
+        filter:
+          type: string
+        orderBy:
+          type: string
+        page:
+          type: integer
+          format: int32
+        parentInode:
+          type: string
+        perPage:
+          type: integer
+          format: int32
+        siteId:
+          type: string
+    CategoryField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    CategoryForm:
+      type: object
+      properties:
+        active:
+          type: boolean
+        categoryName:
+          type: string
+        categoryVelocityVarName:
+          type: string
+        description:
+          type: string
+        inode:
+          type: string
+        key:
+          type: string
+        keywords:
+          type: string
+        parent:
+          type: string
+        siteId:
+          type: string
+        sortOrder:
+          type: integer
+          format: int32
+    CategoryKeysForm:
+      type: object
+      properties:
+        keys:
+          type: array
+          items:
+            type: string
+    ChangeLoggerForm:
+      type: object
+      properties:
+        level:
+          type: string
+        name:
+          type: string
+    CheckboxField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    ColumnField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    CompanyEmailForm:
+      type: object
+      properties:
+        senderAndEmail:
+          type: string
+    CompletionsForm:
+      type: object
+      properties:
+        contentType:
+          type: array
+          items:
+            type: string
+        fieldVar:
+          type: string
+        indexName:
+          type: string
+        language:
+          type: integer
+          format: int64
+        model:
+          type: string
+        operator:
+          type: string
+        prompt:
+          type: string
+          maxLength: 4096
+          minLength: 1
+        responseFormat:
+          type: object
+          additionalProperties:
+            type: object
+        responseLengthTokens:
+          type: integer
+          format: int32
+          minimum: 128
+        searchLimit:
+          type: integer
+          format: int32
+          maximum: 1000
+          minimum: 1
+        searchOffset:
+          type: integer
+          format: int32
+          minimum: 0
+        site:
+          type: string
+        stream:
+          type: boolean
+        temperature:
+          type: number
+          format: float
+          maximum: 2
+          minimum: 0
+        threshold:
+          type: number
+          format: float
+        user:
+          $ref: "#/components/schemas/User"
+    Condition:
+      type: object
+      properties:
+        operator:
+          type: string
+          enum:
+          - EQUALS
+          - CONTAINS
+          - EXISTS
+        parameter:
+          type: string
+        value:
+          type: object
+    ConstantField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    Container:
+      type: object
+      properties:
+        archived:
+          type: boolean
+        categoryId:
+          type: string
+        code:
+          type: string
+        deleted:
+          type: boolean
+        friendlyName:
+          type: string
+        getiDate:
+          type: string
+          format: date-time
+        idate:
+          type: string
+          format: date-time
+        identifier:
+          type: string
+        inode:
+          type: string
+        live:
+          type: boolean
+        locked:
+          type: boolean
+        maxContentlets:
+          type: integer
+          format: int32
+        modDate:
+          type: string
+          format: date-time
+        modUser:
+          type: string
+        name:
+          type: string
+        new:
+          type: boolean
+        notes:
+          type: string
+        owner:
+          type: string
+        parentPermissionable:
+          $ref: "#/components/schemas/Permissionable"
+        parents:
+          type: array
+          items:
+            type: object
+          writeOnly: true
+        permissionId:
+          type: string
+        permissionType:
+          type: string
+        postLoop:
+          type: string
+        preLoop:
+          type: string
+        showOnMenu:
+          type: boolean
+        sortOrder:
+          type: integer
+          format: int32
+        source:
+          type: string
+          enum:
+          - UNKNOWN
+          - DB
+          - FILE
+        title:
+          type: string
+        type:
+          type: string
+        useDiv:
+          type: boolean
+        versionId:
+          type: string
+        versionType:
+          type: string
+        working:
+          type: boolean
+    ContainerEntry:
+      type: object
+      properties:
+        containerId:
+          type: string
+        containerUUID:
+          type: string
+        contentIds:
+          type: array
+          items:
+            type: string
+        personaTag:
+          type: string
+    ContainerForm:
+      type: object
+      properties:
+        code:
+          type: string
+        containerStructures:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContainerStructure"
+        dynamic:
+          type: boolean
+        friendlyName:
+          type: string
+        hostId:
+          type: string
+        identifier:
+          type: string
+        maxContentlets:
+          type: integer
+          format: int32
+        notes:
+          type: string
+        owner:
+          type: string
+        postLoop:
+          type: string
+        preLoop:
+          type: string
+        showOnMenu:
+          type: boolean
+        sortContentletsBy:
+          type: string
+        sortOrder:
+          type: integer
+          format: int32
+        staticify:
+          type: boolean
+        structureInode:
+          type: string
+        title:
+          type: string
+        useDiv:
+          type: boolean
+    ContainerStructure:
+      type: object
+      properties:
+        code:
+          type: string
+        containerId:
+          type: string
+        containerInode:
+          type: string
+        contentTypeVar:
+          type: string
+        id:
+          type: string
+        structureId:
+          type: string
+    ContainerUUID:
+      type: object
+      properties:
+        historyUUIDs:
+          type: array
+          items:
+            type: string
+        identifier:
+          type: string
+        uuid:
+          type: string
+    ContainerView:
+      type: object
+      properties:
+        container:
+          $ref: "#/components/schemas/Container"
+        path:
+          type: string
+    ContentDisposition:
+      type: object
+      properties:
+        creationDate:
+          type: string
+          format: date-time
+        fileName:
+          type: string
+        modificationDate:
+          type: string
+          format: date-time
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        readDate:
+          type: string
+          format: date-time
+        size:
+          type: integer
+          format: int64
+        type:
+          type: string
+    ContentForm:
+      type: object
+      properties:
+        contentlet:
+          type: object
+          additionalProperties:
+            type: object
+    ContentImportForm:
+      type: object
+      properties:
+        commitGranularity:
+          type: integer
+          format: int32
+        contentType:
+          type: string
+        fields:
+          type: array
+          items:
+            type: string
+        language:
+          type: string
+        stopOnError:
+          type: boolean
+        workflowActionId:
+          type: string
+    ContentImportParamsSchema:
+      type: object
+      description: Schema for content import parameters.
+      properties:
+        file:
+          type: string
+          format: binary
+          description: The CSV file to import.
+        form:
+          type: string
+          description: JSON string representing import settings.
+          example: "{\n  \"contentType\": \"activity\",\n  \"language\": \"en-US\"\
+            ,\n  \"workflowActionId\": \"b9d89c80-3d88-4311-8365-187323c96436\",\n\
+            \  \"fields\": [\"title\"]\n  \"stopOnError\":false \n  \"commitGranularity\"\
+            : 100\n}"
+      required:
+      - file
+      - form
+    ContentReferenceView:
+      type: object
+      properties:
+        container:
+          $ref: "#/components/schemas/ContainerView"
+        page:
+          $ref: "#/components/schemas/IHTMLPage"
+        personaName:
+          type: string
+    ContentReportView:
+      type: object
+      properties:
+        contentTypeName:
+          type: string
+        entries:
+          type: integer
+          format: int64
+    ContentSearchForm:
+      type: object
+    ContentType:
+      type: object
+      discriminator:
+        propertyName: clazz
+      properties:
+        clazz:
+          type: string
+        owner:
+          type: string
+      required:
+      - clazz
+    ContentTypeForm:
+      type: object
+      properties:
+        contentType:
+          $ref: "#/components/schemas/ContentType"
+        iterable:
+          type: object
+        requestJson:
+          type: object
+        systemActions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tuple2SystemActionString"
+        workflows:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowFormEntry"
+    ContentletWorkflowStatusView:
+      type: object
+      properties:
+        scheme:
+          $ref: "#/components/schemas/WorkflowScheme"
+        step:
+          $ref: "#/components/schemas/WorkflowStep"
+        task:
+          $ref: "#/components/schemas/WorkflowTask"
+    CopyContentTypeForm:
+      type: object
+      properties:
+        folder:
+          type: string
+        host:
+          type: string
+        icon:
+          type: string
+        name:
+          type: string
+        variable:
+          type: string
+    CopyContentletForm:
+      type: object
+      properties:
+        containerId:
+          type: string
+        contentId:
+          type: string
+        pageId:
+          type: string
+        personalization:
+          type: string
+        relationType:
+          type: string
+        treeOrder:
+          type: integer
+          format: int32
+        variantId:
+          type: string
+    CopySiteForm:
+      type: object
+      properties:
+        copyAll:
+          type: boolean
+        copyContentOnPages:
+          type: boolean
+        copyContentOnSite:
+          type: boolean
+        copyContentTypes:
+          type: boolean
+        copyFolders:
+          type: boolean
+        copyFromSiteId:
+          type: string
+        copyLinks:
+          type: boolean
+        copySiteVariables:
+          type: boolean
+        copyTemplatesContainers:
+          type: boolean
+        site:
+          $ref: "#/components/schemas/SiteForm"
+    CountView:
+      type: object
+      properties:
+        count:
+          type: integer
+          format: int32
+    CountWorkflowAction:
+      type: object
+      properties:
+        conditionPresent:
+          type: boolean
+        count:
+          type: integer
+          format: int64
+        moveable:
+          type: boolean
+        pushPublish:
+          type: boolean
+        workflowAction:
+          $ref: "#/components/schemas/WorkflowAction"
+    CountWorkflowStep:
+      type: object
+      properties:
+        count:
+          type: integer
+          format: int64
+        workflowStep:
+          $ref: "#/components/schemas/WorkflowStep"
+    CredibilityInterval:
+      type: object
+      properties:
+        lower:
+          type: number
+          format: double
+        upper:
+          type: number
+          format: double
+    CustomField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    CustomPortletForm:
+      type: object
+      properties:
+        baseTypes:
+          type: string
+        contentTypes:
+          type: string
+        dataViewMode:
+          type: string
+        portletId:
+          type: string
+        portletName:
+          type: string
+    DateField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    DateTimeField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    DeleteBundlesByIdentifierForm:
+      type: object
+      properties:
+        identifiers:
+          type: array
+          items:
+            type: string
+    DeleteFieldsForm:
+      type: object
+      properties:
+        fieldsID:
+          type: array
+          items:
+            type: string
+    DeleteForm:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: string
+    DeletePPQueueElementsByIdentifierForm:
+      type: object
+      properties:
+        identifiers:
+          type: array
+          items:
+            type: string
+    DeleteSecretForm:
+      type: object
+      properties:
+        key:
+          type: string
+        params:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+        siteId:
+          type: string
+    DifferenceData:
+      type: object
+      properties:
+        controlData:
+          type: array
+          items:
+            type: number
+            format: double
+        differences:
+          type: array
+          items:
+            type: number
+            format: double
+        relativeDifference:
+          type: number
+          format: double
+        testData:
+          type: array
+          items:
+            type: number
+            format: double
+    DoesNotExistException:
+      type: object
+      properties:
+        cause:
+          type: object
+          properties:
+            localizedMessage:
+              type: string
+            message:
+              type: string
+            stackTrace:
+              type: array
+              items:
+                type: object
+                properties:
+                  classLoaderName:
+                    type: string
+                  className:
+                    type: string
+                  fileName:
+                    type: string
+                  lineNumber:
+                    type: integer
+                    format: int32
+                  methodName:
+                    type: string
+                  moduleName:
+                    type: string
+                  moduleVersion:
+                    type: string
+                  nativeMethod:
+                    type: boolean
+        localizedMessage:
+          type: string
+        message:
+          type: string
+        stackTrace:
+          type: array
+          items:
+            type: object
+            properties:
+              classLoaderName:
+                type: string
+              className:
+                type: string
+              fileName:
+                type: string
+              lineNumber:
+                type: integer
+                format: int32
+              methodName:
+                type: string
+              moduleName:
+                type: string
+              moduleVersion:
+                type: string
+              nativeMethod:
+                type: boolean
+        suppressed:
+          type: array
+          items:
+            type: object
+            properties:
+              localizedMessage:
+                type: string
+              message:
+                type: string
+              stackTrace:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    classLoaderName:
+                      type: string
+                    className:
+                      type: string
+                    fileName:
+                      type: string
+                    lineNumber:
+                      type: integer
+                      format: int32
+                    methodName:
+                      type: string
+                    moduleName:
+                      type: string
+                    moduleVersion:
+                      type: string
+                    nativeMethod:
+                      type: boolean
+    DotAssetContentType:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/ContentType"
+      - type: object
+        properties:
+          defaultType:
+            type: boolean
+          description:
+            type: string
+          detailPage:
+            type: string
+          expireDateVar:
+            type: string
+          fixed:
+            type: boolean
+          folder:
+            type: string
+          folderPath:
+            type: string
+          host:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          icon:
+            type: string
+          id:
+            type: string
+          metadata:
+            type: object
+            additionalProperties:
+              type: object
+          modDate:
+            type: string
+            format: date-time
+          multilingualable:
+            type: boolean
+          name:
+            type: string
+          publishDateVar:
+            type: string
+          siteName:
+            type: string
+          sortOrder:
+            type: integer
+            format: int32
+          system:
+            type: boolean
+          urlMapPattern:
+            type: string
+          variable:
+            type: string
+          versionable:
+            type: boolean
+    EmbeddingsForm:
+      type: object
+      properties:
+        fields:
+          type: array
+          items:
+            type: string
+        indexName:
+          type: string
+        limit:
+          type: integer
+          format: int32
+          maximum: 1000
+          minimum: 1
+        model:
+          type: string
+        offset:
+          type: integer
+          format: int32
+          minimum: 0
+        query:
+          type: string
+          maxLength: 4096
+          minLength: 1
+        userId:
+          type: string
+        velocityTemplate:
+          type: string
+    EmptyField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    EndpointForm:
+      type: object
+      properties:
+        address:
+          type: string
+        authorizationToken:
+          type: string
+        enabled:
+          type: boolean
+        environmentId:
+          type: string
+        name:
+          type: string
+        port:
+          type: string
+        protocol:
+          type: string
+        sending:
+          type: boolean
+    Environment:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        owner:
+          type: string
+        permissionId:
+          type: string
+        pushToAll:
+          type: boolean
+    EnvironmentForm:
+      type: object
+      properties:
+        name:
+          type: string
+        pushMode:
+          type: string
+          enum:
+          - PUSH_TO_ONE
+          - PUSH_TO_ALL
+        whoCanSend:
+          type: array
+          items:
+            type: string
+    ErrorDetail:
+      type: object
+      properties:
+        exceptionClass:
+          type: string
+        message:
+          type: string
+        processingStage:
+          type: string
+        stackTrace:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+    ErrorEntity:
+      type: object
+      properties:
+        errorCode:
+          type: string
+        fieldName:
+          type: string
+        message:
+          type: string
+    EventOutput:
+      type: object
+      properties:
+        closed:
+          type: boolean
+        type:
+          type: object
+          properties:
+            typeName:
+              type: string
+    ExcludedExperimentListForm:
+      type: object
+      properties:
+        exclude:
+          type: array
+          items:
+            type: string
+    ExistingLanguagesForContentletView:
+      type: object
+      additionalProperties:
+        type: object
+      properties:
+        empty:
+          type: boolean
+    Experiment:
+      type: object
+      properties:
+        createdBy:
+          type: string
+        creationDate:
+          type: string
+          format: date-time
+        description:
+          type: string
+        goals:
+          $ref: "#/components/schemas/Goals"
+        id:
+          type: string
+        lastModifiedBy:
+          type: string
+        lookBackWindowExpireTime:
+          type: integer
+          format: int64
+        modDate:
+          type: string
+          format: date-time
+        name:
+          type: string
+        pageId:
+          type: string
+        runningIds:
+          $ref: "#/components/schemas/RunningIds"
+        scheduling:
+          $ref: "#/components/schemas/Scheduling"
+        status:
+          type: string
+          enum:
+          - RUNNING
+          - SCHEDULED
+          - ENDED
+          - DRAFT
+          - ARCHIVED
+        targetingConditions:
+          type: array
+          items:
+            $ref: "#/components/schemas/TargetingCondition"
+        trafficAllocation:
+          type: number
+          format: float
+        trafficProportion:
+          $ref: "#/components/schemas/TrafficProportion"
+    ExperimentForm:
+      type: object
+      properties:
+        description:
+          type: string
+        goals:
+          $ref: "#/components/schemas/Goals"
+        lookbackWindow:
+          type: integer
+          format: int32
+        name:
+          type: string
+        pageId:
+          type: string
+        scheduling:
+          $ref: "#/components/schemas/Scheduling"
+        targetingConditions:
+          type: array
+          items:
+            $ref: "#/components/schemas/TargetingCondition"
+        trafficAllocation:
+          type: number
+          format: float
+        trafficProportion:
+          $ref: "#/components/schemas/TrafficProportion"
+    ExperimentResults:
+      type: object
+      properties:
+        bayesianResult:
+          $ref: "#/components/schemas/BayesianResult"
+        goals:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/GoalResults"
+        sessions:
+          $ref: "#/components/schemas/TotalSession"
+    ExperimentVariant:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        promoted:
+          type: boolean
+        url:
+          type: string
+        weight:
+          type: number
+          format: float
+    ExperimentVariantForm:
+      type: object
+      properties:
+        description:
+          type: string
+    ExportSecretForm:
+      type: object
+      properties:
+        appKeys:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+            uniqueItems: true
+          writeOnly: true
+        appKeysBySite:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+            uniqueItems: true
+        exportAll:
+          type: boolean
+        password:
+          type: string
+    ExtraPackagesForm:
+      type: object
+      properties:
+        packages:
+          type: string
+    Field:
+      type: object
+      discriminator:
+        propertyName: clazz
+      properties:
+        clazz:
+          type: string
+        fieldContentTypeProperties:
+          type: array
+          items:
+            type: string
+            enum:
+            - NAME
+            - VALUES
+            - CATEGORIES
+            - RELATIONSHIPS
+            - REGEX_CHECK
+            - HINT
+            - REQUIRED
+            - SEARCHABLE
+            - INDEXED
+            - LISTED
+            - UNIQUE
+            - DEFAULT_VALUE
+            - DATA_TYPE
+      required:
+      - clazz
+    FieldResponseView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/Field"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    FileAssetContentType:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/ContentType"
+      - type: object
+        properties:
+          defaultType:
+            type: boolean
+          description:
+            type: string
+          detailPage:
+            type: string
+          expireDateVar:
+            type: string
+          fixed:
+            type: boolean
+          folder:
+            type: string
+          folderPath:
+            type: string
+          host:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          icon:
+            type: string
+          id:
+            type: string
+          metadata:
+            type: object
+            additionalProperties:
+              type: object
+          modDate:
+            type: string
+            format: date-time
+          multilingualable:
+            type: boolean
+          name:
+            type: string
+          publishDateVar:
+            type: string
+          siteName:
+            type: string
+          sortOrder:
+            type: integer
+            format: int32
+          system:
+            type: boolean
+          urlMapPattern:
+            type: string
+          variable:
+            type: string
+          versionable:
+            type: boolean
+    FileField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    FileUploadDetail:
+      type: object
+      properties:
+        assetPath:
+          type: string
+        language:
+          type: string
+        live:
+          type: boolean
+        status:
+          type: boolean
+          writeOnly: true
+    FilterDescriptorForm:
+      type: object
+      properties:
+        defaultFilter:
+          type: boolean
+        filters:
+          type: object
+          additionalProperties:
+            type: object
+        key:
+          type: string
+        roles:
+          type: string
+        sort:
+          type: string
+        title:
+          type: string
+    FilteredContentTypesForm:
+      type: object
+      properties:
+        direction:
+          type: string
+        filter:
+          type: object
+          additionalProperties:
+            type: object
+        orderBy:
+          type: string
+        page:
+          type: integer
+          format: int32
+        perPage:
+          type: integer
+          format: int32
+    FindAvailableActionsForm:
+      type: object
+      properties:
+        hostId:
+          type: string
+        languageId:
+          type: integer
+          format: int64
+        path:
+          type: string
+        renderMode:
+          type: string
+          enum:
+          - EDITING
+          - LISTING
+    FireActionByNameForm:
+      type: object
+      properties:
+        actionName:
+          type: string
+        assign:
+          type: string
+        comments:
+          type: string
+        contentlet:
+          type: object
+          additionalProperties:
+            type: object
+        expireDate:
+          type: string
+        expireTime:
+          type: string
+        filterKey:
+          type: string
+        individualPermissions:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        iwantTo:
+          type: string
+        neverExpire:
+          type: string
+        pathToMove:
+          type: string
+        publishDate:
+          type: string
+        publishTime:
+          type: string
+        query:
+          type: string
+        timezoneId:
+          type: string
+        whereToSend:
+          type: string
+    FireActionForm:
+      type: object
+      properties:
+        assign:
+          type: string
+        comments:
+          type: string
+        contentlet:
+          type: object
+          additionalProperties:
+            type: object
+        expireDate:
+          type: string
+        expireTime:
+          type: string
+        filterKey:
+          type: string
+        individualPermissions:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        iwantTo:
+          type: string
+        neverExpire:
+          type: string
+        pathToMove:
+          type: string
+        publishDate:
+          type: string
+        publishTime:
+          type: string
+        query:
+          type: string
+        timezoneId:
+          type: string
+        whereToSend:
+          type: string
+    FireBulkActionsForm:
+      type: object
+      properties:
+        additionalParams:
+          $ref: "#/components/schemas/AdditionalParamsBean"
+        contentletIds:
+          type: array
+          items:
+            type: string
+        popupParamsBean:
+          $ref: "#/components/schemas/AdditionalParamsBean"
+        query:
+          type: string
+        workflowActionId:
+          type: string
+    FireMultipleActionForm:
+      type: object
+      properties:
+        assign:
+          type: string
+        comments:
+          type: string
+        contentlet:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: object
+        expireDate:
+          type: string
+        expireTime:
+          type: string
+        filterKey:
+          type: string
+        iwantTo:
+          type: string
+        neverExpire:
+          type: string
+        publishDate:
+          type: string
+        publishTime:
+          type: string
+        timezoneId:
+          type: string
+        whereToSend:
+          type: string
+    ForbiddenException:
+      type: object
+      properties:
+        cause:
+          type: object
+          properties:
+            localizedMessage:
+              type: string
+            message:
+              type: string
+            stackTrace:
+              type: array
+              items:
+                type: object
+                properties:
+                  classLoaderName:
+                    type: string
+                  className:
+                    type: string
+                  fileName:
+                    type: string
+                  lineNumber:
+                    type: integer
+                    format: int32
+                  methodName:
+                    type: string
+                  moduleName:
+                    type: string
+                  moduleVersion:
+                    type: string
+                  nativeMethod:
+                    type: boolean
+        localizedMessage:
+          type: string
+        message:
+          type: string
+        response:
+          type: object
+          properties:
+            allowedMethods:
+              type: array
+              items:
+                type: string
+              uniqueItems: true
+            cookies:
+              type: object
+              additionalProperties:
+                type: object
+                properties:
+                  comment:
+                    type: string
+                  domain:
+                    type: string
+                  expiry:
+                    type: string
+                    format: date-time
+                  httpOnly:
+                    type: boolean
+                  maxAge:
+                    type: integer
+                    format: int32
+                  name:
+                    type: string
+                  path:
+                    type: string
+                  secure:
+                    type: boolean
+                  value:
+                    type: string
+                  version:
+                    type: integer
+                    format: int32
+            date:
+              type: string
+              format: date-time
+            entity:
+              type: object
+            entityTag:
+              type: object
+              properties:
+                value:
+                  type: string
+                weak:
+                  type: boolean
+            headers:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: object
+            language:
+              type: object
+              properties:
+                country:
+                  type: string
+                displayCountry:
+                  type: string
+                displayLanguage:
+                  type: string
+                displayName:
+                  type: string
+                displayScript:
+                  type: string
+                displayVariant:
+                  type: string
+                extensionKeys:
+                  type: array
+                  items:
+                    type: string
+                  uniqueItems: true
+                iso3Country:
+                  type: string
+                iso3Language:
+                  type: string
+                language:
+                  type: string
+                script:
+                  type: string
+                unicodeLocaleAttributes:
+                  type: array
+                  items:
+                    type: string
+                  uniqueItems: true
+                unicodeLocaleKeys:
+                  type: array
+                  items:
+                    type: string
+                  uniqueItems: true
+                variant:
+                  type: string
+            lastModified:
+              type: string
+              format: date-time
+            length:
+              type: integer
+              format: int32
+            links:
+              type: array
+              items:
+                type: object
+                properties:
+                  params:
+                    type: object
+                    additionalProperties:
+                      type: string
+                  rel:
+                    type: string
+                  rels:
+                    type: array
+                    items:
+                      type: string
+                  title:
+                    type: string
+                  type:
+                    type: string
+                  uri:
+                    type: string
+                    format: uri
+                  uriBuilder:
+                    type: object
+              uniqueItems: true
+            location:
+              type: string
+              format: uri
+            mediaType:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  additionalProperties:
+                    type: string
+                subtype:
+                  type: string
+                type:
+                  type: string
+                wildcardSubtype:
+                  type: boolean
+                wildcardType:
+                  type: boolean
+            metadata:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: object
+            status:
+              type: integer
+              format: int32
+            statusInfo:
+              type: object
+              properties:
+                family:
+                  type: string
+                  enum:
+                  - INFORMATIONAL
+                  - SUCCESSFUL
+                  - REDIRECTION
+                  - CLIENT_ERROR
+                  - SERVER_ERROR
+                  - OTHER
+                reasonPhrase:
+                  type: string
+                statusCode:
+                  type: integer
+                  format: int32
+            stringHeaders:
+              type: object
+              additionalProperties:
+                type: array
+                items:
+                  type: string
+        stackTrace:
+          type: array
+          items:
+            type: object
+            properties:
+              classLoaderName:
+                type: string
+              className:
+                type: string
+              fileName:
+                type: string
+              lineNumber:
+                type: integer
+                format: int32
+              methodName:
+                type: string
+              moduleName:
+                type: string
+              moduleVersion:
+                type: string
+              nativeMethod:
+                type: boolean
+        suppressed:
+          type: array
+          items:
+            type: object
+            properties:
+              localizedMessage:
+                type: string
+              message:
+                type: string
+              stackTrace:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    classLoaderName:
+                      type: string
+                    className:
+                      type: string
+                    fileName:
+                      type: string
+                    lineNumber:
+                      type: integer
+                      format: int32
+                    methodName:
+                      type: string
+                    moduleName:
+                      type: string
+                    moduleVersion:
+                      type: string
+                    nativeMethod:
+                      type: boolean
+    ForgotPasswordForm:
+      type: object
+      properties:
+        userId:
+          type: string
+    FormContentType:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/ContentType"
+      - type: object
+        properties:
+          defaultType:
+            type: boolean
+          description:
+            type: string
+          detailPage:
+            type: string
+          expireDateVar:
+            type: string
+          fixed:
+            type: boolean
+          folder:
+            type: string
+          folderPath:
+            type: string
+          host:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          icon:
+            type: string
+          id:
+            type: string
+          metadata:
+            type: object
+            additionalProperties:
+              type: object
+          modDate:
+            type: string
+            format: date-time
+          multilingualable:
+            type: boolean
+          name:
+            type: string
+          publishDateVar:
+            type: string
+          siteName:
+            type: string
+          sortOrder:
+            type: integer
+            format: int32
+          system:
+            type: boolean
+          urlMapPattern:
+            type: string
+          variable:
+            type: string
+          versionable:
+            type: boolean
+    FormDataBodyPart:
+      type: object
+      properties:
+        contentDisposition:
+          $ref: "#/components/schemas/ContentDisposition"
+        entity:
+          type: object
+        formDataContentDisposition:
+          $ref: "#/components/schemas/FormDataContentDisposition"
+        headers:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        mediaType:
+          type: object
+          properties:
+            parameters:
+              type: object
+              additionalProperties:
+                type: string
+            subtype:
+              type: string
+            type:
+              type: string
+            wildcardSubtype:
+              type: boolean
+            wildcardType:
+              type: boolean
+        messageBodyWorkers:
+          $ref: "#/components/schemas/MessageBodyWorkers"
+        name:
+          type: string
+        parameterizedHeaders:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/ParameterizedHeader"
+        parent:
+          $ref: "#/components/schemas/MultiPart"
+        providers:
+          type: object
+        simple:
+          type: boolean
+        value:
+          type: string
+    FormDataContentDisposition:
+      type: object
+      properties:
+        creationDate:
+          type: string
+          format: date-time
+        fileName:
+          type: string
+        modificationDate:
+          type: string
+          format: date-time
+        name:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        readDate:
+          type: string
+          format: date-time
+        size:
+          type: integer
+          format: int64
+        type:
+          type: string
+    FormDataMultiPart:
+      type: object
+      properties:
+        bodyParts:
+          type: array
+          items:
+            $ref: "#/components/schemas/BodyPart"
+        contentDisposition:
+          $ref: "#/components/schemas/ContentDisposition"
+        entity:
+          type: object
+        fields:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/FormDataBodyPart"
+        headers:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        mediaType:
+          type: object
+          properties:
+            parameters:
+              type: object
+              additionalProperties:
+                type: string
+            subtype:
+              type: string
+            type:
+              type: string
+            wildcardSubtype:
+              type: boolean
+            wildcardType:
+              type: boolean
+        messageBodyWorkers:
+          $ref: "#/components/schemas/MessageBodyWorkers"
+        parameterizedHeaders:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/ParameterizedHeader"
+        parent:
+          $ref: "#/components/schemas/MultiPart"
+        providers:
+          type: object
+    GenerateBundleForm:
+      type: object
+      properties:
+        bundleId:
+          type: string
+        filterKey:
+          type: string
+        operation:
+          type: string
+          enum:
+          - PUBLISH
+          - UNPUBLISH
+    Goal:
+      type: object
+      properties:
+        metric:
+          $ref: "#/components/schemas/Metric"
+        type:
+          type: string
+          enum:
+          - MINIMIZE
+          - MAXIMIZE
+          writeOnly: true
+    GoalResults:
+      type: object
+      properties:
+        goal:
+          $ref: "#/components/schemas/Goal"
+        variants:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/VariantResults"
+    Goals:
+      type: object
+      properties:
+        primary:
+          $ref: "#/components/schemas/Goal"
+    HiddenField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    HierarchyShortCategoriesResponseView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/HierarchyShortCategory"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    HierarchyShortCategory:
+      type: object
+      properties:
+        inode:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        parentList:
+          type: array
+          items:
+            $ref: "#/components/schemas/ShortCategory"
+    HostFolderField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    HostVariable:
+      type: object
+      properties:
+        hostId:
+          type: string
+        id:
+          type: string
+        key:
+          type: string
+        lastModDate:
+          type: string
+          format: date-time
+        lastModifierId:
+          type: string
+        name:
+          type: string
+        value:
+          type: string
+    I18NForm:
+      type: object
+      properties:
+        country:
+          type: string
+        language:
+          type: string
+        messagesKey:
+          type: array
+          items:
+            type: string
+    IHTMLPage:
+      type: object
+      properties:
+        archived:
+          type: boolean
+        cacheTTL:
+          type: integer
+          format: int64
+        content:
+          type: boolean
+        friendlyName:
+          type: string
+        host:
+          type: string
+        httpsRequired:
+          type: boolean
+        identifier:
+          type: string
+        inode:
+          type: string
+        languageId:
+          type: integer
+          format: int64
+        live:
+          type: boolean
+        locked:
+          type: boolean
+        map:
+          type: object
+          additionalProperties:
+            type: object
+        menuOrder:
+          type: integer
+          format: int32
+        metadata:
+          type: string
+        modDate:
+          type: string
+          format: date-time
+        modUser:
+          type: string
+        name:
+          type: string
+        owner:
+          type: string
+        pageUrl:
+          type: string
+        parentPermissionable:
+          $ref: "#/components/schemas/Permissionable"
+        permissionId:
+          type: string
+        permissionType:
+          type: string
+        redirect:
+          type: string
+        seoDescription:
+          type: string
+        seoKeywords:
+          type: string
+        showOnMenu:
+          type: boolean
+        templateId:
+          type: string
+        title:
+          type: string
+        type:
+          type: string
+        uri:
+          type: string
+        versionId:
+          type: string
+        versionType:
+          type: string
+        working:
+          type: boolean
+    ImageField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    ImmutableListCondition:
+      type: array
+      items:
+        $ref: "#/components/schemas/Condition"
+      properties:
+        empty:
+          type: boolean
+        first:
+          $ref: "#/components/schemas/Condition"
+        last:
+          $ref: "#/components/schemas/Condition"
+    ImmutableListJob:
+      type: array
+      items:
+        $ref: "#/components/schemas/Job"
+      properties:
+        empty:
+          type: boolean
+        first:
+          $ref: "#/components/schemas/Job"
+        last:
+          $ref: "#/components/schemas/Job"
+    ImmutableListJobView:
+      type: array
+      items:
+        $ref: "#/components/schemas/JobView"
+      properties:
+        empty:
+          type: boolean
+        first:
+          $ref: "#/components/schemas/JobView"
+        last:
+          $ref: "#/components/schemas/JobView"
+    ImmutableListVariantResult:
+      type: array
+      items:
+        $ref: "#/components/schemas/VariantResult"
+      properties:
+        empty:
+          type: boolean
+        first:
+          $ref: "#/components/schemas/VariantResult"
+        last:
+          $ref: "#/components/schemas/VariantResult"
+    ImmutableMapDoubleQuantilePair:
+      type: object
+      additionalProperties:
+        $ref: "#/components/schemas/QuantilePair"
+      properties:
+        empty:
+          type: boolean
+    ImmutableMapStringListSampleData:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          $ref: "#/components/schemas/SampleData"
+      properties:
+        empty:
+          type: boolean
+    ImmutableMapStringObject:
+      type: object
+      additionalProperties:
+        type: object
+      properties:
+        empty:
+          type: boolean
+    ImmutableMapStringString:
+      type: object
+      additionalProperties:
+        type: string
+      properties:
+        empty:
+          type: boolean
+    JSONObject:
+      type: object
+      additionalProperties:
+        type: object
+      properties:
+        asMap:
+          type: object
+          additionalProperties:
+            type: object
+        empty:
+          type: boolean
+    Job:
+      type: object
+      properties:
+        completedAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        executionNode:
+          type: string
+        id:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: object
+          properties:
+            empty:
+              type: boolean
+        progress:
+          type: number
+          format: float
+        queueName:
+          type: string
+        result:
+          $ref: "#/components/schemas/JobResult"
+        retryCount:
+          type: integer
+          format: int32
+        startedAt:
+          type: string
+          format: date-time
+        state:
+          type: string
+          enum:
+          - PENDING
+          - RUNNING
+          - SUCCESS
+          - FAILED
+          - FAILED_PERMANENTLY
+          - ABANDONED
+          - ABANDONED_PERMANENTLY
+          - CANCEL_REQUESTED
+          - CANCELLING
+          - CANCELED
+        updatedAt:
+          type: string
+          format: date-time
+    JobPaginatedResult:
+      type: object
+      properties:
+        jobs:
+          type: array
+          items:
+            $ref: "#/components/schemas/Job"
+          properties:
+            empty:
+              type: boolean
+            first:
+              $ref: "#/components/schemas/Job"
+            last:
+              $ref: "#/components/schemas/Job"
+        page:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        total:
+          type: integer
+          format: int64
+    JobResult:
+      type: object
+      properties:
+        errorDetail:
+          $ref: "#/components/schemas/ErrorDetail"
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+    JobStatusResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        statusUrl:
+          type: string
+    JobView:
+      type: object
+      properties:
+        completedAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        executionNode:
+          type: string
+        id:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            type: object
+          properties:
+            empty:
+              type: boolean
+        progress:
+          type: number
+          format: float
+        queueName:
+          type: string
+        result:
+          $ref: "#/components/schemas/JobResult"
+        retryCount:
+          type: integer
+          format: int32
+        startedAt:
+          type: string
+          format: date-time
+        state:
+          type: string
+          enum:
+          - PENDING
+          - RUNNING
+          - SUCCESS
+          - FAILED
+          - FAILED_PERMANENTLY
+          - ABANDONED
+          - ABANDONED_PERMANENTLY
+          - CANCEL_REQUESTED
+          - CANCELLING
+          - CANCELED
+        updatedAt:
+          type: string
+          format: date-time
+    JobViewPaginatedResult:
+      type: object
+      properties:
+        jobs:
+          type: array
+          items:
+            $ref: "#/components/schemas/JobView"
+          properties:
+            empty:
+              type: boolean
+            first:
+              $ref: "#/components/schemas/JobView"
+            last:
+              $ref: "#/components/schemas/JobView"
+        page:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        total:
+          type: integer
+          format: int64
+    JsonObjectView:
+      type: object
+      properties:
+        jsonObject:
+          type: object
+          additionalProperties:
+            type: object
+          properties:
+            asMap:
+              type: object
+              additionalProperties:
+                type: object
+            empty:
+              type: boolean
+    KeyValueContentType:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/ContentType"
+      - type: object
+        properties:
+          defaultType:
+            type: boolean
+          description:
+            type: string
+          detailPage:
+            type: string
+          expireDateVar:
+            type: string
+          fixed:
+            type: boolean
+          folder:
+            type: string
+          folderPath:
+            type: string
+          host:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          icon:
+            type: string
+          id:
+            type: string
+          metadata:
+            type: object
+            additionalProperties:
+              type: object
+          modDate:
+            type: string
+            format: date-time
+          multilingualable:
+            type: boolean
+          name:
+            type: string
+          publishDateVar:
+            type: string
+          siteName:
+            type: string
+          sortOrder:
+            type: integer
+            format: int32
+          system:
+            type: boolean
+          urlMapPattern:
+            type: string
+          variable:
+            type: string
+          versionable:
+            type: boolean
+    KeyValueField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    KeyValueForm:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+    Language:
+      type: object
+      properties:
+        country:
+          type: string
+        countryCode:
+          type: string
+        id:
+          type: integer
+          format: int64
+        isoCode:
+          type: string
+        language:
+          type: string
+        languageCode:
+          type: string
+    LanguageForm:
+      type: object
+      properties:
+        country:
+          type: string
+        countryCode:
+          type: string
+        isoCode:
+          type: string
+        language:
+          type: string
+        languageCode:
+          type: string
+    LineDividerField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    LoginAsForm:
+      type: object
+      properties:
+        password:
+          type: string
+        userId:
+          type: string
+    LookBackWindow:
+      type: object
+      properties:
+        expireMillis:
+          type: integer
+          format: int64
+        value:
+          type: string
+    MakeDefaultLangForm:
+      type: object
+      properties:
+        fireTransferAssetsJob:
+          type: boolean
+    MessageBodyWorkers:
+      type: object
+    MessageEntity:
+      type: object
+      properties:
+        message:
+          type: string
+    Metric:
+      type: object
+      properties:
+        conditions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Condition"
+          properties:
+            empty:
+              type: boolean
+            first:
+              $ref: "#/components/schemas/Condition"
+            last:
+              $ref: "#/components/schemas/Condition"
+        name:
+          type: string
+        type:
+          type: string
+          enum:
+          - REACH_PAGE
+          - CLICK_ON_ELEMENT
+          - EXIT_RATE
+          - BOUNCE_RATE
+          - URL_PARAMETER
+    MoveFieldsForm:
+      type: object
+    MulitreeView:
+      type: object
+      properties:
+        containerId:
+          type: string
+        contentId:
+          type: string
+        pageId:
+          type: string
+        personalization:
+          type: string
+        relationType:
+          type: string
+        treeOrder:
+          type: integer
+          format: int32
+        variantId:
+          type: string
+    MultiPart:
+      type: object
+      properties:
+        bodyParts:
+          type: array
+          items:
+            $ref: "#/components/schemas/BodyPart"
+        contentDisposition:
+          $ref: "#/components/schemas/ContentDisposition"
+        entity:
+          type: object
+        headers:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string
+        mediaType:
+          type: object
+          properties:
+            parameters:
+              type: object
+              additionalProperties:
+                type: string
+            subtype:
+              type: string
+            type:
+              type: string
+            wildcardSubtype:
+              type: boolean
+            wildcardType:
+              type: boolean
+        messageBodyWorkers:
+          $ref: "#/components/schemas/MessageBodyWorkers"
+        parameterizedHeaders:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/ParameterizedHeader"
+        parent:
+          $ref: "#/components/schemas/MultiPart"
+        providers:
+          type: object
+    MultiSelectField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    OpenFolderForm:
+      type: object
+      properties:
+        path:
+          type: string
+    PageCheckPermissionForm:
+      type: object
+      properties:
+        hostId:
+          type: string
+        languageId:
+          type: integer
+          format: int64
+        path:
+          type: string
+        type:
+          type: string
+          enum:
+          - NONE
+          - READ
+          - USE
+          - EDIT
+          - WRITE
+          - PUBLISH
+          - EDIT_PERMISSIONS
+          - CAN_ADD_CHILDREN
+    PageContainerForm:
+      type: object
+      properties:
+        containerEntries:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContainerEntry"
+        requestJson:
+          type: string
+    PageContentType:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/ContentType"
+      - type: object
+        properties:
+          defaultType:
+            type: boolean
+          description:
+            type: string
+          detailPage:
+            type: string
+          expireDateVar:
+            type: string
+          fixed:
+            type: boolean
+          folder:
+            type: string
+          folderPath:
+            type: string
+          host:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          icon:
+            type: string
+          id:
+            type: string
+          metadata:
+            type: object
+            additionalProperties:
+              type: object
+          modDate:
+            type: string
+            format: date-time
+          multilingualable:
+            type: boolean
+          name:
+            type: string
+          publishDateVar:
+            type: string
+          siteName:
+            type: string
+          sortOrder:
+            type: integer
+            format: int32
+          system:
+            type: boolean
+          urlMapPattern:
+            type: string
+          variable:
+            type: string
+          versionable:
+            type: boolean
+    PageForm:
+      type: object
+      properties:
+        anonymousLayout:
+          type: boolean
+        layout:
+          $ref: "#/components/schemas/TemplateLayout"
+        siteId:
+          type: string
+        themeId:
+          type: string
+        title:
+          type: string
+    PageWorkflowActionsView:
+      type: object
+      properties:
+        actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowActionView"
+        page:
+          type: object
+          additionalProperties:
+            type: object
+    Pagination:
+      type: object
+      properties:
+        currentPage:
+          type: integer
+          format: int32
+        perPage:
+          type: integer
+          format: int32
+        totalEntries:
+          type: integer
+          format: int64
+    ParameterModel:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        ownerId:
+          type: string
+        priority:
+          type: integer
+          format: int32
+        value:
+          type: string
+    ParameterizedHeader:
+      type: object
+      properties:
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+        value:
+          type: string
+    Permission:
+      type: object
+      properties:
+        bitPermission:
+          type: boolean
+        id:
+          type: integer
+          format: int64
+        individualPermission:
+          type: boolean
+        inode:
+          type: string
+        permission:
+          type: integer
+          format: int32
+        roleId:
+          type: string
+        type:
+          type: string
+    PermissionTabField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    PermissionView:
+      type: object
+      properties:
+        bitPermission:
+          type: boolean
+        id:
+          type: integer
+          format: int64
+        inode:
+          type: string
+        permission:
+          type: string
+          enum:
+          - READ
+          - USE
+          - EDIT
+          - WRITE
+          - PUBLISH
+          - EDIT_PERMISSIONS
+          - CAN_ADD_CHILDREN
+        roleId:
+          type: string
+        type:
+          type: string
+    Permissionable:
+      type: object
+      properties:
+        owner:
+          type: string
+        parentPermissionable:
+          $ref: "#/components/schemas/Permissionable"
+        permissionId:
+          type: string
+        permissionType:
+          type: string
+    Persona:
+      type: object
+      properties:
+        archived:
+          type: boolean
+        categoryId:
+          type: string
+        contentTypeId:
+          type: string
+        description:
+          type: string
+        dotAsset:
+          type: boolean
+        fileAsset:
+          type: boolean
+        folder:
+          type: string
+        form:
+          type: boolean
+        host:
+          type: string
+        htmlpage:
+          type: boolean
+        identifier:
+          type: string
+        indexPolicyDependencies:
+          type: string
+          enum:
+          - DEFER
+          - WAIT_FOR
+          - FORCE
+        inode:
+          type: string
+        keyTag:
+          type: string
+        keyValue:
+          type: boolean
+        languageId:
+          type: integer
+          format: int64
+        languageVariable:
+          type: boolean
+        live:
+          type: boolean
+        locked:
+          type: boolean
+        lowIndexPriority:
+          type: boolean
+        modDate:
+          type: string
+          format: date-time
+        modUser:
+          type: string
+        name:
+          type: string
+        new:
+          type: boolean
+        owner:
+          type: string
+        permissionId:
+          type: string
+        permissionType:
+          type: string
+        persona:
+          type: boolean
+        sortOrder:
+          type: integer
+          format: int64
+        structureInode:
+          type: string
+        systemHost:
+          type: boolean
+        tags:
+          type: string
+        title:
+          type: string
+        titleImage:
+          $ref: "#/components/schemas/Field"
+        type:
+          type: string
+        userAPI:
+          $ref: "#/components/schemas/UserAPI"
+        vanityUrl:
+          type: boolean
+        variantId:
+          type: string
+        versionId:
+          type: string
+        versionType:
+          type: string
+        working:
+          type: boolean
+    PersonaContentType:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/ContentType"
+      - type: object
+        properties:
+          defaultType:
+            type: boolean
+          description:
+            type: string
+          detailPage:
+            type: string
+          expireDateVar:
+            type: string
+          fixed:
+            type: boolean
+          folder:
+            type: string
+          folderPath:
+            type: string
+          host:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          icon:
+            type: string
+          id:
+            type: string
+          metadata:
+            type: object
+            additionalProperties:
+              type: object
+          modDate:
+            type: string
+            format: date-time
+          multilingualable:
+            type: boolean
+          name:
+            type: string
+          publishDateVar:
+            type: string
+          siteName:
+            type: string
+          sortOrder:
+            type: integer
+            format: int32
+          system:
+            type: boolean
+          urlMapPattern:
+            type: string
+          variable:
+            type: string
+          versionable:
+            type: boolean
+    PersonalizationPersonaPageForm:
+      type: object
+      properties:
+        pageId:
+          type: string
+        personaTag:
+          type: string
+    PublishingEndPoint:
+      type: object
+      properties:
+        address:
+          type: string
+        authKey:
+          type: object
+          properties:
+            empty:
+              type: boolean
+            length:
+              type: integer
+              format: int32
+              writeOnly: true
+        enabled:
+          type: boolean
+        groupId:
+          type: string
+        id:
+          type: string
+        port:
+          type: string
+        protocol:
+          type: string
+        sending:
+          type: boolean
+        serverName:
+          type: object
+          properties:
+            empty:
+              type: boolean
+            length:
+              type: integer
+              format: int32
+              writeOnly: true
+        tokenExpired:
+          type: boolean
+        tokenInvalid:
+          type: boolean
+    PullRelatedForm:
+      type: object
+      properties:
+        condition:
+          type: string
+        fieldVariable:
+          type: string
+        identifier:
+          type: string
+        limit:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int32
+        orderBy:
+          type: string
+    PushPublishBean:
+      type: object
+      properties:
+        expireDate:
+          type: string
+        expireTime:
+          type: string
+        filterKey:
+          type: string
+        iWantTo:
+          type: string
+          writeOnly: true
+        iwantTo:
+          type: string
+        neverExpire:
+          type: string
+        publishDate:
+          type: string
+        publishTime:
+          type: string
+        timezoneId:
+          type: string
+        whereToSend:
+          type: string
+    QuantilePair:
+      type: object
+      properties:
+        formatted:
+          type: number
+          format: double
+        quantile:
+          type: number
+          format: double
+    QueryForm:
+      type: object
+      properties:
+        query:
+          $ref: "#/components/schemas/AnalyticsQuery"
+    RadioField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    RelationshipField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          skipRelationshipCreation:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    RelationshipsTabField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    RemoteAPITokenForm:
+      type: object
+      properties:
+        tokenInfo:
+          type: object
+          additionalProperties:
+            type: object
+    RemoteUrlForm:
+      type: object
+      properties:
+        accessKey:
+          type: string
+        fileName:
+          type: string
+        maxFileLength:
+          type: integer
+          format: int64
+        remoteUrl:
+          type: string
+        urlTimeoutSeconds:
+          type: integer
+          format: int32
+    ReportResponseEntityView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: object
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResetPasswordForm:
+      type: object
+      properties:
+        password:
+          type: string
+        token:
+          type: string
+    ResponseContentletWorkflowStatusView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/ContentletWorkflowStatusView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityBooleanView:
+      type: object
+      properties:
+        entity:
+          type: boolean
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityBulkActionView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/BulkActionView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityBulkActionsResultView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/BulkActionsResultView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityBundleListView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/BundleMap"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityContainerView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/Container"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityContentletView:
+      type: object
+      properties:
+        entity:
+          type: object
+          additionalProperties:
+            type: object
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityCountView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/CountView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityDefaultWorkflowActionsView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowDefaultActionView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityEndpointView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/PublishingEndPoint"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityEndpointsView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/PublishingEndPoint"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityEnvironmentView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/Environment"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityEnvironmentsView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/Environment"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityExperimentResults:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/ExperimentResults"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityExperimentSelectedView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/SelectedExperiments"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityExperimentView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/Experiment"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityJobPaginatedResultView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/JobPaginatedResult"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityJobStatusView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/JobStatusResponse"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityJobView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/Job"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityListView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            type: object
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityListViewString:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            type: string
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityMapView:
+      type: object
+      properties:
+        entity:
+          type: object
+          additionalProperties:
+            type: object
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityPageWorkflowActionsView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/PageWorkflowActionsView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityPermissionView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/PermissionView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntitySingleExperimentView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/Experiment"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntitySmallRoleView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/SmallRoleView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityStringView:
+      type: object
+      properties:
+        entity:
+          type: string
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntitySystemActionWorkflowActionMapping:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/SystemActionWorkflowActionMapping"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntitySystemActionWorkflowActionMappings:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/SystemActionWorkflowActionMapping"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityTagInodesMapView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagInode"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityTagMapView:
+      type: object
+      properties:
+        entity:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/RestTag"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityUserMapView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/AuthenticationForm"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityUserView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/AuthenticationForm"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityVariantView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/Variant"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityView:
+      type: object
+      properties:
+        entity:
+          type: object
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewJob:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/Job"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewJobPaginatedResult:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/JobPaginatedResult"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewJobView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/JobView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewJobViewPaginatedResult:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/JobViewPaginatedResult"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewLanguage:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/Language"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewListAnnouncement:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/Announcement"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewListContentReferenceView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContentReferenceView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewListExistingLanguagesForContentletView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExistingLanguagesForContentletView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewListMulitreeView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/MulitreeView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewMapStringObject:
+      type: object
+      properties:
+        entity:
+          type: object
+          additionalProperties:
+            type: object
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewMapStringString:
+      type: object
+      properties:
+        entity:
+          type: object
+          additionalProperties:
+            type: string
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewSearchView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/SearchView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewSetString:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityViewString:
+      type: object
+      properties:
+        entity:
+          type: string
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowActionClassesView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowActionClass"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowActionView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/WorkflowAction"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowActionletsView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkFlowActionlet"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowActionsView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowActionView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowCommentView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/WorkflowTimelineItemView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowHistoryCommentsView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowTimelineItemView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowSchemeView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/WorkflowScheme"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowSchemesView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowScheme"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowStepView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/WorkflowStep"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityWorkflowStepsView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowStep"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseHostVariableEntityView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/HostVariable"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseSiteVariablesEntityView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/SiteVariableView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseUserDeletedEntityView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/UserDeletedView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseUserMapEntityView:
+      type: object
+      properties:
+        entity:
+          type: object
+          additionalProperties:
+            type: object
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    RestCondition:
+      type: object
+      properties:
+        conditionlet:
+          type: string
+        operator:
+          type: string
+        owningGroup:
+          type: string
+        priority:
+          type: integer
+          format: int32
+        values:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/RestConditionValue"
+    RestConditionGroup:
+      type: object
+      properties:
+        conditions:
+          type: object
+          additionalProperties:
+            type: boolean
+        operator:
+          type: string
+        priority:
+          type: integer
+          format: int32
+    RestConditionValue:
+      type: object
+      properties:
+        key:
+          type: string
+        priority:
+          type: integer
+          format: int32
+        value:
+          type: string
+    RestLanguage:
+      type: object
+      properties:
+        name:
+          type: string
+    RestPersona:
+      type: object
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+    RestRule:
+      type: object
+      properties:
+        conditionGroups:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/RestConditionGroup"
+        enabled:
+          type: boolean
+        fireOn:
+          type: string
+        name:
+          type: string
+        priority:
+          type: integer
+          format: int32
+        ruleActions:
+          type: object
+          additionalProperties:
+            type: boolean
+        shortCircuit:
+          type: boolean
+    RestRuleAction:
+      type: object
+      properties:
+        actionlet:
+          type: string
+        owningRule:
+          type: string
+        parameters:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ParameterModel"
+        priority:
+          type: integer
+          format: int32
+    RestTag:
+      type: object
+      properties:
+        id:
+          type: string
+        label:
+          type: string
+        persona:
+          type: boolean
+        siteId:
+          type: string
+        siteName:
+          type: string
+    RestUser:
+      type: object
+      properties:
+        admin:
+          type: boolean
+        email:
+          type: string
+        givenName:
+          type: string
+        loginAs:
+          type: boolean
+        roleId:
+          type: string
+        surname:
+          type: string
+        userId:
+          type: string
+    ResultResumeItem:
+      type: object
+      properties:
+        conversionRate:
+          type: number
+          format: float
+        totalSessions:
+          type: integer
+          format: int64
+        uniqueBySession:
+          type: integer
+          format: int64
+    Role:
+      type: object
+      properties:
+        dbfqn:
+          type: string
+        description:
+          type: string
+        editLayouts:
+          type: boolean
+        editPermissions:
+          type: boolean
+        editUsers:
+          type: boolean
+        fqn:
+          type: string
+        id:
+          type: string
+        locked:
+          type: boolean
+        name:
+          type: string
+        parent:
+          type: string
+        roleChildren:
+          type: array
+          items:
+            type: string
+        roleKey:
+          type: string
+        system:
+          type: boolean
+        user:
+          type: boolean
+    RoleForm:
+      type: object
+      properties:
+        canEditLayouts:
+          type: boolean
+        canEditPermissions:
+          type: boolean
+        canEditUsers:
+          type: boolean
+        description:
+          type: string
+        parentRoleId:
+          type: string
+        roleKey:
+          type: string
+        roleName:
+          type: string
+    RoleLayoutForm:
+      type: object
+      properties:
+        layoutIds:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+        roleId:
+          type: string
+    RowField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    RunningId:
+      type: object
+      properties:
+        endDate:
+          type: string
+          format: date-time
+        id:
+          type: string
+        startDate:
+          type: string
+          format: date-time
+    RunningIds:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            $ref: "#/components/schemas/RunningId"
+    SampleData:
+      type: object
+      properties:
+        x:
+          type: number
+          format: double
+        "y":
+          type: number
+          format: double
+    SampleGroup:
+      type: object
+      properties:
+        samples:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/SampleData"
+          properties:
+            empty:
+              type: boolean
+    Scheduling:
+      type: object
+      properties:
+        endDate:
+          type: string
+          format: date-time
+        startDate:
+          type: string
+          format: date-time
+    SchemesAndSchemesContentTypeView:
+      type: object
+      properties:
+        contentTypeSchemes:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowScheme"
+        schemes:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowScheme"
+    SearchByPathForm:
+      type: object
+      properties:
+        path:
+          type: string
+    SearchForm:
+      type: object
+      properties:
+        allCategoriesInfo:
+          type: boolean
+        depth:
+          type: integer
+          format: int32
+        languageId:
+          type: integer
+          format: int64
+        limit:
+          type: integer
+          format: int32
+        offset:
+          type: integer
+          format: int32
+        query:
+          type: string
+        render:
+          type: string
+        sort:
+          type: string
+        userId:
+          type: string
+    SearchSiteByNameForm:
+      type: object
+      properties:
+        siteName:
+          type: string
+    SearchView:
+      type: object
+      properties:
+        contentTook:
+          type: integer
+          format: int64
+        jsonObjectView:
+          $ref: "#/components/schemas/JsonObjectView"
+        queryTook:
+          type: integer
+          format: int64
+        resultsSize:
+          type: integer
+          format: int64
+    SecretForm:
+      type: object
+    SelectField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    SelectedExperiment:
+      type: object
+      properties:
+        id:
+          type: string
+        lookBackWindow:
+          $ref: "#/components/schemas/LookBackWindow"
+        name:
+          type: string
+        pageUrl:
+          type: string
+        regexs:
+          type: object
+          additionalProperties:
+            type: string
+        runningId:
+          type: string
+        variant:
+          $ref: "#/components/schemas/SelectedVariant"
+    SelectedExperiments:
+      type: object
+      properties:
+        excludedExperimentIds:
+          type: array
+          items:
+            type: string
+        excludedExperimentIdsEnded:
+          type: array
+          items:
+            type: string
+        experiments:
+          type: array
+          items:
+            $ref: "#/components/schemas/SelectedExperiment"
+        includedExperimentIds:
+          type: array
+          items:
+            type: string
+    SelectedVariant:
+      type: object
+      properties:
+        name:
+          type: string
+        url:
+          type: string
+    SetForm:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: object
+    SetHashForm:
+      type: object
+      properties:
+        fields:
+          type: object
+          additionalProperties:
+            type: object
+        key:
+          type: string
+    ShortCategory:
+      type: object
+      properties:
+        inode:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+    Sidebar:
+      type: object
+      properties:
+        containers:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContainerUUID"
+        location:
+          type: string
+        preview:
+          type: boolean
+        width:
+          type: string
+        widthPercent:
+          type: integer
+          format: int32
+    SidebarView:
+      type: object
+      properties:
+        containers:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContainerUUID"
+        location:
+          type: string
+        width:
+          type: string
+    SimpleContentType:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/ContentType"
+      - type: object
+        properties:
+          defaultType:
+            type: boolean
+          description:
+            type: string
+          detailPage:
+            type: string
+          expireDateVar:
+            type: string
+          fixed:
+            type: boolean
+          folder:
+            type: string
+          folderPath:
+            type: string
+          host:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          icon:
+            type: string
+          id:
+            type: string
+          metadata:
+            type: object
+            additionalProperties:
+              type: object
+          modDate:
+            type: string
+            format: date-time
+          multilingualable:
+            type: boolean
+          name:
+            type: string
+          publishDateVar:
+            type: string
+          siteName:
+            type: string
+          sortOrder:
+            type: integer
+            format: int32
+          system:
+            type: boolean
+          urlMapPattern:
+            type: string
+          variable:
+            type: string
+          versionable:
+            type: boolean
+    SimpleSiteVariableForm:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        value:
+          type: string
+    SiteForm:
+      type: object
+      properties:
+        addThis:
+          type: string
+        aliases:
+          type: string
+        default:
+          type: boolean
+        description:
+          type: string
+        embeddedDashboard:
+          type: string
+        forceExecution:
+          type: boolean
+        googleAnalytics:
+          type: string
+        googleMap:
+          type: string
+        identifier:
+          type: string
+        inode:
+          type: string
+        keywords:
+          type: string
+        languageId:
+          type: integer
+          format: int64
+        proxyUrlForEditMode:
+          type: string
+        runDashboard:
+          type: boolean
+        siteName:
+          type: string
+        siteThumbnail:
+          type: string
+        tagStorage:
+          type: string
+        variables:
+          type: array
+          items:
+            $ref: "#/components/schemas/SimpleSiteVariableForm"
+    SiteVariableForm:
+      type: object
+      properties:
+        id:
+          type: string
+        key:
+          type: string
+        name:
+          type: string
+        siteId:
+          type: string
+        value:
+          type: string
+    SiteVariableView:
+      type: object
+      properties:
+        hostId:
+          type: string
+        id:
+          type: string
+        key:
+          type: string
+        lastModDate:
+          type: string
+          format: date-time
+        lastModifierFullName:
+          type: string
+        lastModifierId:
+          type: string
+        name:
+          type: string
+        value:
+          type: string
+    SmallRoleView:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        roleKey:
+          type: string
+        user:
+          type: boolean
+    StoryBlockField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    SystemActionWorkflowActionMapping:
+      type: object
+      properties:
+        identifier:
+          type: string
+        owner:
+          type: object
+        ownerContentType:
+          type: boolean
+        ownerScheme:
+          type: boolean
+        systemAction:
+          type: string
+          enum:
+          - NEW
+          - EDIT
+          - PUBLISH
+          - UNPUBLISH
+          - ARCHIVE
+          - UNARCHIVE
+          - DELETE
+          - DESTROY
+        workflowAction:
+          $ref: "#/components/schemas/WorkflowAction"
+    TabDividerField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    TagField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    TagForm:
+      type: object
+      properties:
+        ownerId:
+          type: string
+        tags:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/RestTag"
+    TagInode:
+      type: object
+      properties:
+        fieldVarName:
+          type: string
+        inode:
+          type: string
+        modDate:
+          type: string
+          format: date-time
+        tagId:
+          type: string
+    TargetingCondition:
+      type: object
+      properties:
+        conditionKey:
+          type: string
+        id:
+          type: string
+        operator:
+          type: string
+          enum:
+          - AND
+          - OR
+        values:
+          type: object
+          additionalProperties:
+            type: string
+          properties:
+            empty:
+              type: boolean
+    TemplateForm:
+      type: object
+      properties:
+        body:
+          type: string
+        countAddContainer:
+          type: integer
+          format: int32
+        countContainers:
+          type: integer
+          format: int32
+        drawed:
+          type: boolean
+        drawedBody:
+          type: string
+        footer:
+          type: string
+        footerCheck:
+          type: boolean
+        friendlyName:
+          type: string
+        headCode:
+          type: string
+        header:
+          type: string
+        headerCheck:
+          type: boolean
+        identifier:
+          type: string
+        image:
+          type: string
+        inode:
+          type: string
+        layout:
+          $ref: "#/components/schemas/TemplateLayoutView"
+        name:
+          type: string
+        selectedimage:
+          type: string
+        showOnMenu:
+          type: boolean
+        siteId:
+          type: string
+        sortOrder:
+          type: integer
+          format: int32
+        theme:
+          type: string
+        themeName:
+          type: string
+        title:
+          type: string
+    TemplateImageForm:
+      type: object
+      properties:
+        templateId:
+          type: string
+    TemplateLayout:
+      type: object
+      properties:
+        body:
+          $ref: "#/components/schemas/Body"
+        bodyRows:
+          type: array
+          items:
+            $ref: "#/components/schemas/TemplateLayoutRow"
+          writeOnly: true
+        footer:
+          type: boolean
+        header:
+          type: boolean
+        sidebar:
+          $ref: "#/components/schemas/Sidebar"
+        title:
+          type: string
+        version:
+          type: integer
+          format: int32
+        width:
+          type: string
+    TemplateLayoutColumn:
+      type: object
+      properties:
+        containers:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContainerUUID"
+        left:
+          type: integer
+          format: int32
+        leftOffset:
+          type: integer
+          format: int32
+        preview:
+          type: boolean
+        styleClass:
+          type: string
+        width:
+          type: integer
+          format: int32
+        widthPercent:
+          type: integer
+          format: int32
+    TemplateLayoutColumnView:
+      type: object
+      properties:
+        containers:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContainerUUID"
+        leftOffset:
+          type: integer
+          format: int32
+        styleClass:
+          type: string
+        width:
+          type: integer
+          format: int32
+    TemplateLayoutRow:
+      type: object
+      properties:
+        columns:
+          type: array
+          items:
+            $ref: "#/components/schemas/TemplateLayoutColumn"
+        styleClass:
+          type: string
+    TemplateLayoutRowView:
+      type: object
+      properties:
+        columns:
+          type: array
+          items:
+            $ref: "#/components/schemas/TemplateLayoutColumnView"
+        styleClass:
+          type: string
+    TemplateLayoutView:
+      type: object
+      properties:
+        body:
+          $ref: "#/components/schemas/BodyView"
+        footer:
+          type: boolean
+        header:
+          type: boolean
+        sidebar:
+          $ref: "#/components/schemas/SidebarView"
+        title:
+          type: string
+        width:
+          type: string
+    TextAreaField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    TextField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    TimeField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string
+    TotalSession:
+      type: object
+      properties:
+        total:
+          type: integer
+          format: int64
+        variants:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int64
+    TrafficProportion:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+          - SPLIT_EVENLY
+          - CUSTOM_PERCENTAGES
+        variants:
+          type: array
+          items:
+            $ref: "#/components/schemas/ExperimentVariant"
+          uniqueItems: true
+    Tuple2SystemActionString:
+      type: object
+      properties:
+        _1:
+          type: string
+          enum:
+          - NEW
+          - EDIT
+          - PUBLISH
+          - UNPUBLISH
+          - ARCHIVE
+          - UNARCHIVE
+          - DELETE
+          - DESTROY
+        _2:
+          type: string
+    UniqueBySessionResume:
+      type: object
+      properties:
+        conversionRate:
+          type: number
+          format: float
+        count:
+          type: integer
+          format: int64
+    UpdateCurrentUserForm:
+      type: object
+      properties:
+        currentPassword:
+          type: string
+        email:
+          type: string
+        givenName:
+          type: string
+        newPassword:
+          type: string
+        surname:
+          type: string
+        userId:
+          type: string
+    UpdateFieldForm:
+      type: object
+      properties:
+        field:
+          $ref: "#/components/schemas/Field"
+    UpdateTagForm:
+      type: object
+      properties:
+        siteId:
+          type: string
+        tagId:
+          type: string
+        tagName:
+          type: string
+    UpgradeTaskForm:
+      type: object
+      properties:
+        upgradeTaskClass:
+          type: string
+    User:
+      type: object
+      properties:
+        active:
+          type: boolean
+        actualCompanyId:
+          type: string
+        additionalInfo:
+          type: object
+          additionalProperties:
+            type: object
+        agreedToTermsOfUse:
+          type: boolean
+        aimId:
+          type: string
+        anonymousUser:
+          type: boolean
+        birthday:
+          type: string
+          format: date-time
+        comments:
+          type: string
+        companyId:
+          type: string
+        createDate:
+          type: string
+          format: date-time
+        defaultUser:
+          type: boolean
+        deleteDate:
+          type: string
+          format: date-time
+        deleteInProgress:
+          type: boolean
+        dottedSkins:
+          type: boolean
+        emailAddress:
+          type: string
+        failedLoginAttempts:
+          type: integer
+          format: int32
+        favoriteActivity:
+          type: string
+        favoriteBibleVerse:
+          type: string
+        favoriteFood:
+          type: string
+        favoriteMovie:
+          type: string
+        favoriteMusic:
+          type: string
+        female:
+          type: boolean
+        firstName:
+          type: string
+        fullName:
+          type: string
+        greeting:
+          type: string
+        icqId:
+          type: string
+        languageId:
+          type: string
+        lastLoginDate:
+          type: string
+          format: date-time
+        lastLoginIP:
+          type: string
+        lastName:
+          type: string
+        layoutIds:
+          type: string
+        locale:
+          type: object
+          properties:
+            country:
+              type: string
+            displayCountry:
+              type: string
+            displayLanguage:
+              type: string
+            displayName:
+              type: string
+            displayScript:
+              type: string
+            displayVariant:
+              type: string
+            extensionKeys:
+              type: array
+              items:
+                type: string
+              uniqueItems: true
+            iso3Country:
+              type: string
+            iso3Language:
+              type: string
+            language:
+              type: string
+            script:
+              type: string
+            unicodeLocaleAttributes:
+              type: array
+              items:
+                type: string
+              uniqueItems: true
+            unicodeLocaleKeys:
+              type: array
+              items:
+                type: string
+              uniqueItems: true
+            variant:
+              type: string
+        loginDate:
+          type: string
+          format: date-time
+        loginIP:
+          type: string
+        male:
+          type: boolean
+        middleName:
+          type: string
+        modificationDate:
+          type: string
+          format: date-time
+        modified:
+          type: boolean
+        msnId:
+          type: string
+        multipleRecipients:
+          type: boolean
+        new:
+          type: boolean
+        nickName:
+          type: string
+        password:
+          type: string
+        passwordEncrypted:
+          type: boolean
+        passwordExpirationDate:
+          type: string
+          format: date-time
+        passwordExpired:
+          type: boolean
+        passwordReset:
+          type: boolean
+        recipientAddress:
+          type: string
+        recipientId:
+          type: string
+        recipientInternetAddress:
+          type: string
+        recipientName:
+          type: string
+        refreshRate:
+          type: string
+        resolution:
+          type: string
+        roundedSkins:
+          type: boolean
+        skinId:
+          type: string
+        smsId:
+          type: string
+        timeZone:
+          type: object
+          properties:
+            displayName:
+              type: string
+            dstsavings:
+              type: integer
+              format: int32
+            id:
+              type: string
+            rawOffset:
+              type: integer
+              format: int32
+        timeZoneId:
+          type: string
+        userId:
+          type: string
+        userRole:
+          $ref: "#/components/schemas/Role"
+        ymId:
+          type: string
+    UserAPI:
+      type: object
+      properties:
+        anonymousUser:
+          $ref: "#/components/schemas/User"
+        anonymousUserNoThrow:
+          $ref: "#/components/schemas/User"
+        defaultUser:
+          $ref: "#/components/schemas/User"
+        systemUser:
+          $ref: "#/components/schemas/User"
+        unDeletedUsers:
+          type: array
+          items:
+            $ref: "#/components/schemas/User"
+    UserDeletedView:
+      type: object
+      properties:
+        deletedUser:
+          type: string
+        reassignedTo:
+          type: string
+        status:
+          type: string
+    UserForm:
+      type: object
+      properties:
+        active:
+          type: boolean
+        additionalInfo:
+          type: object
+          additionalProperties:
+            type: object
+        birthday:
+          type: string
+        email:
+          type: string
+        firstName:
+          type: string
+        languageId:
+          type: string
+        lastName:
+          type: string
+        male:
+          type: boolean
+        middleName:
+          type: string
+        nickName:
+          type: string
+        password:
+          type: array
+          items:
+            type: string
+        roles:
+          type: array
+          items:
+            type: string
+        timeZoneId:
+          type: string
+        userId:
+          type: string
+    VanityUrlContentType:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/ContentType"
+      - type: object
+        properties:
+          defaultType:
+            type: boolean
+          description:
+            type: string
+          detailPage:
+            type: string
+          expireDateVar:
+            type: string
+          fixed:
+            type: boolean
+          folder:
+            type: string
+          folderPath:
+            type: string
+          host:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          icon:
+            type: string
+          id:
+            type: string
+          metadata:
+            type: object
+            additionalProperties:
+              type: object
+          modDate:
+            type: string
+            format: date-time
+          multilingualable:
+            type: boolean
+          name:
+            type: string
+          publishDateVar:
+            type: string
+          siteName:
+            type: string
+          sortOrder:
+            type: integer
+            format: int32
+          system:
+            type: boolean
+          urlMapPattern:
+            type: string
+          variable:
+            type: string
+          versionable:
+            type: boolean
+    Variant:
+      type: object
+      properties:
+        archived:
+          type: boolean
+        description:
+          type: string
+        name:
+          type: string
+    VariantForm:
+      type: object
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+    VariantResult:
+      type: object
+      properties:
+        conversionRate:
+          type: number
+          format: double
+        credibilityInterval:
+          $ref: "#/components/schemas/CredibilityInterval"
+        expectedLoss:
+          type: number
+          format: double
+        isControl:
+          type: boolean
+        medianGrowth:
+          type: number
+          format: double
+        probability:
+          type: number
+          format: double
+        risk:
+          type: number
+          format: double
+        variant:
+          type: string
+    VariantResults:
+      type: object
+      properties:
+        details:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/ResultResumeItem"
+        uniqueBySession:
+          $ref: "#/components/schemas/UniqueBySessionResume"
+        variantDescription:
+          type: string
+        variantName:
+          type: string
+        weight:
+          type: number
+          format: float
+    WidgetContentType:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/ContentType"
+      - type: object
+        properties:
+          defaultType:
+            type: boolean
+          description:
+            type: string
+          detailPage:
+            type: string
+          expireDateVar:
+            type: string
+          fixed:
+            type: boolean
+          folder:
+            type: string
+          folderPath:
+            type: string
+          host:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          icon:
+            type: string
+          id:
+            type: string
+          metadata:
+            type: object
+            additionalProperties:
+              type: object
+          modDate:
+            type: string
+            format: date-time
+          multilingualable:
+            type: boolean
+          name:
+            type: string
+          publishDateVar:
+            type: string
+          siteName:
+            type: string
+          sortOrder:
+            type: integer
+            format: int32
+          system:
+            type: boolean
+          urlMapPattern:
+            type: string
+          variable:
+            type: string
+          versionable:
+            type: boolean
+    WorkFlowActionlet:
+      type: object
+      properties:
+        actionClass:
+          type: string
+        howTo:
+          type: string
+        localizedHowto:
+          type: string
+        localizedName:
+          type: string
+        name:
+          type: string
+        parameters:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowActionletParameter"
+    WorkflowAction:
+      type: object
+      properties:
+        archiveActionlet:
+          type: boolean
+          writeOnly: true
+        assignable:
+          type: boolean
+        commentActionlet:
+          type: boolean
+          writeOnly: true
+        commentable:
+          type: boolean
+        condition:
+          type: string
+        deleteActionlet:
+          type: boolean
+          writeOnly: true
+        destroyActionlet:
+          type: boolean
+          writeOnly: true
+        hasArchiveActionlet:
+          type: boolean
+        hasCommentActionlet:
+          type: boolean
+        hasDeleteActionlet:
+          type: boolean
+        hasDestroyActionlet:
+          type: boolean
+        hasMoveActionletActionlet:
+          type: boolean
+        hasMoveActionletHasPathActionlet:
+          type: boolean
+        hasOnlyBatchActionlet:
+          type: boolean
+        hasPublishActionlet:
+          type: boolean
+        hasPushPublishActionlet:
+          type: boolean
+        hasResetActionlet:
+          type: boolean
+        hasSaveActionlet:
+          type: boolean
+        hasUnarchiveActionlet:
+          type: boolean
+        hasUnpublishActionlet:
+          type: boolean
+        icon:
+          type: string
+        id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+        moveActionlet:
+          type: boolean
+          writeOnly: true
+        moveActionletHashPath:
+          type: boolean
+          writeOnly: true
+        name:
+          type: string
+        nextAssign:
+          type: string
+        nextStep:
+          type: string
+        nextStepCurrentStep:
+          type: boolean
+        onlyBatchActionlet:
+          type: boolean
+          writeOnly: true
+        order:
+          type: integer
+          format: int32
+        owner:
+          type: string
+        publishActionlet:
+          type: boolean
+          writeOnly: true
+        pushPublishActionlet:
+          type: boolean
+          writeOnly: true
+        resetable:
+          type: boolean
+          writeOnly: true
+        roleHierarchyForAssign:
+          type: boolean
+        saveActionlet:
+          type: boolean
+          writeOnly: true
+        schemeId:
+          type: string
+        showOn:
+          type: array
+          items:
+            type: string
+            enum:
+            - NEW
+            - LOCKED
+            - UNLOCKED
+            - PUBLISHED
+            - UNPUBLISHED
+            - ARCHIVED
+            - LISTING
+            - EDITING
+          uniqueItems: true
+        unarchiveActionlet:
+          type: boolean
+          writeOnly: true
+        unpublishActionlet:
+          type: boolean
+          writeOnly: true
+    WorkflowActionClass:
+      type: object
+      properties:
+        actionId:
+          type: string
+        actionlet:
+          $ref: "#/components/schemas/WorkFlowActionlet"
+        clazz:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        order:
+          type: integer
+          format: int32
+    WorkflowActionClassParameter:
+      type: object
+      properties:
+        actionClassId:
+          type: string
+        id:
+          type: string
+        key:
+          type: string
+        value:
+          type: string
+    WorkflowActionForm:
+      type: object
+      properties:
+        actionAssignable:
+          type: boolean
+        actionCommentable:
+          type: boolean
+        actionCondition:
+          type: string
+        actionIcon:
+          type: string
+        actionId:
+          type: string
+        actionName:
+          type: string
+        actionNextAssign:
+          type: string
+        actionNextStep:
+          type: string
+        actionRoleHierarchyForAssign:
+          type: boolean
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+        schemeId:
+          type: string
+        showOn:
+          type: array
+          items:
+            type: string
+            enum:
+            - NEW
+            - LOCKED
+            - UNLOCKED
+            - PUBLISHED
+            - UNPUBLISHED
+            - ARCHIVED
+            - LISTING
+            - EDITING
+          uniqueItems: true
+        stepId:
+          type: string
+        whoCanUse:
+          type: array
+          items:
+            type: string
+    WorkflowActionSeparatorForm:
+      type: object
+      properties:
+        schemeId:
+          type: string
+        stepId:
+          type: string
+    WorkflowActionStepForm:
+      type: object
+      properties:
+        actionId:
+          type: string
+    WorkflowActionView:
+      type: object
+      properties:
+        actionInputs:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActionInputView"
+        archiveActionlet:
+          type: boolean
+          writeOnly: true
+        assignable:
+          type: boolean
+        commentActionlet:
+          type: boolean
+          writeOnly: true
+        commentable:
+          type: boolean
+        condition:
+          type: string
+        deleteActionlet:
+          type: boolean
+          writeOnly: true
+        destroyActionlet:
+          type: boolean
+          writeOnly: true
+        hasArchiveActionlet:
+          type: boolean
+        hasCommentActionlet:
+          type: boolean
+        hasDeleteActionlet:
+          type: boolean
+        hasDestroyActionlet:
+          type: boolean
+        hasMoveActionletActionlet:
+          type: boolean
+        hasMoveActionletHasPathActionlet:
+          type: boolean
+        hasOnlyBatchActionlet:
+          type: boolean
+        hasPublishActionlet:
+          type: boolean
+        hasPushPublishActionlet:
+          type: boolean
+        hasResetActionlet:
+          type: boolean
+        hasSaveActionlet:
+          type: boolean
+        hasUnarchiveActionlet:
+          type: boolean
+        hasUnpublishActionlet:
+          type: boolean
+        icon:
+          type: string
+        id:
+          type: string
+        metadata:
+          type: object
+          additionalProperties:
+            type: object
+        moveActionlet:
+          type: boolean
+          writeOnly: true
+        moveActionletHashPath:
+          type: boolean
+          writeOnly: true
+        name:
+          type: string
+        nextAssign:
+          type: string
+        nextStep:
+          type: string
+        nextStepCurrentStep:
+          type: boolean
+        onlyBatchActionlet:
+          type: boolean
+          writeOnly: true
+        order:
+          type: integer
+          format: int32
+        owner:
+          type: string
+        publishActionlet:
+          type: boolean
+          writeOnly: true
+        pushPublishActionlet:
+          type: boolean
+          writeOnly: true
+        resetable:
+          type: boolean
+          writeOnly: true
+        roleHierarchyForAssign:
+          type: boolean
+        saveActionlet:
+          type: boolean
+          writeOnly: true
+        schemeId:
+          type: string
+        showOn:
+          type: array
+          items:
+            type: string
+            enum:
+            - NEW
+            - LOCKED
+            - UNLOCKED
+            - PUBLISHED
+            - UNPUBLISHED
+            - ARCHIVED
+            - LISTING
+            - EDITING
+          uniqueItems: true
+        unarchiveActionlet:
+          type: boolean
+          writeOnly: true
+        unpublishActionlet:
+          type: boolean
+          writeOnly: true
+    WorkflowActionletActionForm:
+      type: object
+      properties:
+        actionletClass:
+          type: string
+        order:
+          type: integer
+          format: int32
+        parameters:
+          type: object
+          additionalProperties:
+            type: string
+    WorkflowActionletParameter:
+      type: object
+      properties:
+        defaultValue:
+          type: string
+        displayName:
+          type: string
+        key:
+          type: string
+        required:
+          type: boolean
+    WorkflowCommentForm:
+      type: object
+      properties:
+        comment:
+          type: string
+    WorkflowCopyForm:
+      type: object
+      properties:
+        name:
+          type: string
+    WorkflowDefaultActionView:
+      type: object
+      properties:
+        action:
+          $ref: "#/components/schemas/WorkflowAction"
+        firstStep:
+          $ref: "#/components/schemas/WorkflowStep"
+        scheme:
+          $ref: "#/components/schemas/WorkflowScheme"
+    WorkflowFormEntry:
+      type: object
+      properties:
+        id:
+          type: string
+        variableName:
+          type: string
+    WorkflowReorderWorkflowActionStepForm:
+      type: object
+      properties:
+        order:
+          type: integer
+          format: int32
+    WorkflowScheme:
+      type: object
+      properties:
+        archived:
+          type: boolean
+        creationDate:
+          type: string
+          format: date-time
+        defaultScheme:
+          type: boolean
+        description:
+          type: string
+        entryActionId:
+          type: string
+        id:
+          type: string
+        mandatory:
+          type: boolean
+        modDate:
+          type: string
+          format: date-time
+        name:
+          type: string
+        system:
+          type: boolean
+        variableName:
+          type: string
+    WorkflowSchemeForm:
+      type: object
+      properties:
+        schemeArchived:
+          type: boolean
+        schemeDescription:
+          type: string
+        schemeName:
+          type: string
+    WorkflowSchemeImportExportObjectView:
+      type: object
+      properties:
+        actionClassParams:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowActionClassParameter"
+        actionClasses:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowActionClass"
+        actionSteps:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              type: string
+        actions:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowAction"
+        schemeSystemActionWorkflowActionMappings:
+          type: array
+          items:
+            $ref: "#/components/schemas/SystemActionWorkflowActionMapping"
+        schemes:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowScheme"
+        steps:
+          type: array
+          items:
+            $ref: "#/components/schemas/WorkflowStep"
+        version:
+          type: string
+    WorkflowSchemeImportObjectForm:
+      type: object
+      properties:
+        permissions:
+          type: array
+          items:
+            $ref: "#/components/schemas/Permission"
+        workflowObject:
+          $ref: "#/components/schemas/WorkflowSchemeImportExportObjectView"
+    WorkflowSchemesForm:
+      type: object
+      properties:
+        schemes:
+          type: array
+          items:
+            type: string
+          uniqueItems: true
+    WorkflowStep:
+      type: object
+      properties:
+        creationDate:
+          type: string
+          format: date-time
+        enableEscalation:
+          type: boolean
+        escalationAction:
+          type: string
+        escalationTime:
+          type: integer
+          format: int32
+        id:
+          type: string
+        myOrder:
+          type: integer
+          format: int32
+        name:
+          type: string
+        resolved:
+          type: boolean
+        schemeId:
+          type: string
+    WorkflowStepAddForm:
+      type: object
+      properties:
+        enableEscalation:
+          type: boolean
+        escalationAction:
+          type: string
+        escalationTime:
+          type: string
+        schemeId:
+          type: string
+        stepName:
+          type: string
+        stepResolved:
+          type: boolean
+    WorkflowStepUpdateForm:
+      type: object
+      properties:
+        enableEscalation:
+          type: boolean
+        escalationAction:
+          type: string
+        escalationTime:
+          type: string
+        stepName:
+          type: string
+        stepOrder:
+          type: integer
+          format: int32
+        stepResolved:
+          type: boolean
+    WorkflowSystemActionForm:
+      type: object
+      properties:
+        actionId:
+          type: string
+        contentTypeVariable:
+          type: string
+        schemeId:
+          type: string
+        systemAction:
+          type: string
+          enum:
+          - NEW
+          - EDIT
+          - PUBLISH
+          - UNPUBLISH
+          - ARCHIVE
+          - UNARCHIVE
+          - DELETE
+          - DESTROY
+    WorkflowTask:
+      type: object
+      properties:
+        assignedTo:
+          type: string
+        belongsTo:
+          type: string
+        createdBy:
+          type: string
+        creationDate:
+          type: string
+          format: date-time
+        description:
+          type: string
+        dueDate:
+          type: string
+          format: date-time
+        id:
+          type: string
+        inode:
+          type: string
+        languageId:
+          type: integer
+          format: int64
+        modDate:
+          type: string
+          format: date-time
+        new:
+          type: boolean
+        status:
+          type: string
+        title:
+          type: string
+        webasset:
+          type: string
+    WorkflowTimelineItemView:
+      type: object
+      properties:
+        commentDescription:
+          type: string
+        createdDate:
+          type: string
+          format: date-time
+        postedBy:
+          type: string
+        roleId:
+          type: string
+        taskId:
+          type: string
+        type:
+          type: string
+    WysiwygField:
+      type: object
+      allOf:
+      - $ref: "#/components/schemas/Field"
+      - type: object
+        properties:
+          contentTypeId:
+            type: string
+          dataType:
+            type: string
+            enum:
+            - none
+            - bool
+            - date
+            - float
+            - integer
+            - text
+            - text_area
+            - system_field
+          dbColumn:
+            type: string
+          defaultValue:
+            type: string
+          fixed:
+            type: boolean
+          forceIncludeInApi:
+            type: boolean
+          hint:
+            type: string
+          iDate:
+            type: string
+            format: date-time
+          id:
+            type: string
+          indexed:
+            type: boolean
+          listed:
+            type: boolean
+          modDate:
+            type: string
+            format: date-time
+          name:
+            type: string
+          owner:
+            type: string
+          readOnly:
+            type: boolean
+          regexCheck:
+            type: string
+          relationType:
+            type: string
+          required:
+            type: boolean
+          searchable:
+            type: boolean
+          sortOrder:
+            type: integer
+            format: int32
+          unique:
+            type: boolean
+          values:
+            type: string
+          variable:
+            type: string

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -127,6 +127,7 @@
         <version.surefire.plugin>3.2.5</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.findbugs.plugin>3.0.5</version.findbugs.plugin>
+        <version.swagger-maven.plugin>2.2.34</version.swagger-maven.plugin>
         <version.gpg.plugin>3.1.0</version.gpg.plugin>
         <version.help.plugin>3.4.0</version.help.plugin>
         <version.install.plugin>3.1.1</version.install.plugin>
@@ -977,6 +978,11 @@
                     <groupId>${quarkus.platform.group-id}</groupId>
                     <artifactId>quarkus-maven-plugin</artifactId>
                     <version>${quarkus.platform.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>io.swagger.core.v3</groupId>
+                    <artifactId>swagger-maven-plugin</artifactId>
+                    <version>${version.swagger-maven.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
### Proposed Changes
This PR implements build-time OpenAPI specification generation and optimizes the pre-commit hook for better developer experience.

#### 🔧 **OpenAPI Generation at Build Time**
* **Added swagger-maven-plugin configuration** to automatically generate `openapi.yaml` during Maven compile phase
* **Output location**: `dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml` - packaged with the application
* **Configured consistent output formatting** with `sortOutput=true` and `prettyPrint=true` for stable diffs and version comparison
* **Early failure detection** - OpenAPI generation fails fast during build if REST annotations are invalid (no running server required)
* **IDE integration** - Generated YAML file can be rendered in IDEs to show Swagger UI representation for immediate preview
* **Scans REST API packages** automatically: `com.dotcms.rest`, `com.dotcms.ai.rest`, `com.dotcms.health`, etc.

#### ⚡ **Pre-commit Hook Optimization**  
* **Smart build detection** - Only runs Maven compile when REST API files change
* **Three execution paths** for maximum performance:
  - 🚀 **Frontend-only changes**: Skip Maven entirely (fastest)
  - ⚡ **Backend non-REST changes**: Run validation only (medium)
  - 🔄 **REST API changes**: Full compile + OpenAPI generation (as needed)
* **Enhanced messaging** with emojis and color-coded feedback for better UX
* **Automatic OpenAPI staging** when regenerated during pre-commit

#### 🔀 **Git Merge Conflict Prevention**
* **Added merge strategy** for generated `openapi.yaml` file using `merge=ours` 
* **Prevents merge conflicts** on generated files that should always be regenerated
* **Documentation** for handling OpenAPI file conflicts and workflows

#### 📝 **Documentation & Configuration**
* **Updated CLAUDE.md** with OpenAPI management guidelines and workflows
* **Added .gitattributes** configuration for generated file handling
* **Comprehensive commenting** in Maven configuration for maintainability

### Checklist
- [x] Tests - OpenAPI generation tested during build
- [x] Translations - N/A for this change
- [x] Security Implications Contemplated - No security changes, only build optimization

### Additional Info
**Performance Impact**: 
- Frontend developers see ~90% faster commits (no Maven execution)
- Backend developers only wait for compile when REST APIs actually change
- OpenAPI specification stays automatically up-to-date

**Development Benefits**:
- **Early API validation** - Invalid REST annotations fail at build time, not runtime
- **Version comparison** - Sorted YAML output enables clean diffs between API versions
- **IDE preview** - Generated file renders as Swagger UI in modern IDEs for immediate documentation review
- **No server dependency** - API documentation generated without needing a running dotCMS instance

**Team Benefits**:
- No more manual OpenAPI file management
- Eliminated merge conflicts on generated files  
- Clear visual feedback during pre-commit process
- Self-documenting API changes

Related to #32606 (Add build time opanapi.yaml creation).

### Technical Details
**File Location & Integration**:
- Generated at: `dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml`
- Packaged with WAR file for runtime access
- Sorted properties ensure consistent diffs for version control

**Maven Plugin Configuration**:
```xml
<plugin>
    <groupId>io.swagger.core.v3</groupId>
    <artifactId>swagger-maven-plugin</artifactId>
    <configuration>
        <outputPath>${project.basedir}/src/main/webapp/WEB-INF/openapi</outputPath>
        <outputFormat>YAML</outputFormat>
        <prettyPrint>true</prettyPrint>
        <sortOutput>true</sortOutput>
        <\!-- Scans all REST API packages -->
    </configuration>
</plugin>
```

**Pre-commit Logic**:
```bash
# Smart detection of what build steps are needed
if needs_maven; then
    if needs_openapi_compile; then
        # Full compile for REST changes
    else  
        # Validation only for other backend changes
    fi
else
    # Skip Maven entirely for frontend-only changes
fi
```

This PR fixes: #32606