### PR TITLE
chore(sdks): Added styleClass to graphql query on client.page.get

### DIFF
--- a/core-web/libs/sdk/angular/package.json
+++ b/core-web/libs/sdk/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcms/angular",
-  "version": "0.0.1-beta.2",
+  "version": "1.0.1",
   "peerDependencies": {
     "rxjs": ">=7.0.0",
     "@angular/common": ">=17.0.0",

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/column/column.component.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/column/column.component.spec.ts
@@ -60,18 +60,4 @@ describe('ColumnComponent', () => {
         const containers = spectator.queryAll('dotcms-container');
         expect(containers.length).toBe(2);
     });
-
-    it('should render column with styleClass', () => {
-        spectator.setInput({
-            column: {
-                styleClass: 'custom-class'
-            }
-        });
-
-        spectator.detectChanges();
-
-        const columnElement = spectator.query(byTestId('dotcms-column'));
-
-        expect(columnElement?.classList.contains('custom-class')).toBe(true);
-    });
 });

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/column/column.component.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/column/column.component.spec.ts
@@ -60,4 +60,18 @@ describe('ColumnComponent', () => {
         const containers = spectator.queryAll('dotcms-container');
         expect(containers.length).toBe(2);
     });
+
+    it('should render column with styleClass', () => {
+        spectator.setInput({
+            column: {
+                styleClass: 'custom-class'
+            }
+        });
+
+        spectator.detectChanges();
+
+        const columnElement = spectator.query(byTestId('dotcms-column'));
+
+        expect(columnElement?.classList.contains('custom-class')).toBe(true);
+    });
 });

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/row/row.component.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/row/row.component.spec.ts
@@ -48,4 +48,18 @@ describe('RowComponent', () => {
         const columns = spectator.queryAll('dotcms-column');
         expect(columns.length).toBe(2);
     });
+
+    it('should render row with styleClass', () => {
+        spectator.setInput({
+            row: {
+                columns: [],
+                styleClass: 'custom-class',
+                identifier: 1
+            }
+        });
+        spectator.detectChanges();
+        const rowElement = spectator.query(byTestId('dotcms-row'));
+
+        expect(rowElement?.classList.contains('custom-class')).toBe(true);
+    });
 });

--- a/core-web/libs/sdk/client/package.json
+++ b/core-web/libs/sdk/client/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@dotcms/client",
-  "version": "0.0.1-beta.2",
+  "version": "1.0.1",
   "description": "Official JavaScript library for interacting with DotCMS REST APIs.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dotCMS/core.git#main"
   },
   "dependencies": {
-    "consola": "^3.4.2"
+    "consola": "^3.4.2" 
   },
   "devDependencies": {
     "@dotcms/types": "latest"

--- a/core-web/libs/sdk/client/src/lib/client/page/utils.ts
+++ b/core-web/libs/sdk/client/src/lib/client/page/utils.ts
@@ -152,6 +152,7 @@ export const buildPageQuery = ({
       footer
       body {
         rows {
+          styleClass
           columns {
             leftOffset
             styleClass

--- a/core-web/libs/sdk/experiments/package.json
+++ b/core-web/libs/sdk/experiments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcms/experiments",
-  "version": "0.0.1-beta.2",
+  "version": "1.0.1",
   "description": "Official JavaScript library to use Experiments with DotCMS.",
   "repository": {
     "type": "git",

--- a/core-web/libs/sdk/react/package.json
+++ b/core-web/libs/sdk/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcms/react",
-  "version": "0.0.1-beta-2",
+  "version": "1.0.1",
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18"

--- a/core-web/libs/sdk/types/package.json
+++ b/core-web/libs/sdk/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dotcms/types",
-    "version": "0.0.1-beta.2",
+    "version": "1.0.1",
     "keywords": [
         "dotCMS",
         "CMS",

--- a/core-web/libs/sdk/uve/package.json
+++ b/core-web/libs/sdk/uve/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcms/uve",
-  "version": "0.0.1-beta.2",
+  "version": "1.0.1",
   "description": "Official JavaScript library for interacting with Universal Visual Editor (UVE)",
   "repository": {
     "type": "git",


### PR DESCRIPTION


https://github.com/user-attachments/assets/c0adafac-3eca-4ca0-b6ca-e64382d93016


This PR bring back the styleClass from rows and columns in both Angular and React sdk.
The issue was we forget add the styleClass on the query, so i just add that attribute

This PR fixes: #32783

This PR fixes: #32783