### PR TITLE
fix(core) : fallback to search host by id if not found by name

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/browser/BrowserUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/browser/BrowserUtil.java
@@ -78,7 +78,7 @@ public class BrowserUtil {
             throws DotDataException, DotSecurityException {
 
         final String  currentHostId = WebAPILocator.getHostWebAPI().getCurrentHost().getIdentifier();
-        return  APILocator.getHostAPI().findByName(currentHostId, user, false);
+        return APILocator.getHostAPI().find(currentHostId, user, false);
     }
 
     private static Optional<Folder> resolveWithFolderHostField(


### PR DESCRIPTION
Closes #33473

### Proposed Changes
* Fixed host lookup method in `BrowserUtil.getCurrentHost` method to use `find()` instead of `findByName()`.
* Added UUID fallback mechanism to `HostFactoryImpl.bySiteName` method. Now the method calls the new `findSiteByIdIfUUID()` helper method when the site is not found by name. The helper method tries to find the site by identifier.

### Checklist
- [x] Tests

This PR fixes: #33473