### PR TITLE
fix(npe): this fixes an npe when the user to check is null

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -1624,7 +1624,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         if (!Config.getBooleanProperty("PERMISSION_SECONDARY_CATEGORY_CHECK", true)) {
             return;
         }
-        if (user.isAdmin()) {
+        if (user != null && user.isAdmin()) {
             return;
         }
 


### PR DESCRIPTION
ref: #33389

Fixing this in the logs:

```
java.lang.NullPointerException: Cannot invoke "com.liferay.portal.model.User.isAdmin()" because "user" is null
	at com.dotcms.content.elasticsearch.business.ESContentletAPIImpl.addCategoryPermissionsToQuery(ESContentletAPIImpl.java:1627) ~[?:?]
	at com.dotcms.content.elasticsearch.business.ESContentletAPIImpl.searchIndex(ESContentletAPIImpl.java:1584) ~[?:?]
	at com.dotcms.content.elasticsearch.business.ESContentletAPIImpl.search(ESContentletAPIImpl.java:1393) ~[?:?]
	at com.dotcms.content.elasticsearch.business.ESContentletAPIImpl.search(ESContentletAPIImpl.java:1374) ~[?:?]
	at com.dotmarketing.portlets.contentlet.business.ContentletAPIInterceptor.search(ContentletAPIInterceptor.java:2115) ~[?:?]
	at com.dotmarketing.portlets.personas.business.PersonaAPIImpl.findPersonaByTag(PersonaAPIImpl.java:519) ~[?:?]
	at com.dotmarketing.portlets.personas.business.PersonaAPIImpl.find(PersonaAPIImpl.java:482) ~[?:?]
	at com.dotmarketing.portlets.personas.business.PersonaAPIImpl.findLive(PersonaAPIImpl.java:467) ~[?:?]
	at com.dotcms.visitor.business.VisitorAPIImpl.getPersona(VisitorAPIImpl.java:119) ~[?:?]
	at com.dotcms.visitor.business.VisitorAPIImpl.getVisitor(VisitorAPIImpl.java:97) ~[?:?]
	at com.dotcms.visitor.business.VisitorAPIImpl.getVisitor(VisitorAPIImpl.java:52) ~[?:?]
	at com.dotcms.personalization.web.PersonalizationWebAPIImpl.getContainerPersonalization(PersonalizationWebAPIImpl.java:32) ~[?:?]
```

This PR fixes: #33389