### PR TITLE
implementation ( Edit Content ): #32516 Textarea field selected mode does not persist after saving 

### DIFF
--- a/core-web/libs/dotcms-models/src/lib/dot-contentlet.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-contentlet.model.ts
@@ -42,6 +42,7 @@ export interface DotCMSContentlet {
     contentTypeIcon?: string;
     variant?: string;
     __icon__?: string;
+    disabledWYSIWYG?: string[];
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: any;
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
@@ -49,6 +49,8 @@
             <ng-container [ngTemplateOutlet]="labelTemplate" />
             <dot-edit-content-text-area
                 [field]="field"
+                [contentlet]="contentlet"
+                (disabledWYSIWYGChange)="disabledWYSIWYGChange.emit($event)"
                 [attr.data-testId]="'field-' + field.variable" />
         }
     }
@@ -137,6 +139,7 @@
             <dot-edit-content-wysiwyg-field
                 [field]="field"
                 [contentlet]="contentlet"
+                (disabledWYSIWYGChange)="disabledWYSIWYGChange.emit($event)"
                 [attr.data-testId]="'field-' + field.variable" />
         }
     }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
@@ -5,7 +5,8 @@ import {
     computed,
     HostBinding,
     inject,
-    input
+    input,
+    output
 } from '@angular/core';
 import { ControlContainer, ReactiveFormsModule } from '@angular/forms';
 
