### PR TITLE
fix(core) revert bad change from @Size to @Length

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ruleengine/conditionlets/RestConditionlet.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ruleengine/conditionlets/RestConditionlet.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import com.dotcms.repackage.com.google.common.collect.ImmutableMap;
 import javax.validation.constraints.NotNull;
-import org.hibernate.validator.constraints.Length;
+import javax.validation.constraints.Size;
 import com.dotcms.rest.api.Validated;
 
 import com.dotmarketing.portlets.rules.parameter.ParameterDefinition;
@@ -21,7 +21,7 @@ public final class RestConditionlet extends Validated {
     public final String i18nKey;
 
     @NotNull
-    @Length(min = 0, max = 100)
+    @Size(min = 0, max = 100)
     public final Map<String, ParameterDefinition> parameterDefinitions;
 
     private RestConditionlet(Builder builder) {


### PR DESCRIPTION
### Proposed Changes

This PR fixes a critical validation error introduced in PR #32678 where `@Size` annotations were incorrectly changed to `@Length` for collection types.

**Specific changes:**
* **File:** `dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ruleengine/conditionlets/RestConditionlet.java`
* **Import:** Changed `org.hibernate.validator.constraints.Length` → `javax.validation.constraints.Size`
* **Annotation:** Changed `@Length(min = 0, max = 100)` → `@Size(min = 0, max = 100)` on `Map<String, ParameterDefinition>` field

**Root Cause:** 
- `@Length` is for String validation only (hibernate-validator)
- `@Size` is for collection validation (Maps, Lists, Sets) (javax.validation)

### Error Fixed
```
HV000030: No validator could be found for constraint 'org.hibernate.validator.constraints.Length' 
validating type 'java.util.Map<java.lang.String, com.dotmarketing.portlets.rules.parameter.ParameterDefinition>'
```

### Checklist
- [x] Tests - Compilation successful, no validation errors
- [x] Translations - No translation changes needed
- [x] Security Implications Contemplated - No security impact, annotation fix only

### Additional Info

**Verification:** 
- Only one file required changes
- All other `@Length` annotations in codebase correctly applied to String fields
- Compilation test confirms fix resolves validation error
- This was a show-stopper preventing proper application startup

**Impact:** Critical fix for rules engine functionality and application stability.

This PR fixes: #32840