### PR TITLE
Move device section to context

### DIFF
--- a/dotCMS/src/main/resources/analytics/validators/all.json
+++ b/dotCMS/src/main/resources/analytics/validators/all.json
@@ -16,6 +16,29 @@
       "user_id": {
         "type": "string",
         "required": true
+      },
+      "device": {
+        "type": "json_object",
+        "required": true,
+
+        "allowed_attributes": {
+          "screen_resolution": {
+            "type": "string",
+            "required": true
+          },
+          "language": {
+            "type": "string",
+            "required": true
+          },
+          "viewport_width": {
+            "type": "string",
+            "required": true
+          },
+          "viewport_height": {
+            "type": "string",
+            "required": true
+          }
+        }
       }
     }
   },

--- a/dotCMS/src/main/resources/analytics/validators/pageview.json
+++ b/dotCMS/src/main/resources/analytics/validators/pageview.json
@@ -38,29 +38,6 @@
       }
     }
   },
-  "device": {
-    "type": "json_object",
-    "required": true,
-
-    "allowed_attributes": {
-      "screen_resolution": {
-        "type": "string",
-        "required": true
-      },
-      "language": {
-        "type": "string",
-        "required": true
-      },
-      "viewport_width": {
-        "type": "string",
-        "required": true
-      },
-      "viewport_height": {
-        "type": "string",
-        "required": true
-      }
-    }
-  },
   "utm": {
     "type": "json_object",
     "allowed_attributes": {

--- a/dotCMS/src/test/java/com/dotcms/jitsu/ValidAnalyticsEventPayloadTest.java
+++ b/dotCMS/src/test/java/com/dotcms/jitsu/ValidAnalyticsEventPayloadTest.java
@@ -17,7 +17,13 @@ public class ValidAnalyticsEventPayloadTest  {
         "\"context\": {" +
             "\"site_key\": \"xyz\"," +
             "\"session_id\": \"abc\"," +
-            "\"user_id\": \"qwe\" " +
+            "\"user_id\": \"qwe\", " +
+            "\"device\": {" +
+                "\"screen_resolution\": \"1280x720\"," +
+                "\"language\": \"en\"," +
+                "\"viewport_width\": \"1280\"," +
+                "\"viewport_height\": \"720\"" +
+            "}" +
         "}," +
          " \"events\": [" +
             "{" +
@@ -37,12 +43,6 @@ public class ValidAnalyticsEventPayloadTest  {
                         "\"doc_search\": \"a=b\"," +
                         "\"referer\": \"referer\"," +
                         "\"user_agent\": \"useragent=b\"" +
-                    "}," +
-                    "\"device\": {" +
-                        "\"screen_resolution\": \"1280x720\"," +
-                        "\"language\": \"en\"," +
-                        "\"viewport_width\": \"1280\"," +
-                        "\"viewport_height\": \"720\"" +
                     "}," +
                     "\"utm\": {" +
                         "\"medium\": \"medium\"," +
@@ -106,13 +106,14 @@ public class ValidAnalyticsEventPayloadTest  {
 
     /**
      * Method to test: {@link ValidAnalyticsEventPayload#payloads()}
-     * when: a {@link ValidAnalyticsEventPayload} is created with a payload with sevarls events
+     * when: a {@link ValidAnalyticsEventPayload} is created with a payload with several events
      * should: return a EventPayload for each event
      */
     @Test
     public void transform() throws IOException {
         Map<String, Object> payloadMap = JsonUtil.getJsonFromString(jsonPayload);
         List<Map<String, Object>> events = (List<Map<String, Object>> ) payloadMap.get("events");
+        Map<String, Object> expectedContext = (Map<String, Object>) payloadMap.get("context");
 
         final ValidAnalyticsEventPayload validAnalyticsEventPayload = new ValidAnalyticsEventPayload(payloadMap);
         int i = 0;
@@ -130,7 +131,7 @@ public class ValidAnalyticsEventPayloadTest  {
 
             Map<String, Object> dataAttributes = (Map<String, Object>) events.get(i).get("data");
             checkAttributes(payload, dataAttributes, "page", Map.of("title", "page_title", "language", "userlanguage"));
-            checkAttributes(payload, dataAttributes, "device", Map.of("language", "user_language"));
+            checkAttributes(payload, expectedContext, "device", Map.of("language", "user_language"));
 
 
             Map<String, Object> utmAttributesExpected = (Map<String, Object>)  dataAttributes.get("utm");

--- a/dotcms-integration/src/test/java/com/dotcms/jitsu/validators/AnalyticsValidatorUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/jitsu/validators/AnalyticsValidatorUtilTest.java
@@ -106,7 +106,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": 123," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[{}]" +
                 "}";
@@ -140,7 +146,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                 "{" +
                     "\"context\": {" +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[{}]" +
                 "}";
@@ -182,7 +194,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"invalid-auth\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                        "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[{}]" +
                 "}";
@@ -228,7 +246,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[{}]" +
                 "}";
@@ -288,7 +312,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[{}]" +
                 "}";
@@ -340,7 +370,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
                         "\"session_id\": 456," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[{}]" +
                 "}";
@@ -374,7 +410,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                 "{" +
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[{}]" +
                 "}";
@@ -409,7 +451,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": 789" +
+                        "\"user_id\": 789," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[{}]" +
                 "}";
@@ -443,7 +491,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                 "{" +
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
-                        "\"session_id\": \"abc\"" +
+                        "\"session_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[{}]" +
                 "}";
@@ -477,6 +531,12 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"site_auth\": 123," +
                     "\"session_id\": \"abc\"," +
                     "\"user_id\": \"abc\"," +
+                    "\"device\": {" +
+                        "\"screen_resolution\": \"1200x800\"," +
+                        "\"language\": \"en\"," +
+                        "\"viewport_width\": \"1200\"," +
+                        "\"viewport_height\": \"800\"" +
+                    "}," +
                     "\"events\":[{}]" +
                 "}";
 
@@ -484,7 +544,7 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
 
         final List<AnalyticsValidatorUtil.Error> errors = AnalyticsValidatorUtil.INSTANCE.validateGlobalContext(jsonObject);
 
-        assertEquals(7, errors.size());
+        assertEquals(16, errors.size());
         final List<String> errorFields =
                 errors.stream().map(AnalyticsValidatorUtil.Error::getField).collect(Collectors.toList());
 
@@ -495,6 +555,15 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
         assertTrue(errorFields.contains("site_auth"));
         assertTrue(errorFields.contains("session_id"));
         assertTrue(errorFields.contains("user_id"));
+        assertTrue(errorFields.contains("context.device.language"));
+        assertTrue(errorFields.contains("context.device.screen_resolution"));
+        assertTrue(errorFields.contains("context.device.viewport_width"));
+        assertTrue(errorFields.contains("context.device.viewport_height"));
+        assertTrue(errorFields.contains("context.device"));
+        assertTrue(errorFields.contains("device.language"));
+        assertTrue(errorFields.contains("device.screen_resolution"));
+        assertTrue(errorFields.contains("device.viewport_width"));
+        assertTrue(errorFields.contains("device.viewport_height"));
 
         for (AnalyticsValidatorUtil.Error error : errors) {
             if (error.getField().equals("context.site_auth")) {
@@ -525,6 +594,42 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                 assertEquals("user_id", error.getField());
                 assertEquals("UNKNOWN_FIELD", error.getCode().toString());
                 assertEquals("Unknown field 'user_id'", error.getMessage());
+            } else  if (error.getField().equals("context.device.language")){
+                assertEquals("context.device.language", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device.language", error.getMessage());
+            } else  if (error.getField().equals("context.device.screen_resolution")){
+                assertEquals("context.device.screen_resolution", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device.screen_resolution", error.getMessage());
+            } else  if (error.getField().equals("context.device.viewport_width")){
+                assertEquals("context.device.viewport_width", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device.viewport_width", error.getMessage());
+            } else  if (error.getField().equals("context.device.viewport_height")){
+                assertEquals("context.device.viewport_height", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device.viewport_height", error.getMessage());
+            } else  if (error.getField().equals("context.device")){
+                assertEquals("context.device", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device", error.getMessage());
+            } else  if (error.getField().equals("device.language")){
+                assertEquals("device.language", error.getField());
+                assertEquals("UNKNOWN_FIELD", error.getCode().toString());
+                assertEquals("Unknown field 'device.language'", error.getMessage());
+            } else  if (error.getField().equals("device.screen_resolution")){
+                assertEquals("device.screen_resolution", error.getField());
+                assertEquals("UNKNOWN_FIELD", error.getCode().toString());
+                assertEquals("Unknown field 'device.screen_resolution'", error.getMessage());
+            } else  if (error.getField().equals("device.viewport_width")){
+                assertEquals("device.viewport_width", error.getField());
+                assertEquals("UNKNOWN_FIELD", error.getCode().toString());
+                assertEquals("Unknown field 'device.viewport_width'", error.getMessage());
+            } else  if (error.getField().equals("device.viewport_height")){
+                assertEquals("device.viewport_height", error.getField());
+                assertEquals("UNKNOWN_FIELD", error.getCode().toString());
+                assertEquals("Unknown field 'device.viewport_height'", error.getMessage());
             } else {
                 throw new AssertionError("Unexpected field: " + errorFields);
             }
@@ -555,7 +660,7 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
 
         final List<AnalyticsValidatorUtil.Error> errors = AnalyticsValidatorUtil.INSTANCE.validateGlobalContext(jsonObject);
 
-        assertEquals(4, errors.size());
+        assertEquals(9, errors.size());
         final List<String> errorFields =
                 errors.stream().map(AnalyticsValidatorUtil.Error::getField).collect(Collectors.toList());
 
@@ -563,6 +668,11 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
         assertTrue(errorFields.contains("context.session_id"));
         assertTrue(errorFields.contains("context.user_id"));
         assertTrue(errorFields.contains("context"));
+        assertTrue(errorFields.contains("context.device.language"));
+        assertTrue(errorFields.contains("context.device.screen_resolution"));
+        assertTrue(errorFields.contains("context.device.viewport_width"));
+        assertTrue(errorFields.contains("context.device.viewport_height"));
+        assertTrue(errorFields.contains("context.device"));
 
         for (AnalyticsValidatorUtil.Error error : errors) {
             if (error.getField().equals("context.site_auth")) {
@@ -577,10 +687,32 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                 assertEquals("context.user_id", error.getField());
                 assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
                 assertEquals("Required field is missing: context.user_id", error.getMessage());
-            } else {
+            } else if (error.getField().equals("context")) {
                 assertEquals("context", error.getField());
                 assertEquals("INVALID_JSON_OBJECT_TYPE", error.getCode().toString());
                 assertEquals("Field value is not a JSON object: 123", error.getMessage());
+            } else  if (error.getField().equals("context.device.language")){
+                assertEquals("context.device.language", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device.language", error.getMessage());
+            } else  if (error.getField().equals("context.device.screen_resolution")){
+                assertEquals("context.device.screen_resolution", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device.screen_resolution", error.getMessage());
+            } else  if (error.getField().equals("context.device.viewport_width")){
+                assertEquals("context.device.viewport_width", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device.viewport_width", error.getMessage());
+            } else  if (error.getField().equals("context.device.viewport_height")){
+                assertEquals("context.device.viewport_height", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device.viewport_height", error.getMessage());
+            } else  if (error.getField().equals("context.device")){
+                assertEquals("context.device", error.getField());
+                assertEquals("REQUIRED_FIELD_MISSING", error.getCode().toString());
+                assertEquals("Required field is missing: context.device", error.getMessage());
+            } else {
+                throw new AssertionError("Unexpected field: " + errorFields);
             }
         }
     }
@@ -605,7 +737,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}," +
                     "}," +
                     "\"events\":123" +
                 "}";
@@ -643,7 +781,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"xyz\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[" +
                         "{" +
@@ -688,13 +832,19 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
      */
     @Test
     public void dataIsRequired() {
-        final int errorsCountExpected = 10;
+        final int errorsCountExpected = 5;
         final String json =
                 "{" +
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[" +
                         "{" +
@@ -718,11 +868,6 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
         assertTrue(errorsField.contains("events[0].data.page.url"));
         assertTrue(errorsField.contains("events[0].data.page.title"));
         assertTrue(errorsField.contains("events[0].data.page.doc_encoding"));
-        assertTrue(errorsField.contains("events[0].data.device"));
-        assertTrue(errorsField.contains("events[0].data.device.screen_resolution"));
-        assertTrue(errorsField.contains("events[0].data.device.language"));
-        assertTrue(errorsField.contains("events[0].data.device.viewport_width"));
-        assertTrue(errorsField.contains("events[0].data.device.viewport_height"));
         assertTrue(errorsField.contains("events[0].local_time"));
 
         final List<ValidationErrorCode> errorsCode = errors.stream()
@@ -742,11 +887,6 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
         assertTrue(errorsMessages.contains("Required field is missing: data.page"));
         assertTrue(errorsMessages.contains("Required field is missing: data.page.url"));
         assertTrue(errorsMessages.contains("Required field is missing: data.page.title"));
-        assertTrue(errorsMessages.contains("Required field is missing: data.device"));
-        assertTrue(errorsMessages.contains("Required field is missing: data.device.screen_resolution"));
-        assertTrue(errorsMessages.contains("Required field is missing: data.device.language"));
-        assertTrue(errorsMessages.contains("Required field is missing: data.device.viewport_width"));
-        assertTrue(errorsMessages.contains("Required field is missing: data.device.viewport_height"));
         assertTrue(errorsMessages.contains("Required field is missing: local_time"));
     }
 
@@ -762,7 +902,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH +"\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[" +
                         "{" +
@@ -773,12 +919,6 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                                     "\"url\": \"http://www.google.com\"," +
                                     "\"title\": \"Google\"," +
                                     "\"doc_encoding\": \"UTF8\"" +
-                                "}," +
-                                "\"device\": {" +
-                                    "\"screen_resolution\": \"1200x800\"," +
-                                    "\"language\": \"en\"," +
-                                    "\"viewport_width\": \"1200\"," +
-                                    "\"viewport_height\": \"800\"" +
                                 "}" +
                             "}" +
                         "}" +
@@ -803,7 +943,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[" +
                         "{" +
@@ -814,12 +960,6 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                                     "\"url\": \"http://www.google.com\"," +
                                     "\"title\": \"Google\"," +
                                     "\"doc_encoding\": \"UTF8\"" +
-                                "}," +
-                                "\"device\": {" +
-                                    "\"screen_resolution\": \"1200x800\"," +
-                                    "\"language\": \"en\"," +
-                                    "\"viewport_width\": \"1200\"," +
-                                    "\"viewport_height\": \"800\"" +
                                 "}" +
                             "}" +
                         "}" +
@@ -848,7 +988,13 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                     "\"context\": {" +
                         "\"site_auth\": \"" + TEST_SITE_AUTH + "\"," +
                         "\"session_id\": \"abc\"," +
-                        "\"user_id\": \"abc\"" +
+                        "\"user_id\": \"abc\"," +
+                        "\"device\": {" +
+                            "\"screen_resolution\": \"1200x800\"," +
+                            "\"language\": \"en\"," +
+                            "\"viewport_width\": \"1200\"," +
+                            "\"viewport_height\": \"800\"" +
+                        "}" +
                     "}," +
                     "\"events\":[" +
                         "{" +
@@ -859,13 +1005,6 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                                     "\"url\": \"http://www.google.com\"," +
                                     "\"title\": \"Google\"," +
                                     "\"doc_encoding\": \"UTF8\"," +
-                                    "\"extra_field\": \"extra\"" +
-                                "}," +
-                                "\"device\": {" +
-                                    "\"screen_resolution\": \"1200x800\"," +
-                                    "\"language\": \"en\"," +
-                                    "\"viewport_width\": \"1200\"," +
-                                    "\"viewport_height\": \"800\"," +
                                     "\"extra_field\": \"extra\"" +
                                 "}" +
                             "}," +
@@ -878,7 +1017,7 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
         final List<AnalyticsValidatorUtil.Error> errors = AnalyticsValidatorUtil.INSTANCE
                 .validateEvents((JSONArray) new JSONObject(json).get("events"));
 
-        assertEquals(4, errors.size());
+        assertEquals(3, errors.size());
 
         final List<String> errorsField = errors.stream()
                 .map(AnalyticsValidatorUtil.Error::getField)
@@ -886,7 +1025,6 @@ public class AnalyticsValidatorUtilTest extends IntegrationTestBase {
                 .collect(Collectors.toList());
 
         assertTrue(errorsField.contains("events[0].data.page.extra_field"));
-        assertTrue(errorsField.contains("events[0].data.device.extra_field"));
         assertTrue(errorsField.contains("events[0].extra_field_1"));
         assertTrue(errorsField.contains("events[0].extra_field_2.extra_field"));
 

--- a/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Content_Analytics.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "6496517b-8250-414a-9539-600f9f9c007a",
+		"_postman_id": "4438f786-b403-474b-81fe-ad4aae6e2ce1",
 		"name": "Content Analytics",
 		"description": "Performs simple data validation for the Content Analytics REST Endpoint. It's very important to notice that, for the time being, the CICD instance does not start up any of the additional third-party tools required to actually run the Content Analytics feature.\n\nThis means that these test do not deal with retrieveing or saving data at all. It verifies that important/required information is present.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -348,7 +348,8 @@
 											"});"
 										],
 										"type": "text/javascript",
-										"packages": {}
+										"packages": {},
+										"requests": {}
 									}
 								}
 							],
@@ -378,7 +379,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"context\": {\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"page_view\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"context\": {\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\",\n        \"device\": {\n            \"screen_resolution\": \"1280x720\",\n            \"language\": \"en\",\n            \"viewport_width\": \"1280\",\n            \"viewport_height\": \"720\"\n        }\n    },\n    \"events\": [\n        {\n            \"event_type\": \"page_view\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -430,7 +431,8 @@
 											"});"
 										],
 										"type": "text/javascript",
-										"packages": {}
+										"packages": {},
+										"requests": {}
 									}
 								}
 							],
@@ -460,7 +462,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    }\n}",
+									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\",\n        \"device\": {\n            \"screen_resolution\": \"1280x720\",\n            \"language\": \"en\",\n            \"viewport_width\": \"1280\",\n            \"viewport_height\": \"720\"\n        }\n    }\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -512,7 +514,8 @@
 											"});"
 										],
 										"type": "text/javascript",
-										"packages": {}
+										"packages": {},
+										"requests": {}
 									}
 								}
 							],
@@ -542,7 +545,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"user_id\": \"qwe\",\n        \"device\": {\n            \"screen_resolution\": \"1280x720\",\n            \"language\": \"en\",\n            \"viewport_width\": \"1280\",\n            \"viewport_height\": \"720\"\n        }\n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -594,7 +597,8 @@
 											"});"
 										],
 										"type": "text/javascript",
-										"packages": {}
+										"packages": {},
+										"requests": {}
 									}
 								}
 							],
