### PR TITLE
feat(EditMode) #33179 : Add option to filter by lang in the history endpoint

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -7160,10 +7160,12 @@ public class ESContentletAPIImpl implements ContentletAPI {
     @Override
     public List<Contentlet> findAllVersions(final SearchCriteria searchCriteria) throws DotSecurityException, DotDataException {
         Logger.debug(this.getClass(), String.format("Retrieving all versions for Identifier [ %s ], " +
-                        "bringOldVersions [ %b ], limit [ %d ], offset [ %d ]", searchCriteria.identifier(),
-                searchCriteria.bringOldVersions(), searchCriteria.limit(), searchCriteria.offset()));
-        final List<Contentlet> contentlets = this.contentFactory.findAllVersions(searchCriteria.identifier(),
-                searchCriteria.bringOldVersions(), searchCriteria.limit(), searchCriteria.offset(), searchCriteria.orderDirection());
+                        "Language ID [ %s ], bringOldVersions [ %b ], limit [ %d ], offset [ %d ]",
+                searchCriteria.identifier(), searchCriteria.languageId(), searchCriteria.bringOldVersions(),
+                searchCriteria.limit(), searchCriteria.offset()));
+        final List<Contentlet> contentlets = this.contentFactory.findAllVersions(
+                searchCriteria.identifier(), searchCriteria.languageId(), searchCriteria.bringOldVersions(),
+                searchCriteria.limit(), searchCriteria.offset(), searchCriteria.orderDirection());
         if (contentlets.isEmpty()) {
             return List.of();
         }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/SearchCriteria.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/SearchCriteria.java
