### PR TITLE
fix(templates) : Prevent theme value overwrite in template properties form

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-theme-selector-dropdown/dot-theme-selector-dropdown.component.ts
@@ -85,17 +85,8 @@ export class DotThemeSelectorDropdownComponent
             }
         }, 0);
 
-        // Here we set the initial value of the dropdown as System Theme
         this.paginatorService.url = 'v1/themes';
         this.paginatorService.paginationPerPage = 5;
-        this.paginatorService.setExtraParams('hostId', 'SYSTEM_HOST');
-        this.paginatorService
-            .get()
-            .pipe(take(1))
-            .subscribe((themes: DotTheme[]) => {
-                this.value = themes[0];
-                this.propagateChange(themes[0].identifier);
-            });
     }
 
     ngAfterViewInit(): void {
@@ -174,6 +165,18 @@ export class DotThemeSelectorDropdownComponent
                         .subscribe((site) => {
                             this.siteSelector?.updateCurrentSite(site);
                         });
+                });
+        } else {
+            // No identifier provided, load default system theme
+            this.paginatorService.setExtraParams('hostId', 'SYSTEM_HOST');
+            this.paginatorService
+                .get()
+                .pipe(take(1))
+                .subscribe((themes: DotTheme[]) => {
+                    if (themes.length > 0) {
+                        this.value = themes[0];
+                        this.propagateChange(themes[0].identifier);
+                    }
                 });
         }
     }


### PR DESCRIPTION
Closes #33130

### Proposed Changes
* Removed the automatic theme loading from the `ngOnInit()` method on the `DotThemeSelectorDropdownComponent`. This prevents the component from overwriting the parent's value.
* Moved the default theme loading logic to the `writeValue()` method. Now the component only sets a default when no identifier is provided by the parent `DotTemplatePropsComponent`.

This PR fixes: #33130