### PR TITLE
fix(content-types) : Fixed adding rows and tabs when editing a content type

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-drop-zone/content-type-fields-drop-zone.component.spec.ts
@@ -700,8 +700,9 @@ describe('Load fields and drag and drop', () => {
 
     it('should handler editField event', () => {
         const field = {
-            clazz: 'classField',
-            name: 'nameField'
+            id: '5',
+            clazz: DotCMSClazzes.TEXT,
+            name: 'field 5'
         };
         const spy = jest.spyOn(comp, 'editFieldHandler');
 

--- a/core-web/libs/utils-testing/src/lib/dot-content-types.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-content-types.mock.ts
@@ -39,7 +39,7 @@ import {
     DotCMSContentTypeField
 } from '@dotcms/dotcms-models';
 
-import { EMPTY_FIELD } from '@dotcms/utils';
+import { EMPTY_SYSTEM_FIELD } from '@dotcms/utils';
 
 export const dotcmsContentTypeBasicMock = {
     baseType: null,
@@ -70,7 +70,7 @@ export const dotcmsContentTypeBasicMock = {
 } as unknown as DotCMSContentType;
 
 export const dotcmsContentTypeFieldBasicMock: DotCMSContentTypeField = {
-    ...EMPTY_FIELD
+    ...EMPTY_SYSTEM_FIELD
 };
 
 export const fieldsWithBreakColumn: DotCMSContentTypeLayoutRow[] = [

--- a/core-web/libs/utils/src/lib/shared/FieldUtil.ts
+++ b/core-web/libs/utils/src/lib/shared/FieldUtil.ts
@@ -2,12 +2,13 @@ import {
     DotCMSClazzes,
     DotCMSContentTypeField,
     DotCMSContentTypeLayoutColumn,
-    DotCMSContentTypeLayoutRow
+    DotCMSContentTypeLayoutRow,
+    DotCMSDataTypes
 } from '@dotcms/dotcms-models';
 
 export const EMPTY_FIELD: DotCMSContentTypeField = {
     contentTypeId: '',
-    dataType: '',
+    dataType: null,
     fieldType: '',
     fieldTypeLabel: '',
     fieldVariables: [],
@@ -31,18 +32,23 @@ export const EMPTY_FIELD: DotCMSContentTypeField = {
     values: null
 };
 
-const COLUMN_FIELD = {
+export const EMPTY_SYSTEM_FIELD: DotCMSContentTypeField = {
     ...EMPTY_FIELD,
+    dataType: DotCMSDataTypes.SYSTEM
+};
+
+const COLUMN_FIELD = {
+    ...EMPTY_SYSTEM_FIELD,
     clazz: DotCMSClazzes.COLUMN
 };
 
 const ROW_FIELD = {
-    ...EMPTY_FIELD,
+    ...EMPTY_SYSTEM_FIELD,
     clazz: DotCMSClazzes.ROW
 };
 
 const TAB_FIELD = {
-    ...EMPTY_FIELD,
+    ...EMPTY_SYSTEM_FIELD,
     clazz: DotCMSClazzes.TAB_DIVIDER
 };
 


### PR DESCRIPTION
Closes #33071

### Proposed Changes
* Added missing `System` to `dataType` field when adding Tabs and Rows to a content type in `FieldUtils.ts`
* Fixed corresponding unit test in drop zone component

### Checklist
- [x] Tests

This PR fixes: #33071