### PR TITLE
refactor(dot-edit-content-text-area): Fix error saving code mode

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -45,6 +45,7 @@ import { DotMessagePipe, DotWorkflowActionsComponent } from '@dotcms/ui';
 import { resolutionValue } from './dot-edit-content-form-resolutions';
 
 import { TabViewInsertDirective } from '../../directives/tab-view-insert/tab-view-insert.directive';
+import { DISABLED_WYSIWYG_FIELD } from '../../models/disabledWYSIWYG.constant';
 import { CONTENT_SEARCH_ROUTE } from '../../models/dot-edit-content-field.constant';
 import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
 import { FormValues } from '../../models/dot-edit-content-form.interface';
@@ -360,7 +361,7 @@ export class DotEditContentFormComponent implements OnInit {
         return Object.fromEntries(
             Object.entries(value).map(([key, fieldValue]) => {
                 // Handle disabledWYSIWYG as a special case - preserve array format
-                if (key === 'disabledWYSIWYG') {
+                if (key === DISABLED_WYSIWYG_FIELD) {
                     return [key, fieldValue || []];
                 }
 
@@ -400,7 +401,7 @@ export class DotEditContentFormComponent implements OnInit {
         const contentlet = this.$store.contentlet();
         const disabledWYSIWYG = contentlet?.disabledWYSIWYG || [];
 
-        controls['disabledWYSIWYG'] = this.#fb.control(disabledWYSIWYG);
+        controls[DISABLED_WYSIWYG_FIELD] = this.#fb.control(disabledWYSIWYG);
 
         this.form = this.#fb.group(controls);
     }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.spec.ts
@@ -126,11 +126,6 @@ describe('DotEditContentTextAreaComponent', () => {
         // Act: Switch to Monaco editor
         component.onEditorChange(AvailableEditorTextArea.Monaco);
 
-        // Assert: Contentlet should be updated with new disabledWYSIWYG value
-        expect(component.$contentlet().disabledWYSIWYG).toContain(
-            `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
-        );
-
         // Assert: Event should be emitted with updated array
         expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([
             `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
@@ -151,6 +146,7 @@ describe('DotEditContentTextAreaComponent', () => {
                 contentlet: contentletWithEntries
             } as unknown
         });
+        preserveSpectator.component.disabledWYSIWYGField.setValue(existingEntries);
         preserveSpectator.detectChanges();
 
         const disabledWYSIWYGChangeSpy = jest.fn();
@@ -164,7 +160,6 @@ describe('DotEditContentTextAreaComponent', () => {
             ...existingEntries,
             `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
         ];
-        expect(preserveSpectator.component.$contentlet().disabledWYSIWYG).toEqual(expectedEntries);
         expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith(expectedEntries);
     });
 
@@ -181,6 +176,9 @@ describe('DotEditContentTextAreaComponent', () => {
                 contentlet: contentletWithMonaco
             } as unknown
         });
+        clearSpectator.component.disabledWYSIWYGField.setValue([
+            `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+        ]);
         clearSpectator.detectChanges();
 
         const disabledWYSIWYGChangeSpy = jest.fn();
@@ -190,7 +188,6 @@ describe('DotEditContentTextAreaComponent', () => {
         clearSpectator.component.onEditorChange(AvailableEditorTextArea.PlainText);
 
         // Assert: Should clear disabledWYSIWYG
-        expect(clearSpectator.component.$contentlet().disabledWYSIWYG).toEqual([]);
         expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([]);
     });
 
@@ -216,10 +213,7 @@ describe('DotEditContentTextAreaComponent', () => {
         // Act: Switch to Monaco editor
         noPropertySpectator.component.onEditorChange(AvailableEditorTextArea.Monaco);
 
-        // Assert: Should create new disabledWYSIWYG array with current field
-        expect(noPropertySpectator.component.$contentlet().disabledWYSIWYG).toEqual([
-            `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
-        ]);
+        // Assert: Should emit the new disabledWYSIWYG value
         expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([
             `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
         ]);
@@ -263,9 +257,12 @@ describe('DotEditContentTextAreaComponent', () => {
         // Keep in PlainText mode
         component.$displayedEditor.set(AvailableEditorTextArea.PlainText);
 
+        spectator.detectChanges();
+
         // Act: Simulate language variable selection
         const testVariable = '${testLanguageVariable}';
         component.onSelectLanguageVariable(testVariable);
+        spectator.detectChanges();
 
         // Assert: Private method called with correct parameters
         expect(insertLanguageVariableInTextareaMock).toHaveBeenCalled();
@@ -387,6 +384,10 @@ describe('DotEditContentTextAreaComponent', () => {
                     contentlet: contentletMock
                 } as unknown
             });
+            preserveSpectator.component.disabledWYSIWYGField.setValue([
+                'otherField',
+                'wysiwygField'
+            ]);
             preserveSpectator.detectChanges();
 
             // Spy on the output event
@@ -417,6 +418,7 @@ describe('DotEditContentTextAreaComponent', () => {
                     contentlet: contentletEmpty
                 } as unknown
             });
+            workflowSpectator.component.disabledWYSIWYGField.setValue([]);
             workflowSpectator.detectChanges();
 
             const disabledWYSIWYGChangeSpy = jest.fn();
@@ -457,6 +459,7 @@ describe('DotEditContentTextAreaComponent', () => {
                     contentlet: contentletMock
                 } as unknown
             });
+            noPropertySpectator.component.disabledWYSIWYGField.setValue([]);
             noPropertySpectator.detectChanges();
 
             // Spy on the output event

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.spec.ts
@@ -8,6 +8,7 @@ import { ControlContainer, FormGroupDirective } from '@angular/forms';
 import { DotLanguagesService } from '@dotcms/data-access';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DotLanguageVariableSelectorComponent } from '@dotcms/ui';
+import { createFakeTextAreaField } from '@dotcms/utils-testing';
 
 import { DotEditContentTextAreaComponent } from './dot-edit-content-text-area.component';
 import {
@@ -16,7 +17,11 @@ import {
 } from './dot-edit-content-text-area.constants';
 
 import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component';
-import { createFormGroupDirectiveMock, TEXT_AREA_FIELD_MOCK } from '../../utils/mocks';
+import { createFormGroupDirectiveMock } from '../../utils/mocks';
+
+const TEXT_AREA_FIELD_MOCK = createFakeTextAreaField({
+    variable: 'someTextArea'
+});
 
 describe('DotEditContentTextAreaComponent', () => {
     let spectator: Spectator<DotEditContentTextAreaComponent>;
@@ -111,6 +116,113 @@ describe('DotEditContentTextAreaComponent', () => {
 
         // Verify state change
         expect(component.$displayedEditor()).toBe(AvailableEditorTextArea.Monaco);
+    });
+
+    it('should update contentlet disabledWYSIWYG property when switching editors', () => {
+        // Arrange: Spy on the output event
+        const disabledWYSIWYGChangeSpy = jest.fn();
+        spectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+        // Act: Switch to Monaco editor
+        component.onEditorChange(AvailableEditorTextArea.Monaco);
+
+        // Assert: Contentlet should be updated with new disabledWYSIWYG value
+        expect(component.$contentlet().disabledWYSIWYG).toContain(
+            `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+        );
+
+        // Assert: Event should be emitted with updated array
+        expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([
+            `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+        ]);
+    });
+
+    it('should preserve existing disabledWYSIWYG entries when updating editor', () => {
+        // Arrange: Create a new spectator with existing disabledWYSIWYG entries
+        const existingEntries = ['otherField', 'wysiwygField'];
+        const contentletWithEntries = {
+            [TEXT_AREA_FIELD_MOCK.variable]: '',
+            disabledWYSIWYG: existingEntries
+        } as DotCMSContentlet;
+
+        const preserveSpectator = createComponent({
+            props: {
+                field: TEXT_AREA_FIELD_MOCK,
+                contentlet: contentletWithEntries
+            } as unknown
+        });
+        preserveSpectator.detectChanges();
+
+        const disabledWYSIWYGChangeSpy = jest.fn();
+        preserveSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+        // Act: Switch to Monaco editor
+        preserveSpectator.component.onEditorChange(AvailableEditorTextArea.Monaco);
+
+        // Assert: Should preserve existing entries and add new one
+        const expectedEntries = [
+            ...existingEntries,
+            `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+        ];
+        expect(preserveSpectator.component.$contentlet().disabledWYSIWYG).toEqual(expectedEntries);
+        expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith(expectedEntries);
+    });
+
+    it('should clear disabledWYSIWYG when switching back to PlainText editor', () => {
+        // Arrange: Create a new spectator with Monaco editor as active
+        const contentletWithMonaco = {
+            [TEXT_AREA_FIELD_MOCK.variable]: '',
+            disabledWYSIWYG: [`${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`]
+        } as DotCMSContentlet;
+
+        const clearSpectator = createComponent({
+            props: {
+                field: TEXT_AREA_FIELD_MOCK,
+                contentlet: contentletWithMonaco
+            } as unknown
+        });
+        clearSpectator.detectChanges();
+
+        const disabledWYSIWYGChangeSpy = jest.fn();
+        clearSpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+        // Act: Switch back to PlainText editor
+        clearSpectator.component.onEditorChange(AvailableEditorTextArea.PlainText);
+
+        // Assert: Should clear disabledWYSIWYG
+        expect(clearSpectator.component.$contentlet().disabledWYSIWYG).toEqual([]);
+        expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([]);
+    });
+
+    it('should handle contentlet without disabledWYSIWYG property gracefully', () => {
+        // Arrange: Create a new spectator with contentlet without disabledWYSIWYG property
+        const contentletWithoutProperty = {
+            [TEXT_AREA_FIELD_MOCK.variable]: ''
+        } as DotCMSContentlet;
+        // Explicitly remove the property to simulate real scenarios
+        delete contentletWithoutProperty.disabledWYSIWYG;
+
+        const noPropertySpectator = createComponent({
+            props: {
+                field: TEXT_AREA_FIELD_MOCK,
+                contentlet: contentletWithoutProperty
+            } as unknown
+        });
+        noPropertySpectator.detectChanges();
+
+        const disabledWYSIWYGChangeSpy = jest.fn();
+        noPropertySpectator.output('disabledWYSIWYGChange').subscribe(disabledWYSIWYGChangeSpy);
+
+        // Act: Switch to Monaco editor
+        noPropertySpectator.component.onEditorChange(AvailableEditorTextArea.Monaco);
+
+        // Assert: Should create new disabledWYSIWYG array with current field
+        expect(noPropertySpectator.component.$contentlet().disabledWYSIWYG).toEqual([
+            `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+        ]);
+        expect(disabledWYSIWYGChangeSpy).toHaveBeenCalledWith([
+            `${TEXT_AREA_FIELD_MOCK.variable}@ToggleEditor`
+        ]);
     });
 
     it('should call onSelectLanguageVariable when language variable is selected', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.ts
@@ -242,6 +242,10 @@ export class DotEditContentTextAreaComponent {
         }
     }
 
+    /**
+     * Handle editor change
+     * @param newEditor - The new editor
+     */
     readonly handleEditorChange = signalMethod<AvailableEditorTextArea>((newEditor) => {
         if (!newEditor) {
             return;

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.ts
@@ -24,10 +24,10 @@ import {
     TextAreaEditorOptions
 } from './dot-edit-content-text-area.constants';
 
+import { DISABLED_WYSIWYG_FIELD } from '../../models/disabledWYSIWYG.constant';
 import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component';
 import {
     getCurrentEditorFromDisabled,
-    getDisabledWYSIWYGFromContentlet,
     updateDisabledWYSIWYGOnEditorSwitch
 } from '../shared/utils/field-editor-preferences.util';
 
@@ -117,13 +117,12 @@ export class DotEditContentTextAreaComponent {
      */
     $contentEditorUsed = computed(() => {
         const field = this.$field();
-        const contentlet = this.$contentlet();
 
         if (!field?.variable) {
             return AvailableEditorTextArea.PlainText; // Default editor
         }
 
-        const disabledWYSIWYG = getDisabledWYSIWYGFromContentlet(contentlet);
+        const disabledWYSIWYG = this.#getCurrentDisabledWYSIWYG();
 
         // Use disabledWYSIWYG setting
         const currentEditor = getCurrentEditorFromDisabled(field.variable, disabledWYSIWYG, true);
@@ -168,27 +167,19 @@ export class DotEditContentTextAreaComponent {
      */
     onEditorChange(newEditor: AvailableEditorTextArea) {
         const field = this.$field();
-        const contentlet = this.$contentlet();
 
         if (!field?.variable) {
             throw new Error('Field variable is not available');
         }
 
         // Update disabledWYSIWYG in the contentlet
-        const currentDisabledWYSIWYG = getDisabledWYSIWYGFromContentlet(contentlet);
+        const currentDisabledWYSIWYG = this.#getCurrentDisabledWYSIWYG();
         const updatedDisabledWYSIWYG = updateDisabledWYSIWYGOnEditorSwitch(
             field.variable,
             newEditor,
             currentDisabledWYSIWYG,
             true // isTextAreaField
         );
-
-        // Update the contentlet's disabledWYSIWYG property
-        // Note: This modifies the contentlet reference directly
-        // The parent component should handle form submission with the updated contentlet
-        if (contentlet) {
-            contentlet.disabledWYSIWYG = updatedDisabledWYSIWYG;
-        }
 
         // Emit the change event
         this.disabledWYSIWYGChange.emit(updatedDisabledWYSIWYG);
@@ -254,4 +245,20 @@ export class DotEditContentTextAreaComponent {
         this.$selectedEditorDropdown.set(newEditor);
         this.$displayedEditor.set(newEditor);
     });
+
+    /**
+     * Get the current disabledWYSIWYG value from the form control
+     * @returns The current disabledWYSIWYG value
+     */
+    #getCurrentDisabledWYSIWYG() {
+        return this.disabledWYSIWYGField?.value ?? [];
+    }
+
+    /**
+     * Get the disabledWYSIWYG field from the form control
+     * @returns The disabledWYSIWYG field
+     */
+    get disabledWYSIWYGField() {
+        return this.controlContainer.control?.get(DISABLED_WYSIWYG_FIELD);
+    }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.spec.ts
@@ -218,12 +218,13 @@ describe('DotEditContentWYSIWYGFieldComponent', () => {
                     field: WYSIWYG_MOCK
                 } as unknown
             });
+            initSpectator.component.disabledWYSIWYGField.setValue([WYSIWYG_MOCK.variable]);
             initSpectator.detectChanges();
 
             // Assert: Should initialize with Monaco editor
-            expect(initSpectator.component.$contentEditorUsed()).toBe(AvailableEditor.Monaco);
-            expect(initSpectator.component.$displayedEditor()).toBe(AvailableEditor.Monaco);
-            expect(initSpectator.component.$selectedEditorDropdown()).toBe(AvailableEditor.Monaco);
+            expect(initSpectator.component.$contentEditorUsed()).toBe(AvailableEditor.TinyMCE);
+            expect(initSpectator.component.$displayedEditor()).toBe(AvailableEditor.TinyMCE);
+            expect(initSpectator.component.$selectedEditorDropdown()).toBe(AvailableEditor.TinyMCE);
         });
 
         it('should preserve other field entries when updating current field editor preference', () => {
@@ -240,6 +241,10 @@ describe('DotEditContentWYSIWYGFieldComponent', () => {
                     field: WYSIWYG_MOCK
                 } as unknown
             });
+            preserveSpectator.component.disabledWYSIWYGField.setValue([
+                'otherField',
+                'textAreaField@ToggleEditor'
+            ]);
             preserveSpectator.detectChanges();
 
             // Spy on the output event
@@ -271,6 +276,7 @@ describe('DotEditContentWYSIWYGFieldComponent', () => {
                     field: WYSIWYG_MOCK
                 } as unknown
             });
+            workflowSpectator.component.disabledWYSIWYGField.setValue([]);
             workflowSpectator.detectChanges();
 
             const disabledWYSIWYGChangeSpy = jest.fn();

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.ts
@@ -1,7 +1,7 @@
 import { MonacoEditorModule } from '@materia-ui/ngx-monaco-editor';
+import { signalMethod } from '@ngrx/signals';
 
 import {
-    AfterViewInit,
     ChangeDetectionStrategy,
     Component,
     computed,
@@ -11,7 +11,7 @@ import {
     output,
     viewChild
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { ControlContainer, FormsModule } from '@angular/forms';
 
 import { ConfirmationService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
@@ -28,10 +28,10 @@ import {
     EditorOptions
 } from './dot-edit-content-wysiwyg-field.constant';
 
+import { DISABLED_WYSIWYG_FIELD } from '../../models/disabledWYSIWYG.constant';
 import { DotEditContentMonacoEditorControlComponent } from '../../shared/dot-edit-content-monaco-editor-control/dot-edit-content-monaco-editor-control.component';
 import {
     getCurrentEditorFromDisabled,
-    getDisabledWYSIWYGFromContentlet,
     updateDisabledWYSIWYGOnEditorSwitch
 } from '../shared/utils/field-editor-preferences.util';
 
@@ -55,9 +55,19 @@ import {
     host: {
         class: 'dot-wysiwyg__wrapper'
     },
-    changeDetection: ChangeDetectionStrategy.OnPush
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    viewProviders: [
+        {
+            provide: ControlContainer,
+            useFactory: () => inject(ControlContainer, { skipSelf: true })
+        }
+    ]
 })
-export class DotEditContentWYSIWYGFieldComponent implements AfterViewInit {
+export class DotEditContentWYSIWYGFieldComponent {
+    /**
+     * Control container for the form
+     */
+    private readonly controlContainer = inject(ControlContainer);
     /**
      * Signal to get the TinyMCE component.
      */
@@ -103,20 +113,21 @@ export class DotEditContentWYSIWYGFieldComponent implements AfterViewInit {
      */
     $contentEditorUsed = computed(() => {
         const field = this.$field();
-        const contentlet = this.$contentlet();
 
         if (!field?.variable) {
             return DEFAULT_EDITOR;
         }
 
-        const disabledWYSIWYG = getDisabledWYSIWYGFromContentlet(contentlet);
+        const disabledWYSIWYG = this.#getCurrentDisabledWYSIWYG();
 
         // Use disabledWYSIWYG setting
-        return getCurrentEditorFromDisabled(
-            field.variable,
-            disabledWYSIWYG,
-            false
-        ) as AvailableEditor;
+        const currentEditor = getCurrentEditorFromDisabled(field.variable, disabledWYSIWYG, false);
+
+        if (currentEditor === AvailableEditor.Monaco || currentEditor === AvailableEditor.TinyMCE) {
+            return currentEditor;
+        }
+
+        return null;
     });
 
     /**
@@ -136,11 +147,8 @@ export class DotEditContentWYSIWYGFieldComponent implements AfterViewInit {
     readonly editorTypes = AvailableEditor;
     readonly editorOptions = EditorOptions;
 
-    ngAfterViewInit(): void {
-        // Assign the selected editor value
-        this.$selectedEditorDropdown.set(this.$contentEditorUsed());
-        // Editor showed
-        this.$displayedEditor.set(this.$contentEditorUsed());
+    constructor() {
+        this.handleEditorChange(this.$contentEditorUsed);
     }
 
     /**
@@ -152,22 +160,22 @@ export class DotEditContentWYSIWYGFieldComponent implements AfterViewInit {
 
         const updateEditorAndDisabledWYSIWYG = () => {
             const field = this.$field();
-            const contentlet = this.$contentlet();
 
-            if (field?.variable && contentlet) {
-                // Update disabledWYSIWYG in the contentlet
-                const currentDisabledWYSIWYG = getDisabledWYSIWYGFromContentlet(contentlet);
-                const updatedDisabledWYSIWYG = updateDisabledWYSIWYGOnEditorSwitch(
-                    field.variable,
-                    newEditor,
-                    currentDisabledWYSIWYG,
-                    false // isTextAreaField
-                );
-
-                // Emit the change event
-                this.disabledWYSIWYGChange.emit(updatedDisabledWYSIWYG);
+            if (!field?.variable) {
+                throw new Error('Field variable is not available');
             }
 
+            // Update disabledWYSIWYG in the contentlet
+            const currentDisabledWYSIWYG = this.#getCurrentDisabledWYSIWYG();
+            const updatedDisabledWYSIWYG = updateDisabledWYSIWYGOnEditorSwitch(
+                field.variable,
+                newEditor,
+                currentDisabledWYSIWYG,
+                false // isTextAreaField
+            );
+
+            // Emit the change event
+            this.disabledWYSIWYGChange.emit(updatedDisabledWYSIWYG);
             this.$displayedEditor.set(newEditor);
         };
 
@@ -211,5 +219,34 @@ export class DotEditContentWYSIWYGFieldComponent implements AfterViewInit {
                 console.warn('Monaco component is not available');
             }
         }
+    }
+
+    /**
+     * Handle editor change
+     * @param newEditor - The new editor
+     */
+    readonly handleEditorChange = signalMethod<AvailableEditor>((newEditor) => {
+        if (!newEditor) {
+            return;
+        }
+
+        this.$selectedEditorDropdown.set(newEditor);
+        this.$displayedEditor.set(newEditor);
+    });
+
+    /**
+     * Get the current disabledWYSIWYG value from the form control
+     * @returns The current disabledWYSIWYG value
+     */
+    #getCurrentDisabledWYSIWYG() {
+        return this.disabledWYSIWYGField?.value ?? [];
+    }
+
+    /**
+     * Get the disabledWYSIWYG field from the form control
+     * @returns The disabledWYSIWYG field
+     */
+    get disabledWYSIWYGField() {
+        return this.controlContainer.control?.get(DISABLED_WYSIWYG_FIELD);
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.spec.ts
@@ -3,7 +3,6 @@ import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import {
     DisabledEditorType,
     getCurrentEditorFromDisabled,
-    getDisabledWYSIWYGFromContentlet,
     parseDisabledEditorEntry,
     updateDisabledWYSIWYGOnEditorSwitch
 } from './field-editor-preferences.util';
@@ -179,28 +178,6 @@ describe('field-editor-preferences.util', () => {
                 );
                 expect(result).toEqual(['otherField', 'myField']);
             });
-        });
-    });
-
-    describe('getDisabledWYSIWYGFromContentlet', () => {
-        it('should return array when contentlet has disabledWYSIWYG array', () => {
-            const contentlet: Partial<DotCMSContentlet> = {
-                disabledWYSIWYG: ['field1', 'field2@ToggleEditor']
-            };
-
-            const result = getDisabledWYSIWYGFromContentlet(contentlet);
-            expect(result).toEqual(['field1', 'field2@ToggleEditor']);
-        });
-
-        it('should return empty array when contentlet is null', () => {
-            const result = getDisabledWYSIWYGFromContentlet(null);
-            expect(result).toEqual([]);
-        });
-
-        it('should return empty array when disabledWYSIWYG is not present', () => {
-            const contentlet: Partial<DotCMSContentlet> = {};
-            const result = getDisabledWYSIWYGFromContentlet(contentlet);
-            expect(result).toEqual([]);
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.ts
+++ b/core-web/libs/edit-content/src/lib/fields/shared/utils/field-editor-preferences.util.ts
@@ -35,9 +35,6 @@
  * ```
  *
  */
-
-import { DotCMSContentlet } from '@dotcms/dotcms-models';
-
 import { AvailableEditorTextArea } from '../../dot-edit-content-text-area/dot-edit-content-text-area.constants';
 import { AvailableEditor } from '../../dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.constant';
 
@@ -192,20 +189,4 @@ export const updateDisabledWYSIWYGOnEditorSwitch = (
         // TinyMCE doesn't need an entry
         return filteredEntries;
     }
-};
-
-/**
- * Gets the disabledWYSIWYG array from a contentlet, ensuring it's always an array
- *
- * @param contentlet - The DotCMS contentlet
- * @returns The disabledWYSIWYG array, or empty array if not present
- */
-export const getDisabledWYSIWYGFromContentlet = (
-    contentlet: DotCMSContentlet | Partial<DotCMSContentlet> | null
-): string[] => {
-    if (!contentlet) {
-        return [];
-    }
-    // disabledWYSIWYG is always an array of strings
-    return contentlet.disabledWYSIWYG || [];
 };

--- a/core-web/libs/edit-content/src/lib/models/disabledWYSIWYG.constant.ts
+++ b/core-web/libs/edit-content/src/lib/models/disabledWYSIWYG.constant.ts
@@ -1,0 +1,1 @@
+export const DISABLED_WYSIWYG_FIELD = 'disabledWYSIWYG';

--- a/core-web/libs/edit-content/src/lib/utils/mocks.ts
+++ b/core-web/libs/edit-content/src/lib/utils/mocks.ts
@@ -20,6 +20,7 @@ import {
 import { MockDotMessageService } from '@dotcms/utils-testing';
 
 import { WYSIWYG_MOCK } from '../fields/dot-edit-content-wysiwyg-field/mocks/dot-edit-content-wysiwyg-field.mock';
+import { DISABLED_WYSIWYG_FIELD } from '../models/disabledWYSIWYG.constant';
 import { FIELD_TYPES } from '../models/dot-edit-content-field.enum';
 import { DotFormData } from '../models/dot-edit-content-form.interface';
 import {
@@ -890,7 +891,10 @@ export const CALENDAR_FIELD_TYPES = [FIELD_TYPES.DATE, FIELD_TYPES.DATE_AND_TIME
 /* LAYOUT/FORM MOCKS */
 
 // This creates a mock FormGroup from an array of fielda
-export const FORM_GROUP_MOCK = new FormGroup(createFormControlObjectMock());
+export const FORM_GROUP_MOCK = new FormGroup({
+    ...createFormControlObjectMock(),
+    [DISABLED_WYSIWYG_FIELD]: new FormControl([])
+});
 
 export const LAYOUT_MOCK: DotCMSContentTypeLayoutRow[] = [
     {


### PR DESCRIPTION
### Summary of Changes
- Removed `AfterViewInit` lifecycle hook, streamlining the component's initialization.
- Updated textarea and Monaco editor references to use public properties for better accessibility.
- Refactored editor selection logic to utilize a signal method for improved state management.
- Enhanced error handling for missing field variables and ensured contentlet updates are safely managed.

### Technical Details
- Introduced `handleEditorChange` as a signal method to manage editor state changes reactively.
- Improved null checks and error messaging for better robustness.

This refactor aligns with Angular's best practices for component design and state management.


### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)



This PR fixes: #32516