### PR TITLE
fix(view-browser): Remove unnecessary long word shortening for asset name

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
@@ -834,7 +834,6 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
                 var assetFullName = name;
 
                 //processing asset description and name to avoid long words that break the column width
-                name = shortenLongWords(name, 30)
                 var title = shortenString(asset.title, 30);
                 var modUserName = shortenString(asset.modUserName, 20);
                 //Show Language Icon for Contents (Pages, Files)


### PR DESCRIPTION
### Proposed Changes
This pull request makes a minor adjustment to the way asset names are displayed in the browser view. The change removes the use of the `shortenLongWords` function on the asset name, which previously truncated long words in the name to prevent them from breaking the column layout.

* Removed the call to `shortenLongWords` on the `name` variable, so asset names will no longer have individual long words truncated in the browser view.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)




This PR fixes: #32802

This PR fixes: #32802