### PR TITLE
[Style-Editor]: Add column style_properties into multi_tree table for persistency - Part 1

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task251103AddStylePropertiesColumnInMultiTree.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task251103AddStylePropertiesColumnInMultiTree.java
@@ -1,0 +1,48 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.startup.AbstractJDBCStartupTask;
+import com.dotmarketing.util.Logger;
+import java.sql.SQLException;
+
+/**
+ * Adds the {@code style_properties} column to the {@code multi_tree} table. This JSONB/JSON
+ * column stores style configuration properties for content placement within containers on pages,
+ * allowing for flexible styling of individual content instances.
+ *
+ * @author Dario Daza
+ * @since Nov 3rd, 2025
+ */
+public class Task251103AddStylePropertiesColumnInMultiTree extends AbstractJDBCStartupTask {
+
+    @Override
+    public boolean forceRun() {
+        try {
+            final DotDatabaseMetaData databaseMetaData = new DotDatabaseMetaData();
+            return !databaseMetaData.hasColumn("multi_tree", "style_properties");
+        } catch (SQLException e) {
+            Logger.error(this, e.getMessage(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public String getPostgresScript() {
+        return "ALTER TABLE multi_tree ADD COLUMN IF NOT EXISTS style_properties JSONB";
+    }
+
+    @Override
+    public String getMySQLScript() {
+        return "ALTER TABLE multi_tree ADD COLUMN style_properties JSON";
+    }
+
+    @Override
+    public String getOracleScript() {
+        return "ALTER TABLE multi_tree ADD style_properties CLOB CHECK (style_properties IS JSON)";
+    }
+
+    @Override
+    public String getMSSQLScript() {
+        return "ALTER TABLE multi_tree ADD style_properties NVARCHAR(MAX)";
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -257,7 +257,7 @@ import com.dotmarketing.startup.runonce.Task250603UpdateIdentifierParentPathChec
 import com.dotmarketing.startup.runonce.Task250604UpdateFolderInodes;
 import com.dotmarketing.startup.runonce.Task250826AddIndexesToUniqueFieldsTable;
 import com.dotmarketing.startup.runonce.Task250828CreateCustomAttributeTable;
-import com.dotmarketing.startup.runonce.Task250910AddAnalyticsDashboardPortletToMenu;
+import com.dotmarketing.startup.runonce.Task251103AddStylePropertiesColumnInMultiTree;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -589,6 +589,7 @@ public class TaskLocatorUtil {
         .add(Task250604UpdateFolderInodes.class)
         .add(Task250826AddIndexesToUniqueFieldsTable.class)
         .add(Task250828CreateCustomAttributeTable.class)
+        .add(Task251103AddStylePropertiesColumnInMultiTree.class)
         .build();
 
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());

--- a/dotCMS/src/main/resources/postgres.sql
+++ b/dotCMS/src/main/resources/postgres.sql
@@ -1060,6 +1060,7 @@ create table multi_tree (
    tree_order int4,
    personalization varchar(255) not null default 'dot:default',
    variant_id varchar(255) default 'DEFAULT' not null,
+   style_properties JSONB,
    primary key (child, parent1, parent2, relation_type, personalization, variant_id)
 );
 create table workflow_task (

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -21,6 +21,7 @@ import com.dotmarketing.portlets.rules.RuleAPITest;
 import com.dotmarketing.startup.runonce.Task230630CreateRunningIdsExperimentFieldIntegrationTest;
 import com.dotmarketing.startup.runonce.Task250604UpdateFolderInodesTest;
 import com.dotmarketing.startup.runonce.Task250826AddIndexesToUniqueFieldsTableTest;
+import com.dotmarketing.startup.runonce.Task251103AddStylePropertiesColumnInMultiTree;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -45,7 +46,8 @@ import org.junit.runners.Suite;
         Task250604UpdateFolderInodesTest.class,
         AnalyticsValidatorUtilTest.class,
         Task250826AddIndexesToUniqueFieldsTableTest.class,
-        SecondaryCategoryPermissionTest.class
+        SecondaryCategoryPermissionTest.class,
+        Task251103AddStylePropertiesColumnInMultiTree.class
 })
 
 public class MainSuite3a {

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -21,7 +21,7 @@ import com.dotmarketing.portlets.rules.RuleAPITest;
 import com.dotmarketing.startup.runonce.Task230630CreateRunningIdsExperimentFieldIntegrationTest;
 import com.dotmarketing.startup.runonce.Task250604UpdateFolderInodesTest;
 import com.dotmarketing.startup.runonce.Task250826AddIndexesToUniqueFieldsTableTest;
-import com.dotmarketing.startup.runonce.Task251103AddStylePropertiesColumnInMultiTree;
+import com.dotmarketing.startup.runonce.Task251103AddStylePropertiesColumnInMultiTreeTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -47,7 +47,7 @@ import org.junit.runners.Suite;
         AnalyticsValidatorUtilTest.class,
         Task250826AddIndexesToUniqueFieldsTableTest.class,
         SecondaryCategoryPermissionTest.class,
-        Task251103AddStylePropertiesColumnInMultiTree.class
+        Task251103AddStylePropertiesColumnInMultiTreeTest.class
 })
 
 public class MainSuite3a {

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task251103AddStylePropertiesColumnInMultiTreeTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task251103AddStylePropertiesColumnInMultiTreeTest.java
@@ -1,0 +1,204 @@
+package com.dotmarketing.startup.runonce;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test class for {@link Task251103AddStylePropertiesColumnInMultiTree}. Verifies that the
+ * style_properties column is correctly added to the multi_tree table.
+ */
+public class Task251103AddStylePropertiesColumnInMultiTreeTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        // Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Method to test: {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} and
+     * {@link Task251103AddStylePropertiesColumnInMultiTree#forceRun()} When: Run the
+     * {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} Should: Create a new
+     * style_properties field in the multi_tree table with correct data type
+     *
+     * @throws SQLException thrown if an error occurs while executing the SQL statement
+     * @throws DotDataException thrown if an error occurs while executing the task
+     */
+    @Test
+    public void test_createStylePropertiesColumn_success() throws SQLException, DotDataException {
+        // Clean up any previous test runs
+        cleanUp();
+
+        final DotDatabaseMetaData databaseMetaData = new DotDatabaseMetaData();
+
+        // Verify column doesn't exist before running task
+        assertFalse("style_properties column should not exist before task runs",
+                databaseMetaData.hasColumn("multi_tree", "style_properties"));
+
+        // Create task and verify forceRun returns true (needs to run)
+        final Task251103AddStylePropertiesColumnInMultiTree task =
+                new Task251103AddStylePropertiesColumnInMultiTree();
+        assertTrue("forceRun should return true before executing", task.forceRun());
+
+        // Execute the upgrade
+        task.executeUpgrade();
+
+        // Verify column now exists
+        assertTrue("style_properties column should exist after task runs",
+                databaseMetaData.hasColumn("multi_tree", "style_properties"));
+
+        // Verify correct data type
+        verifyColumnDataType();
+
+        // Verify forceRun now returns false (already ran)
+        assertFalse("forceRun should return false after executing", task.forceRun());
+    }
+
+    /**
+     * Method to test: {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} When:
+     * Run the {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} twice Should:
+     * Not throw any exception (idempotency test)
+     *
+     * @throws SQLException thrown if an error occurs while executing the SQL statement
+     * @throws DotDataException thrown if an error occurs while executing the task
+     */
+    @Test
+    public void test_runTwice_shouldBeIdempotent() throws SQLException, DotDataException {
+        cleanUp();
+
+        final DotDatabaseMetaData databaseMetaData = new DotDatabaseMetaData();
+        final Task251103AddStylePropertiesColumnInMultiTree task =
+                new Task251103AddStylePropertiesColumnInMultiTree();
+
+        // Verify initial state
+        assertFalse(databaseMetaData.hasColumn("multi_tree", "style_properties"));
+        assertTrue(task.forceRun());
+
+        // Run twice - should not throw exception
+        task.executeUpgrade();
+        task.executeUpgrade();
+
+        // Verify column exists and forceRun returns false
+        assertTrue("style_properties column should exist after task runs",
+                databaseMetaData.hasColumn("multi_tree", "style_properties"));
+        assertFalse("forceRun should return false after executing", task.forceRun());
+    }
+
+    /**
+     * Method to test: {@link Task251103AddStylePropertiesColumnInMultiTree#executeUpgrade()} When:
+     * The style_properties column is added Should: Allow NULL values and accept valid JSON data
+     *
+     * @throws SQLException thrown if an error occurs while executing the SQL statement
+     * @throws DotDataException thrown if an error occurs while executing the task
+     */
+    @Test
+    public void test_stylePropertiesColumn_acceptsJsonData() throws SQLException, DotDataException {
+        cleanUp();
+
+        final Task251103AddStylePropertiesColumnInMultiTree task =
+                new Task251103AddStylePropertiesColumnInMultiTree();
+        task.executeUpgrade();
+
+        final DotConnect dotConnect = new DotConnect();
+
+        // Insert test data with NULL style_properties
+        dotConnect.executeStatement(
+                "INSERT INTO multi_tree (parent1, parent2, child, relation_type, personalization, variant_id, tree_order, style_properties) "
+                        +
+                        "VALUES('test-page-1', 'test-container-1', 'test-content-1', 'test-relation', 'dot:default', 'DEFAULT', 1, NULL)");
+
+        // Verify NULL is accepted
+        Object result = dotConnect.setSQL(
+                        "SELECT style_properties FROM multi_tree WHERE parent1 = 'test-page-1'")
+                .loadObjectResults()
+                .get(0)
+                .get("style_properties");
+
+        assertNull("style_properties should accept NULL", result);
+
+        // Update with JSON data (database-specific syntax)
+        final String style_properties = "'{\"backgroundColor\": \"blue\", \"fontSize\": \"16px\"}'";
+
+        if (DbConnectionFactory.isPostgres()) {
+            dotConnect.executeStatement(
+                    "UPDATE multi_tree SET style_properties =" + style_properties
+                            + "::jsonb WHERE parent1 = 'test-page-1'");
+        } else if (DbConnectionFactory.isMySql()) {
+            dotConnect.executeStatement(
+                    "UPDATE multi_tree SET style_properties =" + style_properties
+                            + " WHERE parent1 = 'test-page-1'");
+        }
+
+        // Clean up test data
+        dotConnect.executeStatement("DELETE FROM multi_tree WHERE parent1 = 'test-page-1'");
+    }
+
+    /**
+     * Removes the style_properties column if it exists to ensure clean test state
+     */
+    private void cleanUp() throws SQLException {
+        try {
+            new DotConnect().executeStatement(
+                    "ALTER TABLE multi_tree DROP COLUMN style_properties");
+        } catch (SQLException e) {
+            // Ignore if column doesn't exist
+        }
+    }
+
+    /**
+     * Verifies the style_properties column has the correct data type for each database
+     */
+    private void verifyColumnDataType() throws SQLException {
+        final Connection connection = DbConnectionFactory.getConnection();
+        final ResultSet columnsMetaData = DotDatabaseMetaData
+                .getColumnsMetaData(connection, "multi_tree");
+
+        boolean stylePropertiesFound = false;
+
+        while (columnsMetaData.next()) {
+            final String columnName = columnsMetaData.getString("COLUMN_NAME");
+
+            if ("style_properties".equalsIgnoreCase(columnName)) {
+                stylePropertiesFound = true;
+                final String columnType = columnsMetaData.getString("TYPE_NAME").toLowerCase();
+
+                // Verify correct data type per database
+                if (DbConnectionFactory.isPostgres()) {
+                    assertTrue("PostgreSQL should use jsonb type",
+                            columnType.contains("jsonb"));
+                } else if (DbConnectionFactory.isMySql()) {
+                    assertTrue("MySQL should use json type",
+                            columnType.contains("json"));
+                } else if (DbConnectionFactory.isOracle()) {
+                    assertTrue("Oracle should use clob type",
+                            columnType.contains("clob"));
+                } else if (DbConnectionFactory.isMsSql()) {
+                    assertTrue("MSSQL should use nvarchar type",
+                            columnType.contains("nvarchar"));
+                }
+
+                // Verify column is nullable
+                final int nullable = columnsMetaData.getInt("NULLABLE");
+                assertEquals("style_properties should be nullable",
+                        java.sql.DatabaseMetaData.columnNullable, nullable);
+
+                break;
+            }
+        }
+
+        assertTrue("style_properties column should exist", stylePropertiesFound);
+    }
+}


### PR DESCRIPTION
## Sumary
### Part 1 of 2
Implement database persistence for style properties by modifying the database schema and updating the MultiTree data model to support the new styling functionality.

### Proposed Changes
- [x] Add `style_properties` field into `multi_tree` table using the `postgres.sql` for new databases.
- [x] Add `style_properties` field into `multi_tree` table using an Update Task for existing databases.
- [x] Integration tests for the Update Task.
- [x] Add new integration test into the Suite a3
