### PR TITLE
chore(js-deploy-action): Added small change to trigger the action

### DIFF
--- a/core-web/libs/sdk/types/README.md
+++ b/core-web/libs/sdk/types/README.md
@@ -92,5 +92,5 @@ This package is maintained as part of the [dotCMS core repository](https://githu
 * dotcms
 * typescript
 * types
-* cms
+* cms 
 * content-management-system


### PR DESCRIPTION
This PR introduce a little change on README to trigger the github action to deploy js libs

This PR fixes: #33165

This PR fixes: #33165