### PR TITLE
fix(core): Fixing folder inconsistencies in old databases before updating folder inodes

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250603UpdateIdentifierParentPathCheckTrigger.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250603UpdateIdentifierParentPathCheckTrigger.java
@@ -24,7 +24,7 @@ public class Task250603UpdateIdentifierParentPathCheckTrigger implements Startup
 
             //Creates a composite index to improve performance in queries filtering by LOWER(parent_path) and LOWER(asset_name)
             //Helpful for queries in FixTask00090RecreateMissingFoldersInParentPath
-            dotConnect.executeStatement("CREATE INDEX idx_identifier_composite_lower ON identifier \n"
+            dotConnect.executeStatement("CREATE INDEX IF NOT EXISTS idx_identifier_composite_lower ON identifier \n"
                     + "(host_inode, asset_type, LOWER(parent_path), LOWER(asset_name))");
 
             //Updates function trigger to support case-insensitive folder lookup

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250603UpdateIdentifierParentPathCheckTrigger.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250603UpdateIdentifierParentPathCheckTrigger.java
@@ -1,0 +1,49 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.startup.StartupTask;
+import java.sql.SQLException;
+
+/**
+ * This task updates the identifier_parent_path_check trigger to validate
+ * existing folders ignoring upper/lower casing in names and paths
+ */
+public class Task250603UpdateIdentifierParentPathCheckTrigger implements StartupTask {
+
+    @Override
+    public boolean forceRun() {
+        return true;
+    }
+
+    @Override
+    public void executeUpgrade() throws DotDataException, DotRuntimeException {
+        final String trigger = "CREATE OR REPLACE FUNCTION identifier_parent_path_check()  RETURNS trigger AS '\n"
+                + "DECLARE\n"
+                + "    folderId varchar(100);\n"
+                + "  BEGIN\n"
+                + "     IF (tg_op = ''INSERT'' OR tg_op = ''UPDATE'') THEN\n"
+                + "      IF(NEW.parent_path=''/'') OR (NEW.parent_path=''/System folder'') THEN\n"
+                + "        RETURN NEW;\n"
+                + "     ELSE\n"
+                + "      select id into folderId from identifier where asset_type=''folder'' and host_inode = NEW.host_inode and lower(parent_path||asset_name||''/'') = lower(NEW.parent_path) and id <> NEW.id;\n"
+                + "      IF FOUND THEN\n"
+                + "        RETURN NEW;\n"
+                + "      ELSE\n"
+                + "        RAISE EXCEPTION ''Cannot % folder % [%] in path % as one or more parent folders do not exist in Site %'', tg_op, NEW.asset_name, NEW.id, NEW.parent_path, NEW.host_inode;\n"
+                + "        RETURN NULL;\n"
+                + "      END IF;\n"
+                + "     END IF;\n"
+                + "    END IF;\n"
+                + "RETURN NULL;\n"
+                + "END\n" +
+                "' LANGUAGE plpgsql;\n";
+
+        try {
+            new DotConnect().executeStatement(trigger);
+        } catch (SQLException e) {
+            throw new DotDataException(e);
+        }
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250603UpdateIdentifierParentPathCheckTrigger.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250603UpdateIdentifierParentPathCheckTrigger.java
@@ -19,29 +19,37 @@ public class Task250603UpdateIdentifierParentPathCheckTrigger implements Startup
 
     @Override
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
-        final String trigger = "CREATE OR REPLACE FUNCTION identifier_parent_path_check()  RETURNS trigger AS '\n"
-                + "DECLARE\n"
-                + "    folderId varchar(100);\n"
-                + "  BEGIN\n"
-                + "     IF (tg_op = ''INSERT'' OR tg_op = ''UPDATE'') THEN\n"
-                + "      IF(NEW.parent_path=''/'') OR (NEW.parent_path=''/System folder'') THEN\n"
-                + "        RETURN NEW;\n"
-                + "     ELSE\n"
-                + "      select id into folderId from identifier where asset_type=''folder'' and host_inode = NEW.host_inode and lower(parent_path||asset_name||''/'') = lower(NEW.parent_path) and id <> NEW.id;\n"
-                + "      IF FOUND THEN\n"
-                + "        RETURN NEW;\n"
-                + "      ELSE\n"
-                + "        RAISE EXCEPTION ''Cannot % folder % [%] in path % as one or more parent folders do not exist in Site %'', tg_op, NEW.asset_name, NEW.id, NEW.parent_path, NEW.host_inode;\n"
-                + "        RETURN NULL;\n"
-                + "      END IF;\n"
-                + "     END IF;\n"
-                + "    END IF;\n"
-                + "RETURN NULL;\n"
-                + "END\n" +
-                "' LANGUAGE plpgsql;\n";
-
         try {
-            new DotConnect().executeStatement(trigger);
+            DotConnect dotConnect = new DotConnect();
+
+            //Creates a composite index to improve performance in queries filtering by LOWER(parent_path) and LOWER(asset_name)
+            //Helpful for queries in FixTask00090RecreateMissingFoldersInParentPath
+            dotConnect.executeStatement("CREATE INDEX idx_identifier_composite_lower ON identifier \n"
+                    + "(host_inode, asset_type, LOWER(parent_path), LOWER(asset_name))");
+
+            //Updates function trigger to support case-insensitive folder lookup
+            final String trigger = "CREATE OR REPLACE FUNCTION identifier_parent_path_check()  RETURNS trigger AS '\n"
+                    + "DECLARE\n"
+                    + "    folderId varchar(100);\n"
+                    + "  BEGIN\n"
+                    + "     IF (tg_op = ''INSERT'' OR tg_op = ''UPDATE'') THEN\n"
+                    + "      IF(NEW.parent_path=''/'') OR (NEW.parent_path=''/System folder'') THEN\n"
+                    + "        RETURN NEW;\n"
+                    + "     ELSE\n"
+                    + "      select id into folderId from identifier where asset_type=''folder'' and host_inode = NEW.host_inode and lower(parent_path||asset_name||''/'') = lower(NEW.parent_path) and id <> NEW.id;\n"
+                    + "      IF FOUND THEN\n"
+                    + "        RETURN NEW;\n"
+                    + "      ELSE\n"
+                    + "        RAISE EXCEPTION ''Cannot % folder % [%] in path % as one or more parent folders do not exist in Site %'', tg_op, NEW.asset_name, NEW.id, NEW.parent_path, NEW.host_inode;\n"
+                    + "        RETURN NULL;\n"
+                    + "      END IF;\n"
+                    + "     END IF;\n"
+                    + "    END IF;\n"
+                    + "RETURN NULL;\n"
+                    + "END\n" +
+                    "' LANGUAGE plpgsql;\n";
+
+                dotConnect.executeStatement(trigger);
         } catch (SQLException e) {
             throw new DotDataException(e);
         }

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250604UpdateFolderInodes.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250604UpdateFolderInodes.java
@@ -1,16 +1,10 @@
 package com.dotmarketing.startup.runonce;
 
 import com.dotmarketing.business.APILocator;
-import com.dotmarketing.business.CacheLocator;
-import com.dotmarketing.common.db.DotConnect;
-import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
-import com.dotmarketing.portlets.folders.business.FolderAPI;
-import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.fixtask.FixTasksExecutor;
 import com.dotmarketing.startup.StartupTask;
-import com.dotmarketing.util.Logger;
-import java.sql.Connection;
 
 /**
  * Upgrade task that sets the system_folder identifier to SYSTEM_FOLDER and updates all folders to use the identifier as
@@ -38,11 +32,12 @@ public class Task250604UpdateFolderInodes implements StartupTask {
     @Override
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
 
+        //Running Update Assets Inconsistencies before fixing folder IDs
+        FixTasksExecutor fixtask = FixTasksExecutor.getInstance();
+        fixtask.execute(null);
+
+        //Updating folder IDs
         APILocator.getFolderAPI().fixFolderIds();
 
-
-
     }
-
-
 }

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250604UpdateFolderInodes.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250604UpdateFolderInodes.java
@@ -3,7 +3,7 @@ package com.dotmarketing.startup.runonce;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
-import com.dotmarketing.fixtask.FixTasksExecutor;
+import com.dotmarketing.fixtask.tasks.FixTask00090RecreateMissingFoldersInParentPath;
 import com.dotmarketing.startup.StartupTask;
 
 /**
@@ -12,16 +12,11 @@ import com.dotmarketing.startup.StartupTask;
  */
 public class Task250604UpdateFolderInodes implements StartupTask {
 
-
-
-
-
     @Override
     public boolean forceRun() {
 
         return APILocator.getFolderAPI().folderIdsNeedFixing();
     }
-
 
     /**
      * Executes the upgrade task, creating the necessary tables and indexes for the Job Queue.
@@ -33,11 +28,13 @@ public class Task250604UpdateFolderInodes implements StartupTask {
     public void executeUpgrade() throws DotDataException, DotRuntimeException {
 
         //Running Update Assets Inconsistencies before fixing folder IDs
-        FixTasksExecutor fixtask = FixTasksExecutor.getInstance();
-        fixtask.execute(null);
+        final FixTask00090RecreateMissingFoldersInParentPath task = new FixTask00090RecreateMissingFoldersInParentPath();
+
+        if (task.shouldRun()){
+            task.executeFix();
+        }
 
         //Updating folder IDs
         APILocator.getFolderAPI().fixFolderIds();
-
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -253,6 +253,7 @@ import com.dotmarketing.startup.runonce.Task241014AddTemplateValueOnContentletIn
 import com.dotmarketing.startup.runonce.Task241015ReplaceLanguagesWithLocalesPortlet;
 import com.dotmarketing.startup.runonce.Task241016AddCustomLanguageVariablesPortletToLayout;
 import com.dotmarketing.startup.runonce.Task250107RemoveEsReadOnlyMonitorJob;
+import com.dotmarketing.startup.runonce.Task250603UpdateIdentifierParentPathCheckTrigger;
 import com.dotmarketing.startup.runonce.Task250604UpdateFolderInodes;
 import com.google.common.collect.ImmutableList;
 
@@ -580,6 +581,7 @@ public class TaskLocatorUtil {
     	.add(Task241016AddCustomLanguageVariablesPortletToLayout.class)
 		.add(Task250107RemoveEsReadOnlyMonitorJob.class)
         .add(Task250113CreatePostgresJobQueueTables.class)
+		.add(Task250603UpdateIdentifierParentPathCheckTrigger.class)
 		.add(Task250604UpdateFolderInodes.class)
 		.build();
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());

--- a/dotCMS/src/main/resources/postgres.sql
+++ b/dotCMS/src/main/resources/postgres.sql
@@ -1939,7 +1939,7 @@ CREATE OR REPLACE FUNCTION identifier_parent_path_check() RETURNS trigger AS '
       IF(NEW.parent_path=''/'') OR (NEW.parent_path=''/System folder'') THEN
         RETURN NEW;
      ELSE
-      select id into folderId from identifier where asset_type=''folder'' and host_inode = NEW.host_inode and parent_path||asset_name||''/'' = NEW.parent_path and id <> NEW.id;
+      select id into folderId from identifier where asset_type=''folder'' and host_inode = NEW.host_inode and lower(parent_path||asset_name||''/'') = lower(NEW.parent_path) and id <> NEW.id;
       IF FOUND THEN
         RETURN NEW;
       ELSE


### PR DESCRIPTION
## Summary
- Added case-insensitive folder lookup in `FixTask00090RecreateMissingFoldersInParentPath` 
- Added `idx_identifier_composite_lower` composite index on `(host_inode, asset_type, LOWER(parent_path), LOWER(asset_name))` for faster case-insensitive queries 
- Updated database trigger `identifier_parent_path_check` to use case-insensitive path validation in PostgreSQL
- Improved transaction handling in the folder creation process. When the LocalTransaction.wrap was used, the transaction never committed and folders were not updated. I only rolled it back to the way I was working before
- Added upgrade task `Task250603UpdateIdentifierParentPathCheckTrigger` to update the `identifier_parent_path_check` trigger in existing databases
- Modified `Task250604UpdateFolderInodes` to run the `FixTask00090RecreateMissingFoldersInParentPath` task before folder ID updates

All these changes are required to make the `Task250604UpdateFolderInodes` compatible with very old databases. These changes have been tested in a customer database

Fixes #32333 

This PR fixes: #32333