### PR TITLE
implementation ( Edit Content ): #31773 Relationship field: Support active filters as chips in search input

### DIFF
--- a/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_table.scss
+++ b/core-web/libs/dotcms-scss/angular/dotcms-theme/components/_table.scss
@@ -39,7 +39,7 @@ $dot-table-cell-height: 1.25rem;
         > .p-datatable-wrapper {
             border-radius: $border-radius-md;
             border: 1px solid $color-palette-gray-400;
-            border-width: 0 1px 1px 1px;
+            border-width: 1px;
         }
 
         .p-paginator-top,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.html
@@ -11,8 +11,7 @@
         <input
             pInputText
             type="text"
-            class="w-22rem h-auto"
-            (keydown.enter)="doSearch()"
+            class="content-search__input w-22rem h-auto"
             [placeholder]="'dot.file.relationship.dialog.search.placeholder' | dm"
             formControlName="query" />
         <p-button

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.scss
@@ -3,3 +3,7 @@
 .search-icon {
     color: $color-palette-gray-600;
 }
+
+input.content-search__input[pInputText]:focus {
+    outline: none;
+}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
@@ -2,6 +2,7 @@ import { createComponentFactory, mockProvider, Spectator } from '@ngneat/spectat
 import { of } from 'rxjs';
 
 import { Component, forwardRef } from '@angular/core';
+import { fakeAsync, tick } from '@angular/core/testing';
 import {
     ControlValueAccessor,
     FormControl,
@@ -22,7 +23,7 @@ import { MockDotMessageService, mockLocales } from '@dotcms/utils-testing';
 
 import { LanguageFieldComponent } from './components/language-field/language-field.component';
 import { SiteFieldComponent } from './components/site-field/site-field.component';
-import { SearchComponent } from './search.component';
+import { SearchComponent, DEBOUNCE_TIME } from './search.component';
 
 import { TreeNodeItem } from '../../../../../../models/dot-edit-content-host-folder-field.interface';
 import { DotEditContentService } from '../../../../../../services/dot-edit-content.service';
@@ -632,6 +633,49 @@ describe('SearchComponent', () => {
         });
     });
 
+    describe('Debounced Search', () => {
+        it('should trigger search automatically after debounce delay', fakeAsync(() => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            // Set query value
+            component.form.get('query')?.setValue('test search');
+
+            // Fast-forward time by less than debounce time - should not trigger search
+            tick(DEBOUNCE_TIME - 1);
+            expect(searchSpy).not.toHaveBeenCalled();
+
+            // Fast-forward remaining time - should trigger search
+            tick(1);
+            expect(searchSpy).toHaveBeenCalledWith({
+                query: 'test search',
+                systemSearchableFields: {}
+            });
+        }));
+
+        it('should include system search fields in debounced search', fakeAsync(() => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            // Set form values
+            component.form.patchValue({
+                query: 'test',
+                systemSearchableFields: {
+                    languageId: 1,
+                    siteOrFolderId: 'site:123'
+                }
+            });
+
+            tick(DEBOUNCE_TIME);
+
+            expect(searchSpy).toHaveBeenCalledWith({
+                query: 'test',
+                systemSearchableFields: {
+                    languageId: 1,
+                    siteId: '123'
+                }
+            });
+        }));
+    });
+
     describe('Integration Tests', () => {
         it('should update form values when input changes', () => {
             const queryInput = spectator.query('input[formControlName="query"]');
@@ -639,6 +683,24 @@ describe('SearchComponent', () => {
 
             expect(component.form.get('query').value).toBe('test query');
         });
+
+        it('should trigger debounced search when typing in input', fakeAsync(() => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+            const queryInput = spectator.query('input[formControlName="query"]');
+
+            spectator.typeInElement('test search', queryInput);
+
+            // Should not trigger immediately
+            expect(searchSpy).not.toHaveBeenCalled();
+
+            // Wait for debounce
+            tick(DEBOUNCE_TIME);
+
+            expect(searchSpy).toHaveBeenCalledWith({
+                query: 'test search',
+                systemSearchableFields: {}
+            });
+        }));
 
         it('should trigger search when search button is clicked (site)', () => {
             const searchSpy = jest.spyOn(component.onSearch, 'emit');

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
@@ -1,4 +1,5 @@
 import { Component, inject, input, output, viewChild, signal, computed } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
@@ -9,6 +10,8 @@ import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
 import { InputTextModule } from 'primeng/inputtext';
 import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
 
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+
 import { DotMessagePipe } from '@dotcms/ui';
 
 import { LanguageFieldComponent } from './components/language-field/language-field.component';
@@ -16,6 +19,8 @@ import { SiteFieldComponent } from './components/site-field/site-field.component
 
 import { TreeNodeItem } from '../../../../../../models/dot-edit-content-host-folder-field.interface';
 import { SearchParams } from '../../../../models/search.model';
+
+export const DEBOUNCE_TIME = 300;
 
 interface ActiveFilter {
     label: string;
@@ -144,6 +149,20 @@ export class SearchComponent {
             siteOrFolderId: ['']
         })
     });
+
+    constructor() {
+        // Simple debounced search - clean and straightforward
+        this.form
+            .get('query')
+            ?.valueChanges.pipe(
+                takeUntilDestroyed(),
+                debounceTime(DEBOUNCE_TIME),
+                distinctUntilChanged()
+            )
+            .subscribe(() => {
+                this.doSearch();
+            });
+    }
 
     /**
      * Resets the search form to its initial state and clears active filters.

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
@@ -151,7 +151,7 @@ export class SearchComponent {
     });
 
     constructor() {
-        // Simple debounced search - clean and straightforward
+        // debounced search.
         this.form
             .get('query')
             ?.valueChanges.pipe(


### PR DESCRIPTION
### Proposed Changes
* Outline feedback 
* missing pixel in table 
* Debounce on search 


### Screenshots
<img width="1014" height="647" alt="image" src="https://github.com/user-attachments/assets/5124c1bf-d6f5-4ef3-abe4-edc20d7811be" />

This PR fixes: #31773