### PR TITLE
implementation ( Edit Content ):  #31773 Relationship field: Support active filters as chips in search input 

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_chip.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_chip.scss
@@ -126,7 +126,6 @@ p-chip .p-chip {
     border-style: solid;
     padding: 0 $spacing-1;
     gap: $spacing-1;
-    flex-direction: row-reverse;
     height: $field-height-md;
 
     .p-chip-icon,

--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_input-group.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/form/_input-group.scss
@@ -55,4 +55,9 @@ p-inputgroup > .p-inputgroup {
         border-top-left-radius: 0;
         border-bottom-left-radius: 0;
     }
+
+    .p-chip.p-component:last-child {
+        border-top-left-radius: $border-radius-sm;
+        border-bottom-left-radius: $border-radius-sm;
+    }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.html
@@ -4,6 +4,7 @@
 
 <p-treeSelect
     (onNodeSelect)="store.chooseNode($event)"
+    (onNodeUnselect)="store.clearSelection()"
     (onNodeExpand)="store.loadChildren($event)"
     [formControl]="siteControl"
     data-testid="site-field-search"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
@@ -75,10 +75,8 @@ export class SiteFieldComponent implements ControlValueAccessor, OnInit {
     constructor() {
         effect(() => {
             const valueToSave = this.store.valueToSave();
-
-            if (valueToSave) {
-                this.onChange(valueToSave);
-            }
+            // Call onChange for both selection (valueToSave is truthy) and deselection (valueToSave is null)
+            this.onChange(valueToSave || '');
         });
 
         effect(() => {
@@ -122,6 +120,7 @@ export class SiteFieldComponent implements ControlValueAccessor, OnInit {
     writeValue(value: string): void {
         if (value === '') {
             this.siteControl.setValue('');
+            this.store.clearSelection();
         }
     }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
@@ -118,7 +118,7 @@ export class SiteFieldComponent implements ControlValueAccessor, OnInit {
      * Implements ControlValueAccessor method to update the control's value programmatically.
      */
     writeValue(value: string): void {
-        if (value === '') {
+        if (!value) {
             this.siteControl.setValue('');
             this.store.clearSelection();
         }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.store.spec.ts
@@ -285,4 +285,42 @@ describe('SiteFieldStore', () => {
             expect(store.nodeSelected()).toBeNull();
         });
     });
+
+    describe('clearSelection', () => {
+        it('should clear the selected node', () => {
+            // First select a node
+            const mockEvent = {
+                originalEvent: createFakeEvent('click'),
+                node: {
+                    label: 'Selected Node',
+                    data: {
+                        id: '123',
+                        hostname: 'demo.dotcms.com',
+                        path: 'selected',
+                        type: 'folder' as const
+                    },
+                    icon: 'pi pi-folder',
+                    leaf: true,
+                    children: []
+                }
+            };
+
+            store.chooseNode(mockEvent);
+            expect(store.nodeSelected()).toEqual(mockEvent.node);
+            expect(store.valueToSave()).toBe('folder:123');
+
+            // Then clear the selection
+            store.clearSelection();
+            expect(store.nodeSelected()).toBeNull();
+            expect(store.valueToSave()).toBeNull();
+        });
+
+        it('should handle clearing when no node is selected', () => {
+            expect(store.nodeSelected()).toBeNull();
+
+            store.clearSelection();
+            expect(store.nodeSelected()).toBeNull();
+            expect(store.valueToSave()).toBeNull();
+        });
+    });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.store.ts
@@ -133,6 +133,13 @@ export const SiteFieldStore = signalStore(
                 }
 
                 patchState(store, { nodeSelected });
+            },
+            /**
+             * Clears the selected node when a node is deselected
+             * @method clearSelection
+             */
+            clearSelection: () => {
+                patchState(store, { nodeSelected: null });
             }
         };
     })

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.html
@@ -1,5 +1,12 @@
 <form [formGroup]="form" #formElement>
-    <p-inputGroup>
+    <p-inputGroup styleClass="flex align-items-center">
+        @for (filter of $activeFilters(); track filter.value; let first = $first) {
+            <p-chip
+                [label]="filter.label"
+                [removable]="true"
+                (onRemove)="removeFilter(filter.type)"
+                [styleClass]="'mr-2 p-chip-sm flex align-items-center ' + (first ? ' ml-1' : '')" />
+        }
         <input
             pInputText
             type="text"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.html
@@ -1,16 +1,17 @@
 <form [formGroup]="form" #formElement>
     <p-inputGroup styleClass="flex align-items-center">
-        @for (filter of $activeFilters(); track filter.value; let first = $first) {
+        <i class="pi pi-search ml-1 mr-1 search-icon"></i>
+        @for (filter of $activeFilters(); track filter.value) {
             <p-chip
                 [label]="filter.label"
                 [removable]="true"
                 (onRemove)="removeFilter(filter.type)"
-                [styleClass]="'mr-2 p-chip-sm flex align-items-center ' + (first ? ' ml-1' : '')" />
+                [styleClass]="'mr-2 p-chip-sm flex align-items-center'" />
         }
         <input
             pInputText
             type="text"
-            class="w-26rem h-auto"
+            class="w-22rem h-auto"
             (keydown.enter)="doSearch()"
             [placeholder]="'dot.file.relationship.dialog.search.placeholder' | dm"
             formControlName="query" />

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.scss
@@ -1,0 +1,5 @@
+@use "variables" as *;
+
+.search-icon {
+    color: $color-palette-gray-600;
+}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
@@ -23,9 +23,11 @@ import { DotEditContentService } from '@dotcms/edit-content/services/dot-edit-co
 import { DotMessagePipe } from '@dotcms/ui';
 import { MockDotMessageService, mockLocales } from '@dotcms/utils-testing';
 
+import { LanguageFieldComponent } from './components/language-field/language-field.component';
+import { SiteFieldComponent } from './components/site-field/site-field.component';
 import { SearchComponent } from './search.component';
 
-// Stub components for testing
+// Mock components for testing
 @Component({
     selector: 'dot-language-field',
     standalone: true,
@@ -33,12 +35,12 @@ import { SearchComponent } from './search.component';
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => StubLanguageFieldComponent),
+            useExisting: forwardRef(() => MockLanguageFieldComponent),
             multi: true
         }
     ]
 })
-class StubLanguageFieldComponent implements ControlValueAccessor {
+class MockLanguageFieldComponent implements ControlValueAccessor {
     languageControl = new FormControl({ isoCode: 'en-US', id: 1 });
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -56,12 +58,12 @@ class StubLanguageFieldComponent implements ControlValueAccessor {
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => StubSiteFieldComponent),
+            useExisting: forwardRef(() => MockSiteFieldComponent),
             multi: true
         }
     ]
 })
