### PR TITLE
#32984 Fix ShortyBundler to use system user for binary file operations

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/bundlers/ShortyBundler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/bundlers/ShortyBundler.java
@@ -348,6 +348,8 @@ public class ShortyBundler implements IBundler {
             request = new FakeHttpRequest(binFile.host.getHostname(), path).request();
             request = new MockServletPathRequest(request, "/contentAsset").request();
 
+            //Every Static Push call to the BinaryServlet must be executed using system user instead of anonymous
+            request.setAttribute(com.liferay.portal.util.WebKeys.USER, APILocator.getUserAPI().getSystemUser());
             try (final OutputStream outputStream = bundleOutput.addFile(binFile.binFile)) {
 
                 response = new MockHttpCaptureResponse(response, outputStream).response();


### PR DESCRIPTION
## Summary
- Fixed ShortyBundler to use system user instead of anonymous user for binary file operations during static publishing
- Prevents permission issues when accessing restricted content during bundle generation
- Ensures proper authentication for all binary file operations in publishing workflows

## Changes Made
- Added system user attribution to request before calling BinaryServlet in `writeBinFile()` method

## Impact
- Resolves access denied errors for restricted content during static publishing
- Improves reliability of bundle generation for sites with permission-restricted assets
- Maintains consistency with other publishing operations that use system user

## Testing
- [ ] Verify static publishing works for sites with restricted binary content
- [ ] Confirm no regression in existing publishing functionality
- [ ] Test bundle generation includes all expected binary files with size > 0 bytes

Fixes #32984

🤖 Generated with [Claude Code](https://claude.ai/code)

This PR fixes: #32984