### PR TITLE
fix(content drive): Improve error handling for move operations

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
@@ -1156,6 +1156,147 @@ describe('DotContentDriveShellComponent', () => {
                     workflowActionId: MOVE_TO_FOLDER_WORKFLOW_ACTION_ID
                 });
             });
+
+            it('should not show success message when successCount is 0', () => {
+                const mockDragItems = [MOCK_ITEMS[0]];
+                store.dragItems.mockReturnValue(mockDragItems);
+                workflowService.bulkFire.mockReturnValue(
+                    of({ successCount: 0, skippedCount: 0, fails: [] })
+                );
+
+                const mockMoveEvent: DotContentDriveMoveItems = {
+                    targetFolder: {
+                        id: 'folder-1',
+                        hostname: 'demo.dotcms.com',
+                        path: '/documents/',
+                        type: 'folder'
+                    }
+                };
+
+                const sidebar = spectator.debugElement.query(By.css('[data-testid="sidebar"]'));
+                spectator.triggerEventHandler(sidebar, 'moveItems', mockMoveEvent);
+
+                const successCalls = messageService.add.mock.calls.filter(
+                    (call) => call[0].severity === 'success'
+                );
+
+                expect(successCalls).toHaveLength(0);
+                expect(store.cleanDragItems).toHaveBeenCalled();
+            });
+
+            it('should show individual error messages for each failed item', () => {
+                const mockDragItems = [MOCK_ITEMS[0], MOCK_ITEMS[1]];
+                store.dragItems.mockReturnValue(mockDragItems);
+                workflowService.bulkFire.mockReturnValue(
+                    of({
+                        successCount: 0,
+                        skippedCount: 0,
+                        fails: [
+                            { inode: MOCK_ITEMS[0].inode, errorMessage: 'Error moving item 1' },
+                            { inode: MOCK_ITEMS[1].inode, errorMessage: 'Error moving item 2' }
+                        ]
+                    })
+                );
+
+                const mockMoveEvent: DotContentDriveMoveItems = {
+                    targetFolder: {
+                        id: 'folder-1',
+                        hostname: 'demo.dotcms.com',
+                        path: '/documents/',
+                        type: 'folder'
+                    }
+                };
+
+                const sidebar = spectator.debugElement.query(By.css('[data-testid="sidebar"]'));
+                spectator.triggerEventHandler(sidebar, 'moveItems', mockMoveEvent);
+
+                const errorCalls = messageService.add.mock.calls.filter(
+                    (call) => call[0].severity === 'error'
+                );
+
+                expect(errorCalls).toHaveLength(2);
+                expect(errorCalls[0][0]).toEqual({
+                    severity: 'error',
+                    summary: expect.any(String),
+                    detail: 'Error moving item 1',
+                    life: ERROR_MESSAGE_LIFE
+                });
+                expect(errorCalls[1][0]).toEqual({
+                    severity: 'error',
+                    summary: expect.any(String),
+                    detail: 'Error moving item 2',
+                    life: ERROR_MESSAGE_LIFE
+                });
+            });
+
+            it('should handle partial success with some fails', () => {
+                const mockDragItems = [MOCK_ITEMS[0], MOCK_ITEMS[1]];
+                store.dragItems.mockReturnValue(mockDragItems);
+                workflowService.bulkFire.mockReturnValue(
+                    of({
+                        successCount: 1,
+                        skippedCount: 0,
+                        fails: [{ inode: MOCK_ITEMS[1].inode, errorMessage: 'Error moving item' }]
+                    })
+                );
+
+                const mockMoveEvent: DotContentDriveMoveItems = {
+                    targetFolder: {
+                        id: 'folder-1',
+                        hostname: 'demo.dotcms.com',
+                        path: '/documents/',
+                        type: 'folder'
+                    }
+                };
+
+                const sidebar = spectator.debugElement.query(By.css('[data-testid="sidebar"]'));
+                spectator.triggerEventHandler(sidebar, 'moveItems', mockMoveEvent);
+
+                const successCalls = messageService.add.mock.calls.filter(
+                    (call) => call[0].severity === 'success'
+                );
+                const errorCalls = messageService.add.mock.calls.filter(
+                    (call) => call[0].severity === 'error'
+                );
+
+                expect(successCalls).toHaveLength(1);
+                expect(errorCalls).toHaveLength(1);
+                expect(store.loadItems).toHaveBeenCalled();
+                expect(store.cleanDragItems).toHaveBeenCalled();
+            });
+
+            it('should handle workflow service error', () => {
+                const mockDragItems = [MOCK_ITEMS[0]];
+                store.dragItems.mockReturnValue(mockDragItems);
+                workflowService.bulkFire.mockReturnValue(
+                    throwError(() => new Error('Workflow error'))
+                );
+
+                const mockMoveEvent: DotContentDriveMoveItems = {
+                    targetFolder: {
+                        id: 'folder-1',
+                        hostname: 'demo.dotcms.com',
+                        path: '/documents/',
+                        type: 'folder'
+                    }
+                };
+
+                const sidebar = spectator.debugElement.query(By.css('[data-testid="sidebar"]'));
+                spectator.triggerEventHandler(sidebar, 'moveItems', mockMoveEvent);
+
+                const errorCalls = messageService.add.mock.calls.filter(
+                    (call) => call[0].severity === 'error'
+                );
+
+                expect(errorCalls.length).toBeGreaterThanOrEqual(1);
+                expect(errorCalls[0][0]).toEqual({
+                    severity: 'error',
+                    summary: expect.any(String),
+                    detail: expect.any(String),
+                    life: ERROR_MESSAGE_LIFE
+                });
+                expect(store.cleanDragItems).toHaveBeenCalled();
+            });
         });
     });
 });

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6079,6 +6079,7 @@ content-drive.move-to-folder-success=Assets moved successfully
 content-drive.move-to-folder-success-detail=<b>{0}</b> asset{1}moved to <b>{2}</b>
 content-drive.move-to-folder-error=Move failed
 content-drive.move-to-folder-error-detail=Please try again later
+content-drive.move-to-folder-error-with-title=Can't move <b>{0}</b>
 
 
 edit.content.preview-link=Preview


### PR DESCRIPTION
## Summary
Fixes silent failures when moving assets in Content Drive by improving error handling and user feedback:

- **Only show success messages when assets actually succeed** - Prevents showing success when `successCount` is 0
- **Display individual error messages for each failed item** - Shows specific error with asset title for better debugging
- **Handle partial success scenarios properly** - Shows both success and error messages when some items succeed and others fail
- **Add error handling for workflow service failures** - Uses `catchError` operator to gracefully handle service errors
- **Comprehensive test coverage** - Added 5 new test cases covering all failure scenarios

https://github.com/user-attachments/assets/aee5ab75-7d80-48d3-8f5f-c923cccdb40f

## Related Issues

Fixes #33472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #33472