### PR TITLE
chore(content-drive): Added language filter to content-drive list

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-language-field/dot-content-drive-language-field.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-language-field/dot-content-drive-language-field.component.html
@@ -1,0 +1,11 @@
+<p-multiSelect
+    [(ngModel)]="$selectedLanguages"
+    [options]="$state.languages()"
+    optionLabel="language"
+    display="chip"
+    optionValue="id"
+    [placeholder]="'content-drive.language-selector.placeholder' | dm"
+    [showToggleAll]="true"
+    (onChange)="onChange()"
+    [resetFilterOnHide]="true"
+    [scrollHeight]="MULTISELECT_SCROLL_HEIGHT" />

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-language-field/dot-content-drive-language-field.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-language-field/dot-content-drive-language-field.component.ts
@@ -1,0 +1,66 @@
+import { patchState, signalState } from '@ngrx/signals';
+import { of } from 'rxjs';
+
+import { Component, inject, linkedSignal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { MultiSelectModule } from 'primeng/multiselect';
+
+import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
+
+import { DotLanguagesService } from '@dotcms/data-access';
+import { DotLanguage } from '@dotcms/dotcms-models';
+import { DotMessagePipe } from '@dotcms/ui';
+
+import { DEBOUNCE_TIME, PANEL_SCROLL_HEIGHT } from '../../../../shared/constants';
+import { DotContentDriveStore } from '../../../../store/dot-content-drive.store';
+
+@Component({
+    selector: 'dot-content-drive-language-field',
+    imports: [MultiSelectModule, FormsModule, DotMessagePipe],
+    templateUrl: './dot-content-drive-language-field.component.html',
+    styleUrls: ['./dot-content-drive-language-field.component.scss']
+})
+export class DotContentDriveLanguageFieldComponent {
+    readonly #dotLanguagesService = inject(DotLanguagesService);
+    readonly #store = inject(DotContentDriveStore);
+
+    $selectedLanguages = linkedSignal(() => {
+        const languageIds = this.#store.getFilterValue('languageId') as string[];
+
+        if (!languageIds) {
+            return [];
+        }
+
+        return languageIds.map((language) => Number(language));
+    });
+
+    readonly $state = signalState<{ languages: DotLanguage[] }>({
+        languages: []
+    });
+
+    protected readonly MULTISELECT_SCROLL_HEIGHT = PANEL_SCROLL_HEIGHT;
+
+    ngOnInit(): void {
+        this.#dotLanguagesService.get().subscribe((languages) => {
+            patchState(this.$state, { languages });
+        });
+    }
+
+    onChange() {
+        of(this.$selectedLanguages() ?? [])
+            .pipe(
+                debounceTime(DEBOUNCE_TIME), // Debounce to avoid spamming the server
+                distinctUntilChanged()
+            )
+            .subscribe((value) => {
+                if (value.length > 0) {
+                    this.#store.patchFilters({
+                        languageId: value.map((language) => language.toString())
+                    });
+                } else {
+                    this.#store.removeFilter('languageId');
+                }
+            });
+    }
+}

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-language-field/dot-content-drive-language-field.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-language-field/dot-content-drive-language-field.spec.ts
@@ -1,0 +1,141 @@
+import { createComponentFactory, mockProvider, Spectator, SpyObject } from '@ngneat/spectator/jest';
+import { of } from 'rxjs';
+
+import { By } from '@angular/platform-browser';
+
+import { MultiSelect, MultiSelectChangeEvent } from 'primeng/multiselect';
+
+import { DotLanguagesService, DotMessageService } from '@dotcms/data-access';
+import { DotLanguage } from '@dotcms/dotcms-models';
+import { createFakeLanguage, MockDotMessageService } from '@dotcms/utils-testing';
+
+import { DotContentDriveLanguageFieldComponent } from './dot-content-drive-language-field.component';
+
+import { DotContentDriveStore } from '../../../../store/dot-content-drive.store';
+
+const MOCK_LANGUAGES: DotLanguage[] = [
+    createFakeLanguage({
+        id: 1,
+        languageCode: 'en',
+        countryCode: 'US',
+        language: 'English',
+        country: 'United States'
+    }),
+    createFakeLanguage({
+        id: 2,
+        languageCode: 'es',
+        countryCode: 'ES',
+        language: 'Spanish',
+        country: 'Spain'
+    }),
+    createFakeLanguage({
+        id: 3,
+        languageCode: 'fr',
+        countryCode: 'FR',
+        language: 'French',
+        country: 'France'
+    })
+];
+
+describe('DotContentDriveLanguageFieldComponent', () => {
+    let spectator: Spectator<DotContentDriveLanguageFieldComponent>;
+    let component: DotContentDriveLanguageFieldComponent;
+    let store: SpyObject<InstanceType<typeof DotContentDriveStore>>;
+    let languagesService: SpyObject<DotLanguagesService>;
+
+    const createComponent = createComponentFactory({
+        component: DotContentDriveLanguageFieldComponent,
+        providers: [
+            mockProvider(DotContentDriveStore, {
+                patchFilters: jest.fn(),
+                removeFilter: jest.fn(),
+                getFilterValue: jest.fn()
+            }),
+            mockProvider(DotLanguagesService, {
+                get: jest.fn().mockReturnValue(of(MOCK_LANGUAGES))
+            }),
+            {
+                provide: DotMessageService,
+                useValue: new MockDotMessageService({
+                    'content-drive.language-selector.placeholder': 'Language'
+                })
+            }
+        ],
+        detectChanges: false
+    });
+
+    beforeEach(() => {
+        spectator = createComponent();
+        component = spectator.component;
+        store = spectator.inject(DotContentDriveStore, true);
+        languagesService = spectator.inject(DotLanguagesService);
+        store.getFilterValue.mockReturnValue([]);
+    });
+
+    it('should fetch languages and populate state', () => {
+        spectator.detectChanges();
+
+        expect(languagesService.get).toHaveBeenCalled();
+        expect(component.$state().languages).toEqual(MOCK_LANGUAGES);
+    });
+
+    it('should set selectedLanguages when store has languageId filter', () => {
+        store.getFilterValue.mockReturnValue(['1', '2']);
+
+        spectator.detectChanges();
+
+        expect(store.getFilterValue).toHaveBeenCalledWith('languageId');
+        expect(component.$selectedLanguages()).toEqual([1, 2]);
+    });
+
+    it('should patch filters with string values when selectedLanguages has values', () => {
+        spectator.detectChanges();
+
+        const multiSelectDebugElement = spectator.fixture.debugElement.query(
+            By.directive(MultiSelect)
+        );
+
+        spectator.triggerEventHandler(multiSelectDebugElement, 'ngModelChange', [1, 2]);
+
+        expect(component.$selectedLanguages()).toEqual([1, 2]);
+
+        spectator.triggerEventHandler(MultiSelect, 'onChange', {} as MultiSelectChangeEvent);
+
+        expect(store.patchFilters).toHaveBeenCalledWith({
+            languageId: ['1', '2']
+        });
+    });
+
+    it('should remove filter when selectedLanguages is empty', () => {
+        component.$selectedLanguages.set([]);
+
+        const multiSelectDebugElement = spectator.fixture.debugElement.query(
+            By.directive(MultiSelect)
+        );
+
+        spectator.triggerEventHandler(multiSelectDebugElement, 'ngModelChange', []);
+
+        spectator.triggerEventHandler(MultiSelect, 'onChange', {} as MultiSelectChangeEvent);
+
+        expect(store.removeFilter).toHaveBeenCalledWith('languageId');
+    });
+
+    describe('MultiSelect', () => {
+        it('should have correct properties configured', () => {
+            spectator.detectChanges();
+
+            const multiSelectDebugElement = spectator.fixture.debugElement.query(
+                By.directive(MultiSelect)
+            );
+            const multiSelectComponent = multiSelectDebugElement.componentInstance;
+
+            expect(multiSelectComponent.scrollHeight).toBe('25rem');
+            expect(multiSelectComponent.resetFilterOnHide).toBe(true);
+            expect(multiSelectComponent.showToggleAll).toBe(true);
+
+            // For placeholder, we need to check the resolved value from the DOM
+            const multiSelectElement = spectator.query('p-multiselect');
+            expect(multiSelectElement.getAttribute('ng-reflect-placeholder')).toBe('Language');
+        });
+    });
+});

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
@@ -19,6 +19,7 @@
         <div class="p-toolbar-group-bottom">
             <dot-content-drive-base-type-selector data-testid="base-type-selector" />
             <dot-content-drive-content-type-field data-testid="content-type-field" />
