### PR TITLE
fix(Relationship field): Content Type dropdown in Relationships Field definition is empty

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.spec.ts
@@ -258,6 +258,94 @@ describe('DotNewRelationshipsComponent', () => {
             expect(dotSearchableDropdown.componentInstance.data).toEqual([contentTypeMock]);
         });
 
+        it('should clear paginator links and update lastSearch when getContentTypeList is called', () => {
+            const filter = 'test filter';
+            const offset = 10;
+
+            fixtureHostComponent.detectChanges();
+
+            // Set up initial links to verify they get cleared
+            paginatorService.links = { next: 'some-url', prev: 'some-other-url' };
+
+            comp.getContentTypeList(filter, offset);
+
+            expect(paginatorService.links).toEqual({});
+            expect(comp.lastSearch()).toEqual({ filter, offset });
+            expect(paginatorService.filter).toBe(filter);
+            expect(paginatorService.getWithOffset).toHaveBeenCalledWith(offset);
+        });
+
+        it('should skip search when editing is true and not update lastSearch', () => {
+            const filter = 'test filter';
+            const offset = 10;
+            const initialLastSearch = comp.lastSearch();
+
+            fixtureHostComponent.componentInstance.editing = true;
+            fixtureHostComponent.detectChanges();
+
+            jest.clearAllMocks();
+
+            comp.getContentTypeList(filter, offset);
+
+            expect(paginatorService.getWithOffset).not.toHaveBeenCalled();
+            expect(comp.lastSearch()).toEqual(initialLastSearch);
+        });
+
+        it('should skip search when filter and offset match lastSearch values', () => {
+            const filter = 'same filter';
+            const offset = 5;
+
+            fixtureHostComponent.detectChanges();
+
+            // First call - should execute
+            comp.getContentTypeList(filter, offset);
+            expect(paginatorService.getWithOffset).toHaveBeenCalledTimes(1);
+
+            jest.clearAllMocks();
+
+            // Second call with same parameters - should skip
+            comp.getContentTypeList(filter, offset);
+            expect(paginatorService.getWithOffset).not.toHaveBeenCalled();
+        });
+
+        it('should not skip search when filter or offset are different from lastSearch', () => {
+            const initialFilter = 'initial filter';
+            const initialOffset = 0;
+            const newFilter = 'new filter';
+            const newOffset = 10;
+
+            fixtureHostComponent.detectChanges();
+
+            // First call
+            comp.getContentTypeList(initialFilter, initialOffset);
+            expect(paginatorService.getWithOffset).toHaveBeenCalledTimes(1);
+
+            jest.clearAllMocks();
+
+            // Second call with different filter
+            comp.getContentTypeList(newFilter, initialOffset);
+            expect(paginatorService.getWithOffset).toHaveBeenCalledTimes(1);
+
+            jest.clearAllMocks();
+
+            // Third call with different offset
+            comp.getContentTypeList(initialFilter, newOffset);
+            expect(paginatorService.getWithOffset).toHaveBeenCalledTimes(1);
+        });
+
+        it('should update lastSearch signal when getContentTypeList executes successfully', () => {
+            const filter = 'test filter';
+            const offset = 20;
+
+            fixtureHostComponent.detectChanges();
+
+            expect(comp.lastSearch()).toEqual({ filter: null, offset: null });
+
+            comp.getContentTypeList(filter, offset);
+
+            expect(comp.lastSearch()).toEqual({ filter, offset });
+        });
+
         it('should tigger change event when content type changed', (done) => {
             fixtureHostComponent.detectChanges();
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/dot-new-relationships/dot-new-relationships.component.ts
@@ -41,7 +41,7 @@ export class DotNewRelationshipsComponent implements OnInit, OnChanges {
     contentType: DotCMSContentType;
     currentCardinalityIndex: number;
 
-    protected readonly lastSearch = signal({
+    readonly lastSearch = signal({
         filter: null,
         offset: null
     });

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/searchable-dropdown/component/searchable-dropdown.component.ts
@@ -25,7 +25,7 @@ import { PrimeTemplate } from 'primeng/api';
 import { DataView, DataViewLazyLoadEvent } from 'primeng/dataview';
 import { OverlayPanel } from 'primeng/overlaypanel';
 
-import { debounceTime, tap } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, map, tap } from 'rxjs/operators';
 
 /**
  * Dropdown with pagination and global search
@@ -152,17 +152,6 @@ export class SearchableDropdownComponent
     selectedOptionIndex = 0;
     selectedOptionValue = '';
 
-    keyMap: string[] = [
-        'Shift',
-        'Alt',
-        'Control',
-        'Meta',
-        'ArrowUp',
-        'ArrowDown',
-        'ArrowLeft',
-        'ArrowRight'
-    ];
-
     propagateChange = (_: unknown) => {
         /**/
     };
@@ -189,12 +178,12 @@ export class SearchableDropdownComponent
                             this.selectDropdownOption(keyboardEvent.key);
                         }
                     }),
+                    map((keyboardEvent: KeyboardEvent) => keyboardEvent.target['value']),
+                    distinctUntilChanged(),
                     debounceTime(500)
                 )
-                .subscribe((keyboardEvent: KeyboardEvent) => {
-                    if (!this.isModifierKey(keyboardEvent.key)) {
-                        this.filterChange.emit(keyboardEvent.target['value']);
-                    }
+                .subscribe((value: string) => {
+                    this.filterChange.emit(value);
                 });
         }
     }
@@ -412,10 +401,6 @@ export class SearchableDropdownComponent
             this.selectedOptionValue = this.getItemLabel(this.options[0]);
             this.selectedOptionIndex = 0;
         }
-    }
-
-    private isModifierKey(key: string): boolean {
-        return this.keyMap.includes(key);
     }
 
     private usePlaceholder(placeholderChange: SimpleChange): boolean {


### PR DESCRIPTION
### Video

https://github.com/user-attachments/assets/b5706b93-570a-454a-ae19-7ad8525c5608



This PR fixes: #33420

This PR fixes: #33420