-class StubSiteFieldComponent implements ControlValueAccessor {
+class MockSiteFieldComponent implements ControlValueAccessor {
     siteControl = new FormControl({
         label: 'demo.dotcms.com',
         data: { id: 'site123', type: 'site' }
@@ -131,8 +133,8 @@ describe('SearchComponent', () => {
             InputTextModule,
             OverlayPanelModule,
             ChipModule,
-            StubLanguageFieldComponent,
-            StubSiteFieldComponent
+            MockLanguageFieldComponent,
+            MockSiteFieldComponent
         ],
         mocks: [DotMessagePipe],
         detectChanges: true,
@@ -188,10 +190,8 @@ describe('SearchComponent', () => {
                 languageControl: {
                     value: { isoCode: 'en-US', id: 1 }
                 }
-            };
-            jest.spyOn(component, '$languageField').mockReturnValue(
-                mockLanguageField as typeof mockLanguageField
-            );
+            } as unknown as LanguageFieldComponent;
+            jest.spyOn(component, '$languageField').mockReturnValue(mockLanguageField);
 
             // Set up mock for site field component
             const mockSiteField = {
@@ -201,10 +201,8 @@ describe('SearchComponent', () => {
                         data: { id: 'site123', type: 'site' }
                     }
                 }
-            };
-            jest.spyOn(component, '$siteField').mockReturnValue(
-                mockSiteField as typeof mockSiteField
-            );
+            } as unknown as SiteFieldComponent;
+            jest.spyOn(component, '$siteField').mockReturnValue(mockSiteField);
         });
 
         it('should return empty filters when no active search params', () => {
@@ -426,10 +424,8 @@ describe('SearchComponent', () => {
                 languageControl: {
                     value: { isoCode: 'en-US', id: 1 }
                 }
-            };
-            jest.spyOn(component, '$languageField').mockReturnValue(
-                mockLanguageField as typeof mockLanguageField
-            );
+            } as unknown as LanguageFieldComponent;
+            jest.spyOn(component, '$languageField').mockReturnValue(mockLanguageField);
 
             const label = component['getLanguageDisplayLabel'](1);
             expect(label).toBe('en-US');
@@ -450,10 +446,8 @@ describe('SearchComponent', () => {
                         data: { id: 'site123', type: 'site' }
                     }
                 }
-            };
-            jest.spyOn(component, '$siteField').mockReturnValue(
-                mockSiteField as typeof mockSiteField
-            );
+            } as unknown as SiteFieldComponent;
+            jest.spyOn(component, '$siteField').mockReturnValue(mockSiteField);
 
             const label = component['getSiteDisplayLabel']('site123');
             expect(label).toBe('demo.dotcms.com');
@@ -475,10 +469,8 @@ describe('SearchComponent', () => {
                         data: { id: 'site123', type: 'site' }
                     }
                 }
-            };
-            jest.spyOn(component, '$siteField').mockReturnValue(
-                mockSiteField as typeof mockSiteField
-            );
+            } as unknown as SiteFieldComponent;
+            jest.spyOn(component, '$siteField').mockReturnValue(mockSiteField);
 
             const label = component['getSiteDisplayLabel']('site123');
             expect(label).toBe(longLabel.substring(0, 70) + '...');
