### PR TITLE
feat(content drive): Implement download functionality for selected assets

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/sidebar/withSidebar.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/sidebar/withSidebar.ts
@@ -6,11 +6,11 @@ import {
     withState,
     withHooks
 } from '@ngrx/signals';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 
 import { inject } from '@angular/core';
 
-import { tap } from 'rxjs/operators';
+import { catchError, take, tap } from 'rxjs/operators';
 
 import { DotFolderService } from '@dotcms/data-access';
 import { DotFolder } from '@dotcms/dotcms-models';
@@ -59,19 +59,33 @@ export function withSidebar() {
                 const urlFolderPath = store.path() || '';
                 const fullPath = `${currentSite.hostname}${urlFolderPath}`;
 
-                getFolderHierarchyByPath(fullPath, dotFolderService).subscribe((folders) => {
-                    const { rootNodes, selectedNode } = buildTreeFolderNodes({
-                        folderHierarchyLevels: folders,
-                        targetPath: urlFolderPath || '/',
-                        rootNode: realAllFolder
-                    });
+                getFolderHierarchyByPath(fullPath, dotFolderService)
+                    .pipe(
+                        take(1),
+                        catchError((response) => {
+                            const error = response.error;
+                            if (error?.message) {
+                                console.error('Error loading folders:', error.message);
+                            } else {
+                                console.error('Error loading folders:', response);
+                            }
 
-                    patchState(store, {
-                        sidebarLoading: false,
-                        folders: [realAllFolder, ...rootNodes],
-                        selectedNode: selectedNode
+                            return of([[realAllFolder as DotFolder]]);
+                        })
+                    )
+                    .subscribe((folders) => {
+                        const { rootNodes, selectedNode } = buildTreeFolderNodes({
+                            folderHierarchyLevels: folders,
+                            targetPath: urlFolderPath || '/',
+                            rootNode: realAllFolder
+                        });
+
+                        patchState(store, {
+                            sidebarLoading: false,
+                            folders: [realAllFolder, ...rootNodes],
+                            selectedNode: selectedNode
+                        });
                     });
-                });
             },
 
             /**

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/workflow-actions.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/workflow-actions.ts
@@ -87,7 +87,7 @@ const SAVE_AS_DRAFT_ACTION: ContentDriveWorkflowAction = {
 };
 
 const PUBLISH_ACTION: ContentDriveWorkflowAction = {
-    name: 'Publish',
+    name: 'Default-Action-Publish',
     id: WORKFLOW_ACTION_ID.PUBLISH,
     showWhen: {
         noneArchived: true,
@@ -96,7 +96,7 @@ const PUBLISH_ACTION: ContentDriveWorkflowAction = {
 };
 
 const UNPUBLISH_ACTION: ContentDriveWorkflowAction = {
-    name: 'Unpublish',
+    name: 'Default-Action-Unpublish',
     id: WORKFLOW_ACTION_ID.UNPUBLISH,
     // Unpublish: showOn: ["LISTING", "LOCKED", "PUBLISHED", "UNLOCKED"]
     showWhen: {
@@ -106,7 +106,7 @@ const UNPUBLISH_ACTION: ContentDriveWorkflowAction = {
 };
 
 const ARCHIVE_ACTION: ContentDriveWorkflowAction = {
-    name: 'Archive',
+    name: 'Default-Action-Archive',
     id: WORKFLOW_ACTION_ID.ARCHIVE,
     // Archive: showOn: ["LISTING", "ARCHIVED", "UNPUBLISHED", "UNLOCKED"]
     showWhen: {
@@ -116,7 +116,7 @@ const ARCHIVE_ACTION: ContentDriveWorkflowAction = {
 };
 
 const UNARCHIVE_ACTION: ContentDriveWorkflowAction = {
-    name: 'Unarchive',
+    name: 'Default-Action-Unarchive',
     id: WORKFLOW_ACTION_ID.UNARCHIVE,
     showWhen: {
         allArchived: true
@@ -125,7 +125,7 @@ const UNARCHIVE_ACTION: ContentDriveWorkflowAction = {
 };
 
 const DELETE_ACTION: ContentDriveWorkflowAction = {
-    name: 'Delete',
+    name: 'Default-Action-Delete',
     id: WORKFLOW_ACTION_ID.DELETE,
     showWhen: {
         allArchived: true
@@ -143,7 +143,7 @@ const RENAME_ACTION: ContentDriveWorkflowAction = {
 };
 
 const DOWNLOAD_ACTION: ContentDriveWorkflowAction = {
-    name: 'Download',
+    name: 'download',
     id: WORKFLOW_ACTION_ID.DOWNLOAD,
     showWhen: {
         allAreAssets: true,

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.scss
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.scss
@@ -58,6 +58,10 @@
                         &.is-dragging {
                             cursor: grabbing;
                         }
+
+                        &:focus:not(.p-highlight) {
+                            background-color: $white;
+                        }
                     }
                 }
             }

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6129,6 +6129,8 @@ content-drive.toast.unlock-success-detail=You’ve unlocked this contentlet for 
 content-drive.toast.unlock-error=Couldn't unlock
 content-drive.toast.unlock-error-detail=Something went wrong. The contentlet wasn’t unlocked.
 
+content-drive.toast.download-success=Downloading {0}
+content-drive.toast.download-success-detail=The download has started.
 
 edit.content.preview-link=Preview
 


### PR DESCRIPTION
## Summary
- Implemented download functionality for FILEASSET and DOTASSET types in Content Drive
- Added comprehensive test coverage for download scenarios
- Improved error handling for folder hierarchy loading
- Fixed UI focus state for table rows when not highlighted
- Added localization for download success messages

https://github.com/user-attachments/assets/2659c300-e949-4c1c-8eeb-a32f9901c3e4


## Changes
### Core Functionality
- **Download Action**: Implemented single asset download using `getImageAssetUrl()` utility
  - Handles both FILEASSET (uses `fileAssetVersion` or `fileAsset`) and DOTASSET (uses `assetVersion` or `asset`) types
  - Appends `force_download=true` query parameter to trigger browser download
  - Displays success toast notification after download initiation
  - File: `dot-content-drive-workflow-actions.component.ts:177-198`

### Testing
- Added comprehensive test suite for download action (5 test cases)
  - Download trigger verification
  - Success message display
  - Empty selection handling
  - DOTASSET type handling (with assetVersion fallback)
  - FILEASSET type handling (with fileAssetVersion fallback)
  - File: `dot-content-drive-workflow-actions.component.spec.ts:595-734`

### Error Handling
- Enhanced sidebar folder loading with error handling
  - Added `catchError` operator to handle folder hierarchy errors
  - Falls back to root folder on error
  - Logs error messages to console
  - File: `store/features/sidebar/withSidebar.ts:62-87`

### UI/UX Improvements
- Fixed table row focus state styling to maintain white background when not highlighted
  - File: `dot-folder-list-view.component.scss:61-64`
- Standardized workflow action names to use proper naming convention (e.g., "Default-Action-Publish" instead of "Publish")
  - File: `utils/workflow-actions.ts`

### Localization
- Added download success messages:
  - `content-drive.toast.download-success`: "Downloading {0}"
  - `content-drive.toast.download-success-detail`: "The download has started."
  - File: `Language.properties:6132-6133`

This PR fixes: #33610

This PR fixes: #33610