### PR TITLE
fixes(unique fields) #32765 : [Unique Fields] Upgrade with inconsistencies leave the system unusable

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/SqlQueries.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/SqlQueries.java
@@ -1,0 +1,164 @@
+package com.dotcms.contenttype.business.uniquefields.extratable;
+
+import static com.dotcms.content.elasticsearch.business.ESContentletAPIImpl.UNIQUE_PER_SITE_FIELD_VARIABLE_NAME;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.CONTENTLET_IDS_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.CONTENT_TYPE_ID_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.FIELD_VALUE_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.FIELD_VARIABLE_NAME_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.LANGUAGE_ID_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.LIVE_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.SITE_ID_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.UNIQUE_PER_SITE_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.VARIANT_ATTR;
+
+/**
+ * This is a simple utility class that exposes the different SQL queries used to perform CRUD
+ * operations on the {@code unique_fields} table.
+ *
+ * @author Jose Castro
+ * @since Aug 6th, 2025
+ */
+public final class SqlQueries {
+
+    private SqlQueries() {}
+
+    public static final String INSERT_SQL = "INSERT INTO unique_fields (unique_key_val, supporting_values) " +
+            "VALUES (encode(sha256(convert_to(?::text, 'UTF8')), 'hex'), ?)";
+
+    public static final String RECALCULATE_UNIQUE_KEY_VAL = "UPDATE unique_fields\n" +
+            "SET unique_key_val = encode(sha256(" +
+            "convert_to(\n" +
+            "CONCAT(" +
+            "    jsonb_extract_path_text(supporting_values, '" + CONTENT_TYPE_ID_ATTR + "')::text || \n" +
+            "    jsonb_extract_path_text(supporting_values, '" + FIELD_VARIABLE_NAME_ATTR + "')::text || \n" +
+            "    jsonb_extract_path_text(supporting_values, '" + LANGUAGE_ID_ATTR + "')::text || \n" +
+            "    jsonb_extract_path_text(supporting_values, '" + FIELD_VALUE_ATTR + "')::text\n" +
+            "    %s \n" +
+            "),'UTF8'\n" +
+            ")\n" +
+            "), 'hex'), \n" +
+            "supporting_values = jsonb_set(supporting_values, '{" + UNIQUE_PER_SITE_ATTR + "}', '%s') \n" +
+            "WHERE supporting_values->>'" + CONTENT_TYPE_ID_ATTR + "' = ?\n" +
+            "AND supporting_values->>'" + FIELD_VARIABLE_NAME_ATTR + "' = ?";
+
+    public static final String UPDATE_CONTENT_LIST ="UPDATE unique_fields " +
+            "SET supporting_values = jsonb_set(supporting_values, '{" + CONTENTLET_IDS_ATTR + "}', ?::jsonb) " +
+            "WHERE unique_key_val = encode(sha256(convert_to(?::text, 'UTF8')), 'hex')";
+
+    public static final String UPDATE_CONTENT_LIST_WITH_HASH ="UPDATE unique_fields " +
+            "SET supporting_values = jsonb_set(supporting_values, '{" + CONTENTLET_IDS_ATTR + "}', ?::jsonb) " +
+            "WHERE unique_key_val = ?";
+
+    public static final String GET_UNIQUE_FIELDS_BY_CONTENTLET = "SELECT * FROM unique_fields " +
+            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb " +
+            "AND supporting_values->>'" + VARIANT_ATTR + "' = ? " +
+            "AND (supporting_values->>'"+ LANGUAGE_ID_ATTR + "')::BIGINT = ? " +
+            "AND supporting_values->>'" + FIELD_VARIABLE_NAME_ATTR + "' = ?";
+
+    public static final String DELETE_UNIQUE_FIELDS_BY_CONTENTLET = "DELETE FROM unique_fields " +
+            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb AND supporting_values->>'" + VARIANT_ATTR + "' = ? " +
+            "AND (supporting_values->>'"+ LANGUAGE_ID_ATTR + "')::BIGINT = ? " +
+            "AND (supporting_values->>'" + LIVE_ATTR + "')::BOOLEAN = ?";
+
+    public static final String SET_LIVE_BY_CONTENTLET = "UPDATE unique_fields " +
+            "SET supporting_values = jsonb_set(supporting_values, '{" + LIVE_ATTR +  "}', ?::jsonb) " +
+            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb " +
+            "AND supporting_values->>'" + VARIANT_ATTR + "' = ? " +
+            "AND (supporting_values->>'"+ LANGUAGE_ID_ATTR + "')::BIGINT = ? " +
+            "AND (supporting_values->>'" + LIVE_ATTR + "')::BOOLEAN = false";
+
+    public static final String GET_UNIQUE_FIELDS_BY_CONTENTLET_AND_LANGUAGE = "SELECT * FROM unique_fields " +
+            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb AND (supporting_values->>'" + LANGUAGE_ID_ATTR +"')::BIGINT = ?";
+
+    public static final String GET_UNIQUE_FIELDS_BY_CONTENTLET_AND_VARIANT= "SELECT * FROM unique_fields " +
+            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb AND supporting_values->>'" + VARIANT_ATTR + "' = ?";
+
+    public static final String DELETE_UNIQUE_FIELDS = "DELETE FROM unique_fields WHERE unique_key_val = ?";
+
+    public static final String GET_UNIQUE_FIELDS_BY_UNIQUE_FIELD_CRITERIA = "SELECT * FROM unique_fields " +
+            "WHERE unique_key_val = encode(sha256(convert_to(?::text, 'UTF8')), 'hex')";
+
+    public static final String DELETE_UNIQUE_FIELDS_BY_FIELD = "DELETE FROM unique_fields " +
+            "WHERE supporting_values->>'" + FIELD_VARIABLE_NAME_ATTR + "' = ?";
+
+    public static final String DELETE_UNIQUE_FIELDS_BY_CONTENT_TYPE = "DELETE FROM unique_fields " +
+            "WHERE supporting_values->>'" + CONTENT_TYPE_ID_ATTR + "' = ?";
+
+    public static final String POPULATE_UNIQUE_FIELDS_VALUES_QUERY = "INSERT INTO unique_fields (unique_key_val, supporting_values) " +
+            "SELECT  encode(" +
+            "            sha256(" +
+            "                    convert_to(" +
+            "                            CONCAT(" +
+            "                                    content_type_id::text," +
+            "                                    field_var_name::text," +
+            "                                    language_id::text," +
+            "                                    LOWER(field_value)::text," +
+            "                                    CASE WHEN uniquePerSite = 'true' THEN COALESCE(host_id::text, '') ELSE '' END" +
+            "                            )," +
+            "                            'UTF8'" +
+            "                    )" +
+            "            )," +
+            "            'hex'" +
+            "       ) AS unique_key_val, " +
+            "       json_build_object('" + CONTENT_TYPE_ID_ATTR + "', content_type_id, " +
+            "'" + FIELD_VARIABLE_NAME_ATTR + "', field_var_name, " +
+            "'" + LANGUAGE_ID_ATTR + "', language_id, " +
+            "'" + FIELD_VALUE_ATTR +"', LOWER(field_value), " +
+            "'" + SITE_ID_ATTR + "', host_id, " +
+            "'" + VARIANT_ATTR + "', variant_id, " +
+            "'" + UNIQUE_PER_SITE_ATTR + "', " + "uniquePerSite, " +
+            "'" + LIVE_ATTR + "', live, " +
+            "'" + CONTENTLET_IDS_ATTR + "', contentlet_identifier) AS supporting_values " +
+            "FROM (" +
+            "        SELECT structure.inode                                       AS content_type_id," +
+            "               field.velocity_var_name                               AS field_var_name," +
+            "               contentlet.language_id                                AS language_id," +
+            "               (CASE WHEN field_variable.variable_value = 'true' THEN identifier.host_inode ELSE '' END) AS host_id," +
+            "               jsonb_extract_path_text(contentlet_as_json -> 'fields', field.velocity_var_name)::jsonb ->>'value' AS field_value," +
+            "               ARRAY_AGG(DISTINCT contentlet.identifier)                      AS contentlet_identifier," +
+            "               (CASE WHEN COUNT(DISTINCT contentlet_version_info.variant_id) > 1 THEN 'DEFAULT' ELSE MAX(contentlet_version_info.variant_id) END) AS variant_id, " +
+            "               ((CASE WHEN COUNT(*) > 1 AND COUNT(DISTINCT contentlet_version_info.live_inode = contentlet.inode) > 1 THEN 0 " +
+            "                   ELSE MAX((CASE WHEN contentlet_version_info.live_inode = contentlet.inode THEN 1 ELSE 0 END)::int) " +
+            "                   END) = 1) AS live," +
+            "               (MAX(CASE WHEN field_variable.variable_value = 'true' THEN 1 ELSE 0 END)) = 1 AS uniquePerSite" +
+            "        FROM contentlet" +
+            "                 INNER JOIN structure ON structure.inode = contentlet.structure_inode" +
+            "                 INNER JOIN field ON structure.inode = field.structure_inode" +
+            "                 INNER JOIN identifier ON contentlet.identifier = identifier.id" +
+            "                 INNER JOIN contentlet_version_info ON contentlet_version_info.live_inode = contentlet.inode OR" +
+            "                                                       contentlet_version_info.working_inode = contentlet.inode" +
+            "                 LEFT JOIN field_variable ON field_variable.field_id = field.inode AND field_variable.variable_key = '" + UNIQUE_PER_SITE_FIELD_VARIABLE_NAME + "'" +
+            "        WHERE jsonb_extract_path_text(contentlet_as_json -> 'fields', field.velocity_var_name) IS NOT NULL" +
+            "          AND field.unique_ = true" +
+            "        GROUP BY structure.inode," +
+            "                 field.velocity_var_name," +
+            "                 contentlet.language_id," +
+            "                 (CASE WHEN field_variable.variable_value = 'true' THEN identifier.host_inode ELSE '' END)," +
+            "                 jsonb_extract_path_text(contentlet_as_json -> 'fields', field.velocity_var_name)::jsonb ->>'value') as data_to_populate";
+
+    /**
+     * Returns the number of records that share the same hash, a.k.a. unique key value. Such records
+     * must be fixed for dotCMS to start up correctly.
+     */
+    public static final String GET_RECORDS_WITH_SAME_HASH = "SELECT unique_key_val, COUNT(unique_key_val) " +
+            "FROM unique_fields u " +
+            "GROUP BY unique_key_val " +
+            "HAVING COUNT(unique_key_val) > 1;";
+
+    /**
+     * Returns all unique fields with the same hash, a.k.a. the same unique key value.
+     */
+    public static final String GET_UNIQUE_FIELDS_BY_HASH = "SELECT * FROM unique_fields " +
+            "WHERE unique_key_val = ?";
+
+    /**
+     * Updates the unique value of the conflicting entries in the {@code unique_fields} table. That
+     * is, entries that belong to separate Contentlets that have the exact same unique value. The
+     * solution is to set a prefix to it, and re-generate the hash.
+     */
+    public static final String FIX_DUPLICATE_ENTRY = "UPDATE unique_fields " +
+            "SET unique_key_val = encode(sha256(convert_to(?::text, 'UTF8')), 'hex'), " +
+            "supporting_values = ? " +
+            "WHERE unique_key_val = ? AND supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb ";
+
+}

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldConflict.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldConflict.java
@@ -1,0 +1,132 @@
+package com.dotcms.contenttype.business.uniquefields.extratable;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a unique field conflict between Contentlets that share the same unique value. Such
+ * conflicts are meant to be reported to user in the back-end so that they can be manually fix them.
+ *
+ * @author Jose Castro
+ * @since Aug 6th, 2025
+ */
+public class UniqueFieldConflict {
+
+    private final String fieldName;
+    private final String contentTypeId;
+    private final String originalValue;
+    private final List<Map<String, Object>> conflictingData;
+
+    private UniqueFieldConflict(final Builder builder) {
+        this.fieldName = builder.fieldName;
+        this.contentTypeId = builder.contentTypeId;
+        this.originalValue = builder.originalValue;
+        this.conflictingData = builder.conflictingData;
+    }
+
+    /**
+     * Returns the name of the field whose value is unique and conflicts with the value of one or
+     * more Contentlets.
+     *
+     * @return The Velocity Variable Name of the field.
+     */
+    @JsonGetter("fieldName")
+    public String fieldName() {
+        return this.fieldName;
+    }
+
+    /**
+     * Returns the ID of the Content Type that contains the field with the conflicting unique
+     * value.
+     *
+     * @return The ID of the Content Type.
+     */
+    @JsonGetter("contentTypeId")
+    public String contentTypeId() {
+        return this.contentTypeId;
+    }
+
+    /**
+     * Returns the value of the field that is unique and conflicts with the value of one or more
+     * Contentlets.
+     *
+     * @return The conflicting unique value.
+     */
+    @JsonGetter("originalValue")
+    public String originalValue() {
+        return this.originalValue;
+    }
+
+    /**
+     * Returns the list of conflicting Contentlets that share the same unique value. It provides the
+     * Contentlet ID and its language ID.
+     *
+     * @return The list of conflicting Contentlets.
+     */
+    @JsonGetter("conflictingData")
+    public List<Map<String, Object>> conflictingData() {
+        return this.conflictingData;
+    }
+
+    @Override
+    public String toString() {
+        return "UniqueFieldConflict{" +
+                "fieldName='" + fieldName + '\'' +
+                ", contentTypeId='" + contentTypeId + '\'' +
+                ", originalValue='" + originalValue + '\'' +
+                ", conflictingData=" + conflictingData +
+                '}';
+    }
+
+    /**
+     * Allows you to create an instance of the {@link UniqueFieldConflict} class.
+     */
+    public static class Builder {
+
+        private String fieldName;
+        private String contentTypeId;
+        private String originalValue;
+        private List<Map<String, Object>> conflictingData;
+
+        public Builder fieldName(final String fieldName) {
+            this.fieldName = fieldName;
+            return this;
+        }
+
+        public String fieldName() {
+            return this.fieldName;
+        }
+
+        public Builder contentTypeId(final String contentTypeId) {
+            this.contentTypeId = contentTypeId;
+            return this;
+        }
+
+        public Builder originalValue(final String originalValue) {
+            this.originalValue = originalValue;
+            return this;
+        }
+
+        public Builder conflictingData(final Map<String, Object> conflictingData) {
+            if (null == this.conflictingData) {
+                this.conflictingData = new ArrayList<>();
+            }
+            this.conflictingData.add(conflictingData);
+            return this;
+        }
+
+        public Builder conflictingData(final List<Map<String, Object>> conflictingData) {
+            this.conflictingData = conflictingData;
+            return this;
+        }
+
+        public UniqueFieldConflict build() {
+            return new UniqueFieldConflict(this);
+        }
+
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtil.java
@@ -1,156 +1,81 @@
 package com.dotcms.contenttype.business.uniquefields.extratable;
 
-
+import com.dotcms.api.system.event.Visibility;
 import com.dotcms.business.CloseDBIfOpened;
 import com.dotcms.business.WrapInTransaction;
-
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.exception.ExceptionUtil;
+import com.dotcms.notifications.bean.NotificationLevel;
+import com.dotcms.notifications.bean.NotificationType;
+import com.dotcms.util.I18NMessage;
+import com.dotcms.util.JsonUtil;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.Role;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
-import com.liferay.util.StringPool;
+import com.dotmarketing.util.UtilMethods;
+import com.liferay.portal.model.User;
+import com.liferay.util.FileUtil;
+import io.vavr.Lazy;
+import io.vavr.control.Try;
 
 import javax.enterprise.context.ApplicationScoped;
+import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-
-import static com.dotcms.content.elasticsearch.business.ESContentletAPIImpl.UNIQUE_PER_SITE_FIELD_VARIABLE_NAME;
-
-import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.*;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.DELETE_UNIQUE_FIELDS;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.DELETE_UNIQUE_FIELDS_BY_CONTENTLET;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.DELETE_UNIQUE_FIELDS_BY_CONTENT_TYPE;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.DELETE_UNIQUE_FIELDS_BY_FIELD;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.FIX_DUPLICATE_ENTRY;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.GET_RECORDS_WITH_SAME_HASH;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.GET_UNIQUE_FIELDS_BY_CONTENTLET;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.GET_UNIQUE_FIELDS_BY_CONTENTLET_AND_LANGUAGE;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.GET_UNIQUE_FIELDS_BY_CONTENTLET_AND_VARIANT;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.GET_UNIQUE_FIELDS_BY_HASH;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.GET_UNIQUE_FIELDS_BY_UNIQUE_FIELD_CRITERIA;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.INSERT_SQL;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.POPULATE_UNIQUE_FIELDS_VALUES_QUERY;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.RECALCULATE_UNIQUE_KEY_VAL;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.SET_LIVE_BY_CONTENTLET;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.UPDATE_CONTENT_LIST;
+import static com.dotcms.contenttype.business.uniquefields.extratable.SqlQueries.UPDATE_CONTENT_LIST_WITH_HASH;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.CONTENTLET_IDS_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.CONTENT_TYPE_ID_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.FIELD_VALUE_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.FIELD_VARIABLE_NAME_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.LANGUAGE_ID_ATTR;
 import static com.dotcms.util.CollectionsUtils.list;
-
+import static com.liferay.util.StringPool.BLANK;
 
 /**
- * Util class to handle QL statement related with the unique_fiedls table
+ * This class allows developers to perform CRUD operations on the {@code unique_fields} table. It
+ * also exposes methods that enforce uniqueness and data integrity for dotCMS to be able to validate
+ * unique values as expected.
+ *
+ * @author Freddy Rodriguez
+ * @since Oct 30th, 2024
  */
 @ApplicationScoped
 public class UniqueFieldDataBaseUtil {
 
-    private static final String INSERT_SQL = "INSERT INTO unique_fields (unique_key_val, supporting_values) VALUES (encode(sha256(convert_to(?::text, 'UTF8')), 'hex'), ?)";
+    private static final String AUDIT_FILE_NAME = "unique_field_data_conflicts.log";
 
-    private static final String RECALCULATE_UNIQUE_KEY_VAL = "UPDATE unique_fields\n" +
-            "SET unique_key_val = encode(sha256(" +
-                "convert_to(\n" +
-                    "CONCAT(" +
-                        "    jsonb_extract_path_text(supporting_values, '" + CONTENT_TYPE_ID_ATTR + "')::text || \n" +
-                        "    jsonb_extract_path_text(supporting_values, '" + FIELD_VARIABLE_NAME_ATTR + "')::text || \n" +
-                        "    jsonb_extract_path_text(supporting_values, '" + LANGUAGE_ID_ATTR + "')::text || \n" +
-                        "    jsonb_extract_path_text(supporting_values, '" + FIELD_VALUE_ATTR + "')::text\n" +
-                        "    %s \n" +
-                    "),'UTF8'\n" +
-                ")\n" +
-            "), 'hex'), \n" +
-            "supporting_values = jsonb_set(supporting_values, '{" + UNIQUE_PER_SITE_ATTR + "}', '%s') \n" +
-            "WHERE supporting_values->>'" + CONTENT_TYPE_ID_ATTR + "' = ?\n" +
-            "AND supporting_values->>'" + FIELD_VARIABLE_NAME_ATTR + "' = ?";
-
-    private static final String UPDATE_CONTENT_LIST ="UPDATE unique_fields " +
-            "SET supporting_values = jsonb_set(supporting_values, '{" + CONTENTLET_IDS_ATTR + "}', ?::jsonb) " +
-            "WHERE unique_key_val = encode(sha256(convert_to(?::text, 'UTF8')), 'hex')";
-
-    private static final String UPDATE_CONTENT_LIST_WITH_HASH ="UPDATE unique_fields " +
-            "SET supporting_values = jsonb_set(supporting_values, '{" + CONTENTLET_IDS_ATTR + "}', ?::jsonb) " +
-            "WHERE unique_key_val = ?";
-
-    private final static String GET_UNIQUE_FIELDS_BY_CONTENTLET = "SELECT * FROM unique_fields " +
-            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb " +
-            "AND supporting_values->>'" + VARIANT_ATTR + "' = ? " +
-            "AND (supporting_values->>'"+ LANGUAGE_ID_ATTR + "')::BIGINT = ? " +
-            "AND supporting_values->>'" + FIELD_VARIABLE_NAME_ATTR + "' = ?";
-
-    private final static String DELETE_UNIQUE_FIELDS_BY_CONTENTLET = "DELETE FROM unique_fields " +
-            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb AND supporting_values->>'" + VARIANT_ATTR + "' = ? " +
-            "AND (supporting_values->>'"+ LANGUAGE_ID_ATTR + "')::BIGINT = ? " +
-            "AND (supporting_values->>'" + LIVE_ATTR + "')::BOOLEAN = ?";
-
-    private final static String SET_LIVE_BY_CONTENTLET = "UPDATE unique_fields " +
-            "SET supporting_values = jsonb_set(supporting_values, '{" + LIVE_ATTR +  "}', ?::jsonb) " +
-            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb " +
-                "AND supporting_values->>'" + VARIANT_ATTR + "' = ? " +
-                "AND (supporting_values->>'"+ LANGUAGE_ID_ATTR + "')::BIGINT = ? " +
-                "AND (supporting_values->>'" + LIVE_ATTR + "')::BOOLEAN = false";
-
-
-    private final static String GET_UNIQUE_FIELDS_BY_CONTENTLET_AND_LANGUAGE = "SELECT * FROM unique_fields " +
-            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb AND (supporting_values->>'" + LANGUAGE_ID_ATTR +"')::BIGINT = ?";
-
-    private final static String GET_UNIQUE_FIELDS_BY_CONTENTLET_AND_VARIANT= "SELECT * FROM unique_fields " +
-            "WHERE supporting_values->'" + CONTENTLET_IDS_ATTR + "' @> ?::jsonb AND supporting_values->>'" + VARIANT_ATTR + "' = ?";
-
-    private final String DELETE_UNIQUE_FIELDS = "DELETE FROM unique_fields WHERE unique_key_val = ?";
-
-    private final String GET_UNIQUE_FIELDS_BY_HASH = "SELECT * FROM unique_fields " +
-            "WHERE unique_key_val = encode(sha256(convert_to(?::text, 'UTF8')), 'hex')";
-
-    private final static String DELETE_UNIQUE_FIELDS_BY_FIELD = "DELETE FROM unique_fields " +
-            "WHERE supporting_values->>'" + FIELD_VARIABLE_NAME_ATTR + "' = ?";
-
-    private final static String DELETE_UNIQUE_FIELDS_BY_CONTENT_TYPE = "DELETE FROM unique_fields " +
-            "WHERE supporting_values->>'" + CONTENT_TYPE_ID_ATTR + "' = ?";
-
-
-    private final static String POPULATE_UNIQUE_FIELDS_VALUES_QUERY = "INSERT INTO unique_fields (unique_key_val, supporting_values) " +
-            "SELECT  encode(" +
-            "            sha256(" +
-            "                    convert_to(" +
-            "                            CONCAT(" +
-            "                                    content_type_id::text," +
-            "                                    field_var_name::text," +
-            "                                    language_id::text," +
-            "                                    LOWER(field_value)::text," +
-            "                                    CASE WHEN uniquePerSite = 'true' THEN COALESCE(host_id::text, '') ELSE '' END" +
-            "                            )," +
-            "                            'UTF8'" +
-            "                    )" +
-            "            )," +
-            "            'hex'" +
-            "       ) AS unique_key_val, " +
-            "       json_build_object('" + CONTENT_TYPE_ID_ATTR + "', content_type_id, " +
-                                    "'" + FIELD_VARIABLE_NAME_ATTR + "', field_var_name, " +
-                                    "'" + LANGUAGE_ID_ATTR + "', language_id, " +
-                                    "'" + FIELD_VALUE_ATTR +"', LOWER(field_value), " +
-                                    "'" + SITE_ID_ATTR + "', host_id, " +
-                                    "'" + VARIANT_ATTR + "', variant_id, " +
-                                    "'" + UNIQUE_PER_SITE_ATTR + "', " + "uniquePerSite, " +
-                                    "'" + LIVE_ATTR + "', live, " +
-                                    "'" + CONTENTLET_IDS_ATTR + "', contentlet_identifier) AS supporting_values " +
-            "FROM (" +
-            "        SELECT structure.inode                                       AS content_type_id," +
-            "               field.velocity_var_name                               AS field_var_name," +
-            "               contentlet.language_id                                AS language_id," +
-            "               (CASE WHEN field_variable.variable_value = 'true' THEN identifier.host_inode ELSE '' END) AS host_id," +
-            "               jsonb_extract_path_text(contentlet_as_json -> 'fields', field.velocity_var_name)::jsonb ->>'value' AS field_value," +
-            "               ARRAY_AGG(DISTINCT contentlet.identifier)                      AS contentlet_identifier," +
-            "               (CASE WHEN COUNT(DISTINCT contentlet_version_info.variant_id) > 1 THEN 'DEFAULT' ELSE MAX(contentlet_version_info.variant_id) END) AS variant_id, " +
-            "               ((CASE WHEN COUNT(*) > 1 AND COUNT(DISTINCT contentlet_version_info.live_inode = contentlet.inode) > 1 THEN 0 " +
-            "                   ELSE MAX((CASE WHEN contentlet_version_info.live_inode = contentlet.inode THEN 1 ELSE 0 END)::int) " +
-            "                   END) = 1) AS live," +
-            "               (MAX(CASE WHEN field_variable.variable_value = 'true' THEN 1 ELSE 0 END)) = 1 AS uniquePerSite" +
-            "        FROM contentlet" +
-            "                 INNER JOIN structure ON structure.inode = contentlet.structure_inode" +
-            "                 INNER JOIN field ON structure.inode = field.structure_inode" +
-            "                 INNER JOIN identifier ON contentlet.identifier = identifier.id" +
-            "                 INNER JOIN contentlet_version_info ON contentlet_version_info.live_inode = contentlet.inode OR" +
-            "                                                       contentlet_version_info.working_inode = contentlet.inode" +
-            "                 LEFT JOIN field_variable ON field_variable.field_id = field.inode AND field_variable.variable_key = '" + UNIQUE_PER_SITE_FIELD_VARIABLE_NAME + "'" +
-            "        WHERE jsonb_extract_path_text(contentlet_as_json -> 'fields', field.velocity_var_name) IS NOT NULL" +
-            "          AND field.unique_ = true" +
-            "        GROUP BY structure.inode," +
-            "                 field.velocity_var_name," +
-            "                 contentlet.language_id," +
-            "                 (CASE WHEN field_variable.variable_value = 'true' THEN identifier.host_inode ELSE '' END)," +
-            "                 jsonb_extract_path_text(contentlet_as_json -> 'fields', field.velocity_var_name)::jsonb ->>'value') as data_to_populate";
-
+    private static final Lazy<String> AUDIT_FILE_PATH = Lazy.of(() -> Config.getStringProperty(
+            "TAIL_LOG_LOG_FOLDER", "./dotsecure/logs") + File.separator + AUDIT_FILE_NAME);
 
     @WrapInTransaction
     public void insert(final String key, final Map<String, Object> supportingValues) throws DotDataException {
-
         new DotConnect()
                 .setSQL(INSERT_SQL)
                 .addParam(key)
@@ -227,37 +152,40 @@ public class UniqueFieldDataBaseUtil {
     }
 
     /**
-     * Return a register filtering by the unique_key_value field
+     * Returns the unique field record that matches a specific Hash.
      *
-     * @param uniqueFieldCriteria to calculate the unique_key_value
-     * @return
-     * @throws DotDataException
+     * @param uniqueFieldCriteria The {@link UniqueFieldCriteria} containing the criteria to
+     *                            retrieve the record.
+     *
+     * @return An {@link Optional} containing the unique field record if it exists, or an empty
+     * optional otherwise.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
      */
     @CloseDBIfOpened
     public Optional<UniqueFieldValue> get(final UniqueFieldCriteria uniqueFieldCriteria) throws DotDataException {
-
-        return new DotConnect().setSQL(GET_UNIQUE_FIELDS_BY_HASH)
+        return new DotConnect().setSQL(GET_UNIQUE_FIELDS_BY_UNIQUE_FIELD_CRITERIA)
                 .addParam(uniqueFieldCriteria.criteria())
                 .loadObjectResults()
                 .stream().findFirst()
                 .map(item ->
                         new UniqueFieldValue(item.get("unique_key_val").toString(), getSupportingValues(item) ));
-
     }
 
     /**
-     * Return the supporting_values from a unique_field table register also turn the supporting_values from a
-     * {@link org.postgresql.util.PGobject} to a Map.
+     * Returns the supporting_values for a specific unique value entry. Also, this method transforms
+     * the {@code supporting_values} from a {@link org.postgresql.util.PGobject} into a Map.
      *
-     * @param uniqueFieldRegister
-     * @return
+     * @param uniqueFieldValues The {@link Map} containing the unique field attributes.
+     *
+     * @return A {@link Map} containing the supporting values.
      */
-    private static Map<String, Object> getSupportingValues(final Map<String, Object> uniqueFieldRegister) {
+    private static Map<String, Object> getSupportingValues(final Map<String, Object> uniqueFieldValues) {
         try {
-            return com.dotcms.util.JsonUtil.getJsonFromString(uniqueFieldRegister.get("supporting_values").toString());
-        } catch (IOException e) {
-            Logger.error(UniqueFieldDataBaseUtil.class.getName(), "Error getting supporting values", e);
-            throw new RuntimeException(e);
+            return JsonUtil.getJsonFromString(uniqueFieldValues.get("supporting_values").toString());
+        } catch (final IOException e) {
+            Logger.error(UniqueFieldDataBaseUtil.class, "Error getting supporting values", e);
+            throw new DotRuntimeException(e);
         }
     }
 
@@ -291,10 +219,20 @@ public class UniqueFieldDataBaseUtil {
     private static String getUniqueRecalculationQuery(final boolean uniquePerSite) {
         return String.format(RECALCULATE_UNIQUE_KEY_VAL, uniquePerSite
                 ? " || jsonb_extract_path_text(supporting_values, '" + UniqueFieldCriteria.SITE_ID_ATTR + "')::bytea"
-                : StringPool.BLANK,
+                : BLANK,
                 uniquePerSite);
     }
 
+    /**
+     * Returns a list of unique values that match a specific Contentlet ID and Language ID.
+     *
+     * @param contentId  The Contentlet ID.
+     * @param languageId The Language ID.
+     *
+     * @return A list of unique values that match the specified criteria.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
+     */
     @CloseDBIfOpened
     public List<Map<String, Object>> get(final String contentId, final long languageId) throws DotDataException {
         return new DotConnect().setSQL(GET_UNIQUE_FIELDS_BY_CONTENTLET_AND_LANGUAGE)
@@ -304,12 +242,14 @@ public class UniqueFieldDataBaseUtil {
     }
 
     /**
-     * Find Unique Field Values by {@link Contentlet} and {@link  com.dotcms.variant.model.Variant}
+     * Returns a list of unique values that match a specific Contentlet ID and Variant ID.
      *
-     * @param contentId
-     * @param variantId
-     * @return
-     * @throws DotDataException
+     * @param contentId The Contentlet ID.
+     * @param variantId The Variant ID.
+     *
+     * @return A list of unique values that match the specified criteria.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
      */
     @CloseDBIfOpened
     public List<Map<String, Object>> get(final String contentId, final String variantId) throws DotDataException {
@@ -320,10 +260,11 @@ public class UniqueFieldDataBaseUtil {
     }
 
     /**
-     * Delete a Unique Field Value by hash
+     * Deletes a Unique Field Value by its unique hash.
      *
-     * @param hash
-     * @throws DotDataException
+     * @param hash The unique hash of the Unique Field Value to delete.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
      */
     @WrapInTransaction
     public void delete(final String hash) throws DotDataException {
@@ -333,10 +274,11 @@ public class UniqueFieldDataBaseUtil {
     }
 
     /**
-     * Delete all the unique values for a Field
+     * Deletes all the unique values for a given Contentlet field.
      *
-     * @param field
-     * @throws DotDataException
+     * @param field The {@link Field} to delete the unique values from.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
      */
     @WrapInTransaction
     public void delete(final Field field) throws DotDataException {
@@ -346,10 +288,11 @@ public class UniqueFieldDataBaseUtil {
     }
 
     /**
-     * Delete all the unique values for a {@link ContentType}
+     * Deletes all the unique values for a given Content Type.
      *
-     * @param contentType
-     * @throws DotDataException
+     * @param contentType The {@link ContentType} to delete the unique values from.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
      */
     @WrapInTransaction
     public void delete(final ContentType contentType) throws DotDataException {
@@ -396,9 +339,9 @@ public class UniqueFieldDataBaseUtil {
     }
 
     /**
-     * Create the {@code unique_fields} table for the new Unique Field Data base
-     * Validation mechanism. The new {@code unique_fields} table will be used to validate fields that must be
-     * unique, and what parameters were used to defined such a uniqueness feature.
+     * Create the {@code unique_fields} table for the new Unique Field Database Validation
+     * mechanism. This new table will be used to validate fields that must be unique, and will store
+     * what parameters were used to defined such a uniqueness feature.
      *
      * <h4>Table Definition:</h4>
      * <pre>
@@ -410,7 +353,8 @@ public class UniqueFieldDataBaseUtil {
      * }
      * </pre>
      * <h4>Columns:</h4>
-     * The {@code unique_key_val} column will store a hash created from a combination of the following:
+     * The {@code unique_key_val} column will store a hash created from a combination of the
+     * following:
      * <ul>
      *     <li>Content type ID.</li>
      *     <li>Field variable name.</li>
@@ -431,7 +375,7 @@ public class UniqueFieldDataBaseUtil {
      *     "uniquePerSite": true|false,
      *     "contentletsId": [...],
      *     "variant": "",
-     *     "live": true|fsle
+     *     "live": true|false
      * }
      * }
      * </pre>
@@ -452,32 +396,243 @@ public class UniqueFieldDataBaseUtil {
     @WrapInTransaction
     public void createUniqueFieldsValidationTable() throws DotDataException {
         new DotConnect().setSQL("CREATE TABLE IF NOT EXISTS unique_fields (" +
-                    "unique_key_val VARCHAR(64) PRIMARY KEY," +
-                    "supporting_values JSONB" +
-                " )").loadObjectResults();
-    }
-
-    @WrapInTransaction
-    public void createTableAndPopulate() throws DotDataException {
-            createUniqueFieldsValidationTable();
-            populateUniqueFieldsTable();
+                    "unique_key_val VARCHAR(64)," +
+                    "supporting_values JSONB)").loadObjectResults();
+        new DotConnect().setSQL("CREATE INDEX temp_idx_unique_key_val ON unique_fields(unique_key_val);")
+                .loadObjectResults();
     }
 
     /**
-     * Drop the {@code unique_fields} table for the new Unique Field Data base validation mechanism.
+     * Creates and populates the {@code unique_fields} table with unique field values extracted from
+     * the {@code contentlet} table.
      *
+     * @throws DotDataException An error occurred when interacting with the database.
+     */
+    public void createTableAndPopulate() throws DotDataException {
+        Logger.info(this, "---> Creating the unique_fields table");
+        createUniqueFieldsValidationTable();
+        Logger.info(this, "---> Populating the unique_fields table");
+        populateUniqueFieldsTable();
+        Logger.info(this, "---> Fixing and reporting records with the same hash, if any");
+        this.handleDuplicateRecords();
+        Logger.info(this, "---> Bringing primary key constraints back");
+        this.addPrimaryKeyConstraintsBack();
+    }
+
+    /**
+     * Locates records that have the exact same hash, but referenced by different Contentlet IDs,
+     * and updates their unique values so that they don't conflict anymore. This involves:
+     * <ul>
+     *     <li>Locating at least two records with the same hash value.</li>
+     *     <li>Setting an updated unique value in the form of:
+     *     {@code legacy*support*<RANDOM-NUMBER>{<ORIGINAL-UNIQUE-VALUE>}}.</li>
+     *     <li>Re-generating its hash so that it won't match any other entry.</li>
+     * </ul>
+     * Additionally, a JSON file containing the affected records will be created under the
+     * following path: {@link #AUDIT_FILE_PATH} . It will be available for download from the
+     * back-end so that users can be notified of the changes and inspect what Contentlets must be
+     * manually updated.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
+     */
+    @CloseDBIfOpened
+    public void handleDuplicateRecords() throws DotDataException {
+        final DotConnect dotConnect = new DotConnect().setSQL(GET_RECORDS_WITH_SAME_HASH);
+        final List<Map<String, Object>> duplicateRecords = dotConnect.loadObjectResults();
+        Logger.info(this, String.format("A total of %d records with the same hash value were found",
+                duplicateRecords.size()));
+        if (duplicateRecords.isEmpty()) {
+            return;
+        }
+        final List<UniqueFieldConflict> duplicateEntriesReport = new ArrayList<>();
+        duplicateRecords.forEach(record -> {
+            final String uniqueKeyVal = Try.of(() -> record.get("unique_key_val").toString()).getOrNull();
+            duplicateEntriesReport.add(this.updateDuplicates(uniqueKeyVal));
+        });
+        this.reportDuplicateRecords(duplicateEntriesReport);
+    }
+
+    /**
+     * Takes the list of conflicting entries in the {@code unique_fields} table and writes them to
+     * the following path: {@link #AUDIT_FILE_PATH}. Moreover, it notifies the user via the static
+     * Notifications System in the back-end so that the audit file is available for download.
+     *
+     * @param duplicateEntriesReport The list of {@link UniqueFieldConflict} objects containing the
+     *                               information of the Contentlets whose specific unique value must
+     *                               be fixed.
+     */
+    private void reportDuplicateRecords(final List<UniqueFieldConflict> duplicateEntriesReport) {
+        final String jsonString = JsonUtil.getPrettyJsonStringFromObject(Map.of("duplicates", duplicateEntriesReport));
+        try {
+            FileUtil.write(new File(AUDIT_FILE_PATH.get()), jsonString);
+            final User systemUser = APILocator.getUserAPI().getSystemUser();
+            final Role cmsAdminRole = APILocator.getRoleAPI().loadCMSAdminRole();
+            APILocator.getNotificationAPI().generateNotification(
+                    new I18NMessage("uniquefields.notification.duplicatevalues.title"),
+                    new I18NMessage("uniquefields.notification.duplicatevalues.message"),
+                    null,
+                    NotificationLevel.WARNING, NotificationType.GENERIC, Visibility.ROLE, cmsAdminRole.getId(),
+                    systemUser.getUserId(),
+                    systemUser.getLocale());
+        } catch (final IOException e) {
+            Logger.error(this, String.format("An error occurred while trying to write the " +
+                    "'%s' audit file: %s", AUDIT_FILE_PATH.get(), ExceptionUtil.getErrorMessage(e)), e);
+        } catch (final DotDataException e) {
+            Logger.error(this, String.format("An error occurred while trying to generate the notification: " +
+                    "%s", ExceptionUtil.getErrorMessage(e)), e);
+        }
+    }
+
+    /**
+     * Once the {@code unique_fields} table has been cleared of any duplicate entries -- i.e.;
+     * entries with the same hash -- this method will add the primary key constraint back to the
+     * table.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
+     */
+    @WrapInTransaction
+    public void addPrimaryKeyConstraintsBack() throws DotDataException {
+        String sqlQuery = "ALTER TABLE unique_fields ALTER COLUMN unique_key_val SET NOT NULL";
+        new DotConnect().setSQL(sqlQuery).loadObjectResults();
+        sqlQuery = "ALTER TABLE unique_fields ADD PRIMARY KEY (unique_key_val)";
+        new DotConnect().setSQL(sqlQuery).loadObjectResults();
+    }
+
+    /**
+     * Updates the unique values of the records that have the same hash, but are referenced by
+     * different Contentlet IDs. During this process, the first record found in the list of
+     * duplicates will be considered as the source of truth. The remaining ones will have their
+     * unique values updated so that they don't conflict anymore.
+     *
+     * @param uniqueKeyVal The hash value that is present in the table more than once.
+     */
+    @CloseDBIfOpened
+    private UniqueFieldConflict updateDuplicates(final String uniqueKeyVal) {
+        final DotConnect dotConnect = new DotConnect().setSQL(GET_UNIQUE_FIELDS_BY_HASH).addParam(uniqueKeyVal);
+        try {
+            final List<Map<String, Object>> uniqueFieldsData = dotConnect.loadObjectResults();
+            final List<String> supportingValuesToUpdate = new ArrayList<>();
+            // Always skip the first record, as it will be the source of truth
+            for (int i = 1; i < uniqueFieldsData.size(); i++) {
+                final String supportingValues = uniqueFieldsData.get(i).get("supporting_values").toString();
+                supportingValuesToUpdate.add(supportingValues);
+            }
+            this.updateUniqueValues(uniqueKeyVal, supportingValuesToUpdate);
+            return this.buildConflict(uniqueFieldsData);
+        } catch (final DotDataException e) {
+            final String errorMsg = String.format("An error occurred while trying to update the unique values for hash " +
+                    "'%s': %s'", uniqueKeyVal, ExceptionUtil.getErrorMessage(e));
+            Logger.error(this, errorMsg, e);
+            throw new DotRuntimeException(errorMsg, e);
+        }
+    }
+
+    /**
+     * Takes the list of records that have the same hash -- a.k.a. unique key value -- and builds
+     * the {@link UniqueFieldConflict} object that will be used to keep track of the specific
+     * conflicting Contentlets via the audit file.
+     *
+     * @param conflictingData The list of Maps containing the raw conflicting data from the
+     *                        database.
+     *
+     * @return The {@link UniqueFieldConflict} tracking object.
+     */
+    private UniqueFieldConflict buildConflict(final List<Map<String, Object>> conflictingData) {
+        try {
+            UniqueFieldConflict.Builder conflictBuilder = new UniqueFieldConflict.Builder();
+            for (final Map<String, Object> rawConflict : conflictingData) {
+                if (null == rawConflict.get("supporting_values")) {
+                    return null;
+                }
+                final Map<String, Object> supportingValuesAsMap = JsonUtil
+                        .getJsonFromString(rawConflict.get("supporting_values").toString());
+                // Set these initial values only once
+                if (UtilMethods.isNotSet(conflictBuilder.fieldName())) {
+                    conflictBuilder = new UniqueFieldConflict.Builder()
+                            .fieldName(supportingValuesAsMap.get(FIELD_VARIABLE_NAME_ATTR).toString())
+                            .contentTypeId(supportingValuesAsMap.get(CONTENT_TYPE_ID_ATTR).toString())
+                            .originalValue(supportingValuesAsMap.get(FIELD_VALUE_ATTR).toString());
+                }
+                conflictBuilder = conflictBuilder.conflictingData(Map.of(
+                        "contentletId", supportingValuesAsMap.get(CONTENTLET_IDS_ATTR).toString(),
+                        "languageId", supportingValuesAsMap.get(LANGUAGE_ID_ATTR)));
+            }
+            return conflictBuilder.build();
+        } catch (final IOException e) {
+            final String errorMsg = String.format("Failed to parse supporting values as JSON into Java map: " +
+                    "%s", ExceptionUtil.getErrorMessage(e));
+            Logger.error(this, errorMsg, e);
+            throw new DotRuntimeException(errorMsg, e);
+        }
+    }
+
+    /**
+     * For a given hash -- a.k.a. unique key value -- takes the list of unique field criteria of the
+     * conflicting entries in the {@code unique_fields} table and updates the corresponding unique
+     * value. This way, a new hash will be generated, and it won't collide with the original one.
+     * <p>There are specific properties that are used to make up the unique field criteria. For more
+     * details, you can refer to: {@link UniqueFieldCriteria#criteria()} .</p>
+     *
+     * @param uniqueKeyVal   The hash value that is present in the table more than once.
+     * @param valuesToUpdate The list of unique field criteria of the conflicting entries.
+     */
+    @WrapInTransaction
+    private void updateUniqueValues(final String uniqueKeyVal, final List<String> valuesToUpdate) {
+        valuesToUpdate.forEach(supportingValues -> {
+
+            try {
+                final Map<String, Object> supportingValuesAsMap = JsonUtil.getJsonFromString(supportingValues);
+                Logger.info(this, String.format("Fixing conflict for Content IDs '%s' with unique value '%s'",
+                        supportingValuesAsMap.get(CONTENTLET_IDS_ATTR), supportingValuesAsMap.get(FIELD_VALUE_ATTR)));
+                final String updatedFieldValue =
+                        this.generateUniqueName(supportingValuesAsMap.getOrDefault("fieldValue", BLANK).toString());
+                supportingValuesAsMap.put("fieldValue", updatedFieldValue);
+                final String updatedCriteria = UniqueFieldCriteria.criteria(supportingValuesAsMap);
+                final DotConnect dotConnect = new DotConnect().setSQL(FIX_DUPLICATE_ENTRY)
+                        .addParam(updatedCriteria)
+                        .addJSONParam(supportingValuesAsMap)
+                        .addParam(uniqueKeyVal)
+                        .addJSONParam(supportingValuesAsMap.get(CONTENTLET_IDS_ATTR));
+                dotConnect.loadObjectResults();
+            } catch (final IOException e) {
+                final String errorMsg = String.format("Failed to transform support values [ %s ] into JSON Map for key " +
+                        "'%s': %s", supportingValues, uniqueKeyVal, ExceptionUtil.getErrorMessage(e));
+                throw new DotRuntimeException(errorMsg, e);
+            } catch (final DotDataException e) {
+                final String errorMsg = String.format("Failed to update Unique Field entry with key " +
+                        "'%s' and support values [ %s ]: %s", uniqueKeyVal, supportingValues,
+                        ExceptionUtil.getErrorMessage(e));
+                throw new DotRuntimeException(errorMsg, e);
+            }
+
+        });
+    }
+
+    /**
+     * Generates a new unique value based on the original one, using a specific format that can also
+     * be used to look for conflicting entries that were fixed.
+     *
+     * @param originalUniqueValue The original unique value.
+     *
+     * @return The new unique value.
+     */
+    private String generateUniqueName(final String originalUniqueValue) {
+        return "legacy*support*{" + originalUniqueValue + "}";
+    }
+
+    /**
+     * Drops the {@code unique_fields} table.
+     *
+     * @throws DotDataException An error occurred when interacting with the database.
      * @see UniqueFieldDataBaseUtil#createUniqueFieldsValidationTable()
-     *
-     * @throws DotDataException
      */
     @WrapInTransaction
     public void dropUniqueFieldsValidationTable() throws DotDataException {
         try {
             new DotConnect().setSQL("DROP TABLE unique_fields").loadObjectResults();
-        } catch (DotDataException e) {
+        } catch (final DotDataException e) {
             final Throwable cause = e.getCause();
-
-            if (!SQLException.class.isInstance(cause) ||
+            if (!(cause instanceof SQLException) ||
                     !"ERROR: table \"unique_fields\" does not exist".equals(cause.getMessage())) {
                 throw e;
             }
@@ -485,14 +640,18 @@ public class UniqueFieldDataBaseUtil {
     }
 
     /**
-     * Populates the {@code unique_fields} table with unique field values extracted from the {@code contentlet} table.
+     * Populates the {@code unique_fields} table with the unique values extracted from the
+     * {@code contentlet} table. This process involves:
+     * <ul>
+     *     <li>Identifying all {@link com.dotcms.contenttype.model.type.ContentType} objects with
+     *     unique fields.</li>
+     *     <li>Retrieving all {@link Contentlet} entries and their corresponding values for both
+     *     LIVE and Working versions.</li>
+     *     <li>Storing these unique field values into the {@code unique_fields} table with all
+     *     this data.</li>
+     * </ul>
      *
-     * The process involves:
-     * - Identifying all {@link com.dotcms.contenttype.model.type.ContentType} objects with unique fields.
-     * - Retrieving all {@link Contentlet} entries and their corresponding values for both LIVE and Working versions.
-     * - Storing these unique field values into the {@code unique_fields} table with all this data.
-     *
-     * @throws DotDataException
+     * @throws DotDataException An error occurred when interacting with the database.
      */
     @WrapInTransaction
     public void populateUniqueFieldsTable() throws DotDataException {
@@ -500,14 +659,21 @@ public class UniqueFieldDataBaseUtil {
     }
 
     /**
-     * Represents a register in the unique_fields table
+     * Represents a record in the {@code unique_fields} table. It consists of:
+     * <ul>
+     *     <li>A unique hash acting as the entry identifier. This is an encoded SHA-256 of the
+     *     unique field criteria</li>
+     *     <li>The supporting values, a.k.a. the unique criteria, which provides information on the
+     *     Contentlet or Contentlets that are using the same unique value. For more details, please
+     *     refer to: {@link UniqueFieldCriteria} .</li>
+     * </ul>
      */
     public static class UniqueFieldValue {
+
         private final String uniqueKeyVal;
         private final Map<String, Object> supportingValues;
 
         public UniqueFieldValue(final String uniqueKeyVal, final Map<String, Object> supportingValues) {
-
             this.uniqueKeyVal = uniqueKeyVal;
             this.supportingValues = supportingValues;
         }
@@ -519,5 +685,7 @@ public class UniqueFieldDataBaseUtil {
         public Map<String, Object> getSupportingValues() {
             return supportingValues;
         }
+
     }
+
 }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtil.java
@@ -398,7 +398,7 @@ public class UniqueFieldDataBaseUtil {
         new DotConnect().setSQL("CREATE TABLE IF NOT EXISTS unique_fields (" +
                     "unique_key_val VARCHAR(64)," +
                     "supporting_values JSONB)").loadObjectResults();
-        new DotConnect().setSQL("CREATE INDEX temp_idx_unique_key_val ON unique_fields(unique_key_val);")
+        new DotConnect().setSQL("CREATE INDEX IF NOT EXISTS idx_unique_key_val ON unique_fields(unique_key_val)")
                 .loadObjectResults();
     }
 

--- a/dotCMS/src/main/java/com/dotcms/util/JsonUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/util/JsonUtil.java
@@ -13,7 +13,8 @@ import java.net.URL;
 import java.util.Map;
 
 /**
- * Util class to handle JSON
+ * This utility class exposes different methods that allow you to transform JSON Strings into Java
+ * Objects and vice versa, as well as methods to validate JSON.
  *
  * @author Freddy Rodriguez
  * @since Jun 8th, 2022
@@ -22,10 +23,12 @@ public class JsonUtil {
 
     public final static ObjectMapper JSON_MAPPER = new ObjectMapper();
 
+    @SuppressWarnings("unchecked")
     public static Map<String, Object> getJsonFileContent(final String path) throws IOException {
         return JSON_MAPPER.readValue(getJsonFileContentAsString(path), Map.class);
     }
 
+    @SuppressWarnings("unchecked")
     public static Map<String, Object> getJsonFromString(final String json) throws IOException {
         return JSON_MAPPER.readValue(json, Map.class);
     }
@@ -78,6 +81,19 @@ public class JsonUtil {
                 () -> JSON_MAPPER.writeValueAsString(object)).getOrElse(StringPool.BLANK);
 
         return json;
+    }
+
+    /**
+     * Transforms the specified object into a prettified JSON String.
+     *
+     * @param object The object to be transformed.
+     *
+     * @return The prettified JSON String.
+     */
+    public static String getPrettyJsonStringFromObject(final Object object) {
+        return Try.of(() ->
+                JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(object))
+                .getOrElse(StringPool.BLANK);
     }
 
     /**
@@ -160,4 +176,5 @@ public class JsonUtil {
             );
         }
     }
+
 }

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6088,3 +6088,5 @@ analytics.search.title=Analytics Search
 analytics.dashboard.title=Analytics Dashboard
 com.dotcms.repackage.javax.portlet.title.analytics-dashboard=Analytics Dashboard
 edit.content.form.field.calendar.never.expires=Never Expires
+uniquefields.notification.duplicatevalues.title=Duplicate Unique Values
+uniquefields.notification.duplicatevalues.message=dotCMS found several Contentlets with the same unique field value. Please go to the Maintenance > Log Files portlet, select and download the 'unique_field_data_conflicts.log' file which provides the information you need to manually fix them.

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtilTest.java
@@ -27,6 +27,7 @@ import com.dotmarketing.portlets.contentlet.business.DotContentletValidationExce
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.StringUtils;
+import com.dotmarketing.util.UUIDGenerator;
 import graphql.AssertException;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -39,6 +40,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -52,6 +54,8 @@ import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFiel
 import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.LANGUAGE_ID_ATTR;
 import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.LIVE_ATTR;
 import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.SITE_ID_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.UNIQUE_PER_SITE_ATTR;
+import static com.dotcms.contenttype.business.uniquefields.extratable.UniqueFieldCriteria.VARIANT_ATTR;
 import static com.dotcms.util.CollectionsUtils.list;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -75,33 +79,39 @@ public class UniqueFieldDataBaseUtilTest {
     }
 
     /**
-     * Method to test: {@link UniqueFieldDataBaseUtil#createUniqueFieldsValidationTable()}
-     * When: call this method
-     * Should: create the unique_fields table with the right columns
+     * <ul>
+     *     <li><b>Method to test:</b>
+     *     {@link UniqueFieldDataBaseUtil#createUniqueFieldsValidationTable()}</li>
+     *     <li><b>Given Scenario:</b> Create the unique_fields table which, by default, has no
+     *     primary key set. This is because there might be situations in which several Contentlets
+     *     may have the same unique value, and that's not correct. Temporarily allowing duplicates
+     *     allows us to find them and fix them appropriately.</li>
+     *     <li><b>Expected Result:</b> The unique_fields table must exist, with the right columns
+     *     .</li>
+     * </ul>
      *
-     * @throws SQLException
-     * @throws DotDataException
+     * @throws SQLException     An error occurred when checking the DBMS metadata.
+     * @throws DotDataException An error occurred when interacting with the database.
      */
     @Test
     public void createUniqueFieldsTable() throws SQLException, DotDataException {
         final Connection connection = DbConnectionFactory.getConnection();
         final DotDatabaseMetaData dotDatabaseMetaData = new DotDatabaseMetaData();
         dotDatabaseMetaData.dropTable(connection, "unique_fields");
-        assertFalse(dotDatabaseMetaData.tableExists(connection, "unique_fields"));
+
+        assertFalse("The 'unique_fields' table was just dropped, and should NOT exist",
+                dotDatabaseMetaData.tableExists(connection, "unique_fields"));
 
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
 
-        assertTrue(dotDatabaseMetaData.tableExists(connection, "unique_fields"));
+        assertTrue("The 'unique_fields' table must exist now",
+                dotDatabaseMetaData.tableExists(connection, "unique_fields"));
 
         final ResultSet uniqueFieldsColumns = DotDatabaseMetaData.getColumnsMetaData(connection,
                 "unique_fields");
-
-
         while (uniqueFieldsColumns.next()) {
-
             final String columnName = uniqueFieldsColumns.getString("COLUMN_NAME");
-
             final String columnType = uniqueFieldsColumns.getString("TYPE_NAME");
             final String columnSize = uniqueFieldsColumns.getString("COLUMN_SIZE");
 
@@ -111,15 +121,9 @@ public class UniqueFieldDataBaseUtilTest {
             } else if (columnName.equals("supporting_values")) {
                 assertEquals("jsonb", columnType);
             } else {
-                throw new AssertException("Column no valid");
+                throw new AssertException("Unexpected column name: " + columnName);
             }
         }
-
-
-        final List<String> primaryKeysFields = DotDatabaseMetaData.getPrimaryKeysFields("unique_fields");
-        assertEquals(1, primaryKeysFields.size());
-        assertTrue(primaryKeysFields.contains("unique_key_val"));
-
     }
 
     /**
@@ -141,6 +145,7 @@ public class UniqueFieldDataBaseUtilTest {
             assertFalse(dotDatabaseMetaData.tableExists(connection, "unique_fields"));
 
             uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
+            uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
 
             assertTrue(dotDatabaseMetaData.tableExists(connection, "unique_fields"));
 
@@ -211,12 +216,13 @@ public class UniqueFieldDataBaseUtilTest {
 
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
+        uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
 
-        assertTrue(getUniqueFieldsRegisters(contentType).isEmpty());
+        assertTrue(getUniqueFieldRecords(contentType).isEmpty());
 
         uniqueFieldDataBaseUtil.populateUniqueFieldsTable();
 
-        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldsRegisters(contentType);
+        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldRecords(contentType);
         assertEquals(3, uniqueFieldsRegisters.size());
 
         for (Map<String, Object> uniqueFieldsRegister : uniqueFieldsRegisters) {
@@ -292,12 +298,13 @@ public class UniqueFieldDataBaseUtilTest {
 
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
+        uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
 
-        assertTrue(getUniqueFieldsRegisters(contentType).isEmpty());
+        assertTrue(getUniqueFieldRecords(contentType).isEmpty());
 
         uniqueFieldDataBaseUtil.populateUniqueFieldsTable();
 
-        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldsRegisters(contentType);
+        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldRecords(contentType);
         assertEquals(1, uniqueFieldsRegisters.size());
 
         final Map<String, Object> uniqueFieldsRegister = uniqueFieldsRegisters.get(0);
@@ -393,12 +400,13 @@ public class UniqueFieldDataBaseUtilTest {
 
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
+        uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
 
-        assertTrue(getUniqueFieldsRegisters(contentType).isEmpty());
+        assertTrue(getUniqueFieldRecords(contentType).isEmpty());
 
         uniqueFieldDataBaseUtil.populateUniqueFieldsTable();
 
-        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldsRegisters(contentType);
+        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldRecords(contentType);
         assertEquals(3, uniqueFieldsRegisters.size());
 
         for (Map<String, Object> uniqueFieldsRegister : uniqueFieldsRegisters) {
@@ -491,12 +499,13 @@ public class UniqueFieldDataBaseUtilTest {
 
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
+        uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
 
-        assertTrue(getUniqueFieldsRegisters(contentType).isEmpty());
+        assertTrue(getUniqueFieldRecords(contentType).isEmpty());
 
         uniqueFieldDataBaseUtil.populateUniqueFieldsTable();
 
-        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldsRegisters(contentType);
+        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldRecords(contentType);
         assertEquals(1, uniqueFieldsRegisters.size());
 
         final Map<String, Object> uniqueFieldsRegister = uniqueFieldsRegisters.get(0);
@@ -569,12 +578,13 @@ public class UniqueFieldDataBaseUtilTest {
 
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
+        uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
 
-        assertTrue(getUniqueFieldsRegisters(contentType).isEmpty());
+        assertTrue(getUniqueFieldRecords(contentType).isEmpty());
 
         uniqueFieldDataBaseUtil.populateUniqueFieldsTable();
 
-        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldsRegisters(contentType);
+        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldRecords(contentType);
         assertEquals(1, uniqueFieldsRegisters.size());
 
         final Map<String, Object> uniqueFieldsRegister = uniqueFieldsRegisters.get(0);
@@ -654,10 +664,11 @@ public class UniqueFieldDataBaseUtilTest {
         dotDatabaseMetaData.dropTable(connection, "unique_fields");
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
-        assertTrue("There must be NO records after dropping the unique fields table", getUniqueFieldsRegisters(contentType).isEmpty());
+        uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
+        assertTrue("There must be NO records after dropping the unique fields table", getUniqueFieldRecords(contentType).isEmpty());
 
         uniqueFieldDataBaseUtil.populateUniqueFieldsTable();
-        final List<Map<String, Object>> uniqueFieldRecords = getUniqueFieldsRegisters(contentType);
+        final List<Map<String, Object>> uniqueFieldRecords = getUniqueFieldRecords(contentType);
         assertEquals("There must be exactly 2 records after populating the unique fields table", 2, uniqueFieldRecords.size());
 
         final List<String> contentletIds = uniqueFieldRecords.stream()
@@ -734,11 +745,12 @@ public class UniqueFieldDataBaseUtilTest {
         dotDatabaseMetaData.dropTable(connection, "unique_fields");
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
-        assertTrue("There must be NO records after dropping the unique fields table", getUniqueFieldsRegisters(contentType).isEmpty());
+        uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
+        assertTrue("There must be NO records after dropping the unique fields table", getUniqueFieldRecords(contentType).isEmpty());
 
         uniqueFieldDataBaseUtil.populateUniqueFieldsTable();
 
-        final List<Map<String, Object>> uniqueFieldRecords = getUniqueFieldsRegisters(contentType);
+        final List<Map<String, Object>> uniqueFieldRecords = getUniqueFieldRecords(contentType);
         assertEquals("There must be exactly 1 record after populating the unique fields table", 1, uniqueFieldRecords.size());
 
         final Map<String, Object> uniqueFieldRecord = uniqueFieldRecords.get(0);
@@ -804,12 +816,13 @@ public class UniqueFieldDataBaseUtilTest {
 
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
+        uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
 
-        assertTrue(getUniqueFieldsRegisters(contentType).isEmpty());
+        assertTrue(getUniqueFieldRecords(contentType).isEmpty());
 
         uniqueFieldDataBaseUtil.populateUniqueFieldsTable();
 
-        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldsRegisters(contentType);
+        final List<Map<String, Object>> uniqueFieldsRegisters = getUniqueFieldRecords(contentType);
         assertEquals(2, uniqueFieldsRegisters.size());
 
         for (Map<String, Object> uniqueFieldsRegister : uniqueFieldsRegisters) {
@@ -837,10 +850,19 @@ public class UniqueFieldDataBaseUtilTest {
         }
     }
 
-
-    private List<Map<String, Object>> getUniqueFieldsRegisters(ContentType contentType) throws DotDataException {
+    /**
+     *
+     * @param contentType
+     * @return
+     * @throws DotDataException
+     */
+    private List<Map<String, Object>> getUniqueFieldRecords(final ContentType contentType) throws DotDataException {
         return new DotConnect().setSQL("SELECT * FROM unique_fields WHERE supporting_values->>'contentTypeId' = ?")
                 .addParam(contentType.id()).loadObjectResults();
+    }
+
+    private List<Map<String, Object>> getUniqueFieldRecordsWithSameHash() throws DotDataException {
+        return new DotConnect().setSQL(SqlQueries.GET_RECORDS_WITH_SAME_HASH).loadObjectResults();
     }
 
     /**
@@ -1120,7 +1142,7 @@ public class UniqueFieldDataBaseUtilTest {
      * @throws DotDataException
      */
     @Test()
-    public void popualteUniqueDtaMustbeCaseInsensitive() throws  DotDataException {
+    public void populatedUniqueDataMustBeCaseInsensitive() throws  DotDataException {
         final String uniqueValue =  "A";
 
         final Language language = new LanguageDataGen().nextPersisted();
@@ -1146,7 +1168,7 @@ public class UniqueFieldDataBaseUtilTest {
         final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         uniqueFieldDataBaseUtil.dropUniqueFieldsValidationTable();
         uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
-
+        uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
         uniqueFieldDataBaseUtil.populateUniqueFieldsTable();
 
         try {
@@ -1161,6 +1183,97 @@ public class UniqueFieldDataBaseUtilTest {
             if (!(e.getCause() instanceof DotContentletValidationException)) {
                 throw new AssertionError("DotContentletValidationException expected");
             }
+        }
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link UniqueFieldDataBaseUtil#handleDuplicateRecords()}</li>
+     *     <li><b>Given Scenario:</b> Manually insert two records in the {@code unique_fields} table
+     *     having the exact same hash. This simulates a situation in an old version of the feature
+     *     that allowed having case-sensitive unique values, which is NOT correct.</li>
+     *     <li><b>Expected Result:</b> The method to test will detect the duplicates and manually
+     *     fixes the conflicts. It leaves only one of the duplicates, updates the unique value of
+     *     the remaining ones, and re-generates their hashes so they can be inserted in the table
+     *     without problems. This error is NOT supposed to happen anymore</li>
+     * </ul>
+     *
+     * @throws SQLException     An error occurred when checking the DBMS metadata.
+     * @throws DotDataException An error occurred when interacting with the database.
+     */
+    @Test
+    public void fixDuplicateEntries() throws DotDataException, DotSecurityException, SQLException {
+        // ╔══════════════════╗
+        // ║  Initialization  ║
+        // ╚══════════════════╝
+        final DotDatabaseMetaData dotDatabaseMetaData = new DotDatabaseMetaData();
+        final Connection connection = DbConnectionFactory.getConnection();
+        final String uniqueValue = "duplicate_unique_value";
+        final String siteId = UUIDGenerator.generateUuid();
+        final String testContentIdOne = UUIDGenerator.generateUuid();
+        final String testContentIdTwo = UUIDGenerator.generateUuid();
+        final long languageId = 1;
+
+        // ╔════════════════════════╗
+        // ║  Generating Test data  ║
+        // ╚════════════════════════╝
+        final Host site = new SiteDataGen().nextPersisted();
+        final Field uniqueTextField = new FieldDataGen()
+                .type(TextField.class)
+                .next();
+
+        final ContentType contentType = new ContentTypeDataGen()
+                .host(site)
+                .fields(list(uniqueTextField))
+                .nextPersisted();
+
+        final ImmutableTextField uniqueFieldUpdated = ImmutableTextField.builder()
+                .from(uniqueTextField)
+                .contentTypeId(contentType.id())
+                .unique(true)
+                .build();
+        APILocator.getContentTypeFieldAPI().save(uniqueFieldUpdated, APILocator.systemUser());
+
+        try {
+            final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
+            dotDatabaseMetaData.dropTable(connection, "unique_fields");
+            uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
+
+            // Generating the duplicate hash key
+            final String uniqueKeyValue = contentType.id() + uniqueTextField.variable() + languageId + uniqueValue;
+
+            // Generating the duplicate record for the first Contentlet
+            final Map<String, Object> supportingValues = new HashMap<>(Map.of(
+                    CONTENTLET_IDS_ATTR, List.of(testContentIdOne),
+                    CONTENT_TYPE_ID_ATTR, contentType.id(),
+                    FIELD_VARIABLE_NAME_ATTR, uniqueTextField.variable(),
+                    FIELD_VALUE_ATTR, uniqueValue,
+                    LANGUAGE_ID_ATTR, languageId,
+                    UNIQUE_PER_SITE_ATTR, false,
+                    VARIANT_ATTR, VariantAPI.DEFAULT_VARIANT.name(),
+                    LIVE_ATTR, true,
+                    SITE_ID_ATTR, siteId
+            ));
+            uniqueFieldDataBaseUtil.insert(uniqueKeyValue, supportingValues);
+
+            // Generating the duplicate record for the second Contentlet
+            supportingValues.put(CONTENTLET_IDS_ATTR, List.of(testContentIdTwo));
+            uniqueFieldDataBaseUtil.insert(uniqueKeyValue, supportingValues);
+
+            // ╔══════════════╗
+            // ║  Assertions  ║
+            // ╚══════════════╝
+            List<Map<String, Object>> recordCountWithSameHash = this.getUniqueFieldRecordsWithSameHash();
+            assertEquals("There must be exactly 2 duplicate records", 2,
+                    Integer.parseInt(recordCountWithSameHash.get(0).get("count").toString()));
+
+            uniqueFieldDataBaseUtil.handleDuplicateRecords();
+
+            recordCountWithSameHash = this.getUniqueFieldRecordsWithSameHash();
+            assertEquals("There must be NO duplicate records as they all should've been fixed",
+                    0, recordCountWithSameHash.size());
+        } finally {
+            dotDatabaseMetaData.dropTable(connection, "unique_fields");
         }
     }
 

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/uniquefields/extratable/UniqueFieldDataBaseUtilTest.java
@@ -1233,9 +1233,8 @@ public class UniqueFieldDataBaseUtilTest {
                 .unique(true)
                 .build();
         APILocator.getContentTypeFieldAPI().save(uniqueFieldUpdated, APILocator.systemUser());
-
+        final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
         try {
-            final UniqueFieldDataBaseUtil uniqueFieldDataBaseUtil = new UniqueFieldDataBaseUtil();
             dotDatabaseMetaData.dropTable(connection, "unique_fields");
             uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
 
@@ -1274,6 +1273,8 @@ public class UniqueFieldDataBaseUtilTest {
                     0, recordCountWithSameHash.size());
         } finally {
             dotDatabaseMetaData.dropTable(connection, "unique_fields");
+            uniqueFieldDataBaseUtil.createUniqueFieldsValidationTable();
+            uniqueFieldDataBaseUtil.addPrimaryKeyConstraintsBack();
         }
     }
 


### PR DESCRIPTION
### Proposed Changes
* Includes a new step in the Database Unique Field Validation process where duplicate records are fixed and reported instead of having dotCMS start up with an invalid `unique_fields` table.
* Records with the same hash belong to Contentlets that have the same unique value with different casing. This is NOT correct. So, what the code does now is:
  * Remove the primary key constraint from the DB table, and load the unique value data as usual.
  * Leave one "as is" and add a "prefix" to the other ones.
  * Re-generate the hash in order to have a different value.
  * Bring the primary key back and let dotCMS start as usual.
  * Generate a log file with absolutely all records with conflicting data. This way, users can inspect it and manually fix the corrupted Contentlets.
  * Such a log file can be displayed and downloaded from the `Logs` portlet in the back-end.

The error scenario experienced by the customer was:

* There were several Contentlets **WITH DIFFERENT IDENTIFIERS** that were sharing **THE EXACT SAME** unique value.
* This was simple to fix as the Contentlet Identifier is a value used to generate the unique key value column. So, temporarily updating the value of the other Contentlets with a prefix/format would fix this.

This PR fixes: #32765

This PR fixes: #32765