### PR TITLE
33391 task more people should be able to review issue templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@
 /.github/ @dotCMS/core-workflow-developers
 
 # Democratize the PR and Issue templates 
-/.github/PULL_REQUEST_TEMPLATE @dotCMS/dotDevelopers @dotCMS/dotProduct
-/.github/ISSUE_TEMPLATE @dotCMS/dotDevelopers @dotCMS/dotProduct
+/.github/PULL_REQUEST_TEMPLATE/ @dotCMS/dotDevelopers @dotCMS/dotProduct
+/.github/ISSUE_TEMPLATE/ @dotCMS/dotDevelopers @dotCMS/dotProduct

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,9 @@
 # Require workflow changes to be approved by developers who understand the codebase
 # and security implications of changes
 
-# Democratize the PR and Issue templates
-/.github/PULL_REQUEST_TEMPLATE @dotCMS/dotDevelopers @dotCMS/dotProduct
-/.github/ISSUE_TEMPLATE @dotCMS/dotDevelopers @dotCMS/dotProduct
-
-# Everything else could be CI/CD or actions
+# Most things are related to CI/CD or actions and should have workflow devs approve
 /.github/ @dotCMS/core-workflow-developers
 
+# Democratize the PR and Issue templates 
+/.github/PULL_REQUEST_TEMPLATE @dotCMS/dotDevelopers @dotCMS/dotProduct
+/.github/ISSUE_TEMPLATE @dotCMS/dotDevelopers @dotCMS/dotProduct

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,10 @@
 # Require workflow changes to be approved by developers who understand the codebase
 # and security implications of changes
 
+# Democratize the PR and Issue templates
+/.github/PULL_REQUEST_TEMPLATE @dotCMS/dotDevelopers @dotCMS/dotProduct
+/.github/ISSUE_TEMPLATE @dotCMS/dotDevelopers @dotCMS/dotProduct
+
+# Everything else could be CI/CD or actions
 /.github/ @dotCMS/core-workflow-developers
 


### PR DESCRIPTION
Expand CODEOWNERS for issue and PR templates. Keeps workflow files under core-workflow-developers, but adds dotDevelopers and dotProduct as reviewers for /.github/ISSUE_TEMPLATE and /.github/PULL_REQUEST_TEMPLATE so more folks can weigh in.

This PR fixes: #33391