### PR TITLE
feat(portlets): add `portlet-url` support to enhance configuration flexibility. ref:#33643

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/menu/MenuHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/menu/MenuHelper.java
@@ -49,13 +49,13 @@ public class MenuHelper implements Serializable {
 
         for (String portletId : portletIds) {
             menuContext.setPortletId( portletId );
-            String linkHREF = getUrl(menuContext);
+            String url = getUrl(menuContext);
             Locale locale = Try.of(()-> new Locale(menuContext.getHttpServletRequest().getSession().getAttribute("com.dotcms.repackage.org.apache.struts.action.LOCALE").toString())).getOrElse(Locale.US);
             String linkName = normalizeLinkName(LanguageUtil.get(locale, PORTLET_KEY_PREFIX + portletId));
             boolean isAngular = isAngular( portletId );
             boolean isAjax = isAjax( portletId );
 
-            menuItems.add ( new MenuItem(portletId, linkHREF, linkName, isAngular, isAjax) );
+            menuItems.add ( new MenuItem(portletId, url, linkName, isAngular, isAjax) );
         }
         return menuItems;
     }
@@ -83,10 +83,11 @@ public class MenuHelper implements Serializable {
 
 
     /**
-     * Validate if the portlet is a PortletController
-     * @param portletId Id of the portlet
-     * @return true if the portlet is a PortletController portlet, false if not
-     * @throws ClassNotFoundException
+     * Determines if the portlet is an Angular-based portlet by checking if it implements PortletController
+     *
+     * @param portletId ID of the portlet to check
+     * @return true if the portlet is an Angular portlet, false if not
+     * @throws ClassNotFoundException if the portlet class cannot be found
      */
     public boolean isAngular(final String portletId) throws ClassNotFoundException {
         final Portlet portlet = APILocator.getPortletAPI().findPortlet(portletId);
@@ -134,6 +135,13 @@ public class MenuHelper implements Serializable {
 
             Logger.debug(MenuResource.class, "### getPortletId" + menuContext.getPortletId());
             Logger.debug(MenuResource.class, "### portletClass" + portletClass);
+
+            if(UtilMethods.isSet(portlet.getPortletUrl())){
+                final String portletUrl = portlet.getPortletUrl();
+                Logger.debug(MenuResource.class, "### portletUrl" + portletUrl);
+                return portletUrl.startsWith(StringPool.FORWARD_SLASH) ? portletUrl : StringPool.FORWARD_SLASH + portletUrl;
+            }
+
             final PortletURLImpl portletURLImpl = new PortletURLImpl(menuContext.getHttpServletRequest(),
                     menuContext.getPortletId(), menuContext.getLayout().getId(), false);
             if ( StrutsPortlet.class.isAssignableFrom(classs)

--- a/dotCMS/src/main/java/com/dotmarketing/business/portal/DotPortlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/portal/DotPortlet.java
@@ -53,6 +53,15 @@ public interface DotPortlet extends XMLSerializable {
     String getPortletClass();
 
     /**
+     * Returns the optional portlet URL.
+     * @return The portlet URL as a String, or null if not set.
+     */
+    @XmlElement(name = "portlet-url", required = false)
+    @JsonProperty("portlet-url")
+    @javax.annotation.Nullable
+    String getPortletUrl();
+
+    /**
      * Returns a list of initialization parameters for the portlet.
      * This method converts the internal Map representation to a List of InitParam objects.
      * @return A List of InitParam objects.
@@ -82,11 +91,16 @@ public interface DotPortlet extends XMLSerializable {
      * @return A new DotPortlet instance.
      */
     static DotPortlet from(Portlet portlet) {
-        return DotPortlet.builder()
+        final DotPortlet.Builder builder = DotPortlet.builder()
                 .portletId(portlet.getPortletId())
                 .portletClass(portlet.getPortletClass())
-                .initParams(portlet.getInitParams())
-                .build();
+                .initParams(portlet.getInitParams());
+
+        if (portlet.getPortletUrl() != null) {
+            builder.portletUrl(portlet.getPortletUrl());
+        }
+
+        return builder.build();
     }
 
     /**
@@ -94,7 +108,7 @@ public interface DotPortlet extends XMLSerializable {
      * @return A new Portlet instance.
      */
     default Portlet toPortlet() {
-        return new Portlet(getPortletId(), getPortletClass(), initParams());
+        return new Portlet(getPortletId(), getPortletClass(), initParams(), getPortletUrl());
     }
 
     /**
@@ -124,9 +138,15 @@ public interface DotPortlet extends XMLSerializable {
          * @return This Builder instance for method chaining.
          */
         public Builder from(Portlet portlet) {
-            return portletId(portlet.getPortletId())
+            final Builder builder = portletId(portlet.getPortletId())
                     .portletClass(portlet.getPortletClass())
                     .initParams(portlet.getInitParams());
+
+            if (portlet.getPortletUrl() != null) {
+                builder.portletUrl(portlet.getPortletUrl());
+            }
+
+            return builder;
         }
     }
 

--- a/dotCMS/src/main/java/com/liferay/portal/model/Portlet.java
+++ b/dotCMS/src/main/java/com/liferay/portal/model/Portlet.java
@@ -29,6 +29,7 @@ public class Portlet extends PortletModel {
   protected String portletId;
   protected String portletClass;
   protected String portletSource;
+  protected String portletUrl;
 
   public static final String MAINTENANCE = "maintenance";
   public static final String DATA_VIEW_MODE_KEY = "dataViewMode";
@@ -42,7 +43,7 @@ public class Portlet extends PortletModel {
     initParams = new HashMap<>();
     portletClass = null;
     portletSource="xml";
-
+    portletUrl = null;
   }
 
   public Portlet(String portletId, String portletClass, Map<String, String> initParams) {
@@ -51,7 +52,7 @@ public class Portlet extends PortletModel {
     this.initParams = initParams;
     this.portletClass = portletClass;
     this.portletSource=initParams.getOrDefault("portletSource", "xml");
-
+    portletUrl = null;
   }
 
   public Portlet(String portletId, String groupId, String portletClass, Map<String, String> initParams) {
@@ -61,6 +62,15 @@ public class Portlet extends PortletModel {
     this.portletClass = portletClass;
     this.portletSource=initParams.getOrDefault("portletSource", "xml");
 
+  }
+
+  public Portlet(String portletId, String portletClass, Map<String, String> initParams, String portletUrl) {
+    super(portletId, "", "dotcms.org", null, false, null, true);
+    this.portletId = portletId;
+    this.initParams = initParams;
+    this.portletClass = portletClass;
+    this.portletSource=initParams.getOrDefault("portletSource", "xml");
+    this.portletUrl = portletUrl;
   }
 
   @Deprecated
@@ -79,6 +89,7 @@ public class Portlet extends PortletModel {
     this.initParams = new HashMap<>();
     this.portletClass = null;
     this.portletSource=initParams.getOrDefault("portletSource", "xml");
+    this.portletUrl = null;
   }
 
   @Deprecated
@@ -93,6 +104,7 @@ public class Portlet extends PortletModel {
     this.initParams = initParams;
     this.portletClass = portletClass;
     this.portletSource=initParams.getOrDefault("portletSource", "xml");
+    this.portletUrl = null;
   }
 
   /**
@@ -166,6 +178,24 @@ public class Portlet extends PortletModel {
    */
   public String getResourceBundle() {
     return "com.liferay.portlet.StrutsResourceBundle" ;
+  }
+
+  /**
+   * Gets the portlet URL.
+   *
+   * @return the portlet URL
+   */
+  public String getPortletUrl() {
+    return this.portletUrl;
+  }
+
+  /**
+   * Sets the portlet URL.
+   *
+   * @param portletUrl the portlet URL
+   */
+  public void setPortletUrl(String portletUrl) {
+    this.portletUrl = portletUrl;
   }
 
   @Override

--- a/dotCMS/src/main/webapp/WEB-INF/portlet.xml
+++ b/dotCMS/src/main/webapp/WEB-INF/portlet.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0"?>
-
 <portlet-app>
-
-
-
-
-
+    <!-- Struts Portlets -->
     <portlet>
         <portlet-name>categories</portlet-name>
         <display-name>Category Manager</display-name>
@@ -14,14 +9,8 @@
             <name>view-action</name>
             <value>/ext/categories/view_categories</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
-
     </portlet>
-
-
 
     <portlet>
         <portlet-name>site-browser</portlet-name>
@@ -45,34 +34,6 @@
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
     </portlet>
 
-
-
-    <!-- BEGIN: PORTLET CONTENT PUBLISHING FRAMEWORK -->
-    <portlet>
-        <portlet-name>publishing-queue</portlet-name>
-        <display-name>Content Publishing Tools</display-name>
-        <portlet-class>com.liferay.portlet.JSPPortlet</portlet-class>
-        <init-param>
-            <name>view-jsp</name>
-            <value>/portlet/ext/contentlet/publishing/view_publish_tool.jsp</value>
-        </init-param>
-        <init-param>
-            <name>useWEBINFDIR</name>
-            <value>false</value>
-        </init-param>
-
-
-        <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
-    </portlet>
-    <!-- END: PORTLET CONTENT PUBLISHING FRAMEWORK -->
-
-    <portlet>
-        <portlet-name>containers</portlet-name>
-        <display-name>Container Manager</display-name>
-        <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
-
-    </portlet>
     <portlet>
         <portlet-name>containers-legacy</portlet-name>
         <display-name>Container Manager (Legacy)</display-name>
@@ -81,23 +42,9 @@
             <name>view-action</name>
             <value>/ext/containers/view_containers</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
     </portlet>
 
-    <portlet>
-        <portlet-name>templates</portlet-name>
-        <display-name>Templates Manager</display-name>
-        <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
-    </portlet>
-
-    <portlet>
-        <portlet-name>pages</portlet-name>
-        <display-name>Pages</display-name>
-        <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
-    </portlet>
     <portlet>
         <portlet-name>html-pages</portlet-name>
         <display-name>HTML Pages Manager</display-name>
@@ -106,14 +53,8 @@
             <name>view-action</name>
             <value>/ext/htmlpages/view_htmlpages</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
-
     </portlet>
-
-
 
     <portlet>
         <portlet-name>links</portlet-name>
@@ -123,11 +64,7 @@
             <name>view-action</name>
             <value>/ext/links/view_links</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
-
     </portlet>
 
     <portlet>
@@ -138,13 +75,8 @@
             <name>view-action</name>
             <value>/ext/workflows/view_workflow_tasks</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
-
     </portlet>
-
 
     <portlet>
         <portlet-name>vanity-urls</portlet-name>
@@ -221,18 +153,6 @@
     </portlet>
 
     <portlet>
-        <portlet-name>roles</portlet-name>
-        <display-name>Roles Admin</display-name>
-        <portlet-class>com.liferay.portlet.JSPPortlet</portlet-class>
-        <init-param>
-            <name>view-jsp</name>
-            <value>/portlet/ext/roleadmin/view_roles.jsp</value>
-        </init-param>
-    </portlet>
-
-
-
-    <portlet>
         <portlet-name>maintenance</portlet-name>
         <display-name>CMS Maintenance</display-name>
         <portlet-class>com.liferay.portlet.StrutsPortlet</portlet-class>
@@ -241,9 +161,7 @@
             <value>/ext/cmsmaintenance/view_cms_maintenance</value>
         </init-param>
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
     </portlet>
-
 
     <portlet>
         <portlet-name>jobs</portlet-name>
@@ -253,10 +171,7 @@
             <name>view-action</name>
             <value>/ext/scheduler/view_schedulers</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
     </portlet>
 
     <portlet>
@@ -267,10 +182,7 @@
             <name>view-action</name>
             <value>/ext/calendar/view_calendar</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
     </portlet>
 
     <portlet>
@@ -281,15 +193,47 @@
             <name>view-action</name>
             <value>/ext/hostadmin/view_hosts</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
-
     </portlet>
 
+    <portlet>
+        <portlet-name>dashboard</portlet-name>
+        <display-name>Dashboard</display-name>
+        <portlet-class>com.liferay.portlet.StrutsPortlet</portlet-class>
+        <init-param>
+            <name>view-action</name>
+            <value>/ext/dashboard/view_dashboard</value>
+        </init-param>
+        <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
+    </portlet>
 
-    <!-- JSP PORTLETS -->
+    <!-- JSP Portlets -->
+
+    <portlet>
+        <portlet-name>publishing-queue</portlet-name>
+        <display-name>Content Publishing Tools</display-name>
+        <portlet-class>com.liferay.portlet.JSPPortlet</portlet-class>
+        <init-param>
+            <name>view-jsp</name>
+            <value>/portlet/ext/contentlet/publishing/view_publish_tool.jsp</value>
+        </init-param>
+        <init-param>
+            <name>useWEBINFDIR</name>
+            <value>false</value>
+        </init-param>
+        <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
+    </portlet>
+
+    <portlet>
+        <portlet-name>roles</portlet-name>
+        <display-name>Roles Admin</display-name>
+        <portlet-class>com.liferay.portlet.JSPPortlet</portlet-class>
+        <init-param>
+            <name>view-jsp</name>
+            <value>/portlet/ext/roleadmin/view_roles.jsp</value>
+        </init-param>
+    </portlet>
+
     <portlet>
         <portlet-name>query-tool</portlet-name>
         <display-name>Lucene Test Tool</display-name>
@@ -302,10 +246,7 @@
             <name>useWEBINFDIR</name>
             <value>true</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
     </portlet>
 
     <portlet>
@@ -316,24 +257,7 @@
             <name>view-jsp</name>
             <value>/portlet/ext/sitesearch/site_search.jsp</value>
         </init-param>
-
     </portlet>
-
-    <portlet>
-        <portlet-name>dashboard</portlet-name>
-        <display-name>Dashboard</display-name>
-        <portlet-class>com.liferay.portlet.StrutsPortlet</portlet-class>
-        <init-param>
-            <name>view-action</name>
-            <value>/ext/dashboard/view_dashboard</value>
-        </init-param>
-
-
-        <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
-
-
-    </portlet>
-
 
     <portlet>
         <portlet-name>workflow-schemes</portlet-name>
@@ -343,9 +267,6 @@
             <name>view-jsp</name>
             <value>/portlet/ext/workflows/schemes/workflow_main.jsp</value>
         </init-param>
-
-
-
     </portlet>
 
     <portlet>
@@ -356,9 +277,6 @@
             <name>view-jsp</name>
             <value>/portlet/ext/osgi/main.jsp</value>
         </init-param>
-
-
-
     </portlet>
 
     <portlet>
@@ -384,8 +302,6 @@
             <name>useWEBINFDIR</name>
             <value>true</value>
         </init-param>
-
-
         <resource-bundle>com.liferay.portlet.StrutsResourceBundle</resource-bundle>
 
     </portlet>
@@ -417,12 +333,64 @@
         </init-param>
     </portlet>
 
-
+    <!-- ESContentResource Portlets -->
 
     <portlet>
         <portlet-name>es-search</portlet-name>
         <display-name>ES Query Tool</display-name>
         <portlet-class>com.dotcms.rest.elasticsearch.ESContentResourcePortlet</portlet-class>
+    </portlet>
+
+    <!-- REST JSP Portlets -->
+
+    <portlet>
+        <portlet-name>embedded-dashboard</portlet-name>
+        <display-name>Embedded Analytics Dashboard</display-name>
+        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
+    </portlet>
+
+    <portlet>
+        <portlet-name>graphql</portlet-name>
+        <display-name>graphql</display-name>
+        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
+    </portlet>
+
+    <portlet>
+        <portlet-name>api_playground</portlet-name>
+        <display-name>API Playground</display-name>
+        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
+    </portlet>
+
+    <portlet>
+        <portlet-name>velocity_playground</portlet-name>
+        <display-name>Velocity Playground</display-name>
+        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
+    </portlet>
+
+    <portlet>
+        <portlet-name>dotai</portlet-name>
+        <display-name>dotAI</display-name>
+        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
+    </portlet>
+
+    <!-- Angular Portlets -->
+
+    <portlet>
+        <portlet-name>containers</portlet-name>
+        <display-name>Container Manager</display-name>
+        <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
+
+    </portlet>
+    <portlet>
+        <portlet-name>templates</portlet-name>
+        <display-name>Templates Manager</display-name>
+        <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
+    </portlet>
+
+    <portlet>
+        <portlet-name>pages</portlet-name>
+        <display-name>Pages</display-name>
+        <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
     </portlet>
     <portlet>
         <portlet-name>rules</portlet-name>
@@ -449,12 +417,6 @@
     </portlet>
 
     <portlet>
-        <portlet-name>embedded-dashboard</portlet-name>
-        <display-name>Embedded Analytics Dashboard</display-name>
-        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
-    </portlet>
-
-    <portlet>
         <portlet-name>forms</portlet-name>
         <display-name>Forms</display-name>
         <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
@@ -464,33 +426,6 @@
         <portlet-name>starter</portlet-name>
         <display-name>Getting Started</display-name>
         <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
-    </portlet>
-
-
-    <portlet>
-        <portlet-name>graphql</portlet-name>
-        <display-name>graphql</display-name>
-        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
-    </portlet>
-
-
-
-    <portlet>
-        <portlet-name>api_playground</portlet-name>
-        <display-name>API Playground</display-name>
-        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
-    </portlet>
-
-    <portlet>
-        <portlet-name>velocity_playground</portlet-name>
-        <display-name>Velocity Playground</display-name>
-        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
-    </portlet>
-
-    <portlet>
-        <portlet-name>dotai</portlet-name>
-        <display-name>dotAI</display-name>
-        <portlet-class>com.dotcms.rest.JSPPortlet</portlet-class>
     </portlet>
 
     <portlet>
@@ -503,16 +438,20 @@
         <portlet-name>analytics-search</portlet-name>
         <display-name>Analytics Search</display-name>
         <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
+        <portlet-url>/analytics/search</portlet-url>
     </portlet>
 
     <portlet>
         <portlet-name>analytics-dashboard</portlet-name>
         <display-name>Analytics Dashboard</display-name>
         <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
+        <portlet-url>/analytics/dashboard</portlet-url>
     </portlet>
+
     <portlet>
         <portlet-name>content-drive</portlet-name>
         <display-name>Content Drive</display-name>
         <portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>
     </portlet>
+
 </portlet-app>

--- a/dotCMS/src/test/java/com/dotmarketing/business/portal/DotPortletTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/business/portal/DotPortletTest.java
@@ -29,6 +29,7 @@ public class DotPortletTest {
         testPortlet = DotPortlet.builder()
                 .portletId("test-portlet")
                 .portletClass("com.example.TestPortlet")
+                .portletUrl("/test-portlet")
                 .initParams(initParams)
                 .build();
 
@@ -64,7 +65,7 @@ public class DotPortletTest {
 
     @Test
     public void testFromPortlet() {
-        Portlet portlet = new Portlet("test-portlet", "com.example.TestPortlet", testPortlet.initParams());
+        Portlet portlet = new Portlet("test-portlet", "com.example.TestPortlet", testPortlet.initParams(),testPortlet.getPortletUrl());
         DotPortlet converted = DotPortlet.from(portlet);
         assertEquals(testPortlet, converted);
     }

--- a/dotCMS/src/test/java/com/dotmarketing/business/portal/PortletUrlTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/business/portal/PortletUrlTest.java
@@ -1,0 +1,298 @@
+package com.dotmarketing.business.portal;
+
+import com.liferay.portal.model.Portlet;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test class for the portlet-url feature.
+ * Tests both backward compatibility (without portlet-url) and new functionality (with portlet-url).
+ */
+public class PortletUrlTest {
+
+    /**
+     * Test XML parsing for portlet WITHOUT portlet-url tag (backward compatibility)
+     */
+    @Test
+    public void testXmlToPortlet_WithoutPortletUrl() throws IOException {
+        String xml = "<portlet>" +
+                "<portlet-name>test-portlet</portlet-name>" +
+                "<portlet-class>com.example.TestPortlet</portlet-class>" +
+                "</portlet>";
+
+        DotPortlet dotPortlet = DotPortlet.builder().fromXml(xml);
+
+        assertNotNull("DotPortlet should not be null", dotPortlet);
+        assertEquals("test-portlet", dotPortlet.getPortletId());
+        assertEquals("com.example.TestPortlet", dotPortlet.getPortletClass());
+        assertNull("portletUrl should be null when not present in XML", dotPortlet.getPortletUrl());
+    }
+
+    /**
+     * Test XML parsing for portlet WITH portlet-url tag
+     */
+    @Test
+    public void testXmlToPortlet_WithPortletUrl() throws IOException {
+        String xml = "<portlet>" +
+                "<portlet-name>content-types-angular</portlet-name>" +
+                "<portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>" +
+                "<portlet-url>contentTypeAngular</portlet-url>" +
+                "</portlet>";
+
+        DotPortlet dotPortlet = DotPortlet.builder().fromXml(xml);
+
+        assertNotNull("DotPortlet should not be null", dotPortlet);
+        assertEquals("content-types-angular", dotPortlet.getPortletId());
+        assertEquals("com.dotcms.spring.portlet.PortletController", dotPortlet.getPortletClass());
+        assertEquals("contentTypeAngular", dotPortlet.getPortletUrl());
+    }
+
+    /**
+     * Test DotPortlet to Portlet conversion WITHOUT portlet-url
+     */
+    @Test
+    public void testToPortlet_WithoutPortletUrl() {
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put("param1", "value1");
+
+        DotPortlet dotPortlet = DotPortlet.builder()
+                .portletId("test-portlet")
+                .portletClass("com.example.TestPortlet")
+                .initParams(initParams)
+                .build();
+
+        Portlet portlet = dotPortlet.toPortlet();
+
+        assertNotNull("Portlet should not be null", portlet);
+        assertEquals("test-portlet", portlet.getPortletId());
+        assertEquals("com.example.TestPortlet", portlet.getPortletClass());
+        assertNull("portletUrl should be null", portlet.getPortletUrl());
+    }
+
+    /**
+     * Test DotPortlet to Portlet conversion WITH portlet-url
+     */
+    @Test
+    public void testToPortlet_WithPortletUrl() {
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put("param1", "value1");
+
+        DotPortlet dotPortlet = DotPortlet.builder()
+                .portletId("content-types-angular")
+                .portletClass("com.dotcms.spring.portlet.PortletController")
+                .portletUrl("contentTypeAngular")
+                .initParams(initParams)
+                .build();
+
+        Portlet portlet = dotPortlet.toPortlet();
+
+        assertNotNull("Portlet should not be null", portlet);
+        assertEquals("content-types-angular", portlet.getPortletId());
+        assertEquals("com.dotcms.spring.portlet.PortletController", portlet.getPortletClass());
+        assertEquals("contentTypeAngular", portlet.getPortletUrl());
+    }
+
+    /**
+     * Test Portlet to DotPortlet conversion WITHOUT portlet-url
+     */
+    @Test
+    public void testFromPortlet_WithoutPortletUrl() {
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put("param1", "value1");
+
+        Portlet portlet = new Portlet("test-portlet", "com.example.TestPortlet", initParams);
+
+        DotPortlet dotPortlet = DotPortlet.from(portlet);
+
+        assertNotNull("DotPortlet should not be null", dotPortlet);
+        assertEquals("test-portlet", dotPortlet.getPortletId());
+        assertEquals("com.example.TestPortlet", dotPortlet.getPortletClass());
+        assertNull("portletUrl should be null", dotPortlet.getPortletUrl());
+    }
+
+    /**
+     * Test Portlet to DotPortlet conversion WITH portlet-url
+     */
+    @Test
+    public void testFromPortlet_WithPortletUrl() {
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put("param1", "value1");
+
+        Portlet portlet = new Portlet("content-types-angular",
+                "com.dotcms.spring.portlet.PortletController",
+                initParams,
+                "contentTypeAngular");
+
+        DotPortlet dotPortlet = DotPortlet.from(portlet);
+
+        assertNotNull("DotPortlet should not be null", dotPortlet);
+        assertEquals("content-types-angular", dotPortlet.getPortletId());
+        assertEquals("com.dotcms.spring.portlet.PortletController", dotPortlet.getPortletClass());
+        assertEquals("contentTypeAngular", dotPortlet.getPortletUrl());
+    }
+
+    /**
+     * Test XML serialization/deserialization round-trip WITHOUT portlet-url
+     */
+    @Test
+    public void testXmlRoundTrip_WithoutPortletUrl() throws IOException {
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put("param1", "value1");
+
+        DotPortlet original = DotPortlet.builder()
+                .portletId("test-portlet")
+                .portletClass("com.example.TestPortlet")
+                .initParams(initParams)
+                .build();
+
+        String xml = original.toXml();
+        DotPortlet deserialized = DotPortlet.builder().fromXml(xml);
+
+        // Note: XML serialization may convert null to empty string, both are acceptable for optional fields
+        assertEquals("portletId should match", original.getPortletId(), deserialized.getPortletId());
+        assertEquals("portletClass should match", original.getPortletClass(), deserialized.getPortletClass());
+        assertEquals("initParams should match", original.initParams(), deserialized.initParams());
+
+        // portletUrl can be null or empty string when not present
+        String portletUrl = deserialized.getPortletUrl();
+        assertTrue("portletUrl should be null or empty",
+                portletUrl == null || portletUrl.isEmpty());
+    }
+
+    /**
+     * Test XML serialization/deserialization round-trip WITH portlet-url
+     */
+    @Test
+    public void testXmlRoundTrip_WithPortletUrl() throws IOException {
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put("param1", "value1");
+
+        DotPortlet original = DotPortlet.builder()
+                .portletId("content-types-angular")
+                .portletClass("com.dotcms.spring.portlet.PortletController")
+                .portletUrl("contentTypeAngular")
+                .initParams(initParams)
+                .build();
+
+        String xml = original.toXml();
+        DotPortlet deserialized = DotPortlet.builder().fromXml(xml);
+
+        assertEquals("Original and deserialized should be equal", original, deserialized);
+        assertEquals("contentTypeAngular", deserialized.getPortletUrl());
+    }
+
+    /**
+     * Test Builder.from() method WITHOUT portlet-url
+     */
+    @Test
+    public void testBuilderFrom_WithoutPortletUrl() {
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put("param1", "value1");
+
+        Portlet portlet = new Portlet("test-portlet", "com.example.TestPortlet", initParams);
+
+        DotPortlet dotPortlet = DotPortlet.builder()
+                .from(portlet)
+                .build();
+
+        assertEquals("test-portlet", dotPortlet.getPortletId());
+        assertEquals("com.example.TestPortlet", dotPortlet.getPortletClass());
+        assertNull("portletUrl should be null", dotPortlet.getPortletUrl());
+    }
+
+    /**
+     * Test Builder.from() method WITH portlet-url
+     */
+    @Test
+    public void testBuilderFrom_WithPortletUrl() {
+        Map<String, String> initParams = new HashMap<>();
+        initParams.put("param1", "value1");
+
+        Portlet portlet = new Portlet("content-types-angular",
+                "com.dotcms.spring.portlet.PortletController",
+                initParams,
+                "contentTypeAngular");
+
+        DotPortlet dotPortlet = DotPortlet.builder()
+                .from(portlet)
+                .build();
+
+        assertEquals("content-types-angular", dotPortlet.getPortletId());
+        assertEquals("com.dotcms.spring.portlet.PortletController", dotPortlet.getPortletClass());
+        assertEquals("contentTypeAngular", dotPortlet.getPortletUrl());
+    }
+
+    /**
+     * Test Portlet constructors initialize portletUrl correctly
+     */
+    @Test
+    public void testPortletConstructors_InitializePortletUrl() {
+        Map<String, String> initParams = new HashMap<>();
+
+        // Constructor without portletUrl
+        Portlet portlet1 = new Portlet("test1", "TestClass1", initParams);
+        assertNull("portletUrl should be null", portlet1.getPortletUrl());
+
+        // Constructor with portletUrl
+        Portlet portlet2 = new Portlet("test2", "TestClass2", initParams, "testUrl");
+        assertEquals("testUrl", portlet2.getPortletUrl());
+
+        // Test setter
+        portlet1.setPortletUrl("newUrl");
+        assertEquals("newUrl", portlet1.getPortletUrl());
+    }
+
+    /**
+     * Test real-world XML from portlet.xml - without portlet-url
+     */
+    @Test
+    public void testRealWorldXml_DotBrowser() throws IOException {
+        String xml = "<portlet>" +
+                "<portlet-name>dot-browser</portlet-name>" +
+                "<display-name>dotCMS Site Browser</display-name>" +
+                "<portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>" +
+                "</portlet>";
+
+        DotPortlet dotPortlet = DotPortlet.builder().fromXml(xml);
+
+        assertNotNull("DotPortlet should not be null", dotPortlet);
+        assertEquals("dot-browser", dotPortlet.getPortletId());
+        assertEquals("com.dotcms.spring.portlet.PortletController", dotPortlet.getPortletClass());
+        assertNull("portletUrl should be null for backward compatibility", dotPortlet.getPortletUrl());
+
+        // Ensure it can be converted to Portlet without errors
+        Portlet portlet = dotPortlet.toPortlet();
+        assertNotNull("Portlet should not be null", portlet);
+        assertNull("Portlet portletUrl should be null", portlet.getPortletUrl());
+    }
+
+    /**
+     * Test real-world XML from portlet.xml - with portlet-url
+     */
+    @Test
+    public void testRealWorldXml_ContentTypesAngular() throws IOException {
+        String xml = "<portlet>" +
+                "<portlet-name>content-types-angular</portlet-name>" +
+                "<display-name>Content Types Angular</display-name>" +
+                "<portlet-class>com.dotcms.spring.portlet.PortletController</portlet-class>" +
+                "<portlet-url>contentTypeAngular</portlet-url>" +
+                "</portlet>";
+
+        DotPortlet dotPortlet = DotPortlet.builder().fromXml(xml);
+
+        assertNotNull("DotPortlet should not be null", dotPortlet);
+        assertEquals("content-types-angular", dotPortlet.getPortletId());
+        assertEquals("com.dotcms.spring.portlet.PortletController", dotPortlet.getPortletClass());
+        assertEquals("contentTypeAngular", dotPortlet.getPortletUrl());
+
+        // Ensure it can be converted to Portlet without errors
+        Portlet portlet = dotPortlet.toPortlet();
+        assertNotNull("Portlet should not be null", portlet);
+        assertEquals("contentTypeAngular", portlet.getPortletUrl());
+    }
+}


### PR DESCRIPTION

### Changes:
- Introduced optional `portlet-url` attribute to the `Portlet` model.
- Updated methods and constructors to handle `portlet-url` for backward compatibility.
- Included comprehensive tests for portlet serialization, deserialization, and round-trip validation with/without the new attribute.
- Refactored `MenuHelper` to support `portlet-url`.
- Organized `portlet.xml` for better readability and added entries for updated portlets.

This PR fixes: #33643