### PR TITLE
fix(ui): fix the content edit API link

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_versions_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_versions_inc.jsp
@@ -45,14 +45,25 @@
 
 
 
-<div class="contentIdentifier">
+<div class="contentIdentifier" style="margin: 0px 18px 18px 18px;">
 <%= LanguageUtil.get(pageContext, "Identifier") %> : <%=ident.getId() %>
+	<style>
+		.hoverable-box {
+			float: right;
+			padding: 4px 8px;
+			border: 1px solid #ccc;
+			cursor: pointer;
+			border-radius: 3px;
+			text-align: center;
+			transition: background 0.3s;
+		}
+		.hoverable-box:hover {
+			background: #e6f3ff; /* Light blue */
+		}
+	</style>
+	<div class="hoverable-box">
 
-
-
-	<div style="float:right">
-	(&nbsp;<a href="/api/content/id/<%=ident.getId() %>" target="_blank">json</a> |
-	<a href="/api/content/id/<%=ident.getId() %>/type/xml" target="_blank">xml</a>&nbsp;)
+		<a href="/api/v1/content/<%=ident.getId() %>" style="text-decoration: none;font-weight: normal" target="_blank">API</a>
 	</div>
 </div>
 <table class="listingTable">
@@ -151,5 +162,3 @@
 	<% } %>
 
 </table>
-
-


### PR DESCRIPTION
ref: #32790

changed the old links:
`/api/content/id/2ee2589d-cfcd-4fc9-b1d5-47f7be6f224f`

to the v1 edition, which has a modern response and works with non-live content:
`/api/v1/content/2ee2589d-cfcd-4fc9-b1d5-47f7be6f224f`


<img width="892" height="376" alt="Screenshot 2025-07-24 at 11 07 39 AM" src="https://github.com/user-attachments/assets/2ee2589d-cfcd-4fc9-b1d5-47f7be6f224f" />

This PR fixes: #32790