### PR TITLE
fix(logging) : Skip logger context shutdown for BasicAsyncLoggerContextSelector

### DIFF
--- a/dotCMS/src/main/docker/original/ROOT/srv/OVERRIDE/WEB-INF/log4j/log4j2.xml
+++ b/dotCMS/src/main/docker/original/ROOT/srv/OVERRIDE/WEB-INF/log4j/log4j2.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="INFO">
-
-
     <Properties>
         <Property name="DOTCMS_LOG_FILE">${sys:catalina.home}/logs/dotcms.log</Property>
         <Property name="DOTCMS_FILENAME_PATTERN">${sys:catalina.home}/logs/archive/dotcms-%i.log.gz</Property>
@@ -11,12 +9,8 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS}  %-5level %logger{2} - %msg%n" />
         </Console>
-       <Async name="generic">
-            <AppenderRef ref="GENERIC-FILE"/>
-        </Async>
-
         <!--  Generic Logging File -->
-        <RollingFile name="GENERIC-FILE"
+        <RollingFile name="Generic-File"
                      fileName="${DOTCMS_LOG_FILE}"
                      filePattern="${DOTCMS_FILENAME_PATTERN}"
                      immediateFlush="false">
@@ -26,12 +20,11 @@
             </Policies>
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
-
     </Appenders>
     <Loggers>
         <Root level="info">
             <AppenderRef ref="Console" />
-            <AppenderRef ref="generic"/>
+            <AppenderRef ref="Generic-File"/>
         </Root>
     </Loggers>
 </Configuration> 

--- a/dotCMS/src/main/java/com/dotmarketing/loggers/Log4jUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/loggers/Log4jUtil.java
@@ -1,7 +1,6 @@
 package com.dotmarketing.loggers;
 
-import com.dotmarketing.util.UtilMethods;
-
+import io.vavr.Lazy;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 
@@ -10,12 +9,15 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
-import org.apache.logging.log4j.core.async.AsyncLoggerContextSelector;
+import org.apache.logging.log4j.core.async.BasicAsyncLoggerContextSelector;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.impl.Log4jContextFactory;
 import org.apache.logging.log4j.core.layout.PatternLayout;
-import java.net.URI;
+import org.apache.logging.log4j.core.selector.ContextSelector;
+import org.apache.logging.log4j.spi.LoggerContextFactory;
+
 import java.util.Collection;
 import java.util.Map;
 
@@ -26,6 +28,18 @@ import java.util.Map;
 public class Log4jUtil {
 
     private final static String LOG4J_CONTEXT_SELECTOR = "Log4jContextSelector";
+    
+    /**
+     * Lazily loaded ContextSelector for shutdown optimization
+     */
+    private static final Lazy<ContextSelector> contextSelector = Lazy.of(() -> {
+        LoggerContextFactory factory = LogManager.getFactory();
+        if (factory instanceof Log4jContextFactory) {
+            // If the factory is a Log4jContextFactory, we can get the selector directly
+            return ((Log4jContextFactory) factory).getSelector();
+        }
+        return null;
+    });
 
     /**
      * Creates a ConsoleAppender in order to add it to the root logger
@@ -113,10 +127,20 @@ public class Log4jUtil {
      * Each LoggerContext registers a shutdown hook that takes care of releasing resources when the JVM exits (unless system property log4j.shutdownHookEnabled is set to false).
      * Web applications should include the log4j-web module in their classpath which disables the shutdown
      * hook but instead cleans up log4j resources when the web application is stopped.
+     * If the ContextSelector in use is BasicAsyncLoggerContextSelector, we skip the shutdown
+     * to avoid shutting down the global async context while still in use (for example, if this method
+     * is called from an OSGi plugin).
+     * @param context the LoggerContext to shutdown
      */
     public static void shutdown(LoggerContext context) {
-        //Shutting down log4j in order to avoid memory leaks
-        Configurator.shutdown(context);
+        // Get the current ContextSelector and check if it's BasicAsyncLoggerContextSelector
+        ContextSelector currentContextSelector = contextSelector.get();
+        
+        // Skip Configurator.shutdown if using BasicAsyncLoggerContextSelector to avoid issues
+        if (!(currentContextSelector instanceof BasicAsyncLoggerContextSelector)) {
+            //Shutting down log4j in order to avoid memory leaks
+            Configurator.shutdown(context);
+        }
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/loggers/Log4jUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/loggers/Log4jUtil.java
@@ -119,7 +119,7 @@ public class Log4jUtil {
         LoggerContext context = (LoggerContext) LogManager.getContext();
 
         //Shutting down log4j in order to avoid memory leaks
-        shutdown(context);
+        shutdown(context, true);
     }
 
     /**
@@ -133,11 +133,25 @@ public class Log4jUtil {
      * @param context the LoggerContext to shutdown
      */
     public static void shutdown(LoggerContext context) {
+        shutdown(context, false);
+    }
+
+    /**
+     * Normally there is no need to do this manually.
+     * Each LoggerContext registers a shutdown hook that takes care of releasing resources when the JVM exits (unless system property log4j.shutdownHookEnabled is set to false).
+     * Web applications should include the log4j-web module in their classpath which disables the shutdown
+     * hook but instead cleans up log4j resources when the web application is stopped.
+     * If the ContextSelector in use is BasicAsyncLoggerContextSelector, we skip the shutdown
+     * to avoid shutting down the global async context while still in use, unless force is set to true.
+     * @param context the LoggerContext to shutdown
+     * @param force if true, forces Configurator.shutdown even with BasicAsyncLoggerContextSelector
+     */
+    public static void shutdown(LoggerContext context, boolean force) {
         // Get the current ContextSelector and check if it's BasicAsyncLoggerContextSelector
         ContextSelector currentContextSelector = contextSelector.get();
         
-        // Skip Configurator.shutdown if using BasicAsyncLoggerContextSelector to avoid issues
-        if (!(currentContextSelector instanceof BasicAsyncLoggerContextSelector)) {
+        // Skip Configurator.shutdown if using BasicAsyncLoggerContextSelector to avoid issues, unless forced
+        if (force || !(currentContextSelector instanceof BasicAsyncLoggerContextSelector)) {
             //Shutting down log4j in order to avoid memory leaks
             Configurator.shutdown(context);
         }


### PR DESCRIPTION
Closes #32860

### Proposed Changes
* Modified `shutdown(LoggerContext context)` method from the `Log4jUtil` class to skip `Configurator.shutdown()` when using `BasicAsyncLoggerContextSelector`, because this `ContextSelector` works with one global context for the JVM instance.
* The previous `ContextSelector` in use was `ClassLoaderContextSelector` that worked with a logger context by class loader, so the `shutdown(LoggerContext context)` method called from an OSGi plugin only shut down the context for the plugin class loader.  On the other hand, calling the `shutdown(LoggerContext context)` method when using `BasicAsyncLoggerContextSelector` will shut down the global logging context, stopping the JVM logging.
* Also removed the `Async` appender for the `dotcms.log` file from the `log4j2.xml` configuration file for Docker. This is no longer required because we use asynchronous loggers now, so no asynchronous appenders are required anymore.


This PR fixes: #32860