### PR TITLE
chore(java): Bump Java version to 21.0.8-ms (#32818)

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # sets the SDKMAN_JAVA_VERSION for dotCMS
 # this is the version of java that will be used as the base image for the docker build
-java=21.0.7-ms
+java=21.0.8-ms


### PR DESCRIPTION
### Proposed Changes
* Bump java to 21.0.8-ms micro update from 21.07-ms.   
* base image was updated to include jmx module and safer to test with a different version instead of builing one that is already in use.  Base image will contain changes introduced in #32805 
* Image for this has been build with the Build SDMMan Base Java Image workflow in advance of this PR

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
Closes #32818

**Issue:** Bump Java version to 21.0.8ms


### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #32818