@@ -624,7 +628,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\"\n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\",\n        \"device\": {\n            \"screen_resolution\": \"1280x720\",\n            \"language\": \"en\",\n            \"viewport_width\": \"1280\",\n            \"viewport_height\": \"720\"\n        }\n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"referer\": \"referer\",\n                    \"user_agent\": \"useragent=b\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\",\n                    \"referer\": \"another_referer\",\n                    \"user_agent\": \"another_useragent=b\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -711,7 +715,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n           \"local_time\": \"2025-07-28T14:30:00+02:00\"\n        },\n        {\n            \"local_time\": \"2025-07-28T14:30:00+02:00\"\n        }\n    ]\n}",
+									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\",\n        \"device\": {\n            \"screen_resolution\": \"1280x720\",\n            \"language\": \"en\",\n            \"viewport_width\": \"1280\",\n            \"viewport_height\": \"720\"\n        }\n    },\n    \"events\": [\n        {\n           \"local_time\": \"2025-07-28T14:30:00+02:00\"\n        },\n        {\n            \"local_time\": \"2025-07-28T14:30:00+02:00\"\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -748,12 +752,12 @@
 											"pm.test(\"Response sould be right\", function () {",
 											"    const responseBody = pm.response.json();",
 											"",
-											"    pm.expect(responseBody.failed).to.be.eq(6);",
+											"    pm.expect(responseBody.failed).to.be.eq(3);",
 											"    pm.expect(responseBody.success).to.be.eq(0);",
 											"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
 											"",
 											"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
