### PR TITLE
fixes(unique fields) #33036 : Add several Indexes to `unique_fields` table to avoid CPU spikes

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250826AddIndexesToUniqueFieldsTable.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task250826AddIndexesToUniqueFieldsTable.java
@@ -1,0 +1,84 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.startup.StartupTask;
+import com.dotmarketing.util.Logger;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * Adds several Indexes to the {@code unique_fields} table for improving its performance. In
+ * summary, the table will have the following indexes:
+ * <ul>
+ *     <li>The {@code BTREE} unique index on the {@code unique_key_val} column, which is already
+ *     present through the Primary Key.</li>
+ *     <li>The {@code GIN} index on the {@code supporting_values->'contentletIds'} attribute.</li>
+ *     <li>The {@code BTREE} indexes for all other attributes in the {@code supporting_values}
+ *     column that are used in {@code WHERE} clauses.</li>
+ * </ul>
+ *
+ * @author Jose Castro
+ * @since Aug 26th, 2025
+ */
+public class Task250826AddIndexesToUniqueFieldsTable implements StartupTask {
+
+    @Override
+    public boolean forceRun() {
+        return true;
+    }
+
+    @Override
+    public void executeUpgrade() throws DotDataException {
+        boolean defaultAutoCommit = false;
+        Connection connection = null;
+        try {
+            connection = DbConnectionFactory.getDataSource().getConnection();
+            defaultAutoCommit = connection.getAutoCommit();
+            connection.setAutoCommit(true);
+            Logger.info(this, "(1/6) Adding GIN Index for the supporting_values->'contentletIds' JSONB attribute");
+            new DotConnect()
+                    .setSQL("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_unique_fields_contentlet_ids_gin ON unique_fields USING GIN ((supporting_values->'contentletIds'))")
+                    .loadResult(connection);
+
+            Logger.info(this, "(2/6) Adding Functional Index for the supporting_values->'languageId' JSONB attribute");
+            new DotConnect()
+                    .setSQL("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_unique_fields_language_id ON unique_fields (((supporting_values->>'languageId')::BIGINT))")
+                    .loadResult(connection);
+
+            Logger.info(this, "(3/6) Adding Functional Index for the supporting_values->'contentTypeId' JSONB attribute");
+            new DotConnect()
+                    .setSQL("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_unique_fields_content_type_id ON unique_fields (((supporting_values->>'contentTypeId')))")
+                    .loadResult(connection);
+
+            Logger.info(this, "(4/6) Adding Functional Index for the supporting_values->'fieldVariableName' JSONB attribute");
+            new DotConnect()
+                    .setSQL("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_unique_fields_field_variable_name ON unique_fields (((supporting_values->>'fieldVariableName')))")
+                    .loadResult(connection);
+
+            Logger.info(this, "(5/6) Adding Functional Index for the supporting_values->'variant' JSONB attribute");
+            new DotConnect()
+                    .setSQL("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_unique_fields_variant ON unique_fields (((supporting_values->>'variant')))")
+                    .loadResult(connection);
+
+            Logger.info(this, "(6/6) Adding Functional Index for the supporting_values->'live' JSONB attribute");
+            new DotConnect()
+                    .setSQL("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_unique_fields_live ON unique_fields (((supporting_values->>'live')::BOOLEAN))")
+                    .loadResult(connection);
+        } catch (final SQLException e) {
+            throw new DotRuntimeException("", e);
+        } finally {
+            if (null != connection) {
+                try {
+                    connection.setAutoCommit(defaultAutoCommit);
+                } catch (final SQLException e) {
+                    Logger.error(this, "", e);
+                }
+            }
+        }
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -247,14 +247,15 @@ import com.dotmarketing.startup.runonce.Task240306MigrateLegacyLanguageVariables
 import com.dotmarketing.startup.runonce.Task240513UpdateContentTypesSystemField;
 import com.dotmarketing.startup.runonce.Task240530AddDotAIPortletToLayout;
 import com.dotmarketing.startup.runonce.Task240606AddVariableColumnToWorkflow;
-import com.dotmarketing.startup.runonce.Task250113CreatePostgresJobQueueTables;
 import com.dotmarketing.startup.runonce.Task241013RemoveFullPathLcColumnFromIdentifier;
 import com.dotmarketing.startup.runonce.Task241014AddTemplateValueOnContentletIndex;
 import com.dotmarketing.startup.runonce.Task241015ReplaceLanguagesWithLocalesPortlet;
 import com.dotmarketing.startup.runonce.Task241016AddCustomLanguageVariablesPortletToLayout;
 import com.dotmarketing.startup.runonce.Task250107RemoveEsReadOnlyMonitorJob;
+import com.dotmarketing.startup.runonce.Task250113CreatePostgresJobQueueTables;
 import com.dotmarketing.startup.runonce.Task250603UpdateIdentifierParentPathCheckTrigger;
 import com.dotmarketing.startup.runonce.Task250604UpdateFolderInodes;
+import com.dotmarketing.startup.runonce.Task250826AddIndexesToUniqueFieldsTable;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -276,7 +277,7 @@ import java.util.stream.Collectors;
  */
 public class TaskLocatorUtil {
 
-	private static final List<Class<?>> userfixTasks = new CopyOnWriteArrayList<>();
+	private static final List<Class<?>> userFixTasks = new CopyOnWriteArrayList<>();
 
 	/**
 	 * Returns the list of tasks that are run to solve internal conflicts
@@ -284,7 +285,7 @@ public class TaskLocatorUtil {
 	 *
 	 * @return The list of Fix Tasks.
 	 */
-	private static final List<Class<?>> systemfixTasks = ImmutableList.of(
+	private static final List<Class<?>> systemFixTasks = ImmutableList.of(
 			FixTask00001CheckAssetsMissingIdentifiers.class,
 			FixTask00003CheckContainersInconsistencies.class,
 			FixTask00006CheckLinksInconsistencies.class,
@@ -312,7 +313,7 @@ public class TaskLocatorUtil {
 	 *            - The new fix task class.
 	 */
 	public static void addFixTask(Class<?> clazz){
-		userfixTasks.add(clazz);
+		userFixTasks.add(clazz);
 	}
 
 	/**
@@ -322,7 +323,7 @@ public class TaskLocatorUtil {
 	 *            - The fix task to remove.
 	 */
 	public static void removeFixTask(Class<?> clazz){
-		userfixTasks.remove(clazz);
+		userFixTasks.remove(clazz);
 	}
 
 	/**
@@ -332,8 +333,8 @@ public class TaskLocatorUtil {
 	 */
 	public static List<Class<?>> getFixTaskClasses() {
 		final List<Class<?>> l = new ArrayList<>();
-		l.addAll(systemfixTasks);
-		l.addAll(userfixTasks);
+		l.addAll(systemFixTasks);
+		l.addAll(userFixTasks);
 		return l;
 	}
 
@@ -583,6 +584,7 @@ public class TaskLocatorUtil {
         .add(Task250113CreatePostgresJobQueueTables.class)
 		.add(Task250603UpdateIdentifierParentPathCheckTrigger.class)
 		.add(Task250604UpdateFolderInodes.class)
+        .add(Task250826AddIndexesToUniqueFieldsTable.class)
 		.build();
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());
 	}

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -19,6 +19,7 @@ import com.dotmarketing.business.DeterministicIdentifierAPITest;
 import com.dotmarketing.portlets.rules.RuleAPITest;
 import com.dotmarketing.startup.runonce.Task230630CreateRunningIdsExperimentFieldIntegrationTest;
 import com.dotmarketing.startup.runonce.Task250604UpdateFolderInodesTest;
+import com.dotmarketing.startup.runonce.Task250826AddIndexesToUniqueFieldsTableTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -41,8 +42,9 @@ import org.junit.runners.Suite;
         TotalSizeOfFilesPerThemeMetricTypeTest.class,
         TimeMachineUtilTest.class,
         Task250604UpdateFolderInodesTest.class,
-        AnalyticsValidatorUtilTest.class
-
+        AnalyticsValidatorUtilTest.class,
+        Task250826AddIndexesToUniqueFieldsTableTest.class
 })
+
 public class MainSuite3a {
 }

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task250826AddIndexesToUniqueFieldsTableTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task250826AddIndexesToUniqueFieldsTableTest.java
@@ -1,0 +1,103 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that the {@link Task250826AddIndexesToUniqueFieldsTable} works as expected.
+ */
+public class Task250826AddIndexesToUniqueFieldsTableTest extends IntegrationTestBase {
+
+    /**
+     * Initializes the test environment.
+     *
+     * @throws Exception if an error occurs during initialization.
+     */
+    @BeforeClass
+    public static void setup() throws Exception {
+        // Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:
+     *     </b>{@link Task250826AddIndexesToUniqueFieldsTable#executeUpgrade()}</li>
+     *     <li><b>Given Scenario: </b>Run the Upgrade Task and verify that the expected indexes
+     *     are created.</li>
+     *     <li>
+     *         <b>Expected Result: </b>There must be 7 Indexes (the existing Primary Key Index
+     *         plus the new ones):
+     *         <ol>
+     *              <li>unique_fields_pkey</li>
+     *              <li>idx_unique_fields_contentlet_ids_gin</li>
+     *              <li>idx_unique_fields_language_id</li>
+     *              <li>idx_unique_fields_content_type_id</li>
+     *              <li>idx_unique_fields_field_variable_name</li>
+     *              <li>idx_unique_fields_variant</li>
+     *              <li>idx_unique_fields_live</li>
+     *         </ol>
+     *     </li>
+     * </ul>
+     */
+    @Test
+    public void executeUpgradeTask() throws DotDataException {
+        // ╔══════════════════╗
+        // ║  Initialization  ║
+        // ╚══════════════════╝
+        final Task250826AddIndexesToUniqueFieldsTable task =
+                new Task250826AddIndexesToUniqueFieldsTable();
+
+        // ╔════════════════════════╗
+        // ║  Generating Test data  ║
+        // ╚════════════════════════╝
+        task.executeUpgrade();
+        final DotConnect dc = new DotConnect().setSQL("SELECT indexname, indexdef FROM pg_indexes WHERE tablename = 'unique_fields'");
+        final List<Map<String, Object>> tableIndexes = dc.loadObjectResults();
+
+        // ╔══════════════╗
+        // ║  Assertions  ║
+        // ╚══════════════╝
+        assertEquals("There must be 7 indexes for the 'unique_fields' table", 7,
+                tableIndexes.size());
+        assertTrue("The 'unique_fields_pkey' Index must be present",
+                this.isIndexPresent("unique_fields_pkey", tableIndexes));
+        assertTrue("The 'idx_unique_fields_contentlet_ids_gin' Index must be present",
+                this.isIndexPresent("idx_unique_fields_contentlet_ids_gin", tableIndexes));
+        assertTrue("The 'idx_unique_fields_language_id' Index must be present",
+                this.isIndexPresent("idx_unique_fields_language_id", tableIndexes));
+        assertTrue("The 'idx_unique_fields_content_type_id' Index must be present",
+                this.isIndexPresent("idx_unique_fields_content_type_id", tableIndexes));
+        assertTrue("The 'idx_unique_fields_field_variable_name' Index must be present",
+                this.isIndexPresent("idx_unique_fields_field_variable_name", tableIndexes));
+        assertTrue("The 'idx_unique_fields_variant' Index must be present",
+                this.isIndexPresent("idx_unique_fields_variant", tableIndexes));
+        assertTrue("The 'idx_unique_fields_live' Index must be present",
+                this.isIndexPresent("idx_unique_fields_live", tableIndexes));
+    }
+
+    /**
+     * Finds the specified Index name in the list of indexes that belong to the
+     * {@code unique_fields} table.
+     *
+     * @param indexName    The index name.
+     * @param tableIndexes The result set.
+     *
+     * @return If the Index was found, returns {@code true}.
+     */
+    private boolean isIndexPresent(final String indexName,
+                                   final List<Map<String, Object>> tableIndexes) {
+        return tableIndexes.stream().anyMatch(index -> index.get("indexname").equals(indexName));
+    }
+
+}


### PR DESCRIPTION
### Proposed Changes
* This PR introduces 6 new Indexes to the `unique_fields` table:
  * A `GIN` Index for the `supporting_values->'contentletIds' JSONB attribute.
  * Five Functional Indexes for the other JSONB attributes:
    * `languageId`
    * `contentTypeId`
    * `fieldVariableName`
    * `variant`
    * `live`
* Even after adding the `GIN` Index only, the improvement in query performance has been outstanding.
* The temporary non-unique index added to the `unique_key_val` column meant to improve performance when solving potential duplicate values is being removed. This is because the Primary Key adds the unique index, which is exactly what we need once the table has the expected data.

For more information, please refer to [my comment in the ticket](https://github.com/dotCMS/core/issues/33036#issuecomment-3224939948).

This PR fixes: #33036