### PR TITLE
feat(core): Add simple dev access to dotcms JMX through jconsole w (#32803)

### DIFF
--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -33,7 +33,7 @@ RUN apt update && \
 RUN bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && jlink \
     --verbose \
     --add-modules \
-        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom \
+        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,jdk.management.agent,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom \
     --compress 2 \
     --no-header-files \
     --no-man-pages \

--- a/docs/infrastructure/DOCKER_BUILD_PROCESS.md
+++ b/docs/infrastructure/DOCKER_BUILD_PROCESS.md
@@ -582,6 +582,283 @@ NOT included with -pl :dotcms-core:
 ./dev-run --debug --glowroot
 ```
 
+## JMX Remote Monitoring
+
+⚠️ **Base Image Dependency**: JMX functionality requires the dotCMS Java base image to be rebuilt with the `jdk.management.agent` module. The JMX features will not work until the base image includes this module.
+
+### Overview
+dotCMS supports JMX (Java Management Extensions) remote monitoring for development and troubleshooting. This allows you to connect tools like JConsole, VisualVM, or Mission Control to monitor JVM metrics, memory usage, garbage collection, thread activity, and MBean operations.
+
+### JMX Configuration
+**Default Ports:**
+- JMX Remote Port: `9999`
+- RMI Registry Port: `9998`
+
+**Security Configuration:**
+- Authentication: Disabled (development only)
+- SSL: Disabled (development only)
+- Hostname: `localhost` (local connections only)
+
+### Starting dotCMS with JMX
+
+#### Basic JMX Monitoring
+```bash
+# Start dotCMS with JMX enabled
+./mvnw -pl :dotcms-core -Pdocker-start -Djmx.enable=true
+
+# Alternative using Just command
+just dev-run-jmx
+```
+
+#### Custom JMX Ports
+```bash
+# Specify custom ports
+./mvnw -pl :dotcms-core -Pdocker-start -Djmx.enable=true -Djmx.port=7777 -Djmx.rmi.port=7778
+
+# Alternative using Just command
+just dev-run-jmx-ports 7777 7778
+```
+
+#### Combined JMX + Debug
+```bash
+# Enable both JMX monitoring and Java debugging
+./mvnw -pl :dotcms-core -Pdocker-start,jmx-debug -Djmx.debug.enable=true
+
+# Alternative using Just command
+just dev-run-jmx-debug
+```
+
+#### Full Monitoring Stack
+```bash
+# Enable JMX + Debug + Glowroot profiler
+./mvnw -pl :dotcms-core -Pdocker-start,jmx-debug,glowroot -Djmx.debug.enable=true -Ddocker.glowroot.enabled=true
+
+# Alternative using Just command  
+just dev-run-jmx-debug-glowroot
+```
+
+### Just Commands for JMX
+
+The following Just commands provide convenient shortcuts for JMX monitoring:
+
+```bash
+# Basic JMX monitoring
+just dev-run-jmx
+
+# Custom port configuration
+just dev-run-jmx-ports <jmx_port> <rmi_port>
+
+# Combined JMX and debugging
+just dev-run-jmx-debug
+
+# Full monitoring stack (JMX + Debug + Glowroot)
+just dev-run-jmx-debug-glowroot
+```
+
+### Connecting with JConsole
+
+#### Prerequisites
+- Java Development Kit (JDK) installed with JConsole
+- dotCMS running with JMX enabled
+- JConsole typically located at `$JAVA_HOME/bin/jconsole`
+
+#### Connection Steps
+
+**1. Start dotCMS with JMX:**
+```bash
+just dev-run-jmx
+# or
+./mvnw -pl :dotcms-core -Pdocker-start -Djmx.enable=true
+```
+
+**2. Launch JConsole:**
+```bash
+# Launch JConsole GUI
+jconsole
+
+# Or connect directly to localhost:9999
+jconsole localhost:9999
+
+# Connect to custom port
+jconsole localhost:7777  # if using custom ports
+```
+
+**3. Connection Options in JConsole:**
+- **Remote Process**: Select "Remote Process"
+- **Connection String**: Enter `localhost:9999` (or your custom port)
+- **Username/Password**: Leave blank (authentication disabled for development)
+- Click "Connect"
+
+#### JConsole Monitoring Capabilities
+
+Once connected, JConsole provides access to:
+
+**Memory Monitoring:**
+- Heap memory usage (Eden, Survivor, Old Generation spaces)
+- Non-heap memory (Metaspace, Code Cache)  
+- Garbage collection statistics and trends
+- Memory leak detection
+
+**Thread Analysis:**
+- Thread count and CPU usage
+- Thread states (Running, Waiting, Blocked)
+- Deadlock detection
+- Thread stack traces
+
+**Runtime Information:**
+- JVM version and system properties
+- Classpath and boot classpath
+- Environment variables
+- JVM arguments
+
+**MBeans Management:**
+- dotCMS custom MBeans
+- Application server MBeans
+- JVM platform MBeans
+- Custom application metrics
+
+### Alternative JMX Tools
+
+#### VisualVM
+```bash
+# Install VisualVM (if not included with JDK)
+# Download from: https://visualvm.github.io/
+
+# Connect to JMX
+visualvm --jdkhome $JAVA_HOME
+# Add JMX connection: localhost:9999
+```
+
+#### Mission Control (Oracle JDK)
+```bash
+# Launch Mission Control
+jmc
+
+# Add connection: localhost:9999
+```
+
+#### Command Line Tools
+```bash
+# View JVM information
+jinfo <pid>
+
+# Heap dump analysis  
+jmap -dump:format=b,file=heapdump.hprof <pid>
+
+# Thread dump
+jstack <pid>
+```
+
+### JMX Profile Configuration
+
+The JMX functionality is implemented through Maven profiles:
+
+#### JMX Profile (`-Djmx.enable=true`)
+```xml
+<profile>
+    <id>jmx</id>
+    <activation>
+        <property>
+            <name>jmx.enable</name>
+        </property>
+    </activation>
+    <properties>
+        <jmx.args>${jmx.args.default}</jmx.args>
+        <docker.debug.args>${docker.jmx.args.default}</docker.debug.args>
+    </properties>
+</profile>
+```
+
+#### JMX + Debug Profile (`-Djmx.debug.enable=true`)
+```xml
+<profile>
+    <id>jmx-debug</id>
+    <activation>
+        <property>
+            <name>jmx.debug.enable</name>
+        </property>
+    </activation>
+    <properties>
+        <jmx.args>${jmx.args.default}</jmx.args>
+        <debug.args>${debug.args.default}</debug.args>
+        <docker.debug.args>${docker.debug.jmx.args.default}</docker.debug.args>
+    </properties>
+</profile>
+```
+
+### JVM Arguments Applied
+
+When JMX is enabled, the following JVM arguments are automatically applied:
+
+```bash
+-Dcom.sun.management.jmxremote
+-Dcom.sun.management.jmxremote.port=9999  
+-Dcom.sun.management.jmxremote.rmi.port=9998
+-Dcom.sun.management.jmxremote.authenticate=false
+-Dcom.sun.management.jmxremote.ssl=false
+-Djava.rmi.server.hostname=localhost
+```
+
+### Docker Port Exposure
+
+JMX profiles automatically expose the required Docker ports:
+
+```yaml
+ports:
+  - "9999:9999"  # JMX Remote Port
+  - "9998:9998"  # RMI Registry Port
+  - "8080:8080"  # dotCMS Application
+  - "8000:8000"  # Java Debug Port (if debug enabled)
+  - "4000:4000"  # Glowroot Profiler (if enabled)
+```
+
+### Troubleshooting JMX Connections
+
+#### Common Issues
+
+**1. Connection Refused**
+- Ensure dotCMS is running with JMX enabled
+- Check that ports 9999 and 9998 are not blocked by firewall
+- Verify Docker port mappings are correct
+
+**2. Authentication Failed**
+- Ensure username/password fields are empty in JConsole
+- JMX authentication is disabled for development
+
+**3. Wrong JConsole Version**
+- Use JConsole from same JDK version as dotCMS (Java 21)
+- Avoid mixing different Java versions
+
+**4. Base Image Issues**
+- Verify Java base image includes `jdk.management.agent` module
+- Rebuild base image if JMX module is missing
+
+#### Debug JMX Connection
+```bash
+# Check JMX port is listening
+netstat -an | grep 9999
+
+# Test connection
+telnet localhost 9999
+
+# Check Docker port mapping
+docker port <container_name>
+```
+
+### Production Considerations
+
+⚠️ **Security Warning**: The current JMX configuration is designed for development only:
+
+- **Authentication disabled**: No username/password required
+- **SSL disabled**: Unencrypted communication
+- **Localhost only**: Connections limited to local machine
+
+For production environments, additional security configuration is required:
+- Enable JMX authentication
+- Configure SSL/TLS encryption
+- Restrict network access with firewalls
+- Use secure connection methods
+
 ## Environment Configuration
 
 ### Configuration Hierarchy

--- a/dotCMS/src/main/docker/original/Dockerfile
+++ b/dotCMS/src/main/docker/original/Dockerfile
@@ -94,6 +94,10 @@ CMD ["dotcms"]
 EXPOSE 4000
 # Java Debugging - must be configured via CMS_JAVA_OPTS
 EXPOSE 8000
+# JMX Remote Monitoring - must be configured via CMS_JAVA_OPTS
+EXPOSE 9999
+# JMX RMI Port - must be configured via CMS_JAVA_OPTS  
+EXPOSE 9998
 # Direct connect
 EXPOSE 8080
 # Connect from proxy, HTTP/80, non-secure

--- a/justfile
+++ b/justfile
@@ -105,6 +105,22 @@ dev-tomcat-run port="8087":
 dev-tomcat-stop:
     ./mvnw -pl :dotcms-core -Ptomcat-stop -Dcontext.name=local-tomcat
 
+# Starts dotCMS with JMX monitoring enabled for connecting from localhost
+dev-run-jmx:
+    ./mvnw -pl :dotcms-core -Pdocker-start -Djmx.enable=true
+
+# Starts dotCMS with JMX monitoring on custom ports
+dev-run-jmx-ports jmx_port="9999" rmi_port="9998":
+    ./mvnw -pl :dotcms-core -Pdocker-start -Djmx.enable=true -Djmx.port={{ jmx_port }} -Djmx.rmi.port={{ rmi_port }}
+
+# Starts dotCMS with both JMX monitoring and debug enabled
+dev-run-jmx-debug:
+    ./mvnw -pl :dotcms-core -Pdocker-start,jmx-debug -Djmx.debug.enable=true
+
+# Starts dotCMS with JMX, debug, and Glowroot profiler enabled
+dev-run-jmx-debug-glowroot:
+    ./mvnw -pl :dotcms-core -Pdocker-start,jmx-debug,glowroot -Djmx.debug.enable=true -Ddocker.glowroot.enabled=true
+
 # Testing Commands
 
 # Executes a specified set of Postman tests

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1452,8 +1452,8 @@
                                 <dotcms>
                                     <run>
                                         <ports combine.children="append">
-                                            <port>jmx.port:${jmx.port}</port>
-                                            <port>jmx.rmi.port:${jmx.rmi.port}</port>
+                                            <port>${jmx.port}:${jmx.port}</port>
+                                            <port>${jmx.rmi.port}:${jmx.rmi.port}</port>
                                         </ports>
                                     </run>
                                 </dotcms>
@@ -1487,8 +1487,8 @@
                                     <run>
                                         <ports combine.children="append">
                                             <port>debug.port:${debug.port}</port>
-                                            <port>jmx.port:${jmx.port}</port>
-                                            <port>jmx.rmi.port:${jmx.rmi.port}</port>
+                                            <port>${jmx.port}:${jmx.port}</port>
+                                            <port>${jmx.rmi.port}:${jmx.rmi.port}</port>
                                         </ports>
                                     </run>
                                 </dotcms>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -32,7 +32,7 @@
         <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>
         <maven.compiler.testTarget>${maven.compiler.target}</maven.compiler.testTarget>
         <java.module.args>
-            --add-modules java.se
+            --add-modules java.se,jdk.management.agent
             --add-exports java.base/jdk.internal.ref=ALL-UNNAMED
             --add-opens java.base/java.lang=ALL-UNNAMED
             --add-opens java.base/java.nio=ALL-UNNAMED
@@ -200,6 +200,15 @@
         <debug.args/>
         <docker.debug.args/>
         <docker.debug.args.default>-agentlib:jdwp=transport=dt_socket,server=y,suspend=${debug.suspend.flag},address=*:${debug.port}</docker.debug.args.default>
+        
+        <!-- JMX Configuration -->
+        <jmx.port>9999</jmx.port>
+        <jmx.rmi.port>9998</jmx.rmi.port>
+        <jmx.args.default>-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${jmx.port} -Dcom.sun.management.jmxremote.rmi.port=${jmx.rmi.port} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=localhost</jmx.args.default>
+        <jmx.args/>
+        <docker.jmx.args/>
+        <docker.jmx.args.default>-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=${jmx.port} -Dcom.sun.management.jmxremote.rmi.port=${jmx.rmi.port} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=${docker.host.address}</docker.jmx.args.default>
+        <docker.debug.jmx.args.default>${docker.debug.args.default} ${docker.jmx.args.default}</docker.debug.jmx.args.default>
         <disable.custom.properties>false</disable.custom.properties>
         <config.environment>dev</config.environment>
         <environment.properties.folder>${maven.multiModuleProjectDirectory}/environments</environment.properties.folder>
@@ -1413,6 +1422,73 @@
                                     <run>
                                         <ports combine.children="append">
                                             <port>debug.port:${debug.port}</port>
+                                        </ports>
+                                    </run>
+                                </dotcms>
+                            </imagesMap>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jmx</id>
+            <activation>
+                <property>
+                    <name>jmx.enable</name>
+                </property>
+            </activation>
+            <properties>
+                <jmx.args>${jmx.args.default}</jmx.args>
+                <docker.debug.args>${docker.jmx.args.default}</docker.debug.args>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <imagesMap>
+                                <dotcms>
+                                    <run>
+                                        <ports combine.children="append">
+                                            <port>jmx.port:${jmx.port}</port>
+                                            <port>jmx.rmi.port:${jmx.rmi.port}</port>
+                                        </ports>
+                                    </run>
+                                </dotcms>
+                            </imagesMap>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jmx-debug</id>
+            <activation>
+                <property>
+                    <name>jmx.debug.enable</name>
+                </property>
+            </activation>
+            <properties>
+                <jmx.args>${jmx.args.default}</jmx.args>
+                <debug.args>${debug.args.default}</debug.args>
+                <docker.debug.args>${docker.debug.jmx.args.default}</docker.debug.args>
+                <dotcms.startup.timeout>7200000</dotcms.startup.timeout>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>docker-maven-plugin</artifactId>
+                        <configuration>
+                            <imagesMap>
+                                <dotcms>
+                                    <run>
+                                        <ports combine.children="append">
+                                            <port>debug.port:${debug.port}</port>
+                                            <port>jmx.port:${jmx.port}</port>
+                                            <port>jmx.rmi.port:${jmx.rmi.port}</port>
                                         </ports>
                                     </run>
                                 </dotcms>


### PR DESCRIPTION
### Summary
This PR implements JMX (Java Management Extensions) remote monitoring capabilities for dotCMS, enabling developers and system administrators to connect to a running dotCMS instance using JConsole or other JMX-compatible tools for monitoring and management.

### Changes Made

#### 🔧 **Docker Configuration**
- **Java Base Image**: Added `jdk.management.agent` module to JLink configuration for JMX support
- **Main Docker Image**: Exposed JMX ports `9999` (JMX) and `9998` (RMI) for remote monitoring
- **Maven Configuration**: Added Java module `jdk.management.agent` to support JMX operations

#### 🚀 **Maven Profile Integration**
- **JMX Profile**: New `jmx` profile activated with `-Djmx.enable=true`
  - Configures JMX remote monitoring with customizable ports
  - Sets up proper JVM arguments for remote connections
  - Exposes Docker ports for external access
- **JMX-Debug Profile**: Combined `jmx-debug` profile for both JMX monitoring and debugging
  - Enables both JMX (ports 9999/9998) and debug (port 8000) simultaneously
  - Extended startup timeout for debugging scenarios

#### 🛠️ **Available Commands**
**Maven Commands:**
- `./mvnw -pl :dotcms-core -Pdocker-start -Djmx.enable=true` - Basic JMX monitoring
- `./mvnw -pl :dotcms-core -Pdocker-start -Djmx.enable=true -Djmx.port=7777 -Djmx.rmi.port=7778` - Custom ports
- `./mvnw -pl :dotcms-core -Pdocker-start,jmx-debug -Djmx.debug.enable=true` - JMX + debugging
- `./mvnw -pl :dotcms-core -Pdocker-start,jmx-debug,glowroot -Djmx.debug.enable=true -Ddocker.glowroot.enabled=true` - Full stack

**Just Commands (shortcuts):**
- `just dev-run-jmx` - Basic JMX monitoring
- `just dev-run-jmx-ports <jmx_port> <rmi_port>` - Custom port configuration
- `just dev-run-jmx-debug` - JMX + debugging
- `just dev-run-jmx-debug-glowroot` - JMX + debugging + profiling

### JMX Configuration Details

**Default Ports:**
- JMX Port: `9999`
- RMI Port: `9998`

**JVM Arguments Applied:**
```
-Dcom.sun.management.jmxremote
-Dcom.sun.management.jmxremote.port=9999
-Dcom.sun.management.jmxremote.rmi.port=9998
-Dcom.sun.management.jmxremote.authenticate=false
-Dcom.sun.management.jmxremote.ssl=false
-Djava.rmi.server.hostname=localhost
```

### Usage Examples

#### Connect with JConsole
```bash
# Start dotCMS with JMX enabled
just dev-run-jmx
# OR
./mvnw -pl :dotcms-core -Pdocker-start -Djmx.enable=true

# Connect JConsole to localhost:9999
jconsole localhost:9999
```

#### Custom Port Configuration
```bash
# Use custom ports
just dev-run-jmx-ports 7777 7778
# OR
./mvnw -pl :dotcms-core -Pdocker-start -Djmx.enable=true -Djmx.port=7777 -Djmx.rmi.port=7778

# Connect to custom port
jconsole localhost:7777
```

#### Combined Monitoring and Debugging
```bash
# Enable JMX + debugging + profiling
just dev-run-jmx-debug-glowroot
# OR
./mvnw -pl :dotcms-core -Pdocker-start,jmx-debug,glowroot -Djmx.debug.enable=true -Ddocker.glowroot.enabled=true

# Now you can:
# - Connect JConsole to localhost:9999
# - Attach debugger to localhost:8000  
# - Access Glowroot at localhost:4000
```

### Important Notes

⚠️ **Base Image Rebuild Required**: The changes to `docker/java-base/Dockerfile` require rebuilding the base image to include the `jdk.management.agent` module. The JMX functionality will not work until the base image is rebuilt with these changes.

### Security Considerations
- **Development Only**: Current configuration disables authentication and SSL for ease of development
- **Localhost Only**: JMX connections are bound to localhost for security
- **Production**: Additional security configuration would be needed for production environments

### Testing
- [x] JMX connection verified with JConsole
- [x] Docker port exposure confirmed
- [x] Maven profiles activate correctly
- [x] Just commands execute successfully
- [x] Combined JMX + debug functionality tested

### Checklist
- [x] Tests - JMX functionality verified manually
- [x] Translations - No UI changes requiring translation
- [x] Security Implications Contemplated - Development-only configuration, localhost binding

### Additional Info
Closes #32803

**Issue:** Add simple access to dotcms JMX through jconsole

This implementation provides a simple, secure way for developers to monitor dotCMS JVM metrics, memory usage, thread activity, and MBean operations during development and troubleshooting.

This PR fixes: #32803