### PR TITLE
fix(block-editor): Prevent margin from global styles to apply on Bubble Menu

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/common.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/common.scss
@@ -146,6 +146,7 @@ $select-border-size: 2px;
 
 #field-panel-items {
     padding: 0;
+    margin: 0;
 }
 
 #field-panel-item {


### PR DESCRIPTION
## Description

This PR addresses styling feedback from PR #32500, which introduced the new `BubbleMenuComponent` to replace the deprecated `BubbleMenuDirective` in the block editor.

## Changes

- Prevent global margin styles from affecting the block editor by adding explicit `margin: 0` to `#field-panel-items` CSS selector

## Screenshot
<img width="737" height="417" alt="Screenshot 2025-07-10 at 2 20 50 PM" src="https://github.com/user-attachments/assets/f46cf4ca-bd99-4f9c-b5c5-20b7c421811a" />

This PR fixes: #32401