### PR TITLE
Fix lock release mechanism for page cache

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityLiveMode.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityLiveMode.java
@@ -194,7 +194,7 @@ public class VelocityLiveMode extends VelocityModeHandler {
             Logger.debug(this.getClass(), "--- ", t);
             throw new DotRuntimeException(t);
         } finally {
-            if (Thread.holdsLock(lock)) {
+            if (hasLock) {
                 lock.unlock();
             }
             byteArrayLocal.get().reset();


### PR DESCRIPTION
### Proposed Changes
* Fixed the lock release mechanism in PageCache by addressing the improper use of `Thread.holdsLock()`.


### Additional Info
The issue stemmed from `Thread.holdsLock()` not supporting weak striped locks. This fix ensures proper release of locks.  The reason it works now is because the Striped.lazyWeakLock that is used gets garbage collected by Z1 milliseconds after the Thread is done - but we cannot count on this as how it should work.

ref: #33287

This PR fixes: #33287