### PR TITLE
feat(edit-content): Implement binary field auto-fill functionality

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.html
@@ -106,6 +106,7 @@
                 [formControlName]="field.variable"
                 [contentlet]="contentlet"
                 [field]="field"
+                (valueUpdated)="onBinaryFieldValueUpdated($event)"
                 [attr.data-testId]="'field-' + field.variable" />
         }
     }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
@@ -249,12 +249,6 @@ describe.each([...FIELDS_TO_BE_RENDER])('DotEditContentFieldComponent all fields
         imports: [...(fieldTestBed?.imports || [])],
         declarations: [...(fieldTestBed?.declarations || [])],
         component: DotEditContentFieldComponent,
-        componentViewProviders: [
-            {
-                provide: ControlContainer,
-                useValue: createFormGroupDirectiveMock()
-            }
-        ],
         providers: [
             FormGroupDirective,
             provideHttpClient(),
@@ -302,7 +296,13 @@ describe.each([...FIELDS_TO_BE_RENDER])('DotEditContentFieldComponent all fields
                 field: fieldMock,
                 ...(fieldTestBed?.props || {})
             },
-            providers: [...(fieldTestBed?.providers || [])]
+            providers: [
+                ...(fieldTestBed?.providers || []),
+                {
+                    provide: ControlContainer,
+                    useValue: createFormGroupDirectiveMock()
+                }
+            ]
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
@@ -8,7 +8,13 @@ import { of } from 'rxjs';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Provider, signal, Type } from '@angular/core';
-import { ControlContainer, FormGroupDirective, ReactiveFormsModule } from '@angular/forms';
+import {
+    ControlContainer,
+    FormControl,
+    FormGroup,
+    FormGroupDirective,
+    ReactiveFormsModule
+} from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
 import { DialogService } from 'primeng/dynamicdialog';
@@ -23,6 +29,7 @@ import {
     DotWorkflowActionsFireService
 } from '@dotcms/data-access';
 import { CoreWebService } from '@dotcms/dotcms-js';
+import { DotCMSBaseTypesContentTypes, DotCMSContentType } from '@dotcms/dotcms-models';
 import { DotKeyValueComponent, DotLanguageVariableSelectorComponent } from '@dotcms/ui';
 import { monacoMock } from '@dotcms/utils-testing';
 
@@ -348,5 +355,419 @@ describe.each([...FIELDS_TO_BE_RENDER])('DotEditContentFieldComponent all fields
                 });
             });
         }
