### PR TITLE
Issue 33104 leading slash new edit content

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
@@ -86,29 +86,67 @@ describe('DotEditContentFormResolutions', () => {
     });
 
     describe('textFieldResolutionFn', () => {
-        it('should remove leading slash from URL', () => {
+        it('should remove leading slash from URL field in HTMLPAGE content', () => {
             const contentlet = {
                 ...mockContentlet,
-                testField: '/test-url'
+                baseType: 'HTMLPAGE',
+                url: '/test-url'
             };
+            const urlField = { ...mockField, variable: 'url' };
 
-            const result = resolutionValue[FIELD_TYPES.TEXT](contentlet, mockField);
+            const result = resolutionValue[FIELD_TYPES.TEXT](contentlet, urlField);
             expect(result).toBe('test-url');
         });
 
-        it('should not modify non-URL values', () => {
+        it('should NOT remove leading slash from non-URL fields in HTMLPAGE content', () => {
             const contentlet = {
                 ...mockContentlet,
-                testField: 'test-value'
+                baseType: 'HTMLPAGE',
+                testField: '/test-value'
             };
 
             const result = resolutionValue[FIELD_TYPES.TEXT](contentlet, mockField);
+            expect(result).toBe('/test-value');
+        });
+
+        it('should NOT remove leading slash from URL field in non-HTMLPAGE content', () => {
+            const contentlet = {
+                ...mockContentlet,
+                baseType: 'CONTENT',
+                url: '/content-url'
+            };
+            const urlField = { ...mockField, variable: 'url' };
+
+            const result = resolutionValue[FIELD_TYPES.TEXT](contentlet, urlField);
+            expect(result).toBe('/content-url');
+        });
+
+        it('should not modify values without leading slash', () => {
+            const contentlet = {
+                ...mockContentlet,
+                baseType: 'HTMLPAGE',
+                url: 'test-value'
+            };
+            const urlField = { ...mockField, variable: 'url' };
+
+            const result = resolutionValue[FIELD_TYPES.TEXT](contentlet, urlField);
             expect(result).toBe('test-value');
         });
 
         it('should handle null values', () => {
             const result = resolutionValue[FIELD_TYPES.TEXT](null, mockField);
             expect(result).toBe('default value');
+        });
+
+        it('should handle non-string values', () => {
+            const contentlet = {
+                ...mockContentlet,
+                baseType: 'HTMLPAGE',
+                testField: 123
+            };
+
+            const result = resolutionValue[FIELD_TYPES.TEXT](contentlet, mockField);
+            expect(result).toBe(123);
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.ts
@@ -45,9 +45,14 @@ const textFieldResolutionFn: FnResolutionValue<string> = (contentlet, field) => 
         ? (contentlet[field.variable] ?? field.defaultValue)
         : field.defaultValue;
 
-    // TODO: Remove this once we have a proper solution for the text field from Backend (URL case)
-    // Remove leading "/" if present
-    return typeof value === 'string' && value.startsWith('/') ? value.substring(1) : value;
+    // Remove leading "/" only for HTMLPAGE baseType with 'url' field variable
+    const shouldRemoveLeadingSlash =
+        contentlet?.baseType === 'HTMLPAGE' &&
+        field.variable === 'url' &&
+        typeof value === 'string' &&
+        value.startsWith('/');
+
+    return shouldRemoveLeadingSlash ? value.substring(1) : value;
 };
 
 /**


### PR DESCRIPTION
### Proposed Changes

This pull request updates the resolution logic for text fields in the edit content form, specifically refining how leading slashes are handled for URL fields. The changes ensure that leading slashes are only removed from the `url` field of `HTMLPAGE` content types, and not from other fields or content types. Additionally, the test coverage for these scenarios has been expanded and clarified.

**Resolution logic improvements:**

* The `textFieldResolutionFn` now removes the leading slash only when the contentlet's `baseType` is `HTMLPAGE` and the field variable is `url`. For all other cases, the value remains unchanged.

**Test coverage enhancements:**

* Added and updated tests to verify that leading slashes are removed only for the `url` field in `HTMLPAGE` contentlets, and not for other fields or content types.
* Added tests to ensure that values without a leading slash, null values, and non-string values are handled correctly and remain unaffected by the slash removal logic.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)



This PR fixes: #33104
