### PR TITLE
chore(block-editor): Added placeholder text per block type

### DIFF
--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.scss
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.scss
@@ -192,8 +192,14 @@
                 color: $color-palette-gray-500;
                 content: attr(data-placeholder);
                 float: left;
-                height: 0;
+                position: absolute;
                 pointer-events: none;
+            }
+
+            blockquote.is-empty::before,
+            ol.is-empty::before,
+            ul.is-empty::before {
+                margin-top: $spacing-1;
             }
 
             .add-button {

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
@@ -457,13 +457,15 @@ export class DotBlockEditorComponent implements OnInit, OnDestroy, ControlValueA
             AssetUploader(this.#injector, this.viewContainerRef),
             IndentExtension,
             Placeholder.configure({
+                emptyEditorClass: 'is-editor-empty',
+                emptyNodeClass: 'is-empty',
                 placeholder: ({ node }) => {
                     if (node.type.name === 'bulletList' || node.type.name === 'orderedList') {
                         return this.#dotMessageService.get('block-editor.placeholder.list');
                     }
 
                     if (node.type.name === 'heading') {
-                        const level = node.attrs['level'];
+                        const level = node.attrs['level'] ?? '';
 
                         return this.#dotMessageService.get(
                             'block-editor.placeholder.heading',

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
@@ -457,9 +457,30 @@ export class DotBlockEditorComponent implements OnInit, OnDestroy, ControlValueA
             AssetUploader(this.#injector, this.viewContainerRef),
             IndentExtension,
             Placeholder.configure({
-                placeholder: 'Start writing or type / to choose a block',
-                emptyEditorClass: 'is-editor-empty',
-                emptyNodeClass: 'is-empty'
+                placeholder: ({ node }) => {
+                    if (node.type.name === 'bulletList' || node.type.name === 'orderedList') {
+                        return this.#dotMessageService.get('block-editor.placeholder.list');
+                    }
+
+                    if (node.type.name === 'heading') {
+                        const level = node.attrs['level'];
+
+                        return this.#dotMessageService.get(
+                            'block-editor.placeholder.heading',
+                            level
+                        );
+                    }
+
+                    if (node.type.name === 'codeBlock') {
+                        return this.#dotMessageService.get('block-editor.placeholder.code');
+                    }
+
+                    if (node.type.name === 'blockquote') {
+                        return this.#dotMessageService.get('block-editor.placeholder.quote');
+                    }
+
+                    return this.#dotMessageService.get('block-editor.placeholder.paragraph');
+                }
             }),
             DotCMSPlusButton.configure({
                 showOnlyWhenEditable: true,

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5792,6 +5792,13 @@ block-editor.extension.ai-image.api-error.no-choice-returned=No choices returned
 block-editor.extension.ai.confirmation.header=Discard Changes?
 block-editor.extension.ai.confirmation.message=It looks like you've made significant or complex edits. Are you sure you want to discard these changes? Any unsaved progress will be lost.
 
+block-editor.placeholder.heading=Enter your Heading {0}
+block-editor.placeholder.list=Enter your list item
+block-editor.placeholder.quote=Enter your quote
+block-editor.placeholder.code=Enter your code
+block-editor.placeholder.paragraph=Start writing or type / to choose a block
+
+
 locales.add.locale=Add Locale
 locales.edit.locale=Edit Locale
 locales.locale=Locale


### PR DESCRIPTION
This PR introduces a ustom placeholder message based on the block-type inside Block Editor.

https://github.com/user-attachments/assets/f933fbd6-91cf-4bf5-8aaf-4412ebe37baa


This PR fixes: #32024