+    });
+});
+
+describe('DotEditContentFieldComponent - Binary Field Auto-fill', () => {
+    let spectator: Spectator<DotEditContentFieldComponent>;
+    let realForm: FormGroup;
+    let formGroupDirective: FormGroupDirective;
+
+    const createComponent = createComponentFactory({
+        component: DotEditContentFieldComponent,
+        providers: [
+            provideHttpClient(),
+            provideHttpClientTesting(),
+            mockProvider(DotHttpErrorManagerService),
+            mockProvider(DotSystemConfigService, {
+                getSystemConfig: jest.fn().mockReturnValue(
+                    of({
+                        systemTimezone: {
+                            id: 'UTC',
+                            label: 'Coordinated Universal Time',
+                            offset: 0
+                        }
+                    })
+                )
+            }),
+            mockProvider(CoreWebService),
+            mockProvider(DotMessageService),
+            mockProvider(DotMessageDisplayService),
+            mockProvider(DotLicenseService),
+            mockProvider(DotWorkflowActionsFireService)
+        ]
+    });
+
+    beforeEach(() => {
+        // Create a real Angular form
+        realForm = new FormGroup({
+            title: new FormControl(''),
+            fileName: new FormControl(''),
+            binaryField: new FormControl('')
+        });
+
+        // Create FormGroupDirective with the real form
+        formGroupDirective = new FormGroupDirective([], []);
+        formGroupDirective.form = realForm;
+
+        spectator = createComponent({
+            props: {
+                field: FIELDS_MOCK.find((f) => f.fieldType === FIELD_TYPES.BINARY),
+                contentType: {
+                    baseType: DotCMSBaseTypesContentTypes.FILEASSET
+                } as DotCMSContentType
+            } as unknown,
+            providers: [
+                {
+                    provide: ControlContainer,
+                    useValue: formGroupDirective
+                }
+            ]
+        });
+    });
+
+    describe('onBinaryFieldValueUpdated', () => {
+        beforeEach(() => {
+            // Reset form to initial state
+            realForm.get('title')?.setValue('');
+            realForm.get('fileName')?.setValue('');
+            realForm.get('title')?.markAsUntouched();
+            realForm.get('fileName')?.markAsUntouched();
+        });
+
+        it('should auto-fill title and fileName when empty for FILEASSET content type', () => {
+            const mockEvent = { value: 'temp123', fileName: 'document.pdf' };
+
+            // Verify initial state - both controls should be empty
+            expect(realForm.get('title')?.value).toBe('');
+            expect(realForm.get('fileName')?.value).toBe('');
+
+            // Call the method
+            spectator.component.onBinaryFieldValueUpdated(mockEvent);
+
+            // Verify that both controls were filled
+            expect(realForm.get('title')?.value).toBe('document.pdf');
+            expect(realForm.get('fileName')?.value).toBe('document.pdf');
+
+            // Verify controls are marked as touched
+            expect(realForm.get('title')?.touched).toBe(true);
+            expect(realForm.get('fileName')?.touched).toBe(true);
+        });
+
+        it('should NOT overwrite existing values', () => {
+            const mockEvent = { value: 'temp123', fileName: 'document.pdf' };
+
+            // Set existing values
+            realForm.get('title')?.setValue('Existing Title');
+            realForm.get('fileName')?.setValue('existing-file.pdf');
+
+            spectator.component.onBinaryFieldValueUpdated(mockEvent);
+
+            // Verify values were not changed
+            expect(realForm.get('title')?.value).toBe('Existing Title');
+            expect(realForm.get('fileName')?.value).toBe('existing-file.pdf');
+        });
+
+        // These tests moved to separate describe blocks to avoid TestBed conflicts
+
+        it('should handle missing form controls gracefully', () => {
+            const mockEvent = { value: 'temp123', fileName: 'document.pdf' };
+
+            // Create a form without title and fileName controls
+            const emptyForm = new FormGroup({
+                binaryField: new FormControl('')
+            });
+            const emptyFormDirective = new FormGroupDirective([], []);
+            emptyFormDirective.form = emptyForm;
+
+            // Replace the form in the component
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (spectator.component as any)['#parentForm'] = emptyForm;
+
+            expect(() => {
+                spectator.component.onBinaryFieldValueUpdated(mockEvent);
+            }).not.toThrow();
+        });
+
+        // These tests moved to separate describe blocks to avoid TestBed conflicts
+    });
+
+    describe('shouldAutoFillFields', () => {
+        it('should return true for FILEASSET baseType', () => {
+            const contentType = {
+                baseType: DotCMSBaseTypesContentTypes.FILEASSET
+            } as DotCMSContentType;
+
+            const result = spectator.component['shouldAutoFillFields'](contentType);
+
+            expect(result).toBe(true);
+        });
+
+        it('should return false for non-FILEASSET baseType', () => {
+            const contentType = {
+                baseType: 'CONTENT'
+            } as DotCMSContentType;
+
+            const result = spectator.component['shouldAutoFillFields'](contentType);
+
+            expect(result).toBe(false);
+        });
+
+        it('should return false for null contentType', () => {
+            const result = spectator.component['shouldAutoFillFields'](null);
+
+            expect(result).toBe(false);
+        });
+    });
+});
+
+describe('DotEditContentFieldComponent - Binary Field Auto-fill (Non-FILEASSET)', () => {
+    let spectator: Spectator<DotEditContentFieldComponent>;
+    let testForm: FormGroup;
+
+    const createComponent = createComponentFactory({
+        component: DotEditContentFieldComponent,
+        providers: [
+            provideHttpClient(),
+            provideHttpClientTesting(),
+            mockProvider(DotHttpErrorManagerService),
+            mockProvider(DotSystemConfigService, {
+                getSystemConfig: jest.fn().mockReturnValue(
+                    of({
+                        systemTimezone: {
+                            id: 'UTC',
+                            label: 'Coordinated Universal Time',
+                            offset: 0
+                        }
+                    })
+                )
+            }),
+            mockProvider(CoreWebService),
+            mockProvider(DotMessageService),
+            mockProvider(DotMessageDisplayService),
+            mockProvider(DotLicenseService),
+            mockProvider(DotWorkflowActionsFireService)
+        ]
+    });
+
+    beforeEach(() => {
+        testForm = new FormGroup({
+            title: new FormControl(''),
+            fileName: new FormControl(''),
+            binaryField: new FormControl('')
+        });
+
+        const formGroupDirective = new FormGroupDirective([], []);
+        formGroupDirective.form = testForm;
+
+        spectator = createComponent({
+            props: {
+                field: FIELDS_MOCK.find((f) => f.fieldType === FIELD_TYPES.BINARY),
+                contentType: {
+                    baseType: 'CONTENT',
+                    variable: 'BlogPost'
+                } as DotCMSContentType
+            } as unknown,
+            providers: [
+                {
+                    provide: ControlContainer,
+                    useValue: formGroupDirective
+                }
+            ]
+        });
+    });
+
+    it('should NOT execute for non-FILEASSET content types', () => {
+        const mockEvent = { value: 'temp123', fileName: 'document.pdf' };
+
+        spectator.component.onBinaryFieldValueUpdated(mockEvent);
+
+        // Verify values were not changed (should still be empty)
+        expect(testForm.get('title')?.value).toBe('');
+        expect(testForm.get('fileName')?.value).toBe('');
+    });
+});
+
+describe('DotEditContentFieldComponent - Binary Field Auto-fill (Null ContentType)', () => {
+    let spectator: Spectator<DotEditContentFieldComponent>;
+    let testForm: FormGroup;
+
+    const createComponent = createComponentFactory({
+        component: DotEditContentFieldComponent,
+        providers: [
+            provideHttpClient(),
+            provideHttpClientTesting(),
+            mockProvider(DotHttpErrorManagerService),
+            mockProvider(DotSystemConfigService, {
+                getSystemConfig: jest.fn().mockReturnValue(
+                    of({
+                        systemTimezone: {
+                            id: 'UTC',
+                            label: 'Coordinated Universal Time',
+                            offset: 0
+                        }
+                    })
+                )
+            }),
+            mockProvider(CoreWebService),
+            mockProvider(DotMessageService),
+            mockProvider(DotMessageDisplayService),
+            mockProvider(DotLicenseService),
+            mockProvider(DotWorkflowActionsFireService)
+        ]
+    });
+
+    beforeEach(() => {
+        testForm = new FormGroup({
+            title: new FormControl(''),
+            fileName: new FormControl(''),
+            binaryField: new FormControl('')
+        });
+
+        const formGroupDirective = new FormGroupDirective([], []);
+        formGroupDirective.form = testForm;
+
+        spectator = createComponent({
+            props: {
+                field: FIELDS_MOCK.find((f) => f.fieldType === FIELD_TYPES.BINARY),
+                contentType: null
+            } as unknown,
+            providers: [
+                {
+                    provide: ControlContainer,
+                    useValue: formGroupDirective
+                }
+            ]
+        });
+    });
+
+    it('should handle null contentType gracefully', () => {
+        const mockEvent = { value: 'temp123', fileName: 'document.pdf' };
+
+        expect(() => {
+            spectator.component.onBinaryFieldValueUpdated(mockEvent);
+        }).not.toThrow();
+
+        // Verify values were not changed (should still be empty)
+        expect(testForm.get('title')?.value).toBe('');
+        expect(testForm.get('fileName')?.value).toBe('');
+    });
+});
+
+describe('DotEditContentFieldComponent - Binary Field Auto-fill (Title Only)', () => {
+    let spectator: Spectator<DotEditContentFieldComponent>;
+    let titleOnlyForm: FormGroup;
+
+    const createComponent = createComponentFactory({
+        component: DotEditContentFieldComponent,
+        providers: [
+            provideHttpClient(),
+            provideHttpClientTesting(),
+            mockProvider(DotHttpErrorManagerService),
+            mockProvider(DotSystemConfigService, {
+                getSystemConfig: jest.fn().mockReturnValue(
+                    of({
+                        systemTimezone: {
+                            id: 'UTC',
+                            label: 'Coordinated Universal Time',
+                            offset: 0
+                        }
+                    })
+                )
+            }),
+            mockProvider(CoreWebService),
+            mockProvider(DotMessageService),
+            mockProvider(DotMessageDisplayService),
+            mockProvider(DotLicenseService),
+            mockProvider(DotWorkflowActionsFireService)
+        ]
+    });
+
+    beforeEach(() => {
+        titleOnlyForm = new FormGroup({
+            title: new FormControl(''),
+            binaryField: new FormControl('')
+        });
+
+        const formGroupDirective = new FormGroupDirective([], []);
+        formGroupDirective.form = titleOnlyForm;
+
+        spectator = createComponent({
+            props: {
+                field: FIELDS_MOCK.find((f) => f.fieldType === FIELD_TYPES.BINARY),
+                contentType: {
+                    baseType: DotCMSBaseTypesContentTypes.FILEASSET
+                } as DotCMSContentType
+            } as unknown,
+            providers: [
+                {
+                    provide: ControlContainer,
+                    useValue: formGroupDirective
+                }
+            ]
+        });
+    });
+
+    it('should only fill empty title control when fileName control does not exist', () => {
+        const mockEvent = { value: 'temp123', fileName: 'document.pdf' };
+
+        spectator.component.onBinaryFieldValueUpdated(mockEvent);
+
+        expect(titleOnlyForm.get('title')?.value).toBe('document.pdf');
+        expect(titleOnlyForm.get('title')?.touched).toBe(true);
+    });
+});
+
+describe('DotEditContentFieldComponent - Binary Field Auto-fill (FileName Only)', () => {
+    let spectator: Spectator<DotEditContentFieldComponent>;
+    let fileNameOnlyForm: FormGroup;
+
+    const createComponent = createComponentFactory({
+        component: DotEditContentFieldComponent,
+        providers: [
+            provideHttpClient(),
+            provideHttpClientTesting(),
+            mockProvider(DotHttpErrorManagerService),
+            mockProvider(DotSystemConfigService, {
+                getSystemConfig: jest.fn().mockReturnValue(
+                    of({
+                        systemTimezone: {
+                            id: 'UTC',
+                            label: 'Coordinated Universal Time',
+                            offset: 0
+                        }
+                    })
+                )
+            }),
+            mockProvider(CoreWebService),
+            mockProvider(DotMessageService),
+            mockProvider(DotMessageDisplayService),
+            mockProvider(DotLicenseService),
+            mockProvider(DotWorkflowActionsFireService)
+        ]
+    });
+
+    beforeEach(() => {
+        fileNameOnlyForm = new FormGroup({
+            fileName: new FormControl(''),
+            binaryField: new FormControl('')
+        });
+
+        const formGroupDirective = new FormGroupDirective([], []);
+        formGroupDirective.form = fileNameOnlyForm;
+
+        spectator = createComponent({
+            props: {
+                field: FIELDS_MOCK.find((f) => f.fieldType === FIELD_TYPES.BINARY),
+                contentType: {
+                    baseType: DotCMSBaseTypesContentTypes.FILEASSET
+                } as DotCMSContentType
+            } as unknown,
+            providers: [
+                {
+                    provide: ControlContainer,
+                    useValue: formGroupDirective
+                }
+            ]
+        });
+    });
+
+    it('should only fill empty fileName control when title control does not exist', () => {
+        const mockEvent = { value: 'temp123', fileName: 'document.pdf' };
+
+        spectator.component.onBinaryFieldValueUpdated(mockEvent);
+
+        expect(fileNameOnlyForm.get('fileName')?.value).toBe('document.pdf');
+        expect(fileNameOnlyForm.get('fileName')?.touched).toBe(true);
     });
 });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.ts
