### PR TITLE
fix(content): fix error when isLocked() is called before a fileAsset has been persisted.

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/VersionableAPIImpl.java
@@ -1,23 +1,14 @@
 
 package com.dotmarketing.business;
 
-import static com.dotcms.util.CollectionsUtils.list;
-
-import com.dotcms.api.system.event.message.MessageSeverity;
-import com.dotcms.api.system.event.message.MessageType;
-import com.dotcms.api.system.event.message.SystemMessageEventUtil;
-import com.dotcms.api.system.event.message.builder.SystemMessageBuilder;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.cdi.CDIUtils;
-import com.dotcms.concurrent.Debouncer;
 import com.dotcms.contenttype.business.uniquefields.UniqueFieldValidationStrategyResolver;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.variant.model.Variant;
 import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.beans.VersionInfo;
-import com.dotmarketing.common.db.DotConnect;
-import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
@@ -27,22 +18,15 @@ import com.dotmarketing.util.ContentPublishDateUtil;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
-import com.google.common.collect.ImmutableList;
-import com.liferay.portal.language.LanguageUtil;
 import com.liferay.portal.model.User;
 import com.rainerhahnekamp.sneakythrow.Sneaky;
-
 import io.vavr.control.Try;
-
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
 import org.apache.commons.beanutils.BeanUtils;
 
 public class VersionableAPIImpl implements VersionableAPI {
@@ -323,8 +307,6 @@ public class VersionableAPIImpl implements VersionableAPI {
                     contentlet.getVariantId());
         }
 
-        if(info.isEmpty())
-            throw new DotStateException("No version info. Call setWorking first "+identifier.getId());
         return info;
     }
 
@@ -344,7 +326,7 @@ public class VersionableAPIImpl implements VersionableAPI {
             final Contentlet contentlet = (Contentlet)versionable;
             final Optional<ContentletVersionInfo> info = getContentletVersionInfo(identifier, contentlet);
 
-            return info.get().isLocked();
+          return info.isPresent() && info.get().isLocked();
         } else {
             final VersionInfo info = versionableFactory.getVersionInfo(versionable.getVersionId());
             if(!UtilMethods.isSet(info.getIdentifier()))

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -889,7 +889,7 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 	 * @throws DotStateException
 	 */
 	public boolean isArchived() throws DotStateException, DotDataException, DotSecurityException {
-		return InodeUtils.isSet(this.getIdentifier())?APILocator.getVersionableAPI().isDeleted(this):false;
+    return UtilMethods.isSet(this.getIdentifier()) ? APILocator.getVersionableAPI().isDeleted(this) : false;
 	}
 
 	/**
@@ -900,7 +900,7 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 	 * @throws DotStateException
 	 */
 	public boolean isLive() throws DotStateException, DotDataException, DotSecurityException {
-		return APILocator.getVersionableAPI().isLive(this);
+    return UtilMethods.isSet(this.getIdentifier()) ? APILocator.getVersionableAPI().isLive(this) : false;
 	}
 
 	/**
@@ -911,7 +911,7 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 	 * @throws DotStateException
 	 */
 	public boolean isLocked() throws DotStateException, DotDataException, DotSecurityException {
-		return APILocator.getVersionableAPI().isLocked(this);
+    return UtilMethods.isSet(this.getIdentifier()) ? APILocator.getVersionableAPI().isLocked(this) : false;
 	}
 
 	/**
@@ -938,7 +938,7 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 	 * @throws DotStateException
 	 */
 	public boolean isWorking() throws DotStateException, DotDataException, DotSecurityException {
-		return InodeUtils.isSet(this.getIdentifier()) && APILocator.getVersionableAPI()
+    return UtilMethods.isSet(this.getIdentifier()) && APILocator.getVersionableAPI()
 				.isWorking(this);
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
@@ -272,29 +272,6 @@ public class FileAsset extends Contentlet implements IFileAsset {
        return isDeleted();
 	}
 
-
-	/**
-	 * Returns the live.
-	 * @return boolean
-	 * @throws DotSecurityException
-	 * @throws DotDataException
-	 * @throws DotStateException
-	 */
-	public boolean isLive() throws DotStateException, DotDataException, DotSecurityException {
-    return super.isLive();
-	}
-
-	/**
-	 * Returns the locked.
-	 * @return boolean
-	 * @throws DotSecurityException
-	 * @throws DotDataException
-	 * @throws DotStateException
-	 */
-	public boolean isLocked() throws DotStateException, DotDataException, DotSecurityException {
-    return super.isLocked();
-   }
-
 	public String getType(){
 		return "file_asset";
 	}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/fileassets/business/FileAsset.java
@@ -16,13 +16,11 @@ import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
-import com.dotmarketing.util.json.JSONIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
-
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -283,7 +281,7 @@ public class FileAsset extends Contentlet implements IFileAsset {
 	 * @throws DotStateException
 	 */
 	public boolean isLive() throws DotStateException, DotDataException, DotSecurityException {
-	    return APILocator.getVersionableAPI().isLive(this);
+    return super.isLive();
 	}
 
 	/**
@@ -294,7 +292,7 @@ public class FileAsset extends Contentlet implements IFileAsset {
 	 * @throws DotStateException
 	 */
 	public boolean isLocked() throws DotStateException, DotDataException, DotSecurityException {
-       return APILocator.getVersionableAPI().isLocked(this);
+    return super.isLocked();
    }
 
 	public String getType(){


### PR DESCRIPTION
Fixes checkin method for FileAssets - and calling isLocked() before an asset has been persisted.  This only occurs if you try to checkin a FileAsset rather than a Contentlet.

ref: #32936

This is the meat of the change:
https://github.com/dotCMS/core/pull/32938/files#diff-735e5108543e2885d74419f1897f8c77bef357968ce74eb88982edca81abad25L326-R310


