### PR TITLE
refactor(edit-content): Enhance host folder resolution logic 

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
@@ -126,9 +126,57 @@ describe('DotEditContentFormResolutions', () => {
     });
 
     describe('hostFolderResolutionFn', () => {
-        it('should construct host folder path from hostName and url', () => {
+        it('should construct host folder path from hostName and url for non-file assets', () => {
             const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](mockContentlet, mockField);
             expect(result).toBe('https://example.com');
+        });
+
+        it('should handle file assets by removing filename from path', () => {
+            const contentlet = {
+                ...mockContentlet,
+                type: 'file_asset',
+                hostName: 'https://example.com',
+                url: '/path/to/file.jpg'
+            };
+
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, mockField);
+            expect(result).toBe('https://example.com/path/to');
+        });
+
+        it('should handle file assets with single segment path', () => {
+            const contentlet = {
+                ...mockContentlet,
+                type: 'file_asset',
+                hostName: 'https://example.com',
+                url: '/file.jpg'
+            };
+
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, mockField);
+            expect(result).toBe('https://example.com');
+        });
+
+        it('should extract path up to /content for non-file assets', () => {
+            const contentlet = {
+                ...mockContentlet,
+                type: 'content',
+                hostName: 'https://example.com',
+                url: '/content/test-page'
+            };
+
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, mockField);
+            expect(result).toBe('https://example.com');
+        });
+
+        it('should return full path when /content is not found', () => {
+            const contentlet = {
+                ...mockContentlet,
+                type: 'content',
+                hostName: 'https://example.com',
+                url: '/some/other/path'
+            };
+
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, mockField);
+            expect(result).toBe('https://example.com/some/other/path');
         });
 
         it('should return defaultValue when hostName is missing', () => {
@@ -145,6 +193,70 @@ describe('DotEditContentFormResolutions', () => {
 
             const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, mockField);
             expect(result).toBe('default value');
+        });
+
+        it('should return defaultValue when hostName is not a string', () => {
+            const contentlet = {
+                ...mockContentlet,
+                hostName: 123
+            } as unknown as DotCMSContentlet;
+
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, mockField);
+            expect(result).toBe('default value');
+        });
+
+        it('should return defaultValue when url is not a string', () => {
+            const contentlet = {
+                ...mockContentlet,
+                url: 123
+            } as unknown as DotCMSContentlet;
+
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, mockField);
+            expect(result).toBe('default value');
+        });
+
+        it('should return defaultValue when contentlet is null', () => {
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](null, mockField);
+            expect(result).toBe('default value');
+        });
+
+        it('should return defaultValue when contentlet is undefined', () => {
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](undefined, mockField);
+            expect(result).toBe('default value');
+        });
+
+        it('should handle error gracefully and return defaultValue', () => {
+            // Mock console.warn to avoid test output
+            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+            const contentlet = {
+                ...mockContentlet,
+                hostName: 'https://example.com',
+                url: '/path/to/file.jpg',
+                type: 'file_asset'
+            };
+
+            // Mock split to throw an error
+            jest.spyOn(String.prototype, 'split').mockImplementation(() => {
+                throw new Error('Test error');
+            });
+
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, mockField);
+            expect(result).toBe('default value');
+            expect(consoleSpy).toHaveBeenCalledWith('Error processing host folder path:', expect.any(Error));
+
+            consoleSpy.mockRestore();
+        });
+
+        it('should return empty string when field has no defaultValue', () => {
+            const field = { ...mockField };
+            delete field.defaultValue;
+
+            const contentlet = { ...mockContentlet };
+            delete contentlet.hostName;
+
+            const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, field);
+            expect(result).toBe('');
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
@@ -1,4 +1,9 @@
-import { DotCMSClazzes, DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
+import {
+    DotCMSBaseTypesContentTypes,
+    DotCMSClazzes,
+    DotCMSContentlet,
+    DotCMSContentTypeField
+} from '@dotcms/dotcms-models';
 import { createFakeContentlet, createFakeSelectField } from '@dotcms/utils-testing';
 
 import { resolutionValue } from './dot-edit-content-form-resolutions';
@@ -134,7 +139,7 @@ describe('DotEditContentFormResolutions', () => {
         it('should handle file assets by removing filename from path', () => {
             const contentlet = {
                 ...mockContentlet,
-                type: 'file_asset',
+                baseType: DotCMSBaseTypesContentTypes.FILEASSET,
                 hostName: 'https://example.com',
                 url: '/path/to/file.jpg'
             };
@@ -146,7 +151,7 @@ describe('DotEditContentFormResolutions', () => {
         it('should handle file assets with single segment path', () => {
             const contentlet = {
                 ...mockContentlet,
-                type: 'file_asset',
+                baseType: DotCMSBaseTypesContentTypes.FILEASSET,
                 hostName: 'https://example.com',
                 url: '/file.jpg'
             };
@@ -233,7 +238,7 @@ describe('DotEditContentFormResolutions', () => {
                 ...mockContentlet,
                 hostName: 'https://example.com',
                 url: '/path/to/file.jpg',
-                type: 'file_asset'
+                baseType: DotCMSBaseTypesContentTypes.FILEASSET
             };
 
             // Mock split to throw an error
@@ -243,7 +248,10 @@ describe('DotEditContentFormResolutions', () => {
 
             const result = resolutionValue[FIELD_TYPES.HOST_FOLDER](contentlet, mockField);
             expect(result).toBe('default value');
-            expect(consoleSpy).toHaveBeenCalledWith('Error processing host folder path:', expect.any(Error));
+            expect(consoleSpy).toHaveBeenCalledWith(
+                'Error processing host folder path:',
+                expect.any(Error)
+            );
 
             consoleSpy.mockRestore();
         });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.ts
@@ -1,4 +1,8 @@
-import { DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
+import {
+    DotCMSBaseTypesContentTypes,
+    DotCMSContentlet,
+    DotCMSContentTypeField
+} from '@dotcms/dotcms-models';
 
 import { FIELD_TYPES } from '../../models/dot-edit-content-field.enum';
 import { getSingleSelectableFieldOptions } from '../../utils/functions.util';
@@ -70,7 +74,7 @@ const hostFolderResolutionFn: FnResolutionValue<string> = (contentlet, field) =>
         return field?.defaultValue || '';
     }
 
-    const { hostName, url, type } = contentlet;
+    const { hostName, url, baseType } = contentlet;
 
     // Ensure hostName and url are strings
     if (typeof hostName !== 'string' || typeof url !== 'string') {
@@ -80,7 +84,7 @@ const hostFolderResolutionFn: FnResolutionValue<string> = (contentlet, field) =>
     const fullPath = `${hostName}${url}`;
 
     try {
-        if (type === 'file_asset') {
+        if (baseType === DotCMSBaseTypesContentTypes.FILEASSET) {
             // For file assets, remove the filename to get the directory path
             const pathSegments = fullPath.split('/');
             if (pathSegments.length > 1) {


### PR DESCRIPTION
### Proposed Changes
This pull request enhances the logic and test coverage for resolving host folder paths in the `DotEditContentFormResolutions` component. The main focus is on improving the `hostFolderResolutionFn` function to handle various contentlet scenarios more robustly and adding comprehensive unit tests to ensure correct behavior for edge cases and error handling.

**Improvements to host folder path resolution:**

* Refactored `hostFolderResolutionFn` in `dot-edit-content-form-resolutions.ts` to handle file assets by removing the filename from the path, and for other content types, extracting the path up to the `/content` segment. Also added early returns for invalid or missing properties and type checks for `hostName` and `url`. Error handling was introduced to gracefully return the default value if an exception occurs.

**Expanded and improved unit tests:**

* Added new test cases in `dot-edit-content-form-resolutions.spec.ts` to cover file assets with and without directory segments, non-file assets with and without `/content` in the URL, and scenarios where `hostName` or `url` are missing or not strings.
* Added tests to verify that the function returns the default value when the contentlet is `null` or `undefined`, and when `hostName` or `url` are not strings.
* Added a test to ensure the function handles errors gracefully and logs a warning, returning the default value if an exception occurs during processing.
* Added a test to confirm that an empty string is returned when the field has no `defaultValue` and required contentlet properties are missing.

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)





This PR fixes: #30860

This PR fixes: #30860