### PR TITLE
feat(analytics): Allow to choose the same day as a range

### DIFF
--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
@@ -98,9 +98,7 @@ export class DotAnalyticsService {
         siteId: string | string[]
     ): Observable<PageViewTimeLineEntity[]> {
         // Determine granularity based on specific timeRange values
-        const granularity = Array.isArray(timeRange)
-            ? 'day' // For custom date ranges, default to day granularity
-            : determineGranularityForTimeRange(timeRange);
+        const granularity = determineGranularityForTimeRange(timeRange);
 
         const queryBuilder = createCubeQuery()
             .measures(['totalRequest'])

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.spec.ts
@@ -757,5 +757,22 @@ describe('Analytics Data Utils', () => {
                 });
             });
         });
+
+        describe('custom date range', () => {
+            it('should return day granularity for custom date range on the same month', () => {
+                const result = determineGranularityForTimeRange(['2024-01-01', '2024-01-31']);
+                expect(result).toBe('day');
+            });
+
+            it('should return hour granularity for custom date range on the same day', () => {
+                const result = determineGranularityForTimeRange(['2024-01-01', '2024-01-01']);
+                expect(result).toBe('hour');
+            });
+
+            it('should return month granularity for custom date range', () => {
+                const result = determineGranularityForTimeRange(['2024-01-01', '2024-04-31']);
+                expect(result).toBe('month');
+            });
+        });
     });
 });

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.ts
@@ -1,10 +1,12 @@
+import { isSameDay, isSameMonth } from 'date-fns';
+
 import {
     ChartData,
     Granularity,
     PageViewDeviceBrowsersEntity,
     PageViewTimeLineEntity,
     TablePageData,
-    TimeRange,
+    TimeRangeInput,
     TopPagePerformanceEntity,
     TopPerformaceTableEntity,
     TotalPageViewsEntity,
@@ -25,7 +27,19 @@ import { parseUserAgent } from '../browser/userAgentParser';
  * @param timeRange - The time range for the analytics query
  * @returns The appropriate granularity level for the given time range
  */
-export function determineGranularityForTimeRange(timeRange: TimeRange): Granularity {
+export function determineGranularityForTimeRange(timeRange: TimeRangeInput): Granularity {
+    if (Array.isArray(timeRange)) {
+        const [fromDate, toDate] = timeRange;
+
+        if (isSameDay(fromDate, toDate)) {
+            return 'hour';
+        } else if (isSameMonth(fromDate, toDate)) {
+            return 'day';
+        } else {
+            return 'month';
+        }
+    }
+
     switch (timeRange) {
         case 'today':
 

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.ts
@@ -29,7 +29,7 @@ import { parseUserAgent } from '../browser/userAgentParser';
  */
 export function determineGranularityForTimeRange(timeRange: TimeRangeInput): Granularity {
     if (Array.isArray(timeRange)) {
-        const [fromDate, toDate] = timeRange;
+        const [fromDate, toDate] = timeRange.map((date) => new Date(date));
 
         if (isSameDay(fromDate, toDate)) {
             return 'hour';

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/components/dot-analytics-dashboard-filters/dot-analytics-dashboard-filters.component.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/components/dot-analytics-dashboard-filters/dot-analytics-dashboard-filters.component.spec.ts
@@ -15,7 +15,7 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
 
     const mockActivatedRoute = {
         snapshot: {
-            queryParams: {}
+            queryParamMap: new Map()
         }
     };
 
@@ -224,9 +224,7 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
 
     describe('URL Initialization', () => {
         it('should initialize from URL with predefined time range', () => {
-            mockActivatedRoute.snapshot.queryParams = {
-                time_range: 'last7days'
-            };
+            mockActivatedRoute.snapshot.queryParamMap = new Map([['time_range', 'last7days']]);
 
             spectator = createComponent();
 
@@ -234,11 +232,11 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
         });
 
         it('should initialize from URL with custom date range', () => {
-            mockActivatedRoute.snapshot.queryParams = {
-                time_range: 'custom',
-                from: '2024-01-01',
-                to: '2024-01-31'
-            };
+            mockActivatedRoute.snapshot.queryParamMap = new Map([
+                ['time_range', 'custom'],
+                ['from', '2024-01-01'],
+                ['to', '2024-01-31']
+            ]);
 
             spectator = createComponent();
 
@@ -250,9 +248,7 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
         });
 
         it('should not initialize from invalid URL params', () => {
-            mockActivatedRoute.snapshot.queryParams = {
-                time_range: 'invalid-range'
-            };
+            mockActivatedRoute.snapshot.queryParamMap = new Map([['time_range', 'invalid-range']]);
 
             spectator = createComponent();
 
@@ -269,9 +265,7 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
         });
 
         it('should not initialize custom range without from/to params', () => {
-            mockActivatedRoute.snapshot.queryParams = {
-                time_range: 'custom'
-            };
+            mockActivatedRoute.snapshot.queryParamMap = new Map([['time_range', 'custom']]);
 
             spectator = createComponent();
 
@@ -280,11 +274,11 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
         });
 
         it('should fall back to default when custom dates are invalid', () => {
-            mockActivatedRoute.snapshot.queryParams = {
-                time_range: 'custom',
-                from: 'invalid-date',
-                to: '2024-01-31'
-            };
+            mockActivatedRoute.snapshot.queryParamMap = new Map([
+                ['time_range', 'custom'],
+                ['from', 'invalid-date'],
+                ['to', '2024-01-31']
+            ]);
 
             spectator = createComponent();
 
@@ -302,11 +296,11 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
         });
 
         it('should fall back to default when from date is after to date', () => {
-            mockActivatedRoute.snapshot.queryParams = {
-                time_range: 'custom',
-                from: '2024-01-31', // After to date
-                to: '2024-01-01'
-            };
+            mockActivatedRoute.snapshot.queryParamMap = new Map([
+                ['time_range', 'custom'],
+                ['from', '2024-01-31'], // After to date
+                ['to', '2024-01-01']
+            ]);
 
             spectator = createComponent();
 
@@ -324,11 +318,11 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
         });
 
         it('should fall back to default when both dates are invalid', () => {
-            mockActivatedRoute.snapshot.queryParams = {
-                time_range: 'custom',
-                from: 'not-a-date',
-                to: 'also-not-a-date'
-            };
+            mockActivatedRoute.snapshot.queryParamMap = new Map([
+                ['time_range', 'custom'],
+                ['from', 'not-a-date'],
+                ['to', 'also-not-a-date']
+            ]);
 
             spectator = createComponent();
 
@@ -337,9 +331,9 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
         });
 
         it('should fall back to default when time_range is invalid predefined value', () => {
-            mockActivatedRoute.snapshot.queryParams = {
-                time_range: 'invalid-time-range'
-            };
+            mockActivatedRoute.snapshot.queryParamMap = new Map([
+                ['time_range', 'invalid-time-range']
+            ]);
 
             spectator = createComponent();
 
@@ -376,9 +370,7 @@ describe('DotAnalyticsDashboardFiltersComponent', () => {
 
         it('should avoid infinite loops with URL synchronization', async () => {
             // Set up URL state that matches what we're about to set
-            mockActivatedRoute.snapshot.queryParams = {
-                time_range: 'last7days'
-            };
+            mockActivatedRoute.snapshot.queryParamMap = new Map([['time_range', 'last7days']]);
 
             // This should not trigger URL update since it matches
             spectator.component.$selectedTimeRange.set('from 7 days ago to now');

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/components/dot-analytics-dashboard-filters/dot-analytics-dashboard-filters.component.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/components/dot-analytics-dashboard-filters/dot-analytics-dashboard-filters.component.ts
@@ -118,7 +118,7 @@ export class DotAnalyticsDashboardFiltersComponent {
 
             // Read current URL param without creating dependency
             const currentUrlTimeRange = untracked(() => {
-                return this.route.snapshot.queryParams['time_range'];
+                return this.route.snapshot.queryParamMap.get('time_range');
             });
 
             // Convert current URL value to internal for comparison
@@ -161,10 +161,10 @@ export class DotAnalyticsDashboardFiltersComponent {
      * Initialize filter state from URL parameters
      */
     private initFromUrl(): void {
-        const params = this.route.snapshot.queryParams;
-        const urlTimeRange = params['time_range'];
-        const fromDate = params['from'];
-        const toDate = params['to'];
+        const params = this.route.snapshot.queryParamMap;
+        const urlTimeRange = params.get('time_range');
+        const fromDate = params.get('from');
+        const toDate = params.get('to');
 
         if (urlTimeRange) {
             // Convert URL-friendly value to internal value

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/utils/dot-analytics.utils.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/utils/dot-analytics.utils.spec.ts
@@ -1,13 +1,9 @@
 import {
-    formatDateForUrl,
     fromUrlFriendly,
     getDefaultTimePeriod,
     getTimePeriodOptions,
     isValidCustomDateRange,
-    isValidDate,
-    isValidDateOrder,
     isValidTimeRange,
-    parseDateFromUrl,
     toUrlFriendly
 } from './dot-analytics.utils';
 
@@ -35,8 +31,8 @@ describe('Analytics Utils', () => {
             expect(isValidCustomDateRange('2024-12-31', '2024-01-01')).toBe(false);
         });
 
-        it('should return false for same dates', () => {
-            expect(isValidCustomDateRange('2024-01-01', '2024-01-01')).toBe(false);
+        it('should return true for same dates', () => {
+            expect(isValidCustomDateRange('2024-01-01', '2024-01-01')).toBe(true);
         });
 
         it('should return false for empty or null dates', () => {
@@ -60,47 +56,6 @@ describe('Analytics Utils', () => {
             expect(isValidTimeRange('from 100 days ago')).toBe(false);
             expect(isValidTimeRange('')).toBe(false);
             expect(isValidTimeRange('random-string')).toBe(false);
-        });
-    });
-
-    describe('isValidDate', () => {
-        it('should return true for valid Date objects', () => {
-            expect(isValidDate(new Date('2024-01-01'))).toBe(true);
-            expect(isValidDate(new Date())).toBe(true);
-        });
-
-        it('should return true for valid date strings', () => {
-            expect(isValidDate('2024-01-01')).toBe(true);
-            expect(isValidDate('2023-12-31')).toBe(true);
-            expect(isValidDate('January 1, 2024')).toBe(true);
-        });
-
-        it('should return false for invalid Date objects', () => {
-            expect(isValidDate(new Date('invalid-date'))).toBe(false);
-        });
-
-        it('should return false for invalid date strings', () => {
-            expect(isValidDate('invalid-date')).toBe(false);
-            expect(isValidDate('not-a-date')).toBe(false);
-            expect(isValidDate('')).toBe(false);
-        });
-    });
-
-    describe('isValidDateOrder', () => {
-        it('should return true when from date is before to date', () => {
-            expect(isValidDateOrder('2024-01-01', '2024-01-31')).toBe(true);
-            expect(isValidDateOrder(new Date('2024-01-01'), new Date('2024-01-31'))).toBe(true);
-            expect(isValidDateOrder('2023-12-01', new Date('2024-01-01'))).toBe(true);
-        });
-
-        it('should return false when from date is after to date', () => {
-            expect(isValidDateOrder('2024-01-31', '2024-01-01')).toBe(false);
-            expect(isValidDateOrder(new Date('2024-01-31'), new Date('2024-01-01'))).toBe(false);
-        });
-
-        it('should return false when dates are equal', () => {
-            expect(isValidDateOrder('2024-01-01', '2024-01-01')).toBe(false);
-            expect(isValidDateOrder(new Date('2024-01-01'), new Date('2024-01-01'))).toBe(false);
         });
     });
 
@@ -149,54 +104,6 @@ describe('Analytics Utils', () => {
             expect(fromUrlFriendly('unknown-url-value')).toBe('unknown-url-value');
             expect(fromUrlFriendly('random-string')).toBe('random-string');
             expect(fromUrlFriendly('')).toBe('');
-        });
-    });
-
-    // ============================================================================
-    // DATE FORMATTING UTILITIES
-    // ============================================================================
-
-    describe('formatDateForUrl', () => {
-        it('should format dates to YYYY-MM-DD format', () => {
-            const date1 = new Date('2024-01-01T10:30:00Z');
-            expect(formatDateForUrl(date1)).toBe('2024-01-01');
-
-            const date2 = new Date('2023-12-31T23:59:59Z');
-            expect(formatDateForUrl(date2)).toBe('2023-12-31');
-        });
-
-        it('should handle different date inputs consistently', () => {
-            const date = new Date(2024, 0, 15); // January 15, 2024
-            expect(formatDateForUrl(date)).toBe('2024-01-15');
-        });
-    });
-
-    describe('parseDateFromUrl', () => {
-        it('should parse valid date strings', () => {
-            const result1 = parseDateFromUrl('2024-01-01');
-            expect(result1).toBeInstanceOf(Date);
-            expect(result1).not.toBeNull();
-
-            const result2 = parseDateFromUrl('2023-12-31');
-            expect(result2).toBeInstanceOf(Date);
-            expect(result2).not.toBeNull();
-
-            // Test that parsing and formatting work together
-            const testDate = new Date('2024-06-15T12:00:00Z');
-            const formatted = formatDateForUrl(testDate);
-            const parsed = parseDateFromUrl(formatted);
-            expect(parsed).toBeInstanceOf(Date);
-            expect(parsed).not.toBeNull();
-        });
-
-        it('should return null for invalid date strings', () => {
-            expect(parseDateFromUrl('invalid-date')).toBeNull();
-            expect(parseDateFromUrl('not-a-date')).toBeNull();
-            expect(parseDateFromUrl('2024-13-01')).toBeNull(); // Invalid month
-        });
-
-        it('should return null for empty strings', () => {
-            expect(parseDateFromUrl('')).toBeNull();
         });
     });
 
@@ -260,48 +167,6 @@ describe('Analytics Utils', () => {
                 const backToInternal = fromUrlFriendly(urlFriendly);
                 expect(backToInternal).toBe(internal);
             });
-        });
-
-        it('should handle date parsing and formatting round-trip', () => {
-            const testDates = [
-                new Date('2024-01-01'),
-                new Date('2023-12-31'),
-                new Date('2024-06-15')
-            ];
-
-            testDates.forEach((originalDate) => {
-                const formatted = formatDateForUrl(originalDate);
-                const parsed = parseDateFromUrl(formatted);
-
-                expect(parsed).not.toBeNull();
-                expect(parsed?.getFullYear()).toBe(originalDate.getFullYear());
-                expect(parsed?.getMonth()).toBe(originalDate.getMonth());
-                expect(parsed?.getDate()).toBe(originalDate.getDate());
-            });
-        });
-
-        it('should validate complete custom date range workflow', () => {
-            const validFrom = '2024-01-01';
-            const validTo = '2024-01-31';
-            const invalidFrom = 'invalid-date';
-            const reversedTo = '2023-12-01';
-
-            // Valid case
-            expect(isValidCustomDateRange(validFrom, validTo)).toBe(true);
-
-            // Invalid date case
-            expect(isValidCustomDateRange(invalidFrom, validTo)).toBe(false);
-
-            // Reversed order case
-            expect(isValidCustomDateRange(validTo, reversedTo)).toBe(false);
-
-            // Individual date validation
-            expect(isValidDate(validFrom)).toBe(true);
-            expect(isValidDate(invalidFrom)).toBe(false);
-
-            // Date order validation
-            expect(isValidDateOrder(validFrom, validTo)).toBe(true);
-            expect(isValidDateOrder(validTo, reversedTo)).toBe(false);
         });
     });
 });

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/utils/dot-analytics.utils.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/utils/dot-analytics.utils.ts
@@ -2,6 +2,8 @@
  * Centralized utilities for analytics dashboard
  */
 
+import { isBefore, isDate, isSameDay } from 'date-fns';
+
 import {
     DEFAULT_TIME_PERIOD,
     TIME_PERIOD_OPTIONS,
@@ -25,16 +27,11 @@ export const isValidCustomDateRange = (fromDate: string, toDate: string): boolea
     const toDateObj = new Date(toDate);
 
     // Check if dates are valid
-    if (isNaN(fromDateObj.getTime()) || isNaN(toDateObj.getTime())) {
+    if (!isDate(fromDateObj) || !isDate(toDateObj)) {
         return false;
     }
 
-    // Check if from date is before to date
-    if (fromDateObj >= toDateObj) {
-        return false;
-    }
-
-    return true;
+    return isBefore(fromDateObj, toDateObj) || isSameDay(fromDateObj, toDateObj);
 };
 
 /**
@@ -63,51 +60,6 @@ export const toUrlFriendly = (internalValue: string): string => {
  */
 export const fromUrlFriendly = (urlValue: string): string => {
     return TIME_RANGE_URL_MAPPING[urlValue as keyof typeof TIME_RANGE_URL_MAPPING] || urlValue;
-};
-
-// ============================================================================
-// VALIDATION UTILITIES
-// ============================================================================
-
-/**
- * Check if a value is a valid date string or Date object
- */
-export const isValidDate = (date: string | Date): boolean => {
-    const dateObj = typeof date === 'string' ? new Date(date) : date;
-
-    return dateObj instanceof Date && !isNaN(dateObj.getTime());
-};
-
-/**
- * Check if a date range has proper order (from < to)
- */
-export const isValidDateOrder = (fromDate: string | Date, toDate: string | Date): boolean => {
-    const from = typeof fromDate === 'string' ? new Date(fromDate) : fromDate;
-    const to = typeof toDate === 'string' ? new Date(toDate) : toDate;
-
-    return from < to;
-};
-
-// ============================================================================
-// DATE FORMATTING UTILITIES
-// ============================================================================
-
-/**
- * Format date to ISO string for URL parameters
- */
-export const formatDateForUrl = (date: Date): string => {
-    return date.toISOString().split('T')[0]; // YYYY-MM-DD format
-};
-
-/**
- * Parse date from URL parameter string
- */
-export const parseDateFromUrl = (dateString: string): Date | null => {
-    if (!dateString) return null;
-
-    const date = new Date(dateString);
-
-    return isValidDate(date) ? date : null;
 };
 
 // ============================================================================


### PR DESCRIPTION
- Introduced a new signal method `#handleChangeCustomDateRange` in `DotAnalyticsDashboardFiltersComponent` to manage custom date range changes and update URL parameters accordingly.
- Refactored the existing logic to utilize the signals system for improved state management and reactivity.
- Updated utility function `isValidCustomDateRange` to leverage `date-fns` for better date validation.
- Removed outdated validation functions and tests related to date handling, streamlining the utility file.

This enhancement improves the user experience by allowing dynamic updates to the date range filters while maintaining clean and modular code.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)


This PR fixes: #32884