### PR TITLE
dotcms-ui: Use new angular syntax

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-generated-string-field/dot-apps-configuration-detail-generated-string-field.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-generated-string-field/dot-apps-configuration-detail-generated-string-field.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import {
     ChangeDetectionStrategy,
@@ -62,7 +61,6 @@ interface GeneratedStringField {
     selector: 'dot-apps-configuration-detail-generated-string-field',
     standalone: true,
     imports: [
-        CommonModule,
         FormsModule,
         DotIconModule,
         DotMessagePipe,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-block-editor-sidebar/dot-block-editor-sidebar.component.html
@@ -8,30 +8,32 @@
     #sidebar
     data-testid="sidebar"
     position="right">
-    <div *ngIf="blockEditorInput" class="container">
-        <dot-block-editor
-            [contentletIdentifier]="blockEditorInput.contentletIdentifier"
-            [field]="blockEditorInput.field"
-            [languageId]="blockEditorInput.languageId"
-            [showVideoThumbnail]="showVideoThumbnail"
-            [value]="blockEditorInput.content"
-            #blockEditor></dot-block-editor>
-        <footer>
-            <button
-                (click)="closeSidebar()"
-                [label]="'Cancel' | dm"
-                class="p-button-outlined"
-                data-testid="cancelBtn"
-                pButton
-                type="button"></button>
-            <button
-                (click)="saveEditorChanges()"
-                [disabled]="saving"
-                [label]="'Update' | dm"
-                [loading]="saving"
-                data-testid="updateBtn"
-                pButton
-                type="button"></button>
-        </footer>
-    </div>
+    @if (blockEditorInput) {
+        <div class="container">
+            <dot-block-editor
+                [contentletIdentifier]="blockEditorInput.contentletIdentifier"
+                [field]="blockEditorInput.field"
+                [languageId]="blockEditorInput.languageId"
+                [showVideoThumbnail]="showVideoThumbnail"
+                [value]="blockEditorInput.content"
+                #blockEditor></dot-block-editor>
+            <footer>
+                <button
+                    (click)="closeSidebar()"
+                    [label]="'Cancel' | dm"
+                    class="p-button-outlined"
+                    data-testid="cancelBtn"
+                    pButton
+                    type="button"></button>
+                <button
+                    (click)="saveEditorChanges()"
+                    [disabled]="saving"
+                    [label]="'Update' | dm"
+                    [loading]="saving"
+                    data-testid="updateBtn"
+                    pButton
+                    type="button"></button>
+            </footer>
+        </div>
+    }
 </p-sidebar>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-edit-page-info/dot-edit-page-info.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-edit-page-info/dot-edit-page-info.component.html
@@ -1,13 +1,14 @@
 <h2>{{ title }}</h2>
-<dot-copy-button
-    *ngIf="url"
-    [copy]="baseUrl + url"
-    [tooltipText]="'dot.common.message.pageurl.copy.clipboard' | dm"
-    [label]="'editpage.header.copy' | dm"></dot-copy-button>
-<dot-api-link *ngIf="innerApiLink" [href]="innerApiLink"></dot-api-link>
+@if (url) {
+    <dot-copy-button
+        [copy]="baseUrl + url"
+        [tooltipText]="'dot.common.message.pageurl.copy.clipboard' | dm"
+        [label]="'editpage.header.copy' | dm"></dot-copy-button>
+}
+@if (innerApiLink) {
+    <dot-api-link [href]="innerApiLink"></dot-api-link>
+}
 
-<dot-link
-    *ngIf="innerApiLink"
-    [href]="previewUrl"
-    label="editpage.preview"
-    icon="pi-eye"></dot-link>
+@if (innerApiLink) {
+    <dot-link [href]="previewUrl" label="editpage.preview" icon="pi-eye"></dot-link>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-content-type/dot-palette-content-type.component.html
@@ -1,27 +1,28 @@
 <dot-palette-input-filter
     (filter)="filterContentTypes($event)"
     #filterInput></dot-palette-input-filter>
-<div *ngIf="items?.length && !loading" class="dot-content-palette__items">
-    <div
-        *ngFor="let item of items"
-        (dragstart)="dragStart(item)"
-        (click)="showContentTypesList(item.variable)"
-        draggable="true"
-        data-testId="paletteItem">
-        <dot-icon [name]="item.icon" size="30"></dot-icon>
-        <p>{{ item.name }}</p>
-        <dot-icon name="keyboard_arrow_right" class="arrow"></dot-icon>
+@if (items?.length && !loading) {
+    <div class="dot-content-palette__items">
+        @for (item of items; track item) {
+            <div
+                (dragstart)="dragStart(item)"
+                (click)="showContentTypesList(item.variable)"
+                draggable="true"
+                data-testId="paletteItem">
+                <dot-icon [name]="item.icon" size="30"></dot-icon>
+                <p>{{ item.name }}</p>
+                <dot-icon name="keyboard_arrow_right" class="arrow"></dot-icon>
+            </div>
+        }
     </div>
-</div>
+}
 
-<dot-spinner
-    *ngIf="loading && viewContentlet === 'contentlet:out'"
-    [size]="'40px'"
-    [borderSize]="'8px'"></dot-spinner>
+@if (loading && viewContentlet === 'contentlet:out') {
+    <dot-spinner [size]="'40px'" [borderSize]="'8px'"></dot-spinner>
+}
 
-<span
-    *ngIf="!items?.length && !loading"
-    data-testId="emptyState"
-    class="dot-content-palette__empty">
-    {{ 'No-Results' | dm }}
-</span>
+@if (!items?.length && !loading) {
+    <span data-testId="emptyState" class="dot-content-palette__empty">
+        {{ 'No-Results' | dm }}
+    </span>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-contentlets/dot-palette-contentlets.component.html
@@ -4,41 +4,39 @@
     [goBackBtn]="true"
     #inputFilter></dot-palette-input-filter>
 
-<div *ngIf="items?.length; else Loading" class="dot-content-palette__items">
-    <div
-        *ngFor="let item of items"
-        (dragstart)="dragStart(item)"
-        draggable="true"
-        data-testId="paletteItem">
-        <img
-            *ngIf="item?.hasTitleImage === true; else showIcon"
-            src="/dA/{{ item.inode }}/titleImage/500w/50q" />
-        <ng-template #showIcon>
-            <dot-contentlet-icon
-                [icon]="
-                    item?.baseType !== 'FILEASSET'
-                        ? item?.contentTypeIcon || item?.icon
-                        : item?.__icon__
-                "
-                size="45px"></dot-contentlet-icon>
-        </ng-template>
-        <p>{{ item.title || item.name }}</p>
+@if (items?.length) {
+    <div class="dot-content-palette__items">
+        @for (item of items; track item) {
+            <div (dragstart)="dragStart(item)" draggable="true" data-testId="paletteItem">
+                @if (item?.hasTitleImage === true) {
+                    <img src="/dA/{{ item.inode }}/titleImage/500w/50q" />
+                } @else {
+                    <dot-contentlet-icon
+                        [icon]="
+                            item?.baseType !== 'FILEASSET'
+                                ? item?.contentTypeIcon || item?.icon
+                                : item?.__icon__
+                        "
+                        size="45px"></dot-contentlet-icon>
+                }
+                <p>{{ item.title || item.name }}</p>
+            </div>
+        }
+        <p-paginator
+            (onPageChange)="onPaginate($event)"
+            [rows]="itemsPerPage"
+            [showFirstLastIcon]="false"
+            [totalRecords]="totalRecords"
+            pageLinkSize="2"></p-paginator>
     </div>
-    <p-paginator
-        (onPageChange)="onPaginate($event)"
-        [rows]="itemsPerPage"
-        [showFirstLastIcon]="false"
-        [totalRecords]="totalRecords"
-        pageLinkSize="2"></p-paginator>
-</div>
+} @else {
+    @if (loading) {
+        <dot-spinner [size]="'40px'" [borderSize]="'8px'"></dot-spinner>
+    }
+}
 
-<ng-template #Loading>
-    <dot-spinner *ngIf="loading" [size]="'40px'" [borderSize]="'8px'"></dot-spinner>
-</ng-template>
-
-<span
-    *ngIf="totalRecords < 1 && !loading"
-    class="dot-content-palette__empty"
-    data-testId="emptyState">
-    {{ 'No-Results' | dm }}
-</span>
+@if (totalRecords < 1 && !loading) {
+    <span class="dot-content-palette__empty" data-testId="emptyState">
+        {{ 'No-Results' | dm }}
+    </span>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette-input-filter/dot-palette-input-filter.component.html
@@ -1,10 +1,11 @@
-<button
-    *ngIf="goBackBtn"
-    (click)="goBack.emit()"
-    class="dot-palette-input-filter__back-btn"
-    data-testId="goBackBtn">
-    <dot-icon data-testId="goBack" name="keyboard_arrow_left" size="18"></dot-icon>
-</button>
+@if (goBackBtn) {
+    <button
+        (click)="goBack.emit()"
+        class="dot-palette-input-filter__back-btn"
+        data-testId="goBackBtn">
+        <dot-icon data-testId="goBack" name="keyboard_arrow_left" size="18"></dot-icon>
+    </button>
+}
 
 <input
     [(ngModel)]="value"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/components/dot-palette/dot-palette.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="vm$ | async as vm">
+@if (vm$ | async; as vm) {
     <div (@inOut.done)="onAnimationDone($event)" [@inOut]="vm.viewContentlet" data-testId="wrapper">
         <dot-palette-content-type
             (filter)="filterContentTypes($event)"
@@ -16,4 +16,4 @@
             [totalRecords]="vm.totalRecords"
             #contentlets></dot-palette-contentlets>
     </div>
-</ng-container>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/components/dot-edit-page-lock-info/dot-edit-page-lock-info.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/components/dot-edit-page-lock-info/dot-edit-page-lock-info.component.html
@@ -1,7 +1,11 @@
-<span *ngIf="show" #lockedPageMessage class="page-info__locked-by-message">
-    {{ 'editpage.toolbar.page.locked.by.user' | dm: [pageState.page.lockedByName] }}
-</span>
+@if (show) {
+    <span #lockedPageMessage class="page-info__locked-by-message">
+        {{ 'editpage.toolbar.page.locked.by.user' | dm: [pageState.page.lockedByName] }}
+    </span>
+}
 
-<span *ngIf="!pageState.page.canEdit" #lockedPageMessage class="page-info__cant-edit-message">
-    {{ 'editpage.toolbar.page.cant.edit' | dm }}
-</span>
+@if (!pageState.page.canEdit) {
+    <span #lockedPageMessage class="page-info__cant-edit-message">
+        {{ 'editpage.toolbar.page.cant.edit' | dm }}
+    </span>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-state-controller/dot-edit-page-state-controller.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="featureFlagEditURLContentMapIsOn; else defaultTabs">
+@if (featureFlagEditURLContentMapIsOn) {
     <p-menu
         (onHide)="dotTabButtons.resetDropdownById(dotPageMode.EDIT)"
         [model]="menuItems"
@@ -12,8 +12,7 @@
         [options]="options"
         #dotTabButtons
         data-testId="dot-tabs-buttons"></dot-tab-buttons>
-</ng-container>
-<ng-template #defaultTabs>
+} @else {
     <p-selectButton
         (onChange)="stateSelectorHandler({ optionId: $event.value })"
         [(ngModel)]="mode"
@@ -21,8 +20,8 @@
         class="p-button-tabbed"
         optionValue="value.id"
         data-testId="selectButton"></p-selectButton>
-</ng-template>
-<ng-container *ngIf="!variant">
+}
+@if (!variant) {
     <p-inputSwitch
         (click)="onLockerClick()"
         (onChange)="lockPageHandler()"
@@ -37,9 +36,8 @@
         [tooltipPosition]="pageState.page.lockedByName ? 'top' : null"
         #locker
         appendTo="target"></p-inputSwitch>
-
     <dot-edit-page-lock-info
         [pageState]="pageState"
         #pageLockInfo
         data-testId="lockInfo"></dot-edit-page-lock-info>
-</ng-container>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-toolbar/dot-edit-page-toolbar.component.html
@@ -1,7 +1,7 @@
 <dot-secondary-toolbar>
     <!-- Header title and actions-->
     <div class="main-toolbar-left flex align-items-center gap-2">
-        <ng-container *ngIf="variant; else defaultHeaderLeftTpl">
+        @if (variant) {
             <button
                 (click)="backToExperiment.emit(true)"
                 [pTooltip]="'editpage.header.back.to.experiment' | dm"
@@ -10,20 +10,62 @@
                 icon="pi pi-arrow-left"
                 pButton
                 tooltipPosition="bottom"></button>
-
             <dot-edit-page-info
                 [title]="variant.variant.title"
                 [url]="variant.variant.url"
                 class="dot-variant-header flex gap-3" />
-        </ng-container>
+        } @else {
+            <dot-edit-page-info
+                [apiLink]="apiLink"
+                [title]="pageState.page.title"
+                [url]="pageState.page.pageURI"
+                class="flex gap-2" />
+            @if (showFavoritePageStar) {
+                <p-button
+                    (click)="favoritePage.emit(true)"
+                    [icon]="!pageState.favoritePage ? 'pi pi-star' : 'pi pi-star-fill'"
+                    [pTooltip]="'favoritePage.star.icon.tooltip' | dm"
+                    class="flex gap-3"
+                    data-testId="addFavoritePageButton"
+                    styleClass="p-button-rounded p-button-sm p-button-text"
+                    tooltipPosition="bottom"></p-button>
+            }
+        }
     </div>
 
     <div class="main-toolbar-right flex align-items-center gap-3">
-        <ng-container *ngIf="variant; else defaultHeaderRightTpl">
+        @if (variant) {
             <dot-global-message data-testId="globalMessage" right />
             <i class="pi pi-filter-fill -rotate-180"></i>
             <h2>{{ variant.experimentName }}</h2>
-        </ng-container>
+        } @else {
+            <dot-global-message data-testId="globalMessage" right />
+            @if (runningExperiment) {
+                <p-tag
+                    [routerLink]="[
+                        '/edit-page/experiments/',
+                        runningExperiment.pageId,
+                        runningExperiment.id,
+                        'reports'
+                    ]"
+                    [value]="
+                        ('running' | dm | titlecase) +
+                        ' ' +
+                        ('dot.common.until' | dm) +
+                        ' ' +
+                        (runningExperiment.scheduling.endDate | date: runningUntilDateFormat)
+                    "
+                    class="sm p-tag-success dot-edit__experiments-results-tag"
+                    data-testId="runningExperimentTag"
+                    queryParamsHandling="preserve"
+                    role="button">
+                    <i class="material-icons">science</i>
+                </p-tag>
+            }
+            <dot-edit-page-workflows-actions
+                (fired)="actionFired.emit($event)"
+                [page]="pageState.page" />
+        }
     </div>
 
     <!-- Tab actions and dropdowns -->
@@ -33,12 +75,13 @@
             [pageState]="pageState"
             [variant]="variant" />
 
-        <p-checkbox
-            *ngIf="showWhatsChanged && isEnterpriseLicense$ | async"
-            (onChange)="whatschange.emit($event.checked)"
-            [binary]="true"
-            [label]="'dot.common.whats.changed' | dm"
-            class="dot-edit__what-changed-button" />
+        @if (showWhatsChanged && isEnterpriseLicense$ | async) {
+            <p-checkbox
+                (onChange)="whatschange.emit($event.checked)"
+                [binary]="true"
+                [label]="'dot.common.whats.changed' | dm"
+                class="dot-edit__what-changed-button" />
+        }
     </div>
 
     <div class="lower-toolbar-right w-5">
@@ -48,48 +91,3 @@
             class="flex w-full gap-2" />
     </div>
 </dot-secondary-toolbar>
-
-<ng-template #defaultHeaderLeftTpl>
-    <dot-edit-page-info
-        [apiLink]="apiLink"
-        [title]="pageState.page.title"
-        [url]="pageState.page.pageURI"
-        class="flex gap-2" />
-
-    <p-button
-        *ngIf="showFavoritePageStar"
-        (click)="favoritePage.emit(true)"
-        [icon]="!pageState.favoritePage ? 'pi pi-star' : 'pi pi-star-fill'"
-        [pTooltip]="'favoritePage.star.icon.tooltip' | dm"
-        class="flex gap-3"
-        data-testId="addFavoritePageButton"
-        styleClass="p-button-rounded p-button-sm p-button-text"
-        tooltipPosition="bottom"></p-button>
-</ng-template>
-
-<ng-template #defaultHeaderRightTpl>
-    <dot-global-message data-testId="globalMessage" right />
-
-    <p-tag
-        *ngIf="runningExperiment"
-        [routerLink]="[
-            '/edit-page/experiments/',
-            runningExperiment.pageId,
-            runningExperiment.id,
-            'reports'
-        ]"
-        [value]="
-            ('running' | dm | titlecase) +
-            ' ' +
-            ('dot.common.until' | dm) +
-            ' ' +
-            (runningExperiment.scheduling.endDate | date: runningUntilDateFormat)
-        "
-        class="sm p-tag-success dot-edit__experiments-results-tag"
-        data-testId="runningExperimentTag"
-        queryParamsHandling="preserve"
-        role="button">
-        <i class="material-icons">science</i>
-    </p-tag>
-    <dot-edit-page-workflows-actions (fired)="actionFired.emit($event)" [page]="pageState.page" />
-</ng-template>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-view-as-controller/dot-edit-page-view-as-controller.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-edit-page-view-as-controller/dot-edit-page-view-as-controller.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="isEnterpriseLicense$ | async as isEnterpriseLicense; else language">
+@if (isEnterpriseLicense$ | async; as isEnterpriseLicense) {
     <dot-device-selector
         (selected)="changeDeviceHandler($event)"
         [pTooltip]="pageState.viewAs.device?.name || ('editpage.viewas.default.device' | dm)"
@@ -6,7 +6,6 @@
         appendTo="body"
         tooltipPosition="bottom"
         tooltipStyleClass="dot-device-selector__dialog" />
-
     <dot-language-selector
         (selected)="changeLanguageHandler($event)"
         [pTooltip]="pageState.viewAs.language.language"
@@ -14,13 +13,16 @@
         appendTo="body"
         tooltipPosition="bottom"
         tooltipStyleClass="dot-language-selector__dialog" />
-
     <dot-persona-selector
         (delete)="deletePersonalization($event)"
         (selected)="changePersonaHandler($event)"
         [disabled]="(dotPageStateService.haveContent$ | async) === false"
         [pageState]="pageState" />
-</ng-container>
+} @else {
+    <dot-language-selector
+        (selected)="changeLanguageHandler($event)"
+        [value]="pageState.viewAs.language" />
+}
 
 <ng-template #language>
     <dot-language-selector

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/components/dot-whats-changed/dot-whats-changed.component.html
@@ -1,6 +1,7 @@
-<dot-iframe *ngIf="whatsChanged.diff; else noChanges" #dotIframe></dot-iframe>
-<ng-template #noChanges>
+@if (whatsChanged.diff) {
+    <dot-iframe #dotIframe></dot-iframe>
+} @else {
     <span class="whats-changed__empty-state">
         {{ 'nothing-changed' | dm }}
     </span>
-</ng-template>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/dot-edit-content.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="pageState$ | async as pageState">
+@if (pageState$ | async; as pageState) {
     <dot-form-selector
         (pick)="onFormSelected($event)"
         (shutdown)="editForm = false"
@@ -9,7 +9,6 @@
         (shutdown)="handleCloseAction()"></dot-create-contentlet>
     <dot-edit-contentlet (custom)="onCustomEvent($event)"></dot-edit-contentlet>
     <dot-reorder-menu (shutdown)="onCloseReorderDialog()" [url]="reorderMenuUrl"></dot-reorder-menu>
-
     <ng-template #enabledComponent>
         <dot-edit-page-toolbar-seo
             (actionFired)="reload($event)"
@@ -22,7 +21,6 @@
             [variant]="variantData | async"
             class="dot-edit__toolbar"></dot-edit-page-toolbar-seo>
     </ng-template>
-
     <ng-template #disabledComponent>
         <dot-edit-page-toolbar
             (actionFired)="reload($event)"
@@ -35,27 +33,25 @@
             [variant]="variantData | async"
             class="dot-edit__toolbar"></dot-edit-page-toolbar>
     </ng-template>
-
     <ng-container
         *dotShowHideFeature="featureFlagSeo; alternate: disabledComponent"
         [ngTemplateOutlet]="enabledComponent"></ng-container>
-
     <div
         [class.dot-edit-content__preview]="!isEditMode"
         class="dot-edit-content__wrapper"
         data-testId="edit-content-wrapper">
         <dot-loading-indicator fullscreen="true"></dot-loading-indicator>
-        <dot-results-seo-tool
-            *ngIf="pageState.seoMedia; else dotEditIframe"
-            [device]="pageState.viewAs.device"
-            [hostName]="pageState.page.hostName"
-            [seoMedia]="pageState.seoMedia"
-            [seoOGTagsResults]="seoOGTagsResults"
-            [seoOGTags]="seoOGTags"></dot-results-seo-tool>
-        <ng-template #dotEditIframe>
-            <dot-select-seo-tool
-                *ngIf="pageState.viewAs.device"
-                [device]="pageState.viewAs.device"></dot-select-seo-tool>
+        @if (pageState.seoMedia) {
+            <dot-results-seo-tool
+                [device]="pageState.viewAs.device"
+                [hostName]="pageState.page.hostName"
+                [seoMedia]="pageState.seoMedia"
+                [seoOGTagsResults]="seoOGTagsResults"
+                [seoOGTags]="seoOGTags"></dot-results-seo-tool>
+        } @else {
+            @if (pageState.viewAs.device) {
+                <dot-select-seo-tool [device]="pageState.viewAs.device"></dot-select-seo-tool>
+            }
             <div
                 [class.dot-edit__page-wrapper--deviced]="pageState.viewAs.device"
                 class="dot-edit__page-wrapper">
@@ -70,47 +66,50 @@
                                 : '100%'
                         }"
                         class="dot-edit__iframe-wrapper">
-                        <dot-overlay-mask
-                            *ngIf="showOverlay"
-                            (click)="iframeOverlayService.hide()"></dot-overlay-mask>
-                        <dot-whats-changed
-                            *ngIf="showWhatsChanged"
-                            [languageId]="pageState.viewAs.language.id"
-                            [pageId]="pageState.page.identifier"></dot-whats-changed>
-                        <iframe
-                            *ngIf="showIframe"
-                            (load)="onLoad($event)"
-                            [ngStyle]="{
-                                visibility: showWhatsChanged ? 'hidden' : '',
-                                position: showWhatsChanged ? 'absolute' : ''
-                            }"
-                            #iframe
-                            class="dot-edit__iframe"
-                            frameborder="0"
-                            height="100%"
-                            title="Edit Content"
-                            width="100%"></iframe>
+                        @if (showOverlay) {
+                            <dot-overlay-mask
+                                (click)="iframeOverlayService.hide()"></dot-overlay-mask>
+                        }
+                        @if (showWhatsChanged) {
+                            <dot-whats-changed
+                                [languageId]="pageState.viewAs.language.id"
+                                [pageId]="pageState.page.identifier"></dot-whats-changed>
+                        }
+                        @if (showIframe) {
+                            <iframe
+                                (load)="onLoad($event)"
+                                [ngStyle]="{
+                                    visibility: showWhatsChanged ? 'hidden' : '',
+                                    position: showWhatsChanged ? 'absolute' : ''
+                                }"
+                                #iframe
+                                class="dot-edit__iframe"
+                                frameborder="0"
+                                height="100%"
+                                title="Edit Content"
+                                width="100%"></iframe>
+                        }
                     </div>
                 </div>
             </div>
-        </ng-template>
-
-        <div
-            *ngIf="(isEnterpriseLicense$ | async) && isEditMode && allowedContent"
-            [class.collapsed]="paletteCollapsed"
-            [class.editMode]="isEditMode"
-            class="dot-edit-content__palette">
-            <dot-palette
-                [allowedContent]="allowedContent"
-                [languageId]="pageLanguageId"></dot-palette>
+        }
+        @if ((isEnterpriseLicense$ | async) && isEditMode && allowedContent) {
             <div
-                (click)="paletteCollapsed = !paletteCollapsed"
-                class="dot-edit-content__palette-visibility"
-                data-testId="palette-visibility">
-                <dot-icon
-                    [name]="paletteCollapsed ? 'chevron_left' : 'chevron_right'"
-                    size="22"></dot-icon>
+                [class.collapsed]="paletteCollapsed"
+                [class.editMode]="isEditMode"
+                class="dot-edit-content__palette">
+                <dot-palette
+                    [allowedContent]="allowedContent"
+                    [languageId]="pageLanguageId"></dot-palette>
+                <div
+                    (click)="paletteCollapsed = !paletteCollapsed"
+                    class="dot-edit-content__palette-visibility"
+                    data-testId="palette-visibility">
+                    <dot-icon
+                        [name]="paletteCollapsed ? 'chevron_left' : 'chevron_right'"
+                        size="22"></dot-icon>
+                </div>
             </div>
-        </div>
+        }
     </div>
-</ng-container>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.html
@@ -30,17 +30,6 @@
                     </span>
                 </span>
             }
-            <ng-template #enterprise>
-                <span
-                    [pTooltip]="'editpage.toolbar.nav.license.enterprise.only' | dm"
-                    class="edit-page-nav__item edit-page-nav__item--disabled"
-                    tooltipPosition="left">
-                    <dot-icon [name]="item.icon" size="32"></dot-icon>
-                    <span class="edit-page-nav__item-text" data-testId="menuListItemText">
-                        {{ item.label }}
-                    </span>
-                </span>
-            </ng-template>
         </li>
     }
 </ul>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/main/dot-edit-page-nav/dot-edit-page-nav.component.html
@@ -1,36 +1,47 @@
 <ul class="edit-page-nav">
-    <li *ngFor="let item of model | async" data-testId="menuListItems">
-        <div *ngIf="!item.needsEntepriseLicense; then basic; else enterprise"></div>
-        <ng-template #basic>
-            <a
-                (click)="item.action ? item.action(pageState.page.inode) : ''"
-                [ngClass]="{
-                    'edit-page-nav__item--disabled': item.disabled,
-                    'edit-page-nav__item--active': item.link
-                        ? item.link.startsWith(this.route.snapshot.firstChild.url[0].path)
-                        : null
-                }"
-                [queryParams]="route.queryParams | async"
-                [routerLink]="!item.disabled && item.link ? ['./' + item.link] : null"
-                class="edit-page-nav__item"
-                pTooltip="{{ item.tooltip }}">
-                <dot-icon [name]="item.icon" size="32"></dot-icon>
-                <span class="edit-page-nav__item-text" data-testId="menuListItemText">
-                    {{ item.label }}
+    @for (item of model | async; track item) {
+        <li data-testId="menuListItems">
+            @if (!item.needsEntepriseLicense) {
+                <a
+                    (click)="item.action ? item.action(pageState.page.inode) : ''"
+                    [ngClass]="{
+                        'edit-page-nav__item--disabled': item.disabled,
+                        'edit-page-nav__item--active': item.link
+                            ? item.link.startsWith(this.route.snapshot.firstChild.url[0].path)
+                            : null
+                    }"
+                    [queryParams]="route.queryParams | async"
+                    [routerLink]="!item.disabled && item.link ? ['./' + item.link] : null"
+                    class="edit-page-nav__item"
+                    pTooltip="{{ item.tooltip }}">
+                    <dot-icon [name]="item.icon" size="32"></dot-icon>
+                    <span class="edit-page-nav__item-text" data-testId="menuListItemText">
+                        {{ item.label }}
+                    </span>
+                </a>
+            } @else {
+                <span
+                    [pTooltip]="'editpage.toolbar.nav.license.enterprise.only' | dm"
+                    class="edit-page-nav__item edit-page-nav__item--disabled"
+                    tooltipPosition="left">
+                    <dot-icon [name]="item.icon" size="32"></dot-icon>
+                    <span class="edit-page-nav__item-text" data-testId="menuListItemText">
+                        {{ item.label }}
+                    </span>
                 </span>
-            </a>
-        </ng-template>
-        <ng-template #enterprise>
-            <span
-                [pTooltip]="'editpage.toolbar.nav.license.enterprise.only' | dm"
-                class="edit-page-nav__item edit-page-nav__item--disabled"
-                tooltipPosition="left">
-                <dot-icon [name]="item.icon" size="32"></dot-icon>
-                <span class="edit-page-nav__item-text" data-testId="menuListItemText">
-                    {{ item.label }}
+            }
+            <ng-template #enterprise>
+                <span
+                    [pTooltip]="'editpage.toolbar.nav.license.enterprise.only' | dm"
+                    class="edit-page-nav__item edit-page-nav__item--disabled"
+                    tooltipPosition="left">
+                    <dot-icon [name]="item.icon" size="32"></dot-icon>
+                    <span class="edit-page-nav__item-text" data-testId="menuListItemText">
+                        {{ item.label }}
+                    </span>
                 </span>
-            </span>
-        </ng-template>
-    </li>
+            </ng-template>
+        </li>
+    }
 </ul>
 <dot-page-tools-seo [currentPageUrlParams]="currentUrlParams" #pageTools></dot-page-tools-seo>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.html
@@ -1,8 +1,11 @@
 <h2>{{ title }}</h2>
-<dot-copy-button
-    *ngIf="url"
-    [copy]="baseUrl + url"
-    [tooltipText]="'dot.common.message.pageurl.copy.clipboard' | dm"
-    [label]="'editpage.header.copy' | dm"
-    data-testId="copy-button"></dot-copy-button>
-<dot-api-link *ngIf="innerApiLink" [href]="innerApiLink" data-testId="api-link"></dot-api-link>
+@if (url) {
+    <dot-copy-button
+        [copy]="baseUrl + url"
+        [tooltipText]="'dot.common.message.pageurl.copy.clipboard' | dm"
+        [label]="'editpage.header.copy' | dm"
+        data-testId="copy-button"></dot-copy-button>
+}
+@if (innerApiLink) {
+    <dot-api-link [href]="innerApiLink" data-testId="api-link"></dot-api-link>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-info-seo/dot-edit-page-info-seo.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule, DOCUMENT } from '@angular/common';
+import { DOCUMENT } from '@angular/common';
 import { Component, Inject, Input } from '@angular/core';
 
 import { ButtonModule } from 'primeng/button';
@@ -24,7 +24,6 @@ import {
     styleUrls: ['./dot-edit-page-info-seo.component.scss'],
     standalone: true,
     imports: [
-        CommonModule,
         ButtonModule,
         DotCopyButtonComponent,
         DotApiLinkComponent,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/components/dot-edit-page-lock-info-seo/dot-edit-page-lock-info-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/components/dot-edit-page-lock-info-seo/dot-edit-page-lock-info-seo.component.html
@@ -1,7 +1,11 @@
-<span *ngIf="show" class="page-info__locked-by-message" #lockedPageMessage>
-    {{ 'editpage.toolbar.page.locked.by.user' | dm: [pageState.page.lockedByName] }}
-</span>
+@if (show) {
+    <span class="page-info__locked-by-message" #lockedPageMessage>
+        {{ 'editpage.toolbar.page.locked.by.user' | dm: [pageState.page.lockedByName] }}
+    </span>
+}
 
-<span *ngIf="!pageState.page.canEdit" class="page-info__cant-edit-message" #lockedPageMessage>
-    {{ 'editpage.toolbar.page.cant.edit' | dm }}
-</span>
+@if (!pageState.page.canEdit) {
+    <span class="page-info__cant-edit-message" #lockedPageMessage>
+        {{ 'editpage.toolbar.page.cant.edit' | dm }}
+    </span>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/components/dot-edit-page-lock-info-seo/dot-edit-page-lock-info-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/components/dot-edit-page-lock-info-seo/dot-edit-page-lock-info-seo.component.ts
@@ -1,4 +1,3 @@
-import { CommonModule } from '@angular/common';
 import { Component, ElementRef, Input, ViewChild } from '@angular/core';
 
 import { InputSwitchModule } from 'primeng/inputswitch';
@@ -18,7 +17,7 @@ import { DotMessagePipe, DotSafeHtmlPipe } from '@dotcms/ui';
     templateUrl: './dot-edit-page-lock-info-seo.component.html',
     styleUrls: ['./dot-edit-page-lock-info-seo.component.scss'],
     standalone: true,
-    imports: [CommonModule, InputSwitchModule, DotSafeHtmlPipe, DotMessagePipe]
+    imports: [InputSwitchModule, DotSafeHtmlPipe, DotMessagePipe]
 })
 export class DotEditPageLockInfoSeoComponent {
     @ViewChild('lockedPageMessage') lockedPageMessage: ElementRef;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.html
@@ -6,13 +6,14 @@
     #deviceSelector
     appendTo="body"
     data-testId="dot-device-selector"></dot-device-selector-seo>
-<p-menu
-    *ngIf="this.featureFlagEditURLContentMapIsOn"
-    (onHide)="tabButtons.resetDropdownById(dotPageMode.EDIT)"
-    [model]="menuItems"
-    [popup]="true"
-    #menu
-    appendTo="body"></p-menu>
+@if (this.featureFlagEditURLContentMapIsOn) {
+    <p-menu
+        (onHide)="tabButtons.resetDropdownById(dotPageMode.EDIT)"
+        [model]="menuItems"
+        [popup]="true"
+        #menu
+        appendTo="body"></p-menu>
+}
 <dot-tab-buttons
     (openMenu)="handleMenuOpen($event)"
     (clickOption)="stateSelectorHandler($event)"
@@ -20,7 +21,7 @@
     [options]="options"
     #tabButtons
     data-testId="dot-tabs-buttons"></dot-tab-buttons>
-<ng-container *ngIf="!variant">
+@if (!variant) {
     <span
         [pTooltip]="
             pageState.state.lockedByAnotherUser && pageState.page.canEdit
@@ -39,7 +40,7 @@
             data-testId="lock-switch"
             appendTo="target"></p-inputSwitch>
     </span>
-</ng-container>
+}
 
 <dot-edit-page-lock-info-seo
     [pageState]="pageState"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-state-controller-seo/dot-edit-page-state-controller-seo.component.ts
@@ -1,6 +1,5 @@
 import { from, Observable, of } from 'rxjs';
 
-import { CommonModule } from '@angular/common';
 import {
     Component,
     EventEmitter,
@@ -56,7 +55,6 @@ enum DotConfirmationType {
     styleUrls: ['./dot-edit-page-state-controller-seo.component.scss'],
     standalone: true,
     imports: [
-        CommonModule,
         FormsModule,
         InputSwitchModule,
         SelectButtonModule,

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-toolbar-seo/dot-edit-page-toolbar-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-toolbar-seo/dot-edit-page-toolbar-seo.component.html
@@ -1,7 +1,7 @@
 <dot-secondary-toolbar>
     <!-- Header title and actions-->
     <div class="main-toolbar-left flex align-items-center gap-2">
-        <ng-container *ngIf="variant; else defaultHeaderLeftTpl">
+        @if (variant) {
             <button
                 (click)="backToExperiment.emit(true)"
                 [pTooltip]="'editpage.header.back.to.experiment' | dm"
@@ -10,21 +10,63 @@
                 icon="pi pi-arrow-left"
                 pButton
                 tooltipPosition="bottom"></button>
-
             <dot-edit-page-info-seo
                 [title]="variant.variant.title"
                 [apiLink]="apiLink"
                 [url]="variant.variant.url"
                 class="dot-variant-header flex gap-3"></dot-edit-page-info-seo>
-        </ng-container>
+        } @else {
+            <dot-edit-page-info-seo
+                [title]="pageState.page.title"
+                [apiLink]="apiLink"
+                [url]="pageState.page.pageURI"
+                class="flex gap-2"></dot-edit-page-info-seo>
+            @if (showFavoritePageStar) {
+                <p-button
+                    (click)="favoritePage.emit(true)"
+                    [icon]="!pageState.favoritePage ? 'pi pi-star' : 'pi pi-star-fill'"
+                    [pTooltip]="'favoritePage.star.icon.tooltip' | dm"
+                    class="flex gap-3"
+                    styleClass="p-button-rounded p-button-sm p-button-text"
+                    data-testId="addFavoritePageButton"
+                    tooltipPosition="bottom"></p-button>
+            }
+        }
     </div>
 
     <div class="main-toolbar-right flex align-items-center gap-3">
-        <ng-container *ngIf="variant; else defaultHeaderRightTpl">
+        @if (variant) {
             <dot-global-message data-testId="globalMessage" right></dot-global-message>
             <i class="pi pi-filter-fill -rotate-180"></i>
             <h2>{{ variant.experimentName }}</h2>
-        </ng-container>
+        } @else {
+            <dot-global-message data-testId="globalMessage" right></dot-global-message>
+            @if (runningExperiment) {
+                <p-tag
+                    [value]="
+                        ('running' | dm | titlecase) +
+                        ' ' +
+                        ('dot.common.until' | dm) +
+                        ' ' +
+                        (runningExperiment.scheduling.endDate | date: runningUntilDateFormat)
+                    "
+                    [routerLink]="[
+                        '/edit-page/experiments/',
+                        runningExperiment.pageId,
+                        runningExperiment.id,
+                        'reports'
+                    ]"
+                    class="sm p-tag-success dot-edit__experiments-results-tag"
+                    role="button"
+                    data-testId="runningExperimentTag"
+                    queryParamsHandling="preserve">
+                    <i class="material-icons">science</i>
+                </p-tag>
+            }
+            <dot-edit-page-workflows-actions
+                (fired)="actionFired.emit($event)"
+                [page]="pageState.page"></dot-edit-page-workflows-actions>
+        }
     </div>
 
     <!-- Tab actions and dropdowns -->
@@ -37,63 +79,18 @@
     </div>
 
     <div class="lower-toolbar-right w-6">
-        <p-checkbox
-            *ngIf="showWhatsChanged && isEnterpriseLicense$ | async"
-            (onChange)="whatschange.emit($event.checked)"
-            [binary]="true"
-            [label]="'dot.common.whats.changed' | dm"
-            [pTooltip]="'dot.common.whats.changed.clipboard' | dm"
-            class="flex dot-edit__what-changed-button"
-            tooltipPosition="bottom"></p-checkbox>
+        @if (showWhatsChanged && isEnterpriseLicense$ | async) {
+            <p-checkbox
+                (onChange)="whatschange.emit($event.checked)"
+                [binary]="true"
+                [label]="'dot.common.whats.changed' | dm"
+                [pTooltip]="'dot.common.whats.changed.clipboard' | dm"
+                class="flex dot-edit__what-changed-button"
+                tooltipPosition="bottom"></p-checkbox>
+        }
         <dot-edit-page-view-as-controller-seo
             [pageState]="pageState"
             [variant]="variant"
             class="flex gap-2"></dot-edit-page-view-as-controller-seo>
     </div>
 </dot-secondary-toolbar>
-
-<ng-template #defaultHeaderLeftTpl>
-    <dot-edit-page-info-seo
-        [title]="pageState.page.title"
-        [apiLink]="apiLink"
-        [url]="pageState.page.pageURI"
-        class="flex gap-2"></dot-edit-page-info-seo>
-    <p-button
-        *ngIf="showFavoritePageStar"
-        (click)="favoritePage.emit(true)"
-        [icon]="!pageState.favoritePage ? 'pi pi-star' : 'pi pi-star-fill'"
-        [pTooltip]="'favoritePage.star.icon.tooltip' | dm"
-        class="flex gap-3"
-        styleClass="p-button-rounded p-button-sm p-button-text"
-        data-testId="addFavoritePageButton"
-        tooltipPosition="bottom"></p-button>
-</ng-template>
-
-<ng-template #defaultHeaderRightTpl>
-    <dot-global-message data-testId="globalMessage" right></dot-global-message>
-
-    <p-tag
-        *ngIf="runningExperiment"
-        [value]="
-            ('running' | dm | titlecase) +
-            ' ' +
-            ('dot.common.until' | dm) +
-            ' ' +
-            (runningExperiment.scheduling.endDate | date: runningUntilDateFormat)
-        "
-        [routerLink]="[
-            '/edit-page/experiments/',
-            runningExperiment.pageId,
-            runningExperiment.id,
-            'reports'
-        ]"
-        class="sm p-tag-success dot-edit__experiments-results-tag"
-        role="button"
-        data-testId="runningExperimentTag"
-        queryParamsHandling="preserve">
-        <i class="material-icons">science</i>
-    </p-tag>
-    <dot-edit-page-workflows-actions
-        (fired)="actionFired.emit($event)"
-        [page]="pageState.page"></dot-edit-page-workflows-actions>
-</ng-template>

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-view-as-controller-seo/dot-edit-page-view-as-controller-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-view-as-controller-seo/dot-edit-page-view-as-controller-seo.component.html
@@ -27,14 +27,6 @@
         [value]="pageState.viewAs.language" />
 }
 
-<ng-template #language>
-    <dot-language-selector
-        (selected)="changeLanguageHandler($event)"
-        [pageId]="pageState.page.identifier"
-        [readonly]="!!variant"
-        [value]="pageState.viewAs.language" />
-</ng-template>
-
 <p-confirmDialog
     [acceptIcon]="null"
     [rejectIcon]="null"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-view-as-controller-seo/dot-edit-page-view-as-controller-seo.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/seo/components/dot-edit-page-view-as-controller-seo/dot-edit-page-view-as-controller-seo.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="isEnterpriseLicense$ | async as isEnterpriseLicense; else language">
+@if (isEnterpriseLicense$ | async; as isEnterpriseLicense) {
     <dot-language-selector
         (selected)="changeLanguageHandler($event)"
         [pTooltip]="pageState.viewAs.language.language"
@@ -7,20 +7,25 @@
         appendTo="body"
         tooltipPosition="bottom"
         tooltipStyleClass="dot-language-selector__dialog" />
-
     <dot-persona-selector
         (delete)="deletePersonalization($event)"
         (selected)="changePersonaHandler($event)"
         [disabled]="(dotPageStateService.haveContent$ | async) === false"
         [pageState]="pageState" />
-
-    <p-checkbox
-        *ngIf="showWhatsChanged && isEnterpriseLicense$ | async"
-        (onChange)="whatschange.emit($event.checked)"
-        [binary]="true"
-        [label]="'dot.common.whats.changed' | dm"
-        class="flex dot-edit__what-changed-button" />
-</ng-container>
+    @if (showWhatsChanged && isEnterpriseLicense$ | async) {
+        <p-checkbox
+            (onChange)="whatschange.emit($event.checked)"
+            [binary]="true"
+            [label]="'dot.common.whats.changed' | dm"
+            class="flex dot-edit__what-changed-button" />
+    }
+} @else {
+    <dot-language-selector
+        (selected)="changeLanguageHandler($event)"
+        [pageId]="pageState.page.identifier"
+        [readonly]="!!variant"
+        [value]="pageState.viewAs.language" />
+}
 
 <ng-template #language>
     <dot-language-selector

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-block-editor-settings/dot-block-editor-settings.component.html
@@ -1,18 +1,20 @@
 <!-- Block Editor Settings -->
 <form [formGroup]="form" class="wrapper">
-    <div *ngFor="let setting of settings" class="field">
-        <label [checkIsRequiredControl]="setting.key" [for]="setting.key" dotFieldRequired>
-            {{ setting.label }}
-        </label>
-        <p-multiSelect
-            [id]="setting.key"
-            [placeholder]="setting.placeholder"
-            [formControlName]="setting.key"
-            [options]="setting.options"
-            [style]="{ width: '100%' }"
-            appendTo="body"
-            display="chip"
-            optionLabel="label"
-            optionValue="code"></p-multiSelect>
-    </div>
+    @for (setting of settings; track setting) {
+        <div class="field">
+            <label [checkIsRequiredControl]="setting.key" [for]="setting.key" dotFieldRequired>
+                {{ setting.label }}
+            </label>
+            <p-multiSelect
+                [id]="setting.key"
+                [placeholder]="setting.placeholder"
+                [formControlName]="setting.key"
+                [options]="setting.options"
+                [style]="{ width: '100%' }"
+                appendTo="body"
+                display="chip"
+                optionLabel="label"
+                optionValue="code"></p-multiSelect>
+        </div>
+    }
 </form>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-convert-to-block-info/dot-convert-to-block-info.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/dot-convert-to-block-info/dot-convert-to-block-info.component.html
@@ -2,17 +2,16 @@
     [innerHTML]="'contenttypes.field.properties.wysiwyg.info.content' | dm"
     data-testId="infoContent"></span>
 
-<button
-    *ngIf="currentField?.id; else learnMore"
-    (click)="action.emit($event)"
-    [label]="'contenttypes.field.properties.wysiwyg.info.button' | dm"
-    class="p-button-outlined p-button-sm"
-    pButton
-    data-testId="button"></button>
-
-<ng-template #learnMore>
+@if (currentField?.id) {
+    <button
+        (click)="action.emit($event)"
+        [label]="'contenttypes.field.properties.wysiwyg.info.button' | dm"
+        class="p-button-outlined p-button-sm"
+        pButton
+        data-testId="button"></button>
+} @else {
     <a
-        [ngStyle]="{ 'text-decoration': 'none' }"
+        [style.text-decoration]="'none'"
         class="p-element p-button-outlined p-button-sm p-button p-component"
         href="https://www.dotcms.com/docs/latest/block-editor"
         rel="noopener"
@@ -20,4 +19,4 @@
         data-testId="learnMore">
         {{ 'learn-more' | dm }}
     </a>
-</ng-template>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-field-dragabble-item/content-type-field-dragabble-item.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-field-dragabble-item/content-type-field-dragabble-item.component.html
@@ -56,14 +56,3 @@
         }
     </div>
 </p-overlayPanel>
-
-<ng-template #attributes>
-    <div class="field-properties__attributes-container">
-        <p class="attributes-container__field-name">{{ fieldTypeLabel }}</p>
-        @for (field of fieldAttributesArray; track field; let index = $index) {
-            <p class="attributes-container__attribute">
-                {{ field }}
-            </p>
-        }
-    </div>
-</ng-template>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-field-dragabble-item/content-type-field-dragabble-item.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-field-dragabble-item/content-type-field-dragabble-item.component.html
@@ -4,28 +4,40 @@
 <div class="field-properties">
     <div class="field-properties__info-container">
         <span class="info-container__name">{{ field.name }}</span>
-        <p-button
-            *ngIf="!field.fixed"
-            (click)="removeItem($event)"
-            id="info-container__delete"
-            styleClass="p-button-text p-button-sm p-button-danger p-button-rounded"
-            icon="pi pi-trash"></p-button>
+        @if (!field.fixed) {
+            <p-button
+                (click)="removeItem($event)"
+                id="info-container__delete"
+                styleClass="p-button-text p-button-sm p-button-danger p-button-rounded"
+                icon="pi pi-trash"></p-button>
+        }
     </div>
     <div class="field-properties__actions-container">
-        <dot-copy-link
-            *ngIf="field.variable"
-            [label]="field.variable"
-            [copy]="field.variable"></dot-copy-link>
+        @if (field.variable) {
+            <dot-copy-link [label]="field.variable" [copy]="field.variable"></dot-copy-link>
+        }
 
-        <div *ngIf="isSmall; else attributes">
-            <p-button
-                *ngIf="true"
-                (click)="openAttr($event)"
-                [class.open]="open"
-                data-testid="field-info-button"
-                styleClass="p-button-text p-button-sm  p-button-rounded"
-                icon="pi pi-info-circle"></p-button>
-        </div>
+        @if (isSmall) {
+            <div>
+                @if (true) {
+                    <p-button
+                        (click)="openAttr($event)"
+                        [class.open]="open"
+                        data-testid="field-info-button"
+                        styleClass="p-button-text p-button-sm  p-button-rounded"
+                        icon="pi pi-info-circle"></p-button>
+                }
+            </div>
+        } @else {
+            <div class="field-properties__attributes-container">
+                <p class="attributes-container__field-name">{{ fieldTypeLabel }}</p>
+                @for (field of fieldAttributesArray; track field; let index = $index) {
+                    <p class="attributes-container__attribute">
+                        {{ field }}
+                    </p>
+                }
+            </div>
+        }
     </div>
 </div>
 
@@ -37,21 +49,21 @@
     styleClass="contentType__overlayPanel">
     <div class="field-properties__overlay-attributes-container">
         <p class="overlay-attributes-container__field-name">{{ fieldTypeLabel }}</p>
-        <p
-            *ngIf="fieldAttributesString.length"
-            class="overlay-attributes-container__attributes-text">
-            {{ fieldAttributesString }}
-        </p>
+        @if (fieldAttributesString.length) {
+            <p class="overlay-attributes-container__attributes-text">
+                {{ fieldAttributesString }}
+            </p>
+        }
     </div>
 </p-overlayPanel>
 
 <ng-template #attributes>
     <div class="field-properties__attributes-container">
         <p class="attributes-container__field-name">{{ fieldTypeLabel }}</p>
-        <p
-            *ngFor="let field of fieldAttributesArray; let index = index"
-            class="attributes-container__attribute">
-            {{ field }}
-        </p>
+        @for (field of fieldAttributesArray; track field; let index = $index) {
+            <p class="attributes-container__attribute">
+                {{ field }}
+            </p>
+        }
     </div>
 </ng-template>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-add-row/content-type-fields-add-row.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-add-row/content-type-fields-add-row.component.html
@@ -1,44 +1,48 @@
 <div class="dot-add-rows__container">
-    <div
-        *ngIf="rowState === 'add'"
-        [ngClass]="{ 'dot-add-rows__add': rowState === 'add' }"
-        class="dot-add-rows-button__container">
-        <p-splitButton
-            (onClick)="setColumnSelect()"
-            [disabled]="disabled"
-            [model]="actions"
-            label="{{ 'contenttypes.dropzone.rows.add' | dm }}"></p-splitButton>
-    </div>
-
-    <div *ngIf="rowState === 'select'" class="dot-add-rows-columns-list__container">
-        <div class="dot-add-rows-columns-list__title">
-            {{ 'contenttypes.content.add_column_title' | dm }}
+    @if (rowState === 'add') {
+        <div
+            [ngClass]="{ 'dot-add-rows__add': rowState === 'add' }"
+            class="dot-add-rows-button__container">
+            <p-splitButton
+                (onClick)="setColumnSelect()"
+                [disabled]="disabled"
+                [model]="actions"
+                label="{{ 'contenttypes.dropzone.rows.add' | dm }}"></p-splitButton>
         </div>
+    }
 
-        <p-button
-            (click)="showAddView()"
-            icon="pi pi-times"
-            styleClass="p-button-rounded  p-button-text p-button-sm"></p-button>
-
-        <ul
-            [ngClass]="{ 'dot-add-rows__select': rowState === 'select' }"
-            class="dot-add-rows-columns-list"
-            #colContainer>
-            <li
-                *ngFor="let colNum of columns; let i = index"
-                (mouseenter)="onMouseEnter(i, $event)"
-                (mouseleave)="onMouseLeave($event)"
-                (click)="emitColumnNumber()"
-                [ngClass]="{ active: i === selectedColumnIndex }"
-                class="dot-add-rows-columns-list__item"
-                tabindex="-1">
-                <span class="dot-add-rows-columns-list__item-title">{{ setColumnValue(i) }}</span>
-                <div class="dot-add-rows-columns-list__item-container">
-                    <div
-                        *ngFor="let i of numberOfCols(colNum)"
-                        class="dot-add-rows-columns-list__item-col"></div>
-                </div>
-            </li>
-        </ul>
-    </div>
+    @if (rowState === 'select') {
+        <div class="dot-add-rows-columns-list__container">
+            <div class="dot-add-rows-columns-list__title">
+                {{ 'contenttypes.content.add_column_title' | dm }}
+            </div>
+            <p-button
+                (click)="showAddView()"
+                icon="pi pi-times"
+                styleClass="p-button-rounded  p-button-text p-button-sm"></p-button>
+            <ul
+                [ngClass]="{ 'dot-add-rows__select': rowState === 'select' }"
+                class="dot-add-rows-columns-list"
+                #colContainer>
+                @for (colNum of columns; track colNum; let i = $index) {
+                    <li
+                        (mouseenter)="onMouseEnter(i, $event)"
+                        (mouseleave)="onMouseLeave($event)"
+                        (click)="emitColumnNumber()"
+                        [class.active]="i === selectedColumnIndex"
+                        class="dot-add-rows-columns-list__item"
+                        tabindex="-1">
+                        <span class="dot-add-rows-columns-list__item-title">
+                            {{ setColumnValue(i) }}
+                        </span>
+                        <div class="dot-add-rows-columns-list__item-container">
+                            @for (i of numberOfCols(colNum); track i) {
+                                <div class="dot-add-rows-columns-list__item-col"></div>
+                            }
+                        </div>
+                    </li>
+                }
+            </ul>
+        </div>
+    }
 </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.html
@@ -4,22 +4,21 @@
         [attr.disabled]="loading"
         class="content-type-fields-drop-zone__container"
         dragula="fields-row-bag">
-        <ng-template [ngForOf]="fieldRows" ngFor let-row let-i="index">
-            <dot-content-type-fields-row
-                *ngIf="row.columns && row.columns.length; else tab_container"
-                (editField)="editFieldHandler($event)"
-                (removeField)="removeField($event)"
-                (removeRow)="removeFieldRow($event, i)"
-                [fieldRow]="row"></dot-content-type-fields-row>
-
-            <ng-template #tab_container>
+        @for (row of fieldRows; track row; let i = $index) {
+            @if (row.columns && row.columns.length) {
+                <dot-content-type-fields-row
+                    (editField)="editFieldHandler($event)"
+                    (removeField)="removeField($event)"
+                    (removeRow)="removeFieldRow($event, i)"
+                    [fieldRow]="row"></dot-content-type-fields-row>
+            } @else {
                 <dot-content-type-fields-tab
                     (editTab)="saveFieldsHandler($event)"
                     (removeTab)="removeTab($event, i)"
                     [fieldTab]="row"
                     class="row-header__drag"></dot-content-type-fields-tab>
-            </ng-template>
-        </ng-template>
+            }
+        }
         <dot-add-rows (selectColums)="addRow($event)"></dot-add-rows>
     </div>
 
@@ -35,14 +34,15 @@
     width="45rem">
     <p-tabView (onChange)="handleTabChange($event.index)" [(activeIndex)]="activeTab">
         <p-tabPanel [header]="'contenttypes.dropzone.tab.overview' | dm">
-            <dot-convert-to-block-info
-                *ngIf="
-                    currentFieldType?.clazz ===
-                    'com.dotcms.contenttype.model.field.ImmutableWysiwygField'
-                "
-                (action)="scrollTo($event)"
-                [currentFieldType]="currentFieldType"
-                [currentField]="currentField"></dot-convert-to-block-info>
+            @if (
+                currentFieldType?.clazz ===
+                'com.dotcms.contenttype.model.field.ImmutableWysiwygField'
+            ) {
+                <dot-convert-to-block-info
+                    (action)="scrollTo($event)"
+                    [currentFieldType]="currentFieldType"
+                    [currentField]="currentField"></dot-convert-to-block-info>
+            }
             <div class="wrapper">
                 <dot-content-type-fields-properties-form
                     (saveField)="saveFieldsHandler($event)"
@@ -50,14 +50,15 @@
                     [formFieldData]="currentField"
                     [contentType]="contentType"
                     #fieldPropertiesForm></dot-content-type-fields-properties-form>
-                <dot-convert-wysiwyg-to-block
-                    *ngIf="
-                        !!currentField?.id &&
-                        currentFieldType?.clazz ===
-                            'com.dotcms.contenttype.model.field.ImmutableWysiwygField'
-                    "
-                    (convert)="convertWysiwygToBlock($event)"
-                    [currentFieldType]="currentFieldType"></dot-convert-wysiwyg-to-block>
+                @if (
+                    !!currentField?.id &&
+                    currentFieldType?.clazz ===
+                        'com.dotcms.contenttype.model.field.ImmutableWysiwygField'
+                ) {
+                    <dot-convert-wysiwyg-to-block
+                        (convert)="convertWysiwygToBlock($event)"
+                        [currentFieldType]="currentFieldType"></dot-convert-wysiwyg-to-block>
+                }
             </div>
         </p-tabPanel>
         @if (!!currentField?.id && isFieldWithSettings) {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/content-type-fields-properties-form.component.html
@@ -3,16 +3,19 @@
     [formGroup]="form"
     class="content-type-fields__properties-form p-fluid"
     novalidate>
-    <div *ngFor="let property of fieldProperties" #properties>
-        <ng-container
-            [propertyName]="property"
-            [field]="formFieldData"
-            [group]="form"
-            dotDynamicFieldProperty></ng-container>
-    </div>
-    <dot-relationship-tree
-        *ngIf="formFieldData?.relationships"
-        [contentType]="contentType"
-        [isParentField]="formFieldData.relationships.isParentField"
-        [velocityVar]="formFieldData.relationships.velocityVar"></dot-relationship-tree>
+    @for (property of fieldProperties; track property) {
+        <div #properties>
+            <ng-container
+                [propertyName]="property"
+                [field]="formFieldData"
+                [group]="form"
+                dotDynamicFieldProperty></ng-container>
+        </div>
+    }
+    @if (formFieldData?.relationships) {
+        <dot-relationship-tree
+            [contentType]="contentType"
+            [isParentField]="formFieldData.relationships.isParentField"
+            [velocityVar]="formFieldData.relationships.velocityVar"></dot-relationship-tree>
+    }
 </form>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/data-type-property/data-type-property.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/data-type-property/data-type-property.component.html
@@ -1,15 +1,18 @@
-<div *ngIf="radioInputs" [formGroup]="group" class="field">
-    <label [for]="property.name" [checkIsRequiredControl]="property.name" dotFieldRequired>
-        {{ 'contenttypes.field.properties.data_type.label' | dm }}
-    </label>
-
-    <div class="formgroup-inline">
-        <div *ngFor="let radio of radioInputs" class="field-checkbox">
-            <p-radioButton
-                [label]="radio.text | dm"
-                [name]="property.name"
-                [value]="radio.value"
-                [formControlName]="property.name"></p-radioButton>
+@if (radioInputs) {
+    <div [formGroup]="group" class="field">
+        <label [for]="property.name" [checkIsRequiredControl]="property.name" dotFieldRequired>
+            {{ 'contenttypes.field.properties.data_type.label' | dm }}
+        </label>
+        <div class="formgroup-inline">
+            @for (radio of radioInputs; track radio) {
+                <div class="field-checkbox">
+                    <p-radioButton
+                        [label]="radio.text | dm"
+                        [name]="property.name"
+                        [value]="radio.value"
+                        [formControlName]="property.name"></p-radioButton>
+                </div>
+            }
         </div>
     </div>
-</div>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-relationships-property.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-relationships-property.component.html
@@ -1,25 +1,37 @@
-<div *ngIf="!editing" class="field relationship__type">
-    <p-radioButton
-        (click)="clean()"
-        [(ngModel)]="status"
-        [label]="'contenttypes.field.properties.relationship.new.label' | dm"
-        [value]="STATUS_NEW"></p-radioButton>
-
-    <p-radioButton
-        (click)="clean()"
-        [(ngModel)]="status"
-        [label]="'contenttypes.field.properties.relationship.existing.label' | dm"
-        [value]="STATUS_EXISTING"></p-radioButton>
-</div>
+@if (!editing) {
+    <div class="field relationship__type">
+        <p-radioButton
+            (click)="clean()"
+            [(ngModel)]="status"
+            [label]="'contenttypes.field.properties.relationship.new.label' | dm"
+            [value]="STATUS_NEW"></p-radioButton>
+        <p-radioButton
+            (click)="clean()"
+            [(ngModel)]="status"
+            [label]="'contenttypes.field.properties.relationship.existing.label' | dm"
+            [value]="STATUS_EXISTING"></p-radioButton>
+    </div>
+}
 
 <div class="relationship__config">
-    <dot-new-relationships
-        *ngIf="status === STATUS_NEW; else existing"
-        (switch)="handleChange($event)"
-        [velocityVar]="group.get(property.name).value.velocityVar"
-        [cardinality]="group.get(property.name).value.cardinality"
-        [editing]="editing"
-        class="relationships__new"></dot-new-relationships>
+    @if (status === STATUS_NEW) {
+        <dot-new-relationships
+            (switch)="handleChange($event)"
+            [velocityVar]="group.get(property.name).value.velocityVar"
+            [cardinality]="group.get(property.name).value.cardinality"
+            [editing]="editing"
+            class="relationships__new"></dot-new-relationships>
+    } @else {
+        <div class="field">
+            <label [for]="property.name" [checkIsRequiredControl]="property.name" dotFieldRequired>
+                Relationship
+            </label>
+            <dot-edit-relationships
+                (switch)="handleChange($event)"
+                [id]="property.name"
+                class="relationships__existing"></dot-edit-relationships>
+        </div>
+    }
 
     <ng-template #existing>
         <div class="field">

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-relationships-property.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-relationships-property.component.html
@@ -4,12 +4,12 @@
             (click)="clean()"
             [(ngModel)]="status"
             [label]="'contenttypes.field.properties.relationship.new.label' | dm"
-            [value]="STATUS_NEW"></p-radioButton>
+            [value]="STATUS_NEW" />
         <p-radioButton
             (click)="clean()"
             [(ngModel)]="status"
             [label]="'contenttypes.field.properties.relationship.existing.label' | dm"
-            [value]="STATUS_EXISTING"></p-radioButton>
+            [value]="STATUS_EXISTING" />
     </div>
 }
 
@@ -20,7 +20,7 @@
             [velocityVar]="group.get(property.name).value.velocityVar"
             [cardinality]="group.get(property.name).value.cardinality"
             [editing]="editing"
-            class="relationships__new"></dot-new-relationships>
+            class="relationships__new" />
     } @else {
         <div class="field">
             <label [for]="property.name" [checkIsRequiredControl]="property.name" dotFieldRequired>
@@ -29,23 +29,11 @@
             <dot-edit-relationships
                 (switch)="handleChange($event)"
                 [id]="property.name"
-                class="relationships__existing"></dot-edit-relationships>
+                class="relationships__existing" />
         </div>
     }
 
-    <ng-template #existing>
-        <div class="field">
-            <label [for]="property.name" [checkIsRequiredControl]="property.name" dotFieldRequired>
-                Relationship
-            </label>
-            <dot-edit-relationships
-                (switch)="handleChange($event)"
-                [id]="property.name"
-                class="relationships__existing"></dot-edit-relationships>
-        </div>
-    </ng-template>
-
     <dot-field-validation-message
         [message]="getValidationErrorMessage()"
-        [field]="group.controls[property.name]"></dot-field-validation-message>
+        [field]="group.controls[property.name]" />
 </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/name-property/name-property.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/name-property/name-property.component.html
@@ -13,10 +13,12 @@
     <dot-field-validation-message
         [message]="'contenttypes.field.properties.name.error.required' | dm"
         [field]="group.controls[property.name]"></dot-field-validation-message>
-    <div *ngIf="property.field.variable" class="form__field-variable">
-        <b>{{ 'contenttypes.field.properties.name.variable' | dm }}:</b>
-        <dot-copy-link
-            [label]="property.field.variable"
-            [copy]="property.field.variable"></dot-copy-link>
-    </div>
+    @if (property.field.variable) {
+        <div class="form__field-variable">
+            <b>{{ 'contenttypes.field.properties.name.variable' | dm }}:</b>
+            <dot-copy-link
+                [label]="property.field.variable"
+                [copy]="property.field.variable"></dot-copy-link>
+        </div>
+    }
 </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.html
@@ -2,27 +2,29 @@
     <dot-icon class="row-header__drag" name="drag_handle"></dot-icon>
 </div>
 <div class="row-columns">
-    <div
-        *ngFor="let column of fieldRow.columns; let i = index"
-        [(dragulaModel)]="column.fields"
-        [class.empty]="!column.fields.length"
-        class="row-columns__item"
-        [attr.data-testid]="'fields-bag-' + i"
-        data-drag-type="target"
-        dragula="fields-bag">
-        <p-button
-            *ngIf="!column.fields.length"
-            (click)="remove(i)"
-            [pTooltip]="'contenttypes.action.delete' | dm"
-            class="row-header__remove"
-            icon="pi pi-trash"
-            styleClass="p-button-rounded p-button-text p-button-sm p-button-danger"></p-button>
-
-        <dot-content-type-field-dragabble-item
-            *ngFor="let field of column.fields"
-            (remove)="onRemoveField($event)"
-            (edit)="this.editField.emit(field)"
-            [field]="field"
-            [isSmall]="fieldRow.columns.length > 1"></dot-content-type-field-dragabble-item>
-    </div>
+    @for (column of fieldRow.columns; track column; let i = $index) {
+        <div
+            [(dragulaModel)]="column.fields"
+            [class.empty]="!column.fields.length"
+            class="row-columns__item"
+            [attr.data-testid]="'fields-bag-' + i"
+            data-drag-type="target"
+            dragula="fields-bag">
+            @if (!column.fields.length) {
+                <p-button
+                    (click)="remove(i)"
+                    [pTooltip]="'contenttypes.action.delete' | dm"
+                    class="row-header__remove"
+                    icon="pi pi-trash"
+                    styleClass="p-button-rounded p-button-text p-button-sm p-button-danger"></p-button>
+            }
+            @for (field of column.fields; track field) {
+                <dot-content-type-field-dragabble-item
+                    (remove)="onRemoveField($event)"
+                    (edit)="this.editField.emit(field)"
+                    [field]="field"
+                    [isSmall]="fieldRow.columns.length > 1"></dot-content-type-field-dragabble-item>
+            }
+        </div>
+    }
 </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/dot-content-type-fields-variables.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/dot-content-type-fields-variables.component.html
@@ -1,6 +1,7 @@
-<dot-key-value-ng
-    *ngIf="showTable"
-    (delete)="deleteFieldVariable($event)"
-    (save)="updateFieldVariable($event)"
-    (update)="updateFieldVariable($event.variable)"
-    [variables]="fieldVariables" />
+@if (showTable) {
+    <dot-key-value-ng
+        (delete)="deleteFieldVariable($event)"
+        (save)="updateFieldVariable($event)"
+        (update)="updateFieldVariable($event.variable)"
+        [variables]="fieldVariables" />
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.html
@@ -4,19 +4,20 @@
     class="content-type__form p-fluid"
     id="content-type-form"
     novalidate>
-    <div
-        *ngIf="newContentEditorEnabled"
-        class="content-type__new-content-banner"
-        data-test-id="content-type__new-content-banner">
-        <p-checkbox
-            class="p-checkbox-sm"
-            formControlName="newEditContent"
-            binary="true"
-            inputId="newEditContentLabel"></p-checkbox>
-        <label for="newEditContentLabel">
-            <span [innerHTML]="'content.type.form.banner.message' | dm"></span>
-        </label>
-    </div>
+    @if (newContentEditorEnabled) {
+        <div
+            class="content-type__new-content-banner"
+            data-test-id="content-type__new-content-banner">
+            <p-checkbox
+                class="p-checkbox-sm"
+                formControlName="newEditContent"
+                binary="true"
+                inputId="newEditContentLabel"></p-checkbox>
+            <label for="newEditContentLabel">
+                <span [innerHTML]="'content.type.form.banner.message' | dm"></span>
+            </label>
+        </div>
+    }
     <div class="field form__group--validation">
         <label dotFieldRequired for="content-type-form-name">{{ nameFieldLabel }}</label>
         <input
@@ -81,12 +82,11 @@
             [workflows]="workflowsSelected$ | async"
             formControlName="NEW"></dot-workflows-actions-selector-field>
     </div>
-    <span
-        *ngIf="form.get('workflows').disabled"
-        class="p-field-hint form-workflow-community-message"
-        id="field-workflow-hint">
-        {{ 'contenttypes.form.hint.error.only.default.scheme.available.in.Community' | dm }}
-    </span>
+    @if (form.get('workflows').disabled) {
+        <span class="p-field-hint form-workflow-community-message" id="field-workflow-hint">
+            {{ 'contenttypes.form.hint.error.only.default.scheme.available.in.Community' | dm }}
+        </span>
+    }
     <div class="content-type__form-dates">
         <div class="field">
             <label for="content-type-form-publish-date-field">
@@ -120,34 +120,37 @@
         </div>
     </div>
 
-    <small
-        *ngIf="!dateVarOptions.length"
-        class="p-field-hint field__date-hint"
-        id="field-dates-hint">
-        {{ 'contenttypes.form.message.no.date.fields.defined' | dm }}
-    </small>
+    @if (!dateVarOptions.length) {
+        <small class="p-field-hint field__date-hint" id="field-dates-hint">
+            {{ 'contenttypes.form.message.no.date.fields.defined' | dm }}
+        </small>
+    }
 
-    <div *ngIf="form.get('detailPage')" class="field">
-        <label for="content-type-form-detail-page">
-            {{ 'contenttypes.form.field.detail.page' | dm }}
-        </label>
-        <dot-page-selector
-            [tabindex]="9"
-            id="content-type-form-detail-page"
-            formControlName="detailPage"></dot-page-selector>
-    </div>
-    <div *ngIf="form.get('urlMapPattern')" class="field form__group--helper">
-        <dot-field-helper
-            [message]="'contenttypes.hint.URL.map.pattern.hint1' | dm"></dot-field-helper>
-        <label for="content-type-form-url-map-pattern">
-            {{ 'contenttypes.form.label.URL.pattern' | dm }}
-        </label>
-        <input
-            [tabindex]="10"
-            id="content-type-form-url-map-pattern"
-            pInputText
-            type="text"
-            name="urlMapPattern"
-            formControlName="urlMapPattern" />
-    </div>
+    @if (form.get('detailPage')) {
+        <div class="field">
+            <label for="content-type-form-detail-page">
+                {{ 'contenttypes.form.field.detail.page' | dm }}
+            </label>
+            <dot-page-selector
+                [tabindex]="9"
+                id="content-type-form-detail-page"
+                formControlName="detailPage"></dot-page-selector>
+        </div>
+    }
+    @if (form.get('urlMapPattern')) {
+        <div class="field form__group--helper">
+            <dot-field-helper
+                [message]="'contenttypes.hint.URL.map.pattern.hint1' | dm"></dot-field-helper>
+            <label for="content-type-form-url-map-pattern">
+                {{ 'contenttypes.form.label.URL.pattern' | dm }}
+            </label>
+            <input
+                [tabindex]="10"
+                id="content-type-form-url-map-pattern"
+                pInputText
+                type="text"
+                name="urlMapPattern"
+                formControlName="urlMapPattern" />
+        </div>
+    }
 </form>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
@@ -73,41 +73,45 @@
             </div>
         </div>
     </p-tabPanel>
-    <p-tabPanel
-        *ngIf="contentType"
-        [cache]="false"
-        class="content-type__relationships"
-        header="{{ 'contenttypes.tab.relationship.header' | dm }}">
-        <ng-template pTemplate="content">
-            <dot-portlet-box>
-                <dot-iframe [src]="relationshipURL"></dot-iframe>
-            </dot-portlet-box>
-        </ng-template>
-    </p-tabPanel>
-    <p-tabPanel
-        *ngIf="contentType && showPermissionsTab | async"
-        [cache]="false"
-        class="content-type__permissions"
-        header="{{ 'contenttypes.tab.permissions.header' | dm }}">
-        <ng-template pTemplate="content">
-            <dot-portlet-box>
-                <dot-iframe [src]="permissionURL"></dot-iframe>
-            </dot-portlet-box>
-        </ng-template>
-    </p-tabPanel>
-    <p-tabPanel
-        *ngIf="contentType"
-        [cache]="false"
-        class="content-type__push_history"
-        header="{{ 'contenttypes.tab.publisher.push.history.header' | dm }}">
-        <ng-template pTemplate="content">
-            <dot-portlet-box>
-                <dot-iframe [src]="pushHistoryURL"></dot-iframe>
-            </dot-portlet-box>
-        </ng-template>
-    </p-tabPanel>
+    @if (contentType) {
+        <p-tabPanel
+            [cache]="false"
+            class="content-type__relationships"
+            header="{{ 'contenttypes.tab.relationship.header' | dm }}">
+            <ng-template pTemplate="content">
+                <dot-portlet-box>
+                    <dot-iframe [src]="relationshipURL"></dot-iframe>
+                </dot-portlet-box>
+            </ng-template>
+        </p-tabPanel>
+    }
+    @if (contentType && showPermissionsTab | async) {
+        <p-tabPanel
+            [cache]="false"
+            class="content-type__permissions"
+            header="{{ 'contenttypes.tab.permissions.header' | dm }}">
+            <ng-template pTemplate="content">
+                <dot-portlet-box>
+                    <dot-iframe [src]="permissionURL"></dot-iframe>
+                </dot-portlet-box>
+            </ng-template>
+        </p-tabPanel>
+    }
+    @if (contentType) {
+        <p-tabPanel
+            [cache]="false"
+            class="content-type__push_history"
+            header="{{ 'contenttypes.tab.publisher.push.history.header' | dm }}">
+            <ng-template pTemplate="content">
+                <dot-portlet-box>
+                    <dot-iframe [src]="pushHistoryURL"></dot-iframe>
+                </dot-portlet-box>
+            </ng-template>
+        </p-tabPanel>
+    }
 </p-tabView>
-<dot-add-to-menu
-    *ngIf="addToMenuContentType"
-    (cancel)="addToMenuContentType = false"
-    [contentType]="contentType"></dot-add-to-menu>
+@if (addToMenuContentType) {
+    <dot-add-to-menu
+        (cancel)="addToMenuContentType = false"
+        [contentType]="contentType"></dot-add-to-menu>
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
@@ -1,18 +1,20 @@
-<dot-content-type-layout
-    *ngIf="isEditMode()"
-    (openEditDialog)="startFormDialog()"
-    (changeContentTypeName)="editContentTypeName($event)"
-    [contentType]="data">
-    <dot-content-type-fields-drop-zone
-        *ngIf="data.id"
-        (saveFields)="saveFields($event)"
-        (removeFields)="removeFields($event)"
-        (editField)="editField($event)"
-        [layout]="layout"
-        [loading]="loadingFields"
-        [contentType]="data"
-        #fieldsDropZone></dot-content-type-fields-drop-zone>
-</dot-content-type-layout>
+@if (isEditMode()) {
+    <dot-content-type-layout
+        (openEditDialog)="startFormDialog()"
+        (changeContentTypeName)="editContentTypeName($event)"
+        [contentType]="data">
+        @if (data.id) {
+            <dot-content-type-fields-drop-zone
+                (saveFields)="saveFields($event)"
+                (removeFields)="removeFields($event)"
+                (editField)="editField($event)"
+                [layout]="layout"
+                [loading]="loadingFields"
+                [contentType]="data"
+                #fieldsDropZone></dot-content-type-fields-drop-zone>
+        }
+    </dot-content-type-layout>
+}
 
 <dot-dialog
     (hide)="onDialogHide()"
@@ -20,11 +22,12 @@
     [actions]="dialogActions"
     [closeable]="dialogCloseable"
     [header]="templateInfo.header">
-    <dot-content-types-form
-        *ngIf="show"
-        (valid)="setDialogOkButtonState($event)"
-        (send)="handleFormSubmit($event)"
-        [layout]="layout"
-        [data]="data"
-        #form></dot-content-types-form>
+    @if (show) {
+        <dot-content-types-form
+            (valid)="setDialogOkButtonState($event)"
+            (send)="handleFormSubmit($event)"
+            [layout]="layout"
+            [data]="data"
+            #form></dot-content-types-form>
+    }
 </dot-dialog>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-reorder-menu/dot-reorder-menu.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-reorder-menu/dot-reorder-menu.component.html
@@ -1,5 +1,6 @@
-<dot-iframe-dialog
-    *ngIf="!!url"
-    (shutdown)="onClose()"
-    [header]="'editpage.content.contentlet.menu.reorder.title' | dm"
-    [url]="url"></dot-iframe-dialog>
+@if (!!url) {
+    <dot-iframe-dialog
+        (shutdown)="onClose()"
+        [header]="'editpage.content.contentlet.menu.reorder.title' | dm"
+        [url]="url" />
+}

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-language-selector/dot-language-selector.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-language-selector/dot-language-selector.component.html
@@ -15,7 +15,9 @@
             <div class="h-full w-full flex align-items-center gap-3">
                 <span>
                     {{ value.language }}
-                    <ng-container *ngIf="value.countryCode">({{ value.countryCode }})</ng-container>
+                    @if (value.countryCode) {
+                        ({{ value.countryCode }})
+                    }
                 </span>
             </div>
         }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-language-selector/dot-language-selector.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-language-selector/dot-language-selector.component.ts
@@ -1,4 +1,3 @@
-import { NgIf } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
@@ -22,7 +21,7 @@ import { DotLanguage } from '@dotcms/dotcms-models';
     standalone: true,
     selector: 'dot-language-selector',
     templateUrl: './dot-language-selector.component.html',
-    imports: [DropdownModule, FormsModule, NgIf],
+    imports: [DropdownModule, FormsModule],
     providers: [DotLanguagesService],
     styleUrls: ['./dot-language-selector.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-portlet-base/components/dot-portlet-toolbar/dot-portlet-toolbar.component.html
@@ -1,6 +1,8 @@
 <p-toolbar>
     <div class="p-toolbar-group-start" data-testId="leftGroup">
-        <h3 *ngIf="title" data-testId="title">{{ title }}</h3>
+        @if (title) {
+            <h3 data-testId="title">{{ title }}</h3>
+        }
         <div class="dot-portlet-toolbar__extra-left">
             <ng-content select="[left]"></ng-content>
         </div>
@@ -12,34 +14,38 @@
         </div>
 
         <div class="dot-portlet-toolbar__actions" data-testId="actionsWrapper">
-            <button
-                *ngIf="actions?.cancel"
-                (click)="onCancelClick($event)"
-                [label]="cancelButtonLabel || ('cancel' | dm)"
-                class="p-button-outlined"
-                data-testId="actionsCancelButton"
-                pButton></button>
-
-            <ng-container *ngIf="actions?.primary?.length">
+            @if (actions?.cancel) {
                 <button
-                    *ngIf="actions?.primary?.length === 1; else elseBlock"
-                    (click)="onPrimaryClick($event)"
-                    [label]="actions?.primary[0]?.label || ('save' | dm)"
-                    [disabled]="actions?.primary[0]?.disabled"
-                    data-testId="actionsPrimaryButton"
+                    (click)="onCancelClick($event)"
+                    [label]="cancelButtonLabel || ('cancel' | dm)"
+                    class="p-button-outlined"
+                    data-testId="actionsCancelButton"
                     pButton></button>
-            </ng-container>
+            }
+
+            @if (actions?.primary?.length) {
+                @if (actions?.primary?.length === 1) {
+                    <button
+                        (click)="onPrimaryClick($event)"
+                        [label]="actions?.primary[0]?.label || ('save' | dm)"
+                        [disabled]="actions?.primary[0]?.disabled"
+                        data-testId="actionsPrimaryButton"
+                        pButton></button>
+                } @else {
+                    <button
+                        (click)="menu.toggle($event)"
+                        [label]="actionsButtonLabel || ('actions' | dm)"
+                        data-testId="actionsMenuButton"
+                        pButton
+                        icon="pi pi-chevron-down"
+                        iconPos="right"></button>
+                    <p-menu
+                        [popup]="true"
+                        [model]="actions?.primary"
+                        #menu
+                        data-testId="actionsMenu"></p-menu>
+                }
+            }
         </div>
     </div>
 </p-toolbar>
-
-<ng-template #elseBlock>
-    <button
-        (click)="menu.toggle($event)"
-        [label]="actionsButtonLabel || ('actions' | dm)"
-        data-testId="actionsMenuButton"
-        pButton
-        icon="pi pi-chevron-down"
-        iconPos="right"></button>
-    <p-menu [popup]="true" [model]="actions?.primary" #menu data-testId="actionsMenu"></p-menu>
-</ng-template>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.html
@@ -27,21 +27,21 @@
             [class.selected]="value && value.identifier === item.identifier"
             [class.highlight]="item.name === selectedOptionValue"
             class="theme-selector__data-list-item">
-            <img
-                *ngIf="item?.themeThumbnail; else imageFallback"
-                [src]="
-                    item.identifier === 'SYSTEM_THEME'
-                        ? item.themeThumbnail
-                        : '/dA/' + item.themeThumbnail + '/titleImage/500w/50q/thumbnail.png'
-                "
-                [alt]="item.name"
-                class="dot-theme-item__image" />
-
-            <ng-template #imageFallback>
+            @if (item?.themeThumbnail) {
+                <img
+                    [src]="
+                        item.identifier === 'SYSTEM_THEME'
+                            ? item.themeThumbnail
+                            : '/dA/' + item.themeThumbnail + '/titleImage/500w/50q/thumbnail.png'
+                    "
+                    [alt]="item.name"
+                    class="dot-theme-item__image" />
+            } @else {
                 <div class="dot-theme-item__image--fallback">
                     <span>{{ item.label.charAt(0) }}</span>
                 </div>
-            </ng-template>
+            }
+
             <span class="dot-theme-item__meta">
                 <span class="dot-theme-item__label">{{ item.label }}</span>
                 <span class="dot-theme-item__date">


### PR DESCRIPTION
### Proposed Changes

This pull request introduces a significant refactor of Angular templates across several components in the `dotcms-ui` application. The primary focus is on replacing Angular's `*ngIf` structural directive with the new `@if` syntax, which improves readability and aligns with modern Angular standards. Additionally, some minor adjustments to imports and template structures were made to streamline the codebase.

### Key Changes:

#### Refactor to `@if` Syntax:
1. **Template Conditionals**:
   - Replaced `*ngIf` directives with `@if` across multiple components, including `dot-block-editor-sidebar`, `dot-edit-page-info`, `dot-palette-content-type`, `dot-palette-contentlets`, `dot-edit-page-toolbar`, and others. This refactor enhances code clarity and consistency. [[1]](diffhunk://#diff-69799abb20abfe7efb785cf4261916042636946a9acc9ea18e05f3e0f77fb5cdL11-R12) [[2]](diffhunk://#diff-a6dc3768a22138335dcd4b74a4517c459e4b5d8ab41dca8e794cebb828751baaR2-R14) [[3]](diffhunk://#diff-bf10890f121779d5904b2a0f2836b9deb02561accb16e5fcd056a865f08fcce3L4-L6) [[4]](diffhunk://#diff-cb6bf786c5993c78425015ae16eeda37f51bce24ca3c75aa6fcb31f26c85bb42L7-R42) [[5]](diffhunk://#diff-6b277e8c9b93c66a7d0fadfe1fbf30999853f646b88c8ace9c1bb99e06683a65L4-R4) [[6]](diffhunk://#diff-82f5d84a678ada73dbcc81e08f878d888cec0f884c682073ca21b28217dd4bcaL1-R1) [[7]](diffhunk://#diff-64e120da3f527462307067b4bcc610218aa5313e79db1700041d7e66d7474d5aL1-R25) [[8]](diffhunk://#diff-11b36b6fc9ed5dd1617b396fa604ef4133f6b40a47ba03ed7ab4a034e81456beL1-R7) [[9]](diffhunk://#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL1-R1)

2. **Nested Conditionals**:
   - Introduced `@else` blocks where applicable to simplify the handling of alternative template logic. For example, in `dot-palette-contentlets` and `dot-edit-page-toolbar`, nested conditions were replaced with a cleaner `@if`/`@else` structure. [[1]](diffhunk://#diff-cb6bf786c5993c78425015ae16eeda37f51bce24ca3c75aa6fcb31f26c85bb42L7-R42) [[2]](diffhunk://#diff-6b277e8c9b93c66a7d0fadfe1fbf30999853f646b88c8ace9c1bb99e06683a65L13-L74)

#### Template Simplifications:
1. **Removed Redundant Imports**:
   - Removed unused `CommonModule` import from `dot-apps-configuration-detail-generated-string-field.component.ts`, reducing unnecessary dependencies. [[1]](diffhunk://#diff-c5841ab1b5dea808936daf5781bc6064b60a08345538d30a4303947076fcf0f7L1) [[2]](diffhunk://#diff-c5841ab1b5dea808936daf5781bc6064b60a08345538d30a4303947076fcf0f7L65)

2. **Code Cleanup**:
   - Consolidated template logic by eliminating redundant `ng-template` blocks and simplifying conditional rendering logic. For instance, `dot-whats-changed` now uses `@if` directly instead of a separate `ng-template`. [[1]](diffhunk://#diff-11b36b6fc9ed5dd1617b396fa604ef4133f6b40a47ba03ed7ab4a034e81456beL1-R7) [[2]](diffhunk://#diff-bdd3ad691984c6a98ed8584d09c67080428ce8738627187e6ab67504d175529fL25)

These updates modernize the codebase and improve maintainability while ensuring compatibility with newer Angular features.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)





This PR fixes: #32733