### PR TITLE
fix(ci): E2E test reporting fails due to bash syntax error  (#33219)

### DIFF
--- a/e2e/dotcms-e2e-node/README.md
+++ b/e2e/dotcms-e2e-node/README.md
@@ -115,7 +115,7 @@ At `e2e/e2e-dotcms-node/frontend/package.json` you can find the available script
 
 ```json
   "scripts": {
-    "show-report": "if [[ \"$CURRENT_ENV\" != \"ci\" ]]; then  fi",
+    "show-report": "bash -c 'if [ \"$CURRENT_ENV\" != \"ci\" ]; then yarn playwright show-report; fi'",
     "start": "PLAYWRIGHT_JUNIT_SUITE_ID=nodee2etestsuite PLAYWRIGHT_JUNIT_SUITE_NAME='E2E Node Test Suite' PLAYWRIGHT_JUNIT_OUTPUT_FILE='../target/failsafe-reports/TEST-e2e-node-results.xml' yarn playwright test ${PLAYWRIGHT_SPECIFIC} ${PLAYWRIGHT_DEBUG}; yarn run show-report",
     "start-local": "CURRENT_ENV=local yarn run start",
     "start-dev": "CURRENT_ENV=dev yarn run start",

--- a/e2e/dotcms-e2e-node/frontend/package.json
+++ b/e2e/dotcms-e2e-node/frontend/package.json
@@ -24,7 +24,7 @@
     "xml2js": "^0.6.2"
   },
   "scripts": {
-    "show-report": "if [[ \"$CURRENT_ENV\" != \"ci\" ]]; then yarn playwright show-report; fi",
+    "show-report": "bash -c 'if [ \"$CURRENT_ENV\" != \"ci\" ]; then yarn playwright show-report; fi'",
     "start": "PLAYWRIGHT_JUNIT_SUITE_ID=nodee2etestsuite PLAYWRIGHT_JUNIT_SUITE_NAME='E2E Node Test Suite' PLAYWRIGHT_JUNIT_OUTPUT_FILE='../target/failsafe-reports/TEST-e2e-node-results.xml' yarn playwright test ${PLAYWRIGHT_SPECIFIC} ${PLAYWRIGHT_DEBUG}; EXIT_CODE=$?; yarn run show-report; exit $EXIT_CODE",
     "start-local": "CURRENT_ENV=local yarn run start",
     "start-dev": "CURRENT_ENV=dev yarn run start",


### PR DESCRIPTION
## Description

Fix bash syntax error in E2E test reporting script that was preventing proper test report generation in CI pipeline. Changed from bash-specific double bracket syntax [[]] to POSIX-compatible single bracket syntax [] with explicit bash invocation for cross-platform compatibility.

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #33219

**Issue:** E2E test reporting fails due to bash syntax error 