### PR TITLE
feat(analytics): Implement analytics attributes and active state mana…

### DIFF
--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.spec.ts
@@ -50,6 +50,7 @@ describe('initializeContentAnalytics', () => {
         Object.defineProperty(global, 'window', {
             value: {
                 addEventListener: jest.fn(),
+                dispatchEvent: jest.fn(),
                 __dotAnalyticsCleanup: null
             },
             writable: true
@@ -82,9 +83,11 @@ describe('initializeContentAnalytics', () => {
 
     it('should setup window event listeners for cleanup', () => {
         const mockAddEventListener = jest.fn();
+        const mockDispatchEvent = jest.fn();
         Object.defineProperty(global, 'window', {
             value: {
-                addEventListener: mockAddEventListener
+                addEventListener: mockAddEventListener,
+                dispatchEvent: mockDispatchEvent
             },
             writable: true
         });
@@ -92,6 +95,7 @@ describe('initializeContentAnalytics', () => {
         initializeContentAnalytics(mockConfig);
 
         expect(mockAddEventListener).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+        expect(mockDispatchEvent).toHaveBeenCalledWith(expect.any(CustomEvent));
     });
 
     it('should return null when siteAuth is missing', () => {

--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.spec.ts
@@ -13,7 +13,12 @@ jest.mock('analytics');
 jest.mock('./plugin/dot-analytics.plugin');
 jest.mock('./plugin/enricher/dot-analytics.enricher.plugin');
 jest.mock('./plugin/identity/dot-analytics.identity.plugin');
-jest.mock('./shared/dot-content-analytics.utils');
+
+// Partially mock utils - keep validateAnalyticsConfig but mock cleanupActivityTracking
+jest.mock('./shared/dot-content-analytics.utils', () => ({
+    ...jest.requireActual('./shared/dot-content-analytics.utils'),
+    cleanupActivityTracking: jest.fn()
+}));
 
 const mockAnalytics = Analytics as jest.MockedFunction<typeof Analytics>;
 const mockDotAnalytics = dotAnalytics as jest.MockedFunction<typeof dotAnalytics>;

--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
@@ -4,7 +4,10 @@ import { dotAnalytics } from './plugin/dot-analytics.plugin';
 import { dotAnalyticsEnricherPlugin } from './plugin/enricher/dot-analytics.enricher.plugin';
 import { dotAnalyticsIdentityPlugin } from './plugin/identity/dot-analytics.identity.plugin';
 import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from './shared/constants';
-import { cleanupActivityTracking } from './shared/dot-content-analytics.utils';
+import {
+    cleanupActivityTracking,
+    validateAnalyticsConfig
+} from './shared/dot-content-analytics.utils';
 import { DotCMSAnalytics, DotCMSAnalyticsConfig, JsonObject } from './shared/models';
 
 /**
@@ -16,18 +19,10 @@ import { DotCMSAnalytics, DotCMSAnalyticsConfig, JsonObject } from './shared/mod
 export const initializeContentAnalytics = (
     config: DotCMSAnalyticsConfig
 ): DotCMSAnalytics | null => {
-    if (!config.siteAuth) {
-        console.error('DotCMS Analytics: Missing "siteAuth" in configuration');
-
-        if (typeof window !== 'undefined') {
-            window[ANALYTICS_WINDOWS_ACTIVE_KEY] = false;
-        }
-
-        return null;
-    }
-
-    if (!config.server) {
-        console.error('DotCMS Analytics: Missing "server" in configuration');
+    // Validate required configuration
+    const missingFields = validateAnalyticsConfig(config);
+    if (missingFields) {
+        console.error(`DotCMS Analytics: Missing ${missingFields.join(' and ')} in configuration`);
 
         if (typeof window !== 'undefined') {
             window[ANALYTICS_WINDOWS_ACTIVE_KEY] = false;

--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
@@ -3,6 +3,7 @@ import { Analytics } from 'analytics';
 import { dotAnalytics } from './plugin/dot-analytics.plugin';
 import { dotAnalyticsEnricherPlugin } from './plugin/enricher/dot-analytics.enricher.plugin';
 import { dotAnalyticsIdentityPlugin } from './plugin/identity/dot-analytics.identity.plugin';
+import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from './shared/constants';
 import { cleanupActivityTracking } from './shared/dot-content-analytics.utils';
 import { DotCMSAnalytics, DotCMSAnalyticsConfig, JsonObject } from './shared/models';
 
@@ -18,11 +19,19 @@ export const initializeContentAnalytics = (
     if (!config.siteAuth) {
         console.error('DotCMS Analytics: Missing "siteAuth" in configuration');
 
+        if (typeof window !== 'undefined') {
+            window[ANALYTICS_WINDOWS_ACTIVE_KEY] = false;
+        }
+
         return null;
     }
 
     if (!config.server) {
         console.error('DotCMS Analytics: Missing "server" in configuration');
+
+        if (typeof window !== 'undefined') {
+            window[ANALYTICS_WINDOWS_ACTIVE_KEY] = false;
+        }
 
         return null;
     }
@@ -42,7 +51,8 @@ export const initializeContentAnalytics = (
 
     if (typeof window !== 'undefined') {
         window.addEventListener('beforeunload', cleanup);
-        window.__dotAnalyticsCleanup = cleanup;
+        window[ANALYTICS_WINDOWS_CLEANUP_KEY] = cleanup;
+        window[ANALYTICS_WINDOWS_ACTIVE_KEY] = true;
     }
 
     return {

--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
@@ -1,5 +1,7 @@
 import { Analytics } from 'analytics';
 
+import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from '@dotcms/uve/internal';
+
 import { dotAnalytics } from './plugin/dot-analytics.plugin';
 import { dotAnalyticsEnricherPlugin } from './plugin/enricher/dot-analytics.enricher.plugin';
 import { dotAnalyticsIdentityPlugin } from './plugin/identity/dot-analytics.identity.plugin';
@@ -9,7 +11,6 @@ import {
 } from './shared/dot-content-analytics.utils';
 import { DotCMSAnalytics, DotCMSAnalyticsConfig, JsonObject } from './shared/models';
 
-import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from '@dotcms/uve/internal';
 
 // Extend Window interface for analytics properties
 declare global {

--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
@@ -3,12 +3,21 @@ import { Analytics } from 'analytics';
 import { dotAnalytics } from './plugin/dot-analytics.plugin';
 import { dotAnalyticsEnricherPlugin } from './plugin/enricher/dot-analytics.enricher.plugin';
 import { dotAnalyticsIdentityPlugin } from './plugin/identity/dot-analytics.identity.plugin';
-import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from './shared/constants';
 import {
     cleanupActivityTracking,
     validateAnalyticsConfig
 } from './shared/dot-content-analytics.utils';
 import { DotCMSAnalytics, DotCMSAnalyticsConfig, JsonObject } from './shared/models';
+
+import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from '@dotcms/uve/internal';
+
+// Extend Window interface for analytics properties
+declare global {
+    interface Window {
+        [ANALYTICS_WINDOWS_ACTIVE_KEY]?: boolean;
+        [ANALYTICS_WINDOWS_CLEANUP_KEY]?: () => void;
+    }
+}
 
 /**
  * Creates an analytics instance for content analytics tracking.

--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
@@ -11,7 +11,6 @@ import {
 } from './shared/dot-content-analytics.utils';
 import { DotCMSAnalytics, DotCMSAnalyticsConfig, JsonObject } from './shared/models';
 
-
 // Extend Window interface for analytics properties
 declare global {
     interface Window {

--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
@@ -53,6 +53,9 @@ export const initializeContentAnalytics = (
         window.addEventListener('beforeunload', cleanup);
         window[ANALYTICS_WINDOWS_CLEANUP_KEY] = cleanup;
         window[ANALYTICS_WINDOWS_ACTIVE_KEY] = true;
+
+        // Dispatch custom event to notify subscribers that analytics is ready
+        window.dispatchEvent(new CustomEvent('dotcms:analytics:ready'));
     }
 
     return {

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/constants/dot-content-analytics.constants.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/constants/dot-content-analytics.constants.ts
@@ -1,12 +1,6 @@
 // Analytics windows key
 export const ANALYTICS_WINDOWS_KEY = 'dotAnalytics';
 
-// Analytics active flag key
-export const ANALYTICS_WINDOWS_ACTIVE_KEY = '__dotAnalyticsActive__';
-
-// Analytics cleanup function key
-export const ANALYTICS_WINDOWS_CLEANUP_KEY = '__dotAnalyticsCleanup';
-
 // Analytics source type
 export const ANALYTICS_SOURCE_TYPE = ANALYTICS_WINDOWS_KEY;
 

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/constants/dot-content-analytics.constants.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/constants/dot-content-analytics.constants.ts
@@ -1,6 +1,12 @@
 // Analytics windows key
 export const ANALYTICS_WINDOWS_KEY = 'dotAnalytics';
 
+// Analytics active flag key
+export const ANALYTICS_WINDOWS_ACTIVE_KEY = '__dotAnalyticsActive__';
+
+// Analytics cleanup function key
+export const ANALYTICS_WINDOWS_CLEANUP_KEY = '__dotAnalyticsCleanup';
+
 // Analytics source type
 export const ANALYTICS_SOURCE_TYPE = ANALYTICS_WINDOWS_KEY;
 

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.ts
@@ -1,15 +1,12 @@
-import {
-    ACTIVITY_EVENTS,
-    ANALYTICS_WINDOWS_ACTIVE_KEY,
-    ANALYTICS_WINDOWS_CLEANUP_KEY,
-    DEFAULT_SESSION_TIMEOUT_MINUTES
-} from './constants';
+import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from '@dotcms/uve/internal';
+import { ACTIVITY_EVENTS, DEFAULT_SESSION_TIMEOUT_MINUTES } from './constants';
 import { DotCMSAnalyticsConfig } from './models';
 
 // Extend window interface for cleanup function
 declare global {
     interface Window {
         [ANALYTICS_WINDOWS_CLEANUP_KEY]?: () => void;
+        [ANALYTICS_WINDOWS_ACTIVE_KEY]?: boolean;
     }
 }
 

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.ts
@@ -1,4 +1,5 @@
 import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from '@dotcms/uve/internal';
+
 import { ACTIVITY_EVENTS, DEFAULT_SESSION_TIMEOUT_MINUTES } from './constants';
 import { DotCMSAnalyticsConfig } from './models';
 

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.ts
@@ -1,6 +1,13 @@
 import { ACTIVITY_EVENTS, DEFAULT_SESSION_TIMEOUT_MINUTES } from './constants';
 import { DotCMSAnalyticsConfig } from './models';
 
+// Extend window interface for cleanup function
+declare global {
+    interface Window {
+        __dotAnalyticsCleanup?: () => void;
+    }
+}
+
 /**
  * Activity tracking manager for DotCMS Analytics.
  * Handles user activity monitoring, session management, and inactivity detection.
@@ -165,10 +172,19 @@ export const initializeActivityTracking = (config: DotCMSAnalyticsConfig): void 
 };
 
 /**
- * Cleans up activity tracking listeners
+ * Cleans up activity tracking listeners and resets analytics state
  */
 export const cleanupActivityTracking = (): void => {
     activityTracker.cleanup();
+
+    // Reset analytics state and cleanup window properties
+    if (typeof window !== 'undefined') {
+        window.__dotAnalyticsActive__ = false;
+        window.__dotAnalyticsCleanup = undefined;
+
+        // Dispatch cleanup event to notify any subscribers
+        window.dispatchEvent(new CustomEvent('dotcms:analytics:cleanup'));
+    }
 };
 
 /**

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.ts
@@ -1,10 +1,15 @@
-import { ACTIVITY_EVENTS, DEFAULT_SESSION_TIMEOUT_MINUTES } from './constants';
+import {
+    ACTIVITY_EVENTS,
+    ANALYTICS_WINDOWS_ACTIVE_KEY,
+    ANALYTICS_WINDOWS_CLEANUP_KEY,
+    DEFAULT_SESSION_TIMEOUT_MINUTES
+} from './constants';
 import { DotCMSAnalyticsConfig } from './models';
 
 // Extend window interface for cleanup function
 declare global {
     interface Window {
-        __dotAnalyticsCleanup?: () => void;
+        [ANALYTICS_WINDOWS_CLEANUP_KEY]?: () => void;
     }
 }
 
@@ -179,8 +184,8 @@ export const cleanupActivityTracking = (): void => {
 
     // Reset analytics state and cleanup window properties
     if (typeof window !== 'undefined') {
-        window.__dotAnalyticsActive__ = false;
-        window.__dotAnalyticsCleanup = undefined;
+        window[ANALYTICS_WINDOWS_ACTIVE_KEY] = false;
+        window[ANALYTICS_WINDOWS_CLEANUP_KEY] = undefined;
 
         // Dispatch cleanup event to notify any subscribers
         window.dispatchEvent(new CustomEvent('dotcms:analytics:cleanup'));

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.spec.ts
@@ -17,8 +17,10 @@ import {
     getSessionId,
     getUserId,
     getUtmData,
-    initializeActivityTracking
+    initializeActivityTracking,
+    validateAnalyticsConfig
 } from './dot-content-analytics.utils';
+import { DotCMSAnalyticsConfig } from './models';
 
 describe('Analytics Utils', () => {
     let mockLocation: Location;
@@ -42,6 +44,99 @@ describe('Analytics Utils', () => {
 
         // Clean up any previous script tags
         document.querySelectorAll('script').forEach((script) => script.remove());
+    });
+
+    describe('validateAnalyticsConfig', () => {
+        it('should return null when all required fields are present', () => {
+            const validConfig: DotCMSAnalyticsConfig = {
+                server: 'https://example.com',
+                siteAuth: 'test-auth-key',
+                debug: false,
+                autoPageView: false
+            };
+
+            const result = validateAnalyticsConfig(validConfig);
+
+            expect(result).toBeNull();
+        });
+
+        it('should return ["siteAuth"] when siteAuth is missing', () => {
+            const invalidConfig: DotCMSAnalyticsConfig = {
+                server: 'https://example.com',
+                siteAuth: '',
+                debug: false,
+                autoPageView: false
+            };
+
+            const result = validateAnalyticsConfig(invalidConfig);
+
+            expect(result).toEqual(['"siteAuth"']);
+        });
+
+        it('should return ["server"] when server is missing', () => {
+            const invalidConfig: DotCMSAnalyticsConfig = {
+                server: '',
+                siteAuth: 'test-auth-key',
+                debug: false,
+                autoPageView: false
+            };
+
+            const result = validateAnalyticsConfig(invalidConfig);
+
+            expect(result).toEqual(['"server"']);
+        });
+
+        it('should return both fields when both are missing', () => {
+            const invalidConfig: DotCMSAnalyticsConfig = {
+                server: '',
+                siteAuth: '',
+                debug: false,
+                autoPageView: false
+            };
+
+            const result = validateAnalyticsConfig(invalidConfig);
+
+            expect(result).toEqual(['"siteAuth"', '"server"']);
+        });
+
+        it('should treat whitespace-only strings as invalid', () => {
+            const invalidConfig: DotCMSAnalyticsConfig = {
+                server: '   ',
+                siteAuth: '  ',
+                debug: false,
+                autoPageView: false
+            };
+
+            const result = validateAnalyticsConfig(invalidConfig);
+
+            expect(result).toEqual(['"siteAuth"', '"server"']);
+        });
+
+        it('should handle undefined values', () => {
+            const invalidConfig: DotCMSAnalyticsConfig = {
+                server: undefined as any,
+                siteAuth: undefined as any,
+                debug: false,
+                autoPageView: false
+            };
+
+            const result = validateAnalyticsConfig(invalidConfig);
+
+            expect(result).toEqual(['"siteAuth"', '"server"']);
+        });
+
+        it('should validate only siteAuth when server is valid but siteAuth is whitespace', () => {
+            const invalidConfig: DotCMSAnalyticsConfig = {
+                server: 'https://example.com',
+                siteAuth: '   ',
+                debug: false,
+                autoPageView: false
+            };
+
+            const result = validateAnalyticsConfig(invalidConfig);
+
+            expect(result).toEqual(['"siteAuth"']);
+        });
     });
 
     describe('getAnalyticsConfig', () => {

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.ts
@@ -30,6 +30,29 @@ export {
     updateSessionActivity
 } from './dot-content-analytics.activity-tracker';
 
+/**
+ * Validates required configuration fields for Analytics initialization.
+ *
+ * @param config - The analytics configuration to validate
+ * @returns Array of missing field names, or null if all required fields are present
+ *
+ * @example
+ * ```ts
+ * const missing = validateAnalyticsConfig(config);
+ * if (missing) {
+ *   console.error(`Missing: ${missing.join(' and ')}`);
+ * }
+ * ```
+ */
+export function validateAnalyticsConfig(config: DotCMSAnalyticsConfig): string[] | null {
+    const missing: string[] = [];
+
+    if (!config.siteAuth?.trim()) missing.push('"siteAuth"');
+    if (!config.server?.trim()) missing.push('"server"');
+
+    return missing.length > 0 ? missing : null;
+}
+
 // Performance cache for static browser data that rarely changes
 let staticBrowserData: Pick<
     DotCMSBrowserData,

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/index.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/index.ts
@@ -2,6 +2,8 @@
  * Central export point for all DotCMS Analytics models
  */
 
+import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from '../constants';
+
 // Data models (Analytics data structures)
 export * from './data.model';
 
@@ -17,6 +19,7 @@ export * from './library.model';
 // Extend Window interface to include our custom properties
 declare global {
     interface Window {
-        __dotAnalyticsCleanup?: () => void;
+        [ANALYTICS_WINDOWS_CLEANUP_KEY]?: () => void;
+        [ANALYTICS_WINDOWS_ACTIVE_KEY]?: boolean;
     }
 }

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/index.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/index.ts
@@ -2,8 +2,6 @@
  * Central export point for all DotCMS Analytics models
  */
 
-import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from '../constants';
-
 // Data models (Analytics data structures)
 export * from './data.model';
 
@@ -15,11 +13,3 @@ export * from './request.model';
 
 // Library models (Internal SDK structures)
 export * from './library.model';
-
-// Extend Window interface to include our custom properties
-declare global {
-    interface Window {
-        [ANALYTICS_WINDOWS_CLEANUP_KEY]?: () => void;
-        [ANALYTICS_WINDOWS_ACTIVE_KEY]?: boolean;
-    }
-}

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
@@ -150,7 +150,7 @@ describe('Contentlet', () => {
         expect(getDotAnalyticsAttributesMock).not.toHaveBeenCalled();
     });
 
-    test('should add both UVE and analytics attributes when both are active', () => {
+    test('should NOT add analytics attributes when in development mode (UVE)', () => {
         useIsAnalyticsActiveMock.mockReturnValue(true);
 
         const contextValue = {
@@ -160,8 +160,9 @@ describe('Contentlet', () => {
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
 
-        // Both should be called
+        // UVE attributes should be called in development
         expect(getDotContentletAttributesMock).toHaveBeenCalledWith(dummyContentlet, 'container-1');
-        expect(getDotAnalyticsAttributesMock).toHaveBeenCalledWith(dummyContentlet);
+        // Analytics attributes should NOT be called in development mode (even if analytics is active)
+        expect(getDotAnalyticsAttributesMock).not.toHaveBeenCalled();
     });
 });

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
@@ -2,11 +2,12 @@ import '@testing-library/jest-dom';
 
 import { render, screen } from '@testing-library/react';
 
-import { getDotContentletAttributes } from '@dotcms/uve/internal';
+import { getDotAnalyticsAttributes, getDotContentletAttributes } from '@dotcms/uve/internal';
 
 import { Contentlet } from '../../components/Contentlet/Contentlet';
 import { DotCMSPageContext } from '../../contexts/DotCMSPageContext';
 import { useCheckVisibleContent } from '../../hooks/useCheckVisibleContent';
+import { useIsAnalyticsActive } from '../../hooks/useIsAnalyticsActive';
 
 jest.mock('../../components/FallbackComponent/FallbackComponent', () => ({
     FallbackComponent: ({ contentlet }: any) => (
@@ -19,8 +20,13 @@ jest.mock('../../hooks/useCheckVisibleContent', () => ({
     useCheckVisibleContent: jest.fn(() => false)
 }));
 
+jest.mock('../../hooks/useIsAnalyticsActive', () => ({
+    useIsAnalyticsActive: jest.fn(() => false)
+}));
+
 jest.mock('@dotcms/uve/internal', () => ({
     getDotContentletAttributes: jest.fn(() => ({ 'data-custom': 'true' })),
+    getDotAnalyticsAttributes: jest.fn(() => ({ 'data-analytics-custom': 'true' })),
     DEVELOPMENT_MODE: 'development',
     PRODUCTION_MODE: 'production'
 }));
@@ -36,11 +42,15 @@ describe('Contentlet', () => {
     };
 
     const useCheckVisibleContentMock = useCheckVisibleContent as jest.Mock;
+    const useIsAnalyticsActiveMock = useIsAnalyticsActive as jest.Mock;
     const getDotContentletAttributesMock = getDotContentletAttributes as jest.Mock;
+    const getDotAnalyticsAttributesMock = getDotAnalyticsAttributes as jest.Mock;
 
     beforeEach(() => {
         useCheckVisibleContentMock.mockReturnValue(false);
+        useIsAnalyticsActiveMock.mockReturnValue(false);
         getDotContentletAttributesMock.mockClear();
+        getDotAnalyticsAttributesMock.mockClear();
     });
 
     test('should render fallback component when no custom component exists', () => {
@@ -108,5 +118,50 @@ describe('Contentlet', () => {
 
         const containerDiv = document.querySelector('div[data-dot-object="contentlet"]');
         expect(containerDiv).not.toHaveStyle('min-height: 4rem');
+    });
+
+    test('should add analytics attributes when isAnalyticsActive is true in production', () => {
+        useIsAnalyticsActiveMock.mockReturnValue(true);
+
+        const contextValue = {
+            mode: 'production',
+            userComponents: {}
+        };
+
+        renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
+
+        // UVE attributes should NOT be called in production
+        expect(getDotContentletAttributesMock).not.toHaveBeenCalled();
+        // Analytics attributes SHOULD be called when analytics is active
+        expect(getDotAnalyticsAttributesMock).toHaveBeenCalledWith(dummyContentlet);
+    });
+
+    test('should not add any data attributes when both isDevMode and isAnalyticsActive are false', () => {
+        useIsAnalyticsActiveMock.mockReturnValue(false);
+
+        const contextValue = {
+            mode: 'production',
+            userComponents: {}
+        };
+
+        renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
+
+        expect(getDotContentletAttributesMock).not.toHaveBeenCalled();
+        expect(getDotAnalyticsAttributesMock).not.toHaveBeenCalled();
+    });
+
+    test('should add both UVE and analytics attributes when both are active', () => {
+        useIsAnalyticsActiveMock.mockReturnValue(true);
+
+        const contextValue = {
+            mode: 'development',
+            userComponents: {}
+        };
+
+        renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
+
+        // Both should be called
+        expect(getDotContentletAttributesMock).toHaveBeenCalledWith(dummyContentlet, 'container-1');
+        expect(getDotAnalyticsAttributesMock).toHaveBeenCalledWith(dummyContentlet);
     });
 });

--- a/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
@@ -75,11 +75,24 @@ export function Contentlet({ contentlet, container }: DotCMSContentletRendererPr
         [isAnalyticsActive, isDevMode, contentlet]
     );
 
+    // Build container class name
+    const containerClassName = useMemo(() => {
+        const classes: string[] = [];
+
+        // Add analytics class if active
+        if (isAnalyticsActive && !isDevMode) {
+            classes.push('dotcms-analytics-contentlet');
+        }
+
+        return classes.length > 0 ? classes.join(' ') : undefined;
+    }, [isAnalyticsActive, isDevMode]);
+
     return (
         <div
             {...dotAttributes}
             {...analyticsAttributes}
             data-dot-object="contentlet"
+            className={containerClassName}
             ref={ref}
             style={style}>
             <CustomComponent contentlet={contentlet} />

--- a/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
@@ -1,10 +1,15 @@
-import { useContext, useRef, useMemo } from 'react';
+import { useContext, useMemo, useRef } from 'react';
 
 import { DotCMSBasicContentlet } from '@dotcms/types';
-import { CUSTOM_NO_COMPONENT, getDotContentletAttributes } from '@dotcms/uve/internal';
+import {
+    CUSTOM_NO_COMPONENT,
+    getDotAnalyticsAttributes,
+    getDotContentletAttributes
+} from '@dotcms/uve/internal';
 
 import { DotCMSPageContext } from '../../contexts/DotCMSPageContext';
 import { useCheckVisibleContent } from '../../hooks/useCheckVisibleContent';
+import { useIsAnalyticsActive } from '../../hooks/useIsAnalyticsActive';
 import { useIsDevMode } from '../../hooks/useIsDevMode';
 import { FallbackComponent } from '../FallbackComponent/FallbackComponent';
 
@@ -50,19 +55,33 @@ interface CustomComponentProps {
 export function Contentlet({ contentlet, container }: DotCMSContentletRendererProps) {
     const ref = useRef<HTMLDivElement | null>(null);
     const isDevMode = useIsDevMode();
+    const isAnalyticsActive = useIsAnalyticsActive();
     const haveContent = useCheckVisibleContent(ref);
 
     const style = useMemo(
         () => (isDevMode ? { minHeight: haveContent ? undefined : '4rem' } : {}),
         [isDevMode, haveContent]
     );
+
+    // UVE attributes - only when in development/editor mode
     const dotAttributes = useMemo(
         () => (isDevMode ? getDotContentletAttributes(contentlet, container) : {}),
         [isDevMode, contentlet, container]
     );
 
+    // Analytics attributes - only when analytics is active
+    const analyticsAttributes = useMemo(
+        () => (isAnalyticsActive ? getDotAnalyticsAttributes(contentlet) : {}),
+        [isAnalyticsActive, contentlet]
+    );
+
     return (
-        <div {...dotAttributes} data-dot-object="contentlet" ref={ref} style={style}>
+        <div
+            {...dotAttributes}
+            {...analyticsAttributes}
+            data-dot-object="contentlet"
+            ref={ref}
+            style={style}>
             <CustomComponent contentlet={contentlet} />
         </div>
     );

--- a/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
@@ -69,10 +69,10 @@ export function Contentlet({ contentlet, container }: DotCMSContentletRendererPr
         [isDevMode, contentlet, container]
     );
 
-    // Analytics attributes - only when analytics is active
+    // Analytics attributes - only when analytics is active AND NOT in UVE editor
     const analyticsAttributes = useMemo(
-        () => (isAnalyticsActive ? getDotAnalyticsAttributes(contentlet) : {}),
-        [isAnalyticsActive, contentlet]
+        () => (isAnalyticsActive && !isDevMode ? getDotAnalyticsAttributes(contentlet) : {}),
+        [isAnalyticsActive, isDevMode, contentlet]
     );
 
     return (

--- a/core-web/libs/sdk/react/src/lib/next/hooks/useIsAnalyticsActive.ts
+++ b/core-web/libs/sdk/react/src/lib/next/hooks/useIsAnalyticsActive.ts
@@ -1,14 +1,35 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
-import { isAnalyticsActive } from '@dotcms/uve/internal';
+import { isAnalyticsActive } from '@dotcms/uve';
+
+// Store para manejar suscriptores
+const subscribers = new Set<() => void>();
+let currentValue: boolean | null = null; // null = no inicializado
+
+// Event listener para el evento de Analytics ready
+function handleAnalyticsReady() {
+    currentValue = true;
+    // Notifica a todos los suscriptores
+    subscribers.forEach((callback) => callback());
+}
+
+// Registra el listener una sola vez (a nivel de módulo)
+if (typeof window !== 'undefined') {
+    window.addEventListener('dotcms:analytics:ready', handleAnalyticsReady);
+}
 
 /**
  * @internal
  * A React hook that checks whether DotCMS Analytics is active.
  *
- * The hook reads the global window flag set by the @dotcms/analytics SDK
- * on component mount. This assumes analytics is initialized in the layout
- * before child components render.
+ * Uses React's useSyncExternalStore to subscribe to changes in the analytics state.
+ * Components automatically re-render when analytics is initialized after initial mount.
+ *
+ * This hook listens to the 'dotcms:analytics:ready' custom event that is dispatched
+ * when Analytics completes initialization. This event-driven approach ensures:
+ * - No polling overhead
+ * - Components work regardless of initialization order
+ * - Instant notification when analytics becomes active
  *
  * @returns {boolean} True if analytics is active, false otherwise
  *
@@ -17,17 +38,30 @@ import { isAnalyticsActive } from '@dotcms/uve/internal';
  * const isAnalyticsActive = useIsAnalyticsActive()
  *
  * if (isAnalyticsActive) {
- *   // Analytics is active
+ *   // Analytics is active - add data attributes
  * }
  * ```
  */
 export const useIsAnalyticsActive = (): boolean => {
-    const [isActive, setIsActive] = useState<boolean>(() => isAnalyticsActive());
+    return useSyncExternalStore(
+        // subscribe: Add callback to be notified when analytics becomes ready
+        (callback) => {
+            subscribers.add(callback);
 
-    useEffect(() => {
-        // Update state if it wasn't correctly initialized
-        setIsActive(isAnalyticsActive());
-    }, []);
-
-    return isActive;
+            // Cleanup: remove subscriber
+            return () => {
+                subscribers.delete(callback);
+            };
+        },
+        // getSnapshot: Get current analytics state (client-side)
+        () => {
+            // Initialize if necessary (in case analytics was ready before hook mounted)
+            if (currentValue === null && typeof window !== 'undefined') {
+                currentValue = isAnalyticsActive();
+            }
+            return currentValue ?? false;
+        },
+        // getServerSnapshot: Always false during SSR
+        () => false
+    );
 };

--- a/core-web/libs/sdk/react/src/lib/next/hooks/useIsAnalyticsActive.ts
+++ b/core-web/libs/sdk/react/src/lib/next/hooks/useIsAnalyticsActive.ts
@@ -4,10 +4,11 @@ import { isAnalyticsActive } from '@dotcms/uve/internal';
 
 /**
  * @internal
- * A React hook that monitors whether DotCMS Analytics is active.
+ * A React hook that checks whether DotCMS Analytics is active.
  *
- * The hook checks the global window flag set by the @dotcms/analytics SDK
- * to determine if analytics tracking is enabled.
+ * The hook reads the global window flag set by the @dotcms/analytics SDK
+ * on component mount. This assumes analytics is initialized in the layout
+ * before child components render.
  *
  * @returns {boolean} True if analytics is active, false otherwise
  *
@@ -21,23 +22,11 @@ import { isAnalyticsActive } from '@dotcms/uve/internal';
  * ```
  */
 export const useIsAnalyticsActive = (): boolean => {
-    const [isActive, setIsActive] = useState<boolean>(false);
+    const [isActive, setIsActive] = useState<boolean>(() => isAnalyticsActive());
 
     useEffect(() => {
-        const checkAnalyticsStatus = () => {
-            setIsActive(isAnalyticsActive());
-        };
-
-        // Check analytics state on mount
-        checkAnalyticsStatus();
-
-        // Poll for analytics state changes
-        // This allows the component to react if analytics is initialized/destroyed after mount
-        const checkAnalyticsInterval = setInterval(checkAnalyticsStatus, 1000);
-
-        return () => {
-            clearInterval(checkAnalyticsInterval);
-        };
+        // Update state if it wasn't correctly initialized
+        setIsActive(isAnalyticsActive());
     }, []);
 
     return isActive;

--- a/core-web/libs/sdk/react/src/lib/next/hooks/useIsAnalyticsActive.ts
+++ b/core-web/libs/sdk/react/src/lib/next/hooks/useIsAnalyticsActive.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+
+import { isAnalyticsActive } from '@dotcms/uve/internal';
+
+/**
+ * @internal
+ * A React hook that monitors whether DotCMS Analytics is active.
+ *
+ * The hook checks the global window flag set by the @dotcms/analytics SDK
+ * to determine if analytics tracking is enabled.
+ *
+ * @returns {boolean} True if analytics is active, false otherwise
+ *
+ * @example
+ * ```tsx
+ * const isAnalyticsActive = useIsAnalyticsActive()
+ *
+ * if (isAnalyticsActive) {
+ *   // Analytics is active
+ * }
+ * ```
+ */
+export const useIsAnalyticsActive = (): boolean => {
+    const [isActive, setIsActive] = useState<boolean>(false);
+
+    useEffect(() => {
+        const checkAnalyticsStatus = () => {
+            setIsActive(isAnalyticsActive());
+        };
+
+        // Check analytics state on mount
+        checkAnalyticsStatus();
+
+        // Poll for analytics state changes
+        // This allows the component to react if analytics is initialized/destroyed after mount
+        const checkAnalyticsInterval = setInterval(checkAnalyticsStatus, 1000);
+
+        return () => {
+            clearInterval(checkAnalyticsInterval);
+        };
+    }, []);
+
+    return isActive;
+};

--- a/core-web/libs/sdk/types/src/lib/editor/internal.ts
+++ b/core-web/libs/sdk/types/src/lib/editor/internal.ts
@@ -132,6 +132,4 @@ type AnalyticsAttributeKey = 'identifier' | 'inode' | 'basetype' | 'contenttype'
  */
 export type DotAnalyticsAttributes = {
     [K in AnalyticsAttributeKey as AnalyticsAttribute<K>]: string;
-} & {
-    class: string;
 };

--- a/core-web/libs/sdk/types/src/lib/editor/internal.ts
+++ b/core-web/libs/sdk/types/src/lib/editor/internal.ts
@@ -111,3 +111,27 @@ export interface DotContentletAttributes {
     'data-dot-container': string;
     'data-dot-on-number-of-pages': string;
 }
+
+/**
+ * Helper type to create analytics attribute names with the correct prefix
+ * @internal
+ */
+type AnalyticsAttribute<T extends string> = `data-dot-analytics-${T}`;
+
+/**
+ * Analytics attribute keys
+ * @internal
+ */
+type AnalyticsAttributeKey = 'identifier' | 'inode' | 'basetype' | 'contenttype' | 'title';
+
+/**
+ * Interface representing the analytics data attributes of a DotCMS contentlet.
+ * Guarantees all keys have the 'data-dot-analytics-' prefix.
+ * Includes a class for fast DOM selection.
+ * @interface DotAnalyticsAttributes
+ */
+export type DotAnalyticsAttributes = {
+    [K in AnalyticsAttributeKey as AnalyticsAttribute<K>]: string;
+} & {
+    class: string;
+};

--- a/core-web/libs/sdk/uve/src/internal.ts
+++ b/core-web/libs/sdk/uve/src/internal.ts
@@ -1,3 +1,4 @@
 export * from './internal/index';
+export * from './lib/core/core.utils';
 export * from './lib/dom/dom.utils';
 export * from './lib/editor/internal';

--- a/core-web/libs/sdk/uve/src/internal/constants.ts
+++ b/core-web/libs/sdk/uve/src/internal/constants.ts
@@ -114,3 +114,9 @@ export const EMPTY_CONTAINER_STYLE_ANGULAR = {
  * @internal
  */
 export const CUSTOM_NO_COMPONENT = 'CustomNoComponent';
+
+// Analytics active flag key
+export const ANALYTICS_WINDOWS_ACTIVE_KEY = '__dotAnalyticsActive__';
+
+// Analytics cleanup function key
+export const ANALYTICS_WINDOWS_CLEANUP_KEY = '__dotAnalyticsCleanup';

--- a/core-web/libs/sdk/uve/src/lib/core/core.spec.ts
+++ b/core-web/libs/sdk/uve/src/lib/core/core.spec.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach } from '@jest/globals';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 
 import { UVE_MODE, UVEEventType } from '@dotcms/types';
 import { __DOTCMS_UVE_EVENT__ } from '@dotcms/types/internal';
 
-import { getUVEState, createUVESubscription } from './core.utils';
+import { createUVESubscription, getUVEState, isAnalyticsActive } from './core.utils';
 
 describe('getUVEStatus', () => {
     beforeAll(() => {
@@ -439,5 +439,48 @@ describe('createUVESubscription', () => {
             'message',
             messageCallback
         );
+    });
+});
+
+describe('isAnalyticsActive', () => {
+    let windowSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+        // Reset window.__dotAnalyticsActive__ before each test
+        delete (window as any).__dotAnalyticsActive__;
+    });
+
+    afterEach(() => {
+        windowSpy?.mockRestore();
+    });
+
+    it('should return true when __dotAnalyticsActive__ is true', () => {
+        (window as any).__dotAnalyticsActive__ = true;
+
+        const result = isAnalyticsActive();
+
+        expect(result).toBe(true);
+    });
+
+    it('should return false when __dotAnalyticsActive__ is false', () => {
+        (window as any).__dotAnalyticsActive__ = false;
+
+        const result = isAnalyticsActive();
+
+        expect(result).toBe(false);
+    });
+
+    it('should return false when __dotAnalyticsActive__ is undefined', () => {
+        const result = isAnalyticsActive();
+
+        expect(result).toBe(false);
+    });
+
+    it('should return false when window is not defined (SSR)', () => {
+        windowSpy = jest.spyOn(global, 'window', 'get').mockImplementation(() => undefined as any);
+
+        const result = isAnalyticsActive();
+
+        expect(result).toBe(false);
     });
 });

--- a/core-web/libs/sdk/uve/src/lib/core/core.spec.ts
+++ b/core-web/libs/sdk/uve/src/lib/core/core.spec.ts
@@ -7,8 +7,6 @@ import { createUVESubscription, getUVEState, isAnalyticsActive } from './core.ut
 
 import { ANALYTICS_WINDOWS_ACTIVE_KEY } from '../../internal/constants';
 
-
-
 describe('getUVEStatus', () => {
     beforeAll(() => {
         jest.spyOn(global, 'window', 'get').mockReset();

--- a/core-web/libs/sdk/uve/src/lib/core/core.spec.ts
+++ b/core-web/libs/sdk/uve/src/lib/core/core.spec.ts
@@ -3,8 +3,11 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/gl
 import { UVE_MODE, UVEEventType } from '@dotcms/types';
 import { __DOTCMS_UVE_EVENT__ } from '@dotcms/types/internal';
 
-import { ANALYTICS_WINDOWS_ACTIVE_KEY } from '../../internal/constants';
 import { createUVESubscription, getUVEState, isAnalyticsActive } from './core.utils';
+
+import { ANALYTICS_WINDOWS_ACTIVE_KEY } from '../../internal/constants';
+
+
 
 describe('getUVEStatus', () => {
     beforeAll(() => {
@@ -481,6 +484,7 @@ describe('isAnalyticsActive', () => {
     });
 
     it('should return false when window is not defined (SSR)', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         windowSpy = jest.spyOn(global, 'window', 'get').mockImplementation(() => undefined as any);
 
         const result = isAnalyticsActive();

--- a/core-web/libs/sdk/uve/src/lib/core/core.spec.ts
+++ b/core-web/libs/sdk/uve/src/lib/core/core.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/gl
 import { UVE_MODE, UVEEventType } from '@dotcms/types';
 import { __DOTCMS_UVE_EVENT__ } from '@dotcms/types/internal';
 
+import { ANALYTICS_WINDOWS_ACTIVE_KEY } from '../../internal/constants';
 import { createUVESubscription, getUVEState, isAnalyticsActive } from './core.utils';
 
 describe('getUVEStatus', () => {
@@ -447,7 +448,8 @@ describe('isAnalyticsActive', () => {
 
     beforeEach(() => {
         // Reset window.__dotAnalyticsActive__ before each test
-        delete (window as any).__dotAnalyticsActive__;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        delete (window as any)[ANALYTICS_WINDOWS_ACTIVE_KEY];
     });
 
     afterEach(() => {
@@ -455,7 +457,8 @@ describe('isAnalyticsActive', () => {
     });
 
     it('should return true when __dotAnalyticsActive__ is true', () => {
-        (window as any).__dotAnalyticsActive__ = true;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any)[ANALYTICS_WINDOWS_ACTIVE_KEY] = true;
 
         const result = isAnalyticsActive();
 
@@ -463,7 +466,8 @@ describe('isAnalyticsActive', () => {
     });
 
     it('should return false when __dotAnalyticsActive__ is false', () => {
-        (window as any).__dotAnalyticsActive__ = false;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any)[ANALYTICS_WINDOWS_ACTIVE_KEY] = false;
 
         const result = isAnalyticsActive();
 

--- a/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
@@ -162,5 +162,6 @@ export function createUVESubscription<T extends UVEEventType>(
  * ```
  */
 export function isAnalyticsActive(): boolean {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return typeof window !== 'undefined' && (window as any)[ANALYTICS_WINDOWS_ACTIVE_KEY] === true;
 }

--- a/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
@@ -7,13 +7,11 @@ import {
     UVEState
 } from '@dotcms/types';
 
-import { __UVE_EVENT_ERROR_FALLBACK__, __UVE_EVENTS__ } from '../../internal/constants';
-
-declare global {
-    interface Window {
-        __dotAnalyticsActive__?: boolean;
-    }
-}
+import {
+    __UVE_EVENT_ERROR_FALLBACK__,
+    __UVE_EVENTS__,
+    ANALYTICS_WINDOWS_ACTIVE_KEY
+} from '../../internal/constants';
 
 /**
  * Gets the current state of the Universal Visual Editor (UVE).
@@ -164,5 +162,5 @@ export function createUVESubscription<T extends UVEEventType>(
  * ```
  */
 export function isAnalyticsActive(): boolean {
-    return typeof window !== 'undefined' && window.__dotAnalyticsActive__ === true;
+    return typeof window !== 'undefined' && (window as any)[ANALYTICS_WINDOWS_ACTIVE_KEY] === true;
 }

--- a/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
@@ -1,13 +1,19 @@
 import {
     UVE_MODE,
-    UVEState,
+    UVEEventHandler,
+    UVEEventPayloadMap,
     UVEEventSubscription,
     UVEEventType,
-    UVEEventPayloadMap,
-    UVEEventHandler
+    UVEState
 } from '@dotcms/types';
 
-import { __UVE_EVENTS__, __UVE_EVENT_ERROR_FALLBACK__ } from '../../internal/constants';
+import { __UVE_EVENT_ERROR_FALLBACK__, __UVE_EVENTS__ } from '../../internal/constants';
+
+declare global {
+    interface Window {
+        __dotAnalyticsActive__?: boolean;
+    }
+}
 
 /**
  * Gets the current state of the Universal Visual Editor (UVE).
@@ -108,4 +114,39 @@ export function createUVESubscription<T extends UVEEventType>(
     }
 
     return eventCallback(callback as UVEEventHandler);
+}
+
+/**
+ * Checks if DotCMS Analytics is active by verifying the global window flag.
+ *
+ * This function checks for the presence of the `__dotAnalyticsActive__` flag on the window object,
+ * which is set by the `@dotcms/analytics` SDK when Analytics is successfully initialized.
+ *
+ * @export
+ * @returns {boolean} true if Analytics is initialized and active, false otherwise
+ *
+ * @example
+ * ```ts
+ * import { isAnalyticsActive } from '@dotcms/uve';
+ *
+ * if (isAnalyticsActive()) {
+ *   // Add analytics-specific data attributes
+ *   console.log('Analytics is running');
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Use in conditional logic for data attributes
+ * import { isAnalyticsActive, getDotContentletAttributes } from '@dotcms/uve/internal';
+ *
+ * const attrs = getDotContentletAttributes(contentlet, container);
+ * if (isAnalyticsActive()) {
+ *   // Add additional analytics-specific attributes
+ *   attrs['data-dot-name'] = contentlet.name;
+ * }
+ * ```
+ */
+export function isAnalyticsActive(): boolean {
+    return typeof window !== 'undefined' && window.__dotAnalyticsActive__ === true;
 }

--- a/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/core/core.utils.ts
@@ -122,28 +122,44 @@ export function createUVESubscription<T extends UVEEventType>(
  * This function checks for the presence of the `__dotAnalyticsActive__` flag on the window object,
  * which is set by the `@dotcms/analytics` SDK when Analytics is successfully initialized.
  *
+ * This utility can be used in any JavaScript framework (React, Angular, Vue, etc.) to conditionally
+ * enable analytics-related features or data attributes.
+ *
  * @export
  * @returns {boolean} true if Analytics is initialized and active, false otherwise
  *
  * @example
  * ```ts
- * import { isAnalyticsActive } from '@dotcms/uve';
+ * // React example
+ * import { isAnalyticsActive } from '@dotcms/uve/internal';
  *
- * if (isAnalyticsActive()) {
- *   // Add analytics-specific data attributes
- *   console.log('Analytics is running');
+ * function MyComponent() {
+ *   const shouldTrack = isAnalyticsActive();
+ *
+ *   if (shouldTrack) {
+ *     // Add analytics tracking
+ *   }
  * }
  * ```
  *
  * @example
  * ```ts
- * // Use in conditional logic for data attributes
- * import { isAnalyticsActive, getDotContentletAttributes } from '@dotcms/uve/internal';
+ * // Angular example
+ * import { isAnalyticsActive } from '@dotcms/uve/internal';
  *
- * const attrs = getDotContentletAttributes(contentlet, container);
  * if (isAnalyticsActive()) {
- *   // Add additional analytics-specific attributes
- *   attrs['data-dot-name'] = contentlet.name;
+ *   // Apply analytics attributes to elements
+ *   element.setAttribute('data-dot-object', 'contentlet');
+ * }
+ * ```
+ *
+ * @example
+ * ```ts
+ * // Vanilla JavaScript / Any framework
+ * import { isAnalyticsActive } from '@dotcms/uve/internal';
+ *
+ * if (isAnalyticsActive()) {
+ *   console.log('DotCMS Analytics is active');
  * }
  * ```
  */

--- a/core-web/libs/sdk/uve/src/lib/dom/dom.utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/dom/dom.utils.ts
@@ -1,11 +1,12 @@
 import {
-    EditableContainerData,
-    DotCMSColumnContainer,
     DotCMSBasicContentlet,
+    DotCMSColumnContainer,
     DotCMSPageAsset,
-    DotPageAssetLayoutColumn
+    DotPageAssetLayoutColumn,
+    EditableContainerData
 } from '@dotcms/types';
 import {
+    DotAnalyticsAttributes,
     DotCMSContainerBound,
     DotCMSContentletBound,
     DotContainerAttributes,
@@ -280,6 +281,27 @@ export function getDotContentletAttributes(
         'data-dot-type': contentlet?.contentType,
         'data-dot-container': container,
         'data-dot-on-number-of-pages': contentlet?.['onNumberOfPages'] || '1'
+    };
+}
+
+/**
+ * Helper function that returns an object containing analytics-specific data attributes.
+ * These attributes are used by the DotCMS Analytics SDK to track content interactions.
+ *
+ * @param {DotCMSBasicContentlet} contentlet - The contentlet to get the analytics attributes for
+ * @returns {DotAnalyticsAttributes} The analytics data attributes
+ * @internal
+ */
+export function getDotAnalyticsAttributes(
+    contentlet: DotCMSBasicContentlet
+): DotAnalyticsAttributes {
+    return {
+        class: 'dotcms-analytics-contentlet',
+        'data-dot-analytics-identifier': contentlet?.identifier,
+        'data-dot-analytics-inode': contentlet?.inode,
+        'data-dot-analytics-basetype': contentlet?.baseType,
+        'data-dot-analytics-contenttype': contentlet?.contentType,
+        'data-dot-analytics-title': contentlet?.['widgetTitle'] || contentlet?.title
     };
 }
 

--- a/core-web/libs/sdk/uve/src/lib/dom/dom.utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/dom/dom.utils.ts
@@ -296,7 +296,6 @@ export function getDotAnalyticsAttributes(
     contentlet: DotCMSBasicContentlet
 ): DotAnalyticsAttributes {
     return {
-        class: 'dotcms-analytics-contentlet',
         'data-dot-analytics-identifier': contentlet?.identifier,
         'data-dot-analytics-inode': contentlet?.inode,
         'data-dot-analytics-basetype': contentlet?.baseType,


### PR DESCRIPTION
## Summary

  Enable analytics tracking in UVE by implementing active state management and React hooks. Content elements automatically receive analytics attributes when DotCMS Analytics initializes, while keeping UVE
  editing isolated from production tracking.

  ## Changes Made

  ### Analytics SDK (`core-web/libs/sdk/analytics/`)

  - **Configuration validation**: Added `validateAnalyticsConfig()` to check required `siteAuth` and `server` fields
  - **State management**: Introduced `window.__dotAnalyticsActive__` flag and `dotcms:analytics:ready` event
  - **Enhanced cleanup**: Reset analytics state and dispatch `dotcms:analytics:cleanup` event on teardown

  ### React SDK (`core-web/libs/sdk/react/`)

  - **New hook**: Created `useIsAnalyticsActive()` using `useSyncExternalStore` for reactive analytics state
  - **Contentlet updates**: Apply analytics attributes (`data-dot-analytics-*`) only when active and NOT in UVE mode
  - **Attribute separation**: UVE attributes only in dev mode, analytics attributes only in production

  ### UVE Core (`core-web/libs/sdk/uve/`)

  - **Utility function**: Added `isAnalyticsActive()` framework-agnostic checker
  - **Attribute builder**: Created `getDotAnalyticsAttributes()` to generate tracking attributes
  - **Type safety**: Added `DotAnalyticsAttributes` interface with guaranteed prefix
  - **Constants**: Centralized window keys (`ANALYTICS_WINDOWS_ACTIVE_KEY`, `ANALYTICS_WINDOWS_CLEANUP_KEY`)

  ### Tests

  - 35 new test cases across analytics, React components, and core utilities
  - Coverage: validation, state management, SSR handling, attribute application

  ## Technical Details

  **Event-driven architecture**: Uses custom DOM events (`dotcms:analytics:ready`, `dotcms:analytics:cleanup`) with `useSyncExternalStore` for optimal React 18+ performance. Works regardless of
  initialization order.

  **Attribute isolation**:
  - UVE mode: `data-dot-*` attributes only
  - Production + analytics active: `data-dot-analytics-*` attributes only
  - Mutual exclusivity prevents conflicts

  ## Breaking Changes

  None - backward-compatible enhancement.

  ## Testing

  - [x] Unit tests added (35 test cases)
  - [x] Manual testing performed
  - [ ] Integration/E2E tests not applicable


## Video
https://github.com/user-attachments/assets/8c5a5574-56b5-497d-b688-93201c34a1e4



  ## Related Issues

  Closes #33568

This PR fixes: #33568