### PR TITLE
feat(content edit) #31734 : Create a REST Endpoint for returning the History data

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/SearchCriteria.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/SearchCriteria.java
@@ -1,0 +1,224 @@
+package com.dotcms.content.elasticsearch.business;
+
+import com.dotcms.util.pagination.OrderDirection;
+import com.dotmarketing.beans.Identifier;
+import com.liferay.portal.model.User;
+
+/**
+ * This class represents a generic multipurpose search criteria object. It can be used by several
+ * APIs to return specific filtered or paginated information. It also helps keeping method
+ * signatures from having lost of parameters.
+ * <p>Developers can add as many filtering or search attributes as they need to.</p>
+ *
+ * @author Jose Castro
+ * @since Aug 4th, 2025
+ */
+public class SearchCriteria {
+
+    private final Identifier identifier;
+
+    private final User user;
+
+    private final boolean bringOldVersions;
+
+    private final int limit;
+    private final int offset;
+    private final OrderDirection orderDirection;
+
+    private final boolean respectFrontendRoles;
+
+    private SearchCriteria(final Builder builder) {
+        this.identifier = builder.identifier;
+        this.user = builder.user;
+        this.bringOldVersions = builder.bringOldVersions;
+        this.limit = builder.limit;
+        this.offset = builder.offset;
+        this.orderDirection = builder.orderDirection;
+        this.respectFrontendRoles = builder.respectFrontendRoles;
+    }
+
+    /**
+     * Returns the {@link Identifier} object that belongs to the contentlet being searched.
+     *
+     * @return The {@link Identifier} of the contentlet.
+     */
+    public Identifier identifier() {
+        return this.identifier;
+    }
+
+    /**
+     * Returns the user that is making the search.
+     *
+     * @return The {@link User}.
+     */
+    public User user() {
+        return this.user;
+    }
+
+    /**
+     * Determines whether to include old versions of the contentlet, and not only its live/working
+     * version. If {@code false}, only the live or working version will be returned for each
+     * language it's available in.
+     *
+     * @return {@code true} if old versions should be included, {@code false} otherwise.
+     */
+    public boolean bringOldVersions() {
+        return this.bringOldVersions;
+    }
+
+    /**
+     * Returns the limit for the number of records to be returned, for pagination purposes.
+     *
+     * @return The limit.
+     */
+    public int limit() {
+        return this.limit;
+    }
+
+    /**
+     * Returns the result offset, for pagination purposes.
+     *
+     * @return The offset.
+     */
+    public int offset() {
+        return this.offset;
+    }
+
+    /**
+     * Returns the {@link OrderDirection} used to sort the results by.
+     *
+     * @return The {@link OrderDirection}.
+     */
+    public OrderDirection orderDirection() {
+        return this.orderDirection;
+    }
+
+    /**
+     * Determines whether to include only contentlets that are visible to the user making the
+     * search.
+     *
+     * @return {@code true} if the search should respect the frontend roles, {@code false}
+     * otherwise.
+     */
+    public boolean respectFrontendRoles() {
+        return this.respectFrontendRoles;
+    }
+
+    @Override
+    public String toString() {
+        return "SearchCriteria{" +
+                "identifier=" + identifier +
+                ", user=" + user +
+                ", bringOldVersions=" + bringOldVersions +
+                ", limit=" + limit +
+                ", offset=" + offset +
+                ", orderDirection=" + orderDirection +
+                ", respectFrontendRoles=" + respectFrontendRoles +
+                '}';
+    }
+
+    public static class Builder {
+
+        private Identifier identifier;
+
+        private User user;
+
+        private boolean bringOldVersions;
+
+        private int limit = -1;
+        private int offset = 0;
+        private OrderDirection orderDirection = OrderDirection.DESC;
+
+        private boolean respectFrontendRoles = true;
+
+        /**
+         * Specifies the {@link Identifier} object that belongs to a contentlet.
+         *
+         * @param identifier The {@link Identifier} of the contentlet to filter by.
+         *
+         * @return The {@link Builder} instance.
+         */
+        public Builder withIdentifier(final Identifier identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        public Builder withUser(final User user) {
+            this.user = user;
+            return this;
+        }
+
+        /**
+         * Determines whether to include old versions of the contentlet, and not only its
+         * live/working version. If set to {@code false}, only the live or working version will be
+         * returned for each language it's available in.
+         *
+         * @param bringOldVersions If old versions should be returned, set to {@code true}.
+         *
+         * @return The {@link Builder} instance.
+         */
+        public Builder withBringOldVersions(final boolean bringOldVersions) {
+            this.bringOldVersions = bringOldVersions;
+            return this;
+        }
+
+        /**
+         * Sets the maximum number of records to be returned, for pagination purposes.
+         *
+         * @param limit The maximum number of records.
+         *
+         * @return The {@link Builder} instance
+         */
+        public Builder withLimit(final int limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        /**
+         * Sets the result offset, for pagination purposes.
+         *
+         * @param offset The result offset.
+         *
+         * @return The {@link Builder} instance.
+         */
+        public Builder withOffset(final int offset) {
+            this.offset = offset;
+            return this;
+        }
+
+        /**
+         * Sets the sorting direction of the results being returned.
+         *
+         * @param orderDirection The {@link OrderDirection}
+         *
+         * @return The {@link Builder} instance.
+         */
+        public Builder withOrderDirection(final OrderDirection orderDirection) {
+            this.orderDirection = orderDirection;
+            return this;
+        }
+
+        /**
+         * Sets whether the search should respect the frontend roles of the specified user.
+         *
+         * @param respectFrontendRoles Whether the search should respect the frontend roles.
+         *
+         * @return The {@link Builder} instance.
+         */
+        public Builder withRespectFrontendRoles(final boolean respectFrontendRoles) {
+            this.respectFrontendRoles = respectFrontendRoles;
+            return this;
+        }
+
+        /**
+         * Builds the {@link SearchCriteria} object.
+         *
+         * @return The {@link SearchCriteria} instance.
+         */
+        public SearchCriteria build() {
+            return new SearchCriteria(this);
+        }
+
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/ResponseEntityPaginatedDataView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/ResponseEntityPaginatedDataView.java
@@ -1,0 +1,16 @@
+package com.dotcms.rest;
+
+/**
+ * This class encapsulates the {@link javax.ws.rs.core.Response} object to include the expected
+ * paginated data.
+ *
+ * @author Jose Castro
+ * @since Jul 31st, 2025
+ */
+public class ResponseEntityPaginatedDataView extends ResponseEntityView<Object> {
+
+    public ResponseEntityPaginatedDataView(final Object entity, final Pagination pagination) {
+        super(entity, pagination);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentVersionResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentVersionResource.java
@@ -1,13 +1,17 @@
 package com.dotcms.rest.api.v1.content;
 
-import static com.dotcms.rest.api.v1.authentication.ResponseUtil.getFormattedMessage;
-
 import com.dotcms.rest.InitDataObject;
+import com.dotcms.rest.ResponseEntityPaginatedDataView;
 import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.rest.api.v1.authentication.ResponseUtil;
 import com.dotcms.rest.exception.BadRequestException;
+import com.dotcms.rest.exception.NotFoundException;
+import com.dotcms.util.PaginationUtil;
+import com.dotcms.util.PaginationUtilParams;
+import com.dotcms.util.pagination.ContentHistoryPaginator;
+import com.dotcms.util.pagination.OrderDirection;
 import com.dotcms.uuid.shorty.ShortType;
 import com.dotcms.uuid.shorty.ShortyId;
 import com.dotmarketing.beans.Identifier;
@@ -23,10 +27,33 @@ import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
+import com.dotmarketing.util.PaginatedArrayList;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.liferay.portal.model.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.glassfish.jersey.server.JSONP;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -36,28 +63,23 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.glassfish.jersey.server.JSONP;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
+import static com.dotcms.rest.api.v1.authentication.ResponseUtil.getFormattedMessage;
+
+/**
+ * This REST Endpoint allows you to retrieve information related to versions of Contentlets in
+ * dotCMS, as well as their History data.
+ *
+ * @author Fabrizzio Araya
+ * @since Dec 18th, 2018
+ */
 @Path("/v1/content/versions")
 @Tag(name = "Content", description = "Endpoints for managing content and contentlets")
 public class ContentVersionResource {
 
     private static final String FIND_BY_ID_ERROR_MESSAGE_KEY = "Unable-to-find-contentlet-by-id";
     private static final String FIND_BY_INODE_ERROR_MESSAGE_KEY = "Unable-to-find-contentlet-by-inode";
-    private static final String DATATYPE_MISSMATCH_ERROR_MESSAGE_KEY = "Data-Type-Missmatch";
+    private static final String DATATYPE_MISMATCH_ERROR_MESSAGE_KEY = "Data-Type-Missmatch";
     private static final String BAD_REQUEST_ERROR_MESSAGE_KEY = "Bad-Request";
 
     private static final String VERSIONS = "versions";
@@ -163,6 +185,80 @@ public class ContentVersionResource {
             return ResponseUtil.mapExceptionResponse(ex);
         }
 
+    }
+
+    @Operation(
+            summary = "Contentlet History",
+            description = "Returns the history of a contentlet with the minimum expected information, " +
+                    "as seen in the History tab in the Content Edition page."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "History data retrieved successfully",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseEntityPaginatedDataView.class))),
+            @ApiResponse(responseCode = "400", description = "The identifier path parameter was not specified.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "401", description = "Authentication required.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "The specified identifier does not match any contentlet.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "500", description = "An internal dotCMS error has occurred.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @GET
+    @Path("/id/{identifier}/history")
+    @Produces(MediaType.APPLICATION_JSON + ";charset=UTF-8")
+    @NoCache
+    public ResponseEntityPaginatedDataView history(@Context final HttpServletRequest request,
+                                                   @Context final HttpServletResponse response,
+                                                   @Parameter(description = "The Identifier of the Contentlet whose history will be retrieved", required = true)
+                                                        @PathParam("identifier") final String identifier,
+                                                   @Parameter(description = "Specified whether the history must be grouped by language or not")
+                                                        @QueryParam("groupByLang") @DefaultValue("false") final boolean groupByLanguage,
+                                                   @Parameter(description = "Specified whether the history must include old versions or not")
+                                                        @QueryParam("bringOldVersions") @DefaultValue("true") final boolean bringOldVersions,
+                                                   @Parameter(description = "Sort direction: Choose between ascending or descending.",
+                                                           schema = @Schema(
+                                                                   type = "string",
+                                                                   allowableValues = {"ASC", "DESC"},
+                                                                   defaultValue = "DESC"))
+                                                        @QueryParam(PaginationUtil.DIRECTION) @DefaultValue("DESC") final String direction,
+                                                   @Parameter(description = "Maximum number or results being returned, for pagination purposes.")
+                                                        @QueryParam("limit") final int limit,
+                                                   @Parameter(description = "Page number of the results being returned, for pagination purposes.")
+                                                        @QueryParam("offset") final int offset)
+            throws DotDataException, DotStateException, DotSecurityException {
+        final InitDataObject initDataObject = new WebResource.InitBuilder(this.webResource)
+                .requestAndResponse(request, response)
+                .rejectWhenNoUser(true)
+                .init();
+        final User user = initDataObject.getUser();
+        if (null == identifier) {
+            throw new BadRequestException(getFormattedMessage(user.getLocale(),
+                    BAD_REQUEST_ERROR_MESSAGE_KEY));
+        }
+        final Identifier identifierObj = this.getIdentifier(identifier, user);
+        if (null == identifierObj) {
+            throw new NotFoundException(getFormattedMessage(user.getLocale(),
+                    BAD_REQUEST_ERROR_MESSAGE_KEY));
+        }
+        final boolean respectFrontendRoles = PageMode.get(request).respectAnonPerms;
+        final PaginationUtil paginationUtil = new PaginationUtil(new ContentHistoryPaginator());
+        final Map<String, Object> extraParams = Map.of(
+                ContentHistoryPaginator.IDENTIFIER, identifierObj,
+                ContentHistoryPaginator.RESPECT_FRONTEND_ROLES, respectFrontendRoles,
+                ContentHistoryPaginator.GROUP_BY_LANG, groupByLanguage,
+                ContentHistoryPaginator.BRING_OLD_VERSIONS, bringOldVersions);
+        final PaginationUtilParams<Map<String, Object>, PaginatedArrayList<?>> params = new PaginationUtilParams.Builder<Map<String, Object>, PaginatedArrayList<?>>()
+                .withRequest(request)
+                .withResponse(response)
+                .withUser(user)
+                .withPage(offset)
+                .withPerPage(limit)
+                .withDirection(OrderDirection.valueOf(direction))
+                .withExtraParams(extraParams)
+                .build();
+        return paginationUtil.getPageView(params);
     }
 
     /**
@@ -291,7 +387,7 @@ public class ContentVersionResource {
 
             if (shorty.type != ShortType.INODE) {
                 throw new BadRequestException(
-                        getFormattedMessage(user.getLocale(), DATATYPE_MISSMATCH_ERROR_MESSAGE_KEY));
+                        getFormattedMessage(user.getLocale(), DATATYPE_MISMATCH_ERROR_MESSAGE_KEY));
             }
 
             final Contentlet contentlet = APILocator.getContentletAPI().find(inode, user, respectFrontendRoles);

--- a/dotCMS/src/main/java/com/dotcms/util/PaginationUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/PaginationUtil.java
@@ -1,6 +1,7 @@
 package com.dotcms.util;
 
 import com.dotcms.rest.Pagination;
+import com.dotcms.rest.ResponseEntityPaginatedDataView;
 import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.util.pagination.OrderDirection;
 import com.dotcms.util.pagination.Paginator;
@@ -14,6 +15,7 @@ import com.liferay.util.StringUtil;
 import org.apache.commons.lang.StringUtils;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -79,18 +81,25 @@ public class PaginationUtil {
 
 	}
 
-	/**
-	 * Returns a paginated response of elements to the User based on a specific set of parameters. Any class inheriting
-	 * the {@link Paginator} interface will be able to provide paginated items.
-	 *
-	 * @param req     The current instance of the {@link HttpServletRequest}.
-	 * @param user    The {@link User} calling this pagination.
-	 * @param filter  A multipurpose String filtering parameter.
-	 * @param page    The page offset value, for pagination purposes.
-	 * @param perPage The number of items per page, for pagination purposes.
-	 *
-	 * @return The {@link Response} object including the paginated items and the respective pagination headers.
-	 */
+    /**
+     * Returns a paginated response of elements to the User based on a specific set of parameters.
+     * Any class inheriting the {@link Paginator} interface will be able to provide paginated
+     * items.
+     *
+     * @param req     The current instance of the {@link HttpServletRequest}.
+     * @param user    The {@link User} calling this pagination.
+     * @param filter  A multipurpose String filtering parameter.
+     * @param page    The page offset value, for pagination purposes.
+     * @param perPage The number of items per page, for pagination purposes.
+     *
+     * @return The {@link Response} object including the paginated items and the respective
+     * pagination headers.
+     *
+     * @deprecated Please use the {@link #getPageView(PaginationUtilParams)} method as it uses the
+     * {@link ResponseEntityPaginatedDataView} instead of the generic {@link Response} for returning
+     * the results.
+     */
+    @Deprecated
 	public Response getPage(final HttpServletRequest req, final User user, final String filter, final int page, final int perPage) {
 		return getPage(req, user, filter, page, perPage, StringUtils.EMPTY, null, null);
 	}
@@ -109,7 +118,12 @@ public class PaginationUtil {
 	 * @param direction The sorting direction for the results: {@code "ASC"} or {@code "DESC"}
 	 *
 	 * @return The {@link Response} object including the paginated items and the respective pagination headers.
+     *
+     * @deprecated Please use the {@link #getPageView(PaginationUtilParams)} method as it uses the
+     * {@link ResponseEntityPaginatedDataView} instead of the generic {@link Response} for returning
+     * the results.
 	 */
+    @Deprecated
 	public Response getPage(final HttpServletRequest req, final User user, final String filter, final int page,
 							final int perPage, final String orderBy, final String direction) {
 		return getPage(req, user, filter, page, perPage, orderBy,
@@ -129,7 +143,12 @@ public class PaginationUtil {
 	 *                    class to return the expected items.
 	 *
 	 * @return The {@link Response} object including the paginated items and the respective pagination headers.
+     *
+     * @deprecated Please use the {@link #getPageView(PaginationUtilParams)} method as it uses the
+     * {@link ResponseEntityPaginatedDataView} instead of the generic {@link Response} for returning
+     * the results.
 	 */
+    @Deprecated
 	public Response getPage(final HttpServletRequest req, final User user, final String filter, final int page,
 							final int perPage, final Map<String, Object>  extraParams) {
 		return getPage(req, user, filter, page, perPage, null, null, extraParams);
@@ -151,7 +170,12 @@ public class PaginationUtil {
 	 *                     class to return the expected items.
 	 *
 	 * @return The {@link Response} object including the paginated items and the respective pagination headers.
+     *
+     * @deprecated Please use the {@link #getPageView(PaginationUtilParams)} method as it uses the
+     * {@link ResponseEntityPaginatedDataView} instead of the generic {@link Response} for returning
+     * the results.
 	 */
+    @Deprecated
 	public Response getPage(final HttpServletRequest req, final User user, final String filter, final int page,
 							final int perPage, final String orderBy, final OrderDirection direction,
 							final Map<String, Object> extraParams) {
@@ -174,7 +198,12 @@ public class PaginationUtil {
 	 * @param function     This is function must feed the items into whatever json we want to use.
 	 *
 	 * @return The {@link Response} object including the paginated items and the respective pagination headers.
+     *
+     * @deprecated Please use the {@link #getPageView(PaginationUtilParams)} method as it uses the
+     * {@link ResponseEntityPaginatedDataView} instead of the generic {@link Response} for returning
+     * the results.
 	 */
+    @Deprecated
 	@SuppressWarnings("unchecked")
 	public <T, R> Response getPage(final HttpServletRequest req, final User user, final String filter, final int page,
 								   final int perPage, final String orderBy, final OrderDirection direction,
@@ -197,6 +226,39 @@ public class PaginationUtil {
 		final Object paginatedItems = null != function ? function.apply(items) : items;
 		return this.createResponse(paginatedItems, linkHeader, pageValue, perPageValue, totalRecords);
 	}
+
+    /**
+     * Returns a {@link ResponseEntityPaginatedDataView} object containing the resulting objects
+     * along with the respective pagination information.
+     *
+     * @param utilParams The {@link PaginationUtilParams} object containing the different pagination
+     *                   parameters and filtering criteria.
+     * @param <T>        Generics for the optional Functional Interface to be applied to every
+     *                   result.
+     * @param <R>        Generics for the optional Functional Interface to be applied to every
+     *                   result.
+     *
+     * @return The {@link ResponseEntityPaginatedDataView} object with the paginated results.
+     */
+    @SuppressWarnings("unchecked")
+    public <T, R> ResponseEntityPaginatedDataView getPageView(final PaginationUtilParams<T, R> utilParams) {
+        final int pageValue = utilParams.page() <= 0 ? FIRST_PAGE_INDEX : utilParams.page();
+        final int perPageValue = utilParams.perPage() <= 0 ? perPageDefault : utilParams.perPage();
+        final int minIndex = this.getMinIndex(pageValue, perPageValue);
+        final String sanitizedFilter = UtilMethods.isSet(utilParams.filter()) ? SQLUtil.sanitizeParameter(utilParams.filter()) : StringPool.BLANK;
+        final Map<String, Object> params = this.getParameters(sanitizedFilter, utilParams.orderBy(), utilParams.direction(), utilParams.extraParams());
+        PaginatedArrayList items = minIndex >= 0 ? paginator.getItems(utilParams.user(), perPageValue, minIndex, params) : null;
+        if (UtilMethods.isNotSet(items)) {
+            items = new PaginatedArrayList<>();
+        }
+        final long totalRecords = items.getTotalResults();
+        final LinkHeader linkHeader =
+                new LinkHeader.Builder().baseUrl(utilParams.request().getRequestURI()).filter(sanitizedFilter).page(pageValue)
+                        .perPage(perPageValue).totalRecords(totalRecords).orderBy(utilParams.orderBy()).direction(utilParams.direction())
+                        .extraParams(utilParams.extraParams()).build();
+        final Object paginatedItems = null != utilParams.function() ? utilParams.function().apply(items) : items;
+        return this.createResponseView(utilParams.response(), paginatedItems, linkHeader, pageValue, perPageValue, totalRecords);
+    }
 
 	/**
 	 * Utility method that condenses a list of provided filtering parameters into a single Object Map.
@@ -287,9 +349,12 @@ public class PaginationUtil {
 	}
 
 	/**
-	 * Builds the expected URL for the {@code Link} header. The syntax to build each URL is the following:
+	 * Builds the expected URL for the {@code Link} header. The syntax to build each URL is the
+     * following:
 	 * <pre>
-	 *     [urlBase]?filter=[filter]&page=[page]&perPage=[perPage]&archived=[showArchived]&direction=[direction]&orderBy=[orderBy]
+     *     {@code
+	 *     [baseUrl]?filter=[filter]&page=[page]&perPage=[perPage]&archived=[showArchived]&direction=[direction]&orderBy=[orderBy]
+     *     }
 	 * </pre>
 	 *
 	 * @param baseUrl     The URI for the current HTTP Request.
@@ -387,9 +452,14 @@ public class PaginationUtil {
 	 * @param totalRecords   The total number of unfiltered items returned by the query.
 	 *
 	 * @return The expected {@link Response} object.
+     *
+     * @deprecated Please use the {@link #getPageView(PaginationUtilParams)} method as it uses the
+     * {@link ResponseEntityPaginatedDataView} instead of the generic {@link Response} for returning
+     * the results.
 	 */
+    @Deprecated
 	private Response createResponse(final Object paginatedItems, final LinkHeader linkHeader, final int pageValue,
-									final int perPageValue, final long totalRecords) {
+                                    final int perPageValue, final long totalRecords) {
 		final String linkHeaderValue = this.getHeaderValue(linkHeader);
 		final Pagination pagination =
 				new Pagination.Builder()
@@ -404,13 +474,48 @@ public class PaginationUtil {
 					   .header(PAGINATION_TOTAL_ENTRIES_HEADER_NAME, totalRecords).build();
 	}
 
+    /**
+     * Creates an instance of the {@link ResponseEntityPaginatedDataView} class including both the
+     * Entity -- i.e., the list of queried objects -- and additional pagination attributes for the
+     * UI layer or any other client to have. This is meant to solve a problem in which certain
+     * proxies may remove the already existing pagination headers.
+     *
+     * @param response       The current instance of the {@link HttpServletResponse}.
+     * @param paginatedItems The paginated data that is being returned.
+     * @param linkHeader     The {@link LinkHeader} object with the information for generating the
+     *                       navigation for the paginated data.
+     * @param pageValue      The currently selected page.
+     * @param perPageValue   The maximum number of items returned in a results page.
+     * @param totalRecords   The total number of unfiltered items returned by the query.
+     *
+     * @return The {@link ResponseEntityPaginatedDataView} object.
+     */
+    private ResponseEntityPaginatedDataView createResponseView(final HttpServletResponse response,
+                                                               final Object paginatedItems,
+                                                               final LinkHeader linkHeader,
+                                                               final int pageValue,
+                                                               final int perPageValue,
+                                                               final long totalRecords) {
+        final String linkHeaderValue = this.getHeaderValue(linkHeader);
+        final Pagination pagination = new Pagination.Builder()
+                .currentPage(pageValue)
+                .perPage(perPageValue)
+                .totalEntries(totalRecords).build();
+        response.setHeader(LINK_HEADER_NAME, linkHeaderValue);
+        response.setHeader(PAGINATION_PER_PAGE_HEADER_NAME, String.valueOf(perPageValue));
+        response.setHeader(PAGINATION_CURRENT_PAGE_HEADER_NAME, String.valueOf(pageValue));
+        response.setHeader(PAGINATION_MAX_LINK_PAGES_HEADER_NAME, String.valueOf(nLinks));
+        response.setHeader(PAGINATION_TOTAL_ENTRIES_HEADER_NAME, String.valueOf(totalRecords));
+        return new ResponseEntityPaginatedDataView(paginatedItems, pagination);
+    }
+
 	/**
 	 * Contains the required information for generating the value of the {@code Link} HTTP Header used by the UI layer.
 	 * There are three values that can be generated:
 	 * <ul>
 	 *     <li>The link to get the <b>first</b> results page.</li>
 	 *     <li>The link to get the <b>last</b> results page.</li>
-	 *     <li>The link to get the <b>a specific</b> results page.</li>
+	 *     <li>The link to get the <b>specific</b> results page.</li>
 	 * </ul>
 	 * For instance, the value of this header may look like this:
 	 * <br/><br/>{@code

--- a/dotCMS/src/main/java/com/dotcms/util/PaginationUtilParams.java
+++ b/dotCMS/src/main/java/com/dotcms/util/PaginationUtilParams.java
@@ -1,0 +1,303 @@
+package com.dotcms.util;
+
+import com.dotcms.util.pagination.OrderDirection;
+import com.dotmarketing.util.PaginatedArrayList;
+import com.liferay.portal.model.User;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static com.liferay.util.StringPool.BLANK;
+
+/**
+ * This class allows developers to easily specify the different filtering and pagination parameters
+ * to Paginators.
+ *
+ * @author Jose Castro
+ * @since Aug 1st, 2025
+ */
+public class PaginationUtilParams<T, R> {
+
+    private final HttpServletRequest request;
+    private final HttpServletResponse response;
+    private final User user;
+    private final String filter;
+    private final int page;
+    private final int perPage;
+    private final String orderBy;
+    private final OrderDirection direction;
+    private final Map<String, Object> extraParams;
+    private final Function<PaginatedArrayList<T>, R> function;
+
+    private PaginationUtilParams(final Builder<T, R> builder) {
+        this.request = builder.request;
+        this.response = builder.response;
+        this.user = builder.user;
+        this.filter = builder.filter;
+        this.page = builder.page;
+        this.perPage = builder.perPage;
+        this.orderBy = builder.orderBy;
+        this.direction = builder.direction;
+        this.extraParams = builder.extraParams;
+        this.function = builder.function;
+    }
+
+    /**
+     * Returns the current instance of the {@link HttpServletRequest}.
+     *
+     * @return The current instance of the {@link HttpServletRequest}.
+     */
+    public HttpServletRequest request() {
+        return request;
+    }
+
+    /**
+     * Returns the current instance of the {@link HttpServletResponse}.
+     *
+     * @return The current instance of the {@link HttpServletResponse}.
+     */
+    public HttpServletResponse response() {
+        return response;
+    }
+
+    /**
+     * Returns the {@link User} that is calling the Paginator.
+     *
+     * @return The {@link User} that is calling the Paginator.
+     */
+    public User user() {
+        return user;
+    }
+
+    /**
+     * Returns the optional filtering parameter. Every paginator can use or implement this parameter
+     * as required.
+     *
+     * @return The optional filtering parameter.
+     */
+    public String filter() {
+        return filter;
+    }
+
+    /**
+     * Returns the result offset value, for pagination purposes.
+     *
+     * @return The offset.
+     */
+    public int page() {
+        return page;
+    }
+
+    /**
+     * Returns the number of items per page, for pagination purposes.
+     *
+     * @return The number of items per page.
+     */
+    public int perPage() {
+        return perPage;
+    }
+
+    /**
+     * Returns the criterion used to sort the returned values.
+     *
+     * @return The criterion used to sort the returned values.
+     */
+    public String orderBy() {
+        return orderBy;
+    }
+
+    /**
+     * Returns the {@link OrderDirection} used to sort the returned values.
+     *
+     * @return The {@link OrderDirection}.
+     */
+    public OrderDirection direction() {
+        return direction;
+    }
+
+    /**
+     * Returns the map with additional/uncommon extra parameters. All Paginators can use this map to
+     * store any extra parameters that may be necessary to the specific Paginator implementation.
+     *
+     * @return The map with extra parameters.
+     */
+    public Map<String, Object> extraParams() {
+        return extraParams;
+    }
+
+    /**
+     * Returns the Functional Interface that will be used to transform every entry in the result set
+     * into an expected value.
+     *
+     * @return The {@link Function}.
+     */
+    public Function<PaginatedArrayList<T>, R> function() {
+        return function;
+    }
+
+    @Override
+    public String toString() {
+        return "PaginationUtilParams{" +
+                "request=" + request +
+                ", response=" + response +
+                ", user=" + user +
+                ", filter='" + filter + '\'' +
+                ", page=" + page +
+                ", perPage=" + perPage +
+                ", orderBy='" + orderBy + '\'' +
+                ", direction=" + direction +
+                ", extraParams=" + extraParams +
+                '}';
+    }
+
+    public static class Builder<T, R> {
+
+        private HttpServletRequest request;
+        private HttpServletResponse response;
+        private User user;
+        private String filter = BLANK;
+        private int page = 0;
+        private int perPage = 10;
+        private String orderBy = BLANK;
+        private OrderDirection direction = OrderDirection.ASC;
+        private Map<String, Object> extraParams = new HashMap<>();
+        private Function<PaginatedArrayList<T>, R> function;
+
+        /**
+         * Sets the current instance of the {@link HttpServletRequest}.
+         *
+         * @param request The current instance of the {@link HttpServletRequest}.
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withRequest(final HttpServletRequest request) {
+            this.request = request;
+            return this;
+        }
+
+        /**
+         * Sets the current instance of the {@link HttpServletResponse}.
+         *
+         * @param response The current instance of the {@link HttpServletResponse}.
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withResponse(final HttpServletResponse response) {
+            this.response = response;
+            return this;
+        }
+
+        /**
+         * Sets the {@link User} that is calling the Paginator.
+         *
+         * @param user The {@link User} that is calling the Paginator.
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withUser(final User user) {
+            this.user = user;
+            return this;
+        }
+
+        /**
+         * Sets the optional filtering parameter. Every paginator can use or implement this
+         * parameter as required.
+         *
+         * @param filter The optional filtering parameter.
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withFilter(final String filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        /**
+         * Sets the result offset value, for pagination purposes.
+         *
+         * @param page The offset.
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withPage(final int page) {
+            this.page = page;
+            return this;
+        }
+
+        /**
+         * Sets the number of items per page, for pagination purposes.
+         *
+         * @param perPage The number of items per page.
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withPerPage(final int perPage) {
+            this.perPage = perPage;
+            return this;
+        }
+
+        /**
+         * Sets the criterion used to sort the returned values.
+         *
+         * @param orderBy The criterion used to sort the returned values.
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withOrderBy(final String orderBy) {
+            this.orderBy = orderBy;
+            return this;
+        }
+
+        /**
+         * Sets the {@link OrderDirection} used to sort the returned values.
+         *
+         * @param direction The {@link OrderDirection}
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withDirection(final OrderDirection direction) {
+            this.direction = direction;
+            return this;
+        }
+
+        /**
+         * Sets any extra parameters that may be necessary to the specific Paginator
+         * implementation.
+         *
+         * @param extraParams The map with extra parameters
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withExtraParams(final Map<String, Object> extraParams) {
+            this.extraParams = extraParams;
+            return this;
+        }
+
+        /**
+         * Sets the Functional Interface that will be used to transform every entry in the result
+         * set into an expected value.
+         *
+         * @param function The {@link Function}
+         *
+         * @return The current instance of the {@link Builder}.
+         */
+        public Builder<T, R> withFunction(final Function<PaginatedArrayList<T>, R> function) {
+            this.function = function;
+            return this;
+        }
+
+        /**
+         * Builds an instance of the {@link PaginationUtilParams} class.
+         *
+         * @return An instance of the {@link PaginationUtilParams}.
+         */
+        public PaginationUtilParams<T, R> build() {
+            return new PaginationUtilParams<T, R>(this);
+        }
+
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/util/pagination/ContentHistoryPaginator.java
+++ b/dotCMS/src/main/java/com/dotcms/util/pagination/ContentHistoryPaginator.java
@@ -1,0 +1,160 @@
+package com.dotcms.util.pagination;
+
+import com.dotcms.content.elasticsearch.business.SearchCriteria;
+import com.dotcms.exception.ExceptionUtil;
+import com.dotmarketing.beans.Identifier;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.contentlet.transform.DotTransformerBuilder;
+import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.PaginatedArrayList;
+import com.liferay.portal.model.User;
+import com.rainerhahnekamp.sneakythrow.Sneaky;
+import io.vavr.control.Try;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * This implementation of the {@link PaginatorOrdered} interface is used to return data related to
+ * versions of a specific Contentlet Identifier, as seen in the {@code History} tab in the
+ * Contentlet Editor window.
+ *
+ *
+ * @author Jose Castro
+ * @since Jul 31st, 2025
+ */
+public class ContentHistoryPaginator implements PaginatorOrdered<Map<String, Object>> {
+
+    public static final String IDENTIFIER = "identifier";
+    public static final String RESPECT_FRONTEND_ROLES = "respectFrontedRoles";
+    public static final String GROUP_BY_LANG = "groupByLang";
+    public static final String BRING_OLD_VERSIONS = "bringOldVersions";
+
+    private final ContentletAPI contentletAPI;
+    private final LanguageAPI languageAPI;
+
+    /**
+     *
+     */
+    public ContentHistoryPaginator() {
+        this.contentletAPI = APILocator.getContentletAPI();
+        this.languageAPI = APILocator.getLanguageAPI();
+    }
+
+    @Override
+    public PaginatedArrayList<Map<String, Object>> getItems(final User user, final String filter,
+                                                            final int limit, final int offset,
+                                                            final String orderBy,
+                                                            final OrderDirection direction,
+                                                            final Map<String, Object> extraParams) throws PaginationException {
+        final Identifier identifier = Try.of(() -> (Identifier) extraParams.get(IDENTIFIER)).getOrElse(new Identifier());
+        final boolean respectFrontendRoles = Try.of(() -> (Boolean) extraParams.get(RESPECT_FRONTEND_ROLES)).getOrElse(false);
+        final boolean groupByLang = Try.of(() -> (Boolean) extraParams.get(GROUP_BY_LANG)).getOrElse(false);
+        final boolean bringOldVersions = Try.of(() -> (Boolean) extraParams.get(BRING_OLD_VERSIONS)).getOrElse(false);
+        final PaginatedArrayList<Map<String, Object>> result = new PaginatedArrayList<>();
+        try {
+            final SearchCriteria criteria = new SearchCriteria.Builder()
+                    .withIdentifier(identifier)
+                    .withUser(user)
+                    .withBringOldVersions(bringOldVersions)
+                    .withLimit(limit)
+                    .withOffset(offset)
+                    .withOrderDirection(direction)
+                    .withRespectFrontendRoles(respectFrontendRoles)
+                    .build();
+            final List<Contentlet> contentletVersions = contentletAPI.findAllVersions(criteria);
+            if (groupByLang) {
+                final Map<String, Object> historyByLang = this.mapHistoryByLang(contentletVersions);
+                result.add(historyByLang);
+            } else {
+                final List<Map<String, Object>> versions = this.mapHistory(contentletVersions);
+                result.addAll(versions);
+            }
+            result.setTotalResults(this.getTotalRecords(identifier, bringOldVersions, user, respectFrontendRoles));
+            return result;
+        } catch (final DotDataException | DotSecurityException e) {
+            final String errorMsg = String.format("Failed to return history for Content ID " +
+                    "'%s': %s", identifier.getId(), ExceptionUtil.getErrorMessage(e));
+            Logger.error(this, errorMsg, e);
+            throw new DotRuntimeException(errorMsg, e);
+        }
+    }
+
+    /**
+     * Retrieves the total number of records that are handled by this paginator. If you DO NOT
+     * specify a limit for it, then all records will be returned. However, keep in mind that doing
+     * so may cause performance issues.
+     *
+     * @param identifier           The {@link Identifier} of the Contentlet whose versions will be
+     *                             returned.
+     * @param bringOldVersions     If true, then all versions will be returned, not only the latest
+     *                             for every language.
+     * @param user                 The {@link User} performing this action.
+     * @param respectFrontendRoles If true, then the user's frontend roles will be considered when
+     *                             retrieving the contentlet versions.
+     *
+     * @return The total number of records.
+     */
+    private long getTotalRecords(final Identifier identifier, final boolean bringOldVersions, final User user,
+                                 final boolean respectFrontendRoles) {
+        return Sneaky.sneak(() -> this.contentletAPI.findAllVersions(identifier, bringOldVersions, user,
+                respectFrontendRoles).size());
+    }
+
+    /**
+     * Generates a list of {@link Map} objects that represent the history of the specified
+     * contentlet versions. Such versions will be transformed to the appropriate JSON views.
+     *
+     * @param contentlets The list of contentlet versions.
+     *
+     * @return A list of {@link Map} objects with the contentlet versions.
+     */
+    private List<Map<String, Object>> mapHistory(final List<Contentlet> contentlets) {
+        return contentlets.stream().map(this::contentletHistoryToMap).collect(Collectors.toList());
+    }
+
+    /**
+     * Generates a list of {@link Map} objects that represent the history of the specified
+     * contentlet versions when they must be grouped by Language. Such versions will be transformed
+     * to the appropriate JSON views.
+     *
+     * @param contentlets The list of contentlet versions.
+     *
+     * @return A {@link Map} of languages, each containing the list of versions that belong to each
+     * of them.
+     */
+    private Map<String, Object> mapHistoryByLang(final List<Contentlet> contentlets){
+        final Map<String, Object> versionsByLang = new HashMap<>();
+        final Map<Long, List<Contentlet>> contentByLangMap = contentlets.stream()
+                .collect(Collectors.groupingBy(Contentlet::getLanguageId));
+        contentByLangMap.forEach((langId, contentletList) -> {
+            final Language lang = this.languageAPI.getLanguage(langId);
+            final List<Map<String, Object>> asMapList = contentletList.stream()
+                    .map(this::contentletHistoryToMap).collect(Collectors.toList());
+            versionsByLang.put(lang.toString(), asMapList);
+        });
+        return versionsByLang;
+    }
+
+    /**
+     * Takes a {@link Contentlet} and transforms it into the expected JSON view that exposes it in
+     * the for of History data.
+     *
+     * @param contentlet The {@link Contentlet} to be transformed.
+     *
+     * @return The transformed {@link Map} object.
+     */
+    private Map<String, Object> contentletHistoryToMap(final Contentlet contentlet) {
+        return new DotTransformerBuilder().historyToMapTransformer().content(contentlet).build().toMaps().get(0);
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableFactoryImpl.java
@@ -208,12 +208,8 @@ public class VersionableFactoryImpl extends VersionableFactory {
 		}
 
 		if ("contentlet".equals(identifier.getAssetType())){
-            try {
-                return Collections.unmodifiableList(FactoryLocator.getContentletFactory()
-                        .findAllVersions(identifier, true, maxResults.isPresent()?maxResults.get():null));
-            } catch (DotSecurityException e) {
-                throw new DotDataException("Cannot get versions for contentlet with identifier:" + identifier);
-            }
+            return Collections.unmodifiableList(FactoryLocator.getContentletFactory()
+                    .findAllVersions(identifier, true, maxResults.isPresent()?maxResults.get():null));
         } else{
             final Class<?> clazz = InodeUtils.getClassByDBType(identifier.getAssetType());
             if(clazz.equals(Inode.class)) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -3,6 +3,7 @@ package com.dotmarketing.portlets.contentlet.business;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
+import com.dotcms.content.elasticsearch.business.SearchCriteria;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Host;
@@ -31,6 +32,7 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PaginatedContentList;
 import com.dotmarketing.util.contentet.pagination.PaginatedContentlets;
 import com.liferay.portal.model.User;
+
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
@@ -1894,6 +1896,21 @@ public interface ContentletAPI {
 	 */
 
 	public List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions, User user, boolean respectFrontendRoles) throws DotSecurityException, DotDataException, DotStateException;
+
+    /**
+     * Retrieves all versions for a given Contentlet Identifier. It's highly recommended to use the
+     * pagination attributes, as this method may pull too many versions.
+     *
+     * @param searchCriteria The {@link SearchCriteria} object that allows you to filter the data
+     *                       being pulled.
+     *
+     * @return The list of contentlet versions matching the specified criteria.
+     *
+     * @throws DotSecurityException The specified user does not have permission to retrieve the
+     *                              versions.
+     * @throws DotDataException     An error occurred when interacting with the data source.
+     */
+    List<Contentlet> findAllVersions(final SearchCriteria searchCriteria) throws DotSecurityException, DotDataException;
 
 	/**
 	 * Retrieves all versions for a contentlet identifier checked in by a real user meaning not the system user

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIInterceptor.java
@@ -2,6 +2,7 @@ package com.dotmarketing.portlets.contentlet.business;
 
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.content.elasticsearch.business.ESSearchResults;
+import com.dotcms.content.elasticsearch.business.SearchCriteria;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
 import com.dotcms.enterprise.license.LicenseManager;
@@ -35,6 +36,8 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PaginatedContentList;
 import com.dotmarketing.util.contentet.pagination.PaginatedContentlets;
 import com.liferay.portal.model.User;
+import org.elasticsearch.action.search.SearchResponse;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -44,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.elasticsearch.action.search.SearchResponse;
 
 /**
  * This interceptor class allows developers to execute Java <b>code</b> before
@@ -884,6 +886,23 @@ public class ContentletAPIInterceptor implements ContentletAPI, Interceptor {
 		}
 		return c;
 	}
+
+    @Override
+    public List<Contentlet> findAllVersions(final SearchCriteria searchCriteria) throws DotSecurityException, DotDataException, DotStateException {
+        for (final ContentletAPIPreHook preHook : preHooks) {
+            final boolean preResult = preHook.findAllVersions(searchCriteria);
+            if (!preResult) {
+                final String errorMessage = String.format(PREHOOK_FAILED_MESSAGE, preHook.getClass().getName());
+                Logger.error(this, errorMessage);
+                throw new DotRuntimeException(errorMessage);
+            }
+        }
+        final List<Contentlet> contentlets = conAPI.findAllVersions(searchCriteria);
+        for (final ContentletAPIPostHook postHook : postHooks) {
+            postHook.findAllVersions(searchCriteria, contentlets);
+        }
+        return contentlets;
+    }
 
 	@Override
 	public List<Contentlet> findByStructure(Structure structure, User user,	boolean respectFrontendRoles, int limit, int offset)	throws DotDataException, DotSecurityException {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.portlets.contentlet.business;
 
+import com.dotcms.content.elasticsearch.business.SearchCriteria;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Host;
@@ -24,6 +25,7 @@ import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.google.common.collect.ImmutableList;
 import com.liferay.portal.model.User;
+
 import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
@@ -1042,6 +1044,18 @@ public interface ContentletAPIPostHook {
 			final User user, boolean respectFrontendRoles){
 
 	}
+
+    /**
+     * Retrieves all versions for a given Contentlet Identifier. It's highly recommended to use the
+     * pagination attributes, as this method may pull too many versions.
+     *
+     * @param searchCriteria The {@link SearchCriteria} object that allows you to filter the data
+     *                       being pulled.
+     * @param returnValue    The list of {@link Contentlet} objects that will be returned by the
+     *                       API call.
+     */
+    default void findAllVersions(final SearchCriteria searchCriteria, final List<Contentlet> returnValue) {
+    }
 
 	/**
 	 * Retrieves all versions for a contentlet identifier

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.portlets.contentlet.business;
 
+import com.dotcms.content.elasticsearch.business.SearchCriteria;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Host;
@@ -21,6 +22,7 @@ import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.liferay.portal.model.User;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -1191,6 +1193,17 @@ public interface ContentletAPIPreHook {
 	 */
 	public default boolean findAllVersions(Identifier identifier, User user, boolean respectFrontendRoles){
       return true;
+    }
+
+    /**
+     * Retrieves all versions for a given Contentlet Identifier. It's highly recommended to use the
+     * pagination attributes, as this method may pull too many versions.
+     *
+     * @param searchCriteria The {@link SearchCriteria} object that allows you to filter the data
+     *                       being pulled.
+     */
+    default boolean findAllVersions(final SearchCriteria searchCriteria) {
+        return true;
     }
 
 	/**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
@@ -3,6 +3,7 @@ package com.dotmarketing.portlets.contentlet.business;
 import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.repackage.net.sf.hibernate.ObjectNotFoundException;
+import com.dotcms.util.pagination.OrderDirection;
 import com.dotcms.util.transform.TransformerLocator;
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Identifier;
@@ -28,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
 
 /**
  * Provides utility methods to interact with {@link Contentlet} objects in
@@ -390,7 +390,7 @@ public abstract class ContentletFactory {
 	 * @throws DotSecurityException
 	 */
 	protected abstract List<Contentlet> findAllVersions(final Identifier identifier, final Variant variant)
-			throws DotDataException, DotSecurityException;
+			throws DotDataException;
 
     /**
      * Retrieves all versions for a contentlet identifier.
@@ -400,9 +400,65 @@ public abstract class ContentletFactory {
      * @param maxResults
      * @return
      * @throws DotDataException
-     * @throws DotSecurityException
      */
-    public abstract List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions, final Integer maxResults) throws DotDataException, DotSecurityException;
+    public abstract List<Contentlet> findAllVersions(Identifier identifier, boolean bringOldVersions, final Integer maxResults) throws DotDataException;
+
+    /**
+     * Retrieves all versions for a given Contentlet Identifier. It's highly recommended to use the
+     * pagination attributes, as this method may pull too many versions.
+     *
+     * @param identifier       The {@link Identifier} of the Contentlet whose versions will be
+     *                         returned.
+     * @param bringOldVersions If {@code true}, the old versions of the Contentlet will be included
+     *                         in the results, and not only its live/working version for each
+     *                         language.
+     * @param limit            The maximum number of versions to retrieve, for pagination purposes.
+     * @param offset           The result offset, for pagination purposes.
+     *
+     * @return A list of {@link Contentlet} objects representing its versions.
+     *
+     * @throws DotDataException An error occurred when retrieving the versions from the database.
+     */
+    public abstract List<Contentlet> findAllVersions(final Identifier identifier, final boolean bringOldVersions, final int limit, final int offset) throws DotDataException;
+
+    /**
+     * Retrieves all versions for a given Contentlet Identifier. It's highly recommended to use the
+     * pagination attributes, as this method may pull too many versions.
+     *
+     * @param identifier       The {@link Identifier} of the Contentlet whose versions will be
+     *                         returned.
+     * @param bringOldVersions If {@code true}, the old versions of the Contentlet will be included
+     *                         in the results, and not only its live/working version for each
+     *                         language.
+     * @param limit            The maximum number of versions to retrieve, for pagination purposes.
+     * @param offset           The result offset, for pagination purposes.
+     * @param orderDirection   The {@link OrderDirection} that will be used to sort the results by.
+     *
+     * @return A list of {@link Contentlet} objects representing its versions.
+     *
+     * @throws DotDataException An error occurred when retrieving the versions from the database.
+     */
+    public abstract List<Contentlet> findAllVersions(final Identifier identifier, final boolean bringOldVersions, final int limit, final int offset, final OrderDirection orderDirection) throws DotDataException;
+
+    /**
+     * Retrieves all versions for a given Contentlet Identifier. It's highly recommended to use the
+     * pagination attributes, as this method may pull too many versions.
+     *
+     * @param identifier       The {@link Identifier} of the Contentlet whose versions will be
+     *                         returned.
+     * @param bringOldVersions If {@code true}, the old versions of the Contentlet will be included
+     *                         in the results, and not only its live/working version for each
+     *                         language.
+     * @param limit            The maximum number of versions to retrieve, for pagination purposes.
+     * @param offset           The result offset, for pagination purposes.
+     * @param orderBy          The column that will be used to order the results.
+     * @param orderDirection   The {@link OrderDirection} that will be used to sort the results by.
+     *
+     * @return A list of {@link Contentlet} objects representing its versions.
+     *
+     * @throws DotDataException An error occurred when retrieving the versions from the database.
+     */
+    public abstract List<Contentlet> findAllVersions(final Identifier identifier, final boolean bringOldVersions, final int limit, final int offset, final String orderBy, final OrderDirection orderDirection) throws DotDataException;
 
 	/**
 	 * Retrieves all versions for a list of contentlet identifiers

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotTransformerBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotTransformerBuilder.java
@@ -1,26 +1,5 @@
 package com.dotmarketing.portlets.contentlet.transform;
 
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.BINARIES;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.BINARIES_VIEW;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_INFO;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_NAME;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_VIEW;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.DATETIME_FIELDS_TO_TIMESTAMP;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.FILEASSET_VIEW;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.IDENTIFIER_VIEW;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.COMMON_PROPS;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CONSTANTS;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.KEY_VALUE_VIEW;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.AVOID_MAP_SUFFIX_FOR_VIEWS;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.SITE_VIEW;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.TAGS;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.VERSION_INFO;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.LANGUAGE_VIEW;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.LANGUAGE_PROPS;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.LOAD_META;
-import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.USE_ALIAS;
-import static com.dotmarketing.util.UtilMethods.isNotSet;
-
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
@@ -32,12 +11,36 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
 import io.vavr.Lazy;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.AVOID_MAP_SUFFIX_FOR_VIEWS;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.BINARIES;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.BINARIES_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_INFO;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_NAME;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CLEAR_EXISTING_DATA;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.COMMON_PROPS;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CONSTANTS;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.DATETIME_FIELDS_TO_TIMESTAMP;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.FILEASSET_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.HISTORY_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.IDENTIFIER_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.KEY_VALUE_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.LANGUAGE_PROPS;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.LANGUAGE_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.LOAD_META;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.SITE_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.TAGS;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.USE_ALIAS;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.VERSION_INFO;
+import static com.dotmarketing.util.UtilMethods.isNotSet;
 
 /**
  * This Class is the entry point to realize any transformation
@@ -240,6 +243,19 @@ public class DotTransformerBuilder {
     public DotTransformerBuilder defaultOptions(){
         optionsHolder.clear();
         optionsHolder.addAll(DotContentletTransformerImpl.defaultOptions);
+        return this;
+    }
+
+    /**
+     * This transformer provides a view for the History of a Contentlet. It exposes a minified map
+     * of properties, just like the data you can see in the History tab in the Content Editor page.
+     * As such, all the other Contentlet properties are removed by default.
+     *
+     * @return The {@link DotTransformerBuilder} instance.
+     */
+    public DotTransformerBuilder historyToMapTransformer(){
+        optionsHolder.clear();
+        optionsHolder.addAll(EnumSet.of(CLEAR_EXISTING_DATA, HISTORY_VIEW));
         return this;
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/HistoryViewStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/HistoryViewStrategy.java
@@ -1,0 +1,73 @@
+package com.dotmarketing.portlets.contentlet.transform.strategy;
+
+import com.dotcms.api.APIProvider;
+import com.dotcms.experiments.model.AbstractExperimentVariant;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.dotmarketing.util.UtilMethods;
+import com.liferay.portal.model.User;
+
+import java.util.Map;
+import java.util.Set;
+
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.ARCHIVED_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.INODE_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.LIVE_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.MOD_DATE_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.MOD_USER_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.TITTLE_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.WORKING_KEY;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.LanguageViewStrategy.mapLanguage;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CLEAR_EXISTING_DATA;
+
+/**
+ * This Transformation Strategy exposes a view of a Contentlet with minimum specific History
+ * properties. They represent basically the information users can see in the History tab of the
+ * Content Editor page.
+ *
+ * @author Jose Castro
+ * @since Jul 28th, 2025
+ */
+class HistoryViewStrategy extends AbstractTransformStrategy<Contentlet> {
+
+    public static final String EXPERIMENT_VARIANT = "experimentVariant";
+
+    HistoryViewStrategy(final APIProvider toolBox) {
+        super(toolBox);
+    }
+
+    @Override
+    protected Map<String, Object> transform(final Contentlet contentlet, final Map<String, Object> map,
+                                            final Set<TransformOptions> options, final User user)
+            throws DotDataException, DotSecurityException {
+        if (options.contains(CLEAR_EXISTING_DATA)) {
+            map.clear();
+        }
+        map.put(INODE_KEY, contentlet.getInode());
+        map.put(TITTLE_KEY, contentlet.getTitle());
+        map.put(WORKING_KEY, contentlet.isWorking());
+        map.put(LIVE_KEY, contentlet.isLive());
+        map.put(ARCHIVED_KEY, contentlet.isArchived());
+        map.put(MOD_USER_KEY, contentlet.getModUser());
+        map.put(MOD_DATE_KEY, contentlet.getModDate());
+        this.addLanguageAttrs(contentlet, map);
+        final boolean isExperimentVariant = UtilMethods.isSet(contentlet.getVariantId())
+                && contentlet.getVariantId().startsWith(AbstractExperimentVariant.EXPERIMENT_VARIANT_NAME_PREFIX);
+        map.put(EXPERIMENT_VARIANT, isExperimentVariant);
+        return map;
+    }
+
+    /**
+     * Retrieves the language of the specific Contentlet and exposes specific attributes of it.
+     *
+     * @param contentlet The {@link Contentlet} object whose language will be retrieved.
+     * @param map        The {@link Map} where the language attributes will be added.
+     */
+    private void addLanguageAttrs(final Contentlet contentlet, final Map<String, Object> map) {
+        final Language language = toolBox.languageAPI.getLanguage(contentlet.getLanguageId());
+        map.putAll(mapLanguage(language, false));
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/StrategyResolverImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/StrategyResolverImpl.java
@@ -17,6 +17,7 @@ import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformO
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.CATEGORIES_VIEW;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.DATETIME_FIELDS_TO_TIMESTAMP;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.FILEASSET_VIEW;
+import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.HISTORY_VIEW;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.IDENTIFIER_VIEW;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.JSON_VIEW;
 import static com.dotmarketing.portlets.contentlet.transform.strategy.TransformOptions.KEY_VALUE_VIEW;
@@ -74,6 +75,17 @@ public class StrategyResolverImpl implements StrategyResolver {
         );
     }
 
+    /**
+     * Loads a {@link Map} of {@link TransformOptions} to
+     * {@link Supplier<AbstractTransformStrategy>} which associates a specific Transformation
+     * Strategy to a specific Transform Options. This way, the Strategies listed in the method can
+     * be exposed and used for returning a JSON representation of a Contentlet in a specific way.
+     *
+     * @param toolBox The {@link APIProvider} object used to access dotCMS APIs.
+     *
+     * @return A {@link Map} of {@link TransformOptions} to
+     * {@link Supplier<AbstractTransformStrategy>}.
+     */
     private static Map<TransformOptions, Supplier<AbstractTransformStrategy>> getStrategyTriggeredByOptionMap(final APIProvider toolBox) {
 
         final Map<TransformOptions, Supplier<AbstractTransformStrategy>> strategyTriggeredByOptionMap = new HashMap<>();
@@ -89,7 +101,7 @@ public class StrategyResolverImpl implements StrategyResolver {
         strategyTriggeredByOptionMap.put(RENDER_FIELDS, () -> new RenderFieldStrategy(toolBox));
         strategyTriggeredByOptionMap.put(JSON_VIEW, () -> new JSONViewStrategy(toolBox));
         strategyTriggeredByOptionMap.put(DATETIME_FIELDS_TO_TIMESTAMP, () -> new DateTimeFieldsToTimeStampStrategy(toolBox));
-
+        strategyTriggeredByOptionMap.put(HISTORY_VIEW, () -> new HistoryViewStrategy(toolBox));
         return strategyTriggeredByOptionMap;
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/TransformOptions.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/TransformOptions.java
@@ -104,7 +104,13 @@ public enum TransformOptions {
      * I hate to introduce this but seems like the safest way to avoid breaking backward compatibility
      * This options controls the Strategy that gets fired by the Widget Content Type which by default will render the widget code
      */
-    SKIP_WIDGET_CODE_RENDERING;
+    SKIP_WIDGET_CODE_RENDERING,
+    /** Instructs the Strategy to include specific properties that are displayed in the History
+     * tab of the Content Editor page. */
+    HISTORY_VIEW,
+    /** Instructs the Strategy to clear all existing data in the Contentlet Map before applying a
+     * specific Strategy. */
+    CLEAR_EXISTING_DATA;
 
     // -----------------------------------------------------------------------------------------
     // Plug additional Transform Options to manipulate the outcome as a particular type of view

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -5777,6 +5777,78 @@ paths:
           description: default response
       tags:
       - Content
+  /v1/content/versions/id/{identifier}/history:
+    get:
+      description: "Returns the history of a contentlet with the minimum expected\
+        \ information, as seen in the History tab in the Content Edition page."
+      operationId: history
+      parameters:
+      - description: The Identifier of the Contentlet whose history will be retrieved
+        in: path
+        name: identifier
+        required: true
+        schema:
+          type: string
+      - description: Specified whether the history must be grouped by language or
+          not
+        in: query
+        name: groupByLang
+        schema:
+          type: boolean
+          default: false
+      - description: Specified whether the history must include old versions or not
+        in: query
+        name: bringOldVersions
+        schema:
+          type: boolean
+          default: true
+      - description: "Sort direction: Choose between ascending or descending."
+        in: query
+        name: direction
+        schema:
+          type: string
+          default: DESC
+          enum:
+          - ASC
+          - DESC
+      - description: "Maximum number or results being returned, for pagination purposes."
+        in: query
+        name: limit
+        schema:
+          type: integer
+          format: int32
+      - description: "Page number of the results being returned, for pagination purposes."
+        in: query
+        name: offset
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityPaginatedDataView"
+          description: History data retrieved successfully
+        "400":
+          content:
+            application/json: {}
+          description: The identifier path parameter was not specified.
+        "401":
+          content:
+            application/json: {}
+          description: Authentication required.
+        "404":
+          content:
+            application/json: {}
+          description: The specified identifier does not match any contentlet.
+        "500":
+          content:
+            application/json: {}
+          description: An internal dotCMS error has occurred.
+      summary: Contentlet History
+      tags:
+      - Content
   /v1/content/versions/{inode}:
     get:
       operationId: findByInode
@@ -22133,6 +22205,29 @@ components:
       properties:
         entity:
           $ref: "#/components/schemas/PageWorkflowActionsView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityPaginatedDataView:
+      type: object
+      properties:
+        entity:
+          type: object
         errors:
           type: array
           items:

--- a/dotcms-postman/src/main/resources/postman/Content_Version_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Version_Resource.postman_collection.json
@@ -14,18 +14,19 @@
 					"name": "Generate Test Data",
 					"item": [
 						{
-							"name": "Find Spanish Language",
+							"name": "Find Second Language",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"exec": [
 											"",
-											"pm.test(\"Spanish language must be present\", function () {",
+											"pm.test(\"A second language must be present\", function () {",
 											"    const responseBody = pm.response.json();",
 											"    pm.expect(responseBody.errors.length).to.equal(0, \"An error occurred when retrieving the Spanish Language\");",
-											"",
-											"    pm.collectionVariables.set(\"esLangId\", responseBody.entity.id);",
+											"    pm.expect(responseBody.entity.length).to.greaterThan(1, \"There must be more than 1 language\");",
+											"    pm.collectionVariables.set(\"secondLangId\", responseBody.entity[1].id);",
+											"    pm.collectionVariables.set(\"isoCode\", responseBody.entity[1].isoCode);",
 											"});",
 											""
 										],
@@ -38,15 +39,14 @@
 								"method": "GET",
 								"header": [],
 								"url": {
-									"raw": "{{serverURL}}/api/v2/languages/es_es",
+									"raw": "{{serverURL}}/api/v2/languages",
 									"host": [
 										"{{serverURL}}"
 									],
 									"path": [
 										"api",
 										"v2",
-										"languages",
-										"es_es"
+										"languages"
 									]
 								}
 							},
@@ -170,14 +170,14 @@
 							"response": []
 						},
 						{
-							"name": "Create Test Content 1 - ES",
+							"name": "Create Test Content 1 - Second Lang",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Contenido de Prueba 1 ES was created successfully\", function () {",
-											"    pm.expect(pm.response.json().errors.length).to.eql(0, \"An error occurred when creating the Contenido de Prueba 1 ES\");",
+											"pm.test(\"Contenido de Prueba 1 in second language was created successfully\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(0, \"An error occurred when creating the Contenido de Prueba 1 second language\");",
 											"});",
 											""
 										],
@@ -201,7 +201,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 1\",\n        \"body\": \"Contenido de Prueba 1 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"{{esLangId}}\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
+									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 1\",\n        \"body\": \"Contenido de Prueba 1 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"{{secondLangId}}\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -284,14 +284,14 @@
 							"response": []
 						},
 						{
-							"name": "Create Test Content 2- ES",
+							"name": "Create Test Content 2- Second Lang",
 							"event": [
 								{
 									"listen": "test",
 									"script": {
 										"exec": [
-											"pm.test(\"Contenido de Prueba 2 ES was created successfully\", function () {",
-											"    pm.expect(pm.response.json().errors.length).to.eql(0, \"An error occurred when creating the Contenido de Prueba 2 ES\");",
+											"pm.test(\"Contenido de Prueba 2 in second language was created successfully\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(0, \"An error occurred when creating the Contenido de Prueba 2 second language\");",
 											"});",
 											""
 										],
@@ -315,7 +315,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 2\",\n        \"body\": \"Contenido de Prueba 2 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"{{esLangId}}\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
+									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 2\",\n        \"body\": \"Contenido de Prueba 2 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"{{secondLangId}}\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -341,7 +341,7 @@
 							"response": []
 						}
 					],
-					"description": "Creates a Contentlet and several different versions for it, in both English and Spanish:\n\n- Three versions in English.\n    \n- Two versions in Spanish.\n    \n\nOrdered by modification date -- descending order -- they will show up like this:\n\n1. _Spanish_.\n    \n2. English.\n    \n3. _Spanish_.\n    \n4. English.\n    \n5. English.",
+					"description": "Creates a Contentlet and several different versions for it, in both English and Spanish:\n\n- Three versions in English.\n    \n- Two versions in a second language.\n    \n\nOrdered by modification date -- descending order -- they will show up like this:\n\n1. _Second language_.\n    \n2. English.\n    \n3. _Second language_.\n    \n4. English.\n    \n5. English.",
 					"event": [
 						{
 							"listen": "prerequest",
@@ -448,19 +448,19 @@
 											"    pm.expect(entity).to.be.an('array').that.is.not.empty;",
 											"    const languageGroups = Object.keys(entity[0]);",
 											"    pm.expect(languageGroups.length).to.eql(2, \"There must be 2 sets of versions, one for each language\");",
-											"    pm.expect(languageGroups[0].length).to.eql(5, \"There\");",
 											"});",
 											"",
 											"pm.test(\"Checking number of entries for each language\", function() {",
 											"    // Ensure entity is defined and has language groups",
 											"    pm.expect(entity).to.be.an('array').that.is.not.empty;",
+											"    const isoCode = pm.collectionVariables.get(\"isoCode\");",
 											"    const enUsEntries = entity[0]['en-us'];",
-											"    const esEsEntries = entity[0]['es-es'];",
+											"    const secondLangEntries = entity[0][isoCode];",
 											"",
 											"    pm.expect(enUsEntries).to.be.an('array', \"The 'en-us' group should be an array\");",
-											"    pm.expect(esEsEntries).to.be.an('array', \"The 'es-es' group should be an array\");",
-											"    pm.expect(enUsEntries.length).to.eql(3, \"There should be 2 entries for 'en-us'\");",
-											"    pm.expect(esEsEntries.length).to.eql(2, \"There should be 2 entries for 'es-es'\");",
+											"    pm.expect(secondLangEntries).to.be.an('array', \"The second language '\" + isoCode + \"' group should be an array\");",
+											"    pm.expect(enUsEntries.length).to.eql(3, \"There should be 3 entries for 'en-us'\");",
+											"    pm.expect(secondLangEntries.length).to.eql(2, \"There should be 2 entries for '\" + isoCode +\"'\");",
 											"});",
 											""
 										],

--- a/dotcms-postman/src/main/resources/postman/Content_Version_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Version_Resource.postman_collection.json
@@ -1,0 +1,807 @@
+{
+	"info": {
+		"_postman_id": "eca2aec6-2606-41ae-a013-6a23cb6061ae",
+		"name": "Content Version Resource",
+		"description": "The Content Versions REST Endpoint allows users to retrieve information related to the different versions a Contentlet has in the dotCMS repository. It's base path is mapped to:\n\n`/api/v1/content/versions`\n\nYou can query Contentlet versions or history data.",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "5403727"
+	},
+	"item": [
+		{
+			"name": "Contentlet History",
+			"item": [
+				{
+					"name": "Generate Test Data",
+					"item": [
+						{
+							"name": "Create Test Content 1 - EN",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Content 1 EN was created successfully\", function () {",
+											"    const entity = pm.response.json().entity;",
+											"    pm.expect(pm.response.json().errors.length).to.eql(0, \"An error occurred when creating the Test Content 1 EN\");",
+											"",
+											"    pm.collectionVariables.set(\"contentIdentifier\", entity.identifier);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Test Content 1\",\n        \"body\": \"Test Content 1 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"1\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/b9d89c80-3d88-4311-8365-187323c96436/fire",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"b9d89c80-3d88-4311-8365-187323c96436",
+										"fire"
+									]
+								},
+								"description": "Create the original Contentlet."
+							},
+							"response": []
+						},
+						{
+							"name": "Create Test Content 2 - EN",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Content 2 EN was created successfully\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(0, \"An error occurred when creating the Test Content 2 EN\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlet\": {\n        \"identifier\": \"{{contentIdentifier}}\",\n        \"contentHost\": \"default\",\n        \"title\": \"Test Content 2\",\n        \"body\": \"Test Content 2 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"1\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/b9d89c80-3d88-4311-8365-187323c96436/fire",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"b9d89c80-3d88-4311-8365-187323c96436",
+										"fire"
+									]
+								},
+								"description": "Create the original Contentlet."
+							},
+							"response": []
+						},
+						{
+							"name": "Create Test Content 1 - ES",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Contenido de Prueba 1 ES was created successfully\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(0, \"An error occurred when creating the Contenido de Prueba 1 ES\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 1\",\n        \"body\": \"Contenido de Prueba 1 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"2\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/b9d89c80-3d88-4311-8365-187323c96436/fire",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"b9d89c80-3d88-4311-8365-187323c96436",
+										"fire"
+									]
+								},
+								"description": "Create the original Contentlet."
+							},
+							"response": []
+						},
+						{
+							"name": "Create Test Content 3 - EN",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Test Content 3 EN was created successfully\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(0, \"An error occurred when creating the Test Content 3 EN\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlet\": {\n        \"identifier\": \"{{contentIdentifier}}\",\n        \"contentHost\": \"default\",\n        \"title\": \"Test Content 3\",\n        \"body\": \"Test Content 3 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"1\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/b9d89c80-3d88-4311-8365-187323c96436/fire",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"b9d89c80-3d88-4311-8365-187323c96436",
+										"fire"
+									]
+								},
+								"description": "Create the original Contentlet."
+							},
+							"response": []
+						},
+						{
+							"name": "Create Test Content 2- ES",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Contenido de Prueba 2 ES was created successfully\", function () {",
+											"    pm.expect(pm.response.json().errors.length).to.eql(0, \"An error occurred when creating the Contenido de Prueba 2 ES\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								},
+								{
+									"listen": "prerequest",
+									"script": {
+										"exec": [
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "PUT",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 2\",\n        \"body\": \"Contenido de Prueba 2 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"2\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/workflow/actions/b9d89c80-3d88-4311-8365-187323c96436/fire",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"workflow",
+										"actions",
+										"b9d89c80-3d88-4311-8365-187323c96436",
+										"fire"
+									]
+								},
+								"description": "Create the original Contentlet."
+							},
+							"response": []
+						}
+					],
+					"description": "Creates a Contentlet and several different versions for it, in both English and Spanish:\n\n- Three versions in English.\n    \n- Two versions in Spanish.\n    \n\nOrdered by modification date -- descending order -- they will show up like this:\n\n1. _Spanish_.\n    \n2. English.\n    \n3. _Spanish_.\n    \n4. English.\n    \n5. English.",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.test(\"HTTP Status code must be successful\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									""
+								]
+							}
+						}
+					]
+				},
+				{
+					"name": "Get Content History Data",
+					"item": [
+						{
+							"name": "With Default Params",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const entity = pm.response.json().entity;",
+											"",
+											"pm.test(\"A total of 5 records must be returned\", function() {",
+											"    pm.expect(entity.length).to.eql(5, \"There must be 5 contents returned as results\");",
+											"});",
+											"",
+											"pm.test(\"Checking total records\", function() {",
+											"    pm.expect(pm.response.json().pagination.totalEntries).to.eql(5, \"Total entries must be 5\");",
+											"});",
+											"",
+											"pm.test(\"Checking default descending order. The latest version is returned first\", function() {",
+											"    pm.expect(entity[0].title).to.eql(\"Contenido de Prueba 2\", \"The 'Contenido de Prueba 2' version must be the first one in the list\");",
+											"});",
+											"",
+											"pm.test(\"Checking default current page value\", function() {",
+											"    pm.expect(pm.response.json().pagination.currentPage).to.eql(1, \"Default page value must be 1\");",
+											"});",
+											"",
+											"pm.test(\"Checking default perPage value\", function() {",
+											"    pm.expect(pm.response.json().pagination.perPage).to.eql(10, \"Default perPage value must be 10\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/versions/id/{{contentIdentifier}}/history",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"versions",
+										"id",
+										"{{contentIdentifier}}",
+										"history"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Grouped by Languages",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const entity = pm.response.json().entity;",
+											"",
+											"pm.test(\"A total of 2 language groups should've been returned\", function() {",
+											"    // Ensure entity is defined and has at least one item",
+											"    pm.expect(entity).to.be.an('array').that.is.not.empty;",
+											"    const languageGroups = Object.keys(entity[0]);",
+											"    pm.expect(languageGroups.length).to.eql(2, \"There must be 2 sets of versions, one for each language\");",
+											"    pm.expect(languageGroups[0].length).to.eql(5, \"There\");",
+											"});",
+											"",
+											"pm.test(\"Checking number of entries for each language\", function() {",
+											"    // Ensure entity is defined and has language groups",
+											"    pm.expect(entity).to.be.an('array').that.is.not.empty;",
+											"    const enUsEntries = entity[0]['en-us'];",
+											"    const esEsEntries = entity[0]['es-es'];",
+											"",
+											"    pm.expect(enUsEntries).to.be.an('array', \"The 'en-us' group should be an array\");",
+											"    pm.expect(esEsEntries).to.be.an('array', \"The 'es-es' group should be an array\");",
+											"    pm.expect(enUsEntries.length).to.eql(3, \"There should be 2 entries for 'en-us'\");",
+											"    pm.expect(esEsEntries.length).to.eql(2, \"There should be 2 entries for 'es-es'\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/versions/id/{{contentIdentifier}}/history?groupByLang=true",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"versions",
+										"id",
+										"{{contentIdentifier}}",
+										"history"
+									],
+									"query": [
+										{
+											"key": "groupByLang",
+											"value": "true"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Do Not Bring Old Versions",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Only 2 records must be returned\", function() {",
+											"    const entity = pm.response.json().entity;",
+											"    // For a total of 5 records, and a page size of 3, only 2 records must be returned",
+											"    pm.expect(entity.length).to.eql(2, \"There must be 2 contents returned as a result\");",
+											"});",
+											"",
+											"pm.test(\"Checking total entries\", function() {",
+											"    pm.expect(pm.response.json().pagination.totalEntries).to.eql(2, \"There must be only 2 entries, a live version for each language\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/versions/id/{{contentIdentifier}}/history?bringOldVersions=false",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"versions",
+										"id",
+										"{{contentIdentifier}}",
+										"history"
+									],
+									"query": [
+										{
+											"key": "bringOldVersions",
+											"value": "false"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "With Ascending Order",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const entity = pm.response.json().entity;",
+											"",
+											"pm.test(\"A total of 5 records must be returned\", function() {",
+											"    pm.expect(entity.length).to.eql(5, \"There must be 5 contents returned as results\");",
+											"});",
+											"",
+											"pm.test(\"Checking that the first-ever record is returned first\", function() {",
+											"    pm.expect(entity[0].title).to.eql(\"Test Content 1\", \"The 'Test Content 1' version must be the first one in the list\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/versions/id/{{contentIdentifier}}/history?direction=ASC",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"versions",
+										"id",
+										"{{contentIdentifier}}",
+										"history"
+									],
+									"query": [
+										{
+											"key": "direction",
+											"value": "ASC"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "With Limit",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Only 1 record must be returned\", function() {",
+											"    const entity = pm.response.json().entity;",
+											"    pm.expect(entity.length).to.eql(1, \"There must be 1 content returned as a result\");",
+											"    pm.expect(entity[0].title).to.eql(\"Contenido de Prueba 2\", \"The 'Contenido de prueba 2' version must be the only one returned as a result\");",
+											"});",
+											"",
+											"pm.test(\"Checking perPage (limit) value\", function() {",
+											"    pm.expect(pm.response.json().pagination.perPage).to.eql(1, \"The perPage value must be 10\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/versions/id/{{contentIdentifier}}/history?limit=1",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"versions",
+										"id",
+										"{{contentIdentifier}}",
+										"history"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "With Limit and Offset",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"pm.test(\"Only 2 records must be returned\", function() {",
+											"    const entity = pm.response.json().entity;",
+											"    // For a total of 5 records, and a page size of 3, only 2 records must be returned",
+											"    pm.expect(entity.length).to.eql(2, \"There must be 2 contents returned as a result\");",
+											"});",
+											"",
+											"pm.test(\"Checking pagination values (limit and offset)\", function() {",
+											"    pm.expect(pm.response.json().pagination.currentPage).to.eql(2, \"The currentPage (offset) value must be 2\");",
+											"    pm.expect(pm.response.json().pagination.perPage).to.eql(3, \"The perPage (limit) value must be 3\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/versions/id/{{contentIdentifier}}/history?limit=3&offset=2",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"versions",
+										"id",
+										"{{contentIdentifier}}",
+										"history"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "3"
+										},
+										{
+											"key": "offset",
+											"value": "2"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					],
+					"description": "Exposes several REST calls with different filtering parameters for returing specific and/or paginated information.",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									""
+								]
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"type": "text/javascript",
+								"packages": {},
+								"exec": [
+									"pm.test(\"HTTP Status code must be successful\", function() {",
+									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"No errors must be returned\", function() {",
+									"    const errors = pm.response.json().errors;",
+									"    pm.expect(errors.length).to.eql(0, \"No errors must be returned.\");",
+									"});",
+									""
+								]
+							}
+						}
+					]
+				}
+			]
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "{{jwt}}",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					"if (!pm.environment.get('jwt')) {",
+					"    console.log(\"generating....\")",
+					"    const serverURL = pm.environment.get('serverURL'); // Get the server URL from the environment variable",
+					"    const apiUrl = `${serverURL}/api/v1/apitoken`; // Construct the full API URL",
+					"",
+					"    if (!pm.environment.get('jwt')) {",
+					"        const username = pm.environment.get(\"user\");",
+					"        const password = pm.environment.get(\"password\");",
+					"        const basicAuth = Buffer.from(`${username}:${password}`).toString('base64');",
+					"",
+					"        const requestOptions = {",
+					"            url: apiUrl,",
+					"            method: \"POST\",",
+					"            header: {",
+					"                \"accept\": \"*/*\",",
+					"                \"content-type\": \"application/json\",",
+					"                \"Authorization\": `Basic ${basicAuth}`",
+					"            },",
+					"            body: {",
+					"                mode: \"raw\",",
+					"                raw: JSON.stringify({",
+					"                    \"expirationSeconds\": 7200,",
+					"                    \"userId\": \"dotcms.org.1\",",
+					"                    \"network\": \"0.0.0.0/0\",",
+					"                    \"claims\": {\"label\": \"postman-tests\"}",
+					"                })",
+					"            }",
+					"        };",
+					"",
+					"        pm.sendRequest(requestOptions, function (err, response) {",
+					"            if (err) {",
+					"                console.log(err);",
+					"            } else {",
+					"                const jwt = response.json().entity.jwt;",
+					"                pm.environment.set('jwt', jwt);",
+					"                console.log(jwt);",
+					"            }",
+					"        });",
+					"    }",
+					"}"
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
+		}
+	]
+}

--- a/dotcms-postman/src/main/resources/postman/Content_Version_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Version_Resource.postman_collection.json
@@ -14,6 +14,45 @@
 					"name": "Generate Test Data",
 					"item": [
 						{
+							"name": "Find Spanish Language",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"",
+											"pm.test(\"Spanish language must be present\", function () {",
+											"    const responseBody = pm.response.json();",
+											"    pm.expect(responseBody.errors.length).to.equal(0, \"An error occurred when retrieving the Spanish Language\");",
+											"",
+											"    pm.collectionVariables.set(\"esLangId\", responseBody.entity.id);",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{serverURL}}/api/v2/languages/es_es",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v2",
+										"languages",
+										"es_es"
+									]
+								}
+							},
+							"response": []
+						},
+						{
 							"name": "Create Test Content 1 - EN",
 							"event": [
 								{
@@ -162,7 +201,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 1\",\n        \"body\": \"Contenido de Prueba 1 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"2\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
+									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 1\",\n        \"body\": \"Contenido de Prueba 1 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"{{esLangId}}\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -276,7 +315,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 2\",\n        \"body\": \"Contenido de Prueba 2 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"2\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
+									"raw": "{\n    \"contentlet\": {\n        \"contentHost\": \"default\",\n        \"title\": \"Contenido de Prueba 2\",\n        \"body\": \"Contenido de Prueba 2 Body\",\n        \"contentType\": \"webPageContent\",\n        \"languageId\": \"{{esLangId}}\",\n        \"identifier\": \"{{contentIdentifier}}\"\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"


### PR DESCRIPTION
### Proposed Changes
* This PR introduces a new REST Endpoint to the `ContentVersionResource`, called `/id/{identifier}/history`. It allows you to retrieve a paginated minified set of versions that belong to a specific Contentlet based on its Identifier. This was done by adding a new Transform Option and its respective implementation, following our existing code pattern.
* The retrieved information can be used for building the `History` tab in the Content Editor window.
* A new implementation using the dedicated `ResponseEntityPaginatedDataView` was added to the `PaginationUtil` class. This allows us to move away from returning the generic `Response` object, and use the Swagger annotations as expected.
* New method overloads for the `ContentletAPI` and the `ContentletFactory` classes allow you to paginate the Contentlet version data. Considering that the number of versions of a given Contentlet can be extremely high, having this feature in place provides developers more control on how they can retrieve data more safely and efficiently.
* A new Postman Collection was added for the `ContentVersionResource`, as we didn't have any tests for it.

This PR fixes: #31734

This PR fixes: #31734