### PR TITLE
Cloning cache object in the ContentletCache

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletCacheImpl.java
@@ -13,6 +13,7 @@ import com.dotmarketing.business.DotCacheException;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.util.Logger;
+import org.apache.commons.lang.SerializationUtils;
 
 /**
  * @author Jason Tesser
@@ -92,11 +93,13 @@ public class ContentletCacheImpl extends ContentletCache {
 		}catch (DotCacheException e) {
 			Logger.debug(this, "Cache Entry not found", e);
 		}
-		return content;
+		return (Contentlet) SerializationUtils.clone(content);
 	}
 
 	/* (non-Javadoc)
      * @see com.dotmarketing.business.PermissionCache#clearCache()
+
+
      */
 	public void clearCache() {
 		// clear the cache

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletCacheImpl.java
@@ -12,6 +12,7 @@ import com.dotmarketing.business.DotCacheAdministrator;
 import com.dotmarketing.business.DotCacheException;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import org.apache.commons.lang.SerializationUtils;
 
@@ -20,6 +21,8 @@ import org.apache.commons.lang.SerializationUtils;
  * @since 1.6
  */
 public class ContentletCacheImpl extends ContentletCache {
+
+	private static final String ENABLED_CLONED_CACHED_CONTENTLET = "ENABLED_CLONED_CACHED_CONTENTLET";
 
 	private DotCacheAdministrator cache;
 
@@ -93,7 +96,11 @@ public class ContentletCacheImpl extends ContentletCache {
 		}catch (DotCacheException e) {
 			Logger.debug(this, "Cache Entry not found", e);
 		}
-		return (Contentlet) SerializationUtils.clone(content);
+
+		boolean enabledClonedCachedContentlet =
+				Config.getBooleanProperty(ENABLED_CLONED_CACHED_CONTENTLET, false);
+
+		return enabledClonedCachedContentlet ? (Contentlet) SerializationUtils.clone(content) : content;
 	}
 
 	/* (non-Javadoc)

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletCacheImpl.java
@@ -100,7 +100,8 @@ public class ContentletCacheImpl extends ContentletCache {
 		boolean enabledClonedCachedContentlet =
 				Config.getBooleanProperty(ENABLED_CLONED_CACHED_CONTENTLET, false);
 
-		return enabledClonedCachedContentlet ? (Contentlet) SerializationUtils.clone(content) : content;
+		return enabledClonedCachedContentlet && content != null
+				? (Contentlet) SerializationUtils.clone(content) : content;
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
### Proposed Changes
* Clone any Contentlet take from the ContentletCache in this way we are going to avoid that the Contentlet in Cached get changed

This PR fixes: #32894