@@ -8,12 +8,13 @@ import {
     input,
     output
 } from '@angular/core';
-import { ControlContainer, ReactiveFormsModule } from '@angular/forms';
+import { ControlContainer, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import { DividerModule } from 'primeng/divider';
 
 import { BlockEditorModule } from '@dotcms/block-editor';
 import {
+    DotCMSBaseTypesContentTypes,
     DotCMSContentlet,
     DotCMSContentType,
     DotCMSContentTypeField,
@@ -81,6 +82,7 @@ import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
 })
 export class DotEditContentFieldComponent {
     readonly #globalStore = inject(GlobalStore);
+    #parentForm = inject(ControlContainer, { skipSelf: true })?.control as FormGroup;
 
     @HostBinding('class') class = 'field';
 
@@ -131,4 +133,42 @@ export class DotEditContentFieldComponent {
 
         return field.fieldVariables.find(({ key }) => key === 'hideLabel')?.value !== 'true';
     });
+
+    /**
+     * Event emitted when the binary field value is updated.
+     * @param event
+     */
+    onBinaryFieldValueUpdated(event: { value: string; fileName: string }) {
+        if (!this.shouldAutoFillFields(this.$contentType())) {
+            return;
+        }
+
+        const { fileName } = event;
+
+        const titleControl = this.#parentForm.get('title');
+        const fileNameControl = this.#parentForm.get('fileName');
+
+        // Auto-fill title if exists and is empty
+        if (titleControl && !titleControl.value) {
+            titleControl.setValue(fileName);
+            titleControl.markAsTouched();
+        }
+
+        // Auto-fill fileName if exists and is empty
+        if (fileNameControl && !fileNameControl.value) {
+            fileNameControl.setValue(fileName);
+            fileNameControl.markAsTouched();
+        }
+    }
+
+    /**
+     * Whether to auto-fill the fields.
+     * @param contentType
+     * @returns
+     */
+    private shouldAutoFillFields(contentType: DotCMSContentType | null): boolean {
+        if (!contentType) return false;
+
+        return contentType.baseType === DotCMSBaseTypesContentTypes.FILEASSET;
+    }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.ts
@@ -41,13 +41,13 @@ import {
     DotGeneratedAIImage
 } from '@dotcms/dotcms-models';
 import {
+    DotAIImagePromptComponent,
     DotDropZoneComponent,
     DotMessagePipe,
     DotSpinnerModule,
     DropZoneErrorType,
     DropZoneFileEvent,
-    DropZoneFileValidity,
-    DotAIImagePromptComponent
+    DropZoneFileValidity
 } from '@dotcms/ui';
 
 import { DotBinaryFieldEditorComponent } from './components/dot-binary-field-editor/dot-binary-field-editor.component';


### PR DESCRIPTION
Added the ability to auto-fill the title and fileName fields in the DotEditContentFieldComponent when a binary field value is updated. This feature enhances user experience by automatically populating relevant fields based on the uploaded file's metadata.

- Introduced  method to handle the auto-fill logic.
- Updated the component template to emit the  event.
- Added unit tests to ensure correct behavior for various scenarios, including handling of empty fields and null content types.


https://github.com/user-attachments/assets/570b16e7-24e6-4adf-9e5b-560fad2be862


This PR fixes: #33105

This PR fixes: #33105