### PR TITLE
fix(block-editor): Check for Image Field on Thumbnail

### DIFF
--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
@@ -117,7 +117,7 @@ export class DotContentletThumbnail {
         return `${this.fieldVariable || this.contentlet.titleImage}/`;
     }
 
-    private switchToIcon(): any {
+    private switchToIcon(): void {
         this.renderImage = false;
     }
 

--- a/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
+++ b/core-web/libs/dotcms-webcomponents/src/elements/dot-contentlet-thumbnail/dot-contentlet-thumbnail.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Host, Prop, State } from '@stencil/core';
+
 import { DotContentletItem } from '../../models/dot-contentlet-item.model';
 
 @Component({
@@ -48,6 +49,7 @@ export class DotContentletThumbnail {
             this.renderImage =
                 hasTitleImage === 'true' ||
                 mimeType === 'application/pdf' ||
+                this.contentlet['image'] ||
                 this.shouldShowVideoThumbnail();
         }
     }
@@ -98,6 +100,9 @@ export class DotContentletThumbnail {
             }/pdf_page/1/resize_w/250/quality_q/45`;
 
         if (this.isSVG) return `/contentAsset/image/${this.contentlet.inode}/asset`;
+
+        if (this.contentlet['image'])
+            return `/dA/${this.contentlet.inode}/${this.contentlet['image']}/resize_w/250/quality_q/45`;
 
         return `/dA/${this.contentlet.inode}/${this.fieldVariablePath()}500w/50q?r=${
             this.contentlet.modDateMilis || this.contentlet.modDate


### PR DESCRIPTION
## 🎯 Solution
The fix addresses the missing preview images by properly detecting when a contentlet has an image field and generating the appropriate thumbnail URL. This ensures that newly saved contentlets with image fields will display their preview thumbnails correctly in the block editor.

## 📝 Technical Details
•  Component: DotContentletThumbnail
•  Logic Enhancement: Added this.contentlet['image'] check to the render condition
•  URL Generation: Implemented specific path for image field thumbnails
•  Optimization: Uses resize and quality parameters for optimal loading performance

## ✅ Impact
•  Fixes missing preview images for new contentlets with image fields
•  Improves user experience in the block editor
•  Maintains backward compatibility with existing thumbnail logic

## Screenshot
https://github.com/user-attachments/assets/fdfc715a-d6ce-47b0-9a02-a7b8eadfc2b7


This PR fixes: #32146

This PR fixes: #32146