### PR TITLE
32566- Refact session storage management

### DIFF
--- a/core-web/libs/data-access/src/lib/dot-router/dot-router.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-router/dot-router.service.ts
@@ -1,6 +1,6 @@
-import { BehaviorSubject, merge, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, Subject } from 'rxjs';
 
-import { Injectable, effect, inject } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
     ActivatedRoute,
@@ -13,7 +13,7 @@ import {
 
 import { MenuItem } from 'primeng/api';
 
-import { filter, map, tap } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 
 import { LOGOUT_URL } from '@dotcms/dotcms-js';
 import { DotAppsSite, DotNavigateToOptions, PortletNav } from '@dotcms/dotcms-models';
@@ -47,11 +47,6 @@ export class DotRouterService {
                 };
             });
         this.buildBreadcrumbs();
-        effect(() => {
-            const breadcrumbs = this.#globalStore.breadcrumbs();
-            console.log('breadcrumbs', breadcrumbs);
-            sessionStorage.setItem('breadcrumbs', JSON.stringify(breadcrumbs));
-        });
     }
 
     get currentSavedURL(): string {

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
@@ -7,7 +7,7 @@ import {
     withState
 } from '@ngrx/signals';
 
-import { computed } from '@angular/core';
+import { computed, effect } from '@angular/core';
 
 import { MenuItem } from 'primeng/api';
 
@@ -139,13 +139,18 @@ export function withBreadcrumbs() {
                 patchState(store, { breadcrumbs });
             };
 
+            const clearBreadcrumbs = () => {
+                patchState(store, { breadcrumbs: [] });
+            };
+
             return {
                 setBreadcrumbs,
                 appendCrumb,
                 truncateBreadcrumbs,
                 setLastBreadcrumb,
                 addNewBreadcrumb,
-                loadBreadcrumbs
+                loadBreadcrumbs,
+                clearBreadcrumbs
             };
         }),
         withHooks({
@@ -153,6 +158,12 @@ export function withBreadcrumbs() {
                 // Load current site on store initialization
                 // System configuration is automatically loaded by withSystem feature
                 store.loadBreadcrumbs();
+
+                // Persist breadcrumbs to sessionStorage whenever they change
+                effect(() => {
+                    const breadcrumbs = store.breadcrumbs();
+                    sessionStorage.setItem('breadcrumbs', JSON.stringify(breadcrumbs));
+                });
             }
         })
     );

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
@@ -31,6 +31,11 @@ const initialBreadcrumbState: BreadcrumbState = {
     breadcrumbs: []
 };
 
+/**
+ * Session storage key for persisting breadcrumbs
+ */
+const BREADCRUMBS_SESSION_KEY = 'breadcrumbs';
+
 const urlsRegex = {
     content: {
         regex: /\/content\/.+/,
@@ -135,7 +140,9 @@ export function withBreadcrumbs() {
             };
 
             const loadBreadcrumbs = () => {
-                const breadcrumbs = JSON.parse(sessionStorage.getItem('breadcrumbs') || '[]');
+                const breadcrumbs = JSON.parse(
+                    sessionStorage.getItem(BREADCRUMBS_SESSION_KEY) || '[]'
+                );
                 patchState(store, { breadcrumbs });
             };
 
@@ -160,8 +167,6 @@ export function withBreadcrumbs() {
                 store.loadBreadcrumbs();
 
                 // Persist breadcrumbs to sessionStorage whenever they change
-                const BREADCRUMBS_SESSION_KEY = 'breadcrumbs';
-
                 effect(() => {
                     const breadcrumbs = store.breadcrumbs();
                     sessionStorage.setItem(BREADCRUMBS_SESSION_KEY, JSON.stringify(breadcrumbs));

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
@@ -160,9 +160,11 @@ export function withBreadcrumbs() {
                 store.loadBreadcrumbs();
 
                 // Persist breadcrumbs to sessionStorage whenever they change
+                const BREADCRUMBS_SESSION_KEY = 'breadcrumbs';
+
                 effect(() => {
                     const breadcrumbs = store.breadcrumbs();
-                    sessionStorage.setItem('breadcrumbs', JSON.stringify(breadcrumbs));
+                    sessionStorage.setItem(BREADCRUMBS_SESSION_KEY, JSON.stringify(breadcrumbs));
                 });
             }
         })


### PR DESCRIPTION
# Refactor: Move breadcrumb sessionStorage persistence to store feature

##  Summary

This PR refactors the breadcrumb persistence logic by moving `sessionStorage` management from the `DotRouterService` to the breadcrumb store feature. This improves separation of concerns and ensures all breadcrumb state changes are automatically persisted.

##  Changes

### Removed unused imports and effects in `dot-router.service.ts`
- Removed `effect` import from `@angular/core` (no longer needed)
- Removed unused imports: `merge` from `rxjs` and `tap` from `rxjs/operators`

### Added `clearBreadcrumbs` method to breadcrumb feature
- Introduced a new `clearBreadcrumbs()` method in `breadcrumb.feature.ts` for better state management
- Allows explicit clearing of breadcrumb state when needed
- Returns breadcrumbs to an empty array state

### Implemented sessionStorage persistence in breadcrumb feature
- Added automatic `sessionStorage` persistence using an `effect` hook in the store's `onInit` lifecycle
- Ensures data consistency and proper state restoration across page reloads

### Enhanced unit tests for sessionStorage verification
- Created comprehensive test suite (`breadcrumb.feature.spec.ts`)  covering:
  - SessionStorage persistence for all breadcrumb modification methods
  - Verification that `sessionStorage.setItem` is called with correct data structure
  - Tests for initial state, computed properties, and edge cases
- All tests verify that any breadcrumb state change triggers `sessionStorage` persistence



## Files Changed

- `core-web/libs/data-access/src/lib/dot-router/dot-router.service.ts`
- `core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts`
- `core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.spec.ts` 


This refactor improves #32566 


This PR fixes: #32566