### PR TITLE
fix(Content Import) Strict Date parse Refs: #33047

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/DateUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/DateUtil.java
@@ -259,6 +259,19 @@ public class DateUtil {
 		return convertDate(date, companyTimeZone.get(), formats);
 	}
 
+    /**
+     * This method try to parse a string into a Date object using an array with
+     * @param date - the string to be parsed
+     * @param lenient - We instruct the Formater to be permissive or stricter
+     * @param formats - the valid format to parse the string
+     * @return return the Date object that represent the string
+     * @throws java.text.ParseException
+     */
+    public static Date convertDate(final String date, final boolean lenient,
+            final String[] formats) throws java.text.ParseException {
+        return convertDate(date, companyTimeZone.get(), lenient, formats);
+    }
+
 	/**
 	 * This method try to parse a string into a Date object using an array with
 	 * the valid formats
@@ -272,12 +285,29 @@ public class DateUtil {
 	 * @return return the Date object that represent the string
 	 * @throws java.text.ParseException
 	 */
+    public static Date convertDate(final String date,
+            final TimeZone timeZone,
+            final String... formats
+    ) throws java.text.ParseException {
+        return convertDate(date, timeZone, true, formats);
+    }
+
+    /**
+     * This method try to parse a string into a Date object using an array with
+     * @param date - the string to be parsed
+     * @param timeZone - time zone
+     * @param lenient - We instruct the Formater to be permissive or stricter
+     * @param formats - the valid format to parse the string
+     * @return return the Date object that represent the string
+     * @throws java.text.ParseException
+     */
 	public static Date convertDate(final String date,
 								   final TimeZone timeZone,
+                                   final boolean lenient,
 								   final String... formats
 								   ) throws java.text.ParseException {
 		Date ret = null;
-		for (final String pattern : formats) { // todo: usually the formaters are cached and thread-safe
+		for (final String pattern : formats) {
 
 			try {
 
@@ -285,12 +315,12 @@ public class DateUtil {
 				if (null != timeZone) {
 					format.setTimeZone(timeZone);
 				}
-
+                format.setLenient(lenient);
 				ret = format.parse(date);
+                Logger.debug(DateUtil.class, "Converted date: " + date + " using pattern: " + pattern + " ret: " + ret);
 				break;
 			} catch (java.text.ParseException e) {
 				// quiet
-				//e.printStackTrace();
 			}
 		}
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -4806,7 +4806,7 @@ public class ImportUtil {
      * @throws ParseException
      */
     private static Date parseExcelDate ( String date ) throws ParseException {
-        return DateUtil.convertDate( date, IMP_DATE_FORMATS );
+        return DateUtil.convertDate( date, false, IMP_DATE_FORMATS );
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -178,7 +178,7 @@ public class ImportUtil {
      * European date formats to support international date parsing
      */
     protected static final String[] EUROPEAN_DATE_FORMATS = new String[] {
-        "d/M/y", "dd/MM/yyyy", "d/M/yyyy", "dd/MM/yy"
+        "d/M/y", "dd/MM/yyyy", "d/M/yyyy", "dd/MM/yy", "dd-MM-yyyy"
     };
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -172,6 +172,28 @@ public class ImportUtil {
         "EEEE, MMMM dd, yyyy", "MM/dd/yyyy", "hh:mm:ss aa", "HH:mm:ss", "hh:mm aa", "yyyy-MM-dd" };
 
     /**
+     * European date formats to support international date parsing
+     */
+    protected static final String[] EUROPEAN_DATE_FORMATS = new String[] {
+        "d/M/y", "dd/MM/yyyy", "d/M/yyyy", "dd/MM/yy"
+    };
+
+    /**
+     * Combined date formats including both US and European patterns for comprehensive date parsing
+     */
+    protected static final String[] ALL_DATE_FORMATS = combineArrays(IMP_DATE_FORMATS, EUROPEAN_DATE_FORMATS);
+
+    /**
+     * Helper method to combine two string arrays
+     */
+    private static String[] combineArrays(String[] array1, String[] array2) {
+        String[] combined = new String[array1.length + array2.length];
+        System.arraycopy(array1, 0, combined, 0, array1.length);
+        System.arraycopy(array2, 0, combined, array1.length, array2.length);
+        return combined;
+    }
+
+    /**
      * Date format patterns for different field types
      */
     private static final String DATE_FIELD_FORMAT_PATTERN = "yyyyMMdd";
@@ -4806,7 +4828,7 @@ public class ImportUtil {
      * @throws ParseException
      */
     private static Date parseExcelDate ( String date ) throws ParseException {
-        return DateUtil.convertDate( date, false, IMP_DATE_FORMATS );
+        return DateUtil.convertDate( date, false, ALL_DATE_FORMATS );
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
@@ -57,8 +57,18 @@ public class DateUtilTest extends UnitTestBase {
 
     // Static European date formats (mirrored from ImportUtil.EUROPEAN_DATE_FORMATS)
     private static final String[] europeanDateFormats = new String[] {
-        "d/M/y", "dd/MM/yyyy", "d/M/yyyy", "dd/MM/yy"
+        "d/M/y", "dd/MM/yyyy", "d/M/yyyy", "dd/MM/yy", "dd-MM-yyyy"
     };
+    
+    // Combined all formats for testing
+    private static final String[] allFormats = combineFormats(dateFormatPatterns, europeanDateFormats);
+    
+    private static String[] combineFormats(String[] array1, String[] array2) {
+        String[] combined = new String[array1.length + array2.length];
+        System.arraycopy(array1, 0, combined, 0, array1.length);
+        System.arraycopy(array2, 0, combined, array1.length, array2.length);
+        return combined;
+    }
 
     @DataProvider
     public static Object[][] dateTimeCases() {
@@ -819,11 +829,6 @@ public class DateUtilTest extends UnitTestBase {
         
         final TimeZone defaultTimeZone = TimeZone.getDefault();
         
-        // Combine all formats for testing
-        final String[] allFormats = new String[dateFormatPatterns.length + europeanDateFormats.length];
-        System.arraycopy(dateFormatPatterns, 0, allFormats, 0, dateFormatPatterns.length);
-        System.arraycopy(europeanDateFormats, 0, allFormats, dateFormatPatterns.length, europeanDateFormats.length);
-        
         // === Test US/Standard Date Format Patterns ===
         
         // d-MMM-yy: "25-Dec-24" 
@@ -981,5 +986,31 @@ public class DateUtilTest extends UnitTestBase {
                     25, december25Dates[i].getDate());
             }
         }
+    }
+
+    @Test
+    public void test_specific_date_14_05_2027_should_pass() throws ParseException {
+        // Test that the date "14-05-2027" parses successfully as May 14, 2027
+        // This uses the dd-MM-yyyy format pattern that was added to support European dates
+        
+        Date result = DateUtil.convertDate("14-05-2027", false, allFormats);
+        assertNotNull("14-05-2027 should parse successfully", result);
+        
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(result);
+        
+        assertEquals("Year should be 2027", 2027, cal.get(Calendar.YEAR));
+        assertEquals("Month should be May (4)", Calendar.MAY, cal.get(Calendar.MONTH));
+        assertEquals("Day should be 14", 14, cal.get(Calendar.DAY_OF_MONTH));
+        
+        // Additional test cases for dd-MM-yyyy format
+        Date result2 = DateUtil.convertDate("01-12-2025", false, allFormats);
+        assertNotNull("01-12-2025 should parse successfully", result2);
+        
+        Calendar cal2 = Calendar.getInstance();
+        cal2.setTime(result2);
+        assertEquals("Year should be 2025", 2025, cal2.get(Calendar.YEAR));
+        assertEquals("Month should be December (11)", Calendar.DECEMBER, cal2.get(Calendar.MONTH));
+        assertEquals("Day should be 1", 1, cal2.get(Calendar.DAY_OF_MONTH));
     }
 }

--- a/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/DateUtilTest.java
@@ -47,6 +47,19 @@ import org.junit.runner.RunWith;
 @RunWith(DataProviderRunner.class)
 public class DateUtilTest extends UnitTestBase {
 
+    // Static date format arrays (mirrored from ImportUtil to avoid direct dependency)
+    private static final String[] dateFormatPatterns = new String[] {
+        "d-MMM-yy", "MMM-yy", "MMMM-yy", "d-MMM", "dd-MMM-yyyy",
+        "MM/dd/yy hh:mm aa", "MM/dd/yyyy hh:mm aa", "MM/dd/yy HH:mm", "MM/dd/yyyy HH:mm", 
+        "MMMM dd, yyyy", "M/d/y", "M/d", "EEEE, MMMM dd, yyyy", "MM/dd/yyyy", 
+        "hh:mm:ss aa", "HH:mm:ss", "hh:mm aa", "yyyy-MM-dd"
+    };
+
+    // Static European date formats (mirrored from ImportUtil.EUROPEAN_DATE_FORMATS)
+    private static final String[] europeanDateFormats = new String[] {
+        "d/M/y", "dd/MM/yyyy", "d/M/yyyy", "dd/MM/yy"
+    };
+
     @DataProvider
     public static Object[][] dateTimeCases() {
 
@@ -592,72 +605,63 @@ public class DateUtilTest extends UnitTestBase {
 
         final TimeZone defaultTimeZone = TimeZone.getDefault();
 
-        // Import date formats from ImportUtil (mirrored here to avoid direct dependency)
-        final String[] dateFormatPatterns = new String[] {
-            "d-MMM-yy", "MMM-yy", "MMMM-yy", "d-MMM", "dd-MMM-yyyy",
-            "MM/dd/yy hh:mm aa", "MM/dd/yyyy hh:mm aa", "MM/dd/yy HH:mm", "MM/dd/yyyy HH:mm", 
-            "MMMM dd, yyyy", "M/d/y", "M/d", "EEEE, MMMM dd, yyyy", "MM/dd/yyyy", 
-            "hh:mm:ss aa", "HH:mm:ss", "hh:mm aa", "yyyy-MM-dd"
-        };
-
-        // Additional European formats to test
-        final String[] europeanDateFormats = new String[] {
-            "d/M/y", "dd/MM/yyyy", "d/M/yyyy", "dd/MM/yy"
-        };
-
-        // Combine all formats for comprehensive testing
+        // Combine all formats for comprehensive testing (mirrored from ImportUtil.ALL_DATE_FORMATS)
         final String[] allFormats = new String[dateFormatPatterns.length + europeanDateFormats.length];
         System.arraycopy(dateFormatPatterns, 0, allFormats, 0, dateFormatPatterns.length);
         System.arraycopy(europeanDateFormats, 0, allFormats, dateFormatPatterns.length, europeanDateFormats.length);
+        // === Test 1: Valid dates in strict mode (like ImportUtil behavior) ===
 
-        // === Test 1: Valid dates should work in both lenient and strict modes ===
-
-        // US format: M/d/y (12/25/2024 = December 25, 2024)
-        Date lenientUSDate = DateUtil.convertDate("12/25/2024", defaultTimeZone, true, "M/d/y", "MM/dd/yyyy");
-        assertNotNull("Valid US date should parse in lenient mode", lenientUSDate);
+        // US format: 12/25/2024 = December 25, 2024 (will match M/d/y pattern from allFormats)
+        Date usDate = DateUtil.convertDate("12/25/2024", defaultTimeZone, false, allFormats);
+        assertNotNull("Valid US date should parse in strict mode", usDate);
         
         // Validate the US date matches the input intention: 12/25/2024 = December 25, 2024
-        assertEquals("US format: Month should be December (11)", Calendar.DECEMBER, lenientUSDate.getMonth());
-        assertEquals("US format: Day should be 25", 25, lenientUSDate.getDate());
-        assertEquals("US format: Year should be 2024", 2024, lenientUSDate.getYear() + 1900); // Date.getYear() returns year - 1900
+        assertEquals("US format: Month should be December", Calendar.DECEMBER, usDate.getMonth());
+        assertEquals("US format: Day should be 25", 25, usDate.getDate());
+        assertEquals("US format: Year should be 2024", 2024, usDate.getYear() + 1900);
 
-        Date strictUSDate = DateUtil.convertDate("12/25/2024", defaultTimeZone, false, "M/d/y", "MM/dd/yyyy");
-        assertNotNull("Valid US date should parse in strict mode", strictUSDate);
-        
-        // Validate strict mode produces the same result
-        assertEquals("US format strict: Month should be December", Calendar.DECEMBER, strictUSDate.getMonth());
-        assertEquals("US format strict: Day should be 25", 25, strictUSDate.getDate());
-        assertEquals("US format strict: Year should be 2024", 2024, strictUSDate.getYear() + 1900);
-
-        // European format: d/M/y (25/12/2024 = December 25, 2024)
-        Date lenientEUDate = DateUtil.convertDate("25/12/2024", defaultTimeZone, true, "d/M/y", "dd/MM/yyyy");
-        assertNotNull("Valid European date should parse in lenient mode", lenientEUDate);
+        // European format: 25/12/2024 = December 25, 2024 (will match d/M/y pattern from allFormats)
+        Date euDate = DateUtil.convertDate("25/12/2024", defaultTimeZone, false, allFormats);
+        assertNotNull("Valid European date should parse in strict mode", euDate);
         
         // Validate the European date matches the input intention: 25/12/2024 = December 25, 2024
-        assertEquals("EU format: Month should be December (11)", Calendar.DECEMBER, lenientEUDate.getMonth());
-        assertEquals("EU format: Day should be 25", 25, lenientEUDate.getDate());
-        assertEquals("EU format: Year should be 2024", 2024, lenientEUDate.getYear() + 1900);
-
-        Date strictEUDate = DateUtil.convertDate("25/12/2024", defaultTimeZone, false, "d/M/y", "dd/MM/yyyy");
-        assertNotNull("Valid European date should parse in strict mode", strictEUDate);
-        
-        // Validate strict mode produces the same result
-        assertEquals("EU format strict: Month should be December", Calendar.DECEMBER, strictEUDate.getMonth());
-        assertEquals("EU format strict: Day should be 25", 25, strictEUDate.getDate());
-        assertEquals("EU format strict: Year should be 2024", 2024, strictEUDate.getYear() + 1900);
+        assertEquals("EU format: Month should be December", Calendar.DECEMBER, euDate.getMonth());
+        assertEquals("EU format: Day should be 25", 25, euDate.getDate());
+        assertEquals("EU format: Year should be 2024", 2024, euDate.getYear() + 1900);
 
         // Verify both formats produce the same date (December 25, 2024)
         assertEquals("US and European formats should produce same year", 
-            lenientUSDate.getYear(), lenientEUDate.getYear());
+            usDate.getYear(), euDate.getYear());
         assertEquals("US and European formats should produce same month", 
-            lenientUSDate.getMonth(), lenientEUDate.getMonth());
+            usDate.getMonth(), euDate.getMonth());
         assertEquals("US and European formats should produce same day", 
-            lenientUSDate.getDate(), lenientEUDate.getDate());
+            usDate.getDate(), euDate.getDate());
 
-        // === Test 2: More valid dates with various IMP_DATE_FORMATS ===
+        // === CRITICAL TEST: Test with entire format patterns set ===
+        
+        // Test 1: American date 25/12/2025 using all available formats - should parse as December 25, 2025
+        Date americanDate = DateUtil.convertDate("25/12/2025", defaultTimeZone, false, allFormats);
+        assertNotNull("25/12/2025 should parse with dateFormatPatterns", americanDate);
+        assertEquals("25/12/2025 with all formats: Month should be December", Calendar.DECEMBER, americanDate.getMonth());
+        assertEquals("25/12/2025 with all formats: Day should be 25", 25, americanDate.getDate());
+        assertEquals("25/12/2025 with all formats: Year should be 2025", 2025, americanDate.getYear() + 1900);
 
-        // ISO format: 2024-12-25 = December 25, 2024
-        Date isoDate = DateUtil.convertDate("2024-12-25", defaultTimeZone, false, "yyyy-MM-dd");
+        // Test 2: European date 25/12/2025 using all available formats - should also parse as December 25, 2025
+        Date europeanDate = DateUtil.convertDate("25/12/2025", defaultTimeZone, false, allFormats);
+        assertNotNull("25/12/2025 should parse with allFormats", europeanDate);
+        assertEquals("25/12/2025 with all formats: Month should be December", Calendar.DECEMBER, europeanDate.getMonth());
+        assertEquals("25/12/2025 with all formats: Day should be 25", 25, europeanDate.getDate());
+        assertEquals("25/12/2025 with all formats: Year should be 2025", 2025, europeanDate.getYear() + 1900);
+
+        // Verify both produce the same result (December 25, 2025)
+        assertEquals("Both format sets should produce same year", americanDate.getYear(), europeanDate.getYear());
+        assertEquals("Both format sets should produce same month", americanDate.getMonth(), europeanDate.getMonth());
+        assertEquals("Both format sets should produce same day", americanDate.getDate(), europeanDate.getDate());
+
+        // === Test 2: Additional valid date formats in strict mode ===
+
+        // ISO format: 2024-12-25 = December 25, 2024 (will match yyyy-MM-dd pattern from allFormats)
+        Date isoDate = DateUtil.convertDate("2024-12-25", defaultTimeZone, false, allFormats);
         assertNotNull("ISO date should parse in strict mode", isoDate);
         
         // Validate ISO date matches input intention: 2024-12-25 = December 25, 2024
@@ -665,8 +669,8 @@ public class DateUtilTest extends UnitTestBase {
         assertEquals("ISO format: Month should be December", Calendar.DECEMBER, isoDate.getMonth());
         assertEquals("ISO format: Day should be 25", 25, isoDate.getDate());
 
-        // Long format: December 25, 2024 = December 25, 2024
-        Date longDate = DateUtil.convertDate("December 25, 2024", defaultTimeZone, false, "MMMM dd, yyyy");
+        // Long format: December 25, 2024 = December 25, 2024 (will match MMMM dd, yyyy pattern from allFormats)
+        Date longDate = DateUtil.convertDate("December 25, 2024", defaultTimeZone, false, allFormats);
         assertNotNull("Long date format should parse in strict mode", longDate);
         
         // Validate long format date matches input intention
@@ -674,8 +678,8 @@ public class DateUtilTest extends UnitTestBase {
         assertEquals("Long format: Month should be December", Calendar.DECEMBER, longDate.getMonth());
         assertEquals("Long format: Day should be 25", 25, longDate.getDate());
 
-        // Short month format: 25-Dec-24 = December 25, 2024
-        Date shortMonthDate = DateUtil.convertDate("25-Dec-24", defaultTimeZone, false, "d-MMM-yy", "dd-MMM-yy");
+        // Short month format: 25-Dec-24 = December 25, 2024 (will match d-MMM-yy pattern from allFormats)
+        Date shortMonthDate = DateUtil.convertDate("25-Dec-24", defaultTimeZone, false, allFormats);
         assertNotNull("Short month format should parse in strict mode", shortMonthDate);
         
         // Validate short month format (note: 2-digit year 24 should be interpreted as 2024)
@@ -684,29 +688,15 @@ public class DateUtilTest extends UnitTestBase {
         assertEquals("Short month format: Day should be 25", 25, shortMonthDate.getDate());
         
         // Verify all date formats produce the same date (December 25, 2024)
-        assertEquals("All formats should produce same year", lenientUSDate.getYear(), isoDate.getYear());
-        assertEquals("All formats should produce same month", lenientUSDate.getMonth(), longDate.getMonth());
-        assertEquals("All formats should produce same day", lenientUSDate.getDate(), shortMonthDate.getDate());
+        assertEquals("All formats should produce same year", usDate.getYear(), isoDate.getYear());
+        assertEquals("All formats should produce same month", usDate.getMonth(), longDate.getMonth());
+        assertEquals("All formats should produce same day", usDate.getDate(), shortMonthDate.getDate());
 
-        // === Test 3: Invalid dates in lenient mode (should auto-correct) ===
-
-        // US format with invalid date (13/32/2024 - month 13, day 32)
-        Date lenientInvalidUS = DateUtil.convertDate("13/32/2024", defaultTimeZone, true, allFormats);
-        assertNotNull("Invalid US date should be auto-corrected in lenient mode", lenientInvalidUS);
-
-        // European format with invalid date (32/13/2024 - day 32, month 13)  
-        Date lenientInvalidEU = DateUtil.convertDate("32/13/2024", defaultTimeZone, true, allFormats);
-        assertNotNull("Invalid European date should be auto-corrected in lenient mode", lenientInvalidEU);
-
-        // February 30th (impossible date)
-        Date lenientFeb30 = DateUtil.convertDate("30/2/2024", defaultTimeZone, true, "d/M/y", "dd/MM/yyyy");
-        assertNotNull("February 30th should be auto-corrected in lenient mode", lenientFeb30);
-
-        // === Test 4: Invalid dates in strict mode (should throw ParseException) ===
+        // === Test 3: Invalid dates in strict mode (should throw ParseException like ImportUtil) ===
 
         // Test the specific example requested: 32/45/2025
         try {
-            DateUtil.convertDate("32/45/2025", defaultTimeZone, false, "d/M/y", "dd/MM/yyyy");
+            DateUtil.convertDate("32/45/2025", defaultTimeZone, false, allFormats);
             Assert.fail("Expected ParseException for '32/45/2025' in strict mode");
         } catch (ParseException e) {
             assertTrue("ParseException should contain the invalid date", 
@@ -715,7 +705,7 @@ public class DateUtilTest extends UnitTestBase {
 
         // US format: Invalid month (13/25/2024)
         try {
-            DateUtil.convertDate("13/25/2024", defaultTimeZone, false, "M/d/y", "MM/dd/yyyy");
+            DateUtil.convertDate("13/25/2024", defaultTimeZone, false, allFormats);
             Assert.fail("Expected ParseException for invalid US month '13' in strict mode");
         } catch (ParseException e) {
             assertTrue("ParseException should contain meaningful message", 
@@ -724,7 +714,7 @@ public class DateUtilTest extends UnitTestBase {
 
         // European format: Invalid day (32/12/2024)
         try {
-            DateUtil.convertDate("32/12/2024", defaultTimeZone, false, "d/M/y", "dd/MM/yyyy");
+            DateUtil.convertDate("32/12/2024", defaultTimeZone, false, allFormats);
             Assert.fail("Expected ParseException for invalid European day '32' in strict mode");
         } catch (ParseException e) {
             assertTrue("ParseException should contain meaningful message", 
@@ -733,7 +723,7 @@ public class DateUtilTest extends UnitTestBase {
 
         // Zero month in US format (0/15/2025)
         try {
-            DateUtil.convertDate("0/15/2025", defaultTimeZone, false, "M/d/y");
+            DateUtil.convertDate("0/15/2025", defaultTimeZone, false, allFormats);
             Assert.fail("Expected ParseException for zero month in US format in strict mode");
         } catch (ParseException e) {
             assertTrue("ParseException should contain meaningful message", 
@@ -742,7 +732,7 @@ public class DateUtilTest extends UnitTestBase {
 
         // Zero day in European format (0/12/2025)
         try {
-            DateUtil.convertDate("0/12/2025", defaultTimeZone, false, "d/M/y");
+            DateUtil.convertDate("0/12/2025", defaultTimeZone, false, allFormats);
             Assert.fail("Expected ParseException for zero day in European format in strict mode");
         } catch (ParseException e) {
             assertTrue("ParseException should contain meaningful message", 
@@ -751,7 +741,7 @@ public class DateUtilTest extends UnitTestBase {
 
         // February 30th in strict mode
         try {
-            DateUtil.convertDate("02/30/2024", defaultTimeZone, false, "MM/dd/yyyy");
+            DateUtil.convertDate("02/30/2024", defaultTimeZone, false, allFormats);
             Assert.fail("Expected ParseException for February 30th in strict mode");
         } catch (ParseException e) {
             assertTrue("ParseException should contain meaningful message", 
@@ -767,62 +757,47 @@ public class DateUtilTest extends UnitTestBase {
                 e.getMessage().contains("99/99/2025"));
         }
 
-        // === Test 5: Format disambiguation - same input, different interpretation ===
+        // === Test 4: Format precedence - demonstrates first matching format wins ===
 
-        // "1/2/25" could be:
-        // - US format (M/d/y): January 2, 2025
-        // - European format (d/M/y): February 1, 2025
+        // "1/2/25" will be parsed using the first matching format in allFormats
+        // Since M/d/y appears before d/M/y in our combined array, it will be interpreted as US format
+        // This demonstrates format precedence in the combined array
 
-        Date usInterpretation = DateUtil.convertDate("1/2/25", defaultTimeZone, false, "M/d/y");
-        Date euInterpretation = DateUtil.convertDate("1/2/25", defaultTimeZone, false, "d/M/y");
-
-        // CRITICAL: Verify they produce different dates to confirm format interpretation
-        assertNotEquals("US and European interpretations of '1/2/25' should be different",
-            usInterpretation.getMonth(), euInterpretation.getMonth());
-
-        // US interpretation: 1/2/25 = January 2, 2025 (M/d/y)
-        assertEquals("US format should interpret as January", Calendar.JANUARY, usInterpretation.getMonth());
-        assertEquals("US format should interpret as day 2", 2, usInterpretation.getDate());
-        assertEquals("US format should interpret as year 2025", 2025, usInterpretation.getYear() + 1900);
+        Date combinedInterpretation = DateUtil.convertDate("1/2/25", defaultTimeZone, false, allFormats);
         
-        // European interpretation: 1/2/25 = February 1, 2025 (d/M/y)  
-        assertEquals("European format should interpret as February", Calendar.FEBRUARY, euInterpretation.getMonth());
-        assertEquals("European format should interpret as day 1", 1, euInterpretation.getDate());
-        assertEquals("European format should interpret as year 2025", 2025, euInterpretation.getYear() + 1900);
+        // The combined format should match the first applicable pattern (M/d/y from IMP_DATE_FORMATS)
+        // So "1/2/25" should be interpreted as January 2, 2025 (US format)
+        assertEquals("Combined format should interpret as January", Calendar.JANUARY, combinedInterpretation.getMonth());
+        assertEquals("Combined format should interpret as day 2", 2, combinedInterpretation.getDate());
+        assertEquals("Combined format should interpret as year 2025", 2025, combinedInterpretation.getYear() + 1900);
 
-        // === Test 6: Additional format validation cases ===
 
-        // Test "12/1/2024" - should be unambiguous
-        // US format (M/d/y): December 1, 2024 
-        // European format (d/M/y): January 12, 2024
-        Date usAmbiguous = DateUtil.convertDate("12/1/2024", defaultTimeZone, false, "M/d/y");
-        Date euAmbiguous = DateUtil.convertDate("12/1/2024", defaultTimeZone, false, "d/M/y");
+        // === Test 5: Edge cases - dates valid in only one format ===
 
-        // US: December 1, 2024
-        assertEquals("US '12/1/2024': Month should be December", Calendar.DECEMBER, usAmbiguous.getMonth());
-        assertEquals("US '12/1/2024': Day should be 1", 1, usAmbiguous.getDate());
-        assertEquals("US '12/1/2024': Year should be 2024", 2024, usAmbiguous.getYear() + 1900);
+        // Test "12/1/2024" - with combined formats, will be interpreted using first matching format
+        // Since M/d/y appears first in our combined array, this will be December 1, 2024 (US format)
+        Date ambiguousDate = DateUtil.convertDate("12/1/2024", defaultTimeZone, false, allFormats);
 
-        // European: January 12, 2024  
-        assertEquals("EU '12/1/2024': Month should be January", Calendar.JANUARY, euAmbiguous.getMonth());
-        assertEquals("EU '12/1/2024': Day should be 12", 12, euAmbiguous.getDate());
-        assertEquals("EU '12/1/2024': Year should be 2024", 2024, euAmbiguous.getYear() + 1900);
+        // Combined format should interpret as US format: December 1, 2024
+        assertEquals("Combined '12/1/2024': Month should be December", Calendar.DECEMBER, ambiguousDate.getMonth());
+        assertEquals("Combined '12/1/2024': Day should be 1", 1, ambiguousDate.getDate());
+        assertEquals("Combined '12/1/2024': Year should be 2024", 2024, ambiguousDate.getYear() + 1900);
 
-        // Test edge case: "31/12/2024" - only valid in European format
-        Date euOnly = DateUtil.convertDate("31/12/2024", defaultTimeZone, false, "d/M/y", "dd/MM/yyyy");
+        // Test edge case: "31/12/2024" - only valid in European format (d/M/y), will be parsed correctly
+        Date euOnly = DateUtil.convertDate("31/12/2024", defaultTimeZone, false, allFormats);
         
-        // European: December 31, 2024
-        assertEquals("EU '31/12/2024': Month should be December", Calendar.DECEMBER, euOnly.getMonth());
-        assertEquals("EU '31/12/2024': Day should be 31", 31, euOnly.getDate());
-        assertEquals("EU '31/12/2024': Year should be 2024", 2024, euOnly.getYear() + 1900);
+        // Should be parsed as European format: December 31, 2024
+        assertEquals("Combined '31/12/2024': Month should be December", Calendar.DECEMBER, euOnly.getMonth());
+        assertEquals("Combined '31/12/2024': Day should be 31", 31, euOnly.getDate());
+        assertEquals("Combined '31/12/2024': Year should be 2024", 2024, euOnly.getYear() + 1900);
 
-        // Test edge case: "12/31/2024" - only valid in US format  
-        Date usOnly = DateUtil.convertDate("12/31/2024", defaultTimeZone, false, "M/d/y", "MM/dd/yyyy");
+        // Test edge case: "12/31/2024" - only valid in US format (M/d/y), will be parsed correctly  
+        Date usOnly = DateUtil.convertDate("12/31/2024", defaultTimeZone, false, allFormats);
         
-        // US: December 31, 2024
-        assertEquals("US '12/31/2024': Month should be December", Calendar.DECEMBER, usOnly.getMonth());
-        assertEquals("US '12/31/2024': Day should be 31", 31, usOnly.getDate());
-        assertEquals("US '12/31/2024': Year should be 2024", 2024, usOnly.getYear() + 1900);
+        // Should be parsed as US format: December 31, 2024
+        assertEquals("Combined '12/31/2024': Month should be December", Calendar.DECEMBER, usOnly.getMonth());
+        assertEquals("Combined '12/31/2024': Day should be 31", 31, usOnly.getDate());
+        assertEquals("Combined '12/31/2024': Year should be 2024", 2024, usOnly.getYear() + 1900);
 
         // Verify both edge cases represent the same logical date (December 31, 2024)
         assertEquals("Both '31/12/2024' and '12/31/2024' should represent same year", 
@@ -831,5 +806,180 @@ public class DateUtilTest extends UnitTestBase {
             euOnly.getMonth(), usOnly.getMonth());
         assertEquals("Both '31/12/2024' and '12/31/2024' should represent same day", 
             euOnly.getDate(), usOnly.getDate());
+    }
+
+    /**
+     * Method to test: {@link DateUtil#convertDate(String, TimeZone, boolean, String...)}
+     * Given Scenario: Test all ImportUtil date format patterns with valid examples
+     * Expected Result: Each format pattern correctly parses its corresponding date string
+     * Focus: Comprehensive validation of all supported date format patterns
+     */
+    @Test
+    public void test_all_import_date_format_patterns() throws ParseException {
+        
+        final TimeZone defaultTimeZone = TimeZone.getDefault();
+        
+        // Combine all formats for testing
+        final String[] allFormats = new String[dateFormatPatterns.length + europeanDateFormats.length];
+        System.arraycopy(dateFormatPatterns, 0, allFormats, 0, dateFormatPatterns.length);
+        System.arraycopy(europeanDateFormats, 0, allFormats, dateFormatPatterns.length, europeanDateFormats.length);
+        
+        // === Test US/Standard Date Format Patterns ===
+        
+        // d-MMM-yy: "25-Dec-24" 
+        Date datePattern1 = DateUtil.convertDate("25-Dec-24", defaultTimeZone, false, allFormats);
+        assertNotNull("d-MMM-yy format should parse", datePattern1);
+        assertEquals("d-MMM-yy: Month should be December", Calendar.DECEMBER, datePattern1.getMonth());
+        assertEquals("d-MMM-yy: Day should be 25", 25, datePattern1.getDate());
+        
+        // MMM-yy: "Dec-24"
+        Date datePattern2 = DateUtil.convertDate("Dec-24", defaultTimeZone, false, allFormats);
+        assertNotNull("MMM-yy format should parse", datePattern2);
+        assertEquals("MMM-yy: Month should be December", Calendar.DECEMBER, datePattern2.getMonth());
+        
+        // MMMM-yy: "December-24"
+        Date datePattern3 = DateUtil.convertDate("December-24", defaultTimeZone, false, allFormats);
+        assertNotNull("MMMM-yy format should parse", datePattern3);
+        assertEquals("MMMM-yy: Month should be December", Calendar.DECEMBER, datePattern3.getMonth());
+        
+        // d-MMM: "25-Dec"
+        Date datePattern4 = DateUtil.convertDate("25-Dec", defaultTimeZone, false, allFormats);
+        assertNotNull("d-MMM format should parse", datePattern4);
+        assertEquals("d-MMM: Month should be December", Calendar.DECEMBER, datePattern4.getMonth());
+        assertEquals("d-MMM: Day should be 25", 25, datePattern4.getDate());
+        
+        // dd-MMM-yyyy: "25-Dec-2024"
+        Date datePattern5 = DateUtil.convertDate("25-Dec-2024", defaultTimeZone, false, allFormats);
+        assertNotNull("dd-MMM-yyyy format should parse", datePattern5);
+        assertEquals("dd-MMM-yyyy: Year should be 2024", 2024, datePattern5.getYear() + 1900);
+        assertEquals("dd-MMM-yyyy: Month should be December", Calendar.DECEMBER, datePattern5.getMonth());
+        assertEquals("dd-MMM-yyyy: Day should be 25", 25, datePattern5.getDate());
+        
+        // MM/dd/yy hh:mm aa: "12/25/24 03:30 PM"
+        Date datePattern6 = DateUtil.convertDate("12/25/24 03:30 PM", defaultTimeZone, false, allFormats);
+        assertNotNull("MM/dd/yy hh:mm aa format should parse", datePattern6);
+        assertEquals("MM/dd/yy hh:mm aa: Month should be December", Calendar.DECEMBER, datePattern6.getMonth());
+        assertEquals("MM/dd/yy hh:mm aa: Day should be 25", 25, datePattern6.getDate());
+        
+        // MM/dd/yyyy hh:mm aa: "12/25/2024 03:30 PM"
+        Date datePattern7 = DateUtil.convertDate("12/25/2024 03:30 PM", defaultTimeZone, false, allFormats);
+        assertNotNull("MM/dd/yyyy hh:mm aa format should parse", datePattern7);
+        assertEquals("MM/dd/yyyy hh:mm aa: Year should be 2024", 2024, datePattern7.getYear() + 1900);
+        assertEquals("MM/dd/yyyy hh:mm aa: Month should be December", Calendar.DECEMBER, datePattern7.getMonth());
+        assertEquals("MM/dd/yyyy hh:mm aa: Day should be 25", 25, datePattern7.getDate());
+        
+        // MM/dd/yy HH:mm: "12/25/24 15:30"
+        Date datePattern8 = DateUtil.convertDate("12/25/24 15:30", defaultTimeZone, false, allFormats);
+        assertNotNull("MM/dd/yy HH:mm format should parse", datePattern8);
+        assertEquals("MM/dd/yy HH:mm: Month should be December", Calendar.DECEMBER, datePattern8.getMonth());
+        assertEquals("MM/dd/yy HH:mm: Day should be 25", 25, datePattern8.getDate());
+        
+        // MM/dd/yyyy HH:mm: "12/25/2024 15:30"
+        Date datePattern9 = DateUtil.convertDate("12/25/2024 15:30", defaultTimeZone, false, allFormats);
+        assertNotNull("MM/dd/yyyy HH:mm format should parse", datePattern9);
+        assertEquals("MM/dd/yyyy HH:mm: Year should be 2024", 2024, datePattern9.getYear() + 1900);
+        assertEquals("MM/dd/yyyy HH:mm: Month should be December", Calendar.DECEMBER, datePattern9.getMonth());
+        assertEquals("MM/dd/yyyy HH:mm: Day should be 25", 25, datePattern9.getDate());
+        
+        // MMMM dd, yyyy: "December 25, 2024"
+        Date datePattern10 = DateUtil.convertDate("December 25, 2024", defaultTimeZone, false, allFormats);
+        assertNotNull("MMMM dd, yyyy format should parse", datePattern10);
+        assertEquals("MMMM dd, yyyy: Year should be 2024", 2024, datePattern10.getYear() + 1900);
+        assertEquals("MMMM dd, yyyy: Month should be December", Calendar.DECEMBER, datePattern10.getMonth());
+        assertEquals("MMMM dd, yyyy: Day should be 25", 25, datePattern10.getDate());
+        
+        // M/d/y: "12/25/2024"
+        Date datePattern11 = DateUtil.convertDate("12/25/2024", defaultTimeZone, false, allFormats);
+        assertNotNull("M/d/y format should parse", datePattern11);
+        assertEquals("M/d/y: Year should be 2024", 2024, datePattern11.getYear() + 1900);
+        assertEquals("M/d/y: Month should be December", Calendar.DECEMBER, datePattern11.getMonth());
+        assertEquals("M/d/y: Day should be 25", 25, datePattern11.getDate());
+        
+        // M/d: "12/25" (current year assumed)
+        Date datePattern12 = DateUtil.convertDate("12/25", defaultTimeZone, false, allFormats);
+        assertNotNull("M/d format should parse", datePattern12);
+        assertEquals("M/d: Month should be December", Calendar.DECEMBER, datePattern12.getMonth());
+        assertEquals("M/d: Day should be 25", 25, datePattern12.getDate());
+        
+        // EEEE, MMMM dd, yyyy: "Wednesday, December 25, 2024"
+        Date datePattern13 = DateUtil.convertDate("Wednesday, December 25, 2024", defaultTimeZone, false, allFormats);
+        assertNotNull("EEEE, MMMM dd, yyyy format should parse", datePattern13);
+        assertEquals("EEEE, MMMM dd, yyyy: Year should be 2024", 2024, datePattern13.getYear() + 1900);
+        assertEquals("EEEE, MMMM dd, yyyy: Month should be December", Calendar.DECEMBER, datePattern13.getMonth());
+        assertEquals("EEEE, MMMM dd, yyyy: Day should be 25", 25, datePattern13.getDate());
+        
+        // MM/dd/yyyy: "12/25/2024"
+        Date datePattern14 = DateUtil.convertDate("12/25/2024", defaultTimeZone, false, allFormats);
+        assertNotNull("MM/dd/yyyy format should parse", datePattern14);
+        assertEquals("MM/dd/yyyy: Year should be 2024", 2024, datePattern14.getYear() + 1900);
+        assertEquals("MM/dd/yyyy: Month should be December", Calendar.DECEMBER, datePattern14.getMonth());
+        assertEquals("MM/dd/yyyy: Day should be 25", 25, datePattern14.getDate());
+        
+        // yyyy-MM-dd: "2024-12-25" (ISO format)
+        Date datePattern15 = DateUtil.convertDate("2024-12-25", defaultTimeZone, false, allFormats);
+        assertNotNull("yyyy-MM-dd format should parse", datePattern15);
+        assertEquals("yyyy-MM-dd: Year should be 2024", 2024, datePattern15.getYear() + 1900);
+        assertEquals("yyyy-MM-dd: Month should be December", Calendar.DECEMBER, datePattern15.getMonth());
+        assertEquals("yyyy-MM-dd: Day should be 25", 25, datePattern15.getDate());
+        
+        // === Test European Date Format Patterns ===
+        
+        // d/M/y: "25/12/2024"
+        Date euPattern1 = DateUtil.convertDate("25/12/2024", defaultTimeZone, false, allFormats);
+        assertNotNull("d/M/y European format should parse", euPattern1);
+        assertEquals("d/M/y: Year should be 2024", 2024, euPattern1.getYear() + 1900);
+        assertEquals("d/M/y: Month should be December", Calendar.DECEMBER, euPattern1.getMonth());
+        assertEquals("d/M/y: Day should be 25", 25, euPattern1.getDate());
+        
+        // dd/MM/yyyy: "25/12/2024"
+        Date euPattern2 = DateUtil.convertDate("25/12/2024", defaultTimeZone, false, allFormats);
+        assertNotNull("dd/MM/yyyy European format should parse", euPattern2);
+        assertEquals("dd/MM/yyyy: Year should be 2024", 2024, euPattern2.getYear() + 1900);
+        assertEquals("dd/MM/yyyy: Month should be December", Calendar.DECEMBER, euPattern2.getMonth());
+        assertEquals("dd/MM/yyyy: Day should be 25", 25, euPattern2.getDate());
+        
+        // d/M/yyyy: "25/12/2024"
+        Date euPattern3 = DateUtil.convertDate("25/12/2024", defaultTimeZone, false, allFormats);
+        assertNotNull("d/M/yyyy European format should parse", euPattern3);
+        assertEquals("d/M/yyyy: Year should be 2024", 2024, euPattern3.getYear() + 1900);
+        assertEquals("d/M/yyyy: Month should be December", Calendar.DECEMBER, euPattern3.getMonth());
+        assertEquals("d/M/yyyy: Day should be 25", 25, euPattern3.getDate());
+        
+        // dd/MM/yy: "25/12/24"
+        Date euPattern4 = DateUtil.convertDate("25/12/24", defaultTimeZone, false, allFormats);
+        assertNotNull("dd/MM/yy European format should parse", euPattern4);
+        assertEquals("dd/MM/yy: Month should be December", Calendar.DECEMBER, euPattern4.getMonth());
+        assertEquals("dd/MM/yy: Day should be 25", 25, euPattern4.getDate());
+        
+        // === Test Time Format Patterns (standalone time patterns) ===
+        
+        // hh:mm:ss aa: "03:30:45 PM"
+        Date timePattern1 = DateUtil.convertDate("03:30:45 PM", defaultTimeZone, false, allFormats);
+        assertNotNull("hh:mm:ss aa time format should parse", timePattern1);
+        
+        // HH:mm:ss: "15:30:45"
+        Date timePattern2 = DateUtil.convertDate("15:30:45", defaultTimeZone, false, allFormats);
+        assertNotNull("HH:mm:ss time format should parse", timePattern2);
+        
+        // hh:mm aa: "03:30 PM"
+        Date timePattern3 = DateUtil.convertDate("03:30 PM", defaultTimeZone, false, allFormats);
+        assertNotNull("hh:mm aa time format should parse", timePattern3);
+        
+        // === Verify All December 25 Patterns Produce Consistent Results ===
+        
+        Date[] december25Dates = {
+            datePattern1, datePattern4, datePattern5, datePattern6, datePattern7, 
+            datePattern8, datePattern9, datePattern10, datePattern11, datePattern12,
+            datePattern13, datePattern14, datePattern15, euPattern1, euPattern2, euPattern3, euPattern4
+        };
+        
+        for (int i = 0; i < december25Dates.length; i++) {
+            if (december25Dates[i] != null) {
+                assertEquals("All December 25 dates should have same month [" + i + "]", 
+                    Calendar.DECEMBER, december25Dates[i].getMonth());
+                assertEquals("All December 25 dates should have same day [" + i + "]", 
+                    25, december25Dates[i].getDate());
+            }
+        }
     }
 }


### PR DESCRIPTION
### Proposed Changes
* We ensure that parsing date errors are minimized by turning off the setLenient, making parse strict, also including European formats 
* Tests were added to corroborate that European/ American dates are parsed correctly 
* This change only affects content import; all other mechanisms using the convertDate methods remain working as before

This PR fixes: #33047

This PR fixes: #33047