### PR TITLE
Fix incorrect key retrieval in Analytics App

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/web/AnalyticsWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/web/AnalyticsWebAPIImpl.java
@@ -4,6 +4,7 @@ import com.dotcms.analytics.app.AnalyticsApp;
 import com.dotcms.business.SystemTableUpdatedKeyEvent;
 import com.dotcms.experiments.business.ConfigExperimentUtil;
 import com.dotcms.featureflag.FeatureFlagName;
+import com.dotcms.rest.api.v1.analytics.content.util.ContentAnalyticsUtil;
 import com.dotcms.security.apps.AppsAPI;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
@@ -43,7 +44,7 @@ public class AnalyticsWebAPIImpl implements AnalyticsWebAPI {
     public AnalyticsWebAPIImpl() {
         this(new AtomicBoolean(Config.getBooleanProperty(ANALYTICS_AUTO_INJECT_TURNED_ON_KEY, true)), // injection turn on by default
                 WebAPILocator.getHostWebAPI(), APILocator.getAppsAPI(),
-                APILocator::systemUser, currentHost->ConfigExperimentUtil.INSTANCE.getAnalyticsKey(currentHost));
+                APILocator::systemUser, currentHost-> String.valueOf(ContentAnalyticsUtil.getSiteKeyFromAppSecrets(currentHost)));
     }
 
     public AnalyticsWebAPIImpl(final AtomicBoolean isAutoInjectTurnedOn,

--- a/dotCMS/src/main/java/com/dotcms/analytics/web/AnalyticsWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/web/AnalyticsWebAPIImpl.java
@@ -86,14 +86,12 @@ public class AnalyticsWebAPIImpl implements AnalyticsWebAPI {
      */
     private boolean anySecrets (final Host host) {
 
-        Try.of(() -> this.appsAPI.getSecrets(
+        return Try.of(() -> this.appsAPI.getSecrets(
                         ContentAnalyticsUtil.CONTENT_ANALYTICS_APP_KEY, true, host, systemUserSupplier.get()).isPresent())
                 .getOrElseGet(e -> {
                     Logger.warn(this, "Error getting analytics secrets. Please check that the App Content Analytics is configured: " + e.getMessage() + " for the site: " + host.getHostname(), e);
                     return false;
                 });
-
-        return true;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/analytics/web/AnalyticsWebAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/web/AnalyticsWebAPIImpl.java
@@ -86,11 +86,14 @@ public class AnalyticsWebAPIImpl implements AnalyticsWebAPI {
      */
     private boolean anySecrets (final Host host) {
 
-        return   Try.of(
-                        () ->
-                                this.appsAPI.getSecrets(
-                                        AnalyticsApp.ANALYTICS_APP_KEY, true, host, systemUserSupplier.get()).isPresent())
-                .getOrElseGet(e -> false);
+        Try.of(() -> this.appsAPI.getSecrets(
+                        ContentAnalyticsUtil.CONTENT_ANALYTICS_APP_KEY, true, host, systemUserSupplier.get()).isPresent())
+                .getOrElseGet(e -> {
+                    Logger.warn(this, "Error getting analytics secrets. Please check that the App Content Analytics is configured: " + e.getMessage() + " for the site: " + host.getHostname(), e);
+                    return false;
+                });
+
+        return true;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
@@ -258,7 +258,7 @@ public class ContentAnalyticsUtil {
     public static Optional<String> getSiteKeyFromAppSecrets(final Host currentSite) {
         try {
             final Optional<AppSecrets> secretsOpt = APILocator.getAppsAPI()
-                    .getSecrets(CONTENT_ANALYTICS_APP_KEY, false, currentSite, APILocator.systemUser());
+                    .getSecrets(CONTENT_ANALYTICS_APP_KEY, true, currentSite, APILocator.systemUser());
             
             if (secretsOpt.isPresent()) {
                 final Map<String, Secret> secretsMap = secretsOpt.get().getSecrets();


### PR DESCRIPTION
### Proposed Changes
* Fixed a bug where the wrong key was being retrieved from the Experiments App instead of the Analytics App.

This PR fixes: #33177

This PR fixes: #33177