### PR TITLE
fix(e2e): Fix e2e test failure reporting in CI/CD pipeline

### DIFF
--- a/.github/actions/core-cicd/maven-job/action.yml
+++ b/.github/actions/core-cicd/maven-job/action.yml
@@ -200,6 +200,7 @@ runs:
       name: Run Maven Build
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
       run: |
+        set -e  # Exit on any command failure
         DEFAULT_ARGS="-e -B --no-transfer-progress --show-version -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dprod=true"
         MAVEN_ARGS="${{ inputs.maven-args }}"
         if [[ "${{ inputs.generate-docker }}" == "true" ]]; then

--- a/.github/workflows/cicd_comp_finalize-phase.yml
+++ b/.github/workflows/cicd_comp_finalize-phase.yml
@@ -74,20 +74,22 @@ jobs:
           if workflow_response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" 2>/dev/null); then
             
-            # Parse job information safely
-            workflow_jobs=$(echo "$workflow_response" | jq -r '.jobs[]? | "\(.name // "unknown"):\(.status // "unknown"):\(.conclusion // "null")"' 2>/dev/null)
-            
-            if [[ -n "$workflow_jobs" ]]; then
+            # Parse job information safely using jq to avoid colon parsing issues
+            if [[ -n "$workflow_response" ]]; then
               echo "All workflow jobs:"
-              echo "$workflow_jobs"
+              echo "$workflow_response" | jq -r '.jobs[]? | "Name: \(.name // "unknown"), Status: \(.status // "unknown"), Conclusion: \(.conclusion // "null")"' 2>/dev/null
               
               # Check for any cancelled or failed jobs in the entire workflow
-              while IFS= read -r job_info; do
-                if [[ -z "$job_info" ]]; then continue; fi
+              # Use temporary file for broader shell compatibility
+              temp_jobs_file=$(mktemp)
+              echo "$workflow_response" | jq -c '.jobs[]?' 2>/dev/null > "$temp_jobs_file"
+              
+              while read -r job_data; do
+                if [[ -z "$job_data" ]]; then continue; fi
                 
-                job_name=$(echo "$job_info" | cut -d: -f1)
-                job_status=$(echo "$job_info" | cut -d: -f2)
-                job_conclusion=$(echo "$job_info" | cut -d: -f3)
+                job_name=$(echo "$job_data" | jq -r '.name // "unknown"')
+                job_status=$(echo "$job_data" | jq -r '.status // "unknown"')
+                job_conclusion=$(echo "$job_data" | jq -r '.conclusion // "null"')
                 
                 # Skip the finalize job itself and related jobs to avoid self-reference
                 if [[ "$job_name" =~ ^(Finalize|Final Status|.*[Ff]inalize.*)$ ]]; then
@@ -112,7 +114,10 @@ jobs:
                 elif [[ "$job_status" == "in_progress" || "$job_status" == "queued" ]]; then
                   echo "Job $job_name is still running (status: $job_status), will rely on dependency data"
                 fi
-              done <<< "$workflow_jobs"
+              done < "$temp_jobs_file"
+              
+              # Clean up temporary file
+              rm -f "$temp_jobs_file"
             else
               echo "Warning: No job data returned from API, using dependency data only"
             fi

