### PR TITLE
feat(calendar-field): Enhance label and tooltip functionality

### DIFF
--- a/core-web/libs/dotcms-scss/shared/_colors.scss
+++ b/core-web/libs/dotcms-scss/shared/_colors.scss
@@ -207,6 +207,7 @@ $error: $color-accessible-text-red;
 $new-content-color: #ddffdd;
 $orange: #f3762a;
 $success: $color-accessible-text-green;
+$foreground-active: #848484;
 
 @mixin root-colors {
     --color-primary-h: 225deg;

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
@@ -306,7 +306,12 @@ describe.each([...FIELDS_TO_BE_RENDER])('DotEditContentFieldComponent all fields
     });
 
     describe(`${fieldMock.fieldType} - ${fieldMock.dataType}`, () => {
-        if (fieldMock.fieldType !== FIELD_TYPES.CUSTOM_FIELD) {
+        if (
+            fieldMock.fieldType !== FIELD_TYPES.CUSTOM_FIELD &&
+            fieldMock.fieldType !== FIELD_TYPES.DATE &&
+            fieldMock.fieldType !== FIELD_TYPES.DATE_AND_TIME &&
+            fieldMock.fieldType !== FIELD_TYPES.TIME
+        ) {
             it('should render the label', () => {
                 spectator.detectChanges();
                 const label = spectator.query(byTestId(`label-${fieldMock.variable}`));
@@ -314,11 +319,17 @@ describe.each([...FIELDS_TO_BE_RENDER])('DotEditContentFieldComponent all fields
             });
         }
 
-        it('should render the hint if present', () => {
-            spectator.detectChanges();
-            const hint = spectator.query(byTestId(`hint-${fieldMock.variable}`));
-            expect(hint?.textContent).toContain(fieldMock.hint);
-        });
+        if (
+            fieldMock.fieldType !== FIELD_TYPES.DATE &&
+            fieldMock.fieldType !== FIELD_TYPES.DATE_AND_TIME &&
+            fieldMock.fieldType !== FIELD_TYPES.TIME
+        ) {
+            it('should render the hint if present', () => {
+                spectator.detectChanges();
+                const hint = spectator.query(byTestId(`hint-${fieldMock.variable}`));
+                expect(hint?.textContent).toContain(fieldMock.hint);
+            });
+        }
 
         it('should render the correct field type', () => {
             spectator.detectChanges();

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.html
@@ -65,13 +65,15 @@
                     </div>
                 }
                 @if (!hasError && hasTimezone && hasHint) {
-                    <small
-                        data-testid="calendar-field-timezone"
-                        class="text-gray-700"
-                        role="status"
-                        aria-live="polite">
-                        {{ systemTimezone.label }}
-                    </small>
+                    <div class="hint-message">
+                        <small
+                            data-testid="calendar-field-timezone"
+                            class="text-gray-700"
+                            role="status"
+                            aria-live="polite">
+                            {{ systemTimezone.label }}
+                        </small>
+                    </div>
                 }
             </div>
         </div>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.html
@@ -1,14 +1,26 @@
 @let field = $field();
 @let variable = field.variable;
 @let name = field.name;
-
+@let showLabel = $showLabel();
 @let fieldTypeConfig = $fieldTypeConfig();
 @let systemTimezone = $systemTimezone();
-
 @let showTimezoneInfo = $showTimezoneInfo();
+@let hasTimezone = showTimezoneInfo && systemTimezone;
+@let hasHint = field.hint;
 
 <dot-card-field [hasError]="hasError">
-    <ng-content />
+    @if (showLabel && hasHint && hasTimezone) {
+        <div class="flex gap-1 align-items-center">
+            <label
+                [attr.data-testid]="'label-' + field.variable"
+                [checkIsRequiredControl]="field.variable"
+                [for]="field.variable"
+                dotFieldRequired>
+                {{ field.name }}
+            </label>
+            <i class="pi pi-info-circle text-xs" [pTooltip]="field.hint"></i>
+        </div>
+    }
     <dot-card-field-content>
         <p-calendar
             class="w-full"
@@ -43,7 +55,7 @@
                     </div>
                 }
 
-                @if (!hasError && field.hint) {
+                @if (!hasError && !hasTimezone && hasHint) {
                     <div class="hint-message" data-testid="calendar-field-hints">
                         <small
                             [attr.data-testId]="'hint-' + field.variable"
@@ -52,16 +64,16 @@
                         </small>
                     </div>
                 }
+                @if (!hasError && hasTimezone && hasHint) {
+                    <small
+                        data-testid="calendar-field-timezone"
+                        class="text-gray-700"
+                        role="status"
+                        aria-live="polite">
+                        {{ systemTimezone.label }}
+                    </small>
+                }
             </div>
-            @if (showTimezoneInfo && systemTimezone) {
-                <small
-                    data-testid="calendar-field-timezone"
-                    class="text-gray-700"
-                    role="status"
-                    aria-live="polite">
-                    {{ systemTimezone.label }}
-                </small>
-            }
         </div>
     </dot-card-field-footer>
 </dot-card-field>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.scss
@@ -13,3 +13,22 @@
     border-left: 2px solid $color-palette-primary;
     padding-left: $spacing-1;
 }
+::ng-deep {
+    .p-tooltip .p-tooltip-text {
+        background: $foreground-active;
+        color: $white;
+    }
+
+    .p-tooltip.p-tooltip-right .p-tooltip-arrow {
+        border-right-color: $foreground-active;
+    }
+    .p-tooltip.p-tooltip-left .p-tooltip-arrow {
+        border-left-color: $color-palette-black-op-50;
+    }
+    .p-tooltip.p-tooltip-top .p-tooltip-arrow {
+        border-top-color: $color-palette-black-op-50;
+    }
+    .p-tooltip.p-tooltip-bottom .p-tooltip-arrow {
+        border-bottom-color: $color-palette-black-op-50;
+    }
+}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.spec.ts
@@ -4,6 +4,7 @@ import { SpectatorHost, byTestId, createHostFactory, mockProvider } from '@ngnea
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import { Calendar } from 'primeng/calendar';
+import { Tooltip, TooltipModule } from 'primeng/tooltip';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { DotSystemTimezone } from '@dotcms/dotcms-models';
@@ -20,7 +21,7 @@ describe('DotEditContentCalendarFieldComponent', () => {
 
     const createHost = createHostFactory({
         component: DotEditContentCalendarFieldComponent,
-        imports: [ReactiveFormsModule],
+        imports: [ReactiveFormsModule, TooltipModule],
         detectChanges: false,
         providers: [
             mockProvider(DotMessageService, {
@@ -165,14 +166,10 @@ describe('DotEditContentCalendarFieldComponent', () => {
             );
             spectator.detectChanges();
 
-            const hintsContainer = spectator.query(byTestId('calendar-field-hints'));
-            expect(hintsContainer).toExist();
-
             expect(fieldWithHint.hint).toBe('Test hint message');
 
-            const hintElement = spectator.query(byTestId(`hint-${fieldWithHint.variable}`));
+            const hintElement = spectator.query(Tooltip);
             expect(hintElement).toExist();
-            expect(hintElement).toContainText('Test hint message');
         });
 
         it('should NOT show hint when field has no hint property', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.ts
@@ -2,13 +2,14 @@ import { ChangeDetectionStrategy, Component, computed, effect, input, OnInit } f
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 import { CalendarModule } from 'primeng/calendar';
+import { TooltipModule } from 'primeng/tooltip';
 
 import {
     DotCMSContentType,
     DotCMSContentTypeField,
     DotSystemTimezone
 } from '@dotcms/dotcms-models';
-import { DotMessagePipe } from '@dotcms/ui';
+import { DotFieldRequiredDirective, DotMessagePipe } from '@dotcms/ui';
 
 import {
     CALENDAR_OPTIONS_PER_TYPE,
@@ -56,7 +57,9 @@ import { BaseFieldComponent } from '../shared/base-field.component';
         DotMessagePipe,
         DotCardFieldComponent,
         DotCardFieldContentComponent,
-        DotCardFieldFooterComponent
+        DotCardFieldFooterComponent,
+        DotFieldRequiredDirective,
+        TooltipModule
     ],
     templateUrl: 'dot-edit-content-calendar-field.component.html',
     styleUrls: ['./dot-edit-content-calendar-field.component.scss'],
@@ -75,6 +78,16 @@ export class DotEditContentCalendarFieldComponent extends BaseFieldComponent imp
      * Alias: utcTimezone
      */
     $systemTimezone = input<DotSystemTimezone | null>(null, { alias: 'utcTimezone' });
+
+    /**
+     * Whether to show the label.
+     */
+    $showLabel = computed(() => {
+        const field = this.$field();
+        if (!field) return true;
+
+        return field.fieldVariables.find(({ key }) => key === 'hideLabel')?.value !== 'true';
+    });
 
     /**
      * The content type (optional).


### PR DESCRIPTION
### Proposed Changes

This pull request enhances the `dot-edit-content-calendar-field` component by improving how field labels, hints, and timezone information are displayed, particularly when all three are present. It also introduces custom tooltip styling for better accessibility and visual consistency, and adds a computed property to control label visibility based on field variables.

**UI/UX Improvements:**

* Improved conditional rendering in `dot-edit-content-calendar-field.component.html` to ensure that the label, hint (with tooltip), and timezone information are displayed together in a user-friendly manner when all are present. The label now uses a tooltip for the hint, and the display logic for hints and timezone info is clarified. [[1]](diffhunk://#diff-7b53b3487cc14a70194752d39ec752b0225874d182fc78b0f19e26b036dd7d48L4-R23) [[2]](diffhunk://#diff-7b53b3487cc14a70194752d39ec752b0225874d182fc78b0f19e26b036dd7d48L46-R58) [[3]](diffhunk://#diff-7b53b3487cc14a70194752d39ec752b0225874d182fc78b0f19e26b036dd7d48L55-R67) [[4]](diffhunk://#diff-7b53b3487cc14a70194752d39ec752b0225874d182fc78b0f19e26b036dd7d48R77)
* Added a computed property `$showLabel` in the component TypeScript to determine label visibility based on the `hideLabel` field variable, improving configurability.

**Styling Enhancements:**

* Introduced a new SCSS variable `$foreground-active` for use in tooltip backgrounds.
* Customized tooltip appearance in `dot-edit-content-calendar-field.component.scss` to use the new `$foreground-active` color for backgrounds and updated tooltip arrow colors for better accessibility and visual integration.

**Dependency Updates:**

* Imported `TooltipModule` from `primeng/tooltip` and registered it in the component to enable tooltip functionality. [[1]](diffhunk://#diff-45105f940f5c94adeb34f9efd7a3888ebb8d90e1c76dfd1d5ee2fd457ba2d817R5-R12) [[2]](diffhunk://#diff-45105f940f5c94adeb34f9efd7a3888ebb8d90e1c76dfd1d5ee2fd457ba2d817L59-R62)

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)



This PR fixes: #33249

This PR fixes: #33249