### PR TITLE
fix(Build) Image download has been restricted Refs: #33093

### DIFF
--- a/core-web/libs/dotcms-field-elements/src/index.html
+++ b/core-web/libs/dotcms-field-elements/src/index.html
@@ -193,7 +193,7 @@
                 mimeType: 'image/jpeg',
                 referenceUrl: '/dA/temp_09ef3de32b/tmp/002.jpg',
                 thumbnailUrl:
-                    'https://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/LARGE_elevation.jpg/800px-LARGE_elevation.jpg',
+                    'https://dotcms-storage.b-cdn.net/800px-LARGE_elevation.jpg',
                 fileName: '002.jpg',
                 folder: '',
                 image: true,

--- a/core-web/libs/dotcms-field-elements/src/index.html
+++ b/core-web/libs/dotcms-field-elements/src/index.html
@@ -192,8 +192,7 @@
                 id: 'temp_09ef3de32b',
                 mimeType: 'image/jpeg',
                 referenceUrl: '/dA/temp_09ef3de32b/tmp/002.jpg',
-                thumbnailUrl:
-                    'https://dotcms-storage.b-cdn.net/800px-LARGE_elevation.jpg',
+                thumbnailUrl: 'https://dotcms-storage.b-cdn.net/800px-LARGE_elevation.jpg',
                 fileName: '002.jpg',
                 folder: '',
                 image: true,

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/temp/TempFileResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/temp/TempFileResourceTest.java
@@ -539,7 +539,7 @@ public class TempFileResourceTest {
     public void test_TempResource_uploadFileByURL_success() {
         HttpServletRequest request = mockRequest();
         final String fileName = "test.png";
-        final String url = "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Bocas2.jpg/250px-Bocas2.jpg";
+        final String url = "https://dotcms-storage.b-cdn.net/Bocas2.jpg";
 
         final RemoteUrlForm remoteUrlForm = new RemoteUrlForm(url, fileName, null);
 

--- a/dotcms-postman/src/main/resources/postman/DotAsset-MultiPart-TempFile.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/DotAsset-MultiPart-TempFile.postman_collection.json
@@ -58,7 +58,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"fileName\":\"250px-Bocas2.jpg\",\n\t\"remoteUrl\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Bocas2.jpg/250px-Bocas2.jpg\"\n}",
+					"raw": "{\n\t\"fileName\":\"250px-Bocas2.jpg\",\n\t\"remoteUrl\": \"https://dotcms-storage.b-cdn.net/Bocas2.jpg\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/dotcms-postman/src/main/resources/postman/ResourceLink.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/ResourceLink.postman_collection.json
@@ -56,7 +56,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"fileName\":\"250px-Bocas2.jpg\",\n\t\"remoteUrl\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Bocas2.jpg/250px-Bocas2.jpg\"\n}",
+					"raw": "{\n\t\"fileName\":\"250px-Bocas2.jpg\",\n\t\"remoteUrl\": \"https://dotcms-storage.b-cdn.net/Bocas2.jpg\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/dotcms-postman/src/main/resources/postman/Site_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Site_Resource.postman_collection.json
@@ -3867,7 +3867,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"fileName\":\"250px-Bocas2.jpg\",\n\t\"remoteUrl\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Bocas2.jpg/250px-Bocas2.jpg\"\n}",
+					"raw": "{\n\t\"fileName\":\"250px-Bocas2.jpg\",\n\t\"remoteUrl\": \"https://dotcms-storage.b-cdn.net/Bocas2.jpg\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/dotcms-postman/src/main/resources/postman/Workflow_Resource_Tests.json
+++ b/dotcms-postman/src/main/resources/postman/Workflow_Resource_Tests.json
@@ -13461,7 +13461,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"fileName\":\"250px-Bocas2.jpg\",\n\t\"remoteUrl\": \"https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Bocas2.jpg/250px-Bocas2.jpg\"\n}",
+							"raw": "{\n\t\"fileName\":\"250px-Bocas2.jpg\",\n\t\"remoteUrl\": \"https://dotcms-storage.b-cdn.net/Bocas2.jpg\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/e2e/dotcms-e2e-node/frontend/src/tests/contentSearch/contentData.ts
+++ b/e2e/dotcms-e2e-node/frontend/src/tests/contentSearch/contentData.ts
@@ -27,7 +27,7 @@ export const fileAssetContent = {
   title: "File Asset title",
   body: "This is a sample file asset content",
   fromURL:
-    "https://upload.wikimedia.org/wikipedia/commons/0/03/DotCMS-logo.svg",
+    "https://dotcms-storage.b-cdn.net/DotCMS-logo.svg",
   newFileName: "New file asset.txt",
   newFileText: "This is a new file asset content",
   newFileTextEdited: "Validate you are able to edit text on binary fields",


### PR DESCRIPTION
### Proposed Changes
* downloading this image https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Bocas2.jpg/250px-Bocas2.jpg is getting a 400 getting it replaced by https://dotcms-storage.b-cdn.net/Bocas2.jpg

This PR fixes: #33093

This PR fixes: #33093