### PR TITLE
implementation ( Edit Content ): #31500 Handle the Disable State for Block Editor Field 

### DIFF
--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.html
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.html
@@ -2,16 +2,19 @@
     <div
         [ngClass]="{
             'editor-wrapper--fullscreen': isFullscreen,
-            'editor-wrapper--default': !isFullscreen
+            'editor-wrapper--default': !isFullscreen,
+            'editor-wrapper--disabled': disabled
         }"
         [style]="customStyles"
-        class="editor-wrapper">
+        class="editor-wrapper"
+        data-testid="block-editor-wrapper">
         <tiptap-editor
             (keyup)="subject.next()"
             (ngModelChange)="onBlockEditorChange($event)"
             [editor]="editor"
-            [ngClass]="{ 'overflow-hidden': freezeScroll }"
-            [ngModel]="content" />
+            [ngClass]="{ 'overflow-hidden': freezeScroll, 'editor-disabled': disabled }"
+            [ngModel]="content"
+            data-testid="tiptap-editor" />
     </div>
 
     <dot-bubble-menu [editor]="editor" />
@@ -20,6 +23,7 @@
         <dot-editor-count-bar
             [charLimit]="charLimit"
             [characterCount]="characterCount"
-            [readingTime]="readingTime" />
+            [readingTime]="readingTime"
+            data-testid="editor-count-bar" />
     }
 }

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.scss
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.scss
@@ -23,9 +23,21 @@
         height: 100%;
     }
 
+    .editor-wrapper--disabled {
+        opacity: $field-disabled-opacity;
+        background-color: $color-palette-gray-100;
+        cursor: not-allowed;
+        pointer-events: none;
+    }
+
     // If a child is focused, set this style to the parent
     &:focus-within {
         outline-color: $color-palette-primary;
+    }
+
+    // Disabled state - prevent focus styling when disabled
+    &.editor-disabled:focus-within {
+        outline-color: $color-palette-gray-300;
     }
 
     tiptap-editor ::ng-deep {
@@ -208,7 +220,30 @@
                 color: #666;
                 background: #ffffff;
             }
+        }
 
