### PR TITLE
Include siteId into the payload sent to jitsu

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Events.js
@@ -212,6 +212,7 @@ cube('request', {
     utmTerm: { sql: 'utm_term', type: `string` },
     utmContent: { sql: 'utm_content', type: `string` },
     key: { sql: 'context_site_key', type: `string` },
+    siteId: { sql: 'context_site_id', type: `string` },
     sessionID: { sql: 'sessionid', type: `string` },
     userId: { sql: 'context_user_id', type: `string` },
     requestId: { sql: 'request_id', type: `string` },

--- a/dotCMS/src/main/java/com/dotcms/jitsu/ValidAnalyticsEventPayloadAttributes.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/ValidAnalyticsEventPayloadAttributes.java
@@ -25,4 +25,6 @@ public interface ValidAnalyticsEventPayloadAttributes {
     String EVENT_TYPE_ATTRIBUTE_NAME = "event_type";
 
     String LOCAL_TIME_ATTRIBUTE_NAME = "local_time";
+
+    String SITE_ID_ATTRIBUTE_NAME = "site_id";
 }

--- a/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteKeyValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/validators/SiteKeyValidator.java
@@ -83,8 +83,8 @@ public class SiteKeyValidator implements AnalyticsValidator {
      *
      * @return The Site that the Event is being sent to.
      */
-    private Host getSiteFromRequest(final HttpServletRequest request) throws AnalyticsValidationException {
-        final Optional<String> siteFromRequestOpt = this.getSiteNameOrAlias(request);
+    public static Host getSiteFromRequest(final HttpServletRequest request) throws AnalyticsValidationException {
+        final Optional<String> siteFromRequestOpt = getSiteNameOrAlias(request);
         if (siteFromRequestOpt.isEmpty()) {
             throw new AnalyticsValidationException("Site could not be retrieved from Origin or Referer HTTP Headers",
                     INVALID_SITE_KEY);
@@ -103,7 +103,7 @@ public class SiteKeyValidator implements AnalyticsValidator {
         } catch (final DotDataException | DotSecurityException e) {
             final String errorMsg = String.format("Failed to retrieve Site with name/alias '%s': %s",
                     siteFromRequestOpt.get(), ExceptionUtil.getErrorMessage(e));
-            Logger.error(this, errorMsg, e);
+            Logger.error(SiteKeyValidator.class, errorMsg, e);
             throw new AnalyticsValidationException(errorMsg, INVALID_SITE_KEY);
         }
     }
@@ -116,7 +116,7 @@ public class SiteKeyValidator implements AnalyticsValidator {
      * @param request The HTTP request to extract the site alias from
      * @return The extracted site alias (domain) or null if not found
      */
-    private Optional<String> getSiteNameOrAlias(final HttpServletRequest request) {
+    public static Optional<String> getSiteNameOrAlias(final HttpServletRequest request) {
         String siteUrl = request.getHeader(HttpHeaders.ORIGIN);
         if (UtilMethods.isNotSet(siteUrl)) {
             siteUrl = request.getHeader(HttpHeaders.REFERER);
@@ -128,9 +128,9 @@ public class SiteKeyValidator implements AnalyticsValidator {
                 if (parsedUrl != null && UtilMethods.isSet(parsedUrl.getHost())) {
                     return Optional.of(parsedUrl.getHost());
                 }
-                Logger.debug(this, String.format("Site Name or Alias could not be retrieved from '%s'", siteUrl));
+                Logger.debug(SiteKeyValidator.class, String.format("Site Name or Alias could not be retrieved from '%s'", siteUrl));
             } catch (final IllegalArgumentException e) {
-                Logger.warn(this, String.format("Site Alias could not be retrieved from HTTP Request: " +
+                Logger.warn(SiteKeyValidator.class, String.format("Site Alias could not be retrieved from HTTP Request: " +
                         "%s", ExceptionUtil.getErrorMessage(e)));
             }
         }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
@@ -6,7 +6,9 @@ import com.dotcms.analytics.track.collectors.EventType;
 import com.dotcms.jitsu.EventLogSubmitter;
 import com.dotcms.jitsu.ValidAnalyticsEventPayload;
 import com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes;
+import com.dotcms.jitsu.validators.AnalyticsValidator;
 import com.dotcms.jitsu.validators.AnalyticsValidatorUtil;
+import com.dotcms.jitsu.validators.SiteKeyValidator;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.web.WebAPILocator;
 import com.dotmarketing.exception.DotDataException;
@@ -28,9 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes.REFERER_ATTRIBUTE_NAME;
-import static com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes.URL_ATTRIBUTE_NAME;
-import static com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes.USER_AGENT_ATTRIBUTE_NAME;
+import static com.dotcms.jitsu.ValidAnalyticsEventPayloadAttributes.*;
 
 /**
  * This utility class provides different methods for interacting with Content Analytics features.
@@ -132,8 +132,20 @@ public class ContentAnalyticsUtil {
             userEventPayload.put(URL_ATTRIBUTE_NAME, "");
         }
 
+        final Host siteFromRequest = getSiteFromRequest(request);
+        final Map<String, Object> contextSection = (Map<String, Object>) userEventPayload.get(CONTEXT_ATTRIBUTE_NAME);
+        contextSection.put(SITE_ID_ATTRIBUTE_NAME, siteFromRequest.getIdentifier());
+
         userEventPayload.put("isExperimentPage", false);
         userEventPayload.put("isTargetPage", false);
+    }
+
+    private static Host getSiteFromRequest(HttpServletRequest request)  {
+        try {
+            return SiteKeyValidator.getSiteFromRequest(request);
+        } catch (AnalyticsValidator.AnalyticsValidationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes
* Turn into public these methods to look for the site 

https://github.com/dotCMS/core/compare/issue-32787-SiteId-must-be-saved-in-CubeJS?expand=1#diff-aa6d8c3cd21e50d4d5a829cf2dd2b8452bda763d62a837362915b25664f08fa8R86

* set the siteId into the general context object 

https://github.com/dotCMS/core/compare/issue-32787-SiteId-must-be-saved-in-CubeJS?expand=1#diff-88f29b9f603e2b639f854482e9ca8d06a26369eb40ac4f40866ef57f892ee9e0R135-R137

* expose the siteId in cubeJS

https://github.com/dotCMS/core/compare/issue-32787-SiteId-must-be-saved-in-CubeJS?expand=1#diff-c291c8a51311832c67ceb2e3fb2a2d4fe1d9c4e02abda400c156e10bed18200eR215


This PR fixes: #32787