### PR TITLE
Expose eventtype in CubeJS Schema

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
@@ -189,6 +189,7 @@ cube('request', {
     }
   },*/
   dimensions: {
+    eventType: { sql: 'event_type', type: `string` },
     userAgent: { sql: 'user_agent', type: `string` },
     referer: { sql: 'referer', type: `string` },
     url: { sql: 'url', type: `string` },


### PR DESCRIPTION
### Proposed Changes
* Expose again eventType in the cubeJS schema
