### PR TITLE
Fixed workflow dropdown on content search

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
@@ -370,9 +370,10 @@
                     data: dataItems
                 });
 
-                if (null != aFilteringSelect) {
-
-                    aFilteringSelect.set('store', dojoSchemeStore);
+                // Update widget - either the provided one or find by ID
+                var widget = aFilteringSelect || dijit.byId('scheme_id');
+                if (null != widget) {
+                    widget.set('store', dojoSchemeStore);
                 }
             }
         }
@@ -384,8 +385,6 @@
 
         reloadSchemeStore(aFilteringSelect, dijit.byId("structure_inode")?dijit.byId("structure_inode").getValue():null);
     }
-
-    reloadSchemeStore(null, "<%=structureSelected%>");
 
     // Workflow Steps
     var dojoStepsStore = null;
@@ -489,7 +488,6 @@
                 id: "scheme_id",
                 name: "scheme_id_select",
                 value: "<%=schemeSelected%>",
-                store: dojoSchemeStore,
                 searchAttr: "textLabel",
                 labelAttr: "label",
                 labelType: "html",
@@ -503,6 +501,9 @@
                 }
             },
             dojo.byId("schemeSelectBox"));
+        
+        // Load the scheme data after widget is created
+        reloadSchemeStore(fsSchemes, "<%=structureSelected%>");
 
         // step select box
         var fsSteps = new dijit.form.FilteringSelect({


### PR DESCRIPTION


https://github.com/user-attachments/assets/e6717e5f-784f-418b-9a37-120ee213d00a

This issue was about a misstime between the load from the API and the load from the component.
Basically, sometimes the API load before the component exists, so the component never was updated.
And sometimes the API load after, thats why the isse was intermitent.

With this change, the component always is loaded before the hydrate the options inside

This PR fixes: #32899

This PR fixes: #32899