### PR TITLE
refactor(tests): Replace deprecated TestBed.get with TestBed.inject

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-apps/dot-apps.service.spec.ts
@@ -3,7 +3,7 @@ import { mockProvider } from '@ngneat/spectator';
 import { throwError } from 'rxjs';
 
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { fakeAsync, getTestBed, TestBed, tick } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { ConfirmationService } from 'primeng/api';
 
@@ -51,7 +51,6 @@ const mockDotApps = [
 ];
 
 describe('DotAppsService', () => {
-    let injector: TestBed;
     let dotAppsService: DotAppsService;
     let dotHttpErrorManagerService: DotHttpErrorManagerService;
     let coreWebService: CoreWebService;
@@ -79,11 +78,10 @@ describe('DotAppsService', () => {
                 mockProvider(DotMessageService)
             ]
         });
-        injector = getTestBed();
-        dotAppsService = injector.get(DotAppsService);
-        dotHttpErrorManagerService = injector.get(DotHttpErrorManagerService);
-        coreWebService = injector.get(CoreWebService);
-        httpMock = injector.get(HttpTestingController);
+        dotAppsService = TestBed.inject(DotAppsService);
+        dotHttpErrorManagerService = TestBed.inject(DotHttpErrorManagerService);
+        coreWebService = TestBed.inject(CoreWebService);
+        httpMock = TestBed.inject(HttpTestingController);
     });
 
     it('should get apps', () => {

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-download-bundle-dialog/dot-download-bundle-dialog.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-download-bundle-dialog/dot-download-bundle-dialog.service.spec.ts
@@ -8,7 +8,7 @@ describe('DotDownloadBundleDialogService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({ providers: [DotDownloadBundleDialogService] });
-        service = TestBed.get(DotDownloadBundleDialogService);
+        service = TestBed.inject(DotDownloadBundleDialogService);
         service.showDialog$.subscribe((data: string) => (bundleID = data));
     });
 

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-template-containers-cache/dot-template-containers-cache.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-template-containers-cache/dot-template-containers-cache.spec.ts
@@ -14,7 +14,7 @@ describe('TemplateContainersCacheService', () => {
             imports: []
         });
 
-        service = TestBed.get(DotTemplateContainersCacheService);
+        service = TestBed.inject(DotTemplateContainersCacheService);
         containers = {
             '/containers/path': {
                 identifier: '1',

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-ui-colors/dot-ui-colors.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-ui-colors/dot-ui-colors.service.spec.ts
@@ -4,15 +4,14 @@ import { DEFAULT_COLORS, DotUiColorsService } from './dot-ui-colors.service';
 
 describe('DotUiColorsService', () => {
     let service: DotUiColorsService;
-    let injector;
     let setPropertySpy;
 
     beforeEach(() => {
-        injector = TestBed.configureTestingModule({
+        TestBed.configureTestingModule({
             providers: [DotUiColorsService]
         });
 
-        service = injector.get(DotUiColorsService);
+        service = TestBed.inject(DotUiColorsService);
 
         setPropertySpy = jasmine.createSpy('setProperty');
         spyOn(document as Document, 'querySelector').and.returnValue({

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/auth-guard.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/auth-guard.service.spec.ts
@@ -30,9 +30,9 @@ describe('ValidAuthGuardService', () => {
             providers: [AuthGuardService, { provide: LoginService, useClass: MockLoginService }]
         });
 
-        authGuardService = TestBed.get(AuthGuardService);
-        dotRouterService = TestBed.get(DotRouterService);
-        loginService = TestBed.get(LoginService);
+        authGuardService = TestBed.inject(AuthGuardService);
+        dotRouterService = TestBed.inject(DotRouterService);
+        loginService = TestBed.inject(LoginService);
         mockRouterStateSnapshot = jasmine.createSpyObj<RouterStateSnapshot>('RouterStateSnapshot', [
             'toString'
         ]);

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/default-guard.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/default-guard.service.spec.ts
@@ -14,8 +14,8 @@ describe('ValidDefaultGuardService', () => {
             providers: [DefaultGuardService]
         });
 
-        defaultGuardService = TestBed.get(DefaultGuardService);
-        dotRouterService = TestBed.get(DotRouterService);
+        defaultGuardService = TestBed.inject(DefaultGuardService);
+        dotRouterService = TestBed.inject(DotRouterService);
     });
 
     it('should redirect to to Main Portlet always', () => {

--- a/core-web/apps/dotcms-ui/src/app/api/services/guards/public-auth-guard.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/guards/public-auth-guard.service.spec.ts
@@ -33,9 +33,9 @@ describe('ValidPublicAuthGuardService', () => {
             ]
         });
 
-        publicAuthGuardService = TestBed.get(PublicAuthGuardService);
-        dotRouterService = TestBed.get(DotRouterService);
-        loginService = TestBed.get(LoginService);
+        publicAuthGuardService = TestBed.inject(PublicAuthGuardService);
+        dotRouterService = TestBed.inject(DotRouterService);
+        loginService = TestBed.inject(LoginService);
         mockRouterStateSnapshot = jasmine.createSpyObj<RouterStateSnapshot>('RouterStateSnapshot', [
             'toString'
         ]);

--- a/core-web/apps/dotcms-ui/src/app/app.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/app.component.spec.ts
@@ -47,10 +47,10 @@ describe('AppComponent', () => {
         fixture = TestBed.createComponent(AppComponent);
         de = fixture.debugElement;
 
-        dotCmsConfigService = de.injector.get(DotcmsConfigService);
-        dotUiColorsService = de.injector.get(DotUiColorsService);
-        dotMessageService = de.injector.get(DotMessageService);
-        dotLicenseService = de.injector.get(DotLicenseService);
+        dotCmsConfigService = TestBed.inject(DotcmsConfigService);
+        dotUiColorsService = TestBed.inject(DotUiColorsService);
+        dotMessageService = TestBed.inject(DotMessageService);
+        dotLicenseService = TestBed.inject(DotLicenseService);
 
         spyOn<any>(dotCmsConfigService, 'getConfig').and.returnValue(
             of({

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration-detail/dot-apps-configuration-detail-resolver.service.spec.ts
@@ -25,7 +25,7 @@ describe('DotAppsConfigurationDetailResolver', () => {
     let dotAppsConfigurationDetailResolver: DotAppsConfigurationDetailResolver;
 
     beforeEach(waitForAsync(() => {
-        const testbed = TestBed.configureTestingModule({
+        TestBed.configureTestingModule({
             providers: [
                 DotAppsConfigurationDetailResolver,
                 { provide: DotAppsService, useClass: AppsServicesMock },
@@ -35,8 +35,8 @@ describe('DotAppsConfigurationDetailResolver', () => {
                 }
             ]
         });
-        dotAppsServices = testbed.get(DotAppsService);
-        dotAppsConfigurationDetailResolver = testbed.get(DotAppsConfigurationDetailResolver);
+        dotAppsServices = TestBed.inject(DotAppsService);
+        dotAppsConfigurationDetailResolver = TestBed.inject(DotAppsConfigurationDetailResolver);
     }));
 
     it('should get and return app with configurations', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-configuration/dot-apps-configuration-resolver.service.spec.ts
@@ -26,7 +26,7 @@ describe('DotAppsConfigurationListResolver', () => {
     let dotAppsConfigurationListResolver: DotAppsConfigurationResolver;
 
     beforeEach(waitForAsync(() => {
-        const testbed = TestBed.configureTestingModule({
+        TestBed.configureTestingModule({
             providers: [
                 DotAppsConfigurationResolver,
                 { provide: DotAppsService, useClass: AppsServicesMock },
@@ -36,8 +36,8 @@ describe('DotAppsConfigurationListResolver', () => {
                 }
             ]
         });
-        dotAppsServices = testbed.get(DotAppsService);
-        dotAppsConfigurationListResolver = testbed.get(DotAppsConfigurationResolver);
+        dotAppsServices = TestBed.inject(DotAppsService);
+        dotAppsConfigurationListResolver = TestBed.inject(DotAppsConfigurationResolver);
     }));
 
     it('should get and return apps with configurations', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-apps/dot-apps-list/dot-apps-list-resolver.service.spec.ts
@@ -33,7 +33,7 @@ describe('DotAppsListResolver', () => {
     let dotAppsListResolver: DotAppsListResolver;
 
     beforeEach(() => {
-        const testbed = TestBed.configureTestingModule({
+        TestBed.configureTestingModule({
             providers: [
                 DotAppsListResolver,
                 { provide: DotLicenseService, useClass: DotLicenseServicesMock },
@@ -44,9 +44,9 @@ describe('DotAppsListResolver', () => {
                 }
             ]
         });
-        dotAppsService = testbed.get(DotAppsService);
-        dotLicenseServices = testbed.get(DotLicenseService);
-        dotAppsListResolver = testbed.get(DotAppsListResolver);
+        dotAppsService = TestBed.inject(DotAppsService);
+        dotLicenseServices = TestBed.inject(DotLicenseService);
+        dotAppsListResolver = TestBed.inject(DotAppsListResolver);
     });
 
     it('should get if portlet can be accessed', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/dot-edit-content-html/dot-edit-content-html.service.spec.ts
@@ -1235,7 +1235,7 @@ xdescribe('DotEditContentHtmlService', () => {
             spyOn(service, 'renderEditedContentlet');
 
             service.currentContainer = currentContainer;
-            dotGlobalMessageService = TestBed.get(DotGlobalMessageService);
+            dotGlobalMessageService = TestBed.inject(DotGlobalMessageService);
         });
 
         it('should render added form', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-dom-html-util.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-dom-html-util.service.spec.ts
@@ -10,7 +10,7 @@ describe('DotDOMHtmlUtilService', () => {
             providers: [DotDOMHtmlUtilService]
         });
 
-        service = TestBed.get(DotDOMHtmlUtilService);
+        service = TestBed.inject(DotDOMHtmlUtilService);
     }));
 
     it('should create a link element', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-edit-page/content/services/html/dot-edit-content-toolbar-html.service.spec.ts
@@ -138,7 +138,7 @@ describe('DotEditContentToolbarHtmlService', () => {
 
                 describe('without license', () => {
                     beforeEach(() => {
-                        const dotLicenseService = TestBed.get(DotLicenseService);
+                        const dotLicenseService = TestBed.inject(DotLicenseService);
                         spyOn(dotLicenseService, 'isEnterprise').and.returnValue(
                             observableOf(false)
                         );

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-porlet-detail/dot-workflow-task/dot-workflow-task.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-porlet-detail/dot-workflow-task/dot-workflow-task.component.spec.ts
@@ -147,10 +147,10 @@ describe('DotWorkflowTaskComponent', () => {
         fixture = TestBed.createComponent(DotWorkflowTaskComponent);
         de = fixture.debugElement;
         component = de.componentInstance;
-        dotWorkflowTaskDetailService = TestBed.get(DotWorkflowTaskDetailService);
-        dotRouterService = TestBed.get(DotRouterService);
-        dotIframeService = TestBed.get(DotIframeService);
-        dotCustomEventHandlerService = TestBed.get(DotCustomEventHandlerService);
+        dotWorkflowTaskDetailService = TestBed.inject(DotWorkflowTaskDetailService);
+        dotRouterService = TestBed.inject(DotRouterService);
+        dotIframeService = TestBed.inject(DotIframeService);
+        dotCustomEventHandlerService = TestBed.inject(DotCustomEventHandlerService);
         spyOn(dotIframeService, 'reloadData');
         fixture.detectChanges();
         taskDetail = de.query(By.css('dot-workflow-task-detail'));

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit-resolver.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit-resolver.service.spec.ts
@@ -3,7 +3,7 @@
 
 import { of as observableOf, throwError as observableThrowError } from 'rxjs';
 
-import { waitForAsync } from '@angular/core/testing';
+import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -38,7 +38,7 @@ describe('DotContentTypeEditResolver', () => {
     let dotHttpErrorManagerService: DotHttpErrorManagerService;
 
     beforeEach(waitForAsync(() => {
-        const testbed = DOTTestBed.configureTestingModule({
+        DOTTestBed.configureTestingModule({
             providers: [
                 DotContentTypeEditResolver,
                 DotContentTypesInfoService,
@@ -56,10 +56,10 @@ describe('DotContentTypeEditResolver', () => {
             ],
             imports: [RouterTestingModule]
         });
-        crudService = testbed.get(DotCrudService);
-        dotContentTypeEditResolver = testbed.get(DotContentTypeEditResolver);
-        dotRouterService = testbed.get(DotRouterService);
-        dotHttpErrorManagerService = testbed.get(DotHttpErrorManagerService);
+        crudService = TestBed.inject(DotCrudService);
+        dotContentTypeEditResolver = TestBed.inject(DotContentTypeEditResolver);
+        dotRouterService = TestBed.inject(DotRouterService);
+        dotHttpErrorManagerService = TestBed.inject(DotHttpErrorManagerService);
     }));
 
     it('should get and return a content type', () => {

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/services/dot-workflows-actions-selector-field.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-workflows-actions-selector-field/services/dot-workflows-actions-selector-field.service.spec.ts
@@ -43,9 +43,9 @@ describe('DotWorkflowsActionsSelectorFieldService', () => {
     );
 
     beforeEach(() => {
-        dotHttpErrorManagerService = TestBed.get(DotHttpErrorManagerService);
-        dotWorkflowsActionsService = TestBed.get(DotWorkflowsActionsService);
-        service = TestBed.get(DotWorkflowsActionsSelectorFieldService);
+        dotHttpErrorManagerService = TestBed.inject(DotHttpErrorManagerService);
+        dotWorkflowsActionsService = TestBed.inject(DotWorkflowsActionsService);
+        service = TestBed.inject(DotWorkflowsActionsSelectorFieldService);
         spy = spyOn(dotWorkflowsActionsService, 'getByWorkflows').and.callThrough();
 
         service.get().subscribe((actions: SelectItemGroup[]) => {

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-component/iframe.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-component/iframe.component.spec.ts
@@ -72,9 +72,9 @@ describe('IframeComponent', () => {
         comp = fixture.componentInstance;
         de = fixture.debugElement;
 
-        dotIframeService = TestBed.get(DotIframeService);
-        dotUiColorsService = TestBed.get(DotUiColorsService);
-        dotRouterService = TestBed.get(DotRouterService);
+        dotIframeService = TestBed.inject(DotIframeService);
+        dotUiColorsService = TestBed.inject(DotUiColorsService);
+        dotRouterService = TestBed.inject(DotRouterService);
         spyOn(dotUiColorsService, 'setColors');
 
         comp.isLoading = false;

--- a/core-web/libs/data-access/src/lib/dot-alert-confirm/dot-alert-confirm.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-alert-confirm/dot-alert-confirm.service.spec.ts
@@ -24,7 +24,7 @@ describe('DotAlertConfirmService', () => {
     let confirmationService: ConfirmationService;
 
     beforeEach(() => {
-        const testbed = TestBed.configureTestingModule({
+        TestBed.configureTestingModule({
             providers: [
                 DotAlertConfirmService,
                 ConfirmationService,
@@ -51,8 +51,8 @@ describe('DotAlertConfirmService', () => {
             }
         };
 
-        service = testbed.get(DotAlertConfirmService);
-        confirmationService = testbed.get(ConfirmationService);
+        service = TestBed.inject(DotAlertConfirmService);
+        confirmationService = TestBed.inject(ConfirmationService);
     });
 
     describe('confirmation', () => {

--- a/core-web/libs/dot-rules/src/lib/directives/dot-autofocus/dot-autofocus.directive.spec.ts
+++ b/core-web/libs/dot-rules/src/lib/directives/dot-autofocus/dot-autofocus.directive.spec.ts
@@ -1,15 +1,16 @@
 import { DebugElement, Component } from '@angular/core';
-import { TestBed, ComponentFixture, waitForAsync, async } from '@angular/core/testing';
+import { TestBed, ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { DotAutofocusDirective } from './dot-autofocus.directive';
 
 @Component({
     template: `
-        <input *ngIf="disabled; else not" type="text" dotAutofocus disabled />
-        <ng-template #not>
+        @if (disabled) {
+            <input type="text" dotAutofocus disabled />
+        } @else {
             <input type="text" dotAutofocus />
-        </ng-template>
+        }
     `
 })
 class TestHostComponent {
@@ -33,7 +34,7 @@ describe('Directive: DotAutofocus', () => {
         component = fixture.componentInstance;
     });
 
-    it('should call focus', async(() => {
+    it('should call focus', waitForAsync(() => {
         fixture.detectChanges();
         inputEl = fixture.debugElement.query(By.css('input'));
         spyOn(inputEl.nativeElement, 'focus');
@@ -43,7 +44,7 @@ describe('Directive: DotAutofocus', () => {
         });
     }));
 
-    it('should NOT call focus', async(() => {
+    it('should NOT call focus', waitForAsync(() => {
         component.setDisabled(true);
         fixture.detectChanges();
         inputEl = fixture.debugElement.query(By.css('input'));

--- a/core-web/libs/dotcms-js/src/lib/core/dot-push-publish-dialog.service.spec.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/dot-push-publish-dialog.service.spec.ts
@@ -5,7 +5,7 @@ import { DotPushPublishDialogService } from './dot-push-publish-dialog.service';
 const mockEventData = { assetIdentifier: 'test', title: 'Title' };
 
 describe('DotPushPublishDialogService', () => {
-    const dotPushPublishDialogService = TestBed.get(DotPushPublishDialogService);
+    const dotPushPublishDialogService = TestBed.inject(DotPushPublishDialogService);
     let data;
 
     beforeEach(() => {

--- a/core-web/libs/dotcms-js/src/lib/core/dot-push-publish-dialog.service.spec.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/dot-push-publish-dialog.service.spec.ts
@@ -1,22 +1,21 @@
-import { TestBed } from '@angular/core/testing';
+import { createServiceFactory, SpectatorService } from '@ngneat/spectator';
 
 import { DotPushPublishDialogService } from './dot-push-publish-dialog.service';
 
 const mockEventData = { assetIdentifier: 'test', title: 'Title' };
 
 describe('DotPushPublishDialogService', () => {
-    const dotPushPublishDialogService = TestBed.inject(DotPushPublishDialogService);
-    let data;
+    let spectator: SpectatorService<DotPushPublishDialogService>;
+    const createService = createServiceFactory(DotPushPublishDialogService);
 
     beforeEach(() => {
-        TestBed.configureTestingModule({});
-        dotPushPublishDialogService.showDialog$.subscribe((dialogData: any) => {
-            data = dialogData;
-        });
+        spectator = createService();
     });
 
     it('should receive data', () => {
-        dotPushPublishDialogService.open(mockEventData);
-        expect(data).toEqual(mockEventData);
+        spectator.service.showDialog$.subscribe((dialogData) => {
+            expect(dialogData).toEqual(mockEventData);
+        });
+        spectator.service.open(mockEventData);
     });
 });


### PR DESCRIPTION
### Summary
This commit updates multiple service test specifications across the codebase to utilize the `TestBed.inject()` method for dependency injection, replacing the deprecated `TestBed.get()`. This change enhances code clarity and aligns with Angular's best practices for dependency management.

<img width="760" height="395" alt="Image" src="https://github.com/user-attachments/assets/c4b92420-e68f-48bf-912c-e79844b91bc9" />


### Affected Files
- Updated service specs in `app.component.spec.ts`, `dot-apps.service.spec.ts`, `dot-download-bundle-dialog.service.spec.ts`, and others to use `TestBed.inject()`.

### Benefits
- Improved maintainability and readability of test code.
- Ensures compatibility with future Angular updates.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)


<img width="643" height="273" alt="Screenshot 2025-07-23 at 11 37 49 AM" src="https://github.com/user-attachments/assets/b6bf3fa1-cb15-4ecf-8bc6-026e80cafb5b" />


This PR fixes: #32778