### PR TITLE
fix(block editor): AI Content Dialog Focus

### DIFF
--- a/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.html
+++ b/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.html
@@ -31,7 +31,6 @@
                     <textarea
                         [placeholder]="'block-editor.extension.ai-content.placeholder' | dm"
                         class="ai-content__generated-text"
-                        tabindex="-1"
                         formControlName="generatedText"
                         #generatedText
                         [readOnly]="true"

--- a/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.html
+++ b/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.html
@@ -14,6 +14,7 @@
             class="ai-content__form">
             @if (vm.status === ComponentStatus.LOADING) {
                 <p-skeleton width="100%" height="22rem" />
+                <p-skeleton class="flex justify-content-center" width="7rem" height="2rem" />
             } @else if (vm.generatedContent[vm.activeIndex]?.error) {
                 <dot-empty-container
                     (buttonAction)="store.generateContent(form.value.textPrompt)"
@@ -22,13 +23,18 @@
                     [secondaryButton]="true"
                     [configuration]="emptyConfiguration" />
             } @else {
-                <div class="ai-content__generated-text-wrapper">
+                <div
+                    class="ai-content__generated-text-wrapper"
+                    [style]="{
+                        display: generatedText.value ? 'flex' : 'none'
+                    }">
                     <textarea
                         [placeholder]="'block-editor.extension.ai-content.placeholder' | dm"
-                        [readOnly]="true"
                         class="ai-content__generated-text"
-                        #generatedText
+                        tabindex="-1"
                         formControlName="generatedText"
+                        #generatedText
+                        [readOnly]="true"
                         pInputTextarea></textarea>
 
                     @if (generatedText.value) {
@@ -37,11 +43,12 @@
                             customClass="p-button-rounded" />
                     }
                 </div>
-            }
-            @if (vm.status === ComponentStatus.LOADING) {
-                <p-skeleton class="flex justify-content-center" width="7rem" height="2rem" />
-            } @else {
-                <div class="ai-content__pagination">
+
+                <div
+                    class="ai-content__pagination"
+                    [style]="{
+                        display: generatedText?.value ? 'flex' : 'none'
+                    }">
                     <button
                         (click)="store.updateActiveIndex(vm.activeIndex - 1)"
                         [disabled]="vm.activeIndex === 0 || vm.generatedContent?.length === 0"
@@ -50,7 +57,8 @@
                         icon="pi pi-chevron-left"
                         pButton></button>
                     <span>
-                        {{ vm.generatedContent?.length ? vm.activeIndex + 1 : 0 }} {{ 'of' | dm }}
+                        {{ vm.generatedContent?.length ? vm.activeIndex + 1 : 0 }}
+                        {{ 'of' | dm }}
                         {{ vm.generatedContent?.length }}
                     </span>
                     <button

--- a/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.html
+++ b/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.html
@@ -47,7 +47,7 @@
                 <div
                     class="ai-content__pagination"
                     [style]="{
-                        display: generatedText?.value ? 'flex' : 'none'
+                        display: generatedText.value ? 'flex' : 'none'
                     }">
                     <button
                         (click)="store.updateActiveIndex(vm.activeIndex - 1)"

