### PR TITLE
fix(core) : cron expression for DropOldContentVersionsJob

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -8725,7 +8725,6 @@ public class ESContentletAPIImpl implements ContentletAPI {
         return contentRelationships;
     }
 
-    @WrapInTransaction
     @Override
     public int deleteOldContent(Date deleteFrom) throws DotDataException {
         int results = 0;

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/DropOldContentVersionsJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/DropOldContentVersionsJob.java
@@ -63,7 +63,7 @@ public class DropOldContentVersionsJob implements StatefulJob {
     /**
      * Fire every Monday at 1:15AM
      */
-    private static final String CRON_EXPRESSION_DEFAULT = "0 15 1 ? * WED";
+    private static final String CRON_EXPRESSION_DEFAULT = "0 15 1 ? * WED *";
 
     public static final Lazy<Boolean> ENABLED =
             Lazy.of(() -> Config.getBooleanProperty(ENABLED_PROP, true));


### PR DESCRIPTION
Closes #32958

### Proposed Changes
* Fixed cron expression for `DropOldContentVersionsJob`
* Removed the not-required `WrapInTransaction` annotation from the `deleteOldContent` method in `ESContentletAPIImpl` class

This PR fixes: #32958