### PR TITLE
fix(CD): Pagination Highlight Incorrect After Clearing Search

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -12,7 +12,7 @@
     (selectionChange)="onSelectionChange()"
     (onPage)="onPage($event)"
     (onSort)="onSort($event)"
-    [first]="$first()"
+    [first]="$currentPageFirstRowIndex()"
     dataKey="identifier"
     sortMode="single"
     selectionMode="multiple"

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -12,6 +12,7 @@
     (selectionChange)="onSelectionChange()"
     (onPage)="onPage($event)"
     (onSort)="onSort($event)"
+    [first]="$first()"
     dataKey="identifier"
     sortMode="single"
     selectionMode="multiple"

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.spec.ts
@@ -147,6 +147,36 @@ describe('DotFolderListViewComponent', () => {
             const tableDebugEl = spectator.debugElement.query(By.css('[data-testId="table"]'));
             expect(tableDebugEl.attributes['ng-reflect-paginator']).toBe('false');
         });
+
+        it('should set first value when calling onPage', () => {
+            spectator.setInput('totalItems', 50); // Enable pagination
+            spectator.detectChanges();
+
+            const mockEvent = { first: 20, rows: 20 };
+            spectator.component.onPage(mockEvent);
+            spectator.detectChanges();
+
+            const tableDebugEl = spectator.debugElement.query(By.css('[data-testId="table"]'));
+            expect(tableDebugEl.attributes['ng-reflect-first']).toBe('20');
+        });
+
+        it('should reset first to 0 when showPagination becomes true', () => {
+            // Start with no pagination (totalItems <= MIN_ROWS_PER_PAGE)
+            spectator.setInput('totalItems', 15);
+            spectator.detectChanges();
+
+            // Set first to some value
+            const mockEvent = { first: 20, rows: 20 };
+            spectator.component.onPage(mockEvent);
+            spectator.detectChanges();
+
+            // Now enable pagination by setting totalItems > MIN_ROWS_PER_PAGE
+            spectator.setInput('totalItems', 50);
+            spectator.detectChanges();
+
+            const tableDebugEl = spectator.debugElement.query(By.css('[data-testId="table"]'));
+            expect(tableDebugEl.attributes['ng-reflect-first']).toBe('0');
+        });
     });
 
     describe('Loading', () => {

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
@@ -55,16 +55,20 @@ export class DotFolderListViewComponent {
         this.$items().length === 0 ? 'dotTable empty-table' : 'dotTable'
     );
 
-    protected readonly $first = signal<number>(0);
+    /**
+     * Index of the first row to be displayed in the current page.
+     * Used by PrimeNG Table for pagination state management.
+     */
+    protected readonly $currentPageFirstRowIndex = signal<number>(0);
     protected readonly firstEffect = effect(() => {
         const showPagination = this.$showPagination();
         if (showPagination) {
-            this.$first.set(0);
+            this.$currentPageFirstRowIndex.set(0);
         }
     });
 
     onPage(event: LazyLoadEvent) {
-        this.$first.set(event.first);
+        this.$currentPageFirstRowIndex.set(event.first);
         this.paginate.emit(event);
     }
 

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.ts
@@ -3,8 +3,10 @@ import {
     Component,
     computed,
     CUSTOM_ELEMENTS_SCHEMA,
+    effect,
     input,
-    output
+    output,
+    signal
 } from '@angular/core';
 
 import { LazyLoadEvent, SortEvent } from 'primeng/api';
@@ -41,6 +43,7 @@ export class DotFolderListViewComponent {
     paginate = output<LazyLoadEvent>();
     sort = output<SortEvent>();
 
+    selectedItems: DotContentDriveItem[] = [];
     readonly MIN_ROWS_PER_PAGE = 20;
     protected readonly rowsPerPageOptions = [this.MIN_ROWS_PER_PAGE, 40, 60];
     protected readonly HEADER_COLUMNS = HEADER_COLUMNS;
@@ -52,10 +55,16 @@ export class DotFolderListViewComponent {
         this.$items().length === 0 ? 'dotTable empty-table' : 'dotTable'
     );
 
-    // Model for the table selection
-    selectedItems: DotContentDriveItem[] = [];
+    protected readonly $first = signal<number>(0);
+    protected readonly firstEffect = effect(() => {
+        const showPagination = this.$showPagination();
+        if (showPagination) {
+            this.$first.set(0);
+        }
+    });
 
     onPage(event: LazyLoadEvent) {
+        this.$first.set(event.first);
         this.paginate.emit(event);
     }
 


### PR DESCRIPTION
**Summary**

Fixes pagination highlight inconsistency in Content Drive when clearing search filters. When users navigated to a page other than page 1 and then cleared a search filter, the pagination highlight remained on the previously selected page while content reset to page 1.

**Problem**

  - User navigates to page 5 in Content Drive
  - User performs a search query
  - User clears the search filter
  - Bug: Pagination still highlights page 5, but content shows page 1 results
  - Expected: Both content and pagination should reset to page 1

 **Solution**

**Implementation Changes**

  1. Added $first signal: Tracks the current pagination starting index for proper
  highlight management
  2. Added firstEffect: Automatically resets pagination to page 1 (first: 0) when
  showPagination becomes true (i.e., when search is cleared and results exceed
  minimum rows)
  3. Enhanced onPage method: Updates the $first signal to maintain accurate
  pagination state
  4. Template binding: Added [first]="$first()" to the p-table component to reflect
  the correct highlighted page

**Key Files Modified**

  - dot-folder-list-view.component.ts - Added pagination state management with
  Angular signals
  - dot-folder-list-view.component.html - Bound first property to maintain highlight
  consistency
  - dot-folder-list-view.component.spec.ts - Added comprehensive test coverage for
  pagination behavior

**Test Plan**

  - Navigate to page 5, search, clear search → pagination resets to page 1
  - Pagination highlight matches displayed content page
  - Works across different page numbers
  - Added unit tests covering pagination state management
  - Added test for first value reset when pagination is re-enabled

**Test Coverage**

Added tests to verify:
  - onPage method properly updates the first value
  - Pagination resets to 0 when showPagination becomes true
  - Template correctly reflects pagination state

### Video

https://github.com/user-attachments/assets/2039f0a9-0b42-479f-b84b-5bbbd2c480d4

  
This PR fixes: #33033

This PR fixes: #33033