### PR TITLE
Update LICENSE date

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -41,7 +41,7 @@ For example:
    Development: an instance that is set up for an internal evaluation.
    Development: A local instance used to develop a new plugin or website.
 
-Change Date:     Four years from June 01, 2025
+Change Date:     Four years from August 01, 2025
 
 Change License:  GNU General Public License (GPL) v3
 


### PR DESCRIPTION
beep boop beep boop... Steve-bot here 

Something's wrong with my automation in #32090 and the license date hasn't been updating automatically.  I'll go sort that out but in the meantime, it's been two months so this PR updates the text of the BSL license to be `August 1st, 2025`