### PR TITLE
fix(Redis) #33143 : Integrity Checker has problems with Redis-managed sessions

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1495,7 +1495,7 @@
             <dependency>
                 <groupId>com.dotcms</groupId>
                 <artifactId>tomcat-redis-session-manager</artifactId>
-                <version>1.3</version>
+                <version>1.4</version>
                 <scope>provided</scope>
             </dependency>
 

--- a/dotCMS/src/main/java/com/dotcms/integritycheckers/AbstractIntegrityChecker.java
+++ b/dotCMS/src/main/java/com/dotcms/integritycheckers/AbstractIntegrityChecker.java
@@ -95,7 +95,7 @@ public abstract class AbstractIntegrityChecker implements IntegrityChecker {
         if (getIntegrityType().hasResultsTable()) {
             discardConflicts(endpointId, getIntegrityType());
         } else {
-            Logger.warn(this, "Results table not supported for integrity type = ["
+            Logger.warn(this, "Results table not defined for integrity type = ["
                     + getIntegrityType() + "], endpointId = [" + endpointId +"]");
         }
     }
@@ -142,7 +142,7 @@ public abstract class AbstractIntegrityChecker implements IntegrityChecker {
             csvFile = new File(outputFile);
             writer = new CsvWriter(new FileWriter(csvFile, true), '|');
 
-            // Query the new content pages pages
+            // Query the new content pages
             final String query = new StringBuilder("SELECT DISTINCT c.identifier, ")
                     .append("cvi.working_inode, cvi.live_inode, i.parent_path, i.asset_name, i.host_inode, c.language_id ")
                     .append("FROM contentlet_version_info cvi ")
@@ -252,7 +252,7 @@ public abstract class AbstractIntegrityChecker implements IntegrityChecker {
 				contentFile.close();
 				final String assetId = UtilMethods.isSet(contentIdentifier) ? contentIdentifier
 						: "";
-                throw new DotDataException(String.format("An error occured when generating temp table for asset '%s':" +
+                throw new DotDataException(String.format("An error occurred when generating temp table for asset '%s':" +
                         " %s", assetId, e.getMessage()), e);
             }
         }
@@ -336,8 +336,8 @@ public abstract class AbstractIntegrityChecker implements IntegrityChecker {
             dc.addParam(endpointId);
 
             if (dc.loadObjectResults().isEmpty()) {
-                Logger.warn(this, "Results table not supported for integrity type = ["
-                        + getIntegrityType() + "]");
+                Logger.warn(this, "Results table [" + getIntegrityType() + "] reported no conflicts for endpoint ["
+                        + endpointId + "]");
             } else {
                 // At least one conflict found
                 exists = true;

--- a/dotCMS/src/main/java/com/dotcms/rest/IntegrityResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/IntegrityResource.java
@@ -16,18 +16,44 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotHibernateException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.exception.InvalidLicenseException;
-import com.dotmarketing.util.*;
 import com.dotmarketing.quartz.QuartzUtils;
 import com.dotmarketing.quartz.job.IntegrityDataGenerationJob;
+import com.dotmarketing.util.ConfigUtils;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.PushPublishLogger;
 import com.dotmarketing.util.UUIDGenerator;
 import com.dotmarketing.util.UtilMethods;
+import com.dotmarketing.util.ZipUtil;
 import com.dotmarketing.util.json.JSONArray;
 import com.dotmarketing.util.json.JSONException;
 import com.dotmarketing.util.json.JSONObject;
 import com.liferay.portal.language.LanguageException;
 import com.liferay.portal.language.LanguageUtil;
 import com.liferay.portal.model.User;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.commons.lang3.StringUtils;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.FormDataParam;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
+import org.quartz.SchedulerException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Cookie;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -37,24 +63,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-import javax.ws.rs.*;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.Cookie;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
-import org.apache.commons.lang3.StringUtils;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.FormDataParam;
-import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
-import org.quartz.SchedulerException;
-import io.swagger.v3.oas.annotations.tags.Tag;
 
 /**
  * This REST end-point provides all the required mechanisms for the execution of
@@ -1010,15 +1018,19 @@ public class IntegrityResource {
     }
 
     /**
-     * Sets the status for the checking integrity process of a given endpoint in session
+     * Sets the status for the checking integrity process of a given endpoint as an attribute in the
+     * current session.
      *
-     * @param session
-     * @param endpointId
-     * @param status
-     * @param message
+     * @param session    The current instance of the {@link HttpSession}.
+     * @param endpointId The ID of the Endpoint whose data integrity is being checked.
+     * @param status     The {@link ProcessStatus} of the integrity check process.
+     * @param message    An optional message associated with the integrity check process.
      */
-    public static void setStatus ( HttpSession session, String endpointId, ProcessStatus status, String message ) {
+    public static void setStatus(final HttpSession session, final String endpointId, final ProcessStatus status, final String message ) {
         session.setAttribute( "integrityCheck_" + endpointId, status );
+        // Required when the Tomcat Redis Session Manager is enabled. This forces the session to be
+        // persisted to Redis and correctly update the Integrity Checker status
+        session.setAttribute( "__dot_session_persist_now__", true);
         if ( message != null ) {
             session.setAttribute( "integrityCheck_message_" + endpointId, message );
         } else {

--- a/dotCMS/src/main/webapp/html/common/bottom_inc.jsp
+++ b/dotCMS/src/main/webapp/html/common/bottom_inc.jsp
@@ -1,22 +1,22 @@
 <iframe name="hidden_iframe" id="hidden_iframe" style="position:absolute;top:-100px;width:0px; height:0px; border: 0px;"></iframe>
 <script>
+
 	function setKeepAlive(){
 		var myId=document.getElementById("hidden_iframe");
 		myId.src ="/html/common/keep_alive.jsp?r=<%=System.currentTimeMillis()%>";
 	}
-	function killSession(){
-		window.location = "/c/portal/logout?referer=/c";
+	function killSession() {
+		window.location = "/dotAdmin/logout?r=<%=System.currentTimeMillis()%>";
 	}
-	<% if(Config.getStringProperty("KEEP_SESSION_ALIVE").equalsIgnoreCase("true")) {%>
+	<% if (Config.getStringProperty("KEEP_SESSION_ALIVE").equalsIgnoreCase("true")) {%>
 		// 15 minutes
 		setTimeout("setKeepAlive()", 60000 * 15);
-	<%}else{%>
-		// 30 minutes
-		setTimeout("killSession()", 60000 * 30);
+	<% } else { %>
+		// Redis or Tomcat-defined timeout
+		setTimeout("killSession()", 1000 * <%= pageContext.getSession().getMaxInactiveInterval() %>);
 	<%} %>
 
 		function dotMakeBodVisible(){
-
 			if(!window.frameElement){
 				console.log("bottom_inc.jsp frame busting");
 				window.top.location="/dotAdmin/";
@@ -26,13 +26,10 @@
 			if(dojo.style(dojo.body(), "visibility") != "visible"){
 				setTimeout( "dotMakeBodVisible()",3000);
 				dojo.style(dojo.body(), "visibility", "visible");
-				
 			}
-
 		}
 		
 		dojo.addOnLoad(dotMakeBodVisible);
-		
 
 	</script>
 	

--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/remotePublishing.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsconfig/remotePublishing.jsp
@@ -186,7 +186,7 @@ function checkIntegrity(identifier) {
             }
 
             showDotCMSSystemMessage(data.message, false);
-            //Lets start checking every 30 seconds the status of this integrity check
+            //Let's start checking the status of the integrity job every 5 seconds
             displayLoadingOnly(identifier);
             checkIntegrityProcessStatus(identifier);
         },
@@ -254,13 +254,11 @@ function checkIntegrityProcessStatus(identifier, callback) {
             }
 
             var status = data.status;
-            if (status == "processing") {//Still processing, check again in 30 seconds
-                //Verify again in 30 seconds
+            if (status == "processing") {
+                // Still processing, check again in 5 seconds
                 setTimeout(function () {
                     checkIntegrityProcessStatus(identifier, callback)
-                }, 10000);
-                //Verify again in 30 seconds
-
+                }, 5000);
             } else if (status == "finished") {//Process finished so show the show results button
                 require([ 'dojo/dom-style', 'dijit/registry' ], function (domStyle, registry) {
                     domStyle.set(registry.byId(buttonId).domNode, 'display', 'none');


### PR DESCRIPTION
### Proposed Changes
* Updating some confusing logging messages related to the Integrity Checker process.
* Updating the integrity data check time from every 10 seconds to every 5 seconds.
* Updating the JSP file used in all legacy portlets to consider the timeout value set via Tomcat or Redis when logging users out. This will go away once all JSP-based portlets are migrated.
* Updating the reference to the Tomcat Redis Session Manager plugin to the latest one containing the code fix: `1.4`

This PR fixes: #33143

This PR fixes: #33143