### PR TITLE
chore(nx): Migrate from @nrwl to @nx for project configurations

### DIFF
--- a/core-web/libs/dotcms/project.json
+++ b/core-web/libs/dotcms/project.json
@@ -5,7 +5,7 @@
     "projectType": "library",
     "targets": {
         "build": {
-            "executor": "@nrwl/js:tsc",
+            "executor": "@nx/js:tsc",
             "outputs": ["{options.outputPath}"],
             "options": {
                 "outputPath": "dist/libs/dotcms",

--- a/core-web/libs/sdk/client/project.json
+++ b/core-web/libs/sdk/client/project.json
@@ -29,7 +29,7 @@
                 "project": "libs/sdk/client/package.json",
                 "entryFile": "libs/sdk/client/src/lib/deprecated/editor/sdk-editor-vtl.ts",
                 "external": ["react/jsx-runtime"],
-                "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+                "rollupConfig": "@nx/react/plugins/bundle-rollup",
                 "compiler": "tsc",
                 "extractCss": false,
                 "minify": true
@@ -55,7 +55,7 @@
             }
         },
         "test": {
-            "executor": "@nrwl/jest:jest",
+            "executor": "@nx/jest:jest",
             "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
             "options": {
                 "jestConfig": "libs/sdk/client/jest.config.ts",

--- a/core-web/libs/sdk/experiments/.babelrc
+++ b/core-web/libs/sdk/experiments/.babelrc
@@ -1,12 +1,12 @@
 {
     "presets": [
-        [
-            "@nrwl/react/babel",
-            {
-                "runtime": "automatic",
-                "useBuiltIns": "usage"
-            }
-        ]
+      [
+        "@nx/react/babel",
+        {
+          "runtime": "automatic",
+          "useBuiltIns": "usage"
+        }
+      ]
     ],
     "plugins": []
-}
+  }

--- a/core-web/libs/sdk/experiments/.eslintrc.json
+++ b/core-web/libs/sdk/experiments/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "extends": ["plugin:@nrwl/nx/react", "../../../.eslintrc.base.json"],
+    "extends": ["plugin:@nx/react", "../../../.eslintrc.base.json"],
     "ignorePatterns": ["!**/*"],
     "overrides": [
         {

--- a/core-web/libs/sdk/experiments/jest.config.ts
+++ b/core-web/libs/sdk/experiments/jest.config.ts
@@ -3,8 +3,8 @@ export default {
     displayName: 'sdk-experiments',
     preset: '../../../jest.preset.js',
     transform: {
-        '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',
-        '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/react/babel'] }]
+        '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+        '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }]
     },
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
     coverageDirectory: '../../../coverage/libs/sdk/experiments'