+        // Disabled state styling for ProseMirror content
+        &.editor-disabled .ProseMirror {
+            color: $color-palette-gray-600;
+            background-color: $color-palette-gray-100;
+            cursor: not-allowed;
+            user-select: none;
+            pointer-events: none;
+
+            // Disabled placeholder styling
+            .is-empty::before {
+                color: $color-palette-gray-400;
+            }
+
+            // Disabled button styling
+            .add-button {
+                cursor: not-allowed;
+                opacity: $field-disabled-opacity;
+                pointer-events: none;
+            }
+        }
+
+        .ProseMirror {
             table {
                 border-collapse: collapse;
                 margin: 0;

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.spec.ts
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.spec.ts
@@ -69,21 +69,63 @@ describe('DotBlockEditorComponent - ControlValueAccesor', () => {
         blockEditorComponent.value = BLOCK_EDITOR_FIELD;
 
         const formValue = spectator.component.form.get('block').value;
-        const expected = {
-            type: 'doc',
-            content: [
-                {
-                    type: 'paragraph',
-                    attrs: { textAlign: 'left' },
-                    content: [
-                        {
-                            type: 'text',
-                            text: '{"attrs":{"charCount":9,"readingTime":1,"wordCount":2},"content":[{"attrs":{"level":1,"textAlign":"left"},"content":[{"text":"A title!!","type":"text"}],"type":"heading"}],"type":"doc"}'
-                        }
-                    ]
-                }
-            ]
-        };
-        expect(formValue).toEqual(JSON.stringify(expected));
+
+        expect(formValue).toEqual(JSON.stringify(BLOCK_EDITOR_FIELD));
+    });
+
+    describe('Disabled State', () => {
+        it('should set disabled state via setDisabledState method', () => {
+            const blockEditorComponent = spectator.query(DotBlockEditorComponent);
+
+            // Initially not disabled
+            expect(blockEditorComponent.disabled).toBe(false);
+
+            // Set disabled state
+            blockEditorComponent.setDisabledState(true);
+
+            expect(blockEditorComponent.disabled).toBe(true);
+        });
+
+        it('should apply disabled CSS classes when disabled', () => {
+            const blockEditorComponent = spectator.query(DotBlockEditorComponent);
+
+            // Check that when editor exists, setEditable is called properly
+            const mockEditor = {
+                setEditable: jest.fn()
+            };
+            blockEditorComponent.editor = mockEditor as any;
+
+            blockEditorComponent.setDisabledState(false);
+            expect(mockEditor.setEditable).toHaveBeenCalledWith(true);
+
+            blockEditorComponent.setDisabledState(true);
+            expect(mockEditor.setEditable).toHaveBeenCalledWith(false);
+        });
+
+        it('should not emit changes when disabled', () => {
+            const blockEditorComponent = spectator.query(DotBlockEditorComponent);
+            const emitSpy = jest.spyOn(blockEditorComponent.valueChange, 'emit');
+
+            // Set disabled state
+            blockEditorComponent.disabled = true;
+
+            // Try to trigger change
+            blockEditorComponent.onBlockEditorChange(BLOCK_EDITOR_FIELD);
+
+            expect(emitSpy).not.toHaveBeenCalled();
+        });
+
+        it('should emit changes when not disabled', () => {
+            const blockEditorComponent = spectator.query(DotBlockEditorComponent);
+            const emitSpy = jest.spyOn(blockEditorComponent.valueChange, 'emit');
+
+            // Ensure not disabled
+            blockEditorComponent.disabled = false;
+
+            // Trigger change
+            blockEditorComponent.onBlockEditorChange(BLOCK_EDITOR_FIELD);
+
+            expect(emitSpy).toHaveBeenCalledWith(BLOCK_EDITOR_FIELD);
+        });
     });
 });

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
@@ -102,6 +102,7 @@ export class DotBlockEditorComponent implements OnInit, OnDestroy, ControlValueA
     public customBlocks = '';
     public content: Content = '';
     public contentletIdentifier: string;
+    public disabled = false;
     editor: Editor;
     subject = new Subject();
     freezeScroll = true;
@@ -162,6 +163,13 @@ export class DotBlockEditorComponent implements OnInit, OnDestroy, ControlValueA
         this.setEditorContent(content);
     }
 
+    setDisabledState(isDisabled: boolean): void {
+        this.disabled = isDisabled;
+        if (this.editor) {
+            this.editor.setEditable(!isDisabled);
+        }
+    }
+
     async loadCustomBlocks(urls: string[]): Promise<PromiseSettledResult<AnyExtension>[]> {
         return Promise.allSettled(urls.map(async (url) => import(/* webpackIgnore: true */ url)));
     }
@@ -199,6 +207,9 @@ export class DotBlockEditorComponent implements OnInit, OnDestroy, ControlValueA
     }
 
     onBlockEditorChange(value: JSONContent) {
+        if (this.disabled) {
+            return;
+        }
         this.valueChange.emit(value);
         this.onChange?.(JSON.stringify(value));
         this.onTouched?.();


### PR DESCRIPTION
### Proposed Changes
* handle disable state in the block editor

### Screenshots
Enable 

<img width="1075" height="857" alt="Image" src="https://github.com/user-attachments/assets/5909cb97-8e7c-413f-ac64-b92a33a193c6" />

Disable

<img width="1085" height="852" alt="Image" src="https://github.com/user-attachments/assets/d04a3e25-455f-46ee-b64a-2535cfad01d3" />

Enable empty: 

<img width="1080" height="449" alt="Image" src="https://github.com/user-attachments/assets/eea40b1d-473d-488a-a54a-de32831fe424" />

Disable empty: 

<img width="1075" height="435" alt="Image" src="https://github.com/user-attachments/assets/046ae61b-8752-43cc-bf7c-752a6c8f2a44" />


This PR fixes: #31500