-											"    pm.expect(responseBody.errors.length).to.be.eq(8);",
+											"    pm.expect(responseBody.errors.length).to.be.eq(4);",
 											"",
 											"    pm.expect(responseBody.errors[0].eventIndex).to.be.eq(0);",
 											"    pm.expect(responseBody.errors[0].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
@@ -774,30 +778,11 @@
 											"    pm.expect(responseBody.errors[3].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
 											"    pm.expect(responseBody.errors[3].field).to.be.eq(\"events[2].data.page.title\");",
 											"    pm.expect(responseBody.errors[3].message).to.be.eq(\"Required field is missing: data.page.title\");",
-											"",
-											"    pm.expect(responseBody.errors[4].eventIndex).to.be.eq(3);",
-											"    pm.expect(responseBody.errors[4].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-											"    pm.expect(responseBody.errors[4].field).to.be.eq(\"events[3].data.device.screen_resolution\");",
-											"    pm.expect(responseBody.errors[4].message).to.be.eq(\"Required field is missing: data.device.screen_resolution\");",
-											"",
-											"    pm.expect(responseBody.errors[5].eventIndex).to.be.eq(4);",
-											"    pm.expect(responseBody.errors[5].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-											"    pm.expect(responseBody.errors[5].field).to.be.eq(\"events[4].data.device.language\");",
-											"    pm.expect(responseBody.errors[5].message).to.be.eq(\"Required field is missing: data.device.language\");",
-											"",
-											"    pm.expect(responseBody.errors[6].eventIndex).to.be.eq(5);",
-											"    pm.expect(responseBody.errors[6].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-											"    pm.expect(responseBody.errors[6].field).to.be.eq(\"events[5].data.device.viewport_height\");",
-											"    pm.expect(responseBody.errors[6].message).to.be.eq(\"Required field is missing: data.device.viewport_height\");",
-											"",
-											"    pm.expect(responseBody.errors[7].eventIndex).to.be.eq(5);",
-											"    pm.expect(responseBody.errors[7].code).to.be.eq(\"REQUIRED_FIELD_MISSING\");",
-											"    pm.expect(responseBody.errors[7].field).to.be.eq(\"events[5].data.device.viewport_width\");",
-											"    pm.expect(responseBody.errors[7].message).to.be.eq(\"Required field is missing: data.device.viewport_width\");",
 											"});"
 										],
 										"type": "text/javascript",
-										"packages": {}
+										"packages": {},
+										"requests": {}
 									}
 								}
 							],
