### PR TITLE
chore(cicd): Added workflow and updated the sdk publish action

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -3,9 +3,8 @@
 # DUAL PUBLISHING BEHAVIOR:
 # LATEST TAG:
 # - If current version contains "alpha" or "beta" -> publishes 1.0.0
-# - If stable version exists -> only publishes on explicit version-type (minor/major/custom)
-# - Patch versions -> skips latest publishing (only publishes to next)
-# - Auto mode with stable version -> skips latest publishing
+# - If stable version exists -> publishes on explicit version-type (patch/minor/major/custom)
+# - Auto mode with stable version -> skips latest publishing (no version change)
 #
 # NEXT TAG:
 # - Always publishes with "-next.X" suffix where X increments
@@ -350,10 +349,6 @@ runs:
         if [ "$CURRENT_VERSION" = "$NEXT_VERSION" ] && [ "$VERSION_TYPE_USED" = "auto-no-increment" ]; then
           echo "🚫 No version change detected for latest tag (${CURRENT_VERSION} → ${NEXT_VERSION})"
           echo "   Skipping latest publishing since version-type is 'auto' and no increment is needed."
-          SHOULD_PUBLISH_LATEST="false"
-        elif [ "$VERSION_TYPE_USED" = "patch" ]; then
-          echo "🚫 Patch version detected (${CURRENT_VERSION} → ${NEXT_VERSION})"
-          echo "   Skipping latest publishing for patch versions - only publishing to next tag."
           SHOULD_PUBLISH_LATEST="false"
         else
           echo "✅ Version will be updated for latest tag (${CURRENT_VERSION} → ${NEXT_VERSION})"

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -3,7 +3,8 @@
 # DUAL PUBLISHING BEHAVIOR:
 # LATEST TAG:
 # - If current version contains "alpha" or "beta" -> publishes 1.0.0
-# - If stable version exists -> only publishes on explicit version-type (patch/minor/major/custom)
+# - If stable version exists -> only publishes on explicit version-type (minor/major/custom)
+# - Patch versions -> skips latest publishing (only publishes to next)
 # - Auto mode with stable version -> skips latest publishing
 #
 # NEXT TAG:
@@ -349,6 +350,10 @@ runs:
         if [ "$CURRENT_VERSION" = "$NEXT_VERSION" ] && [ "$VERSION_TYPE_USED" = "auto-no-increment" ]; then
           echo "🚫 No version change detected for latest tag (${CURRENT_VERSION} → ${NEXT_VERSION})"
           echo "   Skipping latest publishing since version-type is 'auto' and no increment is needed."
+          SHOULD_PUBLISH_LATEST="false"
+        elif [ "$VERSION_TYPE_USED" = "patch" ]; then
+          echo "🚫 Patch version detected (${CURRENT_VERSION} → ${NEXT_VERSION})"
+          echo "   Skipping latest publishing for patch versions - only publishing to next tag."
           SHOULD_PUBLISH_LATEST="false"
         else
           echo "✅ Version will be updated for latest tag (${CURRENT_VERSION} → ${NEXT_VERSION})"

--- a/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-javascript-sdk/action.yml
@@ -127,6 +127,9 @@ runs:
       if: ${{ inputs.version-type == 'custom' }}
       env:
         CUSTOM_VERSION: ${{ inputs.custom-version }}
+        CURRENT_STABLE: ${{ steps.current_version.outputs.current_stable }}
+        CURRENT_BETA: ${{ steps.current_version.outputs.current_beta }}
+        CURRENT_NEXT: ${{ steps.current_version.outputs.current_next }}
       run: |
         echo "::group::Validate custom version"
         
