### PR TITLE
build(docker): Update javabase Dockerfile for native memory analysis (#33133)

### DIFF
--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:24.04 AS base-builder
 WORKDIR /srv
 
 # Defining default Java version, can be any java version provided by sdkman
-ARG SDKMAN_JAVA_VERSION="11.0.22-ms"
+ARG SDKMAN_JAVA_VERSION="21.0.8-ms"
 
 ENV JAVA_OUTPUT_DIR="/java"
 ENV DEBIAN_FRONTEND=noninteractive
@@ -29,11 +29,15 @@ RUN apt update && \
     /usr/bin/pg_dump --version || exit 1 && \
     rm -rf /var/lib/apt/lists/*
 
-# Create a custom JRE using jlink
+# Create a custom JRE using jlink with diagnostic tools
+# Added JDK diagnostic modules for native memory tracking and profiling:
+# - jdk.jcmd: jcmd command for VM.native_memory and other diagnostics
+# - jdk.attach: Required for diagnostic tool attachment to running JVMs
+# Note: jstack and jmap are included in jdk.jcmd in modern Java versions
 RUN bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && jlink \
     --verbose \
     --add-modules \
-        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,jdk.management.agent,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom,jdk.jfr,jdk.management.jfr \
+        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,jdk.management.agent,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom,jdk.jfr,jdk.management.jfr,jdk.jcmd,jdk.attach \
     --compress 2 \
     --no-header-files \
     --no-man-pages \


### PR DESCRIPTION
## Description

Upgrade docker/java-base/Dockerfile from Java 11 to Java 21 with enhanced diagnostic capabilities. Added jdk.jcmd and jdk.attach modules to custom JRE for native memory tracking, profiling, and production diagnostics. 
## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #33133

**Issue:** Update javabase Dockerfile for Java 21 and native 

This PR fixes: #33133