### PR TITLE
Add Home at the beginning of the breadcrumbs

### DIFF
--- a/core-web/libs/data-access/src/lib/dot-router/dot-router.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-router/dot-router.service.ts
@@ -476,7 +476,7 @@ export class DotRouterService {
                     if (item) {
                         this.#globalStore.setBreadcrumbs([
                             {
-                                label: 'dotCMS',
+                                label: 'Home',
                                 disabled: true
                             },
                             {


### PR DESCRIPTION
## Description

This PR updates the breadcrumb navigation to display "Home" instead of "dotCMS" as the first breadcrumb item label, providing a more intuitive and user-friendly navigation experience.

## Changes

- Updated the root breadcrumb label from `"dotCMS"` to `"Home"` in the `DotRouterService.buildBreadcrumbs()` method
- The breadcrumb structure now begins with "Home" → Parent Menu → Current Item

## Impact

This change affects the breadcrumb trail displayed throughout the application when users navigate between different sections. The "Home" label better represents the root level of navigation and aligns with common UX patterns.


This PR fixes: #33579 

This PR fixes: #33579