### PR TITLE
fix(Redis) #33143 : Integrity Checker has problems with Redis-managed sessions

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/IntegrityResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/IntegrityResource.java
@@ -1028,14 +1028,14 @@ public class IntegrityResource {
      */
     public static void setStatus(final HttpSession session, final String endpointId, final ProcessStatus status, final String message ) {
         session.setAttribute( "integrityCheck_" + endpointId, status );
-        // Required when the Tomcat Redis Session Manager is enabled. This forces the session to be
-        // persisted to Redis and correctly update the Integrity Checker status
-        session.setAttribute( "__dot_session_persist_now__", true);
         if ( message != null ) {
             session.setAttribute( "integrityCheck_message_" + endpointId, message );
         } else {
             session.removeAttribute( "integrityCheck_message_" + endpointId );
         }
+        // Required when the Tomcat Redis Session Manager plugin is enabled. This forces the session
+        // to be persisted to Redis and correctly update the Integrity Checker status
+        session.setAttribute( "__dot_session_persist_now__", true);
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes
* Simply moving the code that triggers persisting the session to Redis where it must be.
* The Integrity Checker status message was not being persisted. Moving the addition of the `__dot_session_persist_now__` attribute to the end of the method takes care of it.

This PR fixes: #33143

This PR fixes: #33143