### PR TITLE
[30939] feat: improve swagger documentation of job queues resources

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobParamsSchema.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobParamsSchema.java
@@ -19,11 +19,12 @@ public class JobParamsSchema {
     @Schema(
             description = "JSON string with job-specific parameters.",
             type = "string",
-            example = "{\n" +
-                    "  \"sourceUrl\": \"https://example.com/image.jpeg\",\n" +
-                    "  \"width\": 320,\n" +
-                    "  \"height\": 240,\n" +
-                    "}"
+            example = "{\n"
+                    + "  \"contentType\": \"CustomContentType\",\n"
+                    + "  \"workflowActionId\": \"Workflow-UUID\",\n"
+                    + "  \"language\": \"en-us\",\n"
+                    + "  \"stopOnError\": true\n"
+                    + "}"
     )
     private String params;
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobParamsSchema.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobParamsSchema.java
@@ -1,0 +1,45 @@
+package com.dotcms.rest.api.v1.job;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.ws.rs.FormParam;
+
+@Schema(description = "Schema for multipart job queue parameters.")
+public class JobParamsSchema {
+
+    @FormParam("file")
+    @Schema(
+            description = "The file to be processed by the job.",
+            type = "string",
+            format = "binary"
+    )
+    private String file;
+
+    @FormParam("params")
+    @Schema(
+            description = "JSON string with job-specific parameters.",
+            type = "string",
+            example = "{\n" +
+                    "  \"sourceUrl\": \"https://example.com/image.jpeg\",\n" +
+                    "  \"width\": 320,\n" +
+                    "  \"height\": 240,\n" +
+                    "}"
+    )
+    private String params;
+
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public String getParams() {
+        return params;
+    }
+
+    public void setParams(String params) {
+        this.params = params;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueDocs.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueDocs.java
@@ -1,0 +1,19 @@
+package com.dotcms.rest.api.v1.job;
+
+public class JobQueueDocs {
+
+    public static final String FORM_FIELD_DOC =
+            "This endpoint accepts a `multipart/form-data` request with two fields:\n\n" +
+                    "| **Field** | **Type** | **Required** | **Description** |\n" +
+                    "|-----------|----------|--------------|-----------------|\n" +
+                    "| `file`    | File     | ❌ No        | The file to be processed by the queue.|\n" +
+                    "| `form`    | String   | ❌ No        | A JSON string containing job-specific parameters.|\n\n" +
+                    "**Example `form` value:**\n\n" +
+                    "```json\n" +
+                    "{\n" +
+                    "  \"sourceUrl\": \"https://example.com/image.jpeg\",\n" +
+                    "  \"width\": 320,\n" +
+                    "  \"height\": 240,\n" +
+                    "}\n" +
+                    "```";
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueDocs.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueDocs.java
@@ -11,9 +11,7 @@ public class JobQueueDocs {
                     "**Example `form` value:**\n\n" +
                     "```json\n" +
                     "{\n" +
-                    "  \"sourceUrl\": \"https://example.com/image.jpeg\",\n" +
-                    "  \"width\": 320,\n" +
-                    "  \"height\": 240,\n" +
+                    " \"contentType\":\"CustomContentType\", \"workflowActionId\":\"Workflow-UUID\", \"language\":\"en-us\", \"stopOnError\":true,\n" +
                     "}\n" +
                     "```";
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueResource.java
@@ -3,9 +3,7 @@ package com.dotcms.rest.api.v1.job;
 import com.dotcms.jobs.business.error.JobValidationException;
 import com.dotcms.jobs.business.job.Job;
 import com.dotcms.jobs.business.job.JobPaginatedResult;
-import com.dotcms.rest.ResponseEntityJobStatusView;
-import com.dotcms.rest.ResponseEntityView;
-import com.dotcms.rest.WebResource;
+import com.dotcms.rest.*;
 import com.dotcms.rest.WebResource.InitBuilder;
 import com.dotcms.rest.exception.mapper.ExceptionMapperUtil;
 import com.dotmarketing.exception.DotDataException;
@@ -13,7 +11,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import graphql.VisibleForTesting;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -59,6 +59,11 @@ public class JobQueueResource {
         this.sseMonitorUtil = sseMonitorUtil;
     }
 
+    /**
+     * Creates and enqueues a job whose parameters are supplied as a multipart
+     * form. Typical use-cases include uploading a file together with a JSON
+     * payload of options.
+     */
     @POST
     @Path("/{queueName}")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
@@ -69,19 +74,50 @@ public class JobQueueResource {
             description = "Creates and queues a new background job with multipart form data parameters. " +
                     "Returns the job ID and initial status information.",
             tags = {"Job Queue"},
+            requestBody = @RequestBody(
+                    description = JobQueueDocs.FORM_FIELD_DOC,
+                    required = false,
+                    content = @Content(
+                            mediaType = MediaType.MULTIPART_FORM_DATA,
+                            schema = @Schema(implementation = JobParamsSchema.class)
+                    )
+            ),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Job created successfully",
-                            content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ResponseEntityJobStatusView.class))),
-                    @ApiResponse(responseCode = "400", description = "Bad request - Invalid job parameters or queue name"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized - User not authenticated"),
-                    @ApiResponse(responseCode = "403", description = "Forbidden - User lacks required permissions"),
-                    @ApiResponse(responseCode = "500", description = "Internal server error")
+                            content = @Content(mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResponseEntityJobStatusView.class),
+                                    examples = @ExampleObject(value = "{\n" +
+                                            "  \"entity\": {\n" +
+                                            "    \"jobId\": \"e6d9bae8-657b-4e2f-8524-c0222db66355\",\n" +
+                                            "    \"statusUrl\": \"http://localhost:8080/api/v1/_import/e6d9bae8-657b-4e2f-8524-c0222db66355\"\n" +
+                                            "  },\n" +
+                                            "  \"errors\": [],\n" +
+                                            "  \"i18nMessagesMap\": {},\n" +
+                                            "  \"messages\": [],\n" +
+                                            "  \"pagination\": null,\n" +
+                                            "  \"permissions\": []\n" +
+                                            "}")
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Bad Request: Invalid parameters, malformed multipart payload, or file issues."),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User lacks permission to enqueue jobs in the specified queue."),
+                    @ApiResponse(responseCode = "404", description = "Not Found: Queue with the specified name does not exist."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while creating the job.")
             }
     )
     public Response createJob(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
-            @Parameter(description = "Name of the job queue to submit to") @PathParam("queueName") String queueName,
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("queueName")
+            @Parameter(
+                    name        = "queueName",
+                    in          = ParameterIn.PATH,
+                    required    = true,
+                    description = "Name of the job queue to submit to",
+                    schema      = @Schema(type = "string", example = "image-processing")
+            )
+            String queueName,
             @Parameter(description = "Job parameters as multipart form data") @BeanParam JobParams form) throws JsonProcessingException, DotDataException {
 
         final var initDataObject = new InitBuilder(webResource)
@@ -101,6 +137,13 @@ public class JobQueueResource {
         }
     }
 
+    /**
+     * REST resource for queueing arbitrary jobs.
+     *
+     * <p>This endpoint accepts a JSON payload with job-specific parameters and
+     * enqueues the job on the specified queue, returning a handle that can later
+     * be polled for status updates.</p>
+     */
     @POST
     @Path("/{queueName}")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -111,19 +154,57 @@ public class JobQueueResource {
             description = "Creates and queues a new background job with JSON parameters. " +
                     "Returns the job ID and initial status information.",
             tags = {"Job Queue"},
+            requestBody = @RequestBody(
+                    required    = true,
+                    description = "Opaque key/value map with job-specific parameters.",
+                    content     = @Content(
+                            mediaType = MediaType.APPLICATION_JSON,
+                            examples  = @ExampleObject(
+                                    name  = "ThumbnailJob",
+                                    value = "{\n"
+                                            + "  \"sourceUrl\": \"https://example.com/image.jpeg\",\n"
+                                            + "  \"width\"    : 320,\n"
+                                            + "  \"height\"   : 240\n"
+                                            + "}"
+                            )
+                    )
+            ),
             responses = {
                     @ApiResponse(responseCode = "200", description = "Job created successfully",
                             content = @Content(mediaType = "application/json",
-                                    schema = @Schema(implementation = ResponseEntityJobStatusView.class))),
-                    @ApiResponse(responseCode = "400", description = "Bad request - Invalid job parameters or queue name"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized - User not authenticated"),
-                    @ApiResponse(responseCode = "403", description = "Forbidden - User lacks required permissions"),
-                    @ApiResponse(responseCode = "500", description = "Internal server error")
+                                    schema = @Schema(implementation = ResponseEntityJobStatusView.class),
+                                    examples = @ExampleObject(value = "{\n" +
+                                            "  \"entity\": {\n" +
+                                            "    \"jobId\": \"e6d9bae8-657b-4e2f-8524-c0222db66355\",\n" +
+                                            "    \"statusUrl\": \"http://localhost:8080/api/v1/_import/e6d9bae8-657b-4e2f-8524-c0222db66355\"\n" +
+                                            "  },\n" +
+                                            "  \"errors\": [],\n" +
+                                            "  \"i18nMessagesMap\": {},\n" +
+                                            "  \"messages\": [],\n" +
+                                            "  \"pagination\": null,\n" +
+                                            "  \"permissions\": []\n" +
+                                            "}")
+                            )
+                    ),
+                    @ApiResponse(responseCode = "400", description = "Bad Request: Invalid parameters or malformed JSON."),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User lacks permission to enqueue jobs in the specified queue."),
+                    @ApiResponse(responseCode = "404", description = "Not Found: Queue with the specified name does not exist."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while creating the job.")
             }
     )
     public Response createJob(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
-            @Parameter(description = "Name of the job queue to submit to") @PathParam("queueName") String queueName,
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("queueName")
+            @Parameter(
+                    name        = "queueName",
+                    in          = ParameterIn.PATH,
+                    required    = true,
+                    description = "Name of the job queue to submit to",
+                    schema      = @Schema(type = "string", example = "image-processing")
+            )
+            String queueName,
             @RequestBody(description = "Job parameters as JSON key-value pairs",
                     required = true,
                     content = @Content(schema = @Schema(type = "object", additionalProperties = Schema.AdditionalPropertiesValue.TRUE)))
@@ -146,6 +227,9 @@ public class JobQueueResource {
         }
     }
 
+    /**
+     * Lists all available job queues.
+     */
     @GET
     @Path("/queues")
     @Produces(MediaType.APPLICATION_JSON)
@@ -164,7 +248,8 @@ public class JobQueueResource {
             }
     )
     public ResponseEntityView<Set<String>> getQueues(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response) {
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response) {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
                 .requiredFrontendUser(false)
@@ -174,6 +259,15 @@ public class JobQueueResource {
         return new ResponseEntityView<>(helper.getQueueNames());
     }
 
+    /**
+     * Retrieves the status of a job based on the provided job ID.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param jobId The ID of the job whose status is to be retrieved.
+     * @return A ResponseEntityView containing the job status.
+     * @throws DotDataException If there is an issue with DotData during the retrieval process.
+     */
     @GET
     @Path("/{jobId}/status")
     @Produces(MediaType.APPLICATION_JSON)
@@ -194,8 +288,17 @@ public class JobQueueResource {
             }
     )
     public ResponseEntityView<Job> getJobStatus(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
-            @Parameter(description = "Unique identifier of the job") @PathParam("jobId") String jobId) throws DotDataException {
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("jobId")
+            @Parameter(
+                    name        = "jobId",
+                    in          = ParameterIn.PATH,
+                    required    = true,
+                    description = "Unique identifier (UUID) of the job.",
+                    schema      = @Schema(type = "string", format = "uuid", example = "e6d9bae8-657b-4e2f-8524-c0222db66355")
+            )
+            String jobId) throws DotDataException {
 
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -208,13 +311,59 @@ public class JobQueueResource {
         return new ResponseEntityView<>(job);
     }
 
+    /**
+     * Cancels a job based on the provided job ID.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param jobId The ID of the job to be canceled.
+     * @return A ResponseEntityView containing a message indicating the cancellation status.
+     * @throws DotDataException If there is an issue with DotData during the cancellation process.
+     */
     @POST
     @Path("/{jobId}/cancel")
-    @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.WILDCARD)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "cancelJobQueueJob",
+            summary     = "Cancel a job",
+            description = "Sends an asynchronous cancellation request for the specified job. "
+                    + "The job may still complete if it has already finished or cannot be interrupted.",
+            tags        = {"Job Queue"},
+            responses   = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description  = "Cancellation request accepted.",
+                            content      = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema    = @Schema(implementation = ResponseEntityStringView.class),
+                                    examples  = @ExampleObject(
+                                            value = "{\n"
+                                                    + "  \"entity\": "
+                                                    + "\"Cancellation request successfully sent to job "
+                                                    + "e6d9bae8-657b-4e2f-8524-c0222db66355\"\n"
+                                                    + "}"
+                                    )
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User does not have permission to cancel this job."),
+                    @ApiResponse(responseCode = "404", description = "Not Found: Job with the specified ID does not exist or is already completed/cancelled."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while attempting to cancel the job.")
+            }
+    )
     public ResponseEntityView<String> cancelJob(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
-            @PathParam("jobId") String jobId) throws DotDataException {
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("jobId")
+            @Parameter(
+                    name        = "jobId",
+                    in          = ParameterIn.PATH,
+                    required    = true,
+                    description = "Unique identifier (UUID) of the job to cancel.",
+                    schema      = @Schema(type = "string", format = "uuid", example = "e6d9bae8-657b-4e2f-8524-c0222db66355")
+            )
+            String jobId) throws DotDataException {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
                 .requiredFrontendUser(false)
@@ -225,13 +374,59 @@ public class JobQueueResource {
         return new ResponseEntityView<>("Cancellation request successfully sent to job " + jobId);
     }
 
+    /**
+     * Retrieves the status of active jobs on a given queue.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param queueName The name of the queue to search for active jobs.
+     * @param page The page number for pagination (default is 1).
+     * @param pageSize The number of jobs per page (default is 20).
+     * @return A ResponseEntityView containing the paginated result of active jobs.
+     */
     @GET
     @Path("/{queueName}/active")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "getActiveJobsByQueue",
+            summary     = "Retrieves active jobs in a queue",
+            description = "Fetches a paginated list of active jobs. Results can be paginated using query parameters."
+                    + "for the specified queue.",
+            tags        = {"Job Queue"},
+            responses   = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description  = "Successfully retrieved active jobs for the queue.",
+                            content      = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema    = @Schema(implementation = ResponseEntityJobPaginatedResultView.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User does not have permission to view jobs in this queue."),
+                    @ApiResponse(responseCode = "404", description = "Not Found: Queue with the specified name does not exist."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while retrieving jobs.")
+            }
+    )
     public ResponseEntityView<JobPaginatedResult> activeJobs(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
-            @PathParam("queueName") String queueName,
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("queueName")
+            @Parameter(
+                    name        = "queueName",
+                    in          = ParameterIn.PATH,
+                    required    = true,
+                    description = "Logical name of the queue.",
+                    schema      = @Schema(type = "string", example = "image-processing")
+            )
+            String queueName,
+            @Parameter(
+                    description = "Page number to retrieve (1-based indexing)."
+            )
             @QueryParam("page") @DefaultValue("1") int page,
+            @Parameter(
+                    description = "Number of records per page."
+            )
             @QueryParam("pageSize") @DefaultValue("20") int pageSize) {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -243,11 +438,46 @@ public class JobQueueResource {
         return new ResponseEntityView<>(result);
     }
 
+    /**
+     * Retrieves the status of all jobs.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param page The page number for pagination (default is 1).
+     * @param pageSize The number of jobs per page (default is 20).
+     * @return A ResponseEntityView containing the paginated result of jobs.
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "listJobs",
+            summary = "Retrieves jobs",
+            description = "Fetches a paginated list of all jobs regardless of state. Results can be paginated using query parameters.",
+            tags        = {"Job Queue"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Successfully retrieved the paginated list of jobs.",
+                            content = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResponseEntityJobPaginatedResultView.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User does not have necessary permissions to view jobs."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while retrieving jobs.")
+            }
+    )
     public ResponseEntityView<JobPaginatedResult> listJobs(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @Parameter(
+                    description = "Page number to retrieve (1-based indexing)."
+            )
             @QueryParam("page") @DefaultValue("1") int page,
+            @Parameter(
+                    description = "Number of records per page."
+            )
             @QueryParam("pageSize") @DefaultValue("20") int pageSize) {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -259,12 +489,47 @@ public class JobQueueResource {
         return new ResponseEntityView<>(result);
     }
 
+    /**
+     * Retrieves the status of active jobs.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param page The page number for pagination (default is 1).
+     * @param pageSize The number of jobs per page (default is 20).
+     * @return A ResponseEntityView containing the paginated result of active jobs.
+     */
     @GET
     @Path("/active")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "getActiveJobs",
+            summary = "Retrieves active jobs",
+            description = "Fetches a paginated list of active jobs. Results can be paginated using query parameters.",
+            tags        = {"Job Queue"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Successfully retrieved the paginated list of active jobs.",
+                            content = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResponseEntityJobPaginatedResultView.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User does not have necessary permissions to view jobs."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while retrieving jobs.")
+            }
+    )
     public ResponseEntityView<JobPaginatedResult> activeJobs(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @Parameter(
+                    description = "Page number to retrieve (1-based indexing)."
+            )
             @QueryParam("page") @DefaultValue("1") int page,
+            @Parameter(
+                    description = "Number of records per page."
+            )
             @QueryParam("pageSize") @DefaultValue("20") int pageSize) {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -276,12 +541,47 @@ public class JobQueueResource {
         return new ResponseEntityView<>(result);
     }
 
+    /**
+     * Retrieves the status of completed jobs.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param page The page number for pagination (default is 1).
+     * @param pageSize The number of jobs per page (default is 20).
+     * @return A ResponseEntityView containing the paginated result of completed jobs.
+     */
     @GET
     @Path("/completed")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "getCompletedJobs",
+            summary = "Retrieves completed jobs",
+            description = "Fetches a paginated list of completed jobs. Results can be paginated using query parameters.",
+            tags        = {"Job Queue"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Successfully retrieved the paginated list of completed jobs.",
+                            content = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResponseEntityJobPaginatedResultView.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User does not have necessary permissions to view jobs."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while retrieving jobs.")
+            }
+    )
     public ResponseEntityView<JobPaginatedResult> completedJobs(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @Parameter(
+                    description = "Page number to retrieve (1-based indexing)."
+            )
             @QueryParam("page") @DefaultValue("1") int page,
+            @Parameter(
+                    description = "Number of records per page."
+            )
             @QueryParam("pageSize") @DefaultValue("20") int pageSize) {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -293,13 +593,48 @@ public class JobQueueResource {
         return new ResponseEntityView<>(result);
     }
 
+    /**
+     * Retrieves the status of successful jobs.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param page The page number for pagination (default is 1).
+     * @param pageSize The number of jobs per page (default is 20).
+     * @return A ResponseEntityView containing the paginated result of successful jobs.
+     */
     @GET
     @Path("/successful")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "getSuccessfulJobs",
+            summary = "Retrieves successful jobs",
+            description = "Fetches a paginated list of successful jobs. Results can be paginated using query parameters.",
+            tags        = {"Job Queue"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Successfully retrieved the paginated list of successful jobs.",
+                            content = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResponseEntityJobPaginatedResultView.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User does not have necessary permissions to view jobs."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while retrieving jobs.")
+            }
+    )
     public ResponseEntityView<JobPaginatedResult> successfulJobs(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
-            @QueryParam("page") @DefaultValue("1") int page,
-            @QueryParam("pageSize") @DefaultValue("20") int pageSize) {
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @QueryParam("page")
+            @DefaultValue("1")
+            @Parameter(description = "Page number to retrieve (1-based).")
+            int page,
+            @QueryParam("pageSize")
+            @DefaultValue("20")
+            @Parameter(description = "Number of records per page.")
+            int pageSize) {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
                 .requiredFrontendUser(false)
@@ -310,12 +645,47 @@ public class JobQueueResource {
         return new ResponseEntityView<>(result);
     }
 
+    /**
+     * Retrieves the status of canceled jobs.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param page The page number for pagination (default is 1).
+     * @param pageSize The number of jobs per page (default is 20).
+     * @return A ResponseEntityView containing the paginated result of canceled jobs.
+     */
     @GET
     @Path("/canceled")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "getCanceledJobs",
+            summary     = "Retrieves canceled jobs",
+            description = "Fetches a paginated list of canceled jobs. Results can be paginated using query parameters.",
+            tags        = {"Job Queue"},
+            responses   = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description  = "Successfully retrieved the paginated list of canceled jobs.",
+                            content      = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema    = @Schema(implementation = ResponseEntityJobPaginatedResultView.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User lacks permission to view jobs."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while retrieving jobs.")
+            }
+    )
     public ResponseEntityView<JobPaginatedResult> canceledJobs(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @Parameter(
+                    description = "Page number to retrieve (1-based indexing)."
+            )
             @QueryParam("page") @DefaultValue("1") int page,
+            @Parameter(
+                    description = "Number of records per page."
+            )
             @QueryParam("pageSize") @DefaultValue("20") int pageSize) {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -327,12 +697,47 @@ public class JobQueueResource {
         return new ResponseEntityView<>(result);
     }
 
+    /**
+     * Retrieves the status of failed jobs.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param page The page number for pagination (default is 1).
+     * @param pageSize The number of jobs per page (default is 20).
+     * @return A ResponseEntityView containing the paginated result of failed jobs.
+     */
     @GET
     @Path("/failed")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "getFailedJobs",
+            summary     = "Retrieves failed jobs",
+            description = "Fetches a paginated list of failed jobs. Results can be paginated using query parameters.",
+            tags        = {"Job Queue"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Successfully retrieved the paginated list of failed jobs.",
+                            content = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResponseEntityJobPaginatedResultView.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User does not have necessary permissions to view jobs."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while retrieving jobs.")
+            }
+    )
     public ResponseEntityView<JobPaginatedResult> failedJobs(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @Parameter(
+                    description = "Page number to retrieve (1-based indexing)."
+            )
             @QueryParam("page") @DefaultValue("1") int page,
+            @Parameter(
+                    description = "Number of records per page."
+            )
             @QueryParam("pageSize") @DefaultValue("20") int pageSize) {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -344,12 +749,47 @@ public class JobQueueResource {
         return new ResponseEntityView<>(result);
     }
 
+    /**
+     * Retrieves the status of abandoned jobs.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param page The page number for pagination (default is 1).
+     * @param pageSize The number of jobs per page (default is 20).
+     * @return A ResponseEntityView containing the paginated result of abandoned jobs.
+     */
     @GET
     @Path("/abandoned")
     @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            operationId = "getAbandonedJobs",
+            summary = "Retrieves abandoned jobs",
+            description = "Fetches a paginated list of abandoned jobs. Results can be paginated using query parameters.",
+            tags        = {"Job Queue"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Successfully retrieved the paginated list of abandoned jobs.",
+                            content = @Content(
+                                    mediaType = MediaType.APPLICATION_JSON,
+                                    schema = @Schema(implementation = ResponseEntityJobPaginatedResultView.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User does not have necessary permissions to view jobs."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while retrieving jobs.")
+            }
+    )
     public ResponseEntityView<JobPaginatedResult> abandonedJobs(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @Parameter(
+                    description = "Page number to retrieve (1-based indexing)."
+            )
             @QueryParam("page") @DefaultValue("1") int page,
+            @Parameter(
+                    description = "Number of records per page."
+            )
             @QueryParam("pageSize") @DefaultValue("20") int pageSize) {
         new InitBuilder(webResource)
                 .requiredBackendUser(true)
@@ -361,13 +801,50 @@ public class JobQueueResource {
         return new ResponseEntityView<>(result);
     }
 
+    /**
+     * Monitors the progress of a specific job identified by its jobId.
+     *
+     * @param request The HTTP servlet request containing user and context information.
+     * @param response The HTTP servlet response that will contain the response to the client.
+     * @param jobId The ID of the job whose progress is to be monitored.
+     * @return An EventOutput for real-time job progress updates.
+     */
     @GET
     @Path("/{jobId}/monitor")
     @Produces(SseFeature.SERVER_SENT_EVENTS)
     @SuppressWarnings("java:S1854") // jobWatcher assignment is needed for cleanup in catch blocks
+    @Operation(
+            operationId = "monitorJob",
+            summary     = "Monitor a job in real time",
+            description = "Establishes a Server-Sent Events (SSE) connection to monitor the progress of a specific  job in real-time. This endpoint will continuously send updates as the job progresses, including status changes and completion information.",
+            tags        = {"Job Queue"},
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Server-Sent Events stream established successfully. Events will be sent as the job progresses.",
+                            content = @Content(
+                                    mediaType = SseFeature.SERVER_SENT_EVENTS,
+                                    schema = @Schema(implementation = EventOutput.class)
+                            )
+                    ),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized: Invalid or missing user authentication."),
+                    @ApiResponse(responseCode = "403", description = "Forbidden: User does not have permissions to monitor the specified job."),
+                    @ApiResponse(responseCode = "404", description = "Not Found: Job with the specified ID could not be found."),
+                    @ApiResponse(responseCode = "500", description = "Internal Server Error: An unexpected error occurred while establishing the monitoring connection.")
+            }
+    )
     public EventOutput monitorJob(
-            @Context final HttpServletRequest request, @Context final HttpServletResponse response,
-            @PathParam("jobId") String jobId) {
+            @Context final HttpServletRequest request,
+            @Context final HttpServletResponse response,
+            @PathParam("jobId")
+            @Parameter(
+                    name = "jobId",
+                    in = ParameterIn.PATH,
+                    required = true,
+                    description = "The unique identifier (UUID) of the job whose status is to be retrieved.",
+                    schema = @Schema(type = "string", format = "uuid", example = "e6d9bae8-657b-4e2f-8524-c0222db66355")
+            )
+            String jobId) {
 
         new InitBuilder(webResource)
                 .requiredBackendUser(true)

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueResource.java
@@ -162,9 +162,10 @@ public class JobQueueResource {
                             examples  = @ExampleObject(
                                     name  = "ThumbnailJob",
                                     value = "{\n"
-                                            + "  \"sourceUrl\": \"https://example.com/image.jpeg\",\n"
-                                            + "  \"width\"    : 320,\n"
-                                            + "  \"height\"   : 240\n"
+                                            + "  \"contentType\": \"CustomContentType\",\n"
+                                            + "  \"workflowActionId\": \"Workflow-UUID\",\n"
+                                            + "  \"language\": \"en-us\",\n"
+                                            + "  \"stopOnError\": true\n"
                                             + "}"
                             )
                     )

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueResource.java
@@ -65,7 +65,7 @@ public class JobQueueResource {
      * payload of options.
      */
     @POST
-    @Path("/{queueName}")
+    @Path("/{queueName}/upload")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -21711,12 +21711,8 @@ components:
         params:
           type: string
           description: JSON string with job-specific parameters.
-          example: |-
-            {
-              "sourceUrl": "https://example.com/image.jpeg",
-              "width": 320,
-              "height": 240,
-            }
+          example: "{\"contentType\":\"CustomContentType\",\"workflowActionId\":\"\
+            Workflow-UUID\",\"language\":\"en-us\",\"stopOnError\":true}"
     JobResult:
       type: object
       properties:

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -9266,6 +9266,71 @@ paths:
       summary: Retrieves active jobs in a queue
       tags:
       - Job Queue
+  /v1/jobs/{queueName}/upload:
+    post:
+      description: Creates and queues a new background job with multipart form data
+        parameters. Returns the job ID and initial status information.
+      operationId: createJobWithFormData
+      parameters:
+      - description: Name of the job queue to submit to
+        in: path
+        name: queueName
+        required: true
+        schema:
+          type: string
+          example: image-processing
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/JobParamsSchema"
+        description: |-
+          This endpoint accepts a `multipart/form-data` request with two fields:
+
+          | **Field** | **Type** | **Required** | **Description** |
+          |-----------|----------|--------------|-----------------|
+          | `file`    | File     | ❌ No        | The file to be processed by the queue.|
+          | `form`    | String   | ❌ No        | A JSON string containing job-specific parameters.|
+
+          **Example `form` value:**
+
+          ```json
+          {
+           "contentType":"CustomContentType", "workflowActionId":"Workflow-UUID", "language":"en-us", "stopOnError":true,
+          }
+          ```
+      responses:
+        "200":
+          content:
+            application/json:
+              example:
+                entity:
+                  jobId: e6d9bae8-657b-4e2f-8524-c0222db66355
+                  statusUrl: http://localhost:8080/api/v1/_import/e6d9bae8-657b-4e2f-8524-c0222db66355
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
+              schema:
+                $ref: "#/components/schemas/ResponseEntityJobStatusView"
+          description: Job created successfully
+        "400":
+          description: "Bad Request: Invalid parameters, malformed multipart payload,\
+            \ or file issues."
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User lacks permission to enqueue jobs in the specified\
+            \ queue."
+        "404":
+          description: "Not Found: Queue with the specified name does not exist."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ creating the job."
+      summary: Creates a new job with form data
+      tags:
+      - Job Queue
   /v1/jvm:
     get:
       operationId: getJvmInfo

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -8775,152 +8775,229 @@ paths:
       - Health
   /v1/jobs:
     get:
+      description: Fetches a paginated list of all jobs regardless of state. Results
+        can be paginated using query parameters.
       operationId: listJobs
       parameters:
-      - in: query
+      - description: Page number to retrieve (1-based indexing).
+        in: query
         name: page
         schema:
           type: integer
           format: int32
           default: 1
-      - in: query
+      - description: Number of records per page.
+        in: query
         name: pageSize
         schema:
           type: integer
           format: int32
           default: 20
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
-          description: default response
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves jobs
       tags:
       - Job Queue
   /v1/jobs/abandoned:
     get:
-      operationId: abandonedJobs
+      description: Fetches a paginated list of abandoned jobs. Results can be paginated
+        using query parameters.
+      operationId: getAbandonedJobs
       parameters:
-      - in: query
+      - description: Page number to retrieve (1-based indexing).
+        in: query
         name: page
         schema:
           type: integer
           format: int32
           default: 1
-      - in: query
+      - description: Number of records per page.
+        in: query
         name: pageSize
         schema:
           type: integer
           format: int32
           default: 20
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
-          description: default response
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of abandoned jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves abandoned jobs
       tags:
       - Job Queue
   /v1/jobs/active:
     get:
-      operationId: activeJobs
+      description: Fetches a paginated list of active jobs. Results can be paginated
+        using query parameters.
+      operationId: getActiveJobs
       parameters:
-      - in: query
+      - description: Page number to retrieve (1-based indexing).
+        in: query
         name: page
         schema:
           type: integer
           format: int32
           default: 1
-      - in: query
+      - description: Number of records per page.
+        in: query
         name: pageSize
         schema:
           type: integer
           format: int32
           default: 20
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
-          description: default response
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of active jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves active jobs
       tags:
       - Job Queue
   /v1/jobs/canceled:
     get:
-      operationId: canceledJobs
+      description: Fetches a paginated list of canceled jobs. Results can be paginated
+        using query parameters.
+      operationId: getCanceledJobs
       parameters:
-      - in: query
+      - description: Page number to retrieve (1-based indexing).
+        in: query
         name: page
         schema:
           type: integer
           format: int32
           default: 1
-      - in: query
+      - description: Number of records per page.
+        in: query
         name: pageSize
         schema:
           type: integer
           format: int32
           default: 20
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
-          description: default response
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of canceled jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User lacks permission to view jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves canceled jobs
       tags:
       - Job Queue
   /v1/jobs/completed:
     get:
-      operationId: completedJobs
+      description: Fetches a paginated list of completed jobs. Results can be paginated
+        using query parameters.
+      operationId: getCompletedJobs
       parameters:
-      - in: query
+      - description: Page number to retrieve (1-based indexing).
+        in: query
         name: page
         schema:
           type: integer
           format: int32
           default: 1
-      - in: query
+      - description: Number of records per page.
+        in: query
         name: pageSize
         schema:
           type: integer
           format: int32
           default: 20
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
-          description: default response
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of completed jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves completed jobs
       tags:
       - Job Queue
   /v1/jobs/failed:
     get:
-      operationId: failedJobs
+      description: Fetches a paginated list of failed jobs. Results can be paginated
+        using query parameters.
+      operationId: getFailedJobs
       parameters:
-      - in: query
+      - description: Page number to retrieve (1-based indexing).
+        in: query
         name: page
         schema:
           type: integer
           format: int32
           default: 1
-      - in: query
+      - description: Number of records per page.
+        in: query
         name: pageSize
         schema:
           type: integer
           format: int32
           default: 20
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
-          description: default response
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of failed jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves failed jobs
       tags:
       - Job Queue
   /v1/jobs/queues:
@@ -8946,63 +9023,114 @@ paths:
       - Job Queue
   /v1/jobs/successful:
     get:
-      operationId: successfulJobs
+      description: Fetches a paginated list of successful jobs. Results can be paginated
+        using query parameters.
+      operationId: getSuccessfulJobs
       parameters:
-      - in: query
+      - description: Page number to retrieve (1-based).
+        in: query
         name: page
         schema:
           type: integer
           format: int32
           default: 1
-      - in: query
+      - description: Number of records per page.
+        in: query
         name: pageSize
         schema:
           type: integer
           format: int32
           default: 20
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
-          description: default response
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved the paginated list of successful jobs.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have necessary permissions to view\
+            \ jobs."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves successful jobs
       tags:
       - Job Queue
   /v1/jobs/{jobId}/cancel:
     post:
-      operationId: cancelJob
+      description: Sends an asynchronous cancellation request for the specified job.
+        The job may still complete if it has already finished or cannot be interrupted.
+      operationId: cancelJobQueueJob
       parameters:
-      - in: path
+      - description: Unique identifier (UUID) of the job to cancel.
+        in: path
         name: jobId
         required: true
         schema:
           type: string
+          format: uuid
+          example: e6d9bae8-657b-4e2f-8524-c0222db66355
       responses:
-        default:
+        "200":
           content:
             application/json:
+              example:
+                entity: Cancellation request successfully sent to job e6d9bae8-657b-4e2f-8524-c0222db66355
               schema:
-                $ref: "#/components/schemas/ResponseEntityViewString"
-          description: default response
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Cancellation request accepted.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have permission to cancel this job."
+        "404":
+          description: "Not Found: Job with the specified ID does not exist or is\
+            \ already completed/cancelled."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ attempting to cancel the job."
+      summary: Cancel a job
       tags:
       - Job Queue
   /v1/jobs/{jobId}/monitor:
     get:
+      description: "Establishes a Server-Sent Events (SSE) connection to monitor the\
+        \ progress of a specific  job in real-time. This endpoint will continuously\
+        \ send updates as the job progresses, including status changes and completion\
+        \ information."
       operationId: monitorJob
       parameters:
-      - in: path
+      - description: The unique identifier (UUID) of the job whose status is to be
+          retrieved.
+        in: path
         name: jobId
         required: true
         schema:
           type: string
+          format: uuid
+          example: e6d9bae8-657b-4e2f-8524-c0222db66355
       responses:
-        default:
+        "200":
           content:
             text/event-stream:
               schema:
                 $ref: "#/components/schemas/EventOutput"
-          description: default response
+          description: Server-Sent Events stream established successfully. Events
+            will be sent as the job progresses.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have permissions to monitor the specified\
+            \ job."
+        "404":
+          description: "Not Found: Job with the specified ID could not be found."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ establishing the monitoring connection."
+      summary: Monitor a job in real time
       tags:
       - Job Queue
   /v1/jobs/{jobId}/status:
@@ -9011,12 +9139,14 @@ paths:
         \ progress, state, and results."
       operationId: getJobStatus_1
       parameters:
-      - description: Unique identifier of the job
+      - description: Unique identifier (UUID) of the job.
         in: path
         name: jobId
         required: true
         schema:
           type: string
+          format: uuid
+          example: e6d9bae8-657b-4e2f-8524-c0222db66355
       responses:
         "200":
           content:
@@ -9049,6 +9179,7 @@ paths:
         required: true
         schema:
           type: string
+          example: image-processing
       requestBody:
         content:
           application/json:
@@ -9061,48 +9192,78 @@ paths:
         "200":
           content:
             application/json:
+              example:
+                entity:
+                  jobId: e6d9bae8-657b-4e2f-8524-c0222db66355
+                  statusUrl: http://localhost:8080/api/v1/_import/e6d9bae8-657b-4e2f-8524-c0222db66355
+                errors: []
+                i18nMessagesMap: {}
+                messages: []
+                pagination: null
+                permissions: []
               schema:
                 $ref: "#/components/schemas/ResponseEntityJobStatusView"
           description: Job created successfully
         "400":
-          description: Bad request - Invalid job parameters or queue name
+          description: "Bad Request: Invalid parameters or malformed JSON."
         "401":
-          description: Unauthorized - User not authenticated
+          description: "Unauthorized: Invalid or missing user authentication."
         "403":
-          description: Forbidden - User lacks required permissions
+          description: "Forbidden: User lacks permission to enqueue jobs in the specified\
+            \ queue."
+        "404":
+          description: "Not Found: Queue with the specified name does not exist."
         "500":
-          description: Internal server error
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ creating the job."
       summary: Creates a new job with JSON parameters
       tags:
       - Job Queue
   /v1/jobs/{queueName}/active:
     get:
-      operationId: activeJobs_1
+      description: Fetches a paginated list of active jobs. Results can be paginated
+        using query parameters.for the specified queue.
+      operationId: getActiveJobsByQueue
       parameters:
-      - in: path
+      - description: Logical name of the queue.
+        in: path
         name: queueName
         required: true
         schema:
           type: string
-      - in: query
+          example: image-processing
+      - description: Page number to retrieve (1-based indexing).
+        in: query
         name: page
         schema:
           type: integer
           format: int32
           default: 1
-      - in: query
+      - description: Number of records per page.
+        in: query
         name: pageSize
         schema:
           type: integer
           format: int32
           default: 20
       responses:
-        default:
+        "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityViewJobPaginatedResult"
-          description: default response
+                $ref: "#/components/schemas/ResponseEntityJobPaginatedResultView"
+          description: Successfully retrieved active jobs for the queue.
+        "401":
+          description: "Unauthorized: Invalid or missing user authentication."
+        "403":
+          description: "Forbidden: User does not have permission to view jobs in this\
+            \ queue."
+        "404":
+          description: "Not Found: Queue with the specified name does not exist."
+        "500":
+          description: "Internal Server Error: An unexpected error occurred while\
+            \ retrieving jobs."
+      summary: Retrieves active jobs in a queue
       tags:
       - Job Queue
   /v1/jvm:
@@ -21539,6 +21700,23 @@ components:
         total:
           type: integer
           format: int64
+    JobParamsSchema:
+      type: object
+      description: Schema for multipart job queue parameters.
+      properties:
+        file:
+          type: string
+          format: binary
+          description: The file to be processed by the job.
+        params:
+          type: string
+          description: JSON string with job-specific parameters.
+          example: |-
+            {
+              "sourceUrl": "https://example.com/image.jpeg",
+              "width": 320,
+              "height": 240,
+            }
     JobResult:
       type: object
       properties:

--- a/dotcms-postman/src/main/resources/postman/JobQueueResourceAPITests.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/JobQueueResourceAPITests.postman_collection.json
@@ -154,9 +154,9 @@
           ]
         },
         "url": {
-          "raw": "{{baseUrl}}/api/v1/jobs/{{queueName}}",
+          "raw": "{{baseUrl}}/api/v1/jobs/{{queueName}}/upload",
           "host": ["{{baseUrl}}"],
-          "path": ["api", "v1", "jobs", "{{queueName}}"]
+          "path": ["api", "v1", "jobs", "{{queueName}}", "upload"]
         },
         "description": "Creates a new job with a multipart content type in the specified queue."
       },


