### PR TITLE
33500 task display form validation error alert on save

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -309,6 +309,7 @@ export class DotEditContentFormComponent implements OnInit {
         if (this.form.invalid) {
             this.form.markAllAsTouched();
             this.changeDetectorRef.detectChanges();
+            this.$store.setFormIsValid('invalid');
             requestAnimationFrame(() => {
                 this.scrollToFirstError();
             });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -309,7 +309,7 @@ export class DotEditContentFormComponent implements OnInit {
         if (this.form.invalid) {
             this.form.markAllAsTouched();
             this.changeDetectorRef.detectChanges();
-            this.$store.setFormIsValid('invalid');
+            this.$store.setFormStatus('invalid');
             requestAnimationFrame(() => {
                 this.scrollToFirstError();
             });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.html
@@ -3,6 +3,7 @@
     @let showSelectWorkflowWarning = $store.showSelectWorkflowWarning();
     @let lockWarningMessage = $store.lockWarningMessage();
     @let showBetaMessage = $store.isBetaMessageVisible();
+    @let showInvalidMessage = $store.formStatus() === 'invalid';
 
     @let isEnabledNewContentEditor = $store.isEnabledNewContentEditor();
 
@@ -94,9 +95,25 @@
                 </ng-template>
             </p-messages>
         }
+
+        @if (showInvalidMessage) {
+            <p-messages severity="error" data-testId="edit-content-layout__lock-warning">
+                <ng-template pTemplate>
+                    <div class="flex w-full gap-1">
+                        <i class="pi pi-times-circle"></i>
+                        <div
+                            class="flex align-items-center mr-auto gap-1"
+                            data-testId="edit-content-layout__lock-warning-content">
+                            {{ 'edit.content.layout.invalid.message' | dm }}
+                        </div>
+                    </div>
+                </ng-template>
+            </p-messages>
+        }
     </div>
 
     <dot-edit-content-form
+        #formComponent
         data-testId="edit-content-layout__body"
         (changeValue)="onFormChange($event)"
         class="edit-content-layout__body" />

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.html
@@ -113,7 +113,6 @@
     </div>
 
     <dot-edit-content-form
-        #formComponent
         data-testId="edit-content-layout__body"
         (changeValue)="onFormChange($event)"
         class="edit-content-layout__body" />

--- a/core-web/libs/edit-content/src/lib/store/edit-content.store.ts
+++ b/core-web/libs/edit-content/src/lib/store/edit-content.store.ts
@@ -83,6 +83,7 @@ export interface EditContentState {
 
     // Form state
     formValues: FormValues;
+    formStatus: 'init' | 'valid' | 'invalid';
 
     // Locales state
     locales: DotLanguage[] | null;
@@ -168,6 +169,7 @@ export const initialRootState: EditContentState = {
 
     // Form state
     formValues: {},
+    formStatus: 'init',
 
     // Locales state
     locales: null,

--- a/core-web/libs/edit-content/src/lib/store/features/form/form.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/form/form.feature.ts
@@ -25,7 +25,13 @@ export function withForm() {
             onFormChange: (formValues: FormValues) => {
                 patchState(store, { formValues });
             },
-            setFormIsValid: (state: 'init' | 'valid' | 'invalid') => {
+            /**
+             * Sets the form status.
+             *
+             * @param {('init' | 'valid' | 'invalid')} state
+             * @memberof withForm
+             */
+            setFormStatus: (state: 'init' | 'valid' | 'invalid') => {
                 patchState(store, { formStatus: state });
             }
         }))

--- a/core-web/libs/edit-content/src/lib/store/features/form/form.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/form/form.feature.ts
@@ -24,6 +24,9 @@ export function withForm() {
              */
             onFormChange: (formValues: FormValues) => {
                 patchState(store, { formValues });
+            },
+            setFormIsValid: (state: 'init' | 'valid' | 'invalid') => {
+                patchState(store, { formStatus: state });
             }
         }))
     );

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5909,7 +5909,7 @@ edit.content.processing.workflow.message.title=Processing
 edit.content.layout.back.to.old.edit.content=You are currently viewing the new Edit Content experience. You can easily
 edit.content.layout.back.to.old.edit.content.switch=revert
 edit.content.layout.back.to.old.edit.content.subtitle=to the previous version at any time.
-edit.content.layout.invalid.message=Please fill the fields properly before saving.
+edit.content.layout.invalid.message=Some required fields need your attention. Fix or fill them out to move forward.
 
 edit.content.layout.select.workflow.warning=You haven't selected a Workflow yet.
 edit.content.layout.select.workflow.warning.switch=Select a Workflow

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5909,6 +5909,7 @@ edit.content.processing.workflow.message.title=Processing
 edit.content.layout.back.to.old.edit.content=You are currently viewing the new Edit Content experience. You can easily
 edit.content.layout.back.to.old.edit.content.switch=revert
 edit.content.layout.back.to.old.edit.content.subtitle=to the previous version at any time.
+edit.content.layout.invalid.message=Please fill the fields properly before saving.
 
 edit.content.layout.select.workflow.warning=You haven't selected a Workflow yet.
 edit.content.layout.select.workflow.warning.switch=Select a Workflow


### PR DESCRIPTION
### Proposed Changes

This pull request introduces form validation feedback to the Edit Content workflow. When a user attempts to save an invalid form, the system now displays a clear error message, guiding the user to correct form errors before proceeding. This is achieved by tracking form validity in the store and conditionally rendering an error message in the UI.

Key changes:

**Form Validation State Management:**

* Added a new `formStatus` property (`'init' | 'valid' | 'invalid'`) to the `EditContentState` interface and initialized it in the state (`edit-content.store.ts`). [[1]](diffhunk://#diff-2f1a1d6b895a7f80141dc1acc3663ee94e65a59e505fe3268a56e06c3e2a8f2cR86) [[2]](diffhunk://#diff-2f1a1d6b895a7f80141dc1acc3663ee94e65a59e505fe3268a56e06c3e2a8f2cR172)
* Updated the form feature store to include a `setFormIsValid` method for updating the `formStatus`.
* Modified the form submission logic to set the form status to `'invalid'` when the form is invalid.

**User Interface Feedback:**

* Updated the layout component template to compute and react to the new invalid form state.
* Added a conditional error message in the layout, shown when the form is invalid, using a new localized string. [[1]](diffhunk://#diff-95d5adefae0dd044682f8ccdff07f5008d30161761148365ce9626fa3097b905R98-R112) [[2]](diffhunk://#diff-21db9723fa4c52389731b7575f1e19bd364aa992b7e549e22c08a33456994e94R5912)

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

This PR fixes: #33500

This PR fixes: #33500