--- a/core-web/libs/sdk/experiments/project.json
+++ b/core-web/libs/sdk/experiments/project.json
@@ -5,7 +5,7 @@
     "projectType": "library",
     "targets": {
         "build": {
-            "executor": "@nrwl/rollup:rollup",
+            "executor": "@nx/rollup:rollup",
             "outputs": ["{options.outputPath}"],
             "options": {
                 "outputPath": "dist/libs/sdk/experiments",
@@ -13,7 +13,7 @@
                 "project": "libs/sdk/experiments/package.json",
                 "entryFile": "libs/sdk/experiments/src/index.ts",
                 "external": ["react/jsx-runtime"],
-                "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+                "rollupConfig": "@nx/react/plugins/bundle-rollup",
                 "compiler": "babel",
                 "assets": [
                     {

--- a/core-web/libs/sdk/react/.babelrc
+++ b/core-web/libs/sdk/react/.babelrc
@@ -1,12 +1,12 @@
 {
     "presets": [
-        [
-            "@nrwl/react/babel",
-            {
-                "runtime": "automatic",
-                "useBuiltIns": "usage"
-            }
-        ]
+      [
+        "@nx/react/babel",
+        {
+          "runtime": "automatic",
+          "useBuiltIns": "usage"
+        }
+      ]
     ],
     "plugins": []
-}
+  }

--- a/core-web/libs/sdk/react/.eslintrc.js
+++ b/core-web/libs/sdk/react/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-    extends: ['plugin:@nrwl/nx/react', '../../../.eslintrc.base.json'],
+    extends: ['plugin:@nx/react', '../../../.eslintrc.base.json'],
     ignorePatterns: ['!**/*'],
     parserOptions: {
         sourceType: 'module'

--- a/core-web/libs/sdk/react/.eslintrc.json
+++ b/core-web/libs/sdk/react/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-    "extends": ["plugin:@nrwl/nx/react", "../../../.eslintrc.base.json"],
+    "extends": ["plugin:@nx/react", "../../../.eslintrc.base.json"],
     "ignorePatterns": ["!**/*"],
     "overrides": [
         {

--- a/core-web/libs/sdk/react/jest.config.ts
+++ b/core-web/libs/sdk/react/jest.config.ts
@@ -3,8 +3,8 @@ export default {
     displayName: 'sdk-react',
     preset: '../../../jest.preset.js',
     transform: {
-        '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nrwl/react/plugins/jest',
-        '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nrwl/react/babel'] }]
+        '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
+        '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }]
     },
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
     coverageDirectory: '../../../coverage/libs/sdk/react'

--- a/core-web/libs/sdk/react/project.json
+++ b/core-web/libs/sdk/react/project.json
@@ -23,7 +23,7 @@
                 "project": "libs/sdk/react/package.json",
                 "entryFile": "libs/sdk/react/src/index.ts",
                 "external": ["react/jsx-runtime"],
-                "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
+                "rollupConfig": "@nx/react/plugins/bundle-rollup",
                 "compiler": "babel",
                 "format": ["esm"],
                 "extractCss": false,
@@ -37,7 +37,7 @@
             }
         },
         "test": {
-            "executor": "@nrwl/jest:jest",
+            "executor": "@nx/jest:jest",
             "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
             "options": {
                 "jestConfig": "libs/sdk/react/jest.config.ts",

--- a/core-web/libs/sdk/react/tsconfig.lib.json
+++ b/core-web/libs/sdk/react/tsconfig.lib.json
@@ -5,8 +5,8 @@
         "types": ["node"]
     },
     "files": [
-        "../../../node_modules/@nrwl/react/typings/cssmodule.d.ts",
-        "../../../node_modules/@nrwl/react/typings/image.d.ts"
+        "../../../node_modules/@nx/react/typings/cssmodule.d.ts",
+        "../../../node_modules/@nx/react/typings/image.d.ts"
     ],
     "exclude": [
         "jest.config.ts",

--- a/core-web/libs/sdk/uve/project.json
+++ b/core-web/libs/sdk/uve/project.json
@@ -48,7 +48,6 @@
                 "project": "libs/sdk/uve/package.json",
                 "entryFile": "libs/sdk/uve/src/script/sdk-editor.ts",
                 "external": ["react/jsx-runtime"],
-                "rollupConfig": "@nrwl/react/plugins/bundle-rollup",
                 "compiler": "tsc",
                 "extractCss": false,
                 "minify": true,

--- a/core-web/nx.json
+++ b/core-web/nx.json
@@ -38,28 +38,6 @@
                 "linter": "eslint"
             }
         },
-        "@nrwl/angular:application": {
-            "style": "scss",
-            "linter": "eslint",
-            "unitTestRunner": "karma",
-            "e2eTestRunner": "playwright"
-        },
-        "@nrwl/angular:library": {
-            "linter": "eslint",
-            "unitTestRunner": "karma"
-        },
-        "@nrwl/angular:component": {
-            "style": "scss",
-            "changeDetection": "OnPush"
-        },
-        "@nrwl/react": {
-            "application": {
-                "babel": true
-            },
-            "library": {
-                "unitTestRunner": "jest"
-            }
-        },
         "@nx/react": {
             "library": {
                 "unitTestRunner": "jest"

--- a/core-web/tools/scripts/publish.mjs
+++ b/core-web/tools/scripts/publish.mjs
@@ -7,7 +7,7 @@
  * You might need to authenticate with NPM before running this script.
  */
 
-import { readCachedProjectGraph } from '@nrwl/devkit';
+import { readCachedProjectGraph } from '@nx/devkit';
 import { execSync } from 'child_process';
 import { readFileSync, writeFileSync } from 'fs';
 import chalk from 'chalk';


### PR DESCRIPTION
### Changes Made
- Updated project configurations in `nx.json`, `project.json`, and various `.babelrc` and `.eslintrc` files to replace `@nrwl` references with `@nx`.
- Adjusted executor paths for build and test targets in SDK and DotCMS libraries to align with the new package structure.

### Benefits
- Ensures compatibility with the latest Nx tooling and practices.
- Streamlines project setup and maintenance by standardizing on the `@nx` namespace.

This commit addresses the transition to the new Nx package structure.

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