### PR DESCRIPTION
This pull request introduces a new schema and documentation for handling multipart job queue parameters in the API. The most important changes include the addition of a JobParamsSchema class to define the structure of the job parameters and a JobQueueDocs class to provide documentation for the API endpoint.

Additions to API schema and documentation:
[dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobParamsSchema.java](https://github.com/dotCMS/core/pull/32504/files#diff-948cf1a3843b79cf0b8bf6de2f8d86cd96b9e6c3d8905f7649fe061c2568d98fR1-R46): Added a new class, JobParamsSchema, to define the schema for multipart job queue parameters. This includes fields for a file (file) and job-specific parameters (params), along with their respective getters and setters.

[dotCMS/src/main/java/com/dotcms/rest/api/v1/job/JobQueueDocs.java](https://github.com/dotCMS/core/pull/32504/files#diff-8c562471b62a91702ff765f40a3c4e9779518a9761dfd019f2b17b123f7cd240R1-R19): Added a new class, JobQueueDocs, to provide documentation for the API endpoint. This includes details about the multipart/form-data fields (file and form) and an example JSON for the form field.

<img width="566" height="836" alt="image" src="https://github.com/user-attachments/assets/ac86bcf2-4c16-42f1-8c0a-ec9ee4739621" />

This PR fixes: #30939

This PR fixes: #30939