### PR TITLE
fix(frontend): NX dependency graph fails on clean builds due to Vite timestamp file references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,8 +183,8 @@ dotCMS/dependencies.gradle
 .cursorignore
 
 # Vite config timestamp files
-**/*vite.config*.timestamp-*.mjs
-**/*vite.config*.timestamp-*.ts
+vite.config.*.timestamp*
+vitest.config.*.timestamp*
 
 # Examples package-lock.json
 examples/nextjs/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -183,8 +183,8 @@ dotCMS/dependencies.gradle
 .cursorignore
 
 # Vite config timestamp files
-vite.config.*.timestamp*
-vitest.config.*.timestamp*
+**/*vite.config*.timestamp*
+**/*vitest.config*.timestamp*
 
 # Examples package-lock.json
 examples/nextjs/package-lock.json

--- a/core-web/nx.json
+++ b/core-web/nx.json
@@ -173,7 +173,11 @@
         }
     ],
     "defaultBase": "main",
-    "ignorePatterns": ["**/node_modules"],
+    "ignorePatterns": [
+        "**/node_modules",
+        "**/*vite.config*.timestamp-*.mjs",
+        "**/*vite.config*.timestamp-*.ts"
+    ],
     "release": {
         "version": {
             "preVersionCommand": "yarn nx run-many -t build"

--- a/core-web/nx.json
+++ b/core-web/nx.json
@@ -175,8 +175,8 @@
     "defaultBase": "main",
     "ignorePatterns": [
         "**/node_modules",
-        "**/vite.config.*.timestamp*",
-        "**/vitest.config.*.timestamp*"
+        "**/*vite.config*.timestamp*",
+        "**/*vitest.config*.timestamp*"
     ],
     "release": {
         "version": {

--- a/core-web/nx.json
+++ b/core-web/nx.json
@@ -175,8 +175,8 @@
     "defaultBase": "main",
     "ignorePatterns": [
         "**/node_modules",
-        "**/*vite.config*.timestamp-*.mjs",
-        "**/*vite.config*.timestamp-*.ts"
+        "**/vite.config.*.timestamp*",
+        "**/vitest.config.*.timestamp*"
     ],
     "release": {
         "version": {


### PR DESCRIPTION
## Problem

When running `just build` from a clean repository, the build fails in the core-web module with:

```
NX   Failed to process project graph. Run "nx reset" to fix this.
The "nx/js/dependencies-and-lockfile" plugin threw an error while creating dependencies:
Error: "Unable to load /path/to/vite.config.mts.timestamp-*.mjs: No such file or directory"
```

## Root Cause

NX's dependency graph creation tries to reference Vite's temporary timestamp files that are:
- Ephemeral build artifacts created by Vite during compilation
- Already properly gitignored (lines 185-187 in .gitignore)
- Not guaranteed to exist during clean builds from fresh checkouts

## Solution
updated Vite timestamp file patterns to .gitignore

```
# Vite config timestamp files
**/*vite.config*.timestamp*
**/*vitest.config*.timestamp*
```

Added Vite timestamp file patterns to NX's `ignorePatterns` in `core-web/nx.json`:


```json
"ignorePatterns": [
        "**/node_modules",
        "**/vite.config.*.timestamp*",
        "**/vitest.config.*.timestamp*"
    ]
```

## Impact

- ✅ Eliminates manual `npx nx reset` requirement before builds
- ✅ Makes clean builds reliable and repeatable  
- ✅ No functional changes to application runtime behavior
- ✅ Prevents build failures from stale cache references
- ✅ Improves developer experience on fresh checkouts

## Testing

- [x] Verified clean build that previously failed now succeeds
- [x] Confirmed no impact on existing functionality
- [x] Build artifacts remain unchanged

Closes #32864

This PR fixes: #32864