--- a/.github/workflows/cicd_comp_finalize-phase.yml
+++ b/.github/workflows/cicd_comp_finalize-phase.yml
@@ -50,9 +50,11 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           NEEDS_DATA: ${{ inputs.needsData }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "NEEDS_DATA=${NEEDS_DATA}"
-          # Check for 'cancelled' and 'failure' results
+          
+          # Check for 'cancelled' and 'failure' results from direct dependencies
           cancelled=false
           failure=false
           
@@ -63,9 +65,63 @@ jobs:
             failure=true
           fi
 
-          # Output the results
-          echo "Cancelled: $cancelled"
-          echo "Failure: $failure"
+          echo "Direct dependencies - Cancelled: $cancelled, Failure: $failure"
+          
+          # Enhanced detection: Check ALL jobs in the current workflow run via GitHub API
+          echo "Checking all workflow jobs via GitHub API..."
+          
+          # Fetch workflow jobs with error handling
+          if workflow_response=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" 2>/dev/null); then
+            
+            # Parse job information safely
+            workflow_jobs=$(echo "$workflow_response" | jq -r '.jobs[]? | "\(.name // "unknown"):\(.status // "unknown"):\(.conclusion // "null")"' 2>/dev/null)
+            
+            if [[ -n "$workflow_jobs" ]]; then
+              echo "All workflow jobs:"
+              echo "$workflow_jobs"
+              
+              # Check for any cancelled or failed jobs in the entire workflow
+              while IFS= read -r job_info; do
+                if [[ -z "$job_info" ]]; then continue; fi
+                
+                job_name=$(echo "$job_info" | cut -d: -f1)
+                job_status=$(echo "$job_info" | cut -d: -f2)
+                job_conclusion=$(echo "$job_info" | cut -d: -f3)
+                
+                # Skip the finalize job itself and related jobs to avoid self-reference
+                if [[ "$job_name" =~ ^(Finalize|Final Status|.*[Ff]inalize.*)$ ]]; then
+                  continue
+                fi
+                
+                echo "Checking job: $job_name (status: $job_status, conclusion: $job_conclusion)"
+                
+                # Only check conclusion for completed jobs (status API is reliable)
+                if [[ "$job_status" == "completed" ]]; then
+                  # Detect cancelled jobs (only conclusion can be "cancelled")
+                  if [[ "$job_conclusion" == "cancelled" ]]; then
+                    echo "Found cancelled job: $job_name"
+                    cancelled=true
+                  fi
+                  
+                  # Detect failed jobs (conclusion: failure)
+                  if [[ "$job_conclusion" == "failure" ]]; then
+                    echo "Found failed job: $job_name"
+                    failure=true
+                  fi
+                elif [[ "$job_status" == "in_progress" || "$job_status" == "queued" ]]; then
+                  echo "Job $job_name is still running (status: $job_status), will rely on dependency data"
+                fi
+              done <<< "$workflow_jobs"
+            else
+              echo "Warning: No job data returned from API, using dependency data only"
+            fi
+          else
+            echo "Warning: Failed to fetch workflow jobs from API, using dependency data only"
+          fi
+
+          # Output the final results
+          echo "Final status - Cancelled: $cancelled, Failure: $failure"
           
           AGGREGATE_STATUS="SUCCESS"
           FIRST_FAIL_STEP=""

--- a/e2e/dotcms-e2e-node/frontend/package.json
+++ b/e2e/dotcms-e2e-node/frontend/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "show-report": "if [[ \"$CURRENT_ENV\" != \"ci\" ]]; then yarn playwright show-report; fi",
-    "start": "PLAYWRIGHT_JUNIT_SUITE_ID=nodee2etestsuite PLAYWRIGHT_JUNIT_SUITE_NAME='E2E Node Test Suite' PLAYWRIGHT_JUNIT_OUTPUT_FILE='../target/failsafe-reports/TEST-e2e-node-results.xml' yarn playwright test ${PLAYWRIGHT_SPECIFIC} ${PLAYWRIGHT_DEBUG}; yarn run show-report",
+    "start": "PLAYWRIGHT_JUNIT_SUITE_ID=nodee2etestsuite PLAYWRIGHT_JUNIT_SUITE_NAME='E2E Node Test Suite' PLAYWRIGHT_JUNIT_OUTPUT_FILE='../target/failsafe-reports/TEST-e2e-node-results.xml' yarn playwright test ${PLAYWRIGHT_SPECIFIC} ${PLAYWRIGHT_DEBUG}; EXIT_CODE=$?; yarn run show-report; exit $EXIT_CODE",
     "start-local": "CURRENT_ENV=local yarn run start",
     "start-dev": "CURRENT_ENV=dev yarn run start",
     "start-ci": "CURRENT_ENV=ci yarn run start",


### PR DESCRIPTION
## Summary

Fixes critical issue where e2e tests were failing but the CI/CD pipeline was reporting success, causing false positive build notifications.

## Problem

The CI/CD system was incorrectly reporting "all tests passed" when e2e tests were actually failing. This occurred due to two separate issues:

1. **E2E Node Test Exit Code Loss**: The Playwright test script wasn't preserving failure exit codes
2. **Maven Job Fail-Fast Missing**: The Maven job action lacked proper error handling

This caused failed e2e tests to be reported as successful builds, leading to false confidence in test results.

## Root Cause Analysis

### Issue 1: E2E Node Test Script (package.json)
**Before (broken):**
```bash
yarn playwright test; yarn run show-report
```

**Problem**: When Playwright tests failed, the exit code was lost because the script continued to `yarn run show-report` without preserving the original failure status.

### Issue 2: Maven Job Action 
**Before (broken):**
```bash
# No fail-fast behavior in shell script
```

**Problem**: The shell script didn't exit immediately on command failures, allowing failed builds to continue and potentially report success.

## Solution

### Fix 1: Preserve E2E Test Exit Codes
Updated `e2e/dotcms-e2e-node/frontend/package.json`:

```bash
# FIXED: Capture exit code and re-exit with it
yarn playwright test; EXIT_CODE=$?; yarn run show-report; exit $EXIT_CODE
```

### Fix 2: Add Fail-Fast Behavior  
Updated `.github/actions/core-cicd/maven-job/action.yml`:

```bash
set -e  # Exit immediately on any command failure
```

### Fix 3: Enhanced Finalize Phase Detection
Enhanced the finalize phase workflow to better detect failed and cancelled jobs through:
- Dual detection strategy (direct dependencies + GitHub API)
- Comprehensive status checking for all workflow jobs
- Robust error handling with fallback mechanisms

## Key Changes

### E2E Test Reporting Fix
- **File**: `e2e/dotcms-e2e-node/frontend/package.json`
- **Change**: Added `EXIT_CODE=$?; ... exit $EXIT_CODE` to preserve test failure codes
- **Impact**: Failed e2e tests now properly fail the Maven build

### Maven Job Reliability  
- **File**: `.github/actions/core-cicd/maven-job/action.yml`
- **Change**: Added `set -e` for immediate exit on failures
- **Impact**: Build failures are now properly propagated to CI system

### Finalize Phase Enhancement
- **File**: `.github/workflows/cicd_comp_finalize-phase.yml`
- **Change**: Enhanced job status detection via GitHub API
- **Impact**: More reliable detection of cancelled and failed jobs

## Testing Verification

To verify this fix works:

1. **E2E Test Failure Scenario**:
   ```bash
   # Run e2e tests that should fail
   ./mvnw verify -pl :dotcms-e2e-node -De2e.test.skip=false
   # Should now properly exit with failure code
   ```

2. **Integration Test**:
   - Failed e2e tests should now fail the Maven build
   - CI/CD system should report build failure (not success)
   - Finalize phase should detect and report FAILURE status

3. **Success Scenario**:
   - Passing tests should still report SUCCESS
   - No regression in successful build reporting

## Files Changed

- `e2e/dotcms-e2e-node/frontend/package.json`: Fix e2e test exit code preservation  
- `.github/actions/core-cicd/maven-job/action.yml`: Add fail-fast behavior
- `.github/workflows/cicd_comp_finalize-phase.yml`: Enhanced status detection

## Impact

This fix ensures:
- ✅ Failed e2e tests properly fail CI builds
- ✅ No more false positive "all tests passed" notifications  
- ✅ Accurate build status reporting in GitHub and notifications
- ✅ Reliable test result interpretation for development teams

Closes #32845

🤖 Generated with [Claude Code](https://claude.ai/code)

This PR fixes: #32845