### PR TITLE
fix(apps) : Fixed apps cache invalidation in cluster nodes

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsCacheImpl.java
@@ -226,20 +226,21 @@ public class AppsCacheImpl extends AppsCache {
     }
 
     /**
-     * Single flush by key.
-     * @param key
+     * Invalidates a secret value and the keys set from cache across cluster nodes.
+     * This method handles both CREATE, UPDATE, and DELETE operations by invalidating the cache
+     * and letting the cache-aside pattern reload from KeyStore on next access.
+     * This ensures cluster-wide cache consistency for all secret operations.
+     * @param key the secret key to invalidate
      * @throws DotCacheException
      */
     public void flushSecret(final String key) throws DotCacheException {
-
+        // Invalidate the secret value across cluster nodes
         cache.remove(key, SECRETS_CACHE_GROUP);
-        final Set<String> keys = (Set<String>) cache
-                .get(SECRETS_CACHE_KEY, SECRETS_CACHE_KEYS_GROUP);
-        if (UtilMethods.isSet(keys)) {
-            keys.remove(key);
-            putKeys(keys);
-        }
 
+        // Invalidate the keys set across cluster nodes
+        // This ensures all nodes will reload the keys set from KeyStore on next access
+        // which will reflect creates, updates, or deletes
+        cache.remove(SECRETS_CACHE_KEY, SECRETS_CACHE_KEYS_GROUP);
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreKeyStoreImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/SecretsStoreKeyStoreImplTest.java
@@ -173,7 +173,9 @@ public class SecretsStoreKeyStoreImplTest {
     }
 
     /**
-     * tests to make sure that the listKeys method returns newly saved keys in their list
+     * Given scenario: Three secrets are saved to the store with keys of varying lengths (UUID, UUID, and long key).
+     * Expected Result: The listKeys() method should return all three keys in the list, including the long key.
+     * This verifies that the cache-aside pattern correctly loads all keys from KeyStore.
      */
     @Test
     public void Test_Value_List() {
@@ -190,12 +192,13 @@ public class SecretsStoreKeyStoreImplTest {
 
         secretsStore.saveValue(key2, value2.toCharArray());
 
-        final String key3 = RandomStringUtils.randomAlphanumeric(1024);
+        final String key3 = RandomStringUtils.randomAlphanumeric(1024).toLowerCase();
         final String value3 = RandomStringUtils.randomAlphanumeric(1024);
 
         secretsStore.saveValue(key3, value3.toCharArray());
 
         final Collection<String> keys = secretsStore.listKeys();
+
         assertTrue (keys.size() > 2);
         assertTrue (keys.contains(key));
         assertTrue (keys.contains(key2));


### PR DESCRIPTION
Closes #33417

### Proposed Changes
* When saving or updating secrets via `SecretCachedKeyStoreImpl.saveValue()`, only the local node's cache was updated using `putInCache()`, while other cluster nodes retained stale cached values. Now the cache is invalidated cluster-wide using `flushCache()`, and the not required `putInCache()` method was removed.
* Updated `AppsCacheImpl.flushSecret()` method to remove local cache update logic. Now invalidates both SECRETS_CACHE_GROUP (key and value) and SECRETS_CACHE_KEYS_GROUP (key sets) across the cluster.
* Added test methods to check apps cache invalidation.

### Checklist
- [x] Tests

This PR fixes: #33417