+            <dot-content-drive-language-field data-testid="language-field" />
         </div>
     </div>
 </p-toolbar>

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.scss
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.scss
@@ -12,6 +12,7 @@
             border: none;
             border-bottom: 1px solid $color-palette-gray-300;
             gap: $spacing-1;
+            height: 100%;
         }
     }
 }

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
@@ -4,7 +4,7 @@ import { of } from 'rxjs';
 
 import { provideHttpClient } from '@angular/common/http';
 
-import { DotContentTypeService, DotMessageService } from '@dotcms/data-access';
+import { DotContentTypeService, DotLanguagesService, DotMessageService } from '@dotcms/data-access';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 
 import { DotContentDriveToolbarComponent } from './dot-content-drive-toolbar.component';
@@ -41,6 +41,9 @@ describe('DotContentDriveToolbarComponent', () => {
                     })
                 ),
                 getAllContentTypes: jest.fn().mockReturnValue(of(MOCK_BASE_TYPES))
+            }),
+            mockProvider(DotLanguagesService, {
+                get: jest.fn().mockReturnValue(of())
             }),
             provideHttpClient(),
             mockProvider(DotMessageService, new MockDotMessageService({}))
@@ -96,6 +99,12 @@ describe('DotContentDriveToolbarComponent', () => {
     it('should render the base type selector', () => {
         spectator.detectChanges();
         const selector = spectator.query('[data-testid="base-type-selector"]');
+        expect(selector).toBeTruthy();
+    });
+
+    it('should render the language selector', () => {
+        spectator.detectChanges();
+        const selector = spectator.query('[data-testid="language-field"]');
         expect(selector).toBeTruthy();
     });
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.ts
@@ -5,6 +5,7 @@ import { ToolbarModule } from 'primeng/toolbar';
 
 import { DotContentDriveBaseTypeSelectorComponent } from './components/dot-content-drive-base-type-selector/dot-content-drive-base-type-selector.component';
 import { DotContentDriveContentTypeFieldComponent } from './components/dot-content-drive-content-type-field/dot-content-drive-content-type-field.component';
+import { DotContentDriveLanguageFieldComponent } from './components/dot-content-drive-language-field/dot-content-drive-language-field.component';
 import { DotContentDriveSearchInputComponent } from './components/dot-content-drive-search-input/dot-content-drive-search-input.component';
 import { DotContentDriveTreeTogglerComponent } from './components/dot-content-drive-tree-toggler/dot-content-drive-tree-toggler.component';
 
@@ -18,9 +19,9 @@ import { DotContentDriveStore } from '../../store/dot-content-drive.store';
         DotContentDriveTreeTogglerComponent,
         DotContentDriveBaseTypeSelectorComponent,
         DotContentDriveContentTypeFieldComponent,
-        DotContentDriveSearchInputComponent
+        DotContentDriveSearchInputComponent,
+        DotContentDriveLanguageFieldComponent
     ],
-    providers: [],
     templateUrl: './dot-content-drive-toolbar.component.html',
     styleUrl: './dot-content-drive-toolbar.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
@@ -18,7 +18,8 @@ import {
     DotWorkflowActionsFireService,
     DotWorkflowEventHandlerService,
     DotWorkflowsActionsService,
-    DotRouterService
+    DotRouterService,
+    DotLanguagesService
 } from '@dotcms/data-access';
 import { DotFolderListViewComponent } from '@dotcms/portlets/content-drive/ui';
 import { GlobalStore } from '@dotcms/store';
@@ -57,6 +58,9 @@ describe('DotContentDriveShellComponent', () => {
             mockProvider(DotSystemConfigService),
             mockProvider(DotContentTypeService, {
                 getAllContentTypes: jest.fn().mockReturnValue(of(MOCK_BASE_TYPES))
+            }),
+            mockProvider(DotLanguagesService, {
+                get: jest.fn().mockReturnValue(of())
             }),
             provideHttpClient()
         ],

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/models.ts
@@ -95,6 +95,7 @@ export type DotKnownContentDriveFilters = {
     baseType: string[];
     contentType: string[];
     title: string;
+    languageId: string[];
 };
 
 /**

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/functions.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/functions.spec.ts
@@ -553,7 +553,7 @@ describe('Utility Functions', () => {
                 baseType: ['1', '2'],
                 title: 'dotCMS content management',
                 status: 'published',
-                languageId: '1'
+                languageId: ['1']
             };
 
             const result = buildContentDriveQuery({

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/functions.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/functions.ts
@@ -48,7 +48,8 @@ export const decodeByFilterKey: Record<
     baseType: multiSelector,
     // Should always return an array
     contentType: multiSelector,
-    title: singleSelector
+    title: singleSelector,
+    languageId: multiSelector
 };
 
 /**

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6015,6 +6015,7 @@ uve.editor.error.default.description=Please try again later. If the problem pers
 content-drive.content-type-field.empty-state=No content types found
 content-drive.content-type.placeholder=Content type
 content-drive.base-type.placeholder=Base type
+content-drive.language-selector.placeholder=Locale
 content-drive.context-menu.edit-content=Edit Content
 content-drive.context-menu.edit-page=Edit Page
 content-drive.toast.workflow-executed=Workflow Executed


### PR DESCRIPTION
This PR introduces the filter by language Id on content-drive 

https://github.com/user-attachments/assets/be61460f-e557-4f7b-a78a-51d62d3e9304


This PR fixes: #33161

This PR fixes: #33161