### PR TITLE
Chaging LEGACY_RELATION_TYPE UUID to 1

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -279,8 +279,7 @@ public class PageRenderUtil implements Serializable {
 
             for (final String uniqueId : pageContents.row(containerId).keySet()) {
 
-                final String uniqueUUIDForRender = needParseContainerPrefix(container, uniqueId) ?
-                        ParseContainer.getDotParserContainerUUID(uniqueId) : uniqueId;
+                final String uniqueUUIDForRender = getUniqueUUIDForRender(uniqueId, container);
 
                 if (ContainerUUID.UUID_DEFAULT_VALUE.equals(uniqueId)) {
                     continue;
@@ -344,6 +343,14 @@ public class PageRenderUtil implements Serializable {
 
         return rawContainers;
         }
+
+    private String getUniqueUUIDForRender(String uniqueId, Container container) {
+        if (needParseContainerPrefix(container, uniqueId)) {
+            return ParseContainer.getDotParserContainerUUID(uniqueId);
+        } else {
+            return uniqueId.equals(ContainerUUID.UUID_LEGACY_VALUE) ? ContainerUUID.UUID_START_VALUE : uniqueId;
+        }
+    }
 
     /**
      * Retrieves the Time Machine Date from the current HTTP Request, if available.


### PR DESCRIPTION
### Proposed Changes
* Changing LEGACY_RELATION_TYPE by 1, when we create the contenlet list in the Velocity code, later we are going to look any LEGACY_RELATION_TYPE UUID as 1, when the page is rendered

This PR fixes: #32934

This PR fixes: #32934