### PR TITLE
refactor(ui): Use inject function

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.store.ts
+++ b/core-web/libs/ui/src/lib/components/dot-ai-image-prompt/ai-image-prompt.store.ts
@@ -2,7 +2,7 @@ import { ComponentStore } from '@ngrx/component-store';
 import { tapResponse } from '@ngrx/operators';
 import { Observable, of } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { switchMap, withLatestFrom } from 'rxjs/operators';
 
@@ -54,6 +54,8 @@ const initialState: DotAiImagePromptComponentState = {
 
 @Injectable({ providedIn: 'root' })
 export class DotAiImagePromptStore extends ComponentStore<DotAiImagePromptComponentState> {
+    private dotAiService = inject(DotAiService);
+
     //Selectors
     readonly isOpenDialog$ = this.select(this.state$, ({ showDialog }) => showDialog);
     readonly isLoading$ = this.select(
@@ -201,7 +203,7 @@ export class DotAiImagePromptStore extends ComponentStore<DotAiImagePromptCompon
         });
     }
 
-    constructor(private dotAiService: DotAiService) {
+    constructor() {
         super(initialState);
     }
 }

--- a/core-web/libs/ui/src/lib/components/dot-asset-search/components/dot-asset-search-dialog/dot-asset-search-dialog.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-asset-search/components/dot-asset-search-dialog/dot-asset-search-dialog.component.ts
@@ -14,11 +14,13 @@ import { DotAssetSearchComponent } from '@dotcms/ui';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotAssetSearchDialogComponent {
+    private readonly config = inject(DynamicDialogConfig);
+
     private readonly ref = inject(DynamicDialogRef);
 
     protected editorAssetType: EditorAssetTypes;
 
-    constructor(private readonly config: DynamicDialogConfig) {
+    constructor() {
         this.editorAssetType = this.config.data?.assetType;
     }
 

--- a/core-web/libs/ui/src/lib/components/dot-asset-search/store/dot-asset-search.store.ts
+++ b/core-web/libs/ui/src/lib/components/dot-asset-search/store/dot-asset-search.store.ts
@@ -1,7 +1,7 @@
 import { ComponentStore } from '@ngrx/component-store';
 import { tapResponse } from '@ngrx/operators';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { Observable } from 'rxjs/internal/Observable';
 import { map, switchMap, tap } from 'rxjs/operators';
@@ -35,6 +35,9 @@ const defaultState: DotAssetSearch = {
 
 @Injectable()
 export class DotAssetSearchStore extends ComponentStore<DotAssetSearch> {
+    private dotContentSearchService = inject(DotContentSearchService);
+    private dotLanguagesService = inject(DotLanguagesService);
+
     // Selectors
     readonly vm$ = this.select((state) => state);
 
@@ -59,10 +62,7 @@ export class DotAssetSearchStore extends ComponentStore<DotAssetSearch> {
 
     private languages: { [key: string]: DotLanguage } = {};
 
-    constructor(
-        private dotContentSearchService: DotContentSearchService,
-        private dotLanguagesService: DotLanguagesService
-    ) {
+    constructor() {
         super(defaultState);
 
         this.dotLanguagesService.get().subscribe((languages) => {

--- a/core-web/libs/ui/src/lib/components/dot-binary-option-selector/dot-binary-option-selector.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-binary-option-selector/dot-binary-option-selector.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
@@ -28,14 +28,14 @@ export interface BINARY_OPTION {
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotBinaryOptionSelectorComponent {
+    private readonly ref = inject(DynamicDialogRef);
+    private readonly config = inject(DynamicDialogConfig);
+
     value: string;
     private options: BINARY_OPTION;
     private readonly defaultBtnLabel = 'next';
 
-    constructor(
-        private readonly ref: DynamicDialogRef,
-        private readonly config: DynamicDialogConfig
-    ) {
+    constructor() {
         const { options } = this.config.data || {};
         this.options = options;
         this.value = this.options.option1.value;

--- a/core-web/libs/ui/src/lib/components/dot-drop-zone/directive/dot-drop-zone-value-accesor/dot-drop-zone-value-accessor.directive.stories.ts
+++ b/core-web/libs/ui/src/lib/components/dot-drop-zone/directive/dot-drop-zone-value-accesor/dot-drop-zone-value-accessor.directive.stories.ts
@@ -2,7 +2,7 @@ import { action } from '@storybook/addon-actions';
 import { moduleMetadata, StoryObj, Meta } from '@storybook/angular';
 
 import { CommonModule } from '@angular/common';
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular/core';
 import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { DotDropZoneValueAccessorDirective } from './dot-drop-zone-value-accessor.directive';
@@ -60,6 +60,8 @@ import { DotDropZoneComponent } from '../../dot-drop-zone.component';
     `
 })
 class DotDropZoneValueAccessorTestComponent implements OnInit {
+    private fb = inject(FormBuilder);
+
     @Input() accept: string[];
     @Input() maxFileSize: number;
 
@@ -67,8 +69,6 @@ class DotDropZoneValueAccessorTestComponent implements OnInit {
     @Output() formErrors = new EventEmitter();
 
     myForm: FormGroup;
-
-    constructor(private fb: FormBuilder) {}
 
     ngOnInit() {
         this.myForm = this.fb.group({

--- a/core-web/libs/ui/src/lib/components/dot-drop-zone/directive/dot-drop-zone-value-accesor/dot-drop-zone-value-accessor.directive.ts
+++ b/core-web/libs/ui/src/lib/components/dot-drop-zone/directive/dot-drop-zone-value-accesor/dot-drop-zone-value-accessor.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Host, OnInit, Optional, forwardRef } from '@angular/core';
+import { Directive, OnInit, forwardRef, inject } from '@angular/core';
 import {
     AbstractControl,
     ControlValueAccessor,
@@ -26,10 +26,12 @@ import { DotDropZoneComponent, DropZoneFileEvent } from '../../dot-drop-zone.com
     ]
 })
 export class DotDropZoneValueAccessorDirective implements ControlValueAccessor, Validator, OnInit {
+    private _dotDropZone = inject(DotDropZoneComponent, { optional: true, host: true });
+
     private onChange: (value: File) => void;
     private onTouched: () => void;
 
-    constructor(@Optional() @Host() private _dotDropZone: DotDropZoneComponent) {
+    constructor() {
         if (!this._dotDropZone) {
             throw new Error(
                 'dot-drop-zone-value-accessor can only be used inside of a dot-drop-zone'

--- a/core-web/libs/ui/src/lib/components/dot-field-validation-message/dot-field-validation-message.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-field-validation-message/dot-field-validation-message.component.ts
@@ -10,7 +10,8 @@ import {
     ChangeDetectorRef,
     Component,
     Input,
-    OnDestroy
+    OnDestroy,
+    inject
 } from '@angular/core';
 import { AbstractControl, UntypedFormControl, ValidationErrors } from '@angular/forms';
 
@@ -37,17 +38,15 @@ const NG_DEFAULT_VALIDATORS_ERRORS_MSG: Record<DefaultsNGValidatorsTypes, string
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotFieldValidationMessageComponent implements OnDestroy {
+    private readonly cd = inject(ChangeDetectorRef);
+    private readonly dotMessageService = inject(DotMessageService);
+
     @Input()
     patternErrorMessage: string;
 
     defaultMessage: string;
     errorMsg = '';
     private destroy$: Subject<boolean> = new Subject<boolean>();
-
-    constructor(
-        private readonly cd: ChangeDetectorRef,
-        private readonly dotMessageService: DotMessageService
-    ) {}
 
     /**
      * Manual message when the input has an error.

--- a/core-web/libs/ui/src/lib/components/dot-form-dialog/dot-form-dialog.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-form-dialog/dot-form-dialog.component.ts
@@ -7,7 +7,8 @@ import {
     Input,
     OnDestroy,
     OnInit,
-    Output
+    Output,
+    inject
 } from '@angular/core';
 
 import { ButtonModule } from 'primeng/button';
@@ -26,6 +27,9 @@ import { DotMessagePipe } from '../../dot-message/dot-message.pipe';
     styleUrls: ['./dot-form-dialog.component.scss']
 })
 export class DotFormDialogComponent implements OnInit, OnDestroy {
+    private dynamicDialog = inject(DynamicDialogRef);
+    private el = inject(ElementRef);
+
     destroy = new Subject();
     destroy$ = this.destroy.asObservable();
 
@@ -40,11 +44,6 @@ export class DotFormDialogComponent implements OnInit, OnDestroy {
 
     @Output()
     cancel: EventEmitter<MouseEvent> = new EventEmitter(null);
-
-    constructor(
-        private dynamicDialog: DynamicDialogRef,
-        private el: ElementRef
-    ) {}
 
     ngOnInit(): void {
         const content = document.querySelector('p-dynamicdialog .p-dialog-content');

--- a/core-web/libs/ui/src/lib/components/dot-not-license/dot-not-license.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-not-license/dot-not-license.component.ts
@@ -1,6 +1,6 @@
 import { Subject } from 'rxjs';
 
-import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnDestroy, OnInit, inject } from '@angular/core';
 
 import { ButtonModule } from 'primeng/button';
 
@@ -19,11 +19,11 @@ import { DotMessagePipe } from '../../dot-message/dot-message.pipe';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotNotLicenseComponent implements OnInit, OnDestroy {
+    private dotLicense = inject(DotLicenseService);
+
     unlicenseData: DotUnlicensedPortletData;
 
     private destroy$: Subject<boolean> = new Subject<boolean>();
-
-    constructor(private dotLicense: DotLicenseService) {}
 
     ngOnInit() {
         this.dotLicense.unlicenseData

--- a/core-web/libs/ui/src/lib/components/dot-sidebar-header/dot-sidebar-header.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-sidebar-header/dot-sidebar-header.component.ts
@@ -1,12 +1,5 @@
 import { CommonModule } from '@angular/common';
-import {
-    ChangeDetectionStrategy,
-    Component,
-    Host,
-    Input,
-    Optional,
-    TemplateRef
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, TemplateRef, inject } from '@angular/core';
 
 import { ButtonModule } from 'primeng/button';
 import { Sidebar } from 'primeng/sidebar';
@@ -28,6 +21,8 @@ import { Sidebar } from 'primeng/sidebar';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotSidebarHeaderComponent {
+    private readonly sidebarComponent = inject(Sidebar, { optional: true, host: true });
+
     /**
      * Title of the sidebar
      */
@@ -41,7 +36,9 @@ export class DotSidebarHeaderComponent {
     @Input()
     actionButtonTpl?: TemplateRef<void>;
 
-    constructor(@Optional() @Host() private readonly sidebarComponent: Sidebar) {
+    constructor() {
+        const sidebarComponent = this.sidebarComponent;
+
         if (!sidebarComponent) {
             console.warn('DotSidebarHeaderComponent is for use inside of a PrimeNg Sidebar');
         }

--- a/core-web/libs/ui/src/lib/components/dot-sidebar-header/dot-sidebar-header.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-sidebar-header/dot-sidebar-header.component.ts
@@ -37,9 +37,7 @@ export class DotSidebarHeaderComponent {
     actionButtonTpl?: TemplateRef<void>;
 
     constructor() {
-        const sidebarComponent = this.sidebarComponent;
-
-        if (!sidebarComponent) {
+        if (!this.sidebarComponent) {
             console.warn('DotSidebarHeaderComponent is for use inside of a PrimeNg Sidebar');
         }
     }

--- a/core-web/libs/ui/src/lib/directives/dot-autofocus/dot-autofocus.directive.ts
+++ b/core-web/libs/ui/src/lib/directives/dot-autofocus/dot-autofocus.directive.ts
@@ -1,11 +1,11 @@
-import { Directive, ElementRef, OnInit } from '@angular/core';
+import { Directive, ElementRef, OnInit, inject } from '@angular/core';
 
 @Directive({
     selector: '[dotAutofocus]',
     standalone: true
 })
 export class DotAutofocusDirective implements OnInit {
-    constructor(private el: ElementRef) {}
+    private el = inject(ElementRef);
 
     ngOnInit() {
         if (!this.el.nativeElement.disabled) {

--- a/core-web/libs/ui/src/lib/directives/dot-avatar/dot-avatar.directive.ts
+++ b/core-web/libs/ui/src/lib/directives/dot-avatar/dot-avatar.directive.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Directive, HostListener, Input, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Directive, HostListener, Input, OnInit, inject } from '@angular/core';
 
 import { Avatar } from 'primeng/avatar';
 
@@ -7,12 +7,12 @@ import { Avatar } from 'primeng/avatar';
     standalone: true
 })
 export class DotAvatarDirective implements OnInit {
+    private avatar = inject(Avatar);
+    private cd = inject(ChangeDetectorRef);
+
     @Input() text = 'Default';
 
-    constructor(
-        private avatar: Avatar,
-        private cd: ChangeDetectorRef
-    ) {
+    constructor() {
         this.avatar.shape = 'circle';
     }
 

--- a/core-web/libs/ui/src/lib/directives/dot-dropdown.directive.ts
+++ b/core-web/libs/ui/src/lib/directives/dot-dropdown.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, Optional, Self } from '@angular/core';
+import { Directive, Input, inject } from '@angular/core';
 
 import { Dropdown } from 'primeng/dropdown';
 import { MultiSelect } from 'primeng/multiselect';
@@ -23,13 +23,13 @@ const DEFAULT_VALUE_NAME_INDEX = 'value';
     providers: [DotMessagePipe]
 })
 export class DotDropdownDirective {
+    private readonly primeDropdown = inject(Dropdown, { optional: true, self: true });
+    private readonly primeMultiSelect = inject(MultiSelect, { optional: true, self: true });
+    private readonly dotMessageService = inject(DotMessageService);
+
     control: Dropdown | MultiSelect;
 
-    constructor(
-        @Optional() @Self() private readonly primeDropdown: Dropdown,
-        @Optional() @Self() private readonly primeMultiSelect: MultiSelect,
-        private readonly dotMessageService: DotMessageService
-    ) {
+    constructor() {
         this.control = this.primeDropdown ? this.primeDropdown : this.primeMultiSelect;
 
         if (this.control) {

--- a/core-web/libs/ui/src/lib/directives/dot-dynamic.directive.ts
+++ b/core-web/libs/ui/src/lib/directives/dot-dynamic.directive.ts
@@ -1,9 +1,9 @@
-import { Directive, ViewContainerRef } from '@angular/core';
+import { Directive, ViewContainerRef, inject } from '@angular/core';
 
 @Directive({
     standalone: true,
     selector: '[dotDynamic]'
 })
 export class DotDynamicDirective {
-    constructor(public viewContainerRef: ViewContainerRef) {}
+    viewContainerRef = inject(ViewContainerRef);
 }

--- a/core-web/libs/ui/src/lib/directives/dot-gravatar/dot-gravatar.directive.ts
+++ b/core-web/libs/ui/src/lib/directives/dot-gravatar/dot-gravatar.directive.ts
@@ -1,6 +1,6 @@
 import md5 from 'md5';
 
-import { ChangeDetectorRef, Directive, input, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Directive, input, OnInit, inject } from '@angular/core';
 
 import { Avatar } from 'primeng/avatar';
 
@@ -16,16 +16,16 @@ const DEFAULT_AVATAR_SHAPE = 'circle';
     standalone: true
 })
 export class DotGravatarDirective implements OnInit {
+    private avatar = inject(Avatar);
+    private cd = inject(ChangeDetectorRef);
+
     email = input<string>('');
 
     private readonly GRAVATAR_URL = 'https://www.gravatar.com/avatar/';
     private readonly DEFAULT_SIZE = 48;
     private readonly DEFAULT_RATING = 'g';
 
-    constructor(
-        private avatar: Avatar,
-        private cd: ChangeDetectorRef
-    ) {
+    constructor() {
         this.avatar.shape = DEFAULT_AVATAR_SHAPE;
     }
 

--- a/core-web/libs/ui/src/lib/directives/dot-sidebar.directive.ts
+++ b/core-web/libs/ui/src/lib/directives/dot-sidebar.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, Optional, Self } from '@angular/core';
+import { Directive, Input, inject } from '@angular/core';
 
 import { Sidebar } from 'primeng/sidebar';
 
@@ -21,7 +21,11 @@ export enum SIDEBAR_SIZES {
     selector: '[dotSidebar]'
 })
 export class DotSidebarDirective {
-    constructor(@Optional() @Self() private readonly primeSidebar: Sidebar) {
+    private readonly primeSidebar = inject(Sidebar, { optional: true, self: true });
+
+    constructor() {
+        const primeSidebar = this.primeSidebar;
+
         if (primeSidebar) {
             primeSidebar.position = SIDEBAR_PLACEMENT.RIGHT;
             primeSidebar.styleClass = SIDEBAR_SIZES.MD;

--- a/core-web/libs/ui/src/lib/directives/dot-sidebar.directive.ts
+++ b/core-web/libs/ui/src/lib/directives/dot-sidebar.directive.ts
@@ -24,14 +24,12 @@ export class DotSidebarDirective {
     private readonly primeSidebar = inject(Sidebar, { optional: true, self: true });
 
     constructor() {
-        const primeSidebar = this.primeSidebar;
-
-        if (primeSidebar) {
-            primeSidebar.position = SIDEBAR_PLACEMENT.RIGHT;
-            primeSidebar.styleClass = SIDEBAR_SIZES.MD;
-            primeSidebar.showCloseIcon = false;
-            primeSidebar.dismissible = false;
-            primeSidebar.closeOnEscape = false;
+        if (this.primeSidebar) {
+            this.primeSidebar.position = SIDEBAR_PLACEMENT.RIGHT;
+            this.primeSidebar.styleClass = SIDEBAR_SIZES.MD;
+            this.primeSidebar.showCloseIcon = false;
+            this.primeSidebar.dismissible = false;
+            this.primeSidebar.closeOnEscape = false;
         } else {
             console.warn('DotSidebarDirective is for use with PrimeNg Sidebar');
         }

--- a/core-web/libs/ui/src/lib/directives/dot-string-template-outlet.directive.ts
+++ b/core-web/libs/ui/src/lib/directives/dot-string-template-outlet.directive.ts
@@ -6,7 +6,8 @@ import {
     SimpleChange,
     SimpleChanges,
     TemplateRef,
-    ViewContainerRef
+    ViewContainerRef,
+    inject
 } from '@angular/core';
 
 class DotStringTemplateOutletContext {
@@ -34,14 +35,12 @@ class DotStringTemplateOutletContext {
     selector: '[dotStringTemplateOutlet]'
 })
 export class DotStringTemplateOutletDirective implements OnChanges {
+    private templateRef = inject<TemplateRef<unknown>>(TemplateRef);
+    private viewContainer = inject(ViewContainerRef);
+
     @Input() dotStringTemplateOutlet: unknown | TemplateRef<unknown> = null;
     private embeddedViewRef: EmbeddedViewRef<unknown> | null = null;
     private context = new DotStringTemplateOutletContext();
-
-    constructor(
-        private templateRef: TemplateRef<unknown>,
-        private viewContainer: ViewContainerRef
-    ) {}
 
     ngOnChanges(changes: SimpleChanges): void {
         const { dotStringTemplateOutlet } = changes;

--- a/core-web/libs/ui/src/lib/directives/dot-trim-input/dot-trim-input.directive.ts
+++ b/core-web/libs/ui/src/lib/directives/dot-trim-input/dot-trim-input.directive.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Directive, ElementRef, HostListener, Optional, Self } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, HostListener, inject } from '@angular/core';
 import { NgControl } from '@angular/forms';
 
 /**
@@ -9,10 +9,8 @@ import { NgControl } from '@angular/forms';
     standalone: true
 })
 export class DotTrimInputDirective implements AfterViewInit {
-    constructor(
-        @Optional() @Self() private readonly ngControl: NgControl,
-        private readonly el: ElementRef
-    ) {}
+    private readonly ngControl = inject(NgControl, { optional: true, self: true });
+    private readonly el = inject(ElementRef);
 
     @HostListener('blur')
     onBlur() {

--- a/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.ts
+++ b/core-web/libs/ui/src/lib/dot-container-options/dot-container-options.directive.ts
@@ -1,6 +1,6 @@
 import { Observable, of } from 'rxjs';
 
-import { ChangeDetectorRef, Directive, OnInit, Optional, Self } from '@angular/core';
+import { ChangeDetectorRef, Directive, OnInit, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { Dropdown } from 'primeng/dropdown';
@@ -28,16 +28,16 @@ const DEFAULT_VALUE_NAME_INDEX = 'value';
     standalone: true
 })
 export class DotContainerOptionsDirective implements OnInit {
+    private readonly primeDropdown = inject(Dropdown, { optional: true, self: true });
+    private readonly dotContainersService = inject(DotContainersService);
+    private readonly dotMessageService = inject(DotMessageService);
+    private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
     private readonly control: Dropdown;
     private readonly maxOptions = 10;
     private readonly loadErrorMessage: string;
 
-    constructor(
-        @Optional() @Self() private readonly primeDropdown: Dropdown,
-        private readonly dotContainersService: DotContainersService,
-        private readonly dotMessageService: DotMessageService,
-        private readonly changeDetectorRef: ChangeDetectorRef
-    ) {
+    constructor() {
         this.control = this.primeDropdown;
         this.loadErrorMessage = this.dotMessageService.get(
             'dot.template.builder.box.containers.error'

--- a/core-web/libs/ui/src/lib/dot-field-required/dot-field-required.directive.ts
+++ b/core-web/libs/ui/src/lib/dot-field-required/dot-field-required.directive.ts
@@ -16,9 +16,7 @@ export class DotFieldRequiredDirective {
     private formGroupDirective = inject(FormGroupDirective);
 
     constructor() {
-        const renderer = this.renderer;
-
-        renderer.addClass(this.el.nativeElement, 'p-label-input-required');
+        this.renderer.addClass(this.el.nativeElement, 'p-label-input-required');
     }
 
     /**

--- a/core-web/libs/ui/src/lib/dot-field-required/dot-field-required.directive.ts
+++ b/core-web/libs/ui/src/lib/dot-field-required/dot-field-required.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input, Renderer2 } from '@angular/core';
+import { Directive, ElementRef, Input, Renderer2, inject } from '@angular/core';
 import { FormGroupDirective, Validators } from '@angular/forms';
 
 /**
@@ -11,11 +11,13 @@ import { FormGroupDirective, Validators } from '@angular/forms';
     standalone: true
 })
 export class DotFieldRequiredDirective {
-    constructor(
-        private el: ElementRef,
-        private renderer: Renderer2,
-        private formGroupDirective: FormGroupDirective
-    ) {
+    private el = inject(ElementRef);
+    private renderer = inject(Renderer2);
+    private formGroupDirective = inject(FormGroupDirective);
+
+    constructor() {
+        const renderer = this.renderer;
+
         renderer.addClass(this.el.nativeElement, 'p-label-input-required');
     }
 

--- a/core-web/libs/ui/src/lib/dot-field-required/dot-field-required.spec.ts
+++ b/core-web/libs/ui/src/lib/dot-field-required/dot-field-required.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement } from '@angular/core';
+import { Component, DebugElement, inject } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {
     ReactiveFormsModule,
@@ -29,7 +29,8 @@ import { DotFieldRequiredDirective } from './dot-field-required.directive';
     `
 })
 class TestHostComponent {
-    constructor(private fb: UntypedFormBuilder) {}
+    private fb = inject(UntypedFormBuilder);
+
     form: UntypedFormGroup = this.fb.group({
         name: new UntypedFormControl('', Validators.required),
         text: new UntypedFormControl('')

--- a/core-web/libs/ui/src/lib/dot-message/dot-message.pipe.spec.ts
+++ b/core-web/libs/ui/src/lib/dot-message/dot-message.pipe.spec.ts
@@ -6,47 +6,45 @@ import { MockDotMessageService } from '@dotcms/utils-testing';
 import { DotMessagePipe } from './dot-message.pipe';
 
 describe('DotMessagePipe', () => {
-  let spectator: SpectatorPipe<DotMessagePipe>;
+    let spectator: SpectatorPipe<DotMessagePipe>;
 
-  const mockMessages = {
-    'apps.search.placeholder': 'Search',
-    'apps.best': 'Test {0} {1}'
-  };
+    const mockMessages = {
+        'apps.search.placeholder': 'Search',
+        'apps.best': 'Test {0} {1}'
+    };
 
-  const messageServiceMock = new MockDotMessageService(mockMessages);
+    const messageServiceMock = new MockDotMessageService(mockMessages);
 
-  const createPipe = createPipeFactory({
-    pipe: DotMessagePipe,
-    providers: [
-        { provide: DotMessageService, useValue: messageServiceMock },
-    ]
-  });
-
-  it('should return empty string if param is undefined', () => {
-    spectator = createPipe(`{{ value | dm }}`, {
-      hostProps: { value: undefined }
+    const createPipe = createPipeFactory({
+        pipe: DotMessagePipe,
+        providers: [{ provide: DotMessageService, useValue: messageServiceMock }]
     });
-    expect(spectator.element.textContent).toBe('');
-  });
 
-  it('should return message requested', () => {
-    spectator = createPipe(`{{ value | dm }}`, {
-      hostProps: { value: 'apps.search.placeholder' }
+    it('should return empty string if param is undefined', () => {
+        spectator = createPipe(`{{ value | dm }}`, {
+            hostProps: { value: undefined }
+        });
+        expect(spectator.element.textContent).toBe('');
     });
-    expect(spectator.element.textContent).toBe('Search');
-  });
 
-  it('should return message requested with replaced values', () => {
-    spectator = createPipe(`{{ value | dm:args }}`, {
-      hostProps: { value: 'apps.best', args: ['Costa Rica', 'Panama'] }
+    it('should return message requested', () => {
+        spectator = createPipe(`{{ value | dm }}`, {
+            hostProps: { value: 'apps.search.placeholder' }
+        });
+        expect(spectator.element.textContent).toBe('Search');
     });
-    expect(spectator.element.textContent).toBe('Test Costa Rica Panama');
-  });
 
-  it('should return key if message not found', () => {
-    spectator = createPipe(`{{ value | dm }}`, {
-      hostProps: { value: 'no.label.found' }
+    it('should return message requested with replaced values', () => {
+        spectator = createPipe(`{{ value | dm:args }}`, {
+            hostProps: { value: 'apps.best', args: ['Costa Rica', 'Panama'] }
+        });
+        expect(spectator.element.textContent).toBe('Test Costa Rica Panama');
     });
-    expect(spectator.element.textContent).toBe('no.label.found');
-  });
+
+    it('should return key if message not found', () => {
+        spectator = createPipe(`{{ value | dm }}`, {
+            hostProps: { value: 'no.label.found' }
+        });
+        expect(spectator.element.textContent).toBe('no.label.found');
+    });
 });

--- a/core-web/libs/ui/src/lib/dot-message/dot-message.pipe.ts
+++ b/core-web/libs/ui/src/lib/dot-message/dot-message.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 
 import { DotMessageService } from '@dotcms/data-access';
 
@@ -8,7 +8,7 @@ import { DotMessageService } from '@dotcms/data-access';
     pure: true
 })
 export class DotMessagePipe implements PipeTransform {
-    constructor(private dotMessageService: DotMessageService) {}
+    private dotMessageService = inject(DotMessageService);
 
     transform(value: string, args: string[] = []): string {
         return value ? this.dotMessageService.get(value, ...args) : '';

--- a/core-web/libs/ui/src/lib/dot-site-selector/dot-site-selector.directive.ts
+++ b/core-web/libs/ui/src/lib/dot-site-selector/dot-site-selector.directive.ts
@@ -1,14 +1,6 @@
 import { Subject } from 'rxjs';
 
-import {
-    ChangeDetectorRef,
-    Directive,
-    Input,
-    OnDestroy,
-    OnInit,
-    Optional,
-    Self
-} from '@angular/core';
+import { ChangeDetectorRef, Directive, Input, OnDestroy, OnInit, inject } from '@angular/core';
 
 import { Dropdown } from 'primeng/dropdown';
 
@@ -23,6 +15,11 @@ import { Site } from '@dotcms/dotcms-js';
     standalone: true
 })
 export class DotSiteSelectorDirective implements OnInit, OnDestroy {
+    private readonly primeDropdown = inject(Dropdown, { optional: true, self: true });
+    private readonly dotEventsService = inject(DotEventsService);
+    private readonly dotSiteService = inject(DotSiteService);
+    private readonly cd = inject(ChangeDetectorRef);
+
     @Input() archive = false;
     @Input() live = true;
     @Input() system = true;
@@ -32,12 +29,7 @@ export class DotSiteSelectorDirective implements OnInit, OnDestroy {
     private readonly dotEvents = ['login-as', 'logout-as'];
     private readonly control: Dropdown;
 
-    constructor(
-        @Optional() @Self() private readonly primeDropdown: Dropdown,
-        private readonly dotEventsService: DotEventsService,
-        private readonly dotSiteService: DotSiteService,
-        private readonly cd: ChangeDetectorRef
-    ) {
+    constructor() {
         this.control = this.primeDropdown;
 
         if (this.control) {

--- a/core-web/libs/ui/src/lib/modules/dot-dialog/dot-dialog.component.ts
+++ b/core-web/libs/ui/src/lib/modules/dot-dialog/dot-dialog.component.ts
@@ -9,7 +9,8 @@ import {
     OnChanges,
     Output,
     SimpleChanges,
-    ViewChild
+    ViewChild,
+    inject
 } from '@angular/core';
 
 import { filter } from 'rxjs/operators';
@@ -22,6 +23,8 @@ import { DialogButton, DotDialogActions } from '@dotcms/dotcms-models';
     styleUrls: ['./dot-dialog.component.scss']
 })
 export class DotDialogComponent implements OnChanges {
+    private el = inject(ElementRef);
+
     @ViewChild('dialog') dialog: ElementRef;
 
     @Input()
@@ -71,8 +74,6 @@ export class DotDialogComponent implements OnChanges {
     isContentScrolled: boolean;
 
     private subscription: Subscription[] = [];
-
-    constructor(private el: ElementRef) {}
 
     ngOnChanges(changes: SimpleChanges) {
         if (this.isVisible(changes)) {

--- a/core-web/libs/ui/src/lib/pipes/dot-highlight/dot-highlight.pipe.ts
+++ b/core-web/libs/ui/src/lib/pipes/dot-highlight/dot-highlight.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 
 /**
@@ -23,7 +23,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
     standalone: true
 })
 export class DotHighlightPipe implements PipeTransform {
-    constructor(private sanitizer: DomSanitizer) {}
+    private sanitizer = inject(DomSanitizer);
 
     transform(text: string, search: string | null): SafeHtml {
         if (!text) return '';

--- a/core-web/libs/ui/src/lib/pipes/dot-relative-date/dot-relative-date.pipe.ts
+++ b/core-web/libs/ui/src/lib/pipes/dot-relative-date/dot-relative-date.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 
 import { DotFormatDateService, DotMessageService } from '@dotcms/data-access';
 
@@ -7,10 +7,8 @@ import { DotFormatDateService, DotMessageService } from '@dotcms/data-access';
  */
 @Pipe({ name: 'dotRelativeDate', standalone: true })
 export class DotRelativeDatePipe implements PipeTransform {
-    constructor(
-        private readonly dotFormatDateService: DotFormatDateService,
-        private readonly dotMessageService: DotMessageService
-    ) {}
+    private readonly dotFormatDateService = inject(DotFormatDateService);
+    private readonly dotMessageService = inject(DotMessageService);
 
     transform(date: string | number, format = 'MM/dd/yyyy', timeStampAfter = 7): string {
         const time = date || new Date().getTime();

--- a/core-web/libs/ui/src/lib/pipes/dot-safe-html/dot-safe-html.pipe.spec.ts
+++ b/core-web/libs/ui/src/lib/pipes/dot-safe-html/dot-safe-html.pipe.spec.ts
@@ -5,28 +5,28 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { DotSafeHtmlPipe } from './dot-safe-html.pipe';
 
 describe('DotSafeHtmlPipe', () => {
-  let spectator: SpectatorPipe<DotSafeHtmlPipe>;
-  let sanitizer: SpyObject<DomSanitizer>;
-  const safeHtml = 'safeHtml: <p>Hello World</p>';
+    let spectator: SpectatorPipe<DotSafeHtmlPipe>;
+    let sanitizer: SpyObject<DomSanitizer>;
+    const safeHtml = 'safeHtml: <p>Hello World</p>';
 
-  const createPipe = createPipeFactory({
-    pipe: DotSafeHtmlPipe,
-    providers: [
-      mockProvider(DomSanitizer, {
-        bypassSecurityTrustHtml:  jest.fn().mockReturnValue(safeHtml)
-      })
-    ]
-  });
-
-  it('should call DomSanitizer.bypassSecurityTrustHtml with value', () => {
-    const value = '<p>Hello World</p>';
-
-    spectator = createPipe(`{{ value | safeHtml }}`, {
-      hostProps: { value }
+    const createPipe = createPipeFactory({
+        pipe: DotSafeHtmlPipe,
+        providers: [
+            mockProvider(DomSanitizer, {
+                bypassSecurityTrustHtml: jest.fn().mockReturnValue(safeHtml)
+            })
+        ]
     });
-    sanitizer = spectator.inject(DomSanitizer);
-    spectator.detectChanges();
-    expect(sanitizer.bypassSecurityTrustHtml).toHaveBeenCalledWith(value);
-    expect(spectator.element.textContent).toBe(safeHtml);
-  });
+
+    it('should call DomSanitizer.bypassSecurityTrustHtml with value', () => {
+        const value = '<p>Hello World</p>';
+
+        spectator = createPipe(`{{ value | safeHtml }}`, {
+            hostProps: { value }
+        });
+        sanitizer = spectator.inject(DomSanitizer);
+        spectator.detectChanges();
+        expect(sanitizer.bypassSecurityTrustHtml).toHaveBeenCalledWith(value);
+        expect(spectator.element.textContent).toBe(safeHtml);
+    });
 });

--- a/core-web/libs/ui/src/lib/pipes/dot-safe-html/dot-safe-html.pipe.spec.ts
+++ b/core-web/libs/ui/src/lib/pipes/dot-safe-html/dot-safe-html.pipe.spec.ts
@@ -1,25 +1,32 @@
+import { createPipeFactory, mockProvider, SpectatorPipe, SpyObject } from '@ngneat/spectator/jest';
+
 import { DomSanitizer } from '@angular/platform-browser';
 
 import { DotSafeHtmlPipe } from './dot-safe-html.pipe';
 
-describe('SafeHtmlPipe', () => {
-    let pipe: DotSafeHtmlPipe;
-    let sanitizer: DomSanitizer;
+describe('DotSafeHtmlPipe', () => {
+  let spectator: SpectatorPipe<DotSafeHtmlPipe>;
+  let sanitizer: SpyObject<DomSanitizer>;
+  const safeHtml = 'safeHtml: <p>Hello World</p>';
 
-    beforeEach(() => {
-        sanitizer = {
-            bypassSecurityTrustHtml: jest.fn()
-        } as unknown as DomSanitizer;
-        pipe = new DotSafeHtmlPipe(sanitizer);
-    });
+  const createPipe = createPipeFactory({
+    pipe: DotSafeHtmlPipe,
+    providers: [
+      mockProvider(DomSanitizer, {
+        bypassSecurityTrustHtml:  jest.fn().mockReturnValue(safeHtml)
+      })
+    ]
+  });
 
-    it('should create an instance', () => {
-        expect(pipe).toBeTruthy();
-    });
+  it('should call DomSanitizer.bypassSecurityTrustHtml with value', () => {
+    const value = '<p>Hello World</p>';
 
-    it('should call DomSanitizer.bypassSecurityTrustHtml with value', () => {
-        const value = '<p>Hello World</p>';
-        pipe.transform(value);
-        expect(sanitizer.bypassSecurityTrustHtml).toHaveBeenCalledWith(value);
+    spectator = createPipe(`{{ value | safeHtml }}`, {
+      hostProps: { value }
     });
+    sanitizer = spectator.inject(DomSanitizer);
+    spectator.detectChanges();
+    expect(sanitizer.bypassSecurityTrustHtml).toHaveBeenCalledWith(value);
+    expect(spectator.element.textContent).toBe(safeHtml);
+  });
 });

--- a/core-web/libs/ui/src/lib/pipes/dot-safe-html/dot-safe-html.pipe.ts
+++ b/core-web/libs/ui/src/lib/pipes/dot-safe-html/dot-safe-html.pipe.ts
@@ -1,9 +1,10 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 @Pipe({ name: 'safeHtml', standalone: true })
 export class DotSafeHtmlPipe implements PipeTransform {
-    constructor(private sanitized: DomSanitizer) {}
+    private sanitized = inject(DomSanitizer);
+
     transform(value) {
         return this.sanitized.bypassSecurityTrustHtml(value);
     }

--- a/core-web/libs/ui/src/lib/pipes/safe-url/safe-url.pipe.ts
+++ b/core-web/libs/ui/src/lib/pipes/safe-url/safe-url.pipe.ts
@@ -1,4 +1,4 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, inject } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 
 @Pipe({
@@ -6,7 +6,7 @@ import { DomSanitizer } from '@angular/platform-browser';
     standalone: true
 })
 export class SafeUrlPipe implements PipeTransform {
-    constructor(private sanitizer: DomSanitizer) {}
+    private sanitizer = inject(DomSanitizer);
 
     transform(url: string | InstanceType<typeof String>) {
         return this.sanitizer.bypassSecurityTrustResourceUrl(url.toString());

--- a/core-web/libs/ui/src/lib/resolvers/dot-enterprise-license-resolver.service.ts
+++ b/core-web/libs/ui/src/lib/resolvers/dot-enterprise-license-resolver.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Resolve } from '@angular/router';
 
 import { DotLicenseService } from '@dotcms/data-access';
@@ -14,7 +14,7 @@ import { DotLicenseService } from '@dotcms/data-access';
  */
 @Injectable()
 export class DotEnterpriseLicenseResolver implements Resolve<Observable<boolean>> {
-    constructor(private readonly dotLicenseService: DotLicenseService) {}
+    private readonly dotLicenseService = inject(DotLicenseService);
 
     resolve() {
         return this.dotLicenseService.isEnterprise();

--- a/core-web/libs/ui/src/lib/resolvers/dot-push-publish-enviroments-resolver.service.ts
+++ b/core-web/libs/ui/src/lib/resolvers/dot-push-publish-enviroments-resolver.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { Resolve } from '@angular/router';
 
 import { map } from 'rxjs/operators';
@@ -17,7 +17,7 @@ import { DotEnvironment } from '@dotcms/dotcms-models';
  */
 @Injectable()
 export class DotPushPublishEnvironmentsResolver implements Resolve<Observable<DotEnvironment[]>> {
-    constructor(private readonly pushPublishService: PushPublishService) {}
+    private readonly pushPublishService = inject(PushPublishService);
 
     resolve() {
         //When the is no environments, the endpoint returns [{id: "0", name: ""}]

--- a/core-web/libs/ui/src/lib/services/dot-copy-content-modal/dot-copy-content-modal.service.ts
+++ b/core-web/libs/ui/src/lib/services/dot-copy-content-modal/dot-copy-content-modal.service.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs';
 
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 
 import { DialogService } from 'primeng/dynamicdialog';
 
@@ -19,6 +19,9 @@ export interface ModelCopyContentResponse {
 
 @Injectable()
 export class DotCopyContentModalService {
+    private dialogService = inject(DialogService);
+    private dotMessageService = inject(DotMessageService);
+
     private readonly CONTENT_EDIT_OPTIONS: BINARY_OPTION = {
         option1: {
             value: 'NotCopy',
@@ -35,11 +38,6 @@ export class DotCopyContentModalService {
             buttonLabel: 'editpage.content.edit.content.in.this.page.button.label'
         }
     };
-
-    constructor(
-        private dialogService: DialogService,
-        private dotMessageService: DotMessageService
-    ) {}
 
     /**
      * Open a modal with two options to copy or not the content


### PR DESCRIPTION
### Proposed Changes

This pull request refactors multiple components and directives in the `core-web/libs/ui` library to replace constructor-based dependency injection with the `inject()` function provided by Angular. This change simplifies the codebase and aligns it with modern Angular best practices. Below is a summary of the most important changes grouped by theme:

### Dependency Injection Refactor in Components:

* [`DotAiImagePromptStore`](diffhunk://#diff-1f814fb67beed7304556ea84084e4b2a2ae89508ccbfb17d12d8556428c0078dR57-R58): Replaced the constructor injection of `DotAiService` with `inject()` and removed the constructor entirely. (`[[1]](diffhunk://#diff-1f814fb67beed7304556ea84084e4b2a2ae89508ccbfb17d12d8556428c0078dR57-R58)`, `[[2]](diffhunk://#diff-1f814fb67beed7304556ea84084e4b2a2ae89508ccbfb17d12d8556428c0078dL204-R206)`)
* [`DotAssetSearchDialogComponent`](diffhunk://#diff-12b048fb1384778a16915e1570b87459baceed0f36da4a8b0d34d6456424b17eR17-R23): Replaced constructor injection of `DynamicDialogConfig` and `DynamicDialogRef` with `inject()`. (`[core-web/libs/ui/src/lib/components/dot-asset-search/components/dot-asset-search-dialog/dot-asset-search-dialog.component.tsR17-R23](diffhunk://#diff-12b048fb1384778a16915e1570b87459baceed0f36da4a8b0d34d6456424b17eR17-R23)`)
* [`DotBinaryOptionSelectorComponent`](diffhunk://#diff-ec1b8fbd119344b47b6076f6a7543182e3d1aab4e8199be74f21c5d8721a6625R31-R38): Replaced constructor injection of `DynamicDialogConfig` and `DynamicDialogRef` with `inject()`. (`[core-web/libs/ui/src/lib/components/dot-binary-option-selector/dot-binary-option-selector.component.tsR31-R38](diffhunk://#diff-ec1b8fbd119344b47b6076f6a7543182e3d1aab4e8199be74f21c5d8721a6625R31-R38)`)
* [`DotFormDialogComponent`](diffhunk://#diff-e4659c1960b7cca7aef5618ce56c932ac513c78e33d1cb161f95a3d5aaf8b314R30-R32): Replaced constructor injection of `DynamicDialogRef` and `ElementRef` with `inject()`. (`[[1]](diffhunk://#diff-e4659c1960b7cca7aef5618ce56c932ac513c78e33d1cb161f95a3d5aaf8b314R30-R32)`, `[[2]](diffhunk://#diff-e4659c1960b7cca7aef5618ce56c932ac513c78e33d1cb161f95a3d5aaf8b314L44-L48)`)
* [`DotNotLicenseComponent`](diffhunk://#diff-b5ba2afe39189cce22661dfae15a8f3c3ae8067233a17db93a3ed1611fdefae3R22-L27): Replaced constructor injection of `DotLicenseService` with `inject()`. (`[core-web/libs/ui/src/lib/components/dot-not-license/dot-not-license.component.tsR22-L27](diffhunk://#diff-b5ba2afe39189cce22661dfae15a8f3c3ae8067233a17db93a3ed1611fdefae3R22-L27)`)

### Dependency Injection Refactor in Directives:

* [`DotAutofocusDirective`](diffhunk://#diff-762d630370fb07f88c3471a67ac6b446ea585aa42a912bd38173a5084e8c5586L1-R8): Replaced constructor injection of `ElementRef` with `inject()`. (`[core-web/libs/ui/src/lib/directives/dot-autofocus/dot-autofocus.directive.tsL1-R8](diffhunk://#diff-762d630370fb07f88c3471a67ac6b446ea585aa42a912bd38173a5084e8c5586L1-R8)`)
* [`DotAvatarDirective`](diffhunk://#diff-c18e0e79f169fa9d9a5e8fa38573fd339f14e22979e3a8ce712c21bd0ba6f327R10-R15): Replaced constructor injection of `Avatar` and `ChangeDetectorRef` with `inject()`. (`[core-web/libs/ui/src/lib/directives/dot-avatar/dot-avatar.directive.tsR10-R15](diffhunk://#diff-c18e0e79f169fa9d9a5e8fa38573fd339f14e22979e3a8ce712c21bd0ba6f327R10-R15)`)
* [`DotDropdownDirective`](diffhunk://#diff-9e5074dc0126af23bbbdfd7db72a471cbe62c74e6be53c13276a666adc32d926R26-R32): Replaced constructor injection of `Dropdown`, `MultiSelect`, and `DotMessageService` with `inject()`. (`[core-web/libs/ui/src/lib/directives/dot-dropdown.directive.tsR26-R32](diffhunk://#diff-9e5074dc0126af23bbbdfd7db72a471cbe62c74e6be53c13276a666adc32d926R26-R32)`)
* [`DotDynamicDirective`](diffhunk://#diff-7ce0157859df1a8fb93b75c2cdc68420be7ca2761b00a38d355d0eb16eb91414L1-R8): Replaced constructor injection of `ViewContainerRef` with `inject()`. (`[core-web/libs/ui/src/lib/directives/dot-dynamic.directive.tsL1-R8](diffhunk://#diff-7ce0157859df1a8fb93b75c2cdc68420be7ca2761b00a38d355d0eb16eb91414L1-R8)`)
* [`DotDropZoneValueAccessorDirective`](diffhunk://#diff-fe6bf37dadc43a757cce482233353b7ba77ebcfe5081c8670288a321ed6b14e4R29-R34): Replaced constructor injection of `DotDropZoneComponent` with `inject()`. (`[core-web/libs/ui/src/lib/components/dot-drop-zone/directive/dot-drop-zone-value-accesor/dot-drop-zone-value-accessor.directive.tsR29-R34](diffhunk://#diff-fe6bf37dadc43a757cce482233353b7ba77ebcfe5081c8670288a321ed6b14e4R29-R34)`)

### Dependency Injection Refactor in Stores:

* [`DotAiImagePromptStore`](diffhunk://#diff-1f814fb67beed7304556ea84084e4b2a2ae89508ccbfb17d12d8556428c0078dR57-R58): Replaced constructor injection of `DotAiService` with `inject()` and removed the constructor. (`[[1]](diffhunk://#diff-1f814fb67beed7304556ea84084e4b2a2ae89508ccbfb17d12d8556428c0078dR57-R58)`, `[[2]](diffhunk://#diff-1f814fb67beed7304556ea84084e4b2a2ae89508ccbfb17d12d8556428c0078dL204-R206)`)
* [`DotAssetSearchStore`](diffhunk://#diff-8c6e17fce566a406c8455e49fa807734e1a33cafdd9a00163b8d09cb91ec63ffR38-R40): Replaced constructor injection of `DotContentSearchService` and `DotLanguagesService` with `inject()`. (`[[1]](diffhunk://#diff-8c6e17fce566a406c8455e49fa807734e1a33cafdd9a00163b8d09cb91ec63ffR38-R40)`, `[[2]](diffhunk://#diff-8c6e17fce566a406c8455e49fa807734e1a33cafdd9a00163b8d09cb91ec63ffL62-R65)`)

These changes streamline the codebase by leveraging Angular's `inject()` API, making the code more concise and easier to maintain.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)



This PR fixes: #32744