### PR TITLE
fix(site-selector): #32019 Fix the Site Selector disappearing

### DIFF
--- a/core-web/apps/dotcms-ui/proxy-dev.conf.mjs
+++ b/core-web/apps/dotcms-ui/proxy-dev.conf.mjs
@@ -20,7 +20,7 @@ export default [
             '/tinymce',
             '/ext'
         ],
-        target: 'http://localhost:8080',
+        target: 'https://demo.dotcms.com',
         secure: false,
         logLevel: 'debug',
         pathRewrite: {

--- a/core-web/apps/dotcms-ui/src/app/shared/shared.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/shared.module.ts
@@ -13,7 +13,6 @@ import {
     DotEventsSocketURL,
     LoggerService,
     LoginService,
-    SiteService,
     StringUtils,
     UserModel
 } from '@dotcms/dotcms-js';

--- a/core-web/apps/dotcms-ui/src/app/shared/shared.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/shared/shared.module.ts
@@ -51,7 +51,6 @@ export class SharedModule {
                 DotcmsEventsService,
                 LoggerService,
                 LoginService,
-                SiteService,
                 { provide: DotEventsSocketURL, useFactory: dotEventSocketURLFactory },
                 DotEventsSocket,
                 StringUtils,

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-site-selector/dot-site-selector.component.ts
@@ -88,9 +88,9 @@ export class DotSiteSelectorComponent implements OnInit, OnChanges, OnDestroy {
                 });
         });
 
-        this.siteService.switchSite$.pipe(takeUntil(this.destroy$)).subscribe(() => {
+        this.siteService.switchSite$.pipe(takeUntil(this.destroy$)).subscribe((site) => {
             setTimeout(() => {
-                this.updateCurrentSite(this.siteService.currentSite);
+                this.updateCurrentSite(site);
             }, 200);
         });
     }

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -60,7 +60,6 @@ export class SiteService {
             .subscribeToEvents<Site>(['SWITCH_SITE'])
             .subscribe(({ data }: DotEventTypeWrapper<Site>) => this.setCurrentSite(data));
 
-            debugger
         loginService.watchUser(() => this.loadCurrentSite());
     }
 

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -60,6 +60,7 @@ export class SiteService {
             .subscribeToEvents<Site>(['SWITCH_SITE'])
             .subscribe(({ data }: DotEventTypeWrapper<Site>) => this.setCurrentSite(data));
 
+            debugger
         loginService.watchUser(() => this.loadCurrentSite());
     }
 

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -108,9 +108,7 @@ export class SiteService {
      * @memberof SiteService
      */
     get switchSite$(): Observable<Site> {
-        return this._switchSite$.asObservable().pipe(
-            startWith(this.selectedSite)
-        );
+        return this._switchSite$.asObservable().pipe(startWith(this.selectedSite));
     }
 
     /**

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -2,7 +2,7 @@ import { Observable, Subject, merge, of } from 'rxjs';
 
 import { Injectable, inject } from '@angular/core';
 
-import { map, pluck, switchMap, take, tap } from 'rxjs/operators';
+import { map, pluck, startWith, switchMap, take, tap } from 'rxjs/operators';
 
 import { CoreWebService } from './core-web.service';
 import { DotcmsEventsService } from './dotcms-events.service';
@@ -108,7 +108,9 @@ export class SiteService {
      * @memberof SiteService
      */
     get switchSite$(): Observable<Site> {
-        return this._switchSite$.asObservable();
+        return this._switchSite$.asObservable().pipe(
+            startWith(this.selectedSite)
+        );
     }
 
     /**


### PR DESCRIPTION
- Removed SiteService from SharedModule.
- Updated DotSiteSelectorComponent to use the site parameter in the switchSite$ subscription.
- Enhanced SiteService to start with the selected site in switchSite$ observable.


https://github.com/user-attachments/assets/5ee6ad44-db4a-4641-bebb-84c0e410c0f8