--- a/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.scss
+++ b/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.scss
@@ -33,8 +33,6 @@ form {
     flex-direction: column;
     position: relative;
 
-    transition: all 3s ease-in-out;
-
     .p-inputtext.p-inputtextarea {
         padding: $spacing-1 $spacing-6 $spacing-1 $spacing-4;
         min-height: $spacing-8;

--- a/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.scss
+++ b/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.scss
@@ -33,9 +33,21 @@ form {
     flex-direction: column;
     position: relative;
 
+    transition: all 3s ease-in-out;
+
     .p-inputtext.p-inputtextarea {
         padding: $spacing-1 $spacing-6 $spacing-1 $spacing-4;
         min-height: $spacing-8;
+        resize: vertical;
+
+        &:read-only {
+            // Base styles
+            &:focus,
+            &:hover {
+                outline: none;
+                border: 1.5px solid var(--gray-400);
+            }
+        }
     }
 
     dot-copy-button {
@@ -58,6 +70,7 @@ dot-empty-container {
 }
 
 .ai-content__input-text {
+    resize: vertical;
     height: $spacing-8;
 }
 

--- a/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.scss
+++ b/core-web/libs/block-editor/src/lib/extensions/ai-content-prompt/ai-content-prompt.component.scss
@@ -37,15 +37,6 @@ form {
         padding: $spacing-1 $spacing-6 $spacing-1 $spacing-4;
         min-height: $spacing-8;
         resize: vertical;
-
-        &:read-only {
-            // Base styles
-            &:focus,
-            &:hover {
-                outline: none;
-                border: 1.5px solid var(--gray-400);
-            }
-        }
     }
 
     dot-copy-button {

--- a/core-web/libs/block-editor/src/lib/shared/components/suggestions/suggestions.component.html
+++ b/core-web/libs/block-editor/src/lib/shared/components/suggestions/suggestions.component.html
@@ -1,10 +1,10 @@
-@if (items.length) {
+@if (sortedItems.length) {
     <div>
         @if (!!title) {
             <h3>{{ title }}</h3>
         }
         <dot-suggestion-list #list>
-            @for (item of items; track item) {
+            @for (item of sortedItems; track item) {
                 @if (item.id !== 'divider') {
                     <dot-suggestions-list-item
                         [command]="item.command"

--- a/core-web/libs/block-editor/src/lib/shared/components/suggestions/suggestions.component.ts
+++ b/core-web/libs/block-editor/src/lib/shared/components/suggestions/suggestions.component.ts
@@ -50,6 +50,36 @@ export class SuggestionsComponent implements OnInit {
 
     @Input() onSelectContentlet: (props: SuggestionsCommandProps) => void;
     @Input() items: DotMenuItem[] = [];
+
+    get sortedItems() {
+        const { withAi, withoutAi } = this.items.reduce(
+            (acc, item) => {
+                // Check if the item is an AI item
+                if (item?.label?.toLowerCase().startsWith('ai')) {
+                    acc.withAi.push(item);
+                } else {
+                    acc.withoutAi.push(item);
+                }
+
+                return acc;
+            },
+            {
+                withAi: [],
+                withoutAi: []
+            }
+        );
+
+        // Add a divider between AI and non-AI items
+        const divider: DotMenuItem = { id: 'divider', label: 'DIVIDER', icon: 'divider' };
+
+        // If there are AI items, add a divider after them
+        if (withAi.length) {
+            withAi.push(divider);
+        }
+
+        // Return the items sorted by AI items first, then non-AI items
+        return [...withAi, ...withoutAi];
+    }
     @Input() title = 'Select a block';
     @Input() noResultsMessage = 'No Results';
     @Input() currentLanguage = DEFAULT_LANG_ID;

--- a/core-web/libs/block-editor/src/lib/shared/components/suggestions/suggestions.component.ts
+++ b/core-web/libs/block-editor/src/lib/shared/components/suggestions/suggestions.component.ts
@@ -52,33 +52,14 @@ export class SuggestionsComponent implements OnInit {
     @Input() items: DotMenuItem[] = [];
 
     get sortedItems() {
-        const { withAi, withoutAi } = this.items.reduce(
-            (acc, item) => {
-                // Check if the item is an AI item
-                if (item?.label?.toLowerCase().startsWith('ai')) {
-                    acc.withAi.push(item);
-                } else {
-                    acc.withoutAi.push(item);
-                }
-
-                return acc;
-            },
-            {
-                withAi: [],
-                withoutAi: []
-            }
-        );
-
-        // Add a divider between AI and non-AI items
-        const divider: DotMenuItem = { id: 'divider', label: 'DIVIDER', icon: 'divider' };
-
-        // If there are AI items, add a divider after them
-        if (withAi.length) {
-            withAi.push(divider);
-        }
-
         // Return the items sorted by AI items first, then non-AI items
-        return [...withAi, ...withoutAi];
+        return this.items.sort((a) => {
+            if (a?.label?.toLowerCase().startsWith('ai')) {
+                return -1;
+            }
+
+            return 1;
+        });
     }
     @Input() title = 'Select a block';
     @Input() noResultsMessage = 'No Results';


### PR DESCRIPTION
This PR fixes the issue where the AI content generation dialog doesn't default the cursor to the prompt area when launched from the block editor.

## Changes

- Reorganized the skeleton loading elements for better visual flow
- Added conditional display using `[style]="{ display: generatedText.value ? 'flex' : 'none' }"` to hide the generated text and pagination when no content exists
- Reordered attributes in textarea elements for better readability
- Added `resize: vertical` to textareas to allow users to adjust their height
- Simplified the component structure for better maintainability
- Push AI Blocks to the Top of the list

The primary goal of these changes is to ensure that when the AI content dialog opens, the user's focus automatically goes to the input area where they type their prompt, rather than getting caught in the generated content area. This provides a smoother workflow where users can immediately start typing their prompts when the dialog appears.


https://github.com/user-attachments/assets/aa963411-939f-405e-995e-3da554740107


This PR fixes: #32083