### PR TITLE
Clean up the issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -13,15 +13,6 @@ body:
         
         EPICs represent wide areas of functionality that solve specific problems and deliver significant value.
 
-  - type: input
-    id: epic-title
-    attributes:
-      label: EPIC Title
-      description: Concise, action-based title that reflects user value
-      placeholder: "e.g., Universal Visual Editor Enhancements"
-    validations:
-      required: true
-
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -13,15 +13,6 @@ body:
         
         Features are specific groupings of functionality within an EPIC that provide particular value.
 
-  - type: input
-    id: feature-title
-    attributes:
-      label: Feature Title
-      description: Concise, action-based title that reflects user value
-      placeholder: "e.g., Drag and Drop File Upload Interface"
-    validations:
-      required: true
-
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/pillar.yml
+++ b/.github/ISSUE_TEMPLATE/pillar.yml
@@ -1,8 +1,8 @@
-name: Theme
+name: Pillar
 description: High-level strategic initiative that groups related EPICs
-title: "[THEME] "
+title: "[PILLAR] "
 labels: []
-type: theme
+type: pillar
 assignees: []
 
 body:
@@ -11,23 +11,14 @@ body:
       value: |
         **Note: This template is intended for Product team use only.**
         
-        ## Theme Overview
-        Themes represent broad strategic initiatives that align with product vision and encompass multiple EPICs.
-
-  - type: input
-    id: theme-title
-    attributes:
-      label: Theme Title
-      description: Concise, action-based title that reflects strategic value
-      placeholder: "e.g., Enhanced Content Management Experience"
-    validations:
-      required: true
+        ## Pillar Overview
+        Pillars represent broad strategic initiatives that align with product vision and encompass multiple EPICs.
 
   - type: textarea
     id: vision
     attributes:
       label: Vision
-      description: Explain in detail how this theme will benefit our customers
+      description: Explain in detail how this pillar will benefit our customers
       placeholder: "Describe the strategic value and customer impact..."
     validations:
       required: true
@@ -36,7 +27,7 @@ body:
     id: personas
     attributes:
       label: Target Personas
-      description: Select the personas this theme primarily affects
+      description: Select the personas this pillar primarily affects
       options:
         - label: Developer teams
         - label: Content teams

--- a/.github/ISSUE_TEMPLATE/spike.yaml
+++ b/.github/ISSUE_TEMPLATE/spike.yaml
@@ -11,15 +11,6 @@ body:
       value: |
         **Note: This template is intended for Engineering team use.**
 
-  - type: input
-    id: spike-title
-    attributes:
-      label: Spike Title
-      description: Clear, concise title describing the research objective
-      placeholder: "e.g., Research integration options for new authentication system"
-    validations:
-      required: true
-
   - type: textarea
     id: research-question
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -11,15 +11,6 @@ body:
       value: |
         **Note: This template is intended for Engineering team use.**
 
-  - type: input
-    id: task-title
-    attributes:
-      label: Task Title
-      description: Clear, concise title describing the task
-      placeholder: "e.g., Update dependency versions for security patches"
-    validations:
-      required: true
-
   - type: textarea
     id: description
     attributes:


### PR DESCRIPTION
This pull request updates our GitHub issue templates to streamline the creation process and clarify strategic terminology. The most important changes include removing required title fields from all templates, renaming the "Theme" template to "Pillar" for better alignment with product strategy, and updating related descriptions and labels.

**Template Structure Updates:**

* Removed the required title input field from the `epic.yml`, `feature.yaml`, `spike.yaml`, and `task.yaml` templates to simplify issue creation and reduce friction for users. [[1]](diffhunk://#diff-6df3e39d15158053e5e4ba7a1d3ad97ffca4a1aaaefe8dc741b164671186c134L16-L24) [[2]](diffhunk://#diff-6beb416586c4731c5c2194db41281446efceebf9f99cdbe2fa569d4a50e2d06fL16-L24) [[3]](diffhunk://#diff-9504098a5da71639cbbe142c9af34fecead2c00cbe65b635cae2f0c7dd9b4964L14-L22) [[4]](diffhunk://#diff-8a66f0993793dfea458176fce664e6d39e3be13d3c1aadf0e53225f4ca4f0a49L14-L22)

**Strategic Terminology Alignment:**

* Renamed `.github/ISSUE_TEMPLATE/theme.yml` to `.github/ISSUE_TEMPLATE/pillar.yml`, changed the template type and title from "Theme" to "Pillar", and updated the description to reflect this new terminology.
* Updated all references in the pillar template from "theme" to "pillar" in overviews, labels, and descriptions to ensure consistency. [[1]](diffhunk://#diff-dd0264cba05cd9ba1982787d52ea47009c4f56d9d9a678c31c6e88ce09bbb2e3L14-R21) [[2]](diffhunk://#diff-dd0264cba05cd9ba1982787d52ea47009c4f56d9d9a678c31c6e88ce09bbb2e3L39-R30)

This PR fixes: #33474
