### PR TITLE
add column style_properties into multi_tree table for persistency

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -9299,7 +9299,8 @@ public class ESContentletAPIImpl implements ContentletAPI {
                                     multitree.getRelationType(),
                                     multitree.getTreeOrder(),
                                     multitree.getPersonalization(),
-                                    multitree.getVariantId()));
+                                    multitree.getVariantId(),
+                                    multitree.getStyleProperties()));
                 }
             }
         }

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -342,7 +342,7 @@ public class PageRenderUtil implements Serializable {
         }
 
         return rawContainers;
-        }
+    }
 
     private String getUniqueUUIDForRender(String uniqueId, Container container) {
         if (needParseContainerPrefix(container, uniqueId)) {

--- a/dotCMS/src/main/java/com/dotmarketing/beans/MultiTree.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/MultiTree.java
@@ -45,6 +45,8 @@ public class MultiTree implements Serializable {
 
     private String variantId;
 
+    private String styleProperties;
+
     /**
      * @param htmlPage page's id
      * @param container container's id
@@ -53,6 +55,7 @@ public class MultiTree implements Serializable {
      * @param treeOrder order to be show into the page
      * @param personalization persona's tag
      * @param variantId variant's name
+     * @param styleProperties JSON properties for styling
      */
     /** full constructor */
     public MultiTree(final String htmlPage,
@@ -61,15 +64,27 @@ public class MultiTree implements Serializable {
                      final String instanceId,
                      final int treeOrder,
                      final String personalization,
-                     final String variantId) {
+                     final String variantId,
+                     final String styleProperties) {
 
         this.parent1      = htmlPage;
         this.parent2      = container;
         this.child        = child;
         this.relationType = (instanceId == null) ? LEGACY_INSTANCE_ID : instanceId;
-        this.treeOrder    = (treeOrder < 0) ? 0 : treeOrder;
+        this.treeOrder    = Math.max(treeOrder, 0);
         this.personalization = personalization;
         this.variantId = variantId;
+        this.styleProperties = styleProperties;
+    }
+
+    public MultiTree(final String htmlPage,
+            final String container,
+            final String child,
+            final String instanceId,
+            final int treeOrder,
+            final String personalization,
+            final String variantId) {
+        this(htmlPage, container, child, instanceId, treeOrder, personalization, variantId, null);
     }
 
     /** full constructor */
@@ -80,7 +95,7 @@ public class MultiTree implements Serializable {
                      final int treeOrder) {
 
         this(htmlPage, container, child, instanceId, treeOrder, DOT_PERSONALIZATION_DEFAULT,
-                VariantAPI.DEFAULT_VARIANT.name());
+                VariantAPI.DEFAULT_VARIANT.name(), null);
     }
 
     public MultiTree(final String htmlPage,
@@ -90,7 +105,7 @@ public class MultiTree implements Serializable {
             final int treeOrder,
             final String personalization) {
 
-        this (htmlPage, container, child, instanceId, treeOrder, personalization, VariantAPI.DEFAULT_VARIANT.name());
+        this (htmlPage, container, child, instanceId, treeOrder, personalization, VariantAPI.DEFAULT_VARIANT.name(), null);
     }
 
     /** default constructor */
@@ -104,7 +119,7 @@ public class MultiTree implements Serializable {
     }
 
     private MultiTree(MultiTree tree) {
-        this(tree.parent1, tree.parent2, tree.child, tree.relationType, tree.treeOrder, tree.getPersonalization(), tree.getVariantId());
+        this(tree.parent1, tree.parent2, tree.child, tree.relationType, tree.treeOrder, tree.getPersonalization(), tree.getVariantId(), tree.getStyleProperties());
     }
 
     public static MultiTree buildMultitreeWithVariant(final MultiTree multiTree, final String newVariant) {
@@ -114,10 +129,10 @@ public class MultiTree implements Serializable {
     }
 
     public static MultiTree buildMultitree(final MultiTree multiTree,
-            final String newVariant, final String newPerzonalization) {
+            final String newVariant, final String newPersonalization) {
         final MultiTree newMultiTree = new MultiTree(multiTree);
         newMultiTree.setVariantId(newVariant);
-        newMultiTree.setPersonalization(newPerzonalization);
+        newMultiTree.setPersonalization(newPersonalization);
 
         return newMultiTree;
     }
@@ -128,6 +143,15 @@ public class MultiTree implements Serializable {
 
     public MultiTree setVariantId(final String variantId) {
         this.variantId = variantId;
+        return new MultiTree(this);
+    }
+
+    public String getStyleProperties() {
+        return styleProperties;
+    }
+
+    public MultiTree setStyleProperties(final String styleProperties) {
+        this.styleProperties = styleProperties;
         return new MultiTree(this);
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/beans/transform/MultiTreeTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/transform/MultiTreeTransformer.java
@@ -3,7 +3,6 @@ package com.dotmarketing.beans.transform;
 import com.dotcms.util.ConversionUtils;
 import com.dotcms.util.transform.DBTransformer;
 import com.dotmarketing.beans.MultiTree;
-import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +18,7 @@ public class MultiTreeTransformer implements DBTransformer<MultiTree> {
     private static final String TREE_ORDER = "tree_order";
     private static final String PERSONALIZATION = "personalization";
     private static final String VARIANT = "variant_id";
+    private static final String STYLE_PROPERTIES = "style_properties";
 
     private final ArrayList<MultiTree> list = new ArrayList<>();
 
@@ -51,6 +51,7 @@ public class MultiTreeTransformer implements DBTransformer<MultiTree> {
         if (UtilMethods.isSet(map.get(VARIANT))) {
             multiTree.setVariantId(map.get(VARIANT).toString());
         }
+        multiTree.setStyleProperties((String) map.get(STYLE_PROPERTIES));
         return multiTree;
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPI.java
@@ -329,6 +329,22 @@ public interface MultiTreeAPI {
     MultiTree getMultiTree(String htmlPage, String container, String childContent) throws DotDataException;
 
     /**
+     * Gets a multi-tree by html page, container, child content, container instance,
+     * personalization, variant id, and style properties
+     * @param htmlPage html page
+     * @param container container
+     * @param childContent child content
+     * @param containerInstance container instance
+     * @param personalization personalization
+     * @param variantId variant id
+     * @param styleProperties style properties
+     * @return multi-tree
+     * @throws DotDataException thrown if an error occurs while executing the task
+     */
+    MultiTree getMultiTree(String htmlPage, String container, String childContent,
+            String containerInstance, String personalization, String variantId,
+            String styleProperties) throws DotDataException;
+    /**
      * Gets a list of MultiTrees that have the Identifier as a Parent
      * 
      * @param parent Container or Page

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -99,9 +99,9 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
             "select distinct contentlet.identifier from contentlet,multi_tree where multi_tree.child = contentlet.identifier and multi_tree.parent1 = ? and language_id = ? and variant_id = ?";
 
     private static final String UPDATE_MULTI_TREE_PERSONALIZATION = "update multi_tree set personalization = ? where personalization = ?";
-    private static final String SELECT_SQL = "select * from multi_tree where parent1 = ? and parent2 = ? and child = ? and  relation_type = ? and personalization = ? and variant_id = ?";
+    private static final String SELECT_SQL = "select * from multi_tree where parent1 = ? and parent2 = ? and child = ? and  relation_type = ? and personalization = ? and variant_id = ? and style_properties = ?";
 
-    private static final String INSERT_SQL = "insert into multi_tree (parent1, parent2, child, relation_type, tree_order, personalization, variant_id) values (?,?,?,?,?,?,?)  ";
+    private static final String INSERT_SQL = "insert into multi_tree (parent1, parent2, child, relation_type, tree_order, personalization, variant_id, style_properties) values (?,?,?,?,?,?,?,?)  ";
 
     private static final String SELECT_BY_PAGE = "select * from multi_tree where parent1 = ? order by tree_order";
     private static final String SELECT_BY_PAGE_AND_PERSONALIZATION = "select * from multi_tree where parent1 = ? and personalization = ? and variant_id = ? order by tree_order";
@@ -261,6 +261,34 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
     public MultiTree getMultiTree(final String htmlPage, final String container, final String childContent) throws DotDataException {
 
         return this.getMultiTree(htmlPage, container, childContent, Container.LEGACY_RELATION_TYPE);
+    }
+
+    /**
+     * Gets a multi-tree by html page, container, child content, container instance,
+     * personalization, variant id, and style properties
+     * @param htmlPage html page
+     * @param container container
+     * @param childContent child content
+     * @param containerInstance container instance
+     * @param personalization personalization
+     * @param variantId variant id
+     * @param style_properties style properties
+     * @return multi-tree
+     * @throws DotDataException thrown if an error occurs while executing the task
+     */
+    @Override
+    public MultiTree getMultiTree(final String htmlPage, final String container,
+            final String childContent,
+            final String containerInstance, final String personalization, final String variantId,
+            final String style_properties)
+            throws DotDataException {
+        final DotConnect db =
+                new DotConnect().setSQL(SELECT_SQL).addParam(htmlPage).addParam(container)
+                        .addParam(childContent).addParam(containerInstance)
+                        .addParam(personalization).addParam(variantId).addParam(style_properties);
+        db.loadResult();
+
+        return TransformerLocator.createMultiTreeTransformer(db.loadObjectResults()).findFirst();
     }
 
     @Override
@@ -764,7 +792,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
             insertParams
                     .add(new Params(pageId, tree.getContainerAsID(), tree.getContentlet(),
                             tree.getRelationType(), tree.getTreeOrder(), tree.getPersonalization(),
-                            copiedMultiTreeVariantId));
+                            copiedMultiTreeVariantId, tree.getStyleProperties()));
         }
         db.executeBatch(INSERT_SQL, insertParams);
     }
@@ -866,7 +894,7 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
             for (final MultiTree tree : mTrees) {
                 insertParams
                         .add(new Params(pageId, tree.getContainerAsID(), tree.getContentlet(),
-                                tree.getRelationType(), tree.getTreeOrder(), tree.getPersonalization(), tree.getVariantId()));
+                                tree.getRelationType(), tree.getTreeOrder(), tree.getPersonalization(), tree.getVariantId(), tree.getStyleProperties()));
             }
 
             db.executeBatch(INSERT_SQL, insertParams);
@@ -912,8 +940,11 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
 
         Logger.debug(this, () -> String.format("_dbInsert -> Saving MultiTree: %s", multiTree));
 
-        new DotConnect().setSQL(INSERT_SQL).addParam(multiTree.getHtmlPage()).addParam(multiTree.getContainerAsID()).addParam(multiTree.getContentlet())
-                .addParam(multiTree.getRelationType()).addParam(multiTree.getTreeOrder()).addObject(multiTree.getPersonalization()).addParam(multiTree.getVariantId()).loadResult();
+        new DotConnect().setSQL(INSERT_SQL).addParam(multiTree.getHtmlPage())
+                .addParam(multiTree.getContainerAsID()).addParam(multiTree.getContentlet())
+                .addParam(multiTree.getRelationType()).addParam(multiTree.getTreeOrder())
+                .addObject(multiTree.getPersonalization()).addParam(multiTree.getVariantId())
+                .addParam(multiTree.getStyleProperties()).loadResult();
     }
 
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task251103AddStylePropertiesColumnInMultiTree.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task251103AddStylePropertiesColumnInMultiTree.java
@@ -1,0 +1,48 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.startup.AbstractJDBCStartupTask;
+import com.dotmarketing.util.Logger;
+import java.sql.SQLException;
+
+/**
+ * Adds the {@code style_properties} column to the {@code multi_tree} table. This JSONB/JSON
+ * column stores style configuration properties for content placement within containers on pages,
+ * allowing for flexible styling of individual content instances.
+ *
+ * @author Dario Daza
+ * @since Nov 3rd, 2025
+ */
+public class Task251103AddStylePropertiesColumnInMultiTree extends AbstractJDBCStartupTask {
+
+    @Override
+    public boolean forceRun() {
+        try {
+            final DotDatabaseMetaData databaseMetaData = new DotDatabaseMetaData();
+            return !databaseMetaData.hasColumn("multi_tree", "style_properties");
+        } catch (SQLException e) {
+            Logger.error(this, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public String getPostgresScript() {
+        return "ALTER TABLE multi_tree ADD COLUMN IF NOT EXISTS style_properties JSONB";
+    }
+
+    @Override
+    public String getMySQLScript() {
+        return "ALTER TABLE multi_tree ADD COLUMN style_properties JSON";
+    }
+
+    @Override
+    public String getOracleScript() {
+        return "ALTER TABLE multi_tree ADD style_properties CLOB CHECK (style_properties IS JSON)";
+    }
+
+    @Override
+    public String getMSSQLScript() {
+        return "ALTER TABLE multi_tree ADD style_properties NVARCHAR(MAX)";
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -257,7 +257,7 @@ import com.dotmarketing.startup.runonce.Task250603UpdateIdentifierParentPathChec
 import com.dotmarketing.startup.runonce.Task250604UpdateFolderInodes;
 import com.dotmarketing.startup.runonce.Task250826AddIndexesToUniqueFieldsTable;
 import com.dotmarketing.startup.runonce.Task250828CreateCustomAttributeTable;
-import com.dotmarketing.startup.runonce.Task250910AddAnalyticsDashboardPortletToMenu;
+import com.dotmarketing.startup.runonce.Task251103AddStylePropertiesColumnInMultiTree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -589,6 +589,7 @@ public class TaskLocatorUtil {
         .add(Task250604UpdateFolderInodes.class)
         .add(Task250826AddIndexesToUniqueFieldsTable.class)
         .add(Task250828CreateCustomAttributeTable.class)
+        .add(Task251103AddStylePropertiesColumnInMultiTree.class)
         .build();
 
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());

--- a/dotCMS/src/main/resources/postgres.sql
+++ b/dotCMS/src/main/resources/postgres.sql
@@ -1060,6 +1060,7 @@ create table multi_tree (
    tree_order int4,
    personalization varchar(255) not null default 'dot:default',
    variant_id varchar(255) default 'DEFAULT' not null,
+   style_properties JSONB,
    primary key (child, parent1, parent2, relation_type, personalization, variant_id)
 );
 create table workflow_task (

--- a/dotcms-integration/src/test/java/com/dotcms/datagen/MultiTreeDataGen.java
+++ b/dotcms-integration/src/test/java/com/dotcms/datagen/MultiTreeDataGen.java
@@ -19,6 +19,7 @@ public class MultiTreeDataGen extends AbstractDataGen<MultiTree> {
     private String variantId = VariantAPI.DEFAULT_VARIANT.name();
     private int treeOrder;
     private HTMLPageAsset page;
+    private String styleProperties;
 
     @Override
     public MultiTree next() {
@@ -31,6 +32,7 @@ public class MultiTreeDataGen extends AbstractDataGen<MultiTree> {
         multiTree.setPersonalization(personalization);
         multiTree.setVariantId(variantId);
         multiTree.setTreeOrder(1);
+        multiTree.setStyleProperties(styleProperties);
 
         return multiTree;
     }
@@ -82,6 +84,11 @@ public class MultiTreeDataGen extends AbstractDataGen<MultiTree> {
 
     public MultiTreeDataGen setVariant(final Variant variant) {
         this.variantId = variant.name();
+        return this;
+    }
+
+    public MultiTreeDataGen setStyleProperties(final String styleProperties) {
+        this.styleProperties = styleProperties;
         return this;
     }
 }

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task251103AddStylePropertiesColumnInMultiTreeTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task251103AddStylePropertiesColumnInMultiTreeTest.java
@@ -1,0 +1,204 @@
+package com.dotmarketing.startup.runonce;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test class for {@link Task251103AddStylePropertiesColumnInMultiTree}. Verifies that the
+ * style_properties column is correctly added to the multi_tree table.
+ */
+public class Task251103AddStylePropertiesColumnInMultiTreeTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        // Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Method to test: {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} and
+     * {@link Task251103AddStylePropertiesColumnInMultiTree#forceRun()} When: Run the
+     * {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} Should: Create a new
+     * style_properties field in the multi_tree table with correct data type
+     *
+     * @throws SQLException thrown if an error occurs while executing the SQL statement
+     * @throws DotDataException thrown if an error occurs while executing the task
+     */
+    @Test
+    public void test_createStylePropertiesColumn_success() throws SQLException, DotDataException {
+        // Clean up any previous test runs
+        cleanUp();
+
+        final DotDatabaseMetaData databaseMetaData = new DotDatabaseMetaData();
+
+        // Verify column doesn't exist before running task
+        assertFalse("style_properties column should not exist before task runs",
+                databaseMetaData.hasColumn("multi_tree", "style_properties"));
+
+        // Create task and verify forceRun returns true (needs to run)
+        final Task251103AddStylePropertiesColumnInMultiTree task =
+                new Task251103AddStylePropertiesColumnInMultiTree();
+        assertTrue("forceRun should return true before executing", task.forceRun());
+
+        // Execute the upgrade
+        task.executeUpgrade();
+
+        // Verify column now exists
+        assertTrue("style_properties column should exist after task runs",
+                databaseMetaData.hasColumn("multi_tree", "style_properties"));
+
+        // Verify correct data type
+        verifyColumnDataType();
+
+        // Verify forceRun now returns false (already ran)
+        assertFalse("forceRun should return false after executing", task.forceRun());
+    }
+
+    /**
+     * Method to test: {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} When:
+     * Run the {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} twice Should:
+     * Not throw any exception (idempotency test)
+     *
+     * @throws SQLException thrown if an error occurs while executing the SQL statement
+     * @throws DotDataException thrown if an error occurs while executing the task
+     */
+    @Test
+    public void test_runTwice_shouldBeIdempotent() throws SQLException, DotDataException {
+        cleanUp();
+
+        final DotDatabaseMetaData databaseMetaData = new DotDatabaseMetaData();
+        final Task251103AddStylePropertiesColumnInMultiTree task =
+                new Task251103AddStylePropertiesColumnInMultiTree();
+
+        // Verify initial state
+        assertFalse(databaseMetaData.hasColumn("multi_tree", "style_properties"));
+        assertTrue(task.forceRun());
+
+        // Run twice - should not throw exception
+        task.executeUpgrade();
+        task.executeUpgrade();
+
+        // Verify column exists and forceRun returns false
+        assertTrue("style_properties column should exist after task runs",
+                databaseMetaData.hasColumn("multi_tree", "style_properties"));
+        assertFalse("forceRun should return false after executing", task.forceRun());
+    }
+
+    /**
+     * Method to test: {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} When:
+     * The style_properties column is added Should: Allow NULL values and accept valid JSON data
+     *
+     * @throws SQLException thrown if an error occurs while executing the SQL statement
+     * @throws DotDataException thrown if an error occurs while executing the task
+     */
+    @Test
+    public void test_stylePropertiesColumn_acceptsJsonData() throws SQLException, DotDataException {
+        cleanUp();
+
+        final Task251103AddStylePropertiesColumnInMultiTree task =
+                new Task251103AddStylePropertiesColumnInMultiTree();
+        task.executeUpgrade();
+
+        final DotConnect dotConnect = new DotConnect();
+
+        // Insert test data with NULL style_properties
+        dotConnect.executeStatement(
+                "INSERT INTO multi_tree (parent1, parent2, child, relation_type, personalization, variant_id, tree_order, style_properties) "
+                        +
+                        "VALUES('test-page-1', 'test-container-1', 'test-content-1', 'test-relation', 'dot:default', 'DEFAULT', 1, NULL)");
+
+        // Verify NULL is accepted
+        Object result = dotConnect.setSQL(
+                        "SELECT style_properties FROM multi_tree WHERE parent1 = 'test-page-1'")
+                .loadObjectResults()
+                .get(0)
+                .get("style_properties");
+
+        assertNull("style_properties should accept NULL", result);
+
+        // Update with JSON data (database-specific syntax)
+        final String style_properties = "'{\"backgroundColor\": \"blue\", \"fontSize\": \"16px\"}'";
+
+        if (DbConnectionFactory.isPostgres()) {
+            dotConnect.executeStatement(
+                    "UPDATE multi_tree SET style_properties =" + style_properties
+                            + "::jsonb WHERE parent1 = 'test-page-1'");
+        } else if (DbConnectionFactory.isMySql()) {
+            dotConnect.executeStatement(
+                    "UPDATE multi_tree SET style_properties =" + style_properties
+                            + " WHERE parent1 = 'test-page-1'");
+        }
+
+        // Clean up test data
+        dotConnect.executeStatement("DELETE FROM multi_tree WHERE parent1 = 'test-page-1'");
+    }
+
+    /**
+     * Removes the style_properties column if it exists to ensure clean test state
+     */
+    private void cleanUp() throws SQLException {
+        try {
+            new DotConnect().executeStatement(
+                    "ALTER TABLE multi_tree DROP COLUMN style_properties");
+        } catch (SQLException e) {
+            // Ignore if column doesn't exist
+        }
+    }
+
+    /**
+     * Verifies the style_properties column has the correct data type for each database
+     */
+    private void verifyColumnDataType() throws SQLException {
+        final Connection connection = DbConnectionFactory.getConnection();
+        final ResultSet columnsMetaData = DotDatabaseMetaData
+                .getColumnsMetaData(connection, "multi_tree");
+
+        boolean stylePropertiesFound = false;
+
+        while (columnsMetaData.next()) {
+            final String columnName = columnsMetaData.getString("COLUMN_NAME");
+
+            if ("style_properties".equalsIgnoreCase(columnName)) {
+                stylePropertiesFound = true;
+                final String columnType = columnsMetaData.getString("TYPE_NAME").toLowerCase();
+
+                // Verify correct data type per database
+                if (DbConnectionFactory.isPostgres()) {
+                    assertTrue("PostgreSQL should use jsonb type",
+                            columnType.contains("jsonb"));
+                } else if (DbConnectionFactory.isMySql()) {
+                    assertTrue("MySQL should use json type",
+                            columnType.contains("json"));
+                } else if (DbConnectionFactory.isOracle()) {
+                    assertTrue("Oracle should use clob type",
+                            columnType.contains("clob"));
+                } else if (DbConnectionFactory.isMsSql()) {
+                    assertTrue("MSSQL should use nvarchar type",
+                            columnType.contains("nvarchar"));
+                }
+
+                // Verify column is nullable
+                final int nullable = columnsMetaData.getInt("NULLABLE");
+                assertEquals("style_properties should be nullable",
+                        java.sql.DatabaseMetaData.columnNullable, nullable);
+
+                break;
+            }
+        }
+
+        assertTrue("style_properties column should exist", stylePropertiesFound);
+    }
+}


### PR DESCRIPTION
## Sumary
Implement database persistence for style properties by modifying the database schema and updating the MultiTree data model to support the new styling functionality.

### Proposed Changes
- [x] Add `style_properties` field into `multi_tree` table using the `postgres.sql` for new databases.
- [x] Add `style_properties` field into `multi_tree` table using an Update Task for existing databases.
- [x] Unit tests for the Update Task.