@@ -741,16 +733,12 @@ describe('SearchComponent', () => {
             // Mock the child components to return values
             const mockLanguageField = {
                 languageControl: { value: { isoCode: 'en-US', id: 1 } }
-            };
+            } as unknown as LanguageFieldComponent;
             const mockSiteField = {
                 siteControl: { value: { label: 'demo.dotcms.com' } }
-            };
-            jest.spyOn(component, '$languageField').mockReturnValue(
-                mockLanguageField as typeof mockLanguageField
-            );
-            jest.spyOn(component, '$siteField').mockReturnValue(
-                mockSiteField as typeof mockSiteField
-            );
+            } as unknown as SiteFieldComponent;
+            jest.spyOn(component, '$languageField').mockReturnValue(mockLanguageField);
+            jest.spyOn(component, '$siteField').mockReturnValue(mockSiteField);
 
             spectator.detectChanges();
 
@@ -769,10 +757,8 @@ describe('SearchComponent', () => {
             // Mock the child components
             const mockLanguageField = {
                 languageControl: { value: { isoCode: 'en-US', id: 1 } }
-            };
-            jest.spyOn(component, '$languageField').mockReturnValue(
-                mockLanguageField as typeof mockLanguageField
-            );
+            } as unknown as LanguageFieldComponent;
+            jest.spyOn(component, '$languageField').mockReturnValue(mockLanguageField);
 
             spectator.detectChanges();
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
@@ -460,8 +460,8 @@ describe('SearchComponent', () => {
             expect(label).toBe('site123');
         });
 
-        it('should truncate long labels to 70 characters', () => {
-            const longLabel = 'a'.repeat(75);
+        it('should truncate long labels to 45 characters', () => {
+            const longLabel = 'a'.repeat(45);
             const mockSiteField = {
                 siteControl: {
                     value: {
@@ -473,7 +473,7 @@ describe('SearchComponent', () => {
             jest.spyOn(component, '$siteField').mockReturnValue(mockSiteField);
 
             const label = component['getSiteDisplayLabel']('site123');
-            expect(label).toBe(longLabel.substring(0, 70) + '...');
+            expect(label).toBe(longLabel.substring(0, 45) + '...');
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
@@ -1,10 +1,16 @@
 import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
-import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 
-import { ReactiveFormsModule } from '@angular/forms';
+import { Component, forwardRef } from '@angular/core';
+import {
+    ControlValueAccessor,
+    FormControl,
+    NG_VALUE_ACCESSOR,
+    ReactiveFormsModule
+} from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
+import { ChipModule } from 'primeng/chip';
 import { DropdownModule } from 'primeng/dropdown';
 import { InputGroupModule } from 'primeng/inputgroup';
 import { InputTextModule } from 'primeng/inputtext';
@@ -17,8 +23,57 @@ import { DotEditContentService } from '@dotcms/edit-content/services/dot-edit-co
 import { DotMessagePipe } from '@dotcms/ui';
 import { MockDotMessageService, mockLocales } from '@dotcms/utils-testing';
 
-import { LanguageFieldComponent } from './components/language-field/language-field.component';
 import { SearchComponent } from './search.component';
+
+// Stub components for testing
+@Component({
+    selector: 'dot-language-field',
+    standalone: true,
+    template: '<input [formControlName]="null" />',
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: forwardRef(() => StubLanguageFieldComponent),
+            multi: true
+        }
+    ]
+})
+class StubLanguageFieldComponent implements ControlValueAccessor {
+    languageControl = new FormControl({ isoCode: 'en-US', id: 1 });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    writeValue(): void {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    registerOnChange(): void {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    registerOnTouched(): void {}
+}
+
+@Component({
+    selector: 'dot-site-field',
+    standalone: true,
+    template: '<input [formControlName]="null" />',
+    providers: [
+        {
+            provide: NG_VALUE_ACCESSOR,
+            useExisting: forwardRef(() => StubSiteFieldComponent),
+            multi: true
+        }
+    ]
+})
+class StubSiteFieldComponent implements ControlValueAccessor {
+    siteControl = new FormControl({
+        label: 'demo.dotcms.com',
+        data: { id: 'site123', type: 'site' }
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    writeValue(): void {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    registerOnChange(): void {}
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    registerOnTouched(): void {}
+}
 
 describe('SearchComponent', () => {
     let spectator: Spectator<SearchComponent>;
@@ -74,9 +129,11 @@ describe('SearchComponent', () => {
             DropdownModule,
             InputGroupModule,
             InputTextModule,
-            OverlayPanelModule
+            OverlayPanelModule,
+            ChipModule,
+            StubLanguageFieldComponent,
+            StubSiteFieldComponent
         ],
-        declarations: [MockComponent(LanguageFieldComponent)],
         mocks: [DotMessagePipe],
         detectChanges: true,
         providers: [
@@ -124,6 +181,310 @@ describe('SearchComponent', () => {
         });
     });
 
+    describe('Active Filters', () => {
+        beforeEach(() => {
+            // Set up mock for language field component
+            const mockLanguageField = {
+                languageControl: {
+                    value: { isoCode: 'en-US', id: 1 }
+                }
+            };
+            jest.spyOn(component, '$languageField').mockReturnValue(
+                mockLanguageField as typeof mockLanguageField
+            );
+
+            // Set up mock for site field component
+            const mockSiteField = {
+                siteControl: {
+                    value: {
+                        label: 'demo.dotcms.com',
+                        data: { id: 'site123', type: 'site' }
+                    }
+                }
+            };
+            jest.spyOn(component, '$siteField').mockReturnValue(
+                mockSiteField as typeof mockSiteField
+            );
+        });
+
+        it('should return empty filters when no active search params', () => {
+            expect(component.$activeFilters()).toEqual([]);
+        });
+
+        it('should show language filter when language is selected', () => {
+            component.$activeSearchParams.set({
+                query: 'test',
+                systemSearchableFields: { languageId: 1 }
+            });
+
+            const filters = component.$activeFilters();
+            expect(filters).toHaveLength(1);
+            expect(filters[0]).toEqual({
+                label: 'en-US',
+                value: 1,
+                type: 'language'
+            });
+        });
+
+        it('should show site filter when site is selected', () => {
+            component.$activeSearchParams.set({
+                query: 'test',
+                systemSearchableFields: { siteId: 'site123' }
+            });
+
+            const filters = component.$activeFilters();
+            expect(filters).toHaveLength(1);
+            expect(filters[0]).toEqual({
+                label: 'demo.dotcms.com',
+                value: 'site:site123',
+                type: 'site'
+            });
+        });
+
+        it('should show folder filter when folder is selected', () => {
+            component.$activeSearchParams.set({
+                query: 'test',
+                systemSearchableFields: { folderId: 'folder123' }
+            });
+
+            const filters = component.$activeFilters();
+            expect(filters).toHaveLength(1);
+            expect(filters[0]).toEqual({
+                label: 'demo.dotcms.com',
+                value: 'folder:folder123',
+                type: 'folder'
+            });
+        });
+
+        it('should show multiple filters when multiple are selected', () => {
+            component.$activeSearchParams.set({
+                query: 'test',
+                systemSearchableFields: {
+                    languageId: 1,
+                    siteId: 'site123'
+                }
+            });
+
+            const filters = component.$activeFilters();
+            expect(filters).toHaveLength(2);
+            expect(filters.some((f) => f.type === 'language')).toBe(true);
+            expect(filters.some((f) => f.type === 'site')).toBe(true);
+        });
+
+        it('should not show language filter when languageId is -1', () => {
+            component.$activeSearchParams.set({
+                query: 'test',
+                systemSearchableFields: { languageId: -1 }
+            });
+
+            const filters = component.$activeFilters();
+            expect(filters).toHaveLength(0);
+        });
+    });
+
+    describe('removeFilter', () => {
+        it('should remove language filter and trigger search', () => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            component.form.patchValue({
+                systemSearchableFields: { languageId: 1 }
+            });
+
+            component.removeFilter('language');
+
+            expect(component.form.get('systemSearchableFields.languageId')?.value).toBe(-1);
+            expect(searchSpy).toHaveBeenCalled();
+        });
+
+        it('should remove site filter and trigger search', () => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            component.form.patchValue({
+                systemSearchableFields: { siteOrFolderId: 'site:123' }
+            });
+
+            component.removeFilter('site');
+
+            expect(component.form.get('systemSearchableFields.siteOrFolderId')?.value).toBe('');
+            expect(searchSpy).toHaveBeenCalled();
+        });
+
+        it('should remove folder filter and trigger search', () => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            component.form.patchValue({
+                systemSearchableFields: { siteOrFolderId: 'folder:123' }
+            });
+
+            component.removeFilter('folder');
+
+            expect(component.form.get('systemSearchableFields.siteOrFolderId')?.value).toBe('');
+            expect(searchSpy).toHaveBeenCalled();
+        });
+    });
+
+    describe('getValues', () => {
+        it('should handle site type correctly', () => {
+            component.form.patchValue({
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2,
+                    siteOrFolderId: 'site:site123'
+                }
+            });
+
+            const result = component.getValues();
+
+            expect(result).toEqual({
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2,
+                    siteId: 'site123'
+                }
+            });
+        });
+
+        it('should handle folder type correctly', () => {
+            component.form.patchValue({
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2,
+                    siteOrFolderId: 'folder:folder123'
+                }
+            });
+
+            const result = component.getValues();
+
+            expect(result).toEqual({
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2,
+                    folderId: 'folder123'
+                }
+            });
+        });
+
+        it('should handle empty siteOrFolderId', () => {
+            component.form.patchValue({
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2,
+                    siteOrFolderId: ''
+                }
+            });
+
+            const result = component.getValues();
+
+            expect(result).toEqual({
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2
+                }
+            });
+        });
+
+        it('should handle malformed siteOrFolderId (no colon)', () => {
+            component.form.patchValue({
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2,
+                    siteOrFolderId: 'invalidformat'
+                }
+            });
+
+            const result = component.getValues();
+
+            expect(result).toEqual({
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2
+                }
+            });
+        });
+
+        it('should filter out empty values and -1', () => {
+            component.form.patchValue({
+                query: '',
+                systemSearchableFields: {
+                    languageId: -1,
+                    siteOrFolderId: ''
+                }
+            });
+
+            const result = component.getValues();
+
+            expect(result).toEqual({
+                query: '',
+                systemSearchableFields: {}
+            });
+        });
+    });
+
+    describe('Display Label Methods', () => {
+        it('should get language display label from control value', () => {
+            const mockLanguageField = {
+                languageControl: {
+                    value: { isoCode: 'en-US', id: 1 }
+                }
+            };
+            jest.spyOn(component, '$languageField').mockReturnValue(
+                mockLanguageField as typeof mockLanguageField
+            );
+
+            const label = component['getLanguageDisplayLabel'](1);
+            expect(label).toBe('en-US');
+        });
+
+        it('should fallback to language ID when no control value', () => {
+            jest.spyOn(component, '$languageField').mockReturnValue(null);
+
+            const label = component['getLanguageDisplayLabel'](1);
+            expect(label).toBe('Language Id: 1');
+        });
+
+        it('should get site display label from control value', () => {
+            const mockSiteField = {
+                siteControl: {
+                    value: {
+                        label: 'demo.dotcms.com',
+                        data: { id: 'site123', type: 'site' }
+                    }
+                }
+            };
+            jest.spyOn(component, '$siteField').mockReturnValue(
+                mockSiteField as typeof mockSiteField
+            );
+
+            const label = component['getSiteDisplayLabel']('site123');
+            expect(label).toBe('demo.dotcms.com');
+        });
+
+        it('should fallback to ID when no control value', () => {
+            jest.spyOn(component, '$siteField').mockReturnValue(null);
+
+            const label = component['getSiteDisplayLabel']('site123');
+            expect(label).toBe('site123');
+        });
+
+        it('should truncate long labels to 70 characters', () => {
+            const longLabel = 'a'.repeat(75);
+            const mockSiteField = {
+                siteControl: {
+                    value: {
+                        label: longLabel,
+                        data: { id: 'site123', type: 'site' }
+                    }
+                }
+            };
+            jest.spyOn(component, '$siteField').mockReturnValue(
+                mockSiteField as typeof mockSiteField
+            );
+
+            const label = component['getSiteDisplayLabel']('site123');
+            expect(label).toBe(longLabel.substring(0, 70) + '...');
+        });
+    });
+
     describe('clearForm', () => {
         beforeEach(() => {
             // Set some values in the form
@@ -155,6 +516,25 @@ describe('SearchComponent', () => {
             component.clearForm();
 
             expect(hideSpy).toHaveBeenCalled();
+        });
+
+        it('should clear active search parameters', () => {
+            component.$activeSearchParams.set({
+                query: 'test',
+                systemSearchableFields: { languageId: 1 }
+            });
+
+            component.clearForm();
+
+            expect(component.$activeSearchParams()).toEqual({});
+        });
+
+        it('should emit empty search', () => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            component.clearForm();
+
+            expect(searchSpy).toHaveBeenCalledWith({});
         });
     });
 
@@ -218,6 +598,28 @@ describe('SearchComponent', () => {
                 query: '',
                 systemSearchableFields: {}
             });
+        });
+
+        it('should update active search parameters', () => {
+            const searchParams = {
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2,
+                    siteId: 'site123'
+                }
+            };
+
+            component.form.patchValue({
+                query: 'test search',
+                systemSearchableFields: {
+                    languageId: 2,
+                    siteOrFolderId: 'site:site123'
+                }
+            });
+
+            component.doSearch();
+
+            expect(component.$activeSearchParams()).toEqual(searchParams);
         });
 
         it('should set isLoading to true when search is performed', () => {
@@ -325,6 +727,62 @@ describe('SearchComponent', () => {
                     siteOrFolderId: ''
                 }
             });
+        });
+
+        it('should display filter chips when filters are active', () => {
+            component.$activeSearchParams.set({
+                query: 'test',
+                systemSearchableFields: {
+                    languageId: 1,
+                    siteId: 'site123'
+                }
+            });
+
+            // Mock the child components to return values
+            const mockLanguageField = {
+                languageControl: { value: { isoCode: 'en-US', id: 1 } }
+            };
+            const mockSiteField = {
+                siteControl: { value: { label: 'demo.dotcms.com' } }
+            };
+            jest.spyOn(component, '$languageField').mockReturnValue(
+                mockLanguageField as typeof mockLanguageField
+            );
+            jest.spyOn(component, '$siteField').mockReturnValue(
+                mockSiteField as typeof mockSiteField
+            );
+
+            spectator.detectChanges();
+
+            const chips = spectator.queryAll('p-chip');
+            expect(chips.length).toBe(2);
+        });
+
+        it('should remove filter when chip is removed', () => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            component.$activeSearchParams.set({
+                query: 'test',
+                systemSearchableFields: { languageId: 1 }
+            });
+
+            // Mock the child components
+            const mockLanguageField = {
+                languageControl: { value: { isoCode: 'en-US', id: 1 } }
+            };
+            jest.spyOn(component, '$languageField').mockReturnValue(
+                mockLanguageField as typeof mockLanguageField
+            );
+
+            spectator.detectChanges();
+
+            const chip = spectator.query('p-chip');
+            expect(chip).toBeTruthy();
+
+            // Simulate chip removal
+            component.removeFilter('language');
+
+            expect(searchSpy).toHaveBeenCalled();
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
@@ -1,7 +1,8 @@
-import { Component, inject, input, output, viewChild } from '@angular/core';
+import { Component, inject, input, output, viewChild, signal, computed } from '@angular/core';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
+import { ChipModule } from 'primeng/chip';
 import { DropdownModule } from 'primeng/dropdown';
 import { InputGroupModule } from 'primeng/inputgroup';
 import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
@@ -9,6 +10,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
 
 import { SearchParams } from '@dotcms/edit-content/fields/dot-edit-content-relationship-field/models/search.model';
+import { TreeNodeItem } from '@dotcms/edit-content/models/dot-edit-content-host-folder-field.interface';
 import { DotMessagePipe } from '@dotcms/ui';
 
 import { LanguageFieldComponent } from './components/language-field/language-field.component';
@@ -36,7 +38,8 @@ import { SiteFieldComponent } from './components/site-field/site-field.component
         ReactiveFormsModule,
         LanguageFieldComponent,
         SiteFieldComponent,
-        InputGroupAddonModule
+        InputGroupAddonModule,
+        ChipModule
     ],
     templateUrl: './search.component.html'
 })