@@ -140,10 +143,52 @@ runs:
         if [[ ! "$CUSTOM_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           echo "::error::Invalid custom version format: '$CUSTOM_VERSION'"
           echo "Version must follow semantic versioning format: major.minor.patch (e.g., 1.3.4)"
+          echo "Examples of valid versions: 1.0.0, 2.1.3, 10.15.7"
           exit 1
         fi
         
-        echo "✅ Custom version '$CUSTOM_VERSION' is valid"
+        # Check if custom version already exists in NPM
+        echo "Checking if version $CUSTOM_VERSION already exists in NPM..."
+        
+        # Compare against current stable version
+        if [ -n "$CURRENT_STABLE" ] && [ "$CURRENT_STABLE" != "null" ] && [ "$CURRENT_STABLE" = "$CUSTOM_VERSION" ]; then
+          echo "::error::Custom version $CUSTOM_VERSION already exists as the current stable (latest) version"
+          echo "Please choose a different version number that hasn't been published yet"
+          echo "Current stable version: $CURRENT_STABLE"
+          exit 1
+        fi
+        
+        # Compare against current beta version
+        if [ -n "$CURRENT_BETA" ] && [ "$CURRENT_BETA" != "null" ] && [ "$CURRENT_BETA" = "$CUSTOM_VERSION" ]; then
+          echo "::error::Custom version $CUSTOM_VERSION already exists as the current beta version"
+          echo "Please choose a different version number that hasn't been published yet"
+          echo "Current beta version: $CURRENT_BETA"
+          exit 1
+        fi
+        
+        # Compare against current next version (extract base version)
+        if [ -n "$CURRENT_NEXT" ] && [ "$CURRENT_NEXT" != "null" ]; then
+          CURRENT_NEXT_BASE=$(echo "$CURRENT_NEXT" | sed 's/-next\.[0-9]*$//')
+          if [ "$CURRENT_NEXT_BASE" = "$CUSTOM_VERSION" ]; then
+            echo "::error::Custom version $CUSTOM_VERSION already exists as the base version for current next tag"
+            echo "Please choose a different version number that hasn't been published yet"
+            echo "Current next version: $CURRENT_NEXT (base: $CURRENT_NEXT_BASE)"
+            exit 1
+          fi
+        fi
+        
+        # Additional check: Query NPM directly to see if this exact version exists
+        echo "Performing direct NPM registry check for version $CUSTOM_VERSION..."
+        if npm view @dotcms/client@$CUSTOM_VERSION version >/dev/null 2>&1; then
+          echo "::error::Custom version $CUSTOM_VERSION already exists in NPM registry"
+          echo "Please choose a different version number that hasn't been published yet"
+          echo "You can check existing versions with: npm view @dotcms/client versions --json"
+          exit 1
+        fi
+        
+        echo "✅ Custom version '$CUSTOM_VERSION' is valid and unique"
+        echo "✅ Semantic version format check: PASSED"
+        echo "✅ NPM registry uniqueness check: PASSED"
         echo "::endgroup::"
       shell: bash
 

--- a/.github/workflows/cicd_manual-release-sdks.yml
+++ b/.github/workflows/cicd_manual-release-sdks.yml
@@ -1,0 +1,85 @@
+name: 'Manual SDK Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version-type:
+        description: 'Version increment type'
+        required: true
+        type: choice
+        options:
+          - 'patch'
+          - 'minor'
+          - 'major'
+          - 'custom'
+        default: 'patch'
+      custom-version:
+        description: 'Custom version (e.g., 1.3.4, 2.1.0) - only used when version-type is "custom"'
+        required: false
+        type: string
+        default: ''
+      ref:
+        description: 'Branch to build from'
+        required: false
+        type: string
+        default: 'main'
+
+jobs:
+  release-sdks:
+    name: 'Release SDK Packages'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Validate inputs'
+        run: |
+          echo "::group::Input validation"
+          echo "Version type: ${{ inputs.version-type }}"
+          echo "Custom version: ${{ inputs.custom-version }}"
+          echo "Branch: ${{ inputs.ref }}"
+          
+          # Validate that custom-version is provided when version-type is custom
+          if [ "${{ inputs.version-type }}" = "custom" ]; then
+            if [ -z "${{ inputs.custom-version }}" ]; then
+              echo "::error::Custom version must be provided when version-type is 'custom'"
+              echo "Please provide a valid semantic version (e.g., 1.3.4, 2.0.0, 1.2.1)"
+              exit 1
+            fi
+            
+            # Basic semver validation
+            if [[ ! "${{ inputs.custom-version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid custom version format: '${{ inputs.custom-version }}'"
+              echo "Version must follow semantic versioning format: major.minor.patch (e.g., 1.3.4)"
+              exit 1
+            fi
+            
+            echo "✅ Custom version '${{ inputs.custom-version }}' is valid"
+          fi
+          echo "::endgroup::"
+
+      - name: 'Deploy JavaScript SDK'
+        id: deploy-javascript-sdk
+        uses: ./.github/actions/core-cicd/deployment/deploy-javascript-sdk
+        with:
+          ref: ${{ inputs.ref }}
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          npm-package-tag: 'latest'
+          version-type: ${{ inputs.version-type }}
+          custom-version: ${{ inputs.custom-version }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Display results'
+        if: always()
+        run: |
+          echo "::group::Release Summary"
+          echo "Version type used: ${{ steps.deploy-javascript-sdk.outputs.version-type-used || inputs.version-type }}"
+          echo "Published to latest: ${{ steps.deploy-javascript-sdk.outputs.published-latest || 'unknown' }}"
+          echo "Published to next: ${{ steps.deploy-javascript-sdk.outputs.published-next || 'unknown' }}"
+          echo "NPM package version: ${{ steps.deploy-javascript-sdk.outputs.npm-package-version || 'unknown' }}"
+          echo "Next version: ${{ steps.deploy-javascript-sdk.outputs.npm-package-version-next || 'unknown' }}"
+          echo "::endgroup::"


### PR DESCRIPTION
This PR introduce the new workflow to manually execute the upgrate to patch, minor, major and custom version of our sdks.
You can check the tests here: https://github.com/dotCMS/core-workflow-test/actions/workflows/cicd_manual-release-sdks.yml


This PR fixes: #32597

This PR fixes: #32597