@@ -17,6 +17,8 @@ public class SearchCriteria {
 
     private final Identifier identifier;
 
+    private final long languageId;
+
     private final User user;
 
     private final boolean bringOldVersions;
@@ -29,6 +31,7 @@ public class SearchCriteria {
 
     private SearchCriteria(final Builder builder) {
         this.identifier = builder.identifier;
+        this.languageId = builder.languageId;
         this.user = builder.user;
         this.bringOldVersions = builder.bringOldVersions;
         this.limit = builder.limit;
@@ -47,7 +50,16 @@ public class SearchCriteria {
     }
 
     /**
-     * Returns the user that is making the search.
+     * Returns the ID of the Language that will be used to filter the returned data.
+     *
+     * @return The Language ID.
+     */
+    public long languageId() {
+        return this.languageId;
+    }
+
+    /**
+     * Returns the user that is executing the content search.
      *
      * @return The {@link User}.
      */
@@ -108,6 +120,7 @@ public class SearchCriteria {
     public String toString() {
         return "SearchCriteria{" +
                 "identifier=" + identifier +
+                ", languageId=" + languageId +
                 ", user=" + user +
                 ", bringOldVersions=" + bringOldVersions +
                 ", limit=" + limit +
@@ -120,6 +133,8 @@ public class SearchCriteria {
     public static class Builder {
 
         private Identifier identifier;
+
+        private long languageId = -1;
 
         private User user;
 
@@ -143,6 +158,25 @@ public class SearchCriteria {
             return this;
         }
 
+        /**
+         * Specifies the Language ID used to filter the returned data.
+         *
+         * @param languageId The Language Id to filter by.
+         *
+         * @return The {@link Builder} instance.
+         */
+        public  Builder withLanguageId(final long languageId) {
+            this.languageId = languageId;
+            return this;
+        }
+
+        /**
+         * Specifies the {@link User} that is requesting the filtered data.
+         *
+         * @param user The {@link User} requesting the data.
+         *
+         * @return The {@link Builder} instance.
+         */
         public Builder withUser(final User user) {
             this.user = user;
             return this;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentVersionResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentVersionResource.java
@@ -196,7 +196,8 @@ public class ContentVersionResource {
             @ApiResponse(responseCode = "200", description = "History data retrieved successfully",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ResponseEntityPaginatedDataView.class))),
-            @ApiResponse(responseCode = "400", description = "The identifier path parameter was not specified.",
+            @ApiResponse(responseCode = "400", description = "The identifier path parameter was not specified, or one " +
+                    "of the specified parameters is invalid.",
                     content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "401", description = "Authentication required.",
                     content = @Content(mediaType = "application/json")),
@@ -212,21 +213,23 @@ public class ContentVersionResource {
     public ResponseEntityPaginatedDataView history(@Context final HttpServletRequest request,
                                                    @Context final HttpServletResponse response,
                                                    @Parameter(description = "The Identifier of the Contentlet whose history will be retrieved", required = true)
-                                                        @PathParam("identifier") final String identifier,
+                                                       @PathParam("identifier") final String identifier,
+                                                   @Parameter(description = "The Language ID that the history will be filtered by", required = true)
+                                                       @QueryParam("languageId") final String languageId,
                                                    @Parameter(description = "Specified whether the history must be grouped by language or not")
-                                                        @QueryParam("groupByLang") @DefaultValue("false") final boolean groupByLanguage,
+                                                       @QueryParam("groupByLang") @DefaultValue("false") final boolean groupByLanguage,
                                                    @Parameter(description = "Specified whether the history must include old versions or not")
-                                                        @QueryParam("bringOldVersions") @DefaultValue("true") final boolean bringOldVersions,
+                                                       @QueryParam("bringOldVersions") @DefaultValue("true") final boolean bringOldVersions,
                                                    @Parameter(description = "Sort direction: Choose between ascending or descending.",
                                                            schema = @Schema(
                                                                    type = "string",
                                                                    allowableValues = {"ASC", "DESC"},
                                                                    defaultValue = "DESC"))
-                                                        @QueryParam(PaginationUtil.DIRECTION) @DefaultValue("DESC") final String direction,
+                                                       @QueryParam(PaginationUtil.DIRECTION) @DefaultValue("DESC") final String direction,
                                                    @Parameter(description = "Maximum number or results being returned, for pagination purposes.")
-                                                        @QueryParam("limit") final int limit,
+                                                       @QueryParam("limit") final int limit,
                                                    @Parameter(description = "Page number of the results being returned, for pagination purposes.")
-                                                        @QueryParam("offset") final int offset)
+                                                       @QueryParam("offset") final int offset)
             throws DotDataException, DotStateException, DotSecurityException {
         final InitDataObject initDataObject = new WebResource.InitBuilder(this.webResource)
                 .requestAndResponse(request, response)
@@ -242,10 +245,16 @@ public class ContentVersionResource {
             throw new NotFoundException(getFormattedMessage(user.getLocale(),
                     BAD_REQUEST_ERROR_MESSAGE_KEY));
         }
+        final Optional<Language> languageOpt = APILocator.getLanguageAPI().getLanguageByIdOrIsoCode(languageId);
+        if (UtilMethods.isSet(languageId) && languageOpt.isEmpty()) {
+            throw new BadRequestException(getFormattedMessage(user.getLocale(), String.format("Language ID " +
+                    "'%s' was not found", languageId)));
+        }
         final boolean respectFrontendRoles = PageMode.get(request).respectAnonPerms;
         final PaginationUtil paginationUtil = new PaginationUtil(new ContentHistoryPaginator());
         final Map<String, Object> extraParams = Map.of(
                 ContentHistoryPaginator.IDENTIFIER, identifierObj,
+                ContentHistoryPaginator.LANGUAGE_ID, languageOpt.map(Language::getId).orElse(-1L),
                 ContentHistoryPaginator.RESPECT_FRONTEND_ROLES, respectFrontendRoles,
                 ContentHistoryPaginator.GROUP_BY_LANG, groupByLanguage,
                 ContentHistoryPaginator.BRING_OLD_VERSIONS, bringOldVersions);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
@@ -446,6 +446,27 @@ public abstract class ContentletFactory {
      *
      * @param identifier       The {@link Identifier} of the Contentlet whose versions will be
      *                         returned.
+     * @param languageId       The Language ID of the versions being returned. If all languages are
+     *                         included, just set this to -1.
+     * @param bringOldVersions If {@code true}, the old versions of the Contentlet will be included
+     *                         in the results, and not only its live/working version for each
+     *                         language.
+     * @param limit            The maximum number of versions to retrieve, for pagination purposes.
+     * @param offset           The result offset, for pagination purposes.
+     * @param orderDirection   The {@link OrderDirection} that will be used to sort the results by.
+     *
+     * @return A list of {@link Contentlet} objects representing its versions.
+     *
+     * @throws DotDataException An error occurred when retrieving the versions from the database.
+     */
+    public abstract List<Contentlet> findAllVersions(final Identifier identifier, final long languageId, final boolean bringOldVersions, final int limit, final int offset, final OrderDirection orderDirection) throws DotDataException;
+
+    /**
+     * Retrieves all versions for a given Contentlet Identifier. It's highly recommended to use the
+     * pagination attributes, as this method may pull too many versions.
+     *
+     * @param identifier       The {@link Identifier} of the Contentlet whose versions will be
+     *                         returned.
      * @param bringOldVersions If {@code true}, the old versions of the Contentlet will be included
      *                         in the results, and not only its live/working version for each
      *                         language.
@@ -459,6 +480,28 @@ public abstract class ContentletFactory {
      * @throws DotDataException An error occurred when retrieving the versions from the database.
      */
     public abstract List<Contentlet> findAllVersions(final Identifier identifier, final boolean bringOldVersions, final int limit, final int offset, final String orderBy, final OrderDirection orderDirection) throws DotDataException;
+
+    /**
+     * Retrieves all versions for a given Contentlet Identifier. It's highly recommended to use the
+     * pagination attributes, as this method may pull too many versions.
+     *
+     * @param identifier       The {@link Identifier} of the Contentlet whose versions will be
+     *                         returned.
+     * @param languageId       The Language ID of the versions being returned. If all languages are
+     *                         included, just set this to -1.
+     * @param bringOldVersions If {@code true}, the old versions of the Contentlet will be included
+     *                         in the results, and not only its live/working version for each
+     *                         language.
+     * @param limit            The maximum number of versions to retrieve, for pagination purposes.
+     * @param offset           The result offset, for pagination purposes.
+     * @param orderBy          The column that will be used to order the results.
+     * @param orderDirection   The {@link OrderDirection} that will be used to sort the results by.
+     *
+     * @return A list of {@link Contentlet} objects representing its versions.
+     *
+     * @throws DotDataException An error occurred when retrieving the versions from the database.
+     */
+    public abstract List<Contentlet> findAllVersions(final Identifier identifier, final long languageId, final boolean bringOldVersions, final int limit, final int offset, final String orderBy, final OrderDirection orderDirection) throws DotDataException;
 
 	/**
 	 * Retrieves all versions for a list of contentlet identifiers

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/business/LanguageAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/business/LanguageAPI.java
@@ -8,6 +8,7 @@ import com.dotmarketing.portlets.languagesmanager.model.LanguageKey;
 import com.dotmarketing.util.Config;
 import com.liferay.portal.model.User;
 import io.vavr.Lazy;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
@@ -95,6 +96,16 @@ public interface LanguageAPI {
 	 * @return
 	 */
 	public Language getLanguage(long id);
+
+    /**
+     * Returns a Language by its ID or ISO code.
+     *
+     * @param id The Language ID or ISO code.
+     *
+     * @return An Optional containing the requested {@link Language}, or an empty Optional if no
+     * Language matches the specific ID/ISO code.
+     */
+    Optional<Language> getLanguageByIdOrIsoCode(final Object id);
 
 	/**
 	 * 

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -5848,6 +5848,12 @@ paths:
         required: true
         schema:
           type: string
+      - description: The Language ID that the history will be filtered by
+        in: query
+        name: languageId
+        required: true
+        schema:
+          type: string
       - description: Specified whether the history must be grouped by language or
           not
         in: query
@@ -5892,7 +5898,8 @@ paths:
         "400":
           content:
             application/json: {}
-          description: The identifier path parameter was not specified.
+          description: "The identifier path parameter was not specified, or one of\
+            \ the specified parameters is invalid."
         "401":
           content:
             application/json: {}

--- a/dotcms-postman/src/main/resources/postman/Content_Version_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Version_Resource.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "eca2aec6-2606-41ae-a013-6a23cb6061ae",
+		"_postman_id": "8c59ae8d-4791-4c3d-ba76-862e984f8f40",
 		"name": "Content Version Resource",
 		"description": "The Content Versions REST Endpoint allows users to retrieve information related to the different versions a Contentlet has in the dotCMS repository. It's base path is mapped to:\n\n`/api/v1/content/versions`\n\nYou can query Contentlet versions or history data.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -429,6 +429,144 @@
 										"id",
 										"{{contentIdentifier}}",
 										"history"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "English Versions Only",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const entity = pm.response.json().entity;",
+											"",
+											"pm.test(\"A total of 3 records in EN must be returned\", function() {",
+											"    pm.expect(entity.length).to.eql(3, \"There must be 3 EN contents returned as results\");",
+											"});",
+											"",
+											"pm.test(\"Checking total records\", function() {",
+											"    pm.expect(pm.response.json().pagination.totalEntries).to.eql(3, \"Total entries must be 3\");",
+											"});",
+											"",
+											"pm.test(\"Checking default descending order. The latest version is returned first\", function() {",
+											"    pm.expect(entity[0].title).to.eql(\"Test Content 3\", \"The 'Test Content 3' version must be the first one in the list\");",
+											"});",
+											"",
+											"pm.test(\"Checking default current page value\", function() {",
+											"    pm.expect(pm.response.json().pagination.currentPage).to.eql(1, \"Default page value must be 1\");",
+											"});",
+											"",
+											"pm.test(\"Checking default perPage value\", function() {",
+											"    pm.expect(pm.response.json().pagination.perPage).to.eql(10, \"Default perPage value must be 10\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/versions/id/{{contentIdentifier}}/history?languageId=1",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"versions",
+										"id",
+										"{{contentIdentifier}}",
+										"history"
+									],
+									"query": [
+										{
+											"key": "languageId",
+											"value": "1"
+										}
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Second Lang Versions Only",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"exec": [
+											"const entity = pm.response.json().entity;",
+											"",
+											"pm.test(\"A total of 2 records in second language must be returned\", function() {",
+											"    pm.expect(entity.length).to.eql(2, \"There must be 2 contents in second language returned as results\");",
+											"});",
+											"",
+											"pm.test(\"Checking total records\", function() {",
+											"    pm.expect(pm.response.json().pagination.totalEntries).to.eql(2, \"Total entries must be 2\");",
+											"});",
+											"",
+											"pm.test(\"Checking default descending order. The latest version is returned first\", function() {",
+											"    pm.expect(entity[0].title).to.eql(\"Contenido de Prueba 2\", \"The 'Contenido de Prueba 2' version must be the first one in the list\");",
+											"});",
+											"",
+											"pm.test(\"Checking default current page value\", function() {",
+											"    pm.expect(pm.response.json().pagination.currentPage).to.eql(1, \"Default page value must be 1\");",
+											"});",
+											"",
+											"pm.test(\"Checking default perPage value\", function() {",
+											"    pm.expect(pm.response.json().pagination.perPage).to.eql(10, \"Default perPage value must be 10\");",
+											"});",
+											""
+										],
+										"type": "text/javascript",
+										"packages": {}
+									}
+								}
+							],
+							"protocolProfileBehavior": {
+								"disableBodyPruning": true
+							},
+							"request": {
+								"method": "GET",
+								"header": [],
+								"body": {
+									"mode": "raw",
+									"raw": ""
+								},
+								"url": {
+									"raw": "{{serverURL}}/api/v1/content/versions/id/{{contentIdentifier}}/history?languageId={{secondLangId}}",
+									"host": [
+										"{{serverURL}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"content",
+										"versions",
+										"id",
+										"{{contentIdentifier}}",
+										"history"
+									],
+									"query": [
+										{
+											"key": "languageId",
+											"value": "{{secondLangId}}"
+										}
 									]
 								}
 							},


### PR DESCRIPTION
### Proposed Changes
* The History REST Endpoint allows you to retrieve language-specific history data now.
* The Language ID can be either the internal ID, or the ISO code.
* Fixed potential SQL error in case invalid `orderBy` clauses are passed down.
* New Postman tests were added.

This PR fixes: #33179

This PR fixes: #33179