### PR TITLE
fix(core): Setting the user as part of the request and session

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/bundlers/AbstractServletBundler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/bundlers/AbstractServletBundler.java
@@ -25,6 +25,7 @@ import com.dotmarketing.util.RegEX;
 import com.dotmarketing.util.RegExMatch;
 import com.dotmarketing.util.WebKeys;
 
+import com.liferay.portal.model.User;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileFilter;
@@ -139,7 +140,7 @@ public abstract class AbstractServletBundler implements IBundler {
 		for(String url : bins.keySet()){
 			BinFileExportStruc binFile = bins.get(url);
 			try {
-				writeBinFile(binFile, output);
+				writeBinFile(binFile, output, APILocator.getUserAPI().getSystemUser());
 			} catch (Exception e) {
 				Logger.error(AbstractServletBundler.class,e.getMessage(), e);
 			}
@@ -307,10 +308,12 @@ public abstract class AbstractServletBundler implements IBundler {
 	 * this method takes a URI as a String from the dotCMS and then writes the output to
 	 * the file specified on the destPath
 	 * @param binFile
+	 * @param bundleOutput
+	 * @param user
 	 * @throws IOException
 	 * @throws ServletException
 	 */
-	private void writeBinFile(final BinFileExportStruc binFile, final BundleOutput bundleOutput) throws IOException {
+	private void writeBinFile(final BinFileExportStruc binFile, final BundleOutput bundleOutput, final User user) throws IOException {
 
 		if(binFile.getUri() ==null || binFile.getBinFile() ==null || binFile.getBinFile().exists() ){
 			return;
@@ -325,6 +328,7 @@ public abstract class AbstractServletBundler implements IBundler {
 		request.setRequestURI(uri);
 		request.setAttribute(WebKeys.CURRENT_HOST, binFile.getHost());
 		request.setAttribute(WebKeys.HTMLPAGE_LANGUAGE, binFile.getLanguage());
+		request.setAttribute(com.liferay.portal.util.WebKeys.USER, user);
 
 		try (final OutputStream outputStream = bundleOutput.addFile(binFile.getBinFile().getPath())) {
 			response.setOutputStream(

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/HTMLPageAssetAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/htmlpageasset/business/HTMLPageAssetAPIImpl.java
@@ -856,6 +856,7 @@ public class HTMLPageAssetAPIImpl implements HTMLPageAssetAPI {
             LanguageWebAPI langWebAPI = WebAPILocator.getLanguageWebAPI();
             langWebAPI.checkSessionLocale(requestProxy);
 
+            requestProxy.getSession().setAttribute(com.liferay.portal.util.WebKeys.USER, user);
             requestProxy.getSession().setAttribute(com.liferay.portal.util.WebKeys.USER_ID, user.getUserId());
             requestProxy.setAttribute(com.liferay.portal.util.WebKeys.USER, user);
             return VelocityModeHandler.modeHandler(mode, requestProxy, responseProxy).eval();


### PR DESCRIPTION
### Proposed Changes
* The fix modifies how user context is handled during bundle generation. It ensures the appropriate user (system user) is associated with the request during static operations
* The AbstractServletBundler.java was modified to send the user as part of the request. This change prevented a NullPointerException in [this line](https://github.com/dotCMS/core/blob/main/dotCMS/src/main/java/com/dotcms/csspreproc/CSSPreProcessServlet.java#L320) 

Refs: #32877 

This PR fixes: #32877