### PR TITLE
fix(db): Standardize DB timeout environment variables to milliseconds (#32816)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/db/DockerSecretDataSourceStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DockerSecretDataSourceStrategy.java
@@ -1,8 +1,5 @@
 package com.dotmarketing.db;
 
-
-import static com.dotmarketing.db.DataSourceStrategyProvider.CONNECTION_DB_IDLE_TIMEOUT;
-
 import com.dotmarketing.util.Constants;
 import com.google.common.annotations.VisibleForTesting;
 import com.liferay.util.SystemEnvironmentProperties;
@@ -85,9 +82,7 @@ public class DockerSecretDataSourceStrategy implements DotDataSourceStrategy {
                 dockerSecretsMap.getOrDefault(DataSourceStrategyProvider.CONNECTION_DB_CONNECTION_TIMEOUT, "5000")));
         config.setIdleTimeout(
                 Long.parseLong(
-                        systemEnvironmentProperties.getVariable(CONNECTION_DB_IDLE_TIMEOUT) != null
-                                ? systemEnvironmentProperties.getVariable(CONNECTION_DB_IDLE_TIMEOUT)
-                                : "600000"));
+                        dockerSecretsMap.getOrDefault(DataSourceStrategyProvider.CONNECTION_DB_IDLE_TIMEOUT, "600000")));
         config.setMaxLifetime(Integer.parseInt(
                 dockerSecretsMap.getOrDefault(DataSourceStrategyProvider.CONNECTION_DB_MAX_WAIT, "60000")));
         config.setConnectionTestQuery(dockerSecretsMap.get(

--- a/dotCMS/src/main/java/com/dotmarketing/db/DockerSecretDataSourceStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DockerSecretDataSourceStrategy.java
@@ -1,6 +1,8 @@
 package com.dotmarketing.db;
 
 
+import static com.dotmarketing.db.DataSourceStrategyProvider.CONNECTION_DB_IDLE_TIMEOUT;
+
 import com.dotmarketing.util.Constants;
 import com.google.common.annotations.VisibleForTesting;
 import com.liferay.util.SystemEnvironmentProperties;
@@ -82,9 +84,10 @@ public class DockerSecretDataSourceStrategy implements DotDataSourceStrategy {
         config.setConnectionTimeout(Integer.parseInt(
                 dockerSecretsMap.getOrDefault(DataSourceStrategyProvider.CONNECTION_DB_CONNECTION_TIMEOUT, "5000")));
         config.setIdleTimeout(
-                Integer.parseInt(dockerSecretsMap.getOrDefault(
-                        DataSourceStrategyProvider.CONNECTION_DB_MIN_IDLE, "10"))
-                        * 1000);
+                Long.parseLong(
+                        systemEnvironmentProperties.getVariable(CONNECTION_DB_IDLE_TIMEOUT) != null
+                                ? systemEnvironmentProperties.getVariable(CONNECTION_DB_IDLE_TIMEOUT)
+                                : "600000"));
         config.setMaxLifetime(Integer.parseInt(
                 dockerSecretsMap.getOrDefault(DataSourceStrategyProvider.CONNECTION_DB_MAX_WAIT, "60000")));
         config.setConnectionTestQuery(dockerSecretsMap.get(

--- a/dotCMS/src/main/java/com/dotmarketing/db/SystemEnvDataSourceStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/SystemEnvDataSourceStrategy.java
@@ -68,18 +68,16 @@ public class SystemEnvDataSourceStrategy implements DotDataSourceStrategy {
         
 
         config.setIdleTimeout(
-                Integer.parseInt(
+                Long.parseLong(
                         systemEnvironmentProperties.getVariable(CONNECTION_DB_IDLE_TIMEOUT) != null
                                 ? systemEnvironmentProperties.getVariable(CONNECTION_DB_IDLE_TIMEOUT)
-                                : "10")
-                        * 1000);
+                                : "600000"));
 
         config.setConnectionTimeout(
                 Integer.parseInt(
                         systemEnvironmentProperties.getVariable(CONNECTION_DB_CONNECTION_TIMEOUT) != null
                                 ? systemEnvironmentProperties.getVariable(CONNECTION_DB_CONNECTION_TIMEOUT)
-                                : "5")
-                        * 1000);
+                                : "5000"));
 
         config.setMaxLifetime(Integer.parseInt(
                 systemEnvironmentProperties.getVariable(CONNECTION_DB_MAX_WAIT) != null


### PR DESCRIPTION
### Problem
The database connection configuration had inconsistent time unit handling:
- `setenv.sh` sets `DB_CONNECTION_TIMEOUT=5000` assuming milliseconds
- `SystemEnvDataSourceStrategy` was multiplying by 1000, treating it as seconds
- This caused an effective timeout of ~1.5 hours (5000 * 1000ms) instead of 5 seconds

### Solution
Standardized both timeout environment variables to use milliseconds directly:

**DB_CONNECTION_TIMEOUT:**
- **Before:** `5` (seconds) * 1000 = 5000ms  
- **After:** `5000` (milliseconds) - matches setenv.sh default and Hikari expectations

**DB_IDLE_TIMEOUT:**
- **Before:** `10` (seconds) * 1000 = 10000ms (10s - too small for connection reuse)
- **After:** `600000` (milliseconds) = 10 minutes - better for connection pool efficiency

### Changes Made
- ✅ Removed `* 1000` multiplication in `SystemEnvDataSourceStrategy`
- ✅ Updated default `DB_CONNECTION_TIMEOUT` from `"5"` to `"5000"` (ms)
- ✅ Updated default `DB_IDLE_TIMEOUT` from `"10"` to `"600000"` (ms)  
- ✅ Fixed `DockerSecretDataSourceStrategy` to use consistent idle timeout handling
- ✅ Changed `IdleTimeout` from `Integer.parseInt` to `Long.parseLong` (Hikari expects long)

### Impact
- **No breaking changes** - No known environments customize these values currently
- **Aligns with Hikari defaults** - Connection pool now behaves as expected
- **Improved performance** - Longer idle timeout allows better connection reuse
- **Consistent units** - Both timeout variables now use milliseconds throughout

### Testing
- [x] Verified default connection timeout is 5000ms (5 seconds)  
- [x] Verified default idle timeout is 600000ms (10 minutes)
- [x] Confirmed no multiplication occurs in either strategy

Closes #32816

This PR fixes: #32816