### PR TITLE
Enhance analytics SDK to include device information in context

### DIFF
--- a/core-web/libs/sdk/analytics/README.md
+++ b/core-web/libs/sdk/analytics/README.md
@@ -262,6 +262,12 @@ When you call `pageView(customData?)`, the SDK **automatically enriches** the ev
         site_key: string;          //    Your site key
         session_id: string;        //    Current session ID
         user_id: string;           //    Anonymous user ID
+        device: {                  // 🤖 AUTOMATIC - Device & Browser Info
+            screen_resolution: string;  // Screen size
+            language: string;           // Browser language
+            viewport_width: string;     // Viewport width
+            viewport_height: string;    // Viewport height
+        }
     },
     events: [{
         event_type: "pageview",
@@ -277,12 +283,6 @@ When you call `pageView(customData?)`, the SDK **automatically enriches** the ev
                 doc_search: string;    //  Query string
                 doc_hash: string;      //  URL hash
                 doc_encoding: string;  //  Character encoding
-            },
-            device: {              // 🤖 AUTOMATIC - Device & Browser Info
-                screen_resolution: string;  // Screen size
-                language: string;           // Browser language
-                viewport_width: string;     // Viewport width
-                viewport_height: string;    // Viewport height
             },
             utm?: {                // 🤖 AUTOMATIC - Campaign Tracking (if present in URL)
                 source: string;    //    utm_source
@@ -319,6 +319,12 @@ When you call `track(eventName, properties)`, the following structure is sent:
         site_key: string;      // Your site key
         session_id: string;    // Current session ID
         user_id: string;       // Anonymous user ID
+        device: {              // 🤖 AUTOMATIC - Device & Browser Info
+            screen_resolution: string;  // Screen size
+            language: string;           // Browser language
+            viewport_width: string;     // Viewport width
+            viewport_height: string;    // Viewport height
+        }
     },
     events: [{
         event_type: string,    // Your custom event name

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.spec.ts
@@ -47,9 +47,18 @@ describe('dotAnalyticsEnricherPlugin', () => {
             // Arrange
             const mockPayload = { event: 'pageview', properties: { page: '/test' } } as any;
             mockEnrichPagePayloadOptimized.mockReturnValue({
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
+                context: {
+                    site_key: 'test',
+                    session_id: 'session',
+                    user_id: 'user',
+                    device: {
+                        language: 'en',
+                        screen_resolution: '1920x1080',
+                        viewport_width: '1024',
+                        viewport_height: '768'
+                    }
+                },
                 page: { url: 'test' },
-                device: { language: 'en' },
                 local_time: '2024-01-01T10:00:00.000Z'
             } as any);
 
@@ -61,13 +70,22 @@ describe('dotAnalyticsEnricherPlugin', () => {
             expect(mockEnrichPagePayloadOptimized).toHaveBeenCalledTimes(1);
         });
 
-        it('should return the result from enrichPagePayloadOptimized', () => {
+        it('should return the result from enrichPagePayloadOptimized with device in context', () => {
             // Arrange
             const mockPayload = { event: 'pageview' } as any;
             const expectedEnriched = {
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
+                context: {
+                    site_key: 'test',
+                    session_id: 'session',
+                    user_id: 'user',
+                    device: {
+                        language: 'en',
+                        screen_resolution: '1920x1080',
+                        viewport_width: '1024',
+                        viewport_height: '768'
+                    }
+                },
                 page: { url: 'test', title: 'Test' },
-                device: { language: 'en' },
                 local_time: '2024-01-01T10:00:00.000Z'
             };
             mockEnrichPagePayloadOptimized.mockReturnValue(expectedEnriched as any);
@@ -83,8 +101,7 @@ describe('dotAnalyticsEnricherPlugin', () => {
                         event_type: 'pageview',
                         local_time: expectedEnriched.local_time,
                         data: {
-                            page: expectedEnriched.page,
-                            device: expectedEnriched.device
+                            page: expectedEnriched.page
                         }
                     }
                 ]

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts
@@ -9,8 +9,8 @@ import {
 /**
  * Plugin that enriches the analytics payload data based on the event type.
  * Uses Analytics.js lifecycle events to inject context before processing.
- * The identity plugin runs FIRST to inject context: { session_id, site_auth, user_id }
- * This enricher plugin runs SECOND to add page/device/utm data.
+ * The identity plugin runs FIRST to inject context: { session_id, site_auth, user_id, device }
+ * This enricher plugin runs SECOND to add page/utm/custom data.
  *
  * Returns the final request body structure ready to send to the server.
  */
@@ -28,11 +28,10 @@ export const dotAnalyticsEnricherPlugin = () => {
         }: {
             payload: AnalyticsBasePayloadWithContext;
         }): DotCMSAnalyticsRequestBody => {
-            const { context, page, device, utm, custom, local_time } =
-                enrichPagePayloadOptimized(payload);
+            const { context, page, utm, custom, local_time } = enrichPagePayloadOptimized(payload);
 
-            if (!page || !device) {
-                throw new Error('DotCMS Analytics: Missing required page or device data');
+            if (!page) {
+                throw new Error('DotCMS Analytics: Missing required page data');
             }
 
             return {
@@ -43,7 +42,6 @@ export const dotAnalyticsEnricherPlugin = () => {
                         local_time,
                         data: {
                             page,
-                            device,
                             ...(utm && { utm }),
                             ...(custom && { custom })
                         }

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.ts
@@ -199,6 +199,7 @@ export const getSessionId = (): string => {
 export const getAnalyticsContext = (config: DotCMSAnalyticsConfig): DotCMSAnalyticsEventContext => {
     const sessionId = getSessionId();
     const userId = getUserId();
+    const device = getDeviceDataForContext();
 
     if (config.debug) {
         console.warn('DotCMS Analytics Identity Context:', {
@@ -210,7 +211,8 @@ export const getAnalyticsContext = (config: DotCMSAnalyticsConfig): DotCMSAnalyt
     return {
         site_auth: config.siteAuth,
         session_id: sessionId,
-        user_id: userId
+        user_id: userId,
+        device
     };
 };
 
@@ -275,6 +277,26 @@ const getStaticBrowserData = () => {
     };
 
     return staticBrowserData;
+};
+
+/**
+ * Gets current device data for analytics.
+ * Combines static browser data with dynamic viewport information.
+ * Used by the identity plugin to inject device data into context.
+ *
+ * @returns Device data with screen resolution, language, and viewport dimensions
+ */
+export const getDeviceDataForContext = (): DotCMSEventDeviceData => {
+    const staticData = getStaticBrowserData();
+    const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight || 0;
+
+    return {
+        screen_resolution: staticData.screen_resolution ?? '',
+        language: staticData.user_language ?? '',
+        viewport_width: String(viewportWidth),
+        viewport_height: String(viewportHeight)
+    };
 };
 
 /**
@@ -472,7 +494,7 @@ export const enrichWithUtmData = <T extends Record<string, unknown>>(payload: T)
  *
  * @param payload - The Analytics.js payload with context already injected by identity plugin
  * @param location - The Location object to extract page data from (defaults to window.location)
- * @returns Enriched payload with page, device, UTM, custom data, and local_time
+ * @returns Enriched payload with page, UTM, custom data, and local_time (device is in context)
  */
 export const enrichPagePayloadOptimized = (
     payload: AnalyticsBasePayloadWithContext,
@@ -503,20 +525,12 @@ export const enrichPagePayloadOptimized = (
         title: (properties.title as string) ?? document?.title
     };
 
-    const deviceData: DotCMSEventDeviceData = {
-        screen_resolution: staticData.screen_resolution ?? '',
-        language: staticData.user_language ?? '',
-        viewport_width: String(properties.width),
-        viewport_height: String(properties.height)
-    };
-
     // Extract UTM parameters from the current URL (already transformed to DotCMS format)
     const utmData = extractUTMParameters(location);
 
     return {
         ...payload,
         page: pageData,
-        device: deviceData,
         ...(Object.keys(utmData).length > 0 && { utm: utmData }),
         // Only include custom if there are user-provided properties
         ...(Object.keys(userProvidedProperties).length > 0 && { custom: userProvidedProperties }),

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/data.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/data.model.ts
@@ -55,6 +55,9 @@ export interface DotCMSAnalyticsEventContext {
     session_id: string;
     /** Unique user identifier */
     user_id: string;
+
+    /** Device and browser information */
+    device: DotCMSEventDeviceData;
 }
 
 /**

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/event.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/event.model.ts
@@ -3,7 +3,7 @@
  * Contains interfaces for different types of analytics events
  */
 
-import { DotCMSEventDeviceData, DotCMSEventPageData, DotCMSEventUtmData } from './data.model';
+import { DotCMSEventPageData, DotCMSEventUtmData } from './data.model';
 
 import {
     DotCMSCustomEventType,
@@ -45,13 +45,11 @@ export interface DotCMSEventBase<TEventType extends DotCMSEventType, TData> {
 
 /**
  * Data structure for pageview events.
- * Contains page, device, and optional UTM/custom data.
+ * Contains page and optional UTM/custom data.
  */
 export type DotCMSPageViewEventData = {
     /** Page data associated with the event */
     page: DotCMSEventPageData;
-    /** Device and browser information */
-    device: DotCMSEventDeviceData;
     /** UTM parameters for campaign tracking (optional) */
     utm?: DotCMSEventUtmData;
     /** Custom data associated with the event (any valid JSON) */

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
@@ -3,12 +3,7 @@
  * Contains interfaces for SDK/library internal structures (not for end users)
  */
 
-import {
-    DotCMSAnalyticsEventContext,
-    DotCMSEventDeviceData,
-    DotCMSEventPageData,
-    DotCMSEventUtmData
-} from './data.model';
+import { DotCMSAnalyticsEventContext, DotCMSEventPageData, DotCMSEventUtmData } from './data.model';
 import { JsonObject } from './event.model';
 import { DotCMSAnalyticsRequestBody } from './request.model';
 
@@ -140,13 +135,11 @@ export interface AnalyticsBasePayloadWithContext extends AnalyticsBasePayload {
 /**
  * Enriched analytics payload with DotCMS-specific data.
  * This is the result of enriching the base Analytics.js payload with context (from identity plugin)
- * and then adding page, device, UTM, and custom data (from enricher plugin).
+ * and then adding page, UTM, and custom data (from enricher plugin).
  */
 export type EnrichedAnalyticsPayload = AnalyticsBasePayloadWithContext & {
     /** Page data for the current page */
     page: DotCMSEventPageData;
-    /** Device and browser information */
-    device: DotCMSEventDeviceData;
     /** UTM parameters for campaign tracking */
     utm?: DotCMSEventUtmData;
     /** Custom data associated with the event (any valid JSON) */


### PR DESCRIPTION
## Summary

Refactor analytics SDK to move device information from event data to context, improving data structure consistency and reducing payload duplication across multiple events.

## Changes Made

### Frontend

- **Analytics SDK Context Enhancement** ([core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.ts](core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.ts))
  - Added `getDeviceDataForContext()` function to extract device data for context injection
  - Modified `getAnalyticsContext()` to include device information in context object
  - Updated `enrichPagePayloadOptimized()` to remove device data from event payload (now in context)

- **Plugin Updates** ([core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts](core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts))
  - Removed device data enrichment from enricher plugin (now handled by identity plugin)
  - Updated validation to check for page data only (device no longer required at this stage)
  - Simplified event data structure by removing device from payload

### Data Models

- **Context Model** ([core-web/libs/sdk/analytics/src/lib/core/shared/models/data.model.ts](core-web/libs/sdk/analytics/src/lib/core/shared/models/data.model.ts))
  - Added `device: DotCMSEventDeviceData` field to `DotCMSAnalyticsEventContext` interface

- **Event Model** ([core-web/libs/sdk/analytics/src/lib/core/shared/models/event.model.ts](core-web/libs/sdk/analytics/src/lib/core/shared/models/event.model.ts))
  - Removed `device` field from `DotCMSPageViewEventData` type

- **Library Model** ([core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts](core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts))
  - Removed `device` field from `EnrichedAnalyticsPayload` type

### Tests

- **Unit Tests Updated** ([core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.spec.ts](core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.spec.ts))
  - Updated mock payloads to include device in context instead of event data
  - Modified assertions to validate device-free event payloads
  - Added test coverage for device data in context structure

- **Utility Tests Enhanced** ([core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.spec.ts](core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.spec.ts))
  - Updated `getAnalyticsContext()` tests to validate device data inclusion
  - Modified `enrichPagePayloadOptimized()` tests to reflect device in context
  - Added validation for device data presence in context object

### Documentation

- **README Updates** ([core-web/libs/sdk/analytics/README.md](core-web/libs/sdk/analytics/README.md))
  - Moved device information documentation from event data to context section
  - Updated data structure examples to reflect new device placement
  - Clarified that device data is automatically injected at context level for both pageview and custom events

## Technical Details

This refactoring addresses a structural inconsistency in the analytics payload. Previously, device information was enriched per-event and included in each event's data object, leading to:
- Redundant device data sent with every event in a batch
- Inconsistent data structure between context (session-level) and event (action-level) data

The new structure treats device information as session-level context, similar to `session_id` and `user_id`, since device properties don't change between events within a session. This:
- Reduces payload size for multi-event batches
- Improves data model semantics (context = session-level, event data = action-specific)
- Simplifies plugin responsibilities (identity plugin handles all context, enricher handles event-specific data)

**Data Flow:**
1. Identity plugin runs first → injects `context` with `{ site_auth, session_id, user_id, device }`
2. Enricher plugin runs second → adds `page`, `utm`, `custom` to event data
3. Final payload has device once in context, not duplicated per event

<img width="2622" height="1158" alt="image" src="https://github.com/user-attachments/assets/192144f4-a8a0-4e5b-9299-0f80e187932e" />


This PR fixes: #33572