### PR TITLE
feat(docker): Add JFR modules to java-base Dockerfile jlink configuration (#32963)

### DIFF
--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -33,7 +33,7 @@ RUN apt update && \
 RUN bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && jlink \
     --verbose \
     --add-modules \
-        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,jdk.management.agent,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom \
+        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,jdk.management.agent,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom,jdk.jfr,jdk.management.jfr \
     --compress 2 \
     --no-header-files \
     --no-man-pages \


### PR DESCRIPTION
### Proposed Changes

This PR adds Java Flight Recorder (JFR) modules to the docker java-base image to enable JFR support for observability and profiling features.

**Specific Change:**
* Add `jdk.jfr` and `jdk.management.jfr` modules to the jlink configuration in `docker/java-base/Dockerfile`

**Before:**
```dockerfile
--add-modules \
    java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,jdk.management.agent,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom \
```

**After:**
```dockerfile
--add-modules \
    java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,jdk.management.agent,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom,jdk.jfr,jdk.management.jfr \
```

### Why This Change

- **JFR Support**: Enables Java Flight Recorder capabilities in the custom JRE
- **Observability Foundation**: Required for advanced profiling and monitoring features  
- **Infrastructure Prerequisite**: Deployed separately before main observability features
- **Low Risk**: Additive change that doesn't break existing functionality

### Impact

- **Scope**: All Docker containers using the java-base image
- **Risk**: Low - Only adds modules to JRE, no behavioral changes
- **Benefits**: Enables JFR-based profiling and performance monitoring

### Checklist

- [x] Docker image builds successfully with new JFR modules
- [x] Change is additive and doesn't break existing functionality  
- [ ] Tests (infrastructure change - manual verification)
- [x] Translations (not applicable - infrastructure change)
- [x] Security Implications Contemplated (low risk additive change)

### Additional Info

Closes #32963

This change is extracted as a separate infrastructure update that can be deployed independently before the main observability features. The JFR modules (`jdk.jfr` and `jdk.management.jfr`) are added to the jlink command to include them in the custom JRE built for the java-base Docker image.

This PR fixes: #32963