@@ -45,6 +48,16 @@ export class SearchComponent {
      * Reference to the OverlayPanel component used for advanced search options.
      */
     $overlayPanel = viewChild(OverlayPanel);
+
+    /**
+     * Reference to the language field component to access its store.
+     */
+    $languageField = viewChild(LanguageFieldComponent);
+
+    /**
+     * Reference to the site field component to access its store.
+     */
+    $siteField = viewChild(SiteFieldComponent);
 
     /**
      * Output signal that emits search parameters when the search is performed.
@@ -56,6 +69,54 @@ export class SearchComponent {
      * Input signal that indicates if the search is loading.
      */
     $isLoading = input.required<boolean>({ alias: 'isLoading' });
+
+    /**
+     * Signal that stores the currently active search parameters.
+     * Updated only when a search is actually performed.
+     */
+    $activeSearchParams = signal<SearchParams>({});
+
+    /**
+     * Computed property that returns active filters based on the last executed search.
+     */
+    $activeFilters = computed(() => {
+        const searchParams = this.$activeSearchParams();
+        const filters = [];
+
+        if (!searchParams.systemSearchableFields) return filters;
+
+        // Language filter
+        const languageId = searchParams.systemSearchableFields.languageId;
+        if (languageId && languageId !== -1) {
+            filters.push({
+                label: this.getLanguageDisplayLabel(languageId as number),
+                value: languageId,
+                type: 'language'
+            });
+        }
+
+        // Site filter
+        const siteId = searchParams.systemSearchableFields.siteId as string;
+        if (siteId) {
+            filters.push({
+                label: this.getSiteDisplayLabel(siteId),
+                value: `site:${siteId}`,
+                type: 'site'
+            });
+        }
+
+        // Folder filter
+        const folderId = searchParams.systemSearchableFields.folderId as string;
+        if (folderId) {
+            filters.push({
+                label: this.getSiteDisplayLabel(folderId),
+                value: `folder:${folderId}`,
+                type: 'folder'
+            });
+        }
+
+        return filters;
+    });
 
     /**
      * FormBuilder instance for creating reactive forms.
@@ -78,23 +139,32 @@ export class SearchComponent {
     });
 
     /**
-     * Resets the search form to its initial state and optionally toggles the overlay panel.
+     * Resets the search form to its initial state and clears active filters.
      *
      * @param event - Optional mouse event that triggered the clear action
      */
     clearForm() {
         this.form.reset();
         this.$overlayPanel().hide();
+
+        // Clear active search parameters
+        this.$activeSearchParams.set({});
+
         this.onSearch.emit({});
     }
 
     /**
      * Performs the search by emitting the current form values and hiding the overlay panel.
+     * Also updates the active search parameters for tag display.
      * This method is triggered when the user submits the search form.
      */
     doSearch() {
         this.$overlayPanel().hide();
         const values = this.getValues();
+
+        // Update the active search parameters
+        this.$activeSearchParams.set(values);
+
         this.onSearch.emit(values);
     }
 
@@ -158,5 +228,54 @@ export class SearchComponent {
             },
             {} as Record<string, unknown>
         );
