### PR TITLE
Update defect.yaml with tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yaml
+++ b/.github/ISSUE_TEMPLATE/defect.yaml
@@ -1,7 +1,7 @@
 name: Defect
 description: Report a bug or issue with existing functionality
 title: "[DEFECT] "
-labels: ["Triage"]
+labels: ["Triage","OKR : Customer Support"]
 type: bug
 assignees: []
 


### PR DESCRIPTION
adds "OKR : Customer Support" tag that we use for escape defect tracking still.  Eventually tooling will be updated to leverage type field but that's not ready yet.

### Proposed Changes
* add existing label that we use in our legacy internal escape defect tooling