@@ -832,7 +817,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"3840x2160\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"3840\",\n                    \"viewport_height\": \"2160\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\",\n        \"device\": {\n            \"screen_resolution\": \"1280x720\",\n            \"language\": \"en\",\n            \"viewport_width\": \"1280\",\n            \"viewport_height\": \"720\"\n        }\n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"data\": {\n                \"page\": {\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/another_page#pepe?c=d\",\n                    \"title\": \"This is my another page\",\n                    \"language_id\": \"555555\",\n                    \"persona\": \"ANY_PERSONA_BUT_NOT_PREVIOUS_PERSONA\",\n                    \"doc_path\": \"another_page\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepe\",\n                    \"doc_search\": \"c=d\"\n                },\n                \"utm\": {\n                    \"medium\": \"another_medium\",\n                    \"source\": \"another_source\",\n                    \"campaign\": \"another_campaign\",\n                    \"term\": \"another_term\",\n                    \"content\": \"another_content\"\n                }\n            }\n        },\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\"\n                }\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -874,7 +859,7 @@
 											"    pm.expect(responseBody.status).to.be.eq(\"ERROR\");",
 											"",
 											"    pm.expect(responseBody).to.have.property('errors').that.is.not.empty;",
-											"    pm.expect(responseBody.errors.length).to.be.eq(4);",
+											"    pm.expect(responseBody.errors.length).to.be.eq(3);",
 											"",
 											"    pm.expect(responseBody.errors[0].eventIndex).to.be.eq(0);",
 											"    pm.expect(responseBody.errors[0].code).to.be.eq(\"UNKNOWN_FIELD\");",
