### PR TITLE
Use the inject function on some projects

### DIFF
--- a/core-web/libs/dot-layout-grid/src/lib/components/NgGridPlaceholder.ts
+++ b/core-web/libs/dot-layout-grid/src/lib/components/NgGridPlaceholder.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnInit, Renderer2 } from '@angular/core';
+import { Component, ElementRef, OnInit, Renderer2, inject } from '@angular/core';
 
 import { NgGrid } from '../directives/NgGrid';
 import { NgGridItemPosition, NgGridItemSize } from '../interfaces/INgGrid';
@@ -8,15 +8,13 @@ import { NgGridItemPosition, NgGridItemSize } from '../interfaces/INgGrid';
     template: ''
 })
 export class NgGridPlaceholder implements OnInit {
+    private _ngEl = inject(ElementRef);
+    private _renderer = inject(Renderer2);
+
     private _size: NgGridItemSize;
     private _position: NgGridItemPosition;
     private _ngGrid: NgGrid;
     private _cascadeMode: string;
-
-    constructor(
-        private _ngEl: ElementRef,
-        private _renderer: Renderer2
-    ) {}
 
     public registerGrid(ngGrid: NgGrid) {
         this._ngGrid = ngGrid;

--- a/core-web/libs/dot-layout-grid/src/lib/directives/NgGrid.ts
+++ b/core-web/libs/dot-layout-grid/src/lib/directives/NgGrid.ts
@@ -13,7 +13,8 @@ import {
     OnDestroy,
     DoCheck,
     Output,
-    Renderer2
+    Renderer2,
+    inject
 } from '@angular/core';
 
 import { NgGridItem } from './NgGridItem';
@@ -53,6 +54,11 @@ const CONST_DEFAULT_RESIZE_DIRECTIONS: string[] = [
 })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class NgGrid implements OnInit, DoCheck, OnDestroy {
+    private _differs = inject(KeyValueDiffers);
+    private _ngEl = inject(ElementRef);
+    private _renderer = inject(Renderer2);
+    private componentFactoryResolver = inject(ComponentFactoryResolver);
+
     private static CONST_DEFAULT_CONFIG: NgGridConfig = {
         margins: [10],
         draggable: true,
@@ -182,12 +188,7 @@ export class NgGrid implements OnInit, DoCheck, OnDestroy {
     }
 
     // 	Constructor
-    constructor(
-        private _differs: KeyValueDiffers,
-        private _ngEl: ElementRef,
-        private _renderer: Renderer2,
-        private componentFactoryResolver: ComponentFactoryResolver
-    ) {
+    constructor() {
         this._defineListeners();
     }
 

--- a/core-web/libs/dot-layout-grid/src/lib/directives/NgGridItem.ts
+++ b/core-web/libs/dot-layout-grid/src/lib/directives/NgGridItem.ts
@@ -9,7 +9,8 @@ import {
     ViewContainerRef,
     Output,
     DoCheck,
-    Renderer2
+    Renderer2,
+    inject
 } from '@angular/core';
 
 import { NgGrid } from './NgGrid';
@@ -29,6 +30,12 @@ import {
     selector: '[ngGridItem]'
 })
 export class NgGridItem implements OnInit, OnDestroy, DoCheck {
+    private _differs = inject(KeyValueDiffers);
+    private _ngEl = inject(ElementRef);
+    private _renderer = inject(Renderer2);
+    private _ngGrid = inject(NgGrid);
+    containerRef = inject(ViewContainerRef);
+
     // 	Event Emitters
     @Output()
     public onItemChange: EventEmitter<NgGridItemEvent> = new EventEmitter<NgGridItemEvent>(false);
@@ -166,15 +173,6 @@ export class NgGridItem implements OnInit, OnDestroy, DoCheck {
     get currentRow(): number {
         return this._currentPosition.row;
     }
-
-    // 	Constructor
-    constructor(
-        private _differs: KeyValueDiffers,
-        private _ngEl: ElementRef,
-        private _renderer: Renderer2,
-        private _ngGrid: NgGrid,
-        public containerRef: ViewContainerRef
-    ) {}
 
     public onResizeStartEvent(): void {
         const event: NgGridItemEvent = this.getEventOutput();

--- a/core-web/libs/dot-rules/src/lib/app.component.ts
+++ b/core-web/libs/dot-rules/src/lib/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 
 import { LoginService } from '@dotcms/dotcms-js';
 
@@ -11,5 +11,5 @@ import { LoginService } from '@dotcms/dotcms-js';
         '<cw-rule-engine-container class="rules__engine-container" *ngIf="this.loginService.auth"></cw-rule-engine-container>'
 })
 export class AppRulesComponent {
-    constructor(public loginService: LoginService) {}
+    loginService = inject(LoginService);
 }

--- a/core-web/libs/dot-rules/src/lib/components/dot-unlicense/dot-unlicense.component.ts
+++ b/core-web/libs/dot-rules/src/lib/components/dot-unlicense/dot-unlicense.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 
 import { I18nService } from '../../services/system/locale/I18n';
 
@@ -8,13 +8,13 @@ import { I18nService } from '../../services/system/locale/I18n';
     styleUrls: ['./dot-unlicense.component.scss']
 })
 export class DotUnlicenseComponent implements OnInit {
+    private resources = inject(I18nService);
+
     rulesTitle: string;
     onlyEnterpriseLabel: string;
     learnMoreEnterpriseLabel: string;
     contactUsLabel: string;
     requestTrialLabel: string;
-
-    constructor(private resources: I18nService) {}
 
     ngOnInit() {
         this.resources.get('com.dotcms.repackage.javax.portlet.title.rules').subscribe((label) => {

--- a/core-web/libs/dot-rules/src/lib/components/dropdown/dropdown.ts
+++ b/core-web/libs/dot-rules/src/lib/components/dropdown/dropdown.ts
@@ -3,13 +3,13 @@ import { of, Observable, from } from 'rxjs';
 import {
     Component,
     EventEmitter,
-    Optional,
     OnChanges,
     SimpleChanges,
     ViewChild,
     Output,
     Input,
-    ChangeDetectionStrategy
+    ChangeDetectionStrategy,
+    inject
 } from '@angular/core';
 import { ControlValueAccessor, NgControl } from '@angular/forms';
 
@@ -73,7 +73,9 @@ export class Dropdown implements ControlValueAccessor, OnChanges {
     modelValue: string;
     dropdownOptions: Observable<SelectItem[]>;
 
-    constructor(@Optional() control: NgControl) {
+    constructor() {
+        const control = inject(NgControl, { optional: true });
+
         if (control && !control.valueAccessor) {
             control.valueAccessor = this;
         }

--- a/core-web/libs/dot-rules/src/lib/components/input-date/input-date.ts
+++ b/core-web/libs/dot-rules/src/lib/components/input-date/input-date.ts
@@ -5,7 +5,7 @@ import {
     EventEmitter,
     Input,
     Output,
-    Optional
+    inject
 } from '@angular/core';
 import { NgControl, ControlValueAccessor } from '@angular/forms';
 
@@ -30,6 +30,8 @@ import { isEmpty } from '@dotcms/utils';
     `
 })
 export class InputDate implements ControlValueAccessor {
+    private _elementRef = inject(ElementRef);
+
     private static DEFAULT_VALUE: Date;
     @Input() placeholder = '';
     @Input() type = '';
@@ -60,10 +62,9 @@ export class InputDate implements ControlValueAccessor {
         return d;
     }
 
-    constructor(
-        @Optional() control: NgControl,
-        private _elementRef: ElementRef
-    ) {
+    constructor() {
+        const control = inject(NgControl, { optional: true });
+
         if (control) {
             control.valueAccessor = this;
         }

--- a/core-web/libs/dot-rules/src/lib/components/restdropdown/RestDropdown.ts
+++ b/core-web/libs/dot-rules/src/lib/components/restdropdown/RestDropdown.ts
@@ -4,11 +4,11 @@ import {
     Component,
     EventEmitter,
     OnChanges,
-    Optional,
     AfterViewInit,
     Output,
     Input,
-    ChangeDetectionStrategy
+    ChangeDetectionStrategy,
+    inject
 } from '@angular/core';
 import { NgControl, ControlValueAccessor } from '@angular/forms';
 
@@ -35,6 +35,9 @@ import { Verify } from '../../services/validation/Verify';
     `
 })
 export class RestDropdown implements AfterViewInit, OnChanges, ControlValueAccessor {
+    private coreWebService = inject(CoreWebService);
+    control = inject(NgControl, { optional: true });
+
     @Input() placeholder: string;
     @Input() allowAdditions: boolean;
     @Input() minSelections: number;
@@ -50,10 +53,9 @@ export class RestDropdown implements AfterViewInit, OnChanges, ControlValueAcces
     private _modelValue: string[] | string;
     private _options: Observable<any[]>;
 
-    constructor(
-        private coreWebService: CoreWebService,
-        @Optional() public control: NgControl
-    ) {
+    constructor() {
+        const control = this.control;
+
         if (control) {
             control.valueAccessor = this;
         }

--- a/core-web/libs/dot-rules/src/lib/condition-types/serverside-condition/serverside-condition.ts
+++ b/core-web/libs/dot-rules/src/lib/condition-types/serverside-condition/serverside-condition.ts
@@ -1,4 +1,11 @@
-import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import {
+    Component,
+    Input,
+    Output,
+    EventEmitter,
+    ChangeDetectionStrategy,
+    inject
+} from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 
 import { of } from 'rxjs/internal/observable/of';
@@ -121,6 +128,8 @@ import { Verify } from '../../services/validation/Verify';
     `
 })
 export class ServersideCondition {
+    private loggerService = inject(LoggerService);
+
     @Input() componentInstance: ServerSideFieldModel;
     @Output()
     parameterValueChange: EventEmitter<{ name: string; value: string }> = new EventEmitter(false);
@@ -137,11 +146,9 @@ export class ServersideCondition {
         required: 'Required'
     };
 
-    constructor(
-        _fb: UntypedFormBuilder,
-        resources: I18nService,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const resources = inject(I18nService);
+
         this._resources = resources;
         this._inputs = [];
     }

--- a/core-web/libs/dot-rules/src/lib/custom-types/visitors-location/visitors-location.component.ts
+++ b/core-web/libs/dot-rules/src/lib/custom-types/visitors-location/visitors-location.component.ts
@@ -1,5 +1,12 @@
 import { DecimalPipe } from '@angular/common';
-import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import {
+    Component,
+    Input,
+    Output,
+    EventEmitter,
+    ChangeDetectionStrategy,
+    inject
+} from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 
 import { LoggerService } from '@dotcms/dotcms-js';
@@ -74,6 +81,9 @@ const UNITS = {
     `
 })
 export class VisitorsLocationComponent {
+    decimalPipe = inject(DecimalPipe);
+    private loggerService = inject(LoggerService);
+
     @Input() circle: GCircle = { center: { lat: 38.89, lng: -77.04 }, radius: 10000 };
     @Input() comparisonValue: string;
     @Input() comparisonControl: UntypedFormControl;
@@ -88,10 +98,9 @@ export class VisitorsLocationComponent {
     showingMap = false;
     comparisonDropdown: any;
 
-    constructor(
-        public decimalPipe: DecimalPipe,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const loggerService = this.loggerService;
+
         loggerService.info('VisitorsLocationComponent', 'constructor');
     }
 

--- a/core-web/libs/dot-rules/src/lib/custom-types/visitors-location/visitors-location.container.ts
+++ b/core-web/libs/dot-rules/src/lib/custom-types/visitors-location/visitors-location.container.ts
@@ -1,7 +1,14 @@
 import { Observable, BehaviorSubject } from 'rxjs';
 
 import { DecimalPipe } from '@angular/common';
-import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import {
+    Component,
+    Input,
+    Output,
+    EventEmitter,
+    ChangeDetectionStrategy,
+    inject
+} from '@angular/core';
 import { UntypedFormControl } from '@angular/forms';
 
 import { LoggerService } from '@dotcms/dotcms-js';
@@ -42,6 +49,10 @@ const I8N_BASE = 'api.sites.ruleengine';
     `
 })
 export class VisitorsLocationContainer {
+    resources = inject(I18nService);
+    decimalPipe = inject(DecimalPipe);
+    private loggerService = inject(LoggerService);
+
     @Input() componentInstance: ServerSideFieldModel;
 
     @Output()
@@ -66,11 +77,10 @@ export class VisitorsLocationContainer {
 
     private _rsrcCache: { [key: string]: Observable<string> };
 
-    constructor(
-        public resources: I18nService,
-        public decimalPipe: DecimalPipe,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const resources = this.resources;
+        const loggerService = this.loggerService;
+
         resources.get(I8N_BASE).subscribe((_rsrc) => {});
         this._rsrcCache = {};
 

--- a/core-web/libs/dot-rules/src/lib/directives/dot-autofocus/dot-autofocus.directive.ts
+++ b/core-web/libs/dot-rules/src/lib/directives/dot-autofocus/dot-autofocus.directive.ts
@@ -1,10 +1,10 @@
-import { Directive, ElementRef, OnInit } from '@angular/core';
+import { Directive, ElementRef, OnInit, inject } from '@angular/core';
 
 @Directive({
     selector: '[dotAutofocus]'
 })
 export class DotAutofocusDirective implements OnInit {
-    constructor(private el: ElementRef) {}
+    private el = inject(ElementRef);
 
     ngOnInit() {
         if (!this.el.nativeElement.disabled) {

--- a/core-web/libs/dot-rules/src/lib/google-map/area-picker-dialog.component.ts
+++ b/core-web/libs/dot-rules/src/lib/google-map/area-picker-dialog.component.ts
@@ -6,7 +6,8 @@ import {
     Input,
     Output,
     EventEmitter,
-    OnChanges
+    OnChanges,
+    inject
 } from '@angular/core';
 
 import { LoggerService } from '@dotcms/dotcms-js';
@@ -41,6 +42,9 @@ let mapIdCounter = 1;
     `
 })
 export class AreaPickerDialogComponent implements OnChanges {
+    mapsService = inject(GoogleMapService);
+    private loggerService = inject(LoggerService);
+
     @Input() apiKey = '';
     @Input() headerText = '';
     @Input() hidden = false;
@@ -57,10 +61,7 @@ export class AreaPickerDialogComponent implements OnChanges {
 
     private _prevCircle: GCircle;
 
-    constructor(
-        public mapsService: GoogleMapService,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
         this.loggerService.debug('AreaPickerDialogComponent', 'constructor', this.mapId);
     }
 

--- a/core-web/libs/dot-rules/src/lib/push-publish/add-to-bundle-dialog-container.ts
+++ b/core-web/libs/dot-rules/src/lib/push-publish/add-to-bundle-dialog-container.ts
@@ -6,7 +6,8 @@ import {
     Input,
     Output,
     EventEmitter,
-    OnChanges
+    OnChanges,
+    inject
 } from '@angular/core';
 
 import { BundleService, IBundle } from '../services/bundle-service';
@@ -25,6 +26,8 @@ import { BundleService, IBundle } from '../services/bundle-service';
 })
 // tslint:disable-next-line:component-class-suffix
 export class AddToBundleDialogContainer implements OnChanges {
+    bundleService = inject(BundleService);
+
     @Input() assetId: string;
     @Input() hidden = false;
 
@@ -32,8 +35,6 @@ export class AddToBundleDialogContainer implements OnChanges {
     @Output() cancel: EventEmitter<boolean> = new EventEmitter(false);
 
     errorMessage: BehaviorSubject<string> = new BehaviorSubject(null);
-
-    constructor(public bundleService: BundleService) {}
 
     ngOnChanges(change): void {
         if (change.hidden && !this.hidden) {

--- a/core-web/libs/dot-rules/src/lib/rule-action-component.ts
+++ b/core-web/libs/dot-rules/src/lib/rule-action-component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit, inject } from '@angular/core';
 
 import { LoggerService } from '@dotcms/dotcms-js';
 
@@ -44,6 +44,8 @@ import { ServerSideTypeModel } from './services/ServerSideFieldModel';
     `
 })
 export class RuleActionComponent implements OnInit {
+    private loggerService = inject(LoggerService);
+
     @Input() action: ActionModel;
     @Input() index = 0;
     @Input() actionTypePlaceholder: string;
@@ -55,8 +57,6 @@ export class RuleActionComponent implements OnInit {
     @Output() deleteRuleAction: EventEmitter<RuleActionActionEvent> = new EventEmitter(false);
 
     typeDropdown: any;
-
-    constructor(private loggerService: LoggerService) {}
 
     ngOnChanges(change): void {
         if (change.action) {

--- a/core-web/libs/dot-rules/src/lib/rule-component.ts
+++ b/core-web/libs/dot-rules/src/lib/rule-component.ts
@@ -6,7 +6,8 @@ import {
     ElementRef,
     Input,
     Output,
-    ChangeDetectionStrategy
+    ChangeDetectionStrategy,
+    inject
 } from '@angular/core';
 import {
     UntypedFormControl,
@@ -212,6 +213,13 @@ const I8N_BASE = 'api.sites.ruleengine';
     `
 })
 class RuleComponent {
+    private _user = inject(UserModel);
+    elementRef = inject(ElementRef);
+    resources = inject(I18nService);
+    ruleService = inject(RuleService);
+    apiRoot = inject(ApiRoot);
+    private loggerService = inject(LoggerService);
+
     @Input() rule: RuleModel;
     @Input() saved: boolean;
     @Input() saving: boolean;
@@ -266,15 +274,10 @@ class RuleComponent {
 
     private _rsrcCache: { [key: string]: Observable<string> };
 
-    constructor(
-        private _user: UserModel,
-        public elementRef: ElementRef,
-        public resources: I18nService,
-        public ruleService: RuleService,
-        public apiRoot: ApiRoot,
-        fb: UntypedFormBuilder,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const apiRoot = this.apiRoot;
+        const fb = inject(UntypedFormBuilder);
+
         this._rsrcCache = {};
         this.hideFireOn = document.location.hash.includes('edit-page') || apiRoot.hideFireOn;
 

--- a/core-web/libs/dot-rules/src/lib/rule-condition-component.ts
+++ b/core-web/libs/dot-rules/src/lib/rule-condition-component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit, inject } from '@angular/core';
 
 import { LoggerService } from '@dotcms/dotcms-js';
 
@@ -65,6 +65,9 @@ import { I18nService } from './services/system/locale/I18n';
     `
 })
 export class ConditionComponent implements OnInit {
+    private _resources = inject(I18nService);
+    private loggerService = inject(LoggerService);
+
     @Input() condition: ConditionModel;
     @Input() index: number;
     @Input() conditionTypes: { [key: string]: ServerSideTypeModel } = {};
@@ -88,11 +91,6 @@ export class ConditionComponent implements OnInit {
     }> = new EventEmitter(false);
 
     typeDropdown: any;
-
-    constructor(
-        private _resources: I18nService,
-        private loggerService: LoggerService
-    ) {}
 
     ngOnInit(): void {
         setTimeout(() => {

--- a/core-web/libs/dot-rules/src/lib/rule-condition-group-component.ts
+++ b/core-web/libs/dot-rules/src/lib/rule-condition-group-component.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { Component, EventEmitter, Input, Output, OnChanges } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnChanges, inject } from '@angular/core';
 
 import { LoggerService } from '@dotcms/dotcms-js';
 
@@ -68,6 +68,8 @@ import { I18nService } from './services/system/locale/I18n';
     `
 })
 export class ConditionGroupComponent implements OnChanges {
+    private loggerService = inject(LoggerService);
+
     private static I8N_BASE = 'api.sites.ruleengine.rules';
 
     @Input() group: ConditionGroupModel;
@@ -90,10 +92,9 @@ export class ConditionGroupComponent implements OnChanges {
     private resources: I18nService;
     private _rsrcCache: { [key: string]: Observable<string> };
 
-    constructor(
-        resources: I18nService,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const resources = inject(I18nService);
+
         this.resources = resources;
         this._rsrcCache = {};
     }

--- a/core-web/libs/dot-rules/src/lib/rule-engine.container.ts
+++ b/core-web/libs/dot-rules/src/lib/rule-engine.container.ts
@@ -1,7 +1,7 @@
 import { from as observableFrom, Observable, merge, Subject } from 'rxjs';
 
 // tslint:disable-next-line:max-file-line-count
-import { Component, EventEmitter, ViewEncapsulation, OnDestroy } from '@angular/core';
+import { Component, EventEmitter, ViewEncapsulation, OnDestroy, inject } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 
 import { reduce, mergeMap, take, map, filter, takeUntil } from 'rxjs/operators';
@@ -117,6 +117,15 @@ export interface ConditionActionEvent extends RuleActionEvent {
     `
 })
 export class RuleEngineContainer implements OnDestroy {
+    _ruleService = inject(RuleService);
+    private _ruleActionService = inject(ActionService);
+    private _conditionGroupService = inject(ConditionGroupService);
+    private _conditionService = inject(ConditionService);
+    bundleService = inject(BundleService);
+    private route = inject(ActivatedRoute);
+    private loggerService = inject(LoggerService);
+    private ruleViewService = inject(RuleViewService);
+
     rules: RuleModel[];
     state: RuleEngineState = new RuleEngineState();
 
@@ -131,16 +140,7 @@ export class RuleEngineContainer implements OnDestroy {
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
 
-    constructor(
-        public _ruleService: RuleService,
-        private _ruleActionService: ActionService,
-        private _conditionGroupService: ConditionGroupService,
-        private _conditionService: ConditionService,
-        public bundleService: BundleService,
-        private route: ActivatedRoute,
-        private loggerService: LoggerService,
-        private ruleViewService: RuleViewService
-    ) {
+    constructor() {
         this.rules$.subscribe((rules) => {
             this.rules = rules;
         });

--- a/core-web/libs/dot-rules/src/lib/rule-engine.ts
+++ b/core-web/libs/dot-rules/src/lib/rule-engine.ts
@@ -142,6 +142,9 @@ const I8N_BASE = 'api.sites.ruleengine';
     `
 })
 export class RuleEngineComponent implements OnDestroy {
+    private ruleViewService = inject(RuleViewService);
+    private dotPushPublishDialogService = inject(DotPushPublishDialogService);
+
     @Input() rules: RuleModel[];
     @Input() ruleActionTypes: { [key: string]: ServerSideTypeModel } = {};
     @Input() loading: boolean;
@@ -190,11 +193,9 @@ export class RuleEngineComponent implements OnDestroy {
 
     private readonly route = inject(ActivatedRoute);
 
-    constructor(
-        resources: I18nService,
-        private ruleViewService: RuleViewService,
-        private dotPushPublishDialogService: DotPushPublishDialogService
-    ) {
+    constructor() {
+        const resources = inject(I18nService);
+
         this.resources = resources;
         resources.get(I8N_BASE).subscribe((_rsrc) => {});
         this.filterText = '';

--- a/core-web/libs/dot-rules/src/lib/services/Action.ts
+++ b/core-web/libs/dot-rules/src/lib/services/Action.ts
@@ -2,7 +2,7 @@ import { from as observableFrom, empty as observableEmpty, Subject } from 'rxjs'
 import { Observable } from 'rxjs';
 
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { mergeMap, reduce, catchError, map } from 'rxjs/operators';
 
@@ -23,6 +23,9 @@ import { ServerSideTypeModel } from './ServerSideFieldModel';
 
 @Injectable()
 export class ActionService {
+    private coreWebService = inject(CoreWebService);
+    private loggerService = inject(LoggerService);
+
     private _typeName = 'Action';
 
     private _actionsEndpointUrl: string;
@@ -52,11 +55,9 @@ export class ActionService {
         return json;
     }
 
-    constructor(
-        apiRoot: ApiRoot,
-        private coreWebService: CoreWebService,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const apiRoot = inject(ApiRoot);
+
         this._actionsEndpointUrl = `/api/v1/sites/${apiRoot.siteId}/ruleengine/actions/`;
     }
 

--- a/core-web/libs/dot-rules/src/lib/services/Condition.ts
+++ b/core-web/libs/dot-rules/src/lib/services/Condition.ts
@@ -2,7 +2,7 @@ import { from as observableFrom, empty as observableEmpty, Subject } from 'rxjs'
 import { Observable } from 'rxjs';
 
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { reduce, mergeMap, catchError, map } from 'rxjs/operators';
 
@@ -18,6 +18,9 @@ import { ServerSideTypeModel } from './ServerSideFieldModel';
 
 @Injectable()
 export class ConditionService {
+    private coreWebService = inject(CoreWebService);
+    private loggerService = inject(LoggerService);
+
     public get error(): Observable<string> {
         return this._error.asObservable();
     }
@@ -25,11 +28,9 @@ export class ConditionService {
 
     private _error: Subject<string> = new Subject<string>();
 
-    constructor(
-        apiRoot: ApiRoot,
-        private coreWebService: CoreWebService,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const apiRoot = inject(ApiRoot);
+
         this._baseUrl = `/api/v1/sites/${apiRoot.siteId}/ruleengine/conditions`;
     }
 

--- a/core-web/libs/dot-rules/src/lib/services/ConditionGroup.ts
+++ b/core-web/libs/dot-rules/src/lib/services/ConditionGroup.ts
@@ -2,7 +2,7 @@ import { from as observableFrom, empty as observableEmpty, Subject } from 'rxjs'
 import { Observable } from 'rxjs';
 
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { reduce, mergeMap, catchError, map, tap } from 'rxjs/operators';
 
@@ -14,6 +14,9 @@ import { ConditionGroupModel, IConditionGroup } from './Rule';
 
 @Injectable()
 export class ConditionGroupService {
+    private coreWebService = inject(CoreWebService);
+    private loggerService = inject(LoggerService);
+
     public get error(): Observable<string> {
         return this._error.asObservable();
     }
@@ -23,11 +26,9 @@ export class ConditionGroupService {
 
     private _error: Subject<string> = new Subject<string>();
 
-    constructor(
-        apiRoot: ApiRoot,
-        private coreWebService: CoreWebService,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const apiRoot = inject(ApiRoot);
+
         this._baseUrl = '/api/v1/sites/' + apiRoot.siteId + '/ruleengine/rules';
     }
 

--- a/core-web/libs/dot-rules/src/lib/services/GoogleMapService.ts
+++ b/core-web/libs/dot-rules/src/lib/services/GoogleMapService.ts
@@ -1,7 +1,7 @@
 // tslint:disable:typedef
 import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { switchMap, take, takeUntil, tap } from 'rxjs/operators';
 
@@ -17,12 +17,12 @@ window['mapsApiReady'] = () => {
 
 @Injectable()
 export class GoogleMapService {
+    private siteService = inject(SiteService);
+    private dotSiteService = inject(DotSiteService);
+
     mapsApi$: BehaviorSubject<{ ready: boolean; error?: any }>;
     private destroy$ = new Subject<boolean>();
-    constructor(
-        private siteService: SiteService,
-        private dotSiteService: DotSiteService
-    ) {
+    constructor() {
         this.loadApi(this.siteService.currentSite.identifier).subscribe();
         this.mapsApi$ = window['mapsApi$'];
         this.mapsApi$.subscribe();

--- a/core-web/libs/dot-rules/src/lib/services/Rule.ts
+++ b/core-web/libs/dot-rules/src/lib/services/Rule.ts
@@ -1,7 +1,7 @@
 import { from as observableFrom, Subject, Observable, BehaviorSubject } from 'rxjs';
 
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { mergeMap, reduce, map, tap } from 'rxjs/operators';
 // tslint:disable-next-line:max-file-line-count
@@ -251,6 +251,11 @@ export const DEFAULT_RULE: IRule = {
 // @dynamic
 @Injectable()
 export class RuleService {
+    _apiRoot = inject(ApiRoot);
+    private _resources = inject(I18nService);
+    private siteService = inject(SiteService);
+    private coreWebService = inject(CoreWebService);
+
     get rules(): RuleModel[] {
         return this._rules;
     }
@@ -279,12 +284,9 @@ export class RuleService {
 
     private _rules: RuleModel[];
 
-    constructor(
-        public _apiRoot: ApiRoot,
-        private _resources: I18nService,
-        private siteService: SiteService,
-        private coreWebService: CoreWebService
-    ) {
+    constructor() {
+        const _resources = this._resources;
+
         this._rulesEndpointUrl = `/ruleengine/rules`;
         this._actionsEndpointUrl = `/ruleengine/actions`;
         this._conditionTypesEndpointUrl = `/api/v1/system/ruleengine/conditionlets`;

--- a/core-web/libs/dot-rules/src/lib/services/bundle-service.ts
+++ b/core-web/libs/dot-rules/src/lib/services/bundle-service.ts
@@ -1,7 +1,7 @@
 import { of as observableOf, Observable, Subject } from 'rxjs';
 
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { map, mergeMap } from 'rxjs/operators';
 
@@ -27,6 +27,9 @@ export interface IPublishEnvironment {
 
 @Injectable()
 export class BundleService {
+    _apiRoot = inject(ApiRoot);
+    private coreWebService = inject(CoreWebService);
+
     bundles$: Subject<IBundle[]> = new Subject();
 
     private _bundleStoreUrl: string;
@@ -47,10 +50,7 @@ export class BundleService {
         return data;
     }
 
-    constructor(
-        public _apiRoot: ApiRoot,
-        private coreWebService: CoreWebService
-    ) {
+    constructor() {
         this._bundleStoreUrl = `/api/bundle/getunsendbundles/userid`;
         this._loggedUserUrl = `/api/v1/users/current/`;
         this._addToBundleUrl = `/DotAjaxDirector/com.dotcms.publisher.ajax.RemotePublishAjaxAction/cmd/addToBundle`;

--- a/core-web/libs/dot-rules/src/lib/services/routing-private-auth-service.ts
+++ b/core-web/libs/dot-rules/src/lib/services/routing-private-auth-service.ts
@@ -1,6 +1,6 @@
 import { Observable, Observer } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 
 import { RoutingService } from '@dotcms/dotcms-js';
@@ -9,12 +9,10 @@ import { DotRouterService } from '@dotcms/dotcms-js';
 
 @Injectable()
 export class RoutingPrivateAuthService implements CanActivate {
-    constructor(
-        private router: DotRouterService,
-        private routingService: RoutingService,
-        private loginService: LoginService,
-        private dotcmsConfigService: DotcmsConfigService
-    ) {}
+    private router = inject(DotRouterService);
+    private routingService = inject(RoutingService);
+    private loginService = inject(LoginService);
+    private dotcmsConfigService = inject(DotcmsConfigService);
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
         return Observable.create((obs) => {

--- a/core-web/libs/dot-rules/src/lib/services/system/locale/I18n.ts
+++ b/core-web/libs/dot-rules/src/lib/services/system/locale/I18n.ts
@@ -2,7 +2,7 @@ import { defer as observableDefer, Observer } from 'rxjs';
 import { Observable } from 'rxjs';
 
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { catchError, map } from 'rxjs/operators';
 
@@ -98,15 +98,16 @@ export class TreeNode {
 
 @Injectable()
 export class I18nService {
+    private coreWebService = inject(CoreWebService);
+    private loggerService = inject(LoggerService);
+
     root: TreeNode;
     private _apiRoot: ApiRoot;
     private _baseUrl;
 
-    constructor(
-        apiRoot: ApiRoot,
-        private coreWebService: CoreWebService,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const apiRoot = inject(ApiRoot);
+
         this._apiRoot = apiRoot;
         this._baseUrl = '/api/v1/system/i18n';
         this.root = new TreeNode(null, 'root');

--- a/core-web/libs/dotcms-js/src/lib/core/api-root.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/api-root.service.ts
@@ -1,10 +1,12 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { LoggerService } from './logger.service';
 import { UserModel } from './shared/user.model';
 
 @Injectable()
 export class ApiRoot {
+    private loggerService = inject(LoggerService);
+
     siteId = '48190c8c-42c4-46af-8d1a-0cd5db894797';
     authUser: UserModel;
     hideFireOn = false;
@@ -27,10 +29,9 @@ export class ApiRoot {
         return result;
     }
 
-    constructor(
-        authUser: UserModel,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const authUser = inject(UserModel);
+
         this.authUser = authUser;
 
         try {

--- a/core-web/libs/dotcms-js/src/lib/core/core-web.service.mock.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/core-web.service.mock.ts
@@ -9,7 +9,7 @@ import {
     HttpParams,
     HttpHeaders
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { map, filter } from 'rxjs/operators';
 
@@ -18,7 +18,7 @@ import { ResponseView } from './util/response-view';
 
 @Injectable()
 export class CoreWebServiceMock {
-    constructor(private _http: HttpClient) {}
+    private _http = inject(HttpClient);
 
     request<T = any>(options: DotRequestOptionsArgs): Observable<any> {
         if (!options.method) {

--- a/core-web/libs/dotcms-js/src/lib/core/core-web.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/core-web.service.ts
@@ -10,7 +10,7 @@ import {
     HttpRequest,
     HttpResponse
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 
 import { catchError, filter, map } from 'rxjs/operators';
@@ -60,13 +60,11 @@ export interface DotRequestOptionsArgs {
  */
 @Injectable()
 export class CoreWebService {
-    private httpErrosSubjects: Subject<any>[] = [];
+    private loggerService = inject(LoggerService);
+    private router = inject(Router);
+    private http = inject(HttpClient);
 
-    constructor(
-        private loggerService: LoggerService,
-        private router: Router,
-        private http: HttpClient
-    ) {}
+    private httpErrosSubjects: Subject<any>[] = [];
 
     /**
      *

--- a/core-web/libs/dotcms-js/src/lib/core/dot-router.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/dot-router.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 /**
  * Router service with common routing methods
@@ -9,7 +9,7 @@ import { Router } from '@angular/router';
  */
 @Injectable()
 export class DotRouterService {
-    constructor(private router: Router) {}
+    private router = inject(Router);
 
     public goToMain(): void {
         this.router.navigate(['/c']);

--- a/core-web/libs/dotcms-js/src/lib/core/dotcms-config.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/dotcms-config.service.ts
@@ -1,6 +1,6 @@
 import { Observable, BehaviorSubject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { pluck, filter, map, take } from 'rxjs/operators';
 
@@ -63,6 +63,9 @@ export interface DotTimeZone {
 
 @Injectable()
 export class DotcmsConfigService {
+    private coreWebService = inject(CoreWebService);
+    private loggerService = inject(LoggerService);
+
     private configParamsSubject: BehaviorSubject<ConfigParams> = new BehaviorSubject(null);
     private configUrl: string;
 
@@ -71,10 +74,7 @@ export class DotcmsConfigService {
      *
      * @param configParams - The configuration properties for the current instance.
      */
-    constructor(
-        private coreWebService: CoreWebService,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
         this.configUrl = 'v1/appconfiguration';
         this.loadConfig();
     }

--- a/core-web/libs/dotcms-js/src/lib/core/dotcms-events.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/dotcms-events.service.ts
@@ -1,6 +1,6 @@
 import { Observable, Subscription, Subject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { switchMap } from 'rxjs/operators';
 
@@ -11,13 +11,11 @@ import { DotEventMessage } from './util/models/dot-event-message';
 
 @Injectable()
 export class DotcmsEventsService {
+    private dotEventsSocket = inject(DotEventsSocket);
+    private loggerService = inject(LoggerService);
+
     private subjects = [];
     private messagesSub: Subscription;
-
-    constructor(
-        private dotEventsSocket: DotEventsSocket,
-        private loggerService: LoggerService
-    ) {}
 
     /**
      * Close the socket

--- a/core-web/libs/dotcms-js/src/lib/core/logger.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/logger.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { StringUtils } from './string-utils.service';
 import { HttpRequestUtils } from './util/http-request-utils';
@@ -12,10 +12,12 @@ const DEV_MODE_PARAM = 'devMode';
  */
 @Injectable()
 export class LoggerService {
+    private stringUtils = inject(StringUtils);
+
     private showLogs = true;
     private httpRequestUtils: HttpRequestUtils;
 
-    constructor(private stringUtils: StringUtils) {
+    constructor() {
         this.httpRequestUtils = new HttpRequestUtils();
         this.showLogs = this.shouldShowLogs();
 

--- a/core-web/libs/dotcms-js/src/lib/core/login.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/login.service.ts
@@ -1,7 +1,7 @@
 import { Observable, of, Subject } from 'rxjs';
 
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { map, pluck, tap } from 'rxjs/operators';
 
@@ -29,15 +29,17 @@ export const LOGOUT_URL = '/dotAdmin/logout';
     providedIn: 'root'
 })
 export class LoginService {
+    private coreWebService = inject(CoreWebService);
+    private dotcmsEventsService = inject(DotcmsEventsService);
+
     currentUserLanguageId = '';
     private country = '';
     private lang = '';
     private urls: Record<string, string>;
 
-    constructor(
-        private coreWebService: CoreWebService,
-        private dotcmsEventsService: DotcmsEventsService
-    ) {
+    constructor() {
+        const dotcmsEventsService = this.dotcmsEventsService;
+
         this._loginAsUsersList$ = new Subject<User[]>();
 
         this.urls = {

--- a/core-web/libs/dotcms-js/src/lib/core/no-http-core-web.service.mock.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/no-http-core-web.service.mock.ts
@@ -1,7 +1,7 @@
 import { Observable, of } from 'rxjs';
 
 import { HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { delay } from 'rxjs/operators';
 
@@ -9,7 +9,7 @@ import { ResponseView } from './util/response-view';
 
 @Injectable()
 export class NoHttpCoreWebServiceMock {
-    constructor(private data: any) {}
+    private data = inject(any);
 
     public requestView(): Observable<ResponseView<any>> {
         return of(

--- a/core-web/libs/dotcms-js/src/lib/core/routing.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/routing.service.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 import { Subject } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { CoreWebService } from './core-web.service';
 import { DotRouterService } from './dot-router.service';
@@ -10,6 +10,9 @@ import { LoginService } from './login.service';
 
 @Injectable()
 export class RoutingService {
+    private router = inject(DotRouterService);
+    private coreWebService = inject(CoreWebService);
+
     private _menusChange$: Subject<Menu[]> = new Subject();
     private menus: Menu[];
     private urlMenus: string;
@@ -20,12 +23,10 @@ export class RoutingService {
     private _currentPortlet$ = new Subject<string>();
 
     // TODO: I think we should be able to remove the routing injection
-    constructor(
-        loginService: LoginService,
-        private router: DotRouterService,
-        private coreWebService: CoreWebService,
-        dotcmsEventsService: DotcmsEventsService
-    ) {
+    constructor() {
+        const loginService = inject(LoginService);
+        const dotcmsEventsService = inject(DotcmsEventsService);
+
         this.urlMenus = 'v1/CORE_WEB/menu';
         this.portlets = new Map();
 

--- a/core-web/libs/dotcms-js/src/lib/core/shared/user.model.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/shared/user.model.ts
@@ -1,18 +1,19 @@
-import { Injectable, Inject, LOCALE_ID } from '@angular/core';
+import { Injectable, LOCALE_ID, inject } from '@angular/core';
 
 import { LoggerService } from '../logger.service';
 
 @Injectable()
 export class UserModel {
+    private loggerService = inject(LoggerService);
+
     username: string;
     password: string;
     locale: string;
     suppressAlerts = false;
 
-    constructor(
-        private loggerService: LoggerService,
-        @Inject(LOCALE_ID) localeId: string
-    ) {
+    constructor() {
+        const localeId = inject(LOCALE_ID);
+
         this.locale = localeId; // default to 'en-US'
         try {
             const url = window.location.search.substring(1);

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -1,6 +1,6 @@
 import { Observable, Subject, of, merge } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { pluck, map, take, switchMap, tap } from 'rxjs/operators';
 
@@ -22,6 +22,9 @@ import { DotEventTypeWrapper } from './models/dot-events/dot-event-type-wrapper'
     providedIn: 'root'
 })
 export class SiteService {
+    private coreWebService = inject(CoreWebService);
+    private loggerService = inject(LoggerService);
+
     private selectedSite: Site;
     private urls: any;
     private events: string[] = [
@@ -35,12 +38,10 @@ export class SiteService {
     private _switchSite$: Subject<Site> = new Subject<Site>();
     private _refreshSites$: Subject<Site> = new Subject<Site>();
 
-    constructor(
-        loginService: LoginService,
-        dotcmsEventsService: DotcmsEventsService,
-        private coreWebService: CoreWebService,
-        private loggerService: LoggerService
-    ) {
+    constructor() {
+        const loginService = inject(LoginService);
+        const dotcmsEventsService = inject(DotcmsEventsService);
+
         this.urls = {
             currentSiteUrl: 'v1/site/currentSite',
             sitesUrl: 'v1/site',

--- a/core-web/libs/dotcms-js/src/lib/core/util/dot-event-socket.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/util/dot-event-socket.ts
@@ -1,6 +1,6 @@
 import { Subject, Observable, timer } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { tap } from 'rxjs/operators';
 
@@ -33,6 +33,11 @@ enum ConnectionStatus {
  */
 @Injectable()
 export class DotEventsSocket {
+    private dotEventsSocketURL = inject(DotEventsSocketURL);
+    private dotcmsConfigService = inject(DotcmsConfigService);
+    private loggerService = inject(LoggerService);
+    private coreWebService = inject(CoreWebService);
+
     private protocolImpl: Protocol;
 
     private status: ConnectionStatus = ConnectionStatus.NONE;
@@ -43,20 +48,6 @@ export class DotEventsSocket {
     private readonly INITIAL_RETRY_DELAY = 1000;
     private readonly MAX_RETRY_DELAY = 30000; // 30 seconds max delay
     private retryCount = 0;
-
-    /**
-     * Initializes this service with the configuration properties that are
-     * necessary for opening the Websocket with the System Events end-point.
-     *
-     * @param dotcmsConfigService - The dotCMS configuration properties that include
-     * the Websocket parameters.
-     */
-    constructor(
-        private dotEventsSocketURL: DotEventsSocketURL,
-        private dotcmsConfigService: DotcmsConfigService,
-        private loggerService: LoggerService,
-        private coreWebService: CoreWebService
-    ) {}
 
     /**
      * Connect to a Event socket using  Web Socket protocol,

--- a/core-web/libs/dotcms-js/src/lib/core/util/notification.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/util/notification.service.ts
@@ -17,13 +17,8 @@ declare class Notification {
 @Injectable()
 @Inject('config')
 export class NotificationService {
-    iconPath: string;
-
-    constructor() {
-        const config = inject(AppConfig);
-
-        this.iconPath = config.iconPath;
-    }
+    private config = inject(AppConfig);
+    iconPath = this.config.iconPath;
 
     /**
      * Displays an error message
@@ -56,8 +51,7 @@ export class NotificationService {
      * @param type
      */
     displayMessage(_title: string, body: string, type: string): Notification {
-        let myNotification: Notification;
-        myNotification = new Notification(type, {
+        const myNotification = new Notification(type, {
             body: body,
             icon: this.iconPath + '/' + type + '.png'
         });

--- a/core-web/libs/dotcms-js/src/lib/core/util/notification.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/util/notification.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NgModule } from '@angular/core';
+import { Inject, Injectable, NgModule, inject } from '@angular/core';
 
 import { AppConfig } from './app.config';
 
@@ -19,7 +19,9 @@ declare class Notification {
 export class NotificationService {
     iconPath: string;
 
-    constructor(config: AppConfig) {
+    constructor() {
+        const config = inject(AppConfig);
+
         this.iconPath = config.iconPath;
     }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-url-mode/store/dot-binary-field-url-mode.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-url-mode/store/dot-binary-field-url-mode.store.ts
@@ -2,7 +2,7 @@ import { ComponentStore } from '@ngrx/component-store';
 import { tapResponse } from '@ngrx/operators';
 import { Observable, from } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { switchMap, tap } from 'rxjs/operators';
 
@@ -19,6 +19,9 @@ export interface DotBinaryFieldUrlModeState {
 
 @Injectable()
 export class DotBinaryFieldUrlModeStore extends ComponentStore<DotBinaryFieldUrlModeState> {
+    private readonly dotUploadService = inject(DotUploadService);
+    private readonly dotBinaryFieldValidatorService = inject(DotBinaryFieldValidatorService);
+
     private _maxFileSize: number;
     private _accept: string[];
 
@@ -28,10 +31,7 @@ export class DotBinaryFieldUrlModeStore extends ComponentStore<DotBinaryFieldUrl
 
     readonly error$ = this.select(({ error }) => error);
 
-    constructor(
-        private readonly dotUploadService: DotUploadService,
-        private readonly dotBinaryFieldValidatorService: DotBinaryFieldValidatorService
-    ) {
+    constructor() {
         super({
             tempFile: null,
             isLoading: false,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/store/binary-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/store/binary-field.store.ts
@@ -3,7 +3,7 @@ import { tapResponse } from '@ngrx/operators';
 import { from, Observable, of } from 'rxjs';
 
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { switchMap, tap, map, catchError, distinctUntilChanged } from 'rxjs/operators';
 
@@ -42,6 +42,10 @@ const initialState: BinaryFieldState = {
 
 @Injectable()
 export class DotBinaryFieldStore extends ComponentStore<BinaryFieldState> {
+    private readonly dotUploadService = inject(DotUploadService);
+    private readonly dotLicenseService = inject(DotLicenseService);
+    private readonly http = inject(HttpClient);
+
     private _maxFileSizeInMB = 0;
 
     get maxFile() {
@@ -59,11 +63,7 @@ export class DotBinaryFieldStore extends ComponentStore<BinaryFieldState> {
         fileName: tempFile?.fileName
     })).pipe(distinctUntilChanged((previous, current) => previous.value === current.value));
 
-    constructor(
-        private readonly dotUploadService: DotUploadService,
-        private readonly dotLicenseService: DotLicenseService,
-        private readonly http: HttpClient
-    ) {
+    constructor() {
         super(initialState);
         this.dotLicenseService.isEnterprise().subscribe((isEnterprise) => {
             this.setIsEnterprise(isEnterprise);

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/add-widget/add-widget.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/add-widget/add-widget.component.ts
@@ -7,7 +7,8 @@ import {
     Component,
     ElementRef,
     HostListener,
-    Input
+    Input,
+    inject
 } from '@angular/core';
 
 @Component({
@@ -18,13 +19,13 @@ import {
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AddWidgetComponent implements AfterViewInit {
+    private el = inject(ElementRef);
+
     @Input() label = 'Add Widget';
     @Input() icon = '';
     @Input() gridstackOptions: GridStackWidget;
 
     protected imageError = false;
-
-    constructor(private el: ElementRef) {}
 
     ngAfterViewInit(): void {
         this.el.nativeElement.gridstackNode = {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/remove-confirm-dialog/remove-confirm-dialog.component.ts
@@ -4,7 +4,8 @@ import {
     EventEmitter,
     HostListener,
     Input,
-    Output
+    Output,
+    inject
 } from '@angular/core';
 
 import { ConfirmationService } from 'primeng/api';
@@ -23,15 +24,13 @@ import { DotMessagePipe } from '@dotcms/ui';
     providers: [ConfirmationService, DotMessagePipe]
 })
 export class RemoveConfirmDialogComponent {
+    private confirmationService = inject(ConfirmationService);
+    private dotMessagePipe = inject(DotMessagePipe);
+
     @Input() skipConfirmation: boolean;
     @Output() deleteConfirmed: EventEmitter<void> = new EventEmitter();
     @Output() deleteRejected: EventEmitter<void> = new EventEmitter();
     private currentPopup: ConfirmationService;
-
-    constructor(
-        private confirmationService: ConfirmationService,
-        private dotMessagePipe: DotMessagePipe
-    ) {}
 
     @HostListener('document:keydown.escape', ['$event'])
     onEscapePress() {

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-actions/template-builder-actions.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-actions/template-builder-actions.component.ts
@@ -7,7 +7,8 @@ import {
     Input,
     OnDestroy,
     OnInit,
-    Output
+    Output,
+    inject
 } from '@angular/core';
 import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 
@@ -30,6 +31,8 @@ import { DotLayoutPropertiesModule } from '../dot-layout-properties/dot-layout-p
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TemplateBuilderActionsComponent implements OnInit, OnDestroy {
+    private store = inject(DotTemplateBuilderStore);
+
     @Input() set layoutProperties(layoutProperties: DotTemplateLayoutProperties) {
         this.group?.patchValue(
             {
@@ -51,8 +54,6 @@ export class TemplateBuilderActionsComponent implements OnInit, OnDestroy {
     group: UntypedFormGroup;
 
     destroy$: Subject<boolean> = new Subject<boolean>();
-
-    constructor(private store: DotTemplateBuilderStore) {}
 
     ngOnInit(): void {
         this.group = new UntypedFormGroup({

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-background-columns/template-builder-background-columns.component.ts
@@ -1,5 +1,5 @@
 import { NgStyle } from '@angular/common';
-import { ChangeDetectionStrategy, Component, HostBinding } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, inject } from '@angular/core';
 import { DomSanitizer, SafeStyle } from '@angular/platform-browser';
 
 import { GRID_STACK_MARGIN_HORIZONTAL, GRID_STACK_UNIT } from '../../utils/gridstack-options';
@@ -13,13 +13,15 @@ import { GRID_STACK_MARGIN_HORIZONTAL, GRID_STACK_UNIT } from '../../utils/grids
     imports: [NgStyle]
 })
 export class TemplateBuilderBackgroundColumnsComponent {
+    private sanitizer = inject(DomSanitizer);
+
     readonly columnList = [].constructor(12);
     readonly gridStackGap = `${GRID_STACK_MARGIN_HORIZONTAL * 2}${GRID_STACK_UNIT}`;
 
     @HostBinding('style')
     hostStyle: SafeStyle;
 
-    constructor(private sanitizer: DomSanitizer) {
+    constructor() {
         this.hostStyle = this.sanitizer.bypassSecurityTrustStyle(`gap: ${this.gridStackGap}`);
     }
 }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-box/template-builder-box.component.ts
@@ -8,7 +8,8 @@ import {
     EventEmitter,
     Input,
     OnChanges,
-    Output
+    Output,
+    inject
 } from '@angular/core';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
@@ -45,6 +46,9 @@ import { RemoveConfirmDialogComponent } from '../remove-confirm-dialog/remove-co
     ]
 })
 export class TemplateBuilderBoxComponent implements OnChanges {
+    private el = inject(ElementRef);
+    private dotMessage = inject(DotMessageService);
+
     @Output()
     editClasses: EventEmitter<void> = new EventEmitter<void>();
     @Output()
@@ -63,11 +67,6 @@ export class TemplateBuilderBoxComponent implements OnChanges {
     boxVariant = TemplateBuilderBoxSize.small;
     formControl = new FormControl(null); // used to programmatically set dropdown value, so that the same value can be selected twice consecutively
     protected readonly templateBuilderSizes = TemplateBuilderBoxSize;
-
-    constructor(
-        private el: ElementRef,
-        private dotMessage: DotMessageService
-    ) {}
 
     private _dropdownLabel: string | null = null;
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-row/template-builder-row.component.ts
@@ -1,7 +1,7 @@
 import { GridItemHTMLElement } from 'gridstack';
 
 import { NgStyle } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ElementRef, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Input, inject } from '@angular/core';
 
 import { ButtonModule } from 'primeng/button';
 import { DialogService } from 'primeng/dynamicdialog';
@@ -30,16 +30,14 @@ import { TemplateBuilderBackgroundColumnsComponent } from '../template-builder-b
     ]
 })
 export class TemplateBuilderRowComponent {
+    private el = inject(ElementRef);
+    private store = inject(DotTemplateBuilderStore);
+    private dialogService = inject(DialogService);
+    private dotMessage = inject(DotMessageService);
+
     @Input() row: DotGridStackWidget;
 
     @Input() isResizing = false;
-
-    constructor(
-        private el: ElementRef,
-        private store: DotTemplateBuilderStore,
-        private dialogService: DialogService,
-        private dotMessage: DotMessageService
-    ) {}
 
     get nativeElement(): GridItemHTMLElement {
         return this.el.nativeElement;

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-sidebar/template-builder-sidebar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { DropdownModule } from 'primeng/dropdown';
@@ -17,6 +17,8 @@ import { TemplateBuilderBoxComponent } from '../template-builder-box/template-bu
     styleUrls: ['./template-builder-sidebar.component.scss']
 })
 export class TemplateBuilderSidebarComponent {
+    private store = inject(DotTemplateBuilderStore);
+
     @Input() sidebarProperties: DotLayoutSideBar = {
         width: 'medium',
         containers: []
@@ -24,8 +26,6 @@ export class TemplateBuilderSidebarComponent {
 
     @Input() containerMap: DotContainerMap;
     readonly widthOptions = ['Small', 'Medium', 'Large'];
-
-    constructor(private store: DotTemplateBuilderStore) {}
 
     get width() {
         return (this.sidebarProperties.width ?? 'medium').replace(/^\w/g, (l) => l.toUpperCase());

--- a/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/components/template-builder-theme-selector/template-builder-theme-selector.component.ts
@@ -10,7 +10,8 @@ import {
     OnDestroy,
     OnInit,
     Output,
-    ViewChild
+    ViewChild,
+    inject
 } from '@angular/core';
 
 import { LazyLoadEvent, MessageService } from 'primeng/api';
@@ -51,6 +52,13 @@ import { DotMessagePipe, DotSiteSelectorDirective } from '@dotcms/ui';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class TemplateBuilderThemeSelectorComponent implements OnInit, OnDestroy {
+    private config = inject(DynamicDialogConfig);
+    private dotThemesService = inject(DotThemesService);
+    private paginatorService = inject(PaginatorService);
+    private ref = inject(DynamicDialogRef);
+    private siteService = inject(SiteService);
+    private cd = inject(ChangeDetectorRef);
+
     @Output()
     selected = new EventEmitter<DotTheme>();
 
@@ -66,14 +74,7 @@ export class TemplateBuilderThemeSelectorComponent implements OnInit, OnDestroy 
     private SEARCH_PARAM = 'searchParam';
     private initialLoad = true;
 
-    constructor(
-        private config: DynamicDialogConfig,
-        private dotThemesService: DotThemesService,
-        private paginatorService: PaginatorService,
-        private ref: DynamicDialogRef,
-        private siteService: SiteService,
-        private cd: ChangeDetectorRef
-    ) {
+    constructor() {
         const { themeId } = this.config.data;
         this.themeId = themeId;
 

--- a/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/template-builder.component.ts
@@ -25,7 +25,8 @@ import {
     QueryList,
     SimpleChanges,
     ViewChild,
-    ViewChildren
+    ViewChildren,
+    inject
 } from '@angular/core';
 
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -78,6 +79,11 @@ import {
     providers: [DotTemplateBuilderStore]
 })
 export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestroy, OnChanges {
+    private store = inject(DotTemplateBuilderStore);
+    private dialogService = inject(DialogService);
+    private dotMessage = inject(DotMessageService);
+    private cd = inject(ChangeDetectorRef);
+
     @Input()
     layout!: DotLayout;
 
@@ -185,12 +191,7 @@ export class TemplateBuilderComponent implements OnInit, AfterViewInit, OnDestro
         return this.templateContainerRef.nativeElement;
     }
 
-    constructor(
-        private store: DotTemplateBuilderStore,
-        private dialogService: DialogService,
-        private dotMessage: DotMessageService,
-        private cd: ChangeDetectorRef
-    ) {
+    constructor() {
         this.rows$ = this.store.rows$.pipe(
             filter(({ shouldEmit }) => shouldEmit),
             map(({ rows }) => parseFromGridStackToDotObject(rows))

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/mocks.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid';
 
-import { Component, ElementRef } from '@angular/core';
+import { Component, ElementRef, inject } from '@angular/core';
 
 import { DotLayoutBody } from '@dotcms/dotcms-models';
 import { containersMapMock, MockDotMessageService } from '@dotcms/utils-testing';
@@ -879,7 +879,9 @@ export const BOX_MOCK = {
     template: '<div>Element</div>'
 })
 export class MockGridStackElementComponent {
-    constructor(public el: ElementRef) {
+    el = inject(ElementRef);
+
+    constructor() {
         this.el.nativeElement.ddElement = {
             on: () => {
                 /* noop */

--- a/core-web/libs/utils-testing/src/lib/core-web.service.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/core-web.service.mock.ts
@@ -19,7 +19,6 @@ import { ResponseView, DotCMSResponse, DotRequestOptionsArgs } from '@dotcms/dot
 export class CoreWebServiceMock {
     private _http = inject(HttpClient);
 
-
     request<T = unknown>(
         options: DotRequestOptionsArgs
     ): Observable<HttpResponse<DotCMSResponse<T>> | DotCMSResponse<T>> {

--- a/core-web/libs/utils-testing/src/lib/core-web.service.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/core-web.service.mock.ts
@@ -9,7 +9,7 @@ import {
     HttpParams,
     HttpHeaders
 } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { map, filter } from 'rxjs/operators';
 
@@ -17,7 +17,8 @@ import { ResponseView, DotCMSResponse, DotRequestOptionsArgs } from '@dotcms/dot
 
 @Injectable()
 export class CoreWebServiceMock {
-    constructor(private _http: HttpClient) {}
+    private _http = inject(HttpClient);
+
 
     request<T = unknown>(
         options: DotRequestOptionsArgs


### PR DESCRIPTION
### Proposed Changes

This pull request refactors multiple Angular components, directives, and services to use the `inject()` function for dependency injection instead of constructor-based injection. This change simplifies the codebase and aligns it with Angular's modern dependency injection practices.

### Refactoring to `inject()` for Dependency Injection:

#### Components:
* **`NgGridPlaceholder`**: Replaced constructor-based injection of `ElementRef` and `Renderer2` with `inject()` calls. [[1]](diffhunk://#diff-c2c990f0ed7035e63502b0241d4dbf9f6aa6f5d6a17ba393e4b72d2fc6db8720L1-R1) [[2]](diffhunk://#diff-c2c990f0ed7035e63502b0241d4dbf9f6aa6f5d6a17ba393e4b72d2fc6db8720R11-L20)
* **`AppRulesComponent`**: Updated to use `inject()` for `LoginService`. [[1]](diffhunk://#diff-0bbd023dd9d7b7bbe71a1ae2f0f9d7237ce39ab450b6752f69e72d7c0117b09eL1-R1) [[2]](diffhunk://#diff-0bbd023dd9d7b7bbe71a1ae2f0f9d7237ce39ab450b6752f69e72d7c0117b09eL14-R14)
* **`DotUnlicenseComponent`**: Replaced constructor-based injection of `I18nService` with `inject()`. [[1]](diffhunk://#diff-48fd8e99e7d9bab807ec148423fbc0bbf83ee7a15cd54c145ef3e99c8b4bca00L1-R1) [[2]](diffhunk://#diff-48fd8e99e7d9bab807ec148423fbc0bbf83ee7a15cd54c145ef3e99c8b4bca00R11-L18)
* **`Dropdown`**: Added `inject()` for optional `NgControl` instead of constructor-based injection. [[1]](diffhunk://#diff-28d91a0114a9d0c93801d1182a713283b947f7ca530e51575c72c5970fb56c96L6-R12) [[2]](diffhunk://#diff-28d91a0114a9d0c93801d1182a713283b947f7ca530e51575c72c5970fb56c96L76-R78)
* **`InputDate`**: Replaced constructor-based injection of `ElementRef` and optional `NgControl` with `inject()`. [[1]](diffhunk://#diff-629a7f926160676fea9550d7498ce233fcfb7a66a16724d94cee3a505a1d7ef7L8-R8) [[2]](diffhunk://#diff-629a7f926160676fea9550d7498ce233fcfb7a66a16724d94cee3a505a1d7ef7R33-R34) [[3]](diffhunk://#diff-629a7f926160676fea9550d7498ce233fcfb7a66a16724d94cee3a505a1d7ef7L63-R67)
* **`RestDropdown`**: Updated to use `inject()` for `CoreWebService` and optional `NgControl`. [[1]](diffhunk://#diff-c0ccaef1efbace21c455516a45bf932f7088eff1a11cfc4fcd5961eafa7a8c13L7-R11) [[2]](diffhunk://#diff-c0ccaef1efbace21c455516a45bf932f7088eff1a11cfc4fcd5961eafa7a8c13R38-R40) [[3]](diffhunk://#diff-c0ccaef1efbace21c455516a45bf932f7088eff1a11cfc4fcd5961eafa7a8c13L53-R58)
* **`ServersideCondition`**: Replaced constructor-based injection of `LoggerService` and `I18nService` with `inject()`. [[1]](diffhunk://#diff-3f5b38dac8d6a7f4ce3fb99d5595fef67facb5662570aa26fc0f89bac9de7df1L1-R8) [[2]](diffhunk://#diff-3f5b38dac8d6a7f4ce3fb99d5595fef67facb5662570aa26fc0f89bac9de7df1R131-R132) [[3]](diffhunk://#diff-3f5b38dac8d6a7f4ce3fb99d5595fef67facb5662570aa26fc0f89bac9de7df1L140-R151)
* **`VisitorsLocationComponent`**: Replaced constructor-based injection of `DecimalPipe` and `LoggerService` with `inject()`. [[1]](diffhunk://#diff-a3af52ccdb61e504394f792a476e7ea20c6f3bfb899b7bbf6df405a3d7d7dc80L2-R9) [[2]](diffhunk://#diff-a3af52ccdb61e504394f792a476e7ea20c6f3bfb899b7bbf6df405a3d7d7dc80R84-R86) [[3]](diffhunk://#diff-a3af52ccdb61e504394f792a476e7ea20c6f3bfb899b7bbf6df405a3d7d7dc80L91-R103)
* **`VisitorsLocationContainer`**: Updated to use `inject()` for `I18nService`, `DecimalPipe`, and `LoggerService`. [[1]](diffhunk://#diff-aa0231cc00831ccd4972aab449d5ce669df76f7d26eea20102f0d013447fcc89L4-R11) [[2]](diffhunk://#diff-aa0231cc00831ccd4972aab449d5ce669df76f7d26eea20102f0d013447fcc89R52-R55) [[3]](diffhunk://#diff-aa0231cc00831ccd4972aab449d5ce669df76f7d26eea20102f0d013447fcc89L69-R83)
* **`AreaPickerDialogComponent`**: Replaced constructor-based injection of `GoogleMapService` and `LoggerService` with `inject()`. [[1]](diffhunk://#diff-a5721cea4de5a837b2e125cd3064def6aa994b8ecbfc5ad9b39fa31540b93510L9-R10) [[2]](diffhunk://#diff-a5721cea4de5a837b2e125cd3064def6aa994b8ecbfc5ad9b39fa31540b93510R45-R47) [[3]](diffhunk://#diff-a5721cea4de5a837b2e125cd3064def6aa994b8ecbfc5ad9b39fa31540b93510L60-R64)

#### Directives:
* **`NgGrid`**: Updated to use `inject()` for `KeyValueDiffers`, `ElementRef`, `Renderer2`, and `ComponentFactoryResolver`. Removed the constructor. [[1]](diffhunk://#diff-2db59e014b52b8c6a7702e3e81f3c296b1984c47bab9cfe7b8a5348e46d2a91eL16-R17) [[2]](diffhunk://#diff-2db59e014b52b8c6a7702e3e81f3c296b1984c47bab9cfe7b8a5348e46d2a91eR57-R61) [[3]](diffhunk://#diff-2db59e014b52b8c6a7702e3e81f3c296b1984c47bab9cfe7b8a5348e46d2a91eL185-R191)
* **`NgGridItem`**: Replaced constructor-based injection of `KeyValueDiffers`, `ElementRef`, `Renderer2`, `NgGrid`, and `ViewContainerRef` with `inject()`. [[1]](diffhunk://#diff-0ef658cf4eb1fffbf3e17e1699c187973bf38eee6e5acba839bb4a56d8b1e4b4L12-R13) [[2]](diffhunk://#diff-0ef658cf4eb1fffbf3e17e1699c187973bf38eee6e5acba839bb4a56d8b1e4b4R33-R38) [[3]](diffhunk://#diff-0ef658cf4eb1fffbf3e17e1699c187973bf38eee6e5acba839bb4a56d8b1e4b4L170-L178)
* **`DotAutofocusDirective`**: Replaced constructor-based injection of `ElementRef` with `inject()`.

### Checklist

- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)



This PR fixes: #32716