### PR TITLE
fix: resolve JSON parsing error in issue linking workflow

### DIFF
--- a/.github/workflows/issue_comp_link-issue-to-pr.yml
+++ b/.github/workflows/issue_comp_link-issue-to-pr.yml
@@ -141,23 +141,24 @@ jobs:
       - name: Get existing issue comments
         id: get_comments
         run: |
-          comments=$(curl -s \
+          # Fetch comments and write to temp file to avoid multiline JSON issues in GitHub Actions outputs
+          curl -s \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer ${{ env.GH_TOKEN }}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.determine_issue.outputs.final_issue_number }}/comments \
-            | jq -c .)
-          
-          echo "comments=$comments" >> "$GITHUB_OUTPUT"
+            | jq -c . > /tmp/issue_comments.json
+
+          echo "comments_file=/tmp/issue_comments.json" >> "$GITHUB_OUTPUT"
 
       - name: Check if comment already exists
         id: check_comment
         run: |
-          comments='${{ steps.get_comments.outputs.comments }}'
+          comments_file="${{ steps.get_comments.outputs.comments_file }}"
           pr_url="${{ inputs.pr_url }}"
-          
-          # Check if our bot comment already exists
-          existing_comment=$(echo "$comments" | jq -r '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("PRs linked to this issue"))) | .id' | head -1)
+
+          # Check if our bot comment already exists (read from file instead of env var)
+          existing_comment=$(jq -r '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("PRs linked to this issue"))) | .id' "$comments_file" | head -1)
           
           if [[ -n "$existing_comment" && "$existing_comment" != "null" ]]; then
             echo "Found existing comment: $existing_comment"
@@ -169,7 +170,7 @@ jobs:
           
           # Get existing PR list from the comment if it exists
           if [[ -n "$existing_comment" && "$existing_comment" != "null" ]]; then
-            existing_body=$(echo "$comments" | jq -r --arg id "$existing_comment" '.[] | select(.id == ($id | tonumber)) | .body')
+            existing_body=$(jq -r --arg id "$existing_comment" '.[] | select(.id == ($id | tonumber)) | .body' "$comments_file")
             
             # Extract existing PR lines (lines starting with "- [")
             existing_pr_lines=$(echo "$existing_body" | grep "^- \[" | sort -u)


### PR DESCRIPTION
## Summary

Fixes the JSON parsing error causing the `issue_comp_link-issue-to-pr.yml` workflow to fail at the "Check if comment already exists" step.

## Problem

The workflow was failing with exit code 2 when trying to parse multiline JSON from GitHub API responses. The issue was on line 156 where complex JSON with nested objects, quotes, and special characters was being assigned to a bash variable through GitHub Actions outputs.

**Failed run example:** https://github.com/dotCMS/core/actions/runs/18267305057/job/52003574505

## Solution

Instead of passing JSON through GitHub Actions output variables (which requires complex escaping), this fix writes the API response to a temporary file and reads directly from it in subsequent steps.

### Changes

**Before:**
```yaml
# In get_comments step
echo "comments=$comments" >> "$GITHUB_OUTPUT"

# In check_comment step  
comments='${{ steps.get_comments.outputs.comments }}'  # ❌ Breaks with complex JSON
existing_comment=$(echo "$comments" | jq ...)
```

**After:**
```yaml
# In get_comments step
curl ... | jq -c . > /tmp/issue_comments.json
echo "comments_file=/tmp/issue_comments.json" >> "$GITHUB_OUTPUT"

# In check_comment step
comments_file="${{ steps.get_comments.outputs.comments_file }}"
existing_comment=$(jq -r ... "$comments_file")  # ✅ Works reliably
```

## Benefits

- ✅ Eliminates shell quoting/escaping issues
- ✅ Handles all JSON edge cases (nested objects, quotes, newlines, special chars)
- ✅ More reliable than base64 encoding approach
- ✅ Simpler and more maintainable

## Testing

This fix can be tested by:
1. Creating a PR with issue linking (e.g., branch name `issue-123-feature`)
2. Verifying the workflow completes successfully
3. Checking that the issue comment is created/updated properly

**Test Results:** You can look at the actions for this PR and see it working again 😃 

## Related

Closes #33445

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

This PR fixes: #33445