@@ -883,22 +868,18 @@
 											"",
 											"    pm.expect(responseBody.errors[1].eventIndex).to.be.eq(0);",
 											"    pm.expect(responseBody.errors[1].code).to.be.eq(\"UNKNOWN_FIELD\");",
-											"    pm.expect(responseBody.errors[1].field).to.be.eq(\"events[0].data.device.extra\");",
-											"    pm.expect(responseBody.errors[1].message).to.be.eq(\"Unknown field 'data.device.extra'\");",
+											"    pm.expect(responseBody.errors[1].field).to.be.eq(\"events[0].data.utm.extra\");",
+											"    pm.expect(responseBody.errors[1].message).to.be.eq(\"Unknown field 'data.utm.extra'\");",
 											"",
 											"    pm.expect(responseBody.errors[2].eventIndex).to.be.eq(0);",
 											"    pm.expect(responseBody.errors[2].code).to.be.eq(\"UNKNOWN_FIELD\");",
-											"    pm.expect(responseBody.errors[2].field).to.be.eq(\"events[0].data.utm.extra\");",
-											"    pm.expect(responseBody.errors[2].message).to.be.eq(\"Unknown field 'data.utm.extra'\");",
-											"",
-											"    pm.expect(responseBody.errors[3].eventIndex).to.be.eq(0);",
-											"    pm.expect(responseBody.errors[3].code).to.be.eq(\"UNKNOWN_FIELD\");",
-											"    pm.expect(responseBody.errors[3].field).to.be.eq(\"events[0].data.extra\");",
-											"    pm.expect(responseBody.errors[3].message).to.be.eq(\"Unknown field 'data.extra'\");",
+											"    pm.expect(responseBody.errors[2].field).to.be.eq(\"events[0].data.extra\");",
+											"    pm.expect(responseBody.errors[2].message).to.be.eq(\"Unknown field 'data.extra'\");",
 											"});"
 										],
 										"type": "text/javascript",
