### PR TITLE
task(java): include java.net.http module

### DIFF
--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -37,7 +37,7 @@ RUN apt update && \
 RUN bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && jlink \
     --verbose \
     --add-modules \
-        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,jdk.management.agent,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom,jdk.jfr,jdk.management.jfr,jdk.jcmd,jdk.attach \
+        java.base,jdk.crypto.ec,jdk.jdwp.agent,jdk.management,jdk.management.agent,java.sql,java.naming,java.desktop,java.management,java.security.jgss,java.instrument,jdk.unsupported,java.scripting,java.rmi,jdk.compiler,jdk.zipfs,jdk.naming.dns,jdk.localedata,java.xml,jdk.xml.dom,jdk.jfr,jdk.management.jfr,jdk.jcmd,jdk.attach,java.net.http \
     --compress 2 \
     --no-header-files \
     --no-man-pages \


### PR DESCRIPTION
ref: #33628

Was seen when I tried to run a plugin that uses `java.net.http` - Class not found.
Tried to supply my own version of the system lib but osgi rightly rejected any export of `java.net`

Note: The `java-base` 21-08-ms version with this included has already been built.


This PR fixes: #33628