### PR TITLE
#33175 Update gh issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yaml
+++ b/.github/ISSUE_TEMPLATE/defect.yaml
@@ -2,6 +2,7 @@ name: Defect
 description: Report a bug or issue with existing functionality
 title: "[DEFECT] "
 labels: ["Triage"]
+type: bug
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/defect.yaml
+++ b/.github/ISSUE_TEMPLATE/defect.yaml
@@ -1,133 +1,70 @@
 name: Defect
-description: I need to report a bug or issue with dotCMS.
-labels: ['Type : Defect',Triage]
-projects: ["dotCMS/7"]
+description: Report a bug or issue with existing functionality
+title: "[DEFECT] "
+labels: ["Triage"]
+assignees: []
 
 body:
   - type: markdown
     attributes:
       value: |
-        If you have any questions about how to use this form, check out [How dotCMS uses GitHub](https://docs.google.com/presentation/d/1C1oCESIL9Z84xXo1DPWQZh48c4BSGlVRAn1DYGEFMUw).
+        **Note: This template is intended for Engineering team use.**
 
   - type: textarea
     id: problem-statement
     attributes:
-      label: "Problem Statement"
-      description: "Explain the problem. How common is this issue? Who does it impact? How severely does it affect them? If this is a front-end issue, please include the Browser & OS."
-      placeholder:
-      value: 
+      label: Problem Statement
+      description: Explain the problem. How common is this issue? Who does it impact? How severely does it affect them? If this is a front-end issue, please include the Browser & OS.
+      placeholder: "Describe what happened and the impact..."
     validations:
       required: true
-      
+
   - type: textarea
     id: steps-to-reproduce
     attributes:
-      label: "Steps to Reproduce"
-      description: "How do we reproduce this bug? Ideally, please include a screencast link."
-      placeholder:
-      value: 
-    validations:
-      required: true
-
-  - type: textarea
-    id: acceptance-criteria 
-    attributes:
-      label: "Acceptance Criteria"
-      description: "What objective needs to be met in order to resolve this?"
-      placeholder: 
-      value: 
-    validations:
-      required: true
-
-  - type: textarea
-    id: dotCMS-version
-    attributes:
-      label: "dotCMS Version"
-      description: "What version, or environment, is this problem related to?"
-      placeholder:
-      value: 
-    validations:
-      required: true
-
-  - type: dropdown
-    id: proposed-objective
-    attributes:
-      label: "Proposed Objective"
-      description: 
-      options:
-        - "Please Select"
-        - "Application Performance"
-        - "Business"
-        - "Cloud Engineering"
-        - "Code Maintenance"
-        - "Core Features"
-        - "Customer Success"
-        - "Customer Support"
-        - "Documentation"
-        - "Integrations"
-        - "Marketing"
-        - "Quality Assurance"
-        - "Reliability"
-        - "Sales"
-        - "Security & Privacy"
-        - "Technical User Experience"
-        - "User Experience"
-    validations:
-      required: true
-
-  - type: dropdown
-    id: proposed-prioritiy
-    attributes:
-      label: "Proposed Priority"
-      description: 
-      options:
-        - "Please Select"
-        - "Priority 1 - Show Stopper"
-        - "Priority 2 - Important"
-        - "Priority 3 - Average"
-        - "Priority 4 - Trivial"
-    validations:
-      required: true
-
-  - type: textarea
-    id: external-links 
-    attributes:
-      label: "External Links... Slack Conversations, Support Tickets, Figma Designs, etc."
-      description: "Provide links to any support tickets or Slack conversations that help explain the problem or desired outcome."
-      placeholder: 
-      value: 
-    validations:
-      required: false
-
-  - type: textarea
-    id: assumptions
-    attributes:
-      label: "Assumptions & Initiation Needs"
-      description: "List relevant assumptions, pre-requisite steps, or issues that need to be completed before this issue can be worked on."
-      placeholder:
-      value: 
-    validations:
-      required: false
-
-  - type: textarea
-    id: qa-note
-    attributes:
-      label: "Quality Assurance Notes & Workarounds"
-      description: "Add any additional notes for QA you would like; this field is also for use by the QA Team once the issue is in progress."
-      placeholder:
-      value:
-    validations:
-      required: false
-
-  - type: textarea
-    id: sub-tasks
-    attributes:
-      label: "Sub-Tasks & Estimates"
-      description: "Use a task-list format, and feel free to @ people responsible for completion."
+      label: Steps to Reproduce
+      description: Please provide a video screencast showing the issue. If video is not possible, provide detailed steps.
       placeholder: |
-        - [ ] Some Task Related to this Issue (4 points)
-        - [ ] Some Task for Damen (2 points) @damen-dotcms
-      value:
+        **Video screencast:** [Upload or link to video showing the issue]
+        
+        **Or detailed steps:**
+        1. Go to '...'
+        2. Click on '...'
+        3. Scroll down to '...'
+        4. See error
     validations:
-      required: false
+      required: true
 
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What objective needs to be met in order to resolve this?
+      placeholder: |
+        - [ ] Criteria 1
+        - [ ] Criteria 2
+        - [ ] Criteria 3
+    validations:
+      required: true
+
+  - type: textarea
+    id: dotcms-version
+    attributes:
+      label: dotCMS Version
+      description: What version, or environment, is this problem related to?
+      placeholder: "e.g., 23.10.1, Latest from main branch, Cloud environment"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How severe is this defect?
+      options:
+        - Critical - System unusable
+        - High - Major functionality broken
+        - Medium - Some functionality impacted
+        - Low - Minor issue or cosmetic
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,58 @@
+name: EPIC
+description: Wide area of functionality that delivers significant value within a theme
+title: "[EPIC] "
+labels: []
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note: This template is intended for Product team use only.**
+        
+        EPICs represent wide areas of functionality that solve specific problems and deliver significant value.
+
+  - type: input
+    id: epic-title
+    attributes:
+      label: EPIC Title
+      description: Concise, action-based title that reflects user value
+      placeholder: "e.g., Universal Visual Editor Enhancements"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Explain the problem this EPIC solves and how it will benefit customers
+      placeholder: "Describe the user problem, proposed solution, and customer value..."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: personas
+    attributes:
+      label: Target Personas
+      description: Select the personas this EPIC affects
+      options:
+        - label: Developer teams
+        - label: Content teams
+        - label: DevOps teams
+        - label: System administrators (dotCMS)
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Related resources
+      placeholder: |
+        - [Kickoff deck](url)
+        - [GitHub](url)
+        - [Walkthrough](url)
+        - [Figma](url)
+        - [Slack Channel](url)
+        - [EPIC Folder in Google Drive](url)
+        - [POC](url)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -2,6 +2,7 @@ name: EPIC
 description: Wide area of functionality that delivers significant value within a theme
 title: "[EPIC] "
 labels: []
+type: epic
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -2,6 +2,7 @@ name: Feature
 description: Specific functionality within an EPIC that provides particular value
 title: "[FEATURE] "
 labels: []
+type: feature
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,113 +1,95 @@
 name: Feature
-description: I need to change the way something works, or create new functionality. 
-labels: ['Type : New Functionality', Triage]
-projects: ["dotCMS/7"]
+description: Specific functionality within an EPIC that provides particular value
+title: "[FEATURE] "
+labels: []
+assignees: []
 
 body:
-
   - type: markdown
     attributes:
       value: |
-        If you have any questions about how to use this form, check out [How dotCMS uses GitHub](https://docs.google.com/presentation/d/1C1oCESIL9Z84xXo1DPWQZh48c4BSGlVRAn1DYGEFMUw).
+        **Note: This template is intended for Product team use only.**
+        
+        Features are specific groupings of functionality within an EPIC that provide particular value.
 
-  - type: textarea
-    id: user-story
+  - type: input
+    id: feature-title
     attributes:
-      label: "User Story"
-      description: "As a ___, I want to be able to ___, so I can ___."
-      placeholder:
-      value: 
+      label: Feature Title
+      description: Concise, action-based title that reflects user value
+      placeholder: "e.g., Drag and Drop File Upload Interface"
     validations:
       required: true
 
   - type: textarea
-    id: acceptance-criteria 
+    id: problem
     attributes:
-      label: "Acceptance Criteria"
-      description: "What objective needs to be met in order to resolve this?"
-      placeholder: 
-      value: 
+      label: Problem
+      description: Explain in detail what user problem this feature will solve
+      placeholder: "Describe the specific user pain point..."
     validations:
       required: true
 
-  - type: dropdown
-    id: proposed-objective
+  - type: textarea
+    id: goal
     attributes:
-      label: "Proposed Objective"
-      description: 
+      label: Goal
+      description: Describe the value this delivers to the user or dotCMS. Be specific.
+      placeholder: "Users will be able to... which will result in..."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: personas
+    attributes:
+      label: Target Personas
+      description: Select the personas this feature affects
       options:
-        - "Please Select"
-        - "Application Performance"
-        - "Cloud Engineering"
-        - "Code Maintenance"
-        - "Core Features"
-        - "Customer Success"
-        - "Customer Support"
-        - "Documentation"
-        - "Integrations"
-        - "Marketing"
-        - "Quality Assurance"
-        - "Reliability"
-        - "Sales"
-        - "Security & Privacy"
-        - "Technical User Experience"
-        - "User Experience"
-    validations:
-      required: true
+        - label: Developer teams
+        - label: Content teams
+        - label: DevOps teams
+        - label: System administrators (dotCMS)
 
-  - type: dropdown
-    id: proposed-prioritiy
+  - type: textarea
+    id: demo-expectations
     attributes:
-      label: "Proposed Priority"
-      description: 
-      options:
-        - "Please Select"
-        - "Priority 1 - Show Stopper"
-        - "Priority 2 - Important"
-        - "Priority 3 - Average"
-        - "Priority 4 - Trivial"
+      label: Demo Expectations
+      description: Describe exactly what someone can show in a bi-weekly demo to prove the value is delivered
+      placeholder: "In the demo, we will show..."
     validations:
       required: true
 
   - type: textarea
-    id: external-links 
+    id: acceptance-criteria
     attributes:
-      label: "External Links... Slack Conversations, Support Tickets, Figma Designs, etc."
-      description: "Provide links to any support tickets or Slack conversations that help explain the problem or desired outcome."
-      placeholder: 
-      value: 
-    validations:
-      required: false
-
-  - type: textarea
-    id: assumptions
-    attributes:
-      label: "Assumptions & Initiation Needs"
-      description: "List relevant assumptions, pre-requisite steps, or issues that need to be completed before this issue can be worked on."
-      placeholder:
-      value: 
-    validations:
-      required: false
-
-  - type: textarea
-    id: qa-note
-    attributes:
-      label: "Quality Assurance Notes & Workarounds"
-      description: "Add any additional notes for QA you would like; this field is also for use by the QA Team once the issue is in progress."
-      placeholder:
-      value:
-    validations:
-      required: false
-
-  - type: textarea
-    id: sub-tasks
-    attributes:
-      label: "Sub-Tasks & Estimates"
-      description: "Use a task-list format, and feel free to @ people responsible for completion."
+      label: Acceptance Criteria
+      description: Specific, measurable criteria for feature completion
       placeholder: |
-        - [ ] Some Task Related to this Issue (4 points)
-        - [ ] Some Task for Damen (2 points) @damen-dotcms
-      value:
+        - [ ] Criteria 1
+        - [ ] Criteria 2
+        - [ ] Criteria 3
     validations:
       required: false
 
+  - type: textarea
+    id: user-stories
+    attributes:
+      label: User Stories
+      description: Break down into specific user stories
+      placeholder: |
+        - As a [persona], I want [functionality], so that [benefit]
+        - As a [persona], I want [functionality], so that [benefit]
+    validations:
+      required: false
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Related resources
+      placeholder: |
+        - [Design mockups](url)
+        - [Technical specs](url)
+        - [Research](url)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/spike.yaml
+++ b/.github/ISSUE_TEMPLATE/spike.yaml
@@ -1,0 +1,75 @@
+name: Spike
+description: Timeboxed research to turn unknowns into knowns
+title: "[SPIKE] "
+labels: [""]
+type: task
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note: This template is intended for Engineering team use.**
+
+  - type: input
+    id: spike-title
+    attributes:
+      label: Spike Title
+      description: Clear, concise title describing the research objective
+      placeholder: "e.g., Research integration options for new authentication system"
+    validations:
+      required: true
+
+  - type: textarea
+    id: research-question
+    attributes:
+      label: Research Question
+      description: What specific question or unknown needs to be investigated?
+      placeholder: "What we need to learn or understand..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: timebox
+    attributes:
+      label: Timebox
+      description: How much time should be allocated to this research?
+      options:
+        - 2h
+        - 4h
+        - 8h
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: What deliverables or outcomes define completion of this spike?
+      placeholder: |
+        - [ ] Document findings on approach A vs approach B
+        - [ ] Provide recommendation with pros/cons
+        - [ ] Create proof of concept if feasible
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Background information and why this research is needed
+      placeholder: "Provide context on why this spike is necessary..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Related resources, documentation, or references
+      placeholder: |
+        - [Related documentation](url)
+        - [Similar implementations](url)
+        - [Technical specs](url)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/spike.yaml
+++ b/.github/ISSUE_TEMPLATE/spike.yaml
@@ -2,7 +2,7 @@ name: Spike
 description: Timeboxed research to turn unknowns into knowns
 title: "[SPIKE] "
 labels: [""]
-type: task
+type: spike
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,115 +1,61 @@
 name: Task
-description: I just need to create a simple to-do for someone on the team.
-labels: ['Type : Task',Triage]
-projects: ["dotCMS/7"]
+description: Technical task or improvement that needs to be completed
+title: "[TASK] "
+labels: ["Triage"]
+assignees: []
 
 body:
-
   - type: markdown
     attributes:
       value: |
-        If you have any questions about how to use this form, check out [How dotCMS uses GitHub](https://docs.google.com/presentation/d/1C1oCESIL9Z84xXo1DPWQZh48c4BSGlVRAn1DYGEFMUw).
-      
-  - type: textarea
-    id: task-body
-    attributes:
-      label: "Task"
-      description: "What's this issue meant to track?"
-      placeholder: "Maintenance on XYZ... Refactoring ABC... Library updates... etc."
-      value: 
-    validations:
-      required: true
+        **Note: This template is intended for Engineering team use.**
 
-  - type: dropdown
-    id: proposed-objective
+  - type: input
+    id: task-title
     attributes:
-      label: "Proposed Objective"
-      description: 
-      options:
-        - "Please Select"
-        - "Same as Parent Issue"
-        - "Application Performance"
-        - "Cloud Engineering"
-        - "Code Maintenance"
-        - "Core Features"
-        - "Customer Success"
-        - "Customer Support"
-        - "Documentation"
-        - "Integrations"
-        - "Marketing"
-        - "Quality Assurance"
-        - "Reliability"
-        - "Sales"
-        - "Security & Privacy"
-        - "Technical User Experience"
-        - "User Experience"
-    validations:
-      required: true
-
-  - type: dropdown
-    id: proposed-prioritiy
-    attributes:
-      label: "Proposed Priority"
-      description: 
-      options:
-        - "Please Select"
-        - "Same as Parent Issue"
-        - "Priority 1 - Show Stopper"
-        - "Priority 2 - Important"
-        - "Priority 3 - Average"
-        - "Priority 4 - Trivial"
+      label: Task Title
+      description: Clear, concise title describing the task
+      placeholder: "e.g., Update dependency versions for security patches"
     validations:
       required: true
 
   - type: textarea
-    id: acceptance-criteria 
+    id: description
     attributes:
-      label: "Acceptance Criteria"
-      description: "What objective needs to be met in order to resolve this?"
-      placeholder: 
-      value: 
+      label: Description
+      description: Detailed description of what needs to be done
+      placeholder: "Describe the task, including context and rationale..."
     validations:
-      required: false
+      required: true
 
   - type: textarea
-    id: external-links 
+    id: acceptance-criteria
     attributes:
-      label: "External Links... Slack Conversations, Support Tickets, Figma Designs, etc."
-      description: "Provide links to any support tickets or Slack conversations that help explain the problem or desired outcome."
-      placeholder: 
-      value: 
-    validations:
-      required: false
-
-  - type: textarea
-    id: assumptions
-    attributes:
-      label: "Assumptions & Initiation Needs"
-      description: "List relevant assumptions, pre-requisite steps, or issues that need to be completed before this issue can be worked on."
-      placeholder:
-      value: 
-    validations:
-      required: false
-
-  - type: textarea
-    id: qa-note
-    attributes:
-      label: "Quality Assurance Notes & Workarounds"
-      description: "Add any additional notes for QA you would like; this field is also for use by the QA Team once the issue is in progress."
-      placeholder:
-      value:
-    validations:
-      required: false
-
-  - type: textarea
-    id: sub-tasks
-    attributes:
-      label: "Sub-Tasks & Estimates"
-      description: "Use a task-list format, and feel free to @ people responsible for completion."
+      label: Acceptance Criteria
+      description: Specific criteria that must be met for this task to be considered complete
       placeholder: |
-        - [ ] Some Task Related to this Issue (4 points)
-        - [ ] Some Task for Damen (2 points) @damen-dotcms
-      value:
+        - [ ] Criteria 1
+        - [ ] Criteria 2
+        - [ ] Criteria 3
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Priority level for this task
+      options:
+        - High
+        - Medium
+        - Low
     validations:
       required: false
 
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any additional information that might be helpful
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -2,6 +2,7 @@ name: Task
 description: Technical task or improvement that needs to be completed
 title: "[TASK] "
 labels: ["Triage"]
+type: task
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/theme.yml
+++ b/.github/ISSUE_TEMPLATE/theme.yml
@@ -2,6 +2,7 @@ name: Theme
 description: High-level strategic initiative that groups related EPICs
 title: "[THEME] "
 labels: []
+type: theme
 assignees: []
 
 body:

--- a/.github/ISSUE_TEMPLATE/theme.yml
+++ b/.github/ISSUE_TEMPLATE/theme.yml
@@ -1,0 +1,55 @@
+name: Theme
+description: High-level strategic initiative that groups related EPICs
+title: "[THEME] "
+labels: []
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note: This template is intended for Product team use only.**
+        
+        ## Theme Overview
+        Themes represent broad strategic initiatives that align with product vision and encompass multiple EPICs.
+
+  - type: input
+    id: theme-title
+    attributes:
+      label: Theme Title
+      description: Concise, action-based title that reflects strategic value
+      placeholder: "e.g., Enhanced Content Management Experience"
+    validations:
+      required: true
+
+  - type: textarea
+    id: vision
+    attributes:
+      label: Vision
+      description: Explain in detail how this theme will benefit our customers
+      placeholder: "Describe the strategic value and customer impact..."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: personas
+    attributes:
+      label: Target Personas
+      description: Select the personas this theme primarily affects
+      options:
+        - label: Developer teams
+        - label: Content teams
+        - label: DevOps teams
+        - label: System administrators (dotCMS)
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Related resources (design docs, research, etc.)
+      placeholder: |
+        - [Kickoff deck](url)
+        - [Research document](url)
+        - [Design files](url)
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
Update GitHub issue templates to align with new product development workflow (Themes > EPICs > Features > Issues)

- **Product team templates**: Theme, EPIC, Feature (no triage label, product-managed)
- **Engineering team templates**: Defect, Task (with triage label)
- Removed legacy fields: Proposed Objective, Proposed Priority, External Links, Assumptions & Initiation Needs, QA Notes & Workarounds
- Enhanced defect template to encourage video screencasts for reproduction steps
- Added team usage notes and proper type classifications
- Cleaned up duplicate templates

## Changes
- Updated `theme.yml`, `epic.yml`, `feature.yaml`, `defect.yaml`, `task.yaml`
- Removed duplicate `feature.yml`
- Added `type` field to all templates for proper categorization
- Simplified templates to focus on execution over documentation

Aligns with "[How we do Product at dotCMS](https://docs.google.com/document/d/19WhnR-1-OJUTez398FYX5AN2tV1Qy-uLdbdKZ3Rh2Nc/edit?tab=t.mns47zhipwgy#heading=h.v6j9zn1xlr23)" process document and supports GitHub's parent-child issue functionality.