-										"packages": {}
+										"packages": {},
+										"requests": {}
 									}
 								}
 							],
@@ -933,7 +914,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\" \n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"extra\": \"extra\"\n                },\n                \"device\": {\n                    \"screen_resolution\": \"1280x720\",\n                    \"language\": \"en\",\n                    \"viewport_width\": \"1280\",\n                    \"viewport_height\": \"720\",\n                    \"extra\": \"extra\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\",\n                    \"extra\": \"extra\"\n                },\n                \"extra\": \"extra\"\n            }\n        }\n    ]\n}",
+									"raw": "{\n    \"context\": {\n        \"site_auth\": \"{{testSiteAuth}}\",\n        \"session_id\": \"abc\",\n        \"user_id\": \"qwe\",\n        \"device\": {\n            \"screen_resolution\": \"1280x720\",\n            \"language\": \"en\",\n            \"viewport_width\": \"1280\",\n            \"viewport_height\": \"720\"\n        }\n    },\n    \"events\": [\n        {\n            \"event_type\": \"pageview\",\n            \"local_time\": \"2025-06-09T14:30:00+02:00\",\n            \"data\": {\n                \"page\": {\n                    \"url\": \"http://loquesea.com/index#pepito?a=b\",\n                    \"doc_encoding\": \"UTF8\",\n                    \"title\": \"This is my index page\",\n                    \"language_id\": \"23213\",\n                    \"persona\": \"ANY_PERSONA\",\n                    \"doc_path\": \"index\",\n                    \"doc_host\": \"loquesea.com\",\n                    \"doc_protocol\": \"http\",\n                    \"doc_hash\": \"pepito\",\n                    \"doc_search\": \"a=b\",\n                    \"extra\": \"extra\"\n                },\n                \"utm\": {\n                    \"medium\": \"medium\",\n                    \"source\": \"source\",\n                    \"campaign\": \"campaign\",\n                    \"term\": \"term\",\n                    \"content\": \"content\",\n                    \"extra\": \"extra\"\n                },\n                \"extra\": \"extra\"\n            }\n        }\n    ]\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -1381,6 +1362,18 @@
 		},
 		{
 			"key": "testSiteId",
+			"value": ""
+		},
+		{
+			"key": "siteName",
+			"value": ""
+		},
+		{
+			"key": "siteId",
+			"value": ""
+		},
+		{
+			"key": "customKeyValue",
 			"value": ""
 		}
 	]


### PR DESCRIPTION
### Proposed Changes
* Move device section to be part of a pageview event data, to the context section 

https://github.com/dotCMS/core/pull/33530/files#diff-71bc1784c044ee8b2fd9114b7d2d2ee5c677c748889d587807be5ea4c60bae10L41

https://github.com/dotCMS/core/pull/33530/files#diff-5352c2106204933f4abec46765e701a61d97a0805335fcc85e12d46b5e439273R19

* Before send the payload to Jitsu we need to move the device section to the root of the Json Object, but now we need to look for the device section from another place

https://github.com/dotCMS/core/pull/33530/files#diff-875d75f7bb3357903411de7c75fc9c447989b8100034fdd1028effff0c9fa177R109

This PR fixes: #33480