### PR TITLE
32952 fakerjs

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.spec.ts
@@ -48,7 +48,7 @@ import {
     DotIconModule,
     DotMessagePipe
 } from '@dotcms/ui';
-import { DotLoadingIndicatorService } from '@dotcms/utils';
+import { DotLoadingIndicatorService, FieldUtil } from '@dotcms/utils';
 import {
     cleanUpDialog,
     CoreWebServiceMock,
@@ -56,7 +56,6 @@ import {
     dotcmsContentTypeFieldBasicMock,
     fieldsBrokenWithColumns,
     fieldsWithBreakColumn,
-    FieldUtil,
     MockDotMessageService
 } from '@dotcms/utils-testing';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.ts
@@ -21,6 +21,7 @@ import { takeUntil } from 'rxjs/operators';
 
 import { DotEventsService, DotMessageService } from '@dotcms/data-access';
 import {
+    DotCMSClazzes,
     DotCMSContentType,
     DotCMSContentTypeField,
     DotCMSContentTypeLayoutColumn,
@@ -114,7 +115,7 @@ export class ContentTypeFieldsDropZoneComponent implements OnInit, OnChanges, On
 
     private static findColumnBreakIndex(fields: DotCMSContentTypeField[]): number {
         return fields.findIndex((item: DotCMSContentTypeField) => {
-            return FieldUtil.isColumnBreak(item.clazz);
+            return item.clazz === DotCMSClazzes.COLUMN_BREAK;
         });
     }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.ts
@@ -28,8 +28,7 @@ import {
     DotCMSContentTypeLayoutRow,
     DotDialogActions
 } from '@dotcms/dotcms-models';
-import { DotLoadingIndicatorService } from '@dotcms/utils';
-import { FieldUtil } from '@dotcms/utils-testing';
+import { DotLoadingIndicatorService, FieldUtil } from '@dotcms/utils';
 
 import { ContentTypeFieldsPropertiesFormComponent } from '../content-type-fields-properties-form';
 import { FieldType } from '../models';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.spec.ts
@@ -14,11 +14,8 @@ import {
     DotCMSContentTypeLayoutRow
 } from '@dotcms/dotcms-models';
 import { DotMessagePipe } from '@dotcms/ui';
-import {
-    dotcmsContentTypeFieldBasicMock,
-    FieldUtil,
-    MockDotMessageService
-} from '@dotcms/utils-testing';
+import { FieldUtil } from '@dotcms/utils';
+import { dotcmsContentTypeFieldBasicMock, MockDotMessageService } from '@dotcms/utils-testing';
 
 import { ContentTypeFieldsRowComponent } from '.';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-row/content-type-fields-row.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnInit, Output, inject } from '@angular
 
 import { DotAlertConfirmService, DotMessageService } from '@dotcms/data-access';
 import { DotCMSContentTypeField, DotCMSContentTypeLayoutRow } from '@dotcms/dotcms-models';
-import { FieldUtil } from '@dotcms/utils-testing';
+import { FieldUtil } from '@dotcms/utils';
 
 /**
  * Display all the Field Types

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-icon-map.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-icon-map.ts
@@ -1,4 +1,4 @@
-import { FieldUtil } from '@dotcms/utils-testing';
+import { FieldUtil } from '@dotcms/utils';
 
 const COLUMN_BREAK = FieldUtil.createColumnBreak();
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-types-fields-list/content-types-fields-list.component.ts
@@ -3,7 +3,7 @@ import { Component, inject, Input, OnInit, signal } from '@angular/core';
 import { filter, mergeMap, take, toArray } from 'rxjs/operators';
 
 import { DotCMSClazz, DotCMSClazzes } from '@dotcms/dotcms-models';
-import { FieldUtil } from '@dotcms/utils-testing';
+import { FieldUtil } from '@dotcms/utils';
 
 import { FIELD_ICONS } from './content-types-fields-icon-map';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/dot-content-type-fields-variables.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/dot-content-type-fields-variables/dot-content-type-fields-variables.component.spec.ts
@@ -8,10 +8,10 @@ import { DotMessageDisplayService } from '@dotcms/data-access';
 import { LoginService } from '@dotcms/dotcms-js';
 import { DotCMSClazzes, DotCMSContentTypeField, DotFieldVariable } from '@dotcms/dotcms-models';
 import { DotKeyValueComponent } from '@dotcms/ui';
+import { EMPTY_FIELD } from '@dotcms/utils';
 import {
     dotcmsContentTypeFieldBasicMock,
     DotFieldVariablesServiceMock,
-    EMPTY_FIELD,
     LoginServiceMock,
     mockFieldVariables
 } from '@dotcms/utils-testing';

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.spec.ts
@@ -8,7 +8,8 @@ import { TestBed } from '@angular/core/testing';
 import { filter, map } from 'rxjs/operators';
 
 import { DotAlertConfirmService, DotMessageService } from '@dotcms/data-access';
-import { FieldUtil, MockDotMessageService } from '@dotcms/utils-testing';
+import { FieldUtil } from '@dotcms/utils';
+import { MockDotMessageService } from '@dotcms/utils-testing';
 
 import { FieldDragDropService } from './field-drag-drop.service';
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-drag-drop.service.ts
@@ -7,7 +7,7 @@ import { filter, map, tap } from 'rxjs/operators';
 
 import { DotAlertConfirmService, DotMessageService } from '@dotcms/data-access';
 import { DotCMSContentTypeField, DotCMSContentTypeLayoutRow } from '@dotcms/dotcms-models';
-import { FieldUtil } from '@dotcms/utils-testing';
+import { FieldUtil } from '@dotcms/utils';
 
 const MAX_COLS_PER_ROW = 4;
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/form/content-types-form.component.ts
@@ -34,8 +34,7 @@ import {
     DotCMSWorkflow,
     FeaturedFlags
 } from '@dotcms/dotcms-models';
-import { isEqual } from '@dotcms/utils';
-import { FieldUtil } from '@dotcms/utils-testing';
+import { isEqual, FieldUtil } from '@dotcms/utils';
 
 /**
  * Form component to create or edit content types

--- a/core-web/libs/dotcms-models/src/lib/dot-content-types.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-content-types.model.ts
@@ -1,6 +1,10 @@
 import { DotCMSSystemActionMappings } from './dot-workflow-action.model';
 import { DotCMSWorkflow } from './dot-workflow.model';
 
+/**
+ * Constants defining the Java class names for different DotCMS content type classes
+ * Used for identifying the specific implementation class of content types and fields
+ */
 export const DotCMSClazzes = {
     // Types
     SIMPLE_CONTENT_TYPE: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
@@ -37,8 +41,85 @@ export const DotCMSClazzes = {
     WYSIWYG: 'com.dotcms.contenttype.model.field.ImmutableWysiwygField'
 } as const;
 
+/**
+ * Union type representing all possible DotCMS class names
+ * Derived from the DotCMSClazzes constant object
+ */
 export type DotCMSClazz = (typeof DotCMSClazzes)[keyof typeof DotCMSClazzes];
 
+/**
+ * Constants defining the data types supported by DotCMS content type fields
+ * Maps to the underlying data storage types in the system
+ */
+export const DotCMSDataTypes = {
+    SYSTEM: 'SYSTEM',
+    TEXT: 'TEXT',
+    LONG_TEXT: 'LONG_TEXT',
+    DATE: 'DATE',
+    BOOLEAN: 'BOOL',
+    FLOAT: 'FLOAT',
+    INTEGER: 'INTEGER'
+} as const;
+
+/**
+ * Union type representing all possible DotCMS data types
+ * Derived from the DotCMSDataTypes constant object
+ */
+export type DotCMSDataType = (typeof DotCMSDataTypes)[keyof typeof DotCMSDataTypes];
+
+/**
+ * Constants defining the field types available in DotCMS content types
+ * Includes both layout fields and content type fields
+ */
+export const DotCMSFieldTypes = {
+    // Layout Fields
+    ROW: 'Row',
+    COLUMN: 'Column',
+    TAB_DIVIDER: 'Tab_divider',
+    LINE_DIVIDER: 'Line_divider',
+    COLUMN_BREAK: 'Column_break',
+    // Content Type Fields
+    BINARY: 'Binary',
+    BLOCK_EDITOR: 'Story-Block',
+    CATEGORY: 'Category',
+    CHECKBOX: 'Checkbox',
+    CONSTANT: 'Constant-Field',
+    CUSTOM_FIELD: 'Custom-Field',
+    DATE: 'Date',
+    DATE_AND_TIME: 'Date-and-Time',
+    FILE: 'File',
+    HIDDEN: 'Hidden-Field',
+    IMAGE: 'Image',
+    JSON: 'JSON-Field',
+    KEY_VALUE: 'Key-Value',
+    MULTI_SELECT: 'Multi-Select',
+    RADIO: 'Radio',
+    RELATIONSHIP: 'Relationship',
+    SELECT: 'Select',
+    HOST_FOLDER: 'Host-Folder',
+    TAG: 'Tag',
+    TEXT: 'Text',
+    TEXTAREA: 'Textarea',
+    TIME: 'Time',
+    WYSIWYG: 'WYSIWYG'
+} as const;
+
+/**
+ * Union type representing all possible DotCMS field types
+ * Derived from the DotCMSFieldTypes constant object
+ */
+export type DotCMSFieldType = (typeof DotCMSFieldTypes)[keyof typeof DotCMSFieldTypes];
+
+/**
+ * Additional metadata for content type fields
+ * Flexible key-value structure for field-specific configuration
+ */
+export type DotCMSContentTypeFieldMetadata = Record<string, string | number | boolean>;
+
+/**
+ * Main interface representing a DotCMS content type
+ * Defines the structure and properties of content types including fields, layout, and metadata
+ */
 export interface DotCMSContentType {
     baseType: string;
     icon?: string;
@@ -68,9 +149,380 @@ export interface DotCMSContentType {
     workflows: DotCMSWorkflow[];
     workflow?: string[];
     systemActionMappings?: DotCMSSystemActionMappings;
-    metadata?: { [key: string]: string | number | boolean };
+    metadata?: DotCMSContentTypeFieldMetadata;
 }
 
+/**
+ * Base interface for all DotCMS content type fields
+ * Defines common properties shared by all field types
+ */
+export interface DotCMSContentTypeBaseField {
+    clazz: DotCMSClazz;
+    contentTypeId: string;
+    dataType: DotCMSDataType;
+    defaultValue?: string;
+    fieldContentTypeProperties?: string[];
+    fieldVariables: DotCMSContentTypeFieldVariable[];
+    fieldType: DotCMSFieldType;
+    fieldTypeLabel: string;
+    fieldTypeOptions?: unknown[];
+    fixed: boolean;
+    forceIncludeInApi: boolean;
+    hint?: string;
+    iDate: number;
+    id: string;
+    indexed: boolean;
+    listed: boolean;
+    modDate: number;
+    name: string;
+    readOnly: boolean;
+    required: boolean;
+    searchable: boolean;
+    sortOrder: number;
+    unique: boolean;
+    variable: string;
+    velocityVarName?: string;
+    metadata?: DotCMSContentTypeFieldMetadata;
+    values?: string;
+}
+
+// Layout Fields
+
+/**
+ * Row field for content type layout
+ * Used to create a row in the layout grid
+ */
+export interface ContentTypeRowField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.ROW;
+    clazz: typeof DotCMSClazzes.ROW;
+}
+
+/**
+ * Column field for content type layout
+ * Used to create a column within a row in the layout grid
+ */
+export interface ContentTypeColumnField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.COLUMN;
+    clazz: typeof DotCMSClazzes.COLUMN;
+}
+
+/**
+ * Line divider field for content type layout
+ * Used to create a horizontal line separator in the layout
+ */
+export interface ContentTypeLineDividerField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.LINE_DIVIDER;
+    clazz: typeof DotCMSClazzes.LINE_DIVIDER;
+}
+
+/**
+ * Tab divider field for content type layout
+ * Used to create a tab in the layout
+ */
+export interface ContentTypeTabDividerField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.TAB_DIVIDER;
+    clazz: typeof DotCMSClazzes.TAB_DIVIDER;
+}
+
+/**
+ * Column break field for content type layout
+ * Used to break to a new column in the layout
+ */
+export interface ContentTypeColumnBreakField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.COLUMN_BREAK;
+    clazz: typeof DotCMSClazzes.COLUMN_BREAK;
+}
+
+// Content Type Fields
+
+/**
+ * Binary field for content types
+ * Used for binary data storage
+ */
+export interface ContentTypeBinaryField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.BINARY;
+    clazz: typeof DotCMSClazzes.BINARY;
+}
+
+/**
+ * Block editor field for content types
+ * Used for structured content blocks/stories
+ */
+export interface ContentTypeBlockEditorField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.LONG_TEXT;
+    fieldType: typeof DotCMSFieldTypes.BLOCK_EDITOR;
+    clazz: typeof DotCMSClazzes.BLOCK_EDITOR;
+}
+
+/**
+ * Category field for content types
+ * Used to select categories from the category tree
+ */
+export interface ContentTypeCategoryField extends DotCMSContentTypeBaseField {
+    categories: DotCMSContentTypeFieldCategories;
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.CATEGORY;
+    clazz: typeof DotCMSClazzes.CATEGORY;
+    values: string;
+}
+
+/**
+ * Checkbox field for content types
+ * Used for boolean values or multi-selection
+ */
+export interface ContentTypeCheckboxField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.TEXT;
+    fieldType: typeof DotCMSFieldTypes.CHECKBOX;
+    clazz: typeof DotCMSClazzes.CHECKBOX;
+    values: string;
+}
+
+/**
+ * Constant field for content types
+ * Used for fixed values that don't change
+ */
+export interface ContentTypeConstantField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.CONSTANT;
+    clazz: typeof DotCMSClazzes.CONSTANT;
+    values: string;
+}
+
+/**
+ * Custom field for content types
+ * Used for custom-implemented fields
+ */
+export interface ContentTypeCustomField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.LONG_TEXT;
+    fieldType: typeof DotCMSFieldTypes.CUSTOM_FIELD;
+    clazz: typeof DotCMSClazzes.CUSTOM_FIELD;
+    values: string;
+    regexCheck?: string;
+}
+
+/**
+ * Date field for content types
+ * Used for date values without time
+ */
+export interface ContentTypeDateField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.DATE;
+    fieldType: typeof DotCMSFieldTypes.DATE;
+    clazz: typeof DotCMSClazzes.DATE;
+}
+
+/**
+ * Date and time field for content types
+ * Used for datetime values
+ */
+export interface ContentTypeDateTimeField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.DATE;
+    fieldType: typeof DotCMSFieldTypes.DATE_AND_TIME;
+    clazz: typeof DotCMSClazzes.DATE_AND_TIME;
+}
+
+/**
+ * File field for content types
+ * Used for file uploads
+ */
+export interface ContentTypeFileField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.TEXT;
+    fieldType: typeof DotCMSFieldTypes.FILE;
+    clazz: typeof DotCMSClazzes.FILE;
+}
+
+/**
+ * Hidden field for content types
+ * Used for values not shown in the UI
+ */
+export interface ContentTypeHiddenField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.HIDDEN;
+    values: string;
+    clazz: typeof DotCMSClazzes.HIDDEN;
+}
+
+/**
+ * Image field for content types
+ * Used for image uploads
+ */
+export interface ContentTypeImageField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.TEXT;
+    fieldType: typeof DotCMSFieldTypes.IMAGE;
+    clazz: typeof DotCMSClazzes.IMAGE;
+}
+
+/**
+ * JSON field for content types
+ * Used for storing JSON data
+ */
+export interface ContentTypeJSONField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.LONG_TEXT;
+    fieldType: typeof DotCMSFieldTypes.JSON;
+    clazz: typeof DotCMSClazzes.JSON;
+}
+
+/**
+ * Key-value field for content types
+ * Used for storing key-value pairs
+ */
+export interface ContentTypeKeyValueField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.LONG_TEXT;
+    fieldType: typeof DotCMSFieldTypes.KEY_VALUE;
+    clazz: typeof DotCMSClazzes.KEY_VALUE;
+}
+
+/**
+ * Multi-select field for content types
+ * Used for selecting multiple options from a list
+ */
+export interface ContentTypeMultiSelectField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.LONG_TEXT;
+    fieldType: typeof DotCMSFieldTypes.MULTI_SELECT;
+    values: string;
+    clazz: typeof DotCMSClazzes.MULTI_SELECT;
+}
+
+/**
+ * Radio field for content types
+ * Used for selecting a single option from a list
+ */
+export interface ContentTypeRadioField extends DotCMSContentTypeBaseField {
+    dataType:
+        | typeof DotCMSDataTypes.TEXT
+        | typeof DotCMSDataTypes.BOOLEAN
+        | typeof DotCMSDataTypes.FLOAT
+        | typeof DotCMSDataTypes.INTEGER;
+    fieldType: typeof DotCMSFieldTypes.RADIO;
+    values: string;
+    clazz: typeof DotCMSClazzes.RADIO;
+}
+
+/**
+ * Relationship field for content types
+ * Used for relating content to other content
+ */
+export interface ContentTypeRelationshipField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.RELATIONSHIP;
+    relationships: {
+        cardinality: number;
+        isParentField: boolean;
+        velocityVar: string;
+    };
+    skipRelationshipCreation: boolean;
+    clazz: typeof DotCMSClazzes.RELATIONSHIP;
+}
+
+/**
+ * Select field for content types
+ * Used for dropdown selection
+ */
+export interface ContentTypeSelectField extends DotCMSContentTypeBaseField {
+    dataType:
+        | typeof DotCMSDataTypes.TEXT
+        | typeof DotCMSDataTypes.BOOLEAN
+        | typeof DotCMSDataTypes.FLOAT
+        | typeof DotCMSDataTypes.INTEGER;
+    fieldType: typeof DotCMSFieldTypes.SELECT;
+    values: string;
+    clazz: typeof DotCMSClazzes.SELECT;
+}
+
+/**
+ * Host/folder field for content types
+ * Used for selecting hosts or folders
+ */
+export interface ContentTypeHostFolderField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.HOST_FOLDER;
+    clazz: typeof DotCMSClazzes.HOST_FOLDER;
+}
+
+/**
+ * Tag field for content types
+ * Used for adding tags to content
+ */
+export interface ContentTypeTagField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.SYSTEM;
+    fieldType: typeof DotCMSFieldTypes.TAG;
+    clazz: typeof DotCMSClazzes.TAG;
+}
+
+/**
+ * Text field for content types
+ * Used for single-line text input
+ */
+export interface ContentTypeTextField extends DotCMSContentTypeBaseField {
+    dataType:
+        | typeof DotCMSDataTypes.TEXT
+        | typeof DotCMSDataTypes.FLOAT
+        | typeof DotCMSDataTypes.INTEGER;
+    fieldType: typeof DotCMSFieldTypes.TEXT;
+    regexCheck?: string;
+    clazz: typeof DotCMSClazzes.TEXT;
+}
+
+/**
+ * Text area field for content types
+ * Used for multi-line text input
+ */
+export interface ContentTypeTextAreaField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.LONG_TEXT;
+    fieldType: typeof DotCMSFieldTypes.TEXTAREA;
+    regexCheck?: string;
+    clazz: typeof DotCMSClazzes.TEXTAREA;
+}
+
+/**
+ * Time field for content types
+ * Used for time values without date
+ */
+export interface ContentTypeTimeField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.DATE;
+    fieldType: typeof DotCMSFieldTypes.TIME;
+    clazz: typeof DotCMSClazzes.TIME;
+}
+
+/**
+ * WYSIWYG field for content types
+ * Used for rich text editing
+ */
+export interface ContentTypeWYSIWYGField extends DotCMSContentTypeBaseField {
+    dataType: typeof DotCMSDataTypes.LONG_TEXT;
+    fieldType: typeof DotCMSFieldTypes.WYSIWYG;
+    regexCheck?: string;
+    clazz: typeof DotCMSClazzes.WYSIWYG;
+}
+
+/**
+ * Union type for all calendar-related fields
+ * Groups date, date/time, and time fields
+ */
+export type ContentTypeCalendarField =
+    | ContentTypeDateField
+    | ContentTypeDateTimeField
+    | ContentTypeTimeField;
+
+/**
+ * Calendar field types available in DotCMS
+ * Union type of all field types related to calendar data
+ */
+export type CalendarFieldTypes =
+    | typeof DotCMSFieldTypes.DATE_AND_TIME
+    | typeof DotCMSFieldTypes.DATE
+    | typeof DotCMSFieldTypes.TIME;
+
+/* Legacy Fields */
+
+/**
+ * Legacy interface for DotCMS content type fields
+ */
 export interface DotCMSContentTypeField {
     categories?: DotCMSContentTypeFieldCategories;
     clazz: DotCMSClazz;
@@ -161,7 +613,11 @@ export type DotCopyContentTypeDialogFormFields = {
     icon: string;
 };
 
-/** @private */
+/**
+ * @private
+ * Internal interface for relationship configuration
+ * Used internally by the relationship field implementation
+ */
 interface Relationships {
     cardinality: number;
     isParentField: boolean;

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.util.spec.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from '@jest/globals';
 
 import { DotSystemTimezone } from '@dotcms/dotcms-models';
-import { createFakeTextField } from '@dotcms/utils-testing';
+import {
+    createFakeDateField,
+    createFakeDateTimeField,
+    createFakeTimeField
+} from '@dotcms/utils-testing';
 
 import {
     CALENDAR_OPTIONS_PER_TYPE,
@@ -508,10 +512,9 @@ describe('DotEditContentCalendarFieldUtil - TDD Approach', () => {
     describe('processFieldDefaultValue - Complete Default Processing', () => {
         it('should process fixed datetime defaultValue correctly for Dubai timezone', () => {
             // Given: Field with fixed datetime default
-            const field = createFakeTextField({
+            const field = createFakeDateTimeField({
                 defaultValue: '2025-08-08 15:30:00',
-                variable: 'testField',
-                fieldType: FIELD_TYPES.DATE_AND_TIME
+                variable: 'testField'
             });
 
             // When: Processing default value
@@ -531,10 +534,9 @@ describe('DotEditContentCalendarFieldUtil - TDD Approach', () => {
 
         it('should handle "now" defaultValue correctly for datetime fields', () => {
             // Given: Datetime field with "now" default
-            const field = createFakeTextField({
+            const field = createFakeDateTimeField({
                 defaultValue: 'now',
-                variable: 'testField',
-                fieldType: FIELD_TYPES.DATE_AND_TIME
+                variable: 'testField'
             });
 
             // When: Processing default value
@@ -550,10 +552,9 @@ describe('DotEditContentCalendarFieldUtil - TDD Approach', () => {
 
         it('should handle "now" defaultValue correctly for TIME fields', () => {
             // Given: TIME field with "now" default
-            const field = createFakeTextField({
+            const field = createFakeTimeField({
                 defaultValue: 'now',
-                variable: 'testField',
-                fieldType: FIELD_TYPES.TIME
+                variable: 'testField'
             });
 
             // When: Processing default value
@@ -577,7 +578,7 @@ describe('DotEditContentCalendarFieldUtil - TDD Approach', () => {
 
         it('should handle "now" defaultValue correctly for DATE fields', () => {
             // Given: DATE field with "now" default
-            const field = createFakeTextField({
+            const field = createFakeDateField({
                 defaultValue: 'now',
                 variable: 'testField',
                 fieldType: FIELD_TYPES.DATE
@@ -610,9 +611,8 @@ describe('DotEditContentCalendarFieldUtil - TDD Approach', () => {
 
         it('should return null for empty defaultValue', () => {
             // Given: Field without default value
-            const field = createFakeTextField({
-                variable: 'testField',
-                fieldType: FIELD_TYPES.DATE_AND_TIME
+            const field = createFakeDateTimeField({
+                variable: 'testField'
             });
 
             // When: Processing default value

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-select-existing-file/components/dot-sidebar/dot-sidebar.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-select-existing-file/components/dot-sidebar/dot-sidebar.component.ts
@@ -1,5 +1,3 @@
-import { faker } from '@faker-js/faker';
-
 import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
@@ -108,7 +106,7 @@ export class DotSideBarComponent {
      * @returns {string} A string representing a percentage between 75% and 100%.
      */
     getPercentage(): string {
-        const number = faker.number.int({ max: 100, min: 75 });
+        const number = Math.floor(Math.random() * (100 - 75 + 1)) + 75;
 
         return `${number}%`;
     }

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-utils.spec.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-utils.spec.ts
@@ -4,9 +4,10 @@ import {
     getRemainingSpaceForBox,
     parseFromDotObjectToGridStack,
     parseFromGridStackToDotObject,
-    willBoxFitInRow
+    willBoxFitInRow,
+    EMPTY_ROWS_VALUE
 } from './gridstack-utils';
-import { EMPTY_ROWS_VALUE, FULL_DATA_MOCK_UNSORTED, MINIMAL_DATA_MOCK, ROWS_MOCK } from './mocks';
+import { FULL_DATA_MOCK_UNSORTED, MINIMAL_DATA_MOCK, ROWS_MOCK } from './mocks';
 
 global.structuredClone = jest.fn((val) => {
     return JSON.parse(JSON.stringify(val));

--- a/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-utils.ts
+++ b/core-web/libs/template-builder/src/lib/components/template-builder/utils/gridstack-utils.ts
@@ -2,8 +2,6 @@ import { v4 as uuid } from 'uuid';
 
 import { DotLayoutBody } from '@dotcms/dotcms-models';
 
-import { EMPTY_ROWS_VALUE } from './mocks';
-
 import {
     BOX_WIDTH,
     DotGridStackNode,
@@ -15,6 +13,34 @@ import {
 const emptyChar = '_';
 const boxChar = '#';
 const currentBoxChar = '*';
+
+export const EMPTY_ROWS_VALUE = [
+    {
+        w: 12,
+        h: 1,
+        x: 0,
+        y: 0,
+        subGridOpts: {
+            children: [
+                {
+                    w: 3,
+                    h: 1,
+                    y: 0,
+                    x: 0,
+                    id: uuid(),
+                    styleClass: [],
+                    containers: [
+                        {
+                            identifier: SYSTEM_CONTAINER_IDENTIFIER
+                        }
+                    ]
+                }
+            ]
+        },
+        id: uuid(),
+        styleClass: []
+    }
+];
 
 /**
  * @description This function parses the oldNode and newNode to a DotGridStackWidget array

--- a/core-web/libs/utils-testing/src/index.ts
+++ b/core-web/libs/utils-testing/src/index.ts
@@ -38,7 +38,6 @@ export * from './lib/dot-workflows-actions.mock';
 export * from './lib/dotcms-config.service.mock';
 export * from './lib/dotcms-contentlet.mock';
 export * from './lib/dotcms-events-service.mock';
-export * from './lib/field-util';
 export * from './lib/field-variable-service.mock';
 export * from './lib/format-date-service.mock';
 export * from './lib/login-service.mock';

--- a/core-web/libs/utils-testing/src/lib/dot-content-types.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-content-types.mock.ts
@@ -1,12 +1,47 @@
+import { faker } from '@faker-js/faker';
+
 import {
-    DotCMSContentTypeField,
+    DotCMSContentTypeLayoutRow,
+    ContentTypeCategoryField,
+    DotCMSDataTypes,
+    DotCMSFieldTypes,
+    DotCMSContentTypeBaseField,
+    ContentTypeHostFolderField,
+    ContentTypeTextField,
+    ContentTypeLineDividerField,
+    ContentTypeRelationshipField,
+    ContentTypeRowField,
+    ContentTypeColumnField,
+    ContentTypeRadioField,
+    ContentTypeCheckboxField,
+    ContentTypeTextAreaField,
+    ContentTypeWYSIWYGField,
+    ContentTypeDateField,
+    ContentTypeDateTimeField,
+    ContentTypeTimeField,
+    ContentTypeJSONField,
+    ContentTypeFileField,
+    ContentTypeImageField,
+    ContentTypeSelectField,
+    ContentTypeTagField,
+    DotCMSClazzes,
+    DotCMSClazz,
+    ContentTypeTabDividerField,
+    ContentTypeColumnBreakField,
     DotCMSContentType,
-    DotCMSContentTypeLayoutRow
+    ContentTypeBlockEditorField,
+    ContentTypeMultiSelectField,
+    ContentTypeBinaryField,
+    ContentTypeCustomField,
+    ContentTypeKeyValueField,
+    ContentTypeConstantField,
+    ContentTypeHiddenField,
+    DotCMSContentTypeField
 } from '@dotcms/dotcms-models';
 
-import { EMPTY_FIELD } from './field-util';
+import { EMPTY_FIELD } from '@dotcms/utils';
 
-export const dotcmsContentTypeBasicMock: DotCMSContentType = {
+export const dotcmsContentTypeBasicMock = {
     baseType: null,
     clazz: null,
     defaultType: false,
@@ -32,7 +67,7 @@ export const dotcmsContentTypeBasicMock: DotCMSContentType = {
     versionable: false,
     workflows: [],
     metadata: {}
-};
+} as unknown as DotCMSContentType;
 
 export const dotcmsContentTypeFieldBasicMock: DotCMSContentTypeField = {
     ...EMPTY_FIELD
@@ -98,3 +133,634 @@ export const fieldsBrokenWithColumns: DotCMSContentTypeLayoutRow[] = [
         ]
     }
 ];
+
+/*
+Creates a fake content type with customizable properties
+@param {Partial<DotCMSContentType>} [overrides={}] - Optional properties to override defaults
+@returns {DotCMSContentType} A complete content type object
+*/
+export function createFakeContentType(
+    overrides: Partial<DotCMSContentType> = {}
+): DotCMSContentType {
+    return {
+        baseType: faker.lorem.word(),
+        icon: faker.lorem.word(),
+        clazz: faker.helpers.arrayElement(Object.values(DotCMSClazzes)),
+        defaultType: false,
+        contentType: faker.lorem.word(),
+        description: faker.lorem.word(),
+        detailPage: faker.lorem.word(),
+        expireDateVar: faker.date.recent().toISOString(),
+        fields: [],
+        fixed: false,
+        folder: faker.lorem.word(),
+        host: faker.lorem.word(),
+        iDate: faker.date.recent().getTime(),
+        id: faker.string.uuid(),
+        layout: [],
+        modDate: faker.date.recent().getTime(),
+        multilingualable: false,
+        nEntries: faker.number.int(),
+        name: faker.lorem.word(),
+        owner: faker.lorem.word(),
+        publishDateVar: faker.date.recent().toISOString(),
+        system: false,
+        urlMapPattern: faker.lorem.word(),
+        variable: faker.lorem.word(),
+        versionable: false,
+        workflows: [],
+        workflow: [],
+        systemActionMappings: {},
+        metadata: {},
+        ...overrides
+    };
+}
+
+/**
+ * Base field object used as foundation for creating fake content type fields
+ */
+export type BaseField = Omit<
+    DotCMSContentTypeBaseField,
+    'dataType' | 'fieldType' | 'fieldTypeLabel' | 'clazz'
+>;
+
+export function createFakeBaseField(): BaseField {
+    return {
+        contentTypeId: faker.string.uuid(),
+        fieldVariables: [],
+        fixed: false,
+        iDate: faker.date.recent().getTime(),
+        id: faker.string.uuid(),
+        indexed: false,
+        listed: false,
+        modDate: faker.date.recent().getTime(),
+        name: faker.lorem.word(),
+        readOnly: false,
+        required: false,
+        searchable: false,
+        sortOrder: 0,
+        unique: false,
+        variable: faker.lorem.word(),
+        defaultValue: faker.lorem.word(),
+        hint: faker.lorem.sentence(),
+        forceIncludeInApi: false
+    };
+}
+
+/**
+ * Creates a fake category field with customizable properties
+ *
+ * @param {Partial<ContentTypeCategoryField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeCategoryField} A complete category field object
+ */
+export function createFakeCategoryField(
+    overrides: Partial<ContentTypeCategoryField> = {}
+): ContentTypeCategoryField {
+    const categoryId = faker.string.uuid();
+
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.CATEGORY,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.CATEGORY,
+        fieldTypeLabel: 'Category',
+        categories: {
+            categoryName: faker.lorem.word(),
+            description: faker.lorem.sentence(),
+            inode: categoryId,
+            key: faker.lorem.word(),
+            keywords: faker.lorem.word(),
+            sortOrder: faker.number.int()
+        },
+        values: categoryId,
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake constant field with customizable properties
+ *
+ * @param {Partial<ContentTypeConstantField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeConstantField} A complete constant field object
+ */
+export function createFakeConstantField(
+    overrides: Partial<ContentTypeConstantField> = {}
+): ContentTypeConstantField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.CONSTANT,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.CONSTANT,
+        fieldTypeLabel: 'Constant Field',
+        values: '',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake hidden field with customizable properties
+ *
+ * @param {Partial<ContentTypeHiddenField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeHiddenField} A complete hidden field object
+ */
+export function createFakeHiddenField(
+    overrides: Partial<ContentTypeHiddenField> = {}
+): ContentTypeHiddenField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.HIDDEN,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.HIDDEN,
+        fieldTypeLabel: 'Hidden Field',
+        values: '',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake host folder field with customizable properties
+ *
+ * @param {Partial<ContentTypeHostFolderField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeHostFolderField} A complete host folder field object
+ */
+export function createFakeHostFolderField(
+    overrides: Partial<ContentTypeHostFolderField> = {}
+): ContentTypeHostFolderField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.HOST_FOLDER,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.HOST_FOLDER,
+        fieldTypeLabel: 'Site or Folder',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake text field with customizable properties
+ *
+ * @param {Partial<ContentTypeTextField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeTextField} A complete text field object
+ */
+export function createFakeTextField(
+    overrides: Partial<ContentTypeTextField> = {}
+): ContentTypeTextField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.TEXT,
+        dataType: DotCMSDataTypes.TEXT,
+        fieldType: DotCMSFieldTypes.TEXT,
+        fieldTypeLabel: 'Text',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake line divider field with customizable properties
+ *
+ * @param {Partial<ContentTypeLineDividerField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeLineDividerField} A complete line divider field object
+ */
+export function createFakeLineDividerField(
+    overrides: Partial<ContentTypeLineDividerField> = {}
+): ContentTypeLineDividerField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.LINE_DIVIDER,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.LINE_DIVIDER,
+        fieldTypeLabel: 'Line Divider',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake relationship field with customizable properties
+ *
+ * @param {Partial<ContentTypeRelationshipField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeRelationshipField} A complete relationship field object
+ */
+export function createFakeRelationshipField(
+    overrides: Partial<ContentTypeRelationshipField> = {}
+): ContentTypeRelationshipField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.RELATIONSHIP,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.RELATIONSHIP,
+        fieldTypeLabel: 'Relationships Field',
+        name: 'Relationship Field',
+        relationships: {
+            cardinality: 0,
+            isParentField: true,
+            velocityVar: 'AllTypes'
+        },
+        skipRelationshipCreation: false,
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake row field with customizable properties
+ *
+ * @param {Partial<ContentTypeRowField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeRowField} A complete row field object
+ */
+export function createFakeRowField(
+    overrides: Partial<ContentTypeRowField> = {}
+): ContentTypeRowField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.ROW,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.ROW,
+        fieldTypeLabel: 'Row',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake column field with customizable properties
+ *
+ * @param {Partial<ContentTypeColumnField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeColumnField} A complete column field object
+ */
+export function createFakeColumnField(
+    overrides: Partial<ContentTypeColumnField> = {}
+): ContentTypeColumnField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.COLUMN,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.COLUMN,
+        fieldTypeLabel: 'Column',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake radio field with customizable properties
+ *
+ * @param {Partial<ContentTypeRadioField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeRadioField} A complete radio field object
+ */
+export function createFakeRadioField(
+    overrides: Partial<ContentTypeRadioField> = {}
+): ContentTypeRadioField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.RADIO,
+        dataType: DotCMSDataTypes.TEXT,
+        fieldType: DotCMSFieldTypes.RADIO,
+        fieldTypeLabel: 'Radio',
+        values: 'Yes|true\r\nNo|false',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake checkbox field with customizable properties
+ *
+ * @param {Partial<ContentTypeCheckboxField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeCheckboxField} A complete checkbox field object
+ */
+export function createFakeCheckboxField(
+    overrides: Partial<ContentTypeCheckboxField> = {}
+): ContentTypeCheckboxField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.CHECKBOX,
+        dataType: DotCMSDataTypes.TEXT,
+        fieldType: DotCMSFieldTypes.CHECKBOX,
+        fieldTypeLabel: 'Checkbox',
+        values: 'Option 1|1\r\nOption 2|2\r\nOption 3|3',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake textarea field with customizable properties
+ *
+ * @param {Partial<ContentTypeTextAreaField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeTextAreaField} A complete textarea field object
+ */
+export function createFakeTextAreaField(
+    overrides: Partial<ContentTypeTextAreaField> = {}
+): ContentTypeTextAreaField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.TEXTAREA,
+        dataType: DotCMSDataTypes.LONG_TEXT,
+        fieldType: DotCMSFieldTypes.TEXTAREA,
+        fieldTypeLabel: 'Text Area',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake WYSIWYG field with customizable properties
+ *
+ * @param {Partial<ContentTypeWYSIWYGField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeWYSIWYGField} A complete WYSIWYG field object
+ */
+export function createFakeWYSIWYGField(
+    overrides: Partial<ContentTypeWYSIWYGField> = {}
+): ContentTypeWYSIWYGField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.WYSIWYG,
+        dataType: DotCMSDataTypes.LONG_TEXT,
+        fieldType: DotCMSFieldTypes.WYSIWYG,
+        fieldTypeLabel: 'WYSIWYG',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake date field with customizable properties
+ *
+ * @param {Partial<ContentTypeDateField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeDateField} A complete date field object
+ */
+export function createFakeDateField(
+    overrides: Partial<ContentTypeDateField> = {}
+): ContentTypeDateField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.DATE,
+        dataType: DotCMSDataTypes.DATE,
+        fieldType: DotCMSFieldTypes.DATE,
+        fieldTypeLabel: 'Date',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake date-time field with customizable properties
+ *
+ * @param {Partial<ContentTypeDateTimeField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeDateTimeField} A complete date-time field object
+ */
+export function createFakeDateTimeField(
+    overrides: Partial<ContentTypeDateTimeField> = {}
+): ContentTypeDateTimeField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.DATE_AND_TIME,
+        dataType: DotCMSDataTypes.DATE,
+        fieldType: DotCMSFieldTypes.DATE_AND_TIME,
+        fieldTypeLabel: 'Date and Time',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake time field with customizable properties
+ *
+ * @param {Partial<ContentTypeTimeField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeTimeField} A complete time field object
+ */
+export function createFakeTimeField(
+    overrides: Partial<ContentTypeTimeField> = {}
+): ContentTypeTimeField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.TIME,
+        dataType: DotCMSDataTypes.DATE,
+        fieldType: DotCMSFieldTypes.TIME,
+        fieldTypeLabel: 'Time',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake JSON field with customizable properties
+ *
+ * @param {Partial<ContentTypeJSONField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeJSONField} A complete JSON field object
+ */
+export function createFakeJSONField(
+    overrides: Partial<ContentTypeJSONField> = {}
+): ContentTypeJSONField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.JSON,
+        dataType: DotCMSDataTypes.LONG_TEXT,
+        fieldType: DotCMSFieldTypes.JSON,
+        fieldTypeLabel: 'JSON',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake file field with customizable properties
+ *
+ * @param {Partial<ContentTypeFileField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeFileField} A complete file field object
+ */
+export function createFakeFileField(
+    overrides: Partial<ContentTypeFileField> = {}
+): ContentTypeFileField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.FILE,
+        dataType: DotCMSDataTypes.TEXT,
+        fieldType: DotCMSFieldTypes.FILE,
+        fieldTypeLabel: 'File',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake image field with customizable properties
+ *
+ * @param {Partial<ContentTypeImageField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeImageField} A complete image field object
+ */
+export function createFakeImageField(
+    overrides: Partial<ContentTypeImageField> = {}
+): ContentTypeImageField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.IMAGE,
+        dataType: DotCMSDataTypes.TEXT,
+        fieldType: DotCMSFieldTypes.IMAGE,
+        fieldTypeLabel: 'Image',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake select field with customizable properties
+ *
+ * @param {Partial<ContentTypeSelectField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeSelectField} A complete select field object
+ */
+export function createFakeSelectField(
+    overrides: Partial<ContentTypeSelectField> = {}
+): ContentTypeSelectField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.SELECT,
+        dataType: DotCMSDataTypes.TEXT,
+        fieldType: DotCMSFieldTypes.SELECT,
+        fieldTypeLabel: 'Select',
+        values: 'Option A|a\r\nOption B|b\r\nOption C|c',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake tag field with customizable properties
+ *
+ * @param {Partial<ContentTypeTagField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeTagField} A complete tag field object
+ */
+export function createFakeTagField(
+    overrides: Partial<ContentTypeTagField> = {}
+): ContentTypeTagField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.TAG,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.TAG,
+        fieldTypeLabel: 'Tag',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake tab divider field with customizable properties
+ *
+ * @param {Partial<ContentTypeTabDividerField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeTabDividerField} A complete tab divider field object
+ */
+export function createFakeTabDividerField(
+    overrides: Partial<ContentTypeTabDividerField> = {}
+): ContentTypeTabDividerField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.TAB_DIVIDER,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.TAB_DIVIDER,
+        fieldTypeLabel: 'Tab Divider',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake block editor field with customizable properties
+ *
+ * @param {Partial<ContentTypeBlockEditorField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeBlockEditorField} A complete block editor field object
+ */
+export function createFakeBlockEditorField(
+    overrides: Partial<ContentTypeBlockEditorField> = {}
+): ContentTypeBlockEditorField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.BLOCK_EDITOR,
+        dataType: DotCMSDataTypes.LONG_TEXT,
+        fieldType: DotCMSFieldTypes.BLOCK_EDITOR,
+        fieldTypeLabel: 'Block Editor',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake column break field with customizable properties
+ *
+ * @param {Partial<ContentTypeColumnBreakField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeColumnBreakField} A complete column break field object
+ */
+export function createFakeColumnBreakField(
+    overrides: Partial<ContentTypeColumnBreakField> = {}
+): ContentTypeColumnBreakField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.COLUMN_BREAK,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.COLUMN_BREAK,
+        fieldTypeLabel: 'Column Break',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake multi-select field with customizable properties
+ *
+ * @param {Partial<ContentTypeMultiSelectField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeMultiSelectField} A complete multi-select field object
+ */
+export function createFakeMultiSelectField(
+    overrides: Partial<ContentTypeMultiSelectField> = {}
+): ContentTypeMultiSelectField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.MULTI_SELECT,
+        dataType: DotCMSDataTypes.LONG_TEXT,
+        fieldType: DotCMSFieldTypes.MULTI_SELECT,
+        fieldTypeLabel: 'Multi Select',
+        values: 'Option A|a\r\nOption B|b\r\nOption C|c',
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake binary field with customizable properties
+ *
+ * @param {Partial<ContentTypeBinaryField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeBinaryField} A complete binary field object
+ */
+export function createFakeBinaryField(
+    overrides: Partial<ContentTypeBinaryField> = {}
+): ContentTypeBinaryField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.BINARY,
+        dataType: DotCMSDataTypes.SYSTEM,
+        fieldType: DotCMSFieldTypes.BINARY,
+        fieldTypeLabel: 'Binary Field',
+        fieldVariables: [],
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake custom field with customizable properties
+ *
+ * @param {Partial<ContentTypeCustomField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeCustomField} A complete custom field object
+ */
+export function createFakeCustomField(
+    overrides: Partial<ContentTypeCustomField> = {}
+): ContentTypeCustomField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.CUSTOM_FIELD,
+        dataType: DotCMSDataTypes.LONG_TEXT,
+        fieldType: DotCMSFieldTypes.CUSTOM_FIELD,
+        fieldTypeLabel: 'Custom Field',
+        values: faker.lorem.sentence(),
+        ...overrides
+    };
+}
+
+/**
+ * Creates a fake key/value field with customizable properties
+ *
+ * @param {Partial<ContentTypeKeyValueField>} [overrides={}] - Optional properties to override defaults
+ * @returns {ContentTypeKeyValueField} A complete key/value field object
+ */
+export function createFakeKeyValueField(
+    overrides: Partial<ContentTypeKeyValueField> = {}
+): ContentTypeKeyValueField {
+    return {
+        ...createFakeBaseField(),
+        clazz: DotCMSClazzes.KEY_VALUE,
+        dataType: DotCMSDataTypes.LONG_TEXT,
+        fieldType: DotCMSFieldTypes.KEY_VALUE,
+        fieldTypeLabel: 'Key/Value Field',
+        ...overrides
+    };
+}

--- a/core-web/libs/utils/src/index.ts
+++ b/core-web/libs/utils/src/index.ts
@@ -4,3 +4,4 @@ export * from './lib/services/dot-loading-indicator.service';
 
 export * from './lib/shared/const';
 export * from './lib/shared/lodash/functions';
+export * from './lib/shared/FieldUtil';

--- a/core-web/libs/utils/src/lib/shared/FieldUtil.ts
+++ b/core-web/libs/utils/src/lib/shared/FieldUtil.ts
@@ -1,10 +1,8 @@
-import { faker } from '@faker-js/faker';
-
 import {
+    DotCMSClazzes,
     DotCMSContentTypeField,
-    DotCMSContentTypeLayoutRow,
     DotCMSContentTypeLayoutColumn,
-    DotCMSClazzes
+    DotCMSContentTypeLayoutRow
 } from '@dotcms/dotcms-models';
 
 export const EMPTY_FIELD: DotCMSContentTypeField = {
@@ -52,190 +50,6 @@ const COLUMN_BREAK_FIELD = {
     clazz: DotCMSClazzes.COLUMN_BREAK,
     name: 'Column'
 };
-
-/**
- * Create a fake category field with the given overrides
- *
- * @export
- * @param {Partial<DotCMSContentTypeField>} [overrides={}]
- * @return {*}  {DotCMSContentTypeField}
- */
-export function createFakeCategoryField(
-    overrides: Partial<DotCMSContentTypeField> = {}
-): DotCMSContentTypeField {
-    return {
-        id: faker.string.uuid(),
-        clazz: 'com.dotcms.contenttype.model.field.ImmutableCategoryField',
-        contentTypeId: faker.string.uuid(),
-        dataType: 'TEXT',
-        fieldType: 'Category',
-        fieldTypeLabel: 'Category',
-        fieldVariables: [],
-        fixed: faker.datatype.boolean(),
-        hint: faker.lorem.sentence(),
-        iDate: faker.date.recent().getTime(),
-        indexed: faker.datatype.boolean(),
-        listed: faker.datatype.boolean(),
-        modDate: faker.date.recent().getTime(),
-        name: faker.lorem.word(),
-        readOnly: faker.datatype.boolean(),
-        required: faker.datatype.boolean(),
-        searchable: faker.datatype.boolean(),
-        sortOrder: faker.number.int(),
-        unique: faker.datatype.boolean(),
-        values: faker.lorem.sentence(),
-        variable: faker.lorem.word(),
-        ...overrides
-    };
-}
-
-/**
- * Create a fake host folder field with the given overrides
- *
- * @export
- * @param {Partial<DotCMSContentTypeField>} [overrides={}]
- * @return {*}  {DotCMSContentTypeField}
- */
-export function createFakeHostFolderField(
-    overrides: Partial<DotCMSContentTypeField> = {}
-): DotCMSContentTypeField {
-    return {
-        id: faker.string.uuid(),
-        clazz: 'com.dotcms.contenttype.model.field.ImmutableHostFolderField',
-        contentTypeId: faker.string.uuid(),
-        dataType: 'SYSTEM',
-        fieldType: 'Host-Folder',
-        fieldTypeLabel: 'Site or Folder',
-        fieldVariables: [],
-        fixed: faker.datatype.boolean(),
-        hint: faker.lorem.sentence(),
-        forceIncludeInApi: faker.datatype.boolean(),
-        iDate: faker.date.recent().getTime(),
-        indexed: faker.datatype.boolean(),
-        listed: faker.datatype.boolean(),
-        modDate: faker.date.recent().getTime(),
-        name: faker.lorem.word(),
-        readOnly: faker.datatype.boolean(),
-        required: faker.datatype.boolean(),
-        searchable: faker.datatype.boolean(),
-        sortOrder: faker.number.int(),
-        unique: faker.datatype.boolean(),
-        variable: faker.lorem.word(),
-        ...overrides
-    };
-}
-
-/**
- * Create a fake text field with the given overrides
- *
- * @export
- * @param {Partial<DotCMSContentTypeField>} [overrides={}]
- * @return {*}  {DotCMSContentTypeField}
- */
-export function createFakeTextField(
-    overrides: Partial<DotCMSContentTypeField> = {}
-): DotCMSContentTypeField {
-    return {
-        clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
-        contentTypeId: faker.string.uuid(),
-        dataType: 'TEXT',
-        fieldType: 'Text',
-        fieldTypeLabel: 'Text',
-        fieldVariables: [],
-        fixed: faker.datatype.boolean(),
-        hint: faker.lorem.sentence(),
-        iDate: faker.date.recent().getTime(),
-        id: faker.string.uuid(),
-        indexed: faker.datatype.boolean(),
-        listed: faker.datatype.boolean(),
-        modDate: faker.date.recent().getTime(),
-        name: faker.lorem.word(),
-        readOnly: faker.datatype.boolean(),
-        required: faker.datatype.boolean(),
-        searchable: faker.datatype.boolean(),
-        sortOrder: faker.number.int(),
-        unique: faker.datatype.boolean(),
-        variable: faker.lorem.word(),
-        ...overrides
-    };
-}
-
-/**
- * Create a fake line divider field with the given overrides
- *
- * @export
- * @param {Partial<DotCMSContentTypeField>} [overrides={}]
- * @return {*}  {DotCMSContentTypeField}
- */
-export function createFakeLineDividerField(
-    overrides: Partial<DotCMSContentTypeField> = {}
-): DotCMSContentTypeField {
-    return {
-        clazz: 'com.dotcms.contenttype.model.field.ImmutableLineDividerField',
-        contentTypeId: '799f176a-d32e-4844-a07c-1b5fcd107578',
-        dataType: 'SYSTEM',
-        fieldType: 'Line_divider',
-        fieldTypeLabel: 'Line Divider',
-        fieldVariables: [],
-        fixed: false,
-        forceIncludeInApi: faker.datatype.boolean(),
-        iDate: faker.date.recent().getTime(),
-        id: faker.string.uuid(),
-        indexed: faker.datatype.boolean(),
-        listed: faker.datatype.boolean(),
-        modDate: faker.date.recent().getTime(),
-        name: faker.lorem.word(),
-        readOnly: faker.datatype.boolean(),
-        required: faker.datatype.boolean(),
-        searchable: faker.datatype.boolean(),
-        sortOrder: faker.number.int(),
-        unique: faker.datatype.boolean(),
-        variable: faker.lorem.word(),
-        ...overrides
-    };
-}
-
-/**
- * Create a fake relationship field with the given overrides
- *
- * @export
- * @param {Partial<DotCMSContentTypeField>} [overrides={}]
- * @return {*}  {DotCMSContentTypeField}
- */
-export function createFakeRelationshipField(
-    overrides: Partial<DotCMSContentTypeField> = {}
-): DotCMSContentTypeField {
-    return {
-        clazz: 'com.dotcms.contenttype.model.field.ImmutableRelationshipField',
-        contentTypeId: faker.string.uuid(),
-        dataType: 'SYSTEM',
-        fieldType: 'Relationship',
-        fieldTypeLabel: 'Relationships Field',
-        fieldVariables: [],
-        fixed: faker.datatype.boolean(),
-        forceIncludeInApi: faker.datatype.boolean(),
-        iDate: faker.date.recent().getTime(),
-        id: faker.string.uuid(),
-        indexed: faker.datatype.boolean(),
-        listed: faker.datatype.boolean(),
-        modDate: faker.date.recent().getTime(),
-        name: 'Relationship Field',
-        readOnly: false,
-        relationships: {
-            cardinality: 0,
-            isParentField: true,
-            velocityVar: 'AllTypes'
-        },
-        required: false,
-        searchable: false,
-        skipRelationshipCreation: false,
-        sortOrder: 6,
-        unique: false,
-        variable: 'relationshipField',
-        hint: 'Helper label to be displayed below the field',
-        ...overrides
-    };
-}
 
 export class FieldUtil {
     /**
@@ -456,7 +270,7 @@ export class FieldUtil {
      * @memberof FieldUtil
      */
     static isColumnBreak(clazz: string): boolean {
-        return clazz === COLUMN_BREAK_FIELD.clazz;
+        return clazz === DotCMSClazzes.COLUMN_BREAK;
     }
 
     static createColumnBreak(): { clazz: string; name: string } {


### PR DESCRIPTION
### Proposed Changes

This pull request refactors the usage and location of the `FieldUtil` utility and related test helpers across the codebase. The main goal is to move `FieldUtil` from the testing utilities into the main utilities library, ensuring consistent usage in both production and test code. Additionally, some test helpers are updated to use more specific field creators, and minor code cleanups are performed.

Key changes include:

**Refactoring and relocation of FieldUtil:**

* Moved `FieldUtil` from `@dotcms/utils-testing` to `@dotcms/utils`, updating all imports across the codebase to use the new location. This affects multiple components, services, and test files related to content type fields. [[1]](diffhunk://#diff-68265dbaa48f0d088fb144f7cd1d3bdf5de62807350ff08098becc2086c909bdL1-R5) [[2]](diffhunk://#diff-eed6eb3b744d97d82e3e08ddbe4d1caa3d2638239b5637b2b89eef8cc5e5349aR7) [[3]](diffhunk://#diff-9ab5f7453058fb177f148e614b6ad8e8864543f824713a0d24ab570c12d737f1L41) [[4]](diffhunk://#diff-1eb2ec9164ddd81069ea68f09a2101536b6fa645ac5541bbda106ce4594921d2L1-R1) [[5]](diffhunk://#diff-f84382de3a3f4b0acad278da4d85bd63c44fa77a221a647e116e6757e795895dL6-R6) [[6]](diffhunk://#diff-071c449a7eb3a0aec4deb1488aa21e344fa74755d4923842f82bdda2b98fee8aL5-R5) [[7]](diffhunk://#diff-613673a154d00a52abad3ef967e298ddb3fb36304a5e1c0537cb2a0b14445950L10-R10) [[8]](diffhunk://#diff-f0119127a051b02bbf50323b94f33be9e6203fd63e6907a3be68166fdd27953eL11-R12) [[9]](diffhunk://#diff-c699a0270b0ddb9f06480224ce811b1bc47335d275fe9ffa9c3da396c065e400L37-R37) [[10]](diffhunk://#diff-d3c22cf0ac2d57f6d02b13c6120b253c92d8c8f5a3948dfe8e19a29d61f1fb2aL17-R18) [[11]](diffhunk://#diff-c4c77fba3abe168b6fcc536e786ae05dc32bc3f04bd31a2effecc79decab5fb2L51-L59) [[12]](diffhunk://#diff-b1988fdbb798b95d236e7d8fe4d0225c7ae7d153a4490f8a7eb2a7cb197be6d9R24-R31)

* Updated the implementation of `FieldUtil.isColumnBreak` usage to directly compare with `DotCMSClazzes.COLUMN_BREAK` instead of calling the method, simplifying the logic.

**Test helper improvements:**

* Replaced generic `createFakeTextField` calls in calendar field tests with more specific helpers (`createFakeDateField`, `createFakeDateTimeField`, `createFakeTimeField`) for better clarity and accuracy in test cases. (Fd7ae35aL1, [[1]](diffhunk://#diff-35a422266bdff3888f61420da49b048cd4bca48cd1303e85ffeee171839162f3L511-R517) [[2]](diffhunk://#diff-35a422266bdff3888f61420da49b048cd4bca48cd1303e85ffeee171839162f3L534-R539) [[3]](diffhunk://#diff-35a422266bdff3888f61420da49b048cd4bca48cd1303e85ffeee171839162f3L553-R557) [[4]](diffhunk://#diff-35a422266bdff3888f61420da49b048cd4bca48cd1303e85ffeee171839162f3L580-R581) [[5]](diffhunk://#diff-35a422266bdff3888f61420da49b048cd4bca48cd1303e85ffeee171839162f3L613-R615)

**Other code cleanups:**

* Removed unused imports (e.g., `faker`) from component files and replaced random number generation with standard JavaScript functions where appropriate. [[1]](diffhunk://#diff-b6e7f5a1ad7c221178b3ddf3f3dfc06021ba87b4e18ef9d7f6c6c9a6eab016d3L1-L2) [[2]](diffhunk://#diff-b6e7f5a1ad7c221178b3ddf3f3dfc06021ba87b4e18ef9d7f6c6c9a6eab016d3L111-R109)
* Moved the definition of `EMPTY_ROWS_VALUE` from a mock file into the main gridstack utilities file for better accessibility and maintainability. [[1]](diffhunk://#diff-f3792a46b295fb618b6d4a8d8f4ecef72ec5e3c41a470d6a44886881a6b93659L5-L6) [[2]](diffhunk://#diff-f3792a46b295fb618b6d4a8d8f4ecef72ec5e3c41a470d6a44886881a6b93659R17-R44)
* Fixed import of `EMPTY_FIELD` in test files to use the main utilities package.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
![Uploading share.png…]()



This PR fixes: #32952

This PR fixes: #32952