### PR TITLE
fix(site-selector) prevent set current site undefined #32019

### DIFF
--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -2,7 +2,7 @@ import { Observable, Subject, merge, of } from 'rxjs';
 
 import { Injectable, inject } from '@angular/core';
 
-import { map, pluck, startWith, switchMap, take, tap } from 'rxjs/operators';
+import { filter, map, pluck, startWith, switchMap, take, tap } from 'rxjs/operators';
 
 import { CoreWebService } from './core-web.service';
 import { DotcmsEventsService } from './dotcms-events.service';
@@ -26,7 +26,7 @@ export class SiteService {
     private loggerService = inject(LoggerService);
 
     private selectedSite: Site;
-    private urls: any;
+    private urls: { currentSiteUrl: string; sitesUrl: string; switchSiteUrl: string };
     private events: string[] = [
         'SAVE_SITE',
         'PUBLISH_SITE',
@@ -190,6 +190,7 @@ export class SiteService {
             })
             .pipe(
                 take(1),
+                filter((site) => !!site),
                 tap(() => this.setCurrentSite(site)),
                 map(() => site)
             );
@@ -203,7 +204,7 @@ export class SiteService {
     getCurrentSite(): Observable<Site> {
         return merge(
             this.selectedSite ? of(this.selectedSite) : this.requestCurrentSite(),
-            this.switchSite$
+            this.switchSite$.pipe(filter((site) => !!site))
         );
     }
 
@@ -222,7 +223,10 @@ export class SiteService {
 
     private loadCurrentSite(): void {
         this.getCurrentSite()
-            .pipe(take(1))
+            .pipe(
+                take(1),
+                filter((site) => !!site)
+            )
             .subscribe((currentSite: Site) => {
                 this.setCurrentSite(currentSite);
             });

--- a/core-web/libs/dotcms-js/src/lib/core/site.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/site.service.ts
@@ -190,7 +190,6 @@ export class SiteService {
             })
             .pipe(
                 take(1),
-                filter((site) => !!site),
                 tap(() => this.setCurrentSite(site)),
                 map(() => site)
             );


### PR DESCRIPTION
This pull request improves the robustness of the `SiteService` in `core-web/libs/dotcms-js/src/lib/core/site.service.ts` by ensuring that only valid (non-null/undefined) site objects are processed in key methods. This helps prevent potential errors caused by invalid site data being emitted or used.

**Improvements for site data validation and type safety:**

* Added the `filter` operator to RxJS pipelines in several methods (`requestCurrentSite`, `getCurrentSite`, and `loadCurrentSite`) to ensure only truthy (valid) `site` objects are processed. [[1]](diffhunk://#diff-ebec7159cb4a8660492c16c6797f79029bb5fedea93d4bbad8f44c84729ca61cR193) [[2]](diffhunk://#diff-ebec7159cb4a8660492c16c6797f79029bb5fedea93d4bbad8f44c84729ca61cL206-R207) [[3]](diffhunk://#diff-ebec7159cb4a8660492c16c6797f79029bb5fedea93d4bbad8f44c84729ca61cL225-R229)
* Updated the type of the `urls` property to a more specific object structure for better type safety.
* Included the `filter` operator in the RxJS import statement.

This PR fixes: #32019