@@ -89,6 +90,12 @@ export class DotEditContentFieldComponent {
      * The content type.
      */
     $contentType = input<string>(null, { alias: 'contentType' });
+
+    /**
+     * Event emitted when disabledWYSIWYG changes in any field component.
+     * Emits the updated disabledWYSIWYG array.
+     */
+    disabledWYSIWYGChange = output<string[]>();
 
     readonly fieldTypes = FIELD_TYPES;
     readonly calendarTypes = CALENDAR_FIELD_TYPES as string[];

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
@@ -55,6 +55,7 @@
                                         [contentType]="contentType.variable"
                                         [contentlet]="contentlet"
                                         [field]="field"
+                                        (disabledWYSIWYGChange)="onDisabledWYSIWYGChange($event)"
                                         data-testId="field" />
                                 }
                             </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -50,6 +50,7 @@ import { DotEditContentService } from '../../services/dot-edit-content.service';
 import { DotEditContentStore } from '../../store/edit-content.store';
 import {
     MOCK_CONTENTLET_1_TAB as MOCK_CONTENTLET_1_OR_2_TABS,
+    MOCK_CONTENTLET_WITHOUT_DISABLED_WYSIWYG,
     MOCK_CONTENTTYPE_1_TAB,
     MOCK_CONTENTTYPE_2_TABS,
     MOCK_WORKFLOW_ACTIONS_NEW_ITEMNTTYPE_1_TAB,
@@ -175,6 +176,12 @@ describe('DotFormComponent', () => {
             expect(component.form.get('modUserName')).toBeFalsy();
             expect(component.form.get('publishDate')).toBeFalsy();
         });
+
+        it('should create disabledWYSIWYG form control with existing contentlet values', () => {
+            const disabledWYSIWYGControl = component.form.get('disabledWYSIWYG');
+            expect(disabledWYSIWYGControl).toBeTruthy();
+            expect(disabledWYSIWYGControl?.value).toEqual(['wysiwygField1', 'wysiwygField2']);
+        });
     });
 
     describe('New Content', () => {
@@ -210,6 +217,12 @@ describe('DotFormComponent', () => {
             expect(component.form.get('text1').hasValidator(Validators.required)).toBe(true);
             expect(component.form.get('text2').hasValidator(Validators.required)).toBe(false);
             expect(component.form.get('text3').hasValidator(Validators.required)).toBe(false);
+        });
+
+        it('should create disabledWYSIWYG form control with empty array for new content', () => {
+            const disabledWYSIWYGControl = component.form.get('disabledWYSIWYG');
+            expect(disabledWYSIWYGControl).toBeTruthy();
+            expect(disabledWYSIWYGControl?.value).toEqual([]);
         });
 
         it('should render the correct number of rows, columns and fields', fakeAsync(() => {
@@ -396,7 +409,8 @@ describe('DotFormComponent', () => {
                             text3: 'default value modified',
                             multiselect: 'A,B,C',
                             languageId: '',
-                            identifier: null
+                            identifier: null,
+                            disabledWYSIWYG: ['wysiwygField1', 'wysiwygField2']
                         }
                     }
                 });
@@ -589,6 +603,132 @@ describe('DotFormComponent', () => {
             it('should hide the lock switch when user can not lock', () => {
                 const lockSwitch = spectator.query(InputSwitch);
                 expect(lockSwitch).toBe(null);
+            });
+        });
+    });
+
+    describe('disabledWYSIWYG functionality', () => {
+        describe('onDisabledWYSIWYGChange', () => {
+            beforeEach(() => {
+                dotContentTypeService.getContentType.mockReturnValue(of(MOCK_CONTENTTYPE_1_TAB));
+                workflowActionsService.getByInode.mockReturnValue(
+                    of(MOCK_WORKFLOW_ACTIONS_NEW_ITEMNTTYPE_1_TAB)
+                );
+                dotEditContentService.getContentById.mockReturnValue(
+                    of(MOCK_CONTENTLET_1_OR_2_TABS)
+                );
+                workflowActionsService.getWorkFlowActions.mockReturnValue(
+                    of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+                );
+                dotWorkflowService.getWorkflowStatus.mockReturnValue(of(MOCK_WORKFLOW_STATUS));
+                dotContentletService.canLock.mockReturnValue(
+                    of({ canLock: true } as DotContentletCanLock)
+                );
+
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,
+                    depth: DotContentletDepths.ONE
+                });
+
+                spectator.detectChanges();
+            });
+
+            it('should update disabledWYSIWYG form control when onDisabledWYSIWYGChange is called', () => {
+                const newDisabledWYSIWYG = ['newField1', 'newField2'];
+                const disabledWYSIWYGControl = component.form.get('disabledWYSIWYG');
+
+                // Verify initial value
+                expect(disabledWYSIWYGControl?.value).toEqual(['wysiwygField1', 'wysiwygField2']);
+
+                // Call the method
+                component.onDisabledWYSIWYGChange(newDisabledWYSIWYG);
+
+                // Verify the control was updated
+                expect(disabledWYSIWYGControl?.value).toEqual(newDisabledWYSIWYG);
+            });
+
+            it('should not throw error when onDisabledWYSIWYGChange is called and form does not exist', () => {
+                // Set form to null to simulate case where form doesn't exist
+                component.form = null;
+
+                expect(() => {
+                    component.onDisabledWYSIWYGChange(['test']);
+                }).not.toThrow();
+            });
+
+            it('should not throw error when onDisabledWYSIWYGChange is called and disabledWYSIWYG control does not exist', () => {
+                // Remove the disabledWYSIWYG control
+                component.form.removeControl('disabledWYSIWYG');
+
+                expect(() => {
+                    component.onDisabledWYSIWYGChange(['test']);
+                }).not.toThrow();
+            });
+
+            it('should emit event when disabledWYSIWYG form control value changes', () => {
+                const disabledWYSIWYGControl = component.form.get('disabledWYSIWYG');
+                const spy = jest.spyOn(disabledWYSIWYGControl, 'setValue');
+
+                component.onDisabledWYSIWYGChange(['newField']);
+
+                expect(spy).toHaveBeenCalledWith(['newField'], { emitEvent: true });
+            });
+        });
+
+        describe('with different contentlet scenarios', () => {
+            it('should handle contentlet without disabledWYSIWYG property', () => {
+                dotContentTypeService.getContentType.mockReturnValue(of(MOCK_CONTENTTYPE_1_TAB));
+                workflowActionsService.getByInode.mockReturnValue(
+                    of(MOCK_WORKFLOW_ACTIONS_NEW_ITEMNTTYPE_1_TAB)
+                );
+                dotEditContentService.getContentById.mockReturnValue(
+                    of(MOCK_CONTENTLET_WITHOUT_DISABLED_WYSIWYG)
+                );
+                workflowActionsService.getWorkFlowActions.mockReturnValue(
+                    of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+                );
+                dotWorkflowService.getWorkflowStatus.mockReturnValue(of(MOCK_WORKFLOW_STATUS));
+                dotContentletService.canLock.mockReturnValue(
+                    of({ canLock: true } as DotContentletCanLock)
+                );
+
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_WITHOUT_DISABLED_WYSIWYG.inode,
+                    depth: DotContentletDepths.ONE
+                });
+
+                spectator.detectChanges();
+
+                const disabledWYSIWYGControl = component.form.get('disabledWYSIWYG');
+                expect(disabledWYSIWYGControl).toBeTruthy();
+                expect(disabledWYSIWYGControl?.value).toEqual([]);
+            });
+
+            it('should include disabledWYSIWYG in form values when form is processed', () => {
+                dotContentTypeService.getContentType.mockReturnValue(of(MOCK_CONTENTTYPE_1_TAB));
+                workflowActionsService.getByInode.mockReturnValue(
+                    of(MOCK_WORKFLOW_ACTIONS_NEW_ITEMNTTYPE_1_TAB)
+                );
+                dotEditContentService.getContentById.mockReturnValue(
+                    of(MOCK_CONTENTLET_1_OR_2_TABS)
+                );
+                workflowActionsService.getWorkFlowActions.mockReturnValue(
+                    of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+                );
+                dotWorkflowService.getWorkflowStatus.mockReturnValue(of(MOCK_WORKFLOW_STATUS));
+                dotContentletService.canLock.mockReturnValue(
+                    of({ canLock: true } as DotContentletCanLock)
+                );
+
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,
+                    depth: DotContentletDepths.ONE
+                });
+
+                spectator.detectChanges();
+
+                const formValues = component.form.value;
+                expect(formValues.disabledWYSIWYG).toEqual(['wysiwygField1', 'wysiwygField2']);
             });
         });
     });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -340,6 +340,7 @@ export class DotEditContentFormComponent implements OnInit {
      * Processes the form value, applying specific transformations for different field types.
      *
      * Handles special cases:
+     * - disabledWYSIWYG: Preserves array format for WYSIWYG editor preferences
      * - Flattened fields: Joins array values with commas
      * - Calendar fields: Formats dates to the required string format
      * - Null/undefined values: Converts to empty string
@@ -353,6 +354,11 @@ export class DotEditContentFormComponent implements OnInit {
     ): FormValues {
         return Object.fromEntries(
             Object.entries(value).map(([key, fieldValue]) => {
+                // Handle disabledWYSIWYG as a special case - preserve array format
+                if (key === 'disabledWYSIWYG') {
+                    return [key, fieldValue || []];
+                }
+
                 const field = this.$formFields().find((f) => f.variable === key);
 
                 if (!field) {
@@ -384,7 +390,8 @@ export class DotEditContentFormComponent implements OnInit {
      * This method:
      * 1. Filters out non-form fields
      * 2. Creates form controls with appropriate initial values and validators
-     * 3. Combines all controls into a FormGroup
+     * 3. Adds disabledWYSIWYG as a form control to track WYSIWYG editor preferences
+     * 4. Combines all controls into a FormGroup
      *
      * @private
      */
@@ -396,6 +403,12 @@ export class DotEditContentFormComponent implements OnInit {
             }),
             {}
         );
+
+        // Add disabledWYSIWYG as a form control to track WYSIWYG editor preferences
+        const contentlet = this.$store.contentlet();
+        const disabledWYSIWYG = contentlet?.disabledWYSIWYG || [];
+
+        controls['disabledWYSIWYG'] = this.#fb.control(disabledWYSIWYG);
 
         this.form = this.#fb.group(controls);
     }
@@ -544,5 +557,24 @@ export class DotEditContentFormComponent implements OnInit {
      */
     onContentLockChange(event: InputSwitchChangeEvent) {
         event.checked ? this.$store.lockContent() : this.$store.unlockContent();
+    }
+
+    /**
+     * Handles changes to the disabledWYSIWYG attribute from field components.
+     *
+     * This method is triggered when any field component (WYSIWYG or textarea) changes
+     * the disabledWYSIWYG configuration. It updates the form control to keep the form
+     * data synchronized with the latest WYSIWYG editor preferences.
+     *
+     * Note: The contentlet in the store is already updated by the field components,
+     * this method only ensures the form control reflects those changes.
+     *
+     * @param {string[]} disabledWYSIWYG - The updated disabledWYSIWYG array
+     * @memberof DotEditContentFormComponent
+     */
+    onDisabledWYSIWYGChange(disabledWYSIWYG: string[]) {
+        if (this.form && this.form.get('disabledWYSIWYG')) {
+            this.form.get('disabledWYSIWYG')?.setValue(disabledWYSIWYG, { emitEvent: true });
+        }
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.spec.ts
@@ -6,6 +6,7 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ControlContainer, FormGroupDirective } from '@angular/forms';
 
 import { DotLanguagesService } from '@dotcms/data-access';
+import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DotLanguageVariableSelectorComponent } from '@dotcms/ui';
 
 import { DotEditContentTextAreaComponent } from './dot-edit-content-text-area.component';
@@ -45,9 +46,15 @@ describe('DotEditContentTextAreaComponent', () => {
 
     beforeEach(() => {
         spectator = createComponent({
+            props: {
+                field: TEXT_AREA_FIELD_MOCK,
+                contentlet: {
+                    [TEXT_AREA_FIELD_MOCK.variable]: '',
+                    disabledWYSIWYG: []
+                } as DotCMSContentlet
+            } as unknown,
             detectChanges: false
         });
-        spectator.setInput('field', TEXT_AREA_FIELD_MOCK);
         spectator.detectChanges();
 
         component = spectator.component;
@@ -167,5 +174,193 @@ describe('DotEditContentTextAreaComponent', () => {
 
         // Assert: Private method called with correct parameter
         expect(insertLanguageVariableInMonacoMock).toHaveBeenCalledWith(testVariable);
+    });
+
+    describe('disabledWYSIWYGChange', () => {
+        it('should emit disabledWYSIWYGChange when switching from PlainText to Monaco editor', () => {
+            // Arrange: Create a contentlet with empty content and no disabled settings
+            const contentletMock = {
+                [TEXT_AREA_FIELD_MOCK.variable]: '',
+                disabledWYSIWYG: []
+            } as DotCMSContentlet;
+
+            const switchSpectator = createComponent({
+                props: {
+                    field: TEXT_AREA_FIELD_MOCK,
+                    contentlet: contentletMock
+                } as unknown
+            });
+            switchSpectator.detectChanges();
+
+            // Spy on the output event
+            const disabledWYSIWYGChangeSpy = jest.fn();
+            switchSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+            // Act: Switch to Monaco editor
+            switchSpectator.component.onEditorChange(AvailableEditorTextArea.Monaco);
+
+            // Assert: disabledWYSIWYGChange should be emitted with field variable + @ToggleEditor
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([
+                `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+            ]);
+            expect(switchSpectator.component.$displayedEditor()).toBe(
+                AvailableEditorTextArea.Monaco
+            );
+        });
+
+        it('should emit disabledWYSIWYGChange when switching from Monaco back to PlainText editor', () => {
+            // Arrange: Create a contentlet with Monaco editor already enabled
+            const contentletMock = {
+                [TEXT_AREA_FIELD_MOCK.variable]: '',
+                disabledWYSIWYG: [`${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`]
+            } as DotCMSContentlet;
+
+            const switchBackSpectator = createComponent({
+                props: {
+                    field: TEXT_AREA_FIELD_MOCK,
+                    contentlet: contentletMock
+                } as unknown
+            });
+            switchBackSpectator.detectChanges();
+
+            // Spy on the output event
+            const disabledWYSIWYGChangeSpy = jest.fn();
+            switchBackSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+            // Act: Switch to PlainText editor
+            switchBackSpectator.component.onEditorChange(AvailableEditorTextArea.PlainText);
+
+            // Assert: disabledWYSIWYG should be cleared for PlainText
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([]);
+            expect(switchBackSpectator.component.$displayedEditor()).toBe(
+                AvailableEditorTextArea.PlainText
+            );
+        });
+
+        it('should correctly initialize with Monaco editor when contentlet has preference set', () => {
+            // Arrange: Contentlet with Monaco editor preference already set
+            const contentletWithMonaco = {
+                [TEXT_AREA_FIELD_MOCK.variable]: '',
+                disabledWYSIWYG: [`${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`]
+            } as DotCMSContentlet;
+
+            const initSpectator = createComponent({
+                props: {
+                    field: TEXT_AREA_FIELD_MOCK,
+                    contentlet: contentletWithMonaco
+                } as unknown
+            });
+            initSpectator.detectChanges();
+
+            // Assert: Should initialize with Monaco editor
+            expect(initSpectator.component.$contentEditorUsed()).toBe(
+                AvailableEditorTextArea.Monaco
+            );
+            expect(initSpectator.component.$displayedEditor()).toBe(AvailableEditorTextArea.Monaco);
+            expect(initSpectator.component.$selectedEditorDropdown()).toBe(
+                AvailableEditorTextArea.Monaco
+            );
+        });
+
+        it('should preserve other field entries when updating current field editor preference', () => {
+            // Arrange: Contentlet with existing entries for other fields
+            const contentletMock = {
+                [TEXT_AREA_FIELD_MOCK.variable]: '',
+                disabledWYSIWYG: ['otherField', 'wysiwygField']
+            } as DotCMSContentlet;
+
+            const preserveSpectator = createComponent({
+                props: {
+                    field: TEXT_AREA_FIELD_MOCK,
+                    contentlet: contentletMock
+                } as unknown
+            });
+            preserveSpectator.detectChanges();
+
+            // Spy on the output event
+            const disabledWYSIWYGChangeSpy = jest.fn();
+            preserveSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+            // Act: Switch to Monaco editor for current field
+            preserveSpectator.component.onEditorChange(AvailableEditorTextArea.Monaco);
+
+            // Assert: Should preserve other entries and add current field with @ToggleEditor suffix
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([
+                'otherField',
+                'wysiwygField',
+                `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+            ]);
+        });
+
+        it('should handle smooth editor switching workflow without conflicts', () => {
+            // Arrange: Start with clean contentlet
+            const contentletEmpty = {
+                [TEXT_AREA_FIELD_MOCK.variable]: '',
+                disabledWYSIWYG: []
+            } as DotCMSContentlet;
+
+            const workflowSpectator = createComponent({
+                props: {
+                    field: TEXT_AREA_FIELD_MOCK,
+                    contentlet: contentletEmpty
+                } as unknown
+            });
+            workflowSpectator.detectChanges();
+
+            const disabledWYSIWYGChangeSpy = jest.fn();
+            workflowSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+            // Act 1: Switch to Monaco
+            workflowSpectator.component.onEditorChange(AvailableEditorTextArea.Monaco);
+
+            // Assert 1: Monaco active
+            expect(workflowSpectator.component.$displayedEditor()).toBe(
+                AvailableEditorTextArea.Monaco
+            );
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([
+                `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+            ]);
+
+            // Act 2: Switch back to PlainText
+            workflowSpectator.component.onEditorChange(AvailableEditorTextArea.PlainText);
+
+            // Assert 2: PlainText active and preferences cleared
+            expect(workflowSpectator.component.$displayedEditor()).toBe(
+                AvailableEditorTextArea.PlainText
+            );
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([]);
+        });
+
+        it('should handle contentlet without disabledWYSIWYG property', () => {
+            // Arrange: Create a contentlet without disabledWYSIWYG property
+            const contentletMock = {
+                [TEXT_AREA_FIELD_MOCK.variable]: ''
+            } as DotCMSContentlet;
+            // Explicitly remove the property to simulate real scenarios
+            delete contentletMock.disabledWYSIWYG;
+
+            const noPropertySpectator = createComponent({
+                props: {
+                    field: TEXT_AREA_FIELD_MOCK,
+                    contentlet: contentletMock
+                } as unknown
+            });
+            noPropertySpectator.detectChanges();
+
+            // Spy on the output event
+            const disabledWYSIWYGChangeSpy = jest.fn();
+            noPropertySpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+            // Act: Switch to Monaco editor
+            noPropertySpectator.component.onEditorChange(AvailableEditorTextArea.Monaco);
+
+            // Assert: disabledWYSIWYGChange should be emitted with new entry
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([
+                `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+            ]);
+            expect(noPropertySpectator.component.$displayedEditor()).toBe(
+                AvailableEditorTextArea.Monaco
+            );
+        });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.ts
@@ -79,16 +79,12 @@ export class DotEditContentTextAreaComponent implements AfterViewInit {
     /**
      * Input field DotCMSContentTypeField
      */
-    $field = input<DotCMSContentTypeField | null>(null, {
-        alias: 'field'
-    });
+    $field = input.required<DotCMSContentTypeField | null>({ alias: 'field' });
 
     /**
      * Input contentlet DotCMSContentlet
      */
-    $contentlet = input<DotCMSContentlet | null>(null, {
-        alias: 'contentlet'
-    });
+    $contentlet = input.required<DotCMSContentlet | null>({ alias: 'contentlet' });
 
     /**
      * Event emitted when disabledWYSIWYG changes.
@@ -118,14 +114,13 @@ export class DotEditContentTextAreaComponent implements AfterViewInit {
 
     /**
      * Computed property that determines the current editor based on disabledWYSIWYG settings
-     * with fallback to content analysis when no entry exists.
      */
     $contentEditorUsed = computed(() => {
         const field = this.$field();
         const contentlet = this.$contentlet();
 
         if (!field?.variable) {
-            return AvailableEditorTextArea.PlainText;
+            return AvailableEditorTextArea.PlainText; // Default editor
         }
 
         const disabledWYSIWYG = getDisabledWYSIWYGFromContentlet(contentlet);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/components/dot-wysiwyg-tinymce/dot-wysiwyg-tinymce.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/components/dot-wysiwyg-tinymce/dot-wysiwyg-tinymce.component.ts
@@ -19,10 +19,7 @@ import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
 import { DotWysiwygTinymceService } from './service/dot-wysiwyg-tinymce.service';
 
 import { getFieldVariablesParsed, stringToJson } from '../../../../utils/functions.util';
-import {
-    COMMENT_TINYMCE,
-    DEFAULT_TINYMCE_CONFIG
-} from '../../dot-edit-content-wysiwyg-field.constant';
+import { DEFAULT_TINYMCE_CONFIG } from '../../dot-edit-content-wysiwyg-field.constant';
 import { DotWysiwygPluginService } from '../../dot-wysiwyg-plugin/dot-wysiwyg-plugin.service';
 
 @Component({
@@ -83,18 +80,6 @@ export class DotWysiwygTinymceComponent implements OnDestroy {
             ...this.$customPropsContentField(),
             setup: (editor) => {
                 this.#dotWysiwygPluginService.initializePlugins(editor);
-                // TODO: Remove this when the content type saved by the user can preserve the selection
-                const ensureSingleComment = (content: string): string => {
-                    if (content.includes(COMMENT_TINYMCE)) {
-                        content = content.replace(new RegExp(COMMENT_TINYMCE, 'g'), '');
-                    }
-
-                    return COMMENT_TINYMCE + content;
-                };
-
-                editor.on('GetContent', (e) => {
-                    e.content = ensureSingleComment(e.content);
-                });
             }
         };
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.spec.ts
@@ -12,6 +12,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DropdownModule } from 'primeng/dropdown';
 
 import { DotPropertiesService, DotUploadFileService } from '@dotcms/data-access';
+import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DotLanguageVariableSelectorComponent } from '@dotcms/ui';
 import { DotMessagePipe, mockMatchMedia, monacoMock } from '@dotcms/utils-testing';
 
@@ -144,6 +145,150 @@ describe('DotEditContentWYSIWYGFieldComponent', () => {
 
         it('should render language variable selector', () => {
             expect(spectator.query(DotLanguageVariableSelectorComponent)).toBeTruthy();
+        });
+    });
+
+    describe('disabledWYSIWYGChange', () => {
+        it('should emit disabledWYSIWYGChange when switching from TinyMCE to Monaco editor', () => {
+            // Arrange: Create a contentlet with empty content and no disabled settings
+            const contentletMock = {
+                ...WYSIWYG_FIELD_CONTENTLET_MOCK_NO_CONTENT,
+                [WYSIWYG_MOCK.variable]: '',
+                disabledWYSIWYG: []
+            } as DotCMSContentlet;
+
+            const switchSpectator = createComponent({
+                props: {
+                    contentlet: contentletMock,
+                    field: WYSIWYG_MOCK
+                } as unknown
+            });
+            switchSpectator.detectChanges();
+
+            // Spy on the output event
+            const disabledWYSIWYGChangeSpy = jest.fn();
+            switchSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+            // Act: Switch to Monaco editor (no content, so no confirmation dialog)
+            switchSpectator.component.onEditorChange(AvailableEditor.Monaco);
+
+            // Assert: disabledWYSIWYGChange should be emitted with field variable
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([WYSIWYG_MOCK.variable]);
+            expect(switchSpectator.component.$displayedEditor()).toBe(AvailableEditor.Monaco);
+        });
+
+        it('should emit disabledWYSIWYGChange when switching from Monaco back to TinyMCE editor', () => {
+            // Arrange: Create a contentlet with Monaco editor already enabled
+            const contentletMock = {
+                ...WYSIWYG_FIELD_CONTENTLET_MOCK_NO_CONTENT,
+                [WYSIWYG_MOCK.variable]: '',
+                disabledWYSIWYG: [WYSIWYG_MOCK.variable]
+            } as DotCMSContentlet;
+
+            const switchBackSpectator = createComponent({
+                props: {
+                    contentlet: contentletMock,
+                    field: WYSIWYG_MOCK
+                } as unknown
+            });
+            switchBackSpectator.detectChanges();
+
+            // Spy on the output event
+            const disabledWYSIWYGChangeSpy = jest.fn();
+            switchBackSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+            // Act: Switch to TinyMCE editor (should work without confirmation)
+            switchBackSpectator.component.onEditorChange(AvailableEditor.TinyMCE);
+
+            // Assert: disabledWYSIWYG should be cleared for TinyMCE
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([]);
+            expect(switchBackSpectator.component.$displayedEditor()).toBe(AvailableEditor.TinyMCE);
+        });
+
+        it('should correctly initialize with Monaco editor when contentlet has preference set', () => {
+            // Arrange: Contentlet with Monaco editor preference already set
+            const contentletWithMonaco = {
+                ...WYSIWYG_FIELD_CONTENTLET_MOCK_NO_CONTENT,
+                disabledWYSIWYG: [WYSIWYG_MOCK.variable]
+            } as DotCMSContentlet;
+
+            const initSpectator = createComponent({
+                props: {
+                    contentlet: contentletWithMonaco,
+                    field: WYSIWYG_MOCK
+                } as unknown
+            });
+            initSpectator.detectChanges();
+
+            // Assert: Should initialize with Monaco editor
+            expect(initSpectator.component.$contentEditorUsed()).toBe(AvailableEditor.Monaco);
+            expect(initSpectator.component.$displayedEditor()).toBe(AvailableEditor.Monaco);
+            expect(initSpectator.component.$selectedEditorDropdown()).toBe(AvailableEditor.Monaco);
+        });
+
+        it('should preserve other field entries when updating current field editor preference', () => {
+            // Arrange: Contentlet with existing entries for other fields
+            const contentletMock = {
+                ...WYSIWYG_FIELD_CONTENTLET_MOCK_NO_CONTENT,
+                [WYSIWYG_MOCK.variable]: '',
+                disabledWYSIWYG: ['otherField', 'textAreaField@ToggleEditor']
+            } as DotCMSContentlet;
+
+            const preserveSpectator = createComponent({
+                props: {
+                    contentlet: contentletMock,
+                    field: WYSIWYG_MOCK
+                } as unknown
+            });
+            preserveSpectator.detectChanges();
+
+            // Spy on the output event
+            const disabledWYSIWYGChangeSpy = jest.fn();
+            preserveSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+            // Act: Switch to Monaco editor for current field
+            preserveSpectator.component.onEditorChange(AvailableEditor.Monaco);
+
+            // Assert: Should preserve other entries and add current field
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([
+                'otherField',
+                'textAreaField@ToggleEditor',
+                WYSIWYG_MOCK.variable
+            ]);
+        });
+
+        it('should handle smooth editor switching workflow without conflicts', () => {
+            // Arrange: Start with clean contentlet
+            const contentletEmpty = {
+                ...WYSIWYG_FIELD_CONTENTLET_MOCK_NO_CONTENT,
+                [WYSIWYG_MOCK.variable]: '',
+                disabledWYSIWYG: []
+            } as DotCMSContentlet;
+
+            const workflowSpectator = createComponent({
+                props: {
+                    contentlet: contentletEmpty,
+                    field: WYSIWYG_MOCK
+                } as unknown
+            });
+            workflowSpectator.detectChanges();
+
+            const disabledWYSIWYGChangeSpy = jest.fn();
+            workflowSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+            // Act 1: Switch to Monaco
+            workflowSpectator.component.onEditorChange(AvailableEditor.Monaco);
+
+            // Assert 1: Monaco active
+            expect(workflowSpectator.component.$displayedEditor()).toBe(AvailableEditor.Monaco);
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([WYSIWYG_MOCK.variable]);
+
+            // Act 2: Switch back to TinyMCE
+            workflowSpectator.component.onEditorChange(AvailableEditor.TinyMCE);
+
+            // Assert 2: TinyMCE active and preferences cleared
+            expect(workflowSpectator.component.$displayedEditor()).toBe(AvailableEditor.TinyMCE);
+            expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([]);
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.ts
@@ -32,7 +32,6 @@ import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edi
 import {
     getCurrentEditorFromDisabled,
     getDisabledWYSIWYGFromContentlet,
-    migrateLegacyPlainEditor,
     updateDisabledWYSIWYGOnEditorSwitch
 } from '../shared/utils/field-editor-preferences.util';
 
@@ -165,17 +164,8 @@ export class DotEditContentWYSIWYGFieldComponent implements AfterViewInit {
                     false // isTextAreaField
                 );
 
-                // Migrate legacy PLAIN editor entries if switching to TinyMCE
-                const finalDisabledWYSIWYG =
-                    newEditor === AvailableEditor.TinyMCE
-                        ? migrateLegacyPlainEditor(updatedDisabledWYSIWYG, field.variable)
-                        : updatedDisabledWYSIWYG;
-
-                // Update the contentlet's disabledWYSIWYG property
-                contentlet.disabledWYSIWYG = finalDisabledWYSIWYG;
-
                 // Emit the change event
-                this.disabledWYSIWYGChange.emit(finalDisabledWYSIWYG);
+                this.disabledWYSIWYGChange.emit(updatedDisabledWYSIWYG);
             }
 
             this.$displayedEditor.set(newEditor);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.utils.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.utils.spec.ts
@@ -1,4 +1,4 @@
-import { COMMENT_TINYMCE, MD_SYNTAX } from './dot-edit-content-wysiwyg-field.constant';
+import { MD_SYNTAX } from './dot-edit-content-wysiwyg-field.constant';
 import {
     CountOccurrences,
     isHtml,
@@ -53,10 +53,6 @@ describe('WYSIWYG Field Utils', () => {
 
         it('should return true for string with only whitespace', () => {
             expect(shouldUseDefaultEditor('   ')).toBe(true);
-        });
-
-        it('should return true for COMMENT_TINYMCE', () => {
-            expect(shouldUseDefaultEditor(COMMENT_TINYMCE)).toBe(true);
         });
 
         it('should return false for non-empty strings', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.utils.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.utils.ts
@@ -1,5 +1,4 @@
 import {
-    COMMENT_TINYMCE,
     HTML_TAGS,
     JS_KEYWORDS,
     MD_SYNTAX,
@@ -33,12 +32,7 @@ export const CountOccurrences = (str: string, searchStr: string) => {
  * @returns {boolean} True if the default editor should be used, false otherwise.
  */
 export const shouldUseDefaultEditor = (content: unknown): boolean => {
-    return (
-        !content ||
-        typeof content !== 'string' ||
-        content.trim() === '' ||
-        content.trim() === COMMENT_TINYMCE
-    );
+    return !content || typeof content !== 'string' || content.trim() === '';
 };
 
 /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/mocks/dot-edit-content-wysiwyg-field.mock.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/mocks/dot-edit-content-wysiwyg-field.mock.ts
@@ -1,7 +1,5 @@
 import { DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
 
-import { COMMENT_TINYMCE } from '../dot-edit-content-wysiwyg-field.constant';
-
 export const WYSIWYG_VARIABLE_NAME = 'variable';
 
 export const WYSIWYG_MOCK: DotCMSContentTypeField = {
@@ -62,7 +60,7 @@ export const WYSIWYG_FIELD_CONTENTLET_MOCK_WITH_WYSIWYG_CONTENT: DotCMSContentle
     baseType: 'CONTENT',
     contentType: 'Test2',
     creationDate: 1727121715503,
-    [WYSIWYG_VARIABLE_NAME]: `${COMMENT_TINYMCE}<p>contenido</p>`,
+    [WYSIWYG_VARIABLE_NAME]: '<p>contenido</p>',
     folder: 'SYSTEM_FOLDER',
     hasLiveVersion: false,
     hasTitleImage: false,

--- a/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.spec.ts
@@ -1,0 +1,307 @@
+import { DotCMSContentlet } from '@dotcms/dotcms-models';
+
+import {
+    DisabledEditorType,
+    getCurrentEditorFromDisabled,
+    getDisabledWYSIWYGFromContentlet,
+    migrateLegacyPlainEditor,
+    parseDisabledEditorEntry,
+    updateDisabledWYSIWYGOnEditorSwitch
+} from './field-editor-preferences.util';
+
+import { AvailableEditorTextArea } from '../../dot-edit-content-text-area/dot-edit-content-text-area.constants';
+import { AvailableEditor } from '../../dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.constant';
+
+describe('field-editor-preferences.util', () => {
+    describe('parseDisabledEditorEntry', () => {
+        it('should parse textarea Monaco entry correctly', () => {
+            const result = parseDisabledEditorEntry('myField@ToggleEditor');
+            expect(result).toEqual({
+                fieldVariable: 'myField',
+                editorType: DisabledEditorType.MonacoTextArea,
+                fullEntry: 'myField@ToggleEditor'
+            });
+        });
+
+        it('should parse WYSIWYG Monaco entry correctly', () => {
+            const result = parseDisabledEditorEntry('myField');
+            expect(result).toEqual({
+                fieldVariable: 'myField',
+                editorType: DisabledEditorType.MonacoWYSIWYG,
+                fullEntry: 'myField'
+            });
+        });
+
+        it('should parse legacy PLAIN entry correctly', () => {
+            const result = parseDisabledEditorEntry('myField@PLAIN');
+            expect(result).toEqual({
+                fieldVariable: 'myField',
+                editorType: DisabledEditorType.PlainLegacy,
+                fullEntry: 'myField@PLAIN'
+            });
+        });
+
+        it('should handle unknown suffixes', () => {
+            const result = parseDisabledEditorEntry('myField@Unknown');
+            expect(result).toEqual({
+                fieldVariable: 'myField',
+                editorType: null,
+                fullEntry: 'myField@Unknown'
+            });
+        });
+
+        it('should handle empty or invalid entries', () => {
+            expect(parseDisabledEditorEntry('')).toEqual({
+                fieldVariable: '',
+                editorType: null,
+                fullEntry: ''
+            });
+
+            expect(parseDisabledEditorEntry(null)).toEqual({
+                fieldVariable: '',
+                editorType: null,
+                fullEntry: null
+            });
+        });
+    });
+
+    describe('getCurrentEditorFromDisabled', () => {
+        describe('for textarea fields', () => {
+            it('should return Monaco when ToggleEditor entry exists', () => {
+                const disabledWYSIWYG = ['myField@ToggleEditor'];
+                const result = getCurrentEditorFromDisabled('myField', disabledWYSIWYG, true);
+                expect(result).toBe(AvailableEditorTextArea.Monaco);
+            });
+
+            it('should return PlainText when no entry exists', () => {
+                const disabledWYSIWYG = ['otherField@ToggleEditor'];
+                const result = getCurrentEditorFromDisabled('myField', disabledWYSIWYG, true);
+                expect(result).toBe(AvailableEditorTextArea.PlainText);
+            });
+
+            it('should return PlainText for empty disabledWYSIWYG', () => {
+                const result = getCurrentEditorFromDisabled('myField', [], true);
+                expect(result).toBe(AvailableEditorTextArea.PlainText);
+            });
+        });
+
+        describe('for WYSIWYG fields', () => {
+            it('should return Monaco when field variable entry exists', () => {
+                const disabledWYSIWYG = ['myField'];
+                const result = getCurrentEditorFromDisabled('myField', disabledWYSIWYG, false);
+                expect(result).toBe(AvailableEditor.Monaco);
+            });
+
+            it('should return Monaco when legacy PLAIN entry exists', () => {
+                const disabledWYSIWYG = ['myField@PLAIN'];
+                const result = getCurrentEditorFromDisabled('myField', disabledWYSIWYG, false);
+                expect(result).toBe(AvailableEditor.Monaco);
+            });
+
+            it('should return TinyMCE when no entry exists', () => {
+                const disabledWYSIWYG = ['otherField'];
+                const result = getCurrentEditorFromDisabled('myField', disabledWYSIWYG, false);
+                expect(result).toBe(AvailableEditor.TinyMCE);
+            });
+
+            it('should return TinyMCE for empty disabledWYSIWYG', () => {
+                const result = getCurrentEditorFromDisabled('myField', [], false);
+                expect(result).toBe(AvailableEditor.TinyMCE);
+            });
+        });
+    });
+
+    describe('updateDisabledWYSIWYGOnEditorSwitch', () => {
+        describe('for textarea fields', () => {
+            it('should add Monaco entry when switching to Monaco', () => {
+                const current = ['otherField@ToggleEditor'];
+                const result = updateDisabledWYSIWYGOnEditorSwitch(
+                    'myField',
+                    AvailableEditorTextArea.Monaco,
+                    current,
+                    true
+                );
+                expect(result).toEqual(['otherField@ToggleEditor', 'myField@ToggleEditor']);
+            });
+
+            it('should remove entry when switching to PlainText', () => {
+                const current = ['myField@ToggleEditor', 'otherField@ToggleEditor'];
+                const result = updateDisabledWYSIWYGOnEditorSwitch(
+                    'myField',
+                    AvailableEditorTextArea.PlainText,
+                    current,
+                    true
+                );
+                expect(result).toEqual(['otherField@ToggleEditor']);
+            });
+
+            it('should replace existing entry when switching to Monaco', () => {
+                const current = ['myField@SomeOtherEntry', 'otherField@ToggleEditor'];
+                const result = updateDisabledWYSIWYGOnEditorSwitch(
+                    'myField',
+                    AvailableEditorTextArea.Monaco,
+                    current,
+                    true
+                );
+                expect(result).toEqual(['otherField@ToggleEditor', 'myField@ToggleEditor']);
+            });
+        });
+
+        describe('for WYSIWYG fields', () => {
+            it('should add field variable entry when switching to Monaco', () => {
+                const current = ['otherField'];
+                const result = updateDisabledWYSIWYGOnEditorSwitch(
+                    'myField',
+                    AvailableEditor.Monaco,
+                    current,
+                    false
+                );
+                expect(result).toEqual(['otherField', 'myField']);
+            });
+
+            it('should remove entry when switching to TinyMCE', () => {
+                const current = ['myField', 'otherField'];
+                const result = updateDisabledWYSIWYGOnEditorSwitch(
+                    'myField',
+                    AvailableEditor.TinyMCE,
+                    current,
+                    false
+                );
+                expect(result).toEqual(['otherField']);
+            });
+
+            it('should replace legacy PLAIN entry when switching to Monaco', () => {
+                const current = ['myField@PLAIN', 'otherField'];
+                const result = updateDisabledWYSIWYGOnEditorSwitch(
+                    'myField',
+                    AvailableEditor.Monaco,
+                    current,
+                    false
+                );
+                expect(result).toEqual(['otherField', 'myField']);
+            });
+        });
+    });
+
+    describe('migrateLegacyPlainEditor', () => {
+        it('should convert legacy PLAIN entry to Monaco format for specified field', () => {
+            const disabledWYSIWYG = ['myField@PLAIN', 'otherField', 'anotherField@PLAIN'];
+            const result = migrateLegacyPlainEditor(disabledWYSIWYG, 'myField');
+            expect(result).toEqual(['otherField', 'anotherField@PLAIN', 'myField']);
+        });
+
+        it('should return unchanged array when no legacy PLAIN entry exists', () => {
+            const disabledWYSIWYG = ['myField', 'otherField@ToggleEditor'];
+            const result = migrateLegacyPlainEditor(disabledWYSIWYG, 'myField');
+            expect(result).toEqual(['myField', 'otherField@ToggleEditor']);
+        });
+
+        it('should handle empty array', () => {
+            const result = migrateLegacyPlainEditor([], 'myField');
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('getDisabledWYSIWYGFromContentlet', () => {
+        it('should return array when contentlet has disabledWYSIWYG array', () => {
+            const contentlet: Partial<DotCMSContentlet> = {
+                disabledWYSIWYG: ['field1', 'field2@ToggleEditor']
+            };
+
+            const result = getDisabledWYSIWYGFromContentlet(contentlet);
+            expect(result).toEqual(['field1', 'field2@ToggleEditor']);
+        });
+
+        it('should return empty array when contentlet is null', () => {
+            const result = getDisabledWYSIWYGFromContentlet(null);
+            expect(result).toEqual([]);
+        });
+
+        it('should return empty array when disabledWYSIWYG is not present', () => {
+            const contentlet: Partial<DotCMSContentlet> = {};
+            const result = getDisabledWYSIWYGFromContentlet(contentlet);
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe('integration scenarios', () => {
+        it('should handle complete workflow for textarea field', () => {
+            const contentlet: Partial<DotCMSContentlet> = {
+                disabledWYSIWYG: []
+            };
+
+            // Initially no entry, should default to PlainText
+            expect(
+                getCurrentEditorFromDisabled('myTextArea', contentlet.disabledWYSIWYG, true)
+            ).toBe(AvailableEditorTextArea.PlainText);
+
+            // Switch to Monaco
+            contentlet.disabledWYSIWYG = updateDisabledWYSIWYGOnEditorSwitch(
+                'myTextArea',
+                AvailableEditorTextArea.Monaco,
+                contentlet.disabledWYSIWYG,
+                true
+            );
+
+            expect(contentlet.disabledWYSIWYG).toEqual(['myTextArea@ToggleEditor']);
+            expect(
+                getCurrentEditorFromDisabled('myTextArea', contentlet.disabledWYSIWYG, true)
+            ).toBe(AvailableEditorTextArea.Monaco);
+
+            // Switch back to PlainText
+            contentlet.disabledWYSIWYG = updateDisabledWYSIWYGOnEditorSwitch(
+                'myTextArea',
+                AvailableEditorTextArea.PlainText,
+                contentlet.disabledWYSIWYG,
+                true
+            );
+
+            expect(contentlet.disabledWYSIWYG).toEqual([]);
+            expect(
+                getCurrentEditorFromDisabled('myTextArea', contentlet.disabledWYSIWYG, true)
+            ).toBe(AvailableEditorTextArea.PlainText);
+        });
+
+        it('should handle complete workflow for WYSIWYG field with legacy migration', () => {
+            const contentlet: Partial<DotCMSContentlet> = {
+                disabledWYSIWYG: ['myWysiwyg@PLAIN']
+            };
+
+            // Legacy PLAIN entry should map to Monaco
+            expect(
+                getCurrentEditorFromDisabled('myWysiwyg', contentlet.disabledWYSIWYG, false)
+            ).toBe(AvailableEditor.Monaco);
+
+            // Switch to Monaco
+            contentlet.disabledWYSIWYG = updateDisabledWYSIWYGOnEditorSwitch(
+                'myWysiwyg',
+                AvailableEditor.Monaco,
+                contentlet.disabledWYSIWYG,
+                false
+            );
+
+            expect(contentlet.disabledWYSIWYG).toEqual(['myWysiwyg']);
+            expect(
+                getCurrentEditorFromDisabled('myWysiwyg', contentlet.disabledWYSIWYG, false)
+            ).toBe(AvailableEditor.Monaco);
+
+            // Switch back to TinyMCE and migrate legacy entry
+            contentlet.disabledWYSIWYG = updateDisabledWYSIWYGOnEditorSwitch(
+                'myWysiwyg',
+                AvailableEditor.TinyMCE,
+                contentlet.disabledWYSIWYG,
+                false
+            );
+
+            contentlet.disabledWYSIWYG = migrateLegacyPlainEditor(
+                contentlet.disabledWYSIWYG,
+                'myWysiwyg'
+            );
+
+            expect(contentlet.disabledWYSIWYG).toEqual([]);
+            expect(
+                getCurrentEditorFromDisabled('myWysiwyg', contentlet.disabledWYSIWYG, false)
+            ).toBe(AvailableEditor.TinyMCE);
+        });
+    });
+});

--- a/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.spec.ts
@@ -4,7 +4,6 @@ import {
     DisabledEditorType,
     getCurrentEditorFromDisabled,
     getDisabledWYSIWYGFromContentlet,
-    migrateLegacyPlainEditor,
     parseDisabledEditorEntry,
     updateDisabledWYSIWYGOnEditorSwitch
 } from './field-editor-preferences.util';
@@ -183,25 +182,6 @@ describe('field-editor-preferences.util', () => {
         });
     });
 
-    describe('migrateLegacyPlainEditor', () => {
-        it('should convert legacy PLAIN entry to Monaco format for specified field', () => {
-            const disabledWYSIWYG = ['myField@PLAIN', 'otherField', 'anotherField@PLAIN'];
-            const result = migrateLegacyPlainEditor(disabledWYSIWYG, 'myField');
-            expect(result).toEqual(['otherField', 'anotherField@PLAIN', 'myField']);
-        });
-
-        it('should return unchanged array when no legacy PLAIN entry exists', () => {
-            const disabledWYSIWYG = ['myField', 'otherField@ToggleEditor'];
-            const result = migrateLegacyPlainEditor(disabledWYSIWYG, 'myField');
-            expect(result).toEqual(['myField', 'otherField@ToggleEditor']);
-        });
-
-        it('should handle empty array', () => {
-            const result = migrateLegacyPlainEditor([], 'myField');
-            expect(result).toEqual([]);
-        });
-    });
-
     describe('getDisabledWYSIWYGFromContentlet', () => {
         it('should return array when contentlet has disabledWYSIWYG array', () => {
             const contentlet: Partial<DotCMSContentlet> = {
@@ -293,10 +273,7 @@ describe('field-editor-preferences.util', () => {
                 false
             );
 
-            contentlet.disabledWYSIWYG = migrateLegacyPlainEditor(
-                contentlet.disabledWYSIWYG,
-                'myWysiwyg'
-            );
+            // Legacy entries are handled automatically by getCurrentEditorFromDisabled
 
             expect(contentlet.disabledWYSIWYG).toEqual([]);
             expect(

--- a/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.ts
+++ b/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.ts
@@ -38,8 +38,8 @@
 
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
 
-import { AvailableEditor } from '../../dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.constant';
 import { AvailableEditorTextArea } from '../../dot-edit-content-text-area/dot-edit-content-text-area.constants';
+import { AvailableEditor } from '../../dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.constant';
 
 /**
  * Enum representing the different editor types that can be disabled via disabledWYSIWYG attribute
@@ -195,35 +195,6 @@ export const updateDisabledWYSIWYGOnEditorSwitch = (
 };
 
 /**
- * Migrates legacy PLAIN editor entries to current format
- * This should be called when saving contentlet to eventually remove legacy entries
- *
- * @param disabledWYSIWYG - Current disabledWYSIWYG array
- * @param fieldVariable - The field variable being processed
- * @returns Updated array with legacy entries handled
- */
-export const migrateLegacyPlainEditor = (
-    disabledWYSIWYG: string[] = [],
-    fieldVariable: string
-): string[] => {
-    const entry = disabledWYSIWYG
-        .map(parseDisabledEditorEntry)
-        .find(
-            (entry) =>
-                entry.fieldVariable === fieldVariable &&
-                entry.editorType === DisabledEditorType.PlainLegacy
-        );
-
-    if (entry) {
-        // Convert legacy PLAIN entry to Monaco format (just field name)
-        const filteredEntries = disabledWYSIWYG.filter((item) => item !== entry.fullEntry);
-        return [...filteredEntries, fieldVariable];
-    }
-
-    return disabledWYSIWYG;
-};
-
-/**
  * Gets the disabledWYSIWYG array from a contentlet, ensuring it's always an array
  *
  * @param contentlet - The DotCMS contentlet
@@ -235,13 +206,6 @@ export const getDisabledWYSIWYGFromContentlet = (
     if (!contentlet) {
         return [];
     }
-
-    const disabledWYSIWYG = contentlet.disabledWYSIWYG;
-
-    if (!disabledWYSIWYG) {
-        return [];
-    }
-
     // disabledWYSIWYG is always an array of strings
-    return disabledWYSIWYG;
+    return contentlet.disabledWYSIWYG || [];
 };

--- a/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.ts
+++ b/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.ts
@@ -1,0 +1,247 @@
+/**
+ * Field Editor Preferences Utility
+ *
+ * Manages editor preferences for DotCMS content fields using the `disabledWYSIWYG`
+ * contentlet attribute. This replaces content-based editor detection with explicit
+ * user preferences that persist across sessions.
+ *
+ * ## Entry Formats
+ *
+ * ### Text Area Fields
+ * - No entry: Plain text editor (default)
+ * - `FIELD@ToggleEditor`: Monaco code editor
+ *
+ * ### WYSIWYG Fields
+ * - No entry: TinyMCE editor (default)
+ * - `FIELD`: Monaco code editor
+ * - `FIELD@PLAIN`: Legacy format (maps to Monaco)
+ *
+ * ## Usage Examples
+ *
+ * ```typescript
+ * // Parse entry
+ * const result = parseDisabledEditorEntry('myField@ToggleEditor');
+ *
+ * // Get current editor
+ * const editor = getCurrentEditorFromDisabled('myField', ['myField@ToggleEditor'], true);
+ *
+ * // Update on editor switch
+ * const updated = updateDisabledWYSIWYGOnEditorSwitch(
+ *     'myField',
+ *     AvailableEditorTextArea.Monaco,
+ *     [],
+ *     true
+ * );
+ * ```
+ *
+ */
+
+import { DotCMSContentlet } from '@dotcms/dotcms-models';
+
+import { AvailableEditor } from '../../dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.constant';
+import { AvailableEditorTextArea } from '../../dot-edit-content-text-area/dot-edit-content-text-area.constants';
+
+/**
+ * Enum representing the different editor types that can be disabled via disabledWYSIWYG attribute
+ */
+export enum DisabledEditorType {
+    /** Monaco/Code editor for textarea fields - format: FIELD_VARIABLE_NAME@ToggleEditor */
+    MonacoTextArea = 'ToggleEditor',
+    /** Monaco/Code editor for WYSIWYG fields - format: FIELD_VARIABLE_NAME */
+    MonacoWYSIWYG = 'Monaco',
+    /** Legacy PLAIN editor for WYSIWYG fields - format: FIELD_VARIABLE_NAME@PLAIN (maps to Monaco) */
+    PlainLegacy = 'PLAIN'
+}
+
+/**
+ * Interface representing a parsed disabledWYSIWYG entry
+ */
+export interface DisabledEditorEntry {
+    fieldVariable: string;
+    editorType: DisabledEditorType | null;
+    /** The full entry string as it appears in disabledWYSIWYG array */
+    fullEntry: string;
+}
+
+/**
+ * Parses a disabledWYSIWYG entry string into its components
+ *
+ * Entry formats:
+ * - FIELD_VARIABLE_NAME@ToggleEditor (Monaco for textarea)
+ * - FIELD_VARIABLE_NAME (Monaco for WYSIWYG)
+ * - FIELD_VARIABLE_NAME@PLAIN (Legacy PLAIN for WYSIWYG)
+ *
+ * @param entry - The disabledWYSIWYG entry string to parse
+ * @returns Parsed entry with field variable and editor type
+ */
+export const parseDisabledEditorEntry = (entry: string): DisabledEditorEntry => {
+    if (!entry || typeof entry !== 'string') {
+        return { fieldVariable: '', editorType: null, fullEntry: entry };
+    }
+
+    const parts = entry.split('@');
+    const fieldVariable = parts[0] || '';
+
+    if (parts.length === 1) {
+        // Just field variable name means Monaco for WYSIWYG
+        return {
+            fieldVariable,
+            editorType: DisabledEditorType.MonacoWYSIWYG,
+            fullEntry: entry
+        };
+    }
+
+    const editorSuffix = parts[1];
+    let editorType: DisabledEditorType | null = null;
+
+    switch (editorSuffix) {
+        case DisabledEditorType.MonacoTextArea:
+            editorType = DisabledEditorType.MonacoTextArea;
+            break;
+        case DisabledEditorType.PlainLegacy:
+            editorType = DisabledEditorType.PlainLegacy;
+            break;
+        default:
+            // Unknown suffix, treat as null
+            editorType = null;
+            break;
+    }
+
+    return { fieldVariable, editorType, fullEntry: entry };
+};
+
+/**
+ * Gets the current editor type for a field based on disabledWYSIWYG entries
+ *
+ * @param fieldVariable - The field variable name to check
+ * @param disabledWYSIWYG - Array of disabled WYSIWYG entries from contentlet
+ * @param isTextAreaField - Whether this is a textarea field (true) or WYSIWYG field (false)
+ * @returns The current editor type for the field
+ */
+export const getCurrentEditorFromDisabled = (
+    fieldVariable: string,
+    disabledWYSIWYG: string[] = [],
+    isTextAreaField: boolean
+): AvailableEditorTextArea | AvailableEditor => {
+    const relevantEntry = disabledWYSIWYG
+        .map(parseDisabledEditorEntry)
+        .find((entry) => entry.fieldVariable === fieldVariable);
+
+    if (!relevantEntry) {
+        // No entry found - use default editors
+        return isTextAreaField ? AvailableEditorTextArea.PlainText : AvailableEditor.TinyMCE;
+    }
+
+    if (isTextAreaField) {
+        // For textarea fields
+        switch (relevantEntry.editorType) {
+            case DisabledEditorType.MonacoTextArea:
+                return AvailableEditorTextArea.Monaco;
+            default:
+                return AvailableEditorTextArea.PlainText;
+        }
+    } else {
+        // For WYSIWYG fields
+        switch (relevantEntry.editorType) {
+            case DisabledEditorType.MonacoWYSIWYG:
+                return AvailableEditor.Monaco;
+            case DisabledEditorType.PlainLegacy:
+                // Legacy PLAIN editor maps to Monaco code editor
+                return AvailableEditor.Monaco;
+            default:
+                return AvailableEditor.TinyMCE;
+        }
+    }
+};
+
+/**
+ * Updates the disabledWYSIWYG array when switching editors
+ *
+ * @param fieldVariable - The field variable name
+ * @param newEditor - The new editor being switched to
+ * @param currentDisabledWYSIWYG - Current disabledWYSIWYG array
+ * @param isTextAreaField - Whether this is a textarea field (true) or WYSIWYG field (false)
+ * @returns Updated disabledWYSIWYG array
+ */
+export const updateDisabledWYSIWYGOnEditorSwitch = (
+    fieldVariable: string,
+    newEditor: AvailableEditorTextArea | AvailableEditor,
+    currentDisabledWYSIWYG: string[] = [],
+    isTextAreaField: boolean
+): string[] => {
+    // Remove any existing entries for this field
+    const filteredEntries = currentDisabledWYSIWYG.filter((entry) => {
+        const parsed = parseDisabledEditorEntry(entry);
+        return parsed.fieldVariable !== fieldVariable;
+    });
+
+    if (isTextAreaField) {
+        // For textarea fields
+        if (newEditor === AvailableEditorTextArea.Monaco) {
+            // Add Monaco entry for textarea
+            return [...filteredEntries, `${fieldVariable}@${DisabledEditorType.MonacoTextArea}`];
+        }
+        // PlainText doesn't need an entry
+        return filteredEntries;
+    } else {
+        // For WYSIWYG fields
+        if (newEditor === AvailableEditor.Monaco) {
+            // Add Monaco entry for WYSIWYG
+            return [...filteredEntries, fieldVariable];
+        }
+        // TinyMCE doesn't need an entry
+        return filteredEntries;
+    }
+};
+
+/**
+ * Migrates legacy PLAIN editor entries to current format
+ * This should be called when saving contentlet to eventually remove legacy entries
+ *
+ * @param disabledWYSIWYG - Current disabledWYSIWYG array
+ * @param fieldVariable - The field variable being processed
+ * @returns Updated array with legacy entries handled
+ */
+export const migrateLegacyPlainEditor = (
+    disabledWYSIWYG: string[] = [],
+    fieldVariable: string
+): string[] => {
+    const entry = disabledWYSIWYG
+        .map(parseDisabledEditorEntry)
+        .find(
+            (entry) =>
+                entry.fieldVariable === fieldVariable &&
+                entry.editorType === DisabledEditorType.PlainLegacy
+        );
+
+    if (entry) {
+        // Convert legacy PLAIN entry to Monaco format (just field name)
+        const filteredEntries = disabledWYSIWYG.filter((item) => item !== entry.fullEntry);
+        return [...filteredEntries, fieldVariable];
+    }
+
+    return disabledWYSIWYG;
+};
+
+/**
+ * Gets the disabledWYSIWYG array from a contentlet, ensuring it's always an array
+ *
+ * @param contentlet - The DotCMS contentlet
+ * @returns The disabledWYSIWYG array, or empty array if not present
+ */
+export const getDisabledWYSIWYGFromContentlet = (
+    contentlet: DotCMSContentlet | Partial<DotCMSContentlet> | null
+): string[] => {
+    if (!contentlet) {
+        return [];
+    }
+
+    const disabledWYSIWYG = contentlet.disabledWYSIWYG;
+
+    if (!disabledWYSIWYG) {
+        return [];
+    }
+
+    // disabledWYSIWYG is always an array of strings
+    return disabledWYSIWYG;
+};

--- a/core-web/libs/edit-content/src/lib/shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component.ts
+++ b/core-web/libs/edit-content/src/lib/shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component.ts
@@ -25,7 +25,6 @@ import { PaginatorModule } from 'primeng/paginator';
 import { DotCMSContentTypeField } from '@dotcms/dotcms-models';
 
 import { dotVelocityLanguageDefinition } from '../../custom-languages/velocity-monaco-language';
-import { COMMENT_TINYMCE } from '../../fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.constant';
 import {
     isHtml,
     isJavascript,
@@ -187,7 +186,7 @@ export class DotEditContentMonacoEditorControlComponent implements OnDestroy, On
     onEditorInit($editorRef: monaco.editor.IStandaloneCodeEditor) {
         this.#editor = $editorRef;
 
-        this.processEditorContent();
+        this.detectLanguage();
         this.setupContentChangeListener();
     }
 
@@ -210,37 +209,9 @@ export class DotEditContentMonacoEditorControlComponent implements OnDestroy, On
         }
     }
 
-    private processEditorContent() {
-        if (this.#editor) {
-            const currentContent = this.#editor.getValue();
-
-            const processedContent = this.removeWysiwygComment(currentContent);
-            if (currentContent !== processedContent) {
-                this.#editor.setValue(processedContent);
-
-                // Update the form control value, needed when switching between editor types
-                this.#formControl.setValue(processedContent, { emitEvent: true });
-            }
-
-            this.detectLanguage();
-        }
-    }
-
     private removeEditor() {
         this.#editor.dispose();
         this.#editor = null;
-    }
-
-    /**
-     * Removes the TinyMCE comment from the content.
-     *
-     * @param {string} content - The content to remove the comment from.
-     * @returns {string} The content with the TinyMCE comment removed.
-     */
-    private removeWysiwygComment(content: string): string {
-        const regex = new RegExp(`^\\s*${COMMENT_TINYMCE}\\s*`);
-
-        return content.replace(regex, '');
     }
 
     /**
@@ -249,7 +220,7 @@ export class DotEditContentMonacoEditorControlComponent implements OnDestroy, On
     private setupContentChangeListener() {
         if (this.#editor) {
             this.#contentChangeDisposable = this.#editor.onDidChangeModelContent(() => {
-                this.processEditorContent();
+                this.detectLanguage();
             });
         }
     }

--- a/core-web/libs/edit-content/src/lib/utils/edit-content.mock.ts
+++ b/core-web/libs/edit-content/src/lib/utils/edit-content.mock.ts
@@ -454,7 +454,14 @@ export const MOCK_CONTENTLET_1_TAB: DotCMSContentlet = {
     title: '2978bb3b66e372b1ffffa9376f33c37b',
     titleImage: 'TITLE_IMAGE_NOT_FOUND',
     url: '/content.7af6259d-51b0-4c49-9e08-67cbc74100d6',
-    working: true
+    working: true,
+    disabledWYSIWYG: ['wysiwygField1', 'wysiwygField2'] // WYSIWYG fields disabled for code editor
+};
+
+// Mock contentlet without disabledWYSIWYG for testing new content scenarios
+export const MOCK_CONTENTLET_WITHOUT_DISABLED_WYSIWYG: DotCMSContentlet = {
+    ...MOCK_CONTENTLET_1_TAB,
+    disabledWYSIWYG: undefined
 };
 
 // ContentType with 2 tabs


### PR DESCRIPTION
### Proposed Changes
* persist editor preference based on `disabledWYSIWYG ` property for the textarea and wysiwyg field. 
* support transition from old editor to the new one, or the other direction if the user prefer to do a rollback. 


#### Textarea scenarios

https://github.com/user-attachments/assets/f24df2fa-7138-4134-afa6-6a901a74008b

#### Wysiwyg scenarios

https://github.com/user-attachments/assets/602962a4-e45d-4e75-9dbb-23fae21a552e



This PR fixes: #32516

This PR fixes: #32516