### PR TITLE
Fix: Making Flushable public

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/Flushable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/Flushable.java
@@ -4,7 +4,7 @@ package com.dotmarketing.portlets.contentlet.business;
  * A Flushable is a API that handle cache and provided public mehod to flush the content away
  * @param <T>
  */
-interface Flushable<T> {
+public interface Flushable<T> {
 
     /**
      * Flush all the cache away


### PR DESCRIPTION
It fixed #32784

### Proposed Changes
Weld is trying to generate a proxy for HostWebAPIImpl that also implements Flushable. However, since Flushable is not public, if the proxy is created in a different package, it won’t be visible to the runtime-generated proxy class.

This PR fixes: #32784