+    }
+
+    /**
+     * Removes a specific filter and performs a new search.
+     *
+     * @param filterType - The type of filter to remove ('language' | 'site' | 'folder')
+     */
+    removeFilter(filterType: 'language' | 'site' | 'folder') {
+        if (filterType === 'language') {
+            this.form.get('systemSearchableFields.languageId')?.setValue(-1);
+        } else {
+            this.form.get('systemSearchableFields.siteOrFolderId')?.setValue('');
+        }
+
+        this.doSearch();
+    }
+
+    /**
+     * Gets a display-friendly label for the language filter.
+     *
+     * @param languageId - The language ID
+     * @returns A formatted label for display
+     */
+    private getLanguageDisplayLabel(languageId: number): string {
+        const languageValue = this.$languageField()?.languageControl?.value;
+
+        return languageValue?.isoCode || `Language Id: ${languageId}`;
+    }
+
+    /**
+     * Gets a display-friendly label for the site/folder filter.
+     *
+     * @param siteOrFolderId - The site or folder ID in format "type:id"
+     * @returns A formatted label for display, truncated to 70 characters with ellipsis if needed
+     */
+    private getSiteDisplayLabel(siteOrFolderId: string): string {
+        const siteFieldValue = this.$siteField()?.siteControl?.value as TreeNodeItem;
+        let label: string;
+
+        // Try to get the site/folder name from the child component if available
+        if (siteFieldValue) {
+            label = siteFieldValue.label;
+        } else {
+            // Fallback to ID only
+            label = siteOrFolderId;
+        }
+
+        // Truncate if longer than 70 characters
+        return label.length > 70 ? label.substring(0, 70) + '...' : label;
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
@@ -16,6 +16,12 @@ import { DotMessagePipe } from '@dotcms/ui';
 import { LanguageFieldComponent } from './components/language-field/language-field.component';
 import { SiteFieldComponent } from './components/site-field/site-field.component';
 
+interface ActiveFilter {
+    label: string;
+    value: string | number;
+    type: string;
+}
+
 /**
  * A standalone component that provides search functionality with language and site filtering.
  * This component includes a search input field and advanced filtering options through an overlay panel.
@@ -41,23 +47,24 @@ import { SiteFieldComponent } from './components/site-field/site-field.component
         InputGroupAddonModule,
         ChipModule
     ],
+    styleUrls: ['./search.component.scss'],
     templateUrl: './search.component.html'
 })
 export class SearchComponent {
     /**
      * Reference to the OverlayPanel component used for advanced search options.
      */
-    $overlayPanel = viewChild(OverlayPanel);
+    $overlayPanel = viewChild.required(OverlayPanel);
 
     /**
      * Reference to the language field component to access its store.
      */
-    $languageField = viewChild(LanguageFieldComponent);
+    $languageField = viewChild.required(LanguageFieldComponent);
 
     /**
      * Reference to the site field component to access its store.
      */
-    $siteField = viewChild(SiteFieldComponent);
+    $siteField = viewChild.required(SiteFieldComponent);
 
     /**
      * Output signal that emits search parameters when the search is performed.
@@ -81,12 +88,12 @@ export class SearchComponent {
      */
     $activeFilters = computed(() => {
         const searchParams = this.$activeSearchParams();
-        const filters = [];
+        const filters: ActiveFilter[] = [];
 
         if (!searchParams.systemSearchableFields) return filters;
 
         // Language filter
-        const languageId = searchParams.systemSearchableFields.languageId;
+        const languageId = searchParams.systemSearchableFields.languageId as number;
         if (languageId && languageId !== -1) {
             filters.push({
                 label: this.getLanguageDisplayLabel(languageId as number),
@@ -261,7 +268,7 @@ export class SearchComponent {
      * Gets a display-friendly label for the site/folder filter.
      *
      * @param siteOrFolderId - The site or folder ID in format "type:id"
-     * @returns A formatted label for display, truncated to 70 characters with ellipsis if needed
+     * @returns A formatted label for display, truncated to 45 characters with ellipsis if needed
      */
     private getSiteDisplayLabel(siteOrFolderId: string): string {
         const siteFieldValue = this.$siteField()?.siteControl?.value as TreeNodeItem;
@@ -275,7 +282,7 @@ export class SearchComponent {
             label = siteOrFolderId;
         }
 
-        // Truncate if longer than 70 characters
-        return label.length > 70 ? label.substring(0, 70) + '...' : label;
+        // Truncate if 45 characters or longer
+        return label.length >= 45 ? label.substring(0, 45) + '...' : label;
     }
 }


### PR DESCRIPTION
### Proposed Changes
*  Support active filters as chips in search input 


### Screenshots

https://github.com/user-attachments/assets/521e441e-5a6f-484b-a33e-1084e61b80f4


This PR fixes: #31773

This PR fixes: #31773