### PR TITLE
fix(content drive): Redirects to content search after closing edit dialog

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.spec.ts
@@ -201,6 +201,37 @@ describe('DotContentletWrapperComponent', () => {
                 expect(dotRouterService.goToEditPage).not.toHaveBeenCalled();
             });
 
+            it('should close the dialog and navigate to content-drive when CD query params exist', () => {
+                const contentDriveParams = {
+                    folderId: '123',
+                    path: '/images'
+                };
+
+                Object.defineProperty(dotRouterService, 'currentPortlet', {
+                    value: {
+                        url: '/test?CD_folderId=123&CD_path=/images',
+                        id: '123'
+                    },
+                    writable: true
+                });
+
+                jest.spyOn(dotRouterService, 'gotoPortlet');
+
+                dotIframeDialog.triggerEventHandler('custom', {
+                    detail: {
+                        name: 'close'
+                    }
+                });
+
+                expect(dotAddContentletService.clear).toHaveBeenCalledTimes(1);
+                expect(component.header).toBe('');
+                expect(component.custom.emit).toHaveBeenCalledTimes(1);
+                expect(component.shutdown.emit).toHaveBeenCalledTimes(1);
+                expect(dotRouterService.gotoPortlet).toHaveBeenCalledWith('content-drive', {
+                    queryParams: contentDriveParams
+                });
+            });
+
             it('should called goToEdit', () => {
                 dotIframeDialog.triggerEventHandler('custom', {
                     detail: {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-contentlet-editor/components/dot-contentlet-wrapper/dot-contentlet-wrapper.component.ts
@@ -8,6 +8,7 @@ import {
     DotRouterService,
     DotIframeService
 } from '@dotcms/data-access';
+import { mapParamsFromEditContentlet } from '@dotcms/utils';
 
 import { DotContentletEditorService } from '../../services/dot-contentlet-editor.service';
 
@@ -150,6 +151,19 @@ export class DotContentletWrapperComponent {
         this.isContentletModified = false;
         this.header = '';
         this.shutdown.emit();
+
+        const searchParams = new URL(
+            this.dotRouterService.currentPortlet.url,
+            window.location.origin
+        ).searchParams;
+
+        const contentDriveParams = mapParamsFromEditContentlet(searchParams);
+
+        if (Object.keys(contentDriveParams).length) {
+            this.dotRouterService.gotoPortlet('content-drive', {
+                queryParams: contentDriveParams
+            });
+        }
     }
 
     /**

--- a/core-web/libs/data-access/src/lib/dot-router/dot-router.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-router/dot-router.service.spec.ts
@@ -40,9 +40,11 @@ class RouterMock {
         return this._events.asObservable();
     }
 
-    getCurrentNavigation() {
+    getCurrentNavigation(): { finalUrl: { queryParams: { [key: string]: string } } } | null {
         return {
-            finalUrl: {}
+            finalUrl: {
+                queryParams: {}
+            }
         };
     }
 
@@ -61,7 +63,7 @@ class ActivatedRouteMock {
 
 describe('DotRouterService', () => {
     let service: DotRouterService;
-    let router;
+    let router: InstanceType<typeof RouterMock>;
 
     beforeEach(waitForAsync(() => {
         const testbed = TestBed.configureTestingModule({
@@ -84,7 +86,7 @@ describe('DotRouterService', () => {
         });
 
         service = testbed.inject(DotRouterService);
-        router = testbed.inject(Router);
+        router = testbed.inject(Router) as unknown as InstanceType<typeof RouterMock>;
     }));
 
     it('should set current url value', () => {
@@ -250,7 +252,10 @@ describe('DotRouterService', () => {
 
     it('should got to porlet by URL', () => {
         service.gotoPortlet('/c/test');
-        expect(router.createUrlTree).toHaveBeenCalledWith(['/c/test'], { queryParamsHandling: '' });
+        expect(router.createUrlTree).toHaveBeenCalledWith(['/c/test'], {
+            queryParamsHandling: '',
+            queryParams: {}
+        });
         expect(router.navigateByUrl).toHaveBeenCalledWith(['/c/test'], { replaceUrl: false });
     });
 
@@ -260,9 +265,32 @@ describe('DotRouterService', () => {
             replaceUrl: false
         });
         expect(router.createUrlTree).toHaveBeenCalledWith(['/c/test?filter="Blog"'], {
-            queryParamsHandling: 'preserve'
+            queryParamsHandling: 'preserve',
+            queryParams: {}
         });
         expect(router.navigateByUrl).toHaveBeenCalledWith(['/c/test?filter="Blog"'], {
+            replaceUrl: false
+        });
+    });
+
+    it('should go to porlet by URL with queryParams', () => {
+        const queryParams = {
+            folderId: '123',
+            path: '/images'
+        };
+
+        service.gotoPortlet('/c/content-drive', {
+            queryParams
+        });
+
+        expect(router.createUrlTree).toHaveBeenCalledWith(['/c/content-drive'], {
+            queryParamsHandling: '',
+            queryParams: {
+                folderId: '123',
+                path: '/images'
+            }
+        });
+        expect(router.navigateByUrl).toHaveBeenCalledWith(['/c/content-drive'], {
             replaceUrl: false
         });
     });

--- a/core-web/libs/data-access/src/lib/dot-router/dot-router.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-router/dot-router.service.ts
@@ -338,8 +338,15 @@ export class DotRouterService {
      * @memberof DotRouterService
      */
     gotoPortlet(link: string, navigateToPorletOptions?: DotNavigateToOptions): Promise<boolean> {
-        const { replaceUrl = false, queryParamsHandling = '' } = navigateToPorletOptions || {};
-        const url = this.router.createUrlTree([link], { queryParamsHandling });
+        const {
+            replaceUrl = false,
+            queryParamsHandling = '',
+            queryParams = {}
+        } = navigateToPorletOptions || {};
+        const url = this.router.createUrlTree([link], {
+            queryParamsHandling,
+            queryParams
+        });
 
         return this.router.navigateByUrl(url, { replaceUrl });
     }

--- a/core-web/libs/dotcms-models/src/lib/navigation/navigate-to-options.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/navigation/navigate-to-options.model.ts
@@ -3,4 +3,5 @@ import { QueryParamsHandling } from '@angular/router';
 export interface DotNavigateToOptions {
     replaceUrl?: boolean;
     queryParamsHandling?: QueryParamsHandling;
+    queryParams?: Record<string, string>;
 }

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-sidebar/dot-content-drive-sidebar.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-sidebar/dot-content-drive-sidebar.component.spec.ts
@@ -13,14 +13,14 @@ import {
     DotContentDriveUploadFiles,
     DotTreeFolderComponent,
     DotFolderTreeNodeItem,
-    DotContentDriveMoveItems
+    DotContentDriveMoveItems,
+    ALL_FOLDER
 } from '@dotcms/portlets/content-drive/ui';
 import { GlobalStore } from '@dotcms/store';
 
 import { DotContentDriveSidebarComponent } from './dot-content-drive-sidebar.component';
 
 import { DotContentDriveStore } from '../../store/dot-content-drive.store';
-import { ALL_FOLDER } from '../../utils/tree-folder.utils';
 
 describe('DotContentDriveSidebarComponent', () => {
     let spectator: Spectator<DotContentDriveSidebarComponent>;

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-sidebar/dot-content-drive-sidebar.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-sidebar/dot-content-drive-sidebar.component.ts
@@ -10,6 +10,7 @@ import {
 import { TreeNodeCollapseEvent, TreeNodeExpandEvent, TreeNodeSelectEvent } from 'primeng/tree';
 
 import {
+    ALL_FOLDER,
     DotContentDriveMoveItems,
     DotContentDriveUploadFiles,
     DotTreeFolderComponent
@@ -95,7 +96,7 @@ export class DotContentDriveSidebarComponent {
     protected onNodeCollapse(event: TreeNodeCollapseEvent): void {
         const { node } = event;
 
-        if (node.key === 'ALL_FOLDER') {
+        if (node.key === ALL_FOLDER.key) {
             node.expanded = true;
             return;
         }

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-content-type-field/dot-content-drive-content-type-field.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-content-type-field/dot-content-drive-content-type-field.component.spec.ts
@@ -551,6 +551,13 @@ describe('DotContentDriveContentTypeFieldComponent', () => {
 
     describe('Content Type Selection & Store Integration', () => {
         beforeEach(() => {
+            // Populate the state with content types so onChange can work
+            patchState(spectator.component.$state, {
+                contentTypes: MOCK_CONTENT_TYPES.filter(
+                    (ct) => ct.baseType !== DotCMSBaseTypesContentTypes.FORM && !ct.system
+                )
+            });
+
             // Set up component with pre-selected content types for testing
             spectator.component.$selectedContentTypes.set([
                 MOCK_CONTENT_TYPES[0], // blog

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-content-type-field/dot-content-drive-content-type-field.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-content-type-field/dot-content-drive-content-type-field.component.ts
@@ -64,22 +64,29 @@ export class DotContentDriveContentTypeFieldComponent implements OnInit {
         contentTypes: []
     });
 
-    readonly $selectedContentTypes = linkedSignal<DotCMSContentType[]>(() => {
-        const contentTypesParam = this.#store.getFilterValue('contentType') as string[];
+    readonly $selectedContentTypes = linkedSignal<DotCMSContentType[]>(
+        () => {
+            const contentTypesParam = this.#store.getFilterValue('contentType') as string[];
 
-        if (!contentTypesParam) {
-            return [];
+            if (!contentTypesParam) {
+                return [];
+            }
+
+            const contentType = this.$state.contentTypes();
+
+            // Get contentTypes using the contentTypesParam
+            const contentTypes = contentType.filter((item) =>
+                contentTypesParam.includes(item.variable)
+            );
+
+            return contentTypes ?? [];
+        },
+        {
+            // It will only trigger changes when we have content types to check for.
+            equal: (a, b) =>
+                !this.$state.contentTypes().length || (a?.length === b?.length && a === b)
         }
-
-        const contentType = this.$state.contentTypes();
-
-        // Get contentTypes using the contentTypesParam
-        const contentTypes = contentType.filter((item) =>
-            contentTypesParam.includes(item.variable)
-        );
-
-        return contentTypes ?? [];
-    });
+    );
 
     /**
      * Maps the ensured content types to a string
@@ -164,6 +171,11 @@ export class DotContentDriveContentTypeFieldComponent implements OnInit {
      */
     protected onChange() {
         const value = this.$selectedContentTypes();
+
+        // If there is no content types, don't update the store
+        if (!this.$state.contentTypes().length) {
+            return;
+        }
 
         if (value?.length) {
             this.#store.patchFilters({

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-search-input/dot-content-drive-search-input.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-search-input/dot-content-drive-search-input.component.spec.ts
@@ -13,10 +13,11 @@ import { IconFieldModule } from 'primeng/iconfield';
 import { InputIconModule } from 'primeng/inputicon';
 import { InputTextModule } from 'primeng/inputtext';
 
+import { ALL_FOLDER } from '@dotcms/portlets/content-drive/ui';
+
 import { DotContentDriveSearchInputComponent } from './dot-content-drive-search-input.component';
 
 import { DotContentDriveStore } from '../../../../store/dot-content-drive.store';
-import { ALL_FOLDER } from '../../../../utils/tree-folder.utils';
 
 describe('DotContentDriveSearchInputComponent', () => {
     let spectator: Spectator<DotContentDriveSearchInputComponent>;

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-search-input/dot-content-drive-search-input.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-search-input/dot-content-drive-search-input.component.ts
@@ -8,9 +8,10 @@ import { InputTextModule } from 'primeng/inputtext';
 
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
+import { ALL_FOLDER } from '@dotcms/portlets/content-drive/ui';
+
 import { DEBOUNCE_TIME } from '../../../../shared/constants';
 import { DotContentDriveStore } from '../../../../store/dot-content-drive.store';
-import { ALL_FOLDER } from '../../../../utils/tree-folder.utils';
 
 @Component({
     selector: 'dot-content-drive-search-input',

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
@@ -29,7 +29,8 @@ import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import {
     DotFolderListViewComponent,
     DotFolderTreeNodeItem,
-    DotContentDriveMoveItems
+    DotContentDriveMoveItems,
+    ALL_FOLDER
 } from '@dotcms/portlets/content-drive/ui';
 import { GlobalStore } from '@dotcms/store';
 
@@ -54,7 +55,6 @@ import {
 } from '../shared/mocks';
 import { DotContentDriveSortOrder, DotContentDriveStatus } from '../shared/models';
 import { DotContentDriveStore } from '../store/dot-content-drive.store';
-import { ALL_FOLDER } from '../utils/tree-folder.utils';
 
 describe('DotContentDriveShellComponent', () => {
     let spectator: Spectator<DotContentDriveShellComponent>;

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/services/dot-content-drive-navigation.service.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/services/dot-content-drive-navigation.service.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import { Injectable, inject } from '@angular/core';
 import { Router } from '@angular/router';
 
@@ -9,12 +10,14 @@ import {
     DotContentDriveItem,
     FeaturedFlags
 } from '@dotcms/dotcms-models';
+import { mapQueryParamsToCDParams } from '@dotcms/utils';
 
 @Injectable({
     providedIn: 'root'
 })
 export class DotContentDriveNavigationService {
     readonly #router = inject(Router);
+    readonly #location = inject(Location);
     readonly #dotContentTypeService = inject(DotContentTypeService);
     readonly #dotRouterService = inject(DotRouterService);
     /**
@@ -51,6 +54,9 @@ export class DotContentDriveNavigationService {
      * @param contentlet - The contentlet to edit
      */
     #editContentlet(contentlet: DotContentDriveItem) {
+        const currentPath = this.#location.path(true);
+        const currentQueryParams = new URL(currentPath, window.location.origin).searchParams;
+
         this.#dotContentTypeService
             .getContentType(contentlet.contentType)
             .pipe(take(1))
@@ -58,8 +64,12 @@ export class DotContentDriveNavigationService {
                 const shouldRedirectToOldContentEditor =
                     !contentType?.metadata?.[FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED];
 
+                const mappedQueryParams = mapQueryParamsToCDParams(currentQueryParams);
+
                 if (shouldRedirectToOldContentEditor) {
-                    this.#router.navigate([`c/content/${contentlet.inode}`]);
+                    this.#router.navigate([`c/content/${contentlet.inode}`], {
+                        queryParams: mappedQueryParams
+                    });
                     return;
                 }
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/sidebar/withSidebar.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/sidebar/withSidebar.spec.ts
@@ -4,7 +4,7 @@ import { signalStore, withState } from '@ngrx/signals';
 import { of } from 'rxjs';
 
 import { DotFolderService } from '@dotcms/data-access';
-import { DotFolderTreeNodeItem } from '@dotcms/portlets/content-drive/ui';
+import { ALL_FOLDER, DotFolderTreeNodeItem } from '@dotcms/portlets/content-drive/ui';
 import { createFakeFolder, createFakeSite } from '@dotcms/utils-testing';
 
 import { withSidebar } from './withSidebar';
@@ -14,7 +14,6 @@ import {
     DotContentDriveState,
     DotContentDriveStatus
 } from '../../../shared/models';
-import { ALL_FOLDER } from '../../../utils/tree-folder.utils';
 
 const mockSite = createFakeSite();
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/sidebar/withSidebar.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/sidebar/withSidebar.ts
@@ -14,11 +14,11 @@ import { catchError, take, tap } from 'rxjs/operators';
 
 import { DotFolderService } from '@dotcms/data-access';
 import { DotFolder } from '@dotcms/dotcms-models';
-import { DotFolderTreeNodeItem } from '@dotcms/portlets/content-drive/ui';
+import { ALL_FOLDER, DotFolderTreeNodeItem } from '@dotcms/portlets/content-drive/ui';
 
 import { DotContentDriveState } from '../../../shared/models';
 import { getFolderHierarchyByPath, getFolderNodesByPath } from '../../../utils/functions';
-import { ALL_FOLDER, buildTreeFolderNodes } from '../../../utils/tree-folder.utils';
+import { buildTreeFolderNodes } from '../../../utils/tree-folder.utils';
 
 interface WithSidebarState {
     sidebarLoading: boolean;

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/functions.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/functions.spec.ts
@@ -424,7 +424,7 @@ describe('Utility Functions', () => {
             expect(result).toContain('+catchall:*test search*');
             // Should include title_dotraw search with boost
             expect(result).toContain('title_dotraw:*test search*^5');
-            // Should include exact title search with higher boost (uses double quotes)
+            // Should include exact title search with higher boost (uses single quotes)
             expect(result).toContain(`title:'test search'^15`);
             // Should include individual word searches
             expect(result).toContain('title:test^5');

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/functions.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/functions.ts
@@ -17,6 +17,43 @@ import {
 } from '../shared/models';
 
 /**
+ * Escapes special Lucene characters in a search term.
+ * Special characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
+ *
+ * WHY WE NEED THIS:
+ * Without escaping, Lucene interprets special characters as query operators:
+ * - Searching "profile-test" would be interpreted as "profile" NOT "test" (dash means exclusion)
+ * - Searching "A+B" would be interpreted as "A" AND "B" (plus means required term)
+ * - This causes queries to fail or return wrong results
+ *
+ * By escaping (adding backslash before special chars), we tell Lucene to treat them as literal text.
+ *
+ * WHY WE HAVE DIFFERENT SEARCH STRATEGIES:
+ * - Analyzed fields ('title', 'catchall'): Lucene strips special chars during indexing
+ *   Example: "profile-test" is indexed as ["profile", "test"] - the dash is removed
+ *   Searching for escaped "profile\-test" won't match because the dash doesn't exist in the index
+ *
+ * - Non-analyzed fields ('title_dotraw'): Preserve exact text including special chars
+ *   Example: "profile-test" is indexed as "profile-test" - the dash is kept
+ *   Searching for escaped "profile\-test" WILL match because we're looking for the literal dash
+ *
+ * This is why we use escaped values for title_dotraw but not for catchall/title fields.
+ *
+ * @see https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/analysis/package-summary.html
+ * @see https://www.baeldung.com/lucene-analyzers
+ *
+ * @param {string} term - The term to escape
+ * @return {string} The escaped term
+ * @example
+ * escapeLuceneSpecialChars('profile-test') // returns 'profile\\-test'
+ * escapeLuceneSpecialChars('A+B') // returns 'A\\+B'
+ */
+export function escapeLuceneSpecialChars(term: string): string {
+    // Escape special Lucene characters by prefixing with backslash
+    return term.replace(/([+\-&|!(){}[\]^"~*?:\\/])/g, '\\$1');
+}
+
+/**
  * Decodes a multi-selector value.
  *
  * @param {string} value
@@ -219,15 +256,32 @@ export function buildContentDriveQuery({
 
             // Handle raw search for title
             if (key === 'title') {
-                modifiedQuery = modifiedQuery.raw(
-                    `+catchall:*${value}* title_dotraw:*${value}*^5 title:'${value}'^15`
-                );
-                value
-                    .split(' ')
-                    .filter((word) => word.trim().length > 0)
-                    .forEach((word) => {
-                        modifiedQuery = modifiedQuery.raw(`title:${word}^5`);
-                    });
+                // Check if the search term contains special characters
+                const hasSpecialChars = /[+\-&|!(){}[\]^"~*?:\\/]/.test(value);
+
+                if (hasSpecialChars) {
+                    // Always escape special characters for Lucene
+                    const escapedValue = escapeLuceneSpecialChars(value);
+                    // For searches with special chars, search both title_dotraw and catchall
+                    /// We cannot use title field because it is analyzed and special characters are stripped
+                    modifiedQuery = modifiedQuery.raw(
+                        `+(title_dotraw:*${escapedValue}*^20 OR catchall:*${escapedValue}*^10)`
+                    );
+                } else {
+                    // For regular searches without special chars, use the original broader approach
+                    modifiedQuery = modifiedQuery.raw(
+                        `+catchall:*${value}* title_dotraw:*${value}*^5 title:'${value}'^15`
+                    );
+
+                    // Split by spaces only (not dashes) and search individual words
+                    value
+                        .split(/\s+/)
+                        .filter((word) => word.trim().length > 0)
+                        .forEach((word) => {
+                            modifiedQuery = modifiedQuery.raw(`title:${word}^5`);
+                        });
+                }
+
                 return;
             }
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/tree-folder.utils.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/tree-folder.utils.spec.ts
@@ -1,19 +1,14 @@
 import { DotFolder } from '@dotcms/dotcms-models';
-import { DotFolderTreeNodeItem } from '@dotcms/portlets/content-drive/ui';
+import { ALL_FOLDER, DotFolderTreeNodeItem } from '@dotcms/portlets/content-drive/ui';
 
-import {
-    ALL_FOLDER,
-    buildTreeFolderNodes,
-    createTreeNode,
-    generateAllParentPaths
-} from './tree-folder.utils';
+import { buildTreeFolderNodes, createTreeNode, generateAllParentPaths } from './tree-folder.utils';
 
 describe('Sidebar Utils', () => {
     describe('ALL_FOLDER constant', () => {
         it('should have correct structure', () => {
             expect(ALL_FOLDER).toEqual({
                 key: 'ALL_FOLDER',
-                label: 'All',
+                label: 'content-drive.all-folder.label',
                 loading: false,
                 data: {
                     type: 'folder',

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/tree-folder.utils.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/tree-folder.utils.ts
@@ -3,20 +3,6 @@ import { DotFolderTreeNodeItem } from '@dotcms/portlets/content-drive/ui';
 
 import { BuildTreeFolderNodesParams } from '../shared/models';
 
-export const ALL_FOLDER: DotFolderTreeNodeItem = {
-    key: 'ALL_FOLDER',
-    label: 'All',
-    loading: false,
-    data: {
-        type: 'folder',
-        path: '',
-        hostname: '',
-        id: ''
-    },
-    leaf: false,
-    expanded: true
-};
-
 /**
  * Generates all parent paths from a target path
  *

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-tree-folder/dot-tree-folder.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-tree-folder/dot-tree-folder.component.html
@@ -20,7 +20,7 @@
                 data-testid="tree-node-label"
                 [attr.data-json-node]="node.data | json"
                 [class.active]="$activeDropNode()?.id === node?.data.id">
-                {{ node.label | folderName }}
+                {{ node.key === ALL_FOLDER_KEY ? (node.label | dm) : (node.label | folderName) }}
             </span>
         </ng-template>
         <!-- LOADING WONT WORK WITH CUSTOM TEMPLATE: https://github.com/primefaces/primeng/blob/v17/src/app/components/tree/tree.ts#L113 -->

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-tree-folder/dot-tree-folder.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-tree-folder/dot-tree-folder.component.ts
@@ -17,6 +17,7 @@ import { TreeModule, TreeNodeExpandEvent, TreeNodeCollapseEvent } from 'primeng/
 
 import { DotMessagePipe, FolderNamePipe } from '@dotcms/ui';
 
+import { ALL_FOLDER } from '../shared/constants';
 import {
     DotFolderTreeNodeData,
     DotContentDriveUploadFiles,
@@ -123,6 +124,8 @@ export class DotTreeFolderComponent {
     readonly treeStyleClasses = computed(
         () => `w-full h-full ${this.$showFolderIconOnFirstOnly() ? 'first-only' : 'folder-all'}`
     );
+
+    protected readonly ALL_FOLDER_KEY = ALL_FOLDER.key;
 
     /**
      * @description Set the dropzone as active when the drag enters the dropzone

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/shared/constants.ts
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/shared/constants.ts
@@ -1,4 +1,4 @@
-import { DotFolderListViewColumn } from './models';
+import { DotFolderListViewColumn, DotFolderTreeNodeItem } from './models';
 
 export const HEADER_COLUMNS: DotFolderListViewColumn[] = [
     { field: 'title', header: 'title', width: '40%', order: 1, sortable: true },
@@ -17,3 +17,22 @@ export const SYSTEM_HOST_ID = 'SYSTEM_HOST';
  * @type DOT_DRAG_ITEM
  */
 export const DOT_DRAG_ITEM = 'dotcms/item';
+
+/**
+ * @export
+ * @type ALL_FOLDER
+ * @description All folder node
+ */
+export const ALL_FOLDER: DotFolderTreeNodeItem = {
+    key: 'ALL_FOLDER',
+    label: 'content-drive.all-folder.label',
+    loading: false,
+    data: {
+        type: 'folder',
+        path: '',
+        hostname: '',
+        id: ''
+    },
+    leaf: false,
+    expanded: true
+};

--- a/core-web/libs/utils-testing/src/lib/dot-content-types.mock.ts
+++ b/core-web/libs/utils-testing/src/lib/dot-content-types.mock.ts
@@ -25,7 +25,6 @@ import {
     ContentTypeSelectField,
     ContentTypeTagField,
     DotCMSClazzes,
-    DotCMSClazz,
     ContentTypeTabDividerField,
     ContentTypeColumnBreakField,
     DotCMSContentType,

--- a/core-web/libs/utils/src/lib/dot-utils.spec.ts
+++ b/core-web/libs/utils/src/lib/dot-utils.spec.ts
@@ -1,7 +1,51 @@
-import { DotCMSBaseTypesContentTypes, DotPageToolUrlParams } from '@dotcms/dotcms-models';
-import { EMPTY_CONTENTLET } from '@dotcms/utils-testing';
+import {
+    DotCMSBaseTypesContentTypes,
+    DotCMSContentlet,
+    DotPageToolUrlParams
+} from '@dotcms/dotcms-models';
 
-import { getImageAssetUrl, ellipsizeText, getRunnableLink, hasValidValue } from './dot-utils';
+import {
+    getImageAssetUrl,
+    ellipsizeText,
+    getRunnableLink,
+    hasValidValue,
+    mapQueryParamsToCDParams,
+    mapParamsFromEditContentlet
+} from './dot-utils';
+
+const EMPTY_CONTENTLET: DotCMSContentlet = {
+    inode: '14dd5ad9-55ae-42a8-a5a7-e259b6d0901a',
+    variantId: 'DEFAULT',
+    locked: false,
+    stInode: 'd5ea385d-32ee-4f35-8172-d37f58d9cd7a',
+    contentType: 'Image',
+    height: 4000,
+    identifier: '93ca45e0-06d2-4eef-be1d-79bd6bf0fc99',
+    hasTitleImage: true,
+    sortOrder: 0,
+    hostName: 'demo.dotcms.com',
+    extension: 'jpg',
+    isContent: true,
+    baseType: 'FILEASSETS',
+    archived: false,
+    working: true,
+    live: true,
+    isContentlet: true,
+    languageId: 1,
+    titleImage: 'fileAsset',
+    hasLiveVersion: true,
+    deleted: false,
+    folder: '',
+    host: '',
+    modDate: '',
+    modUser: '',
+    modUserName: '',
+    owner: '',
+    title: '',
+    url: '',
+    contentTypeIcon: 'assessment',
+    __icon__: 'Icon'
+};
 
 describe('Dot Utils', () => {
     describe('getImageAssetUrl', () => {
@@ -102,17 +146,17 @@ describe('Ellipsize Text Utility', () => {
         expect(ellipsizeText(text, 18)).toEqual(truncated);
     });
     it('should return empty string when a non-string value is passed', () => {
-        expect(ellipsizeText(12345 as any, 10)).toEqual('');
-        expect(ellipsizeText({} as any, 10)).toEqual('');
-        expect(ellipsizeText([] as any, 10)).toEqual('');
+        expect(ellipsizeText(12345 as unknown as string, 10)).toEqual('');
+        expect(ellipsizeText({} as unknown as string, 10)).toEqual('');
+        expect(ellipsizeText([] as unknown as string, 10)).toEqual('');
         expect(ellipsizeText(null, 10)).toEqual('');
     });
     it('should return empty string when limit is not a number', () => {
         const text = 'Any text';
         expect(ellipsizeText(text, NaN)).toEqual('');
-        expect(ellipsizeText(text, 'abc' as any)).toEqual('');
-        expect(ellipsizeText(text, {} as any)).toEqual('');
-        expect(ellipsizeText(text, [] as any)).toEqual('');
+        expect(ellipsizeText(text, 'abc' as unknown as number)).toEqual('');
+        expect(ellipsizeText(text, {} as unknown as number)).toEqual('');
+        expect(ellipsizeText(text, [] as unknown as number)).toEqual('');
         expect(ellipsizeText(text, null)).toEqual('');
     });
 
@@ -416,6 +460,83 @@ describe('Dot Utils', () => {
 
         it('should return TRUE when value is false', () => {
             expect(hasValidValue(false)).toEqual(true);
+        });
+    });
+
+    describe('mapQueryParamsToCDParams', () => {
+        it('should add CD_ prefix to query parameters', () => {
+            const queryParams = new URLSearchParams('folderId=123&path=/images');
+
+            expect(mapQueryParamsToCDParams(queryParams)).toEqual({
+                CD_folderId: '123',
+                CD_path: '/images'
+            });
+        });
+
+        it('should return empty object when no query parameters', () => {
+            const queryParams = new URLSearchParams('');
+
+            expect(mapQueryParamsToCDParams(queryParams)).toEqual({});
+        });
+
+        it('should handle single query parameter', () => {
+            const queryParams = new URLSearchParams('folderId=456');
+
+            expect(mapQueryParamsToCDParams(queryParams)).toEqual({
+                CD_folderId: '456'
+            });
+        });
+
+        it('should handle multiple query parameters', () => {
+            const queryParams = new URLSearchParams('folderId=123&path=/images&filter=active');
+
+            expect(mapQueryParamsToCDParams(queryParams)).toEqual({
+                CD_folderId: '123',
+                CD_path: '/images',
+                CD_filter: 'active'
+            });
+        });
+    });
+
+    describe('mapParamsFromEditContentlet', () => {
+        it('should extract CD_ prefixed params and remove prefix', () => {
+            const cdParams = new URLSearchParams('CD_folderId=123&CD_path=/images');
+
+            expect(mapParamsFromEditContentlet(cdParams)).toEqual({
+                folderId: '123',
+                path: '/images'
+            });
+        });
+
+        it('should return empty object when no CD_ params', () => {
+            const cdParams = new URLSearchParams('folderId=123&path=/images');
+
+            expect(mapParamsFromEditContentlet(cdParams)).toEqual({});
+        });
+
+        it('should filter out non-CD_ params', () => {
+            const cdParams = new URLSearchParams(
+                'CD_folderId=123&CD_path=/images&regularParam=value'
+            );
+
+            expect(mapParamsFromEditContentlet(cdParams)).toEqual({
+                folderId: '123',
+                path: '/images'
+            });
+        });
+
+        it('should handle single CD_ parameter', () => {
+            const cdParams = new URLSearchParams('CD_folderId=456');
+
+            expect(mapParamsFromEditContentlet(cdParams)).toEqual({
+                folderId: '456'
+            });
+        });
+
+        it('should return empty object when URLSearchParams is empty', () => {
+            const cdParams = new URLSearchParams('');
+
+            expect(mapParamsFromEditContentlet(cdParams)).toEqual({});
         });
     });
 });

--- a/core-web/libs/utils/src/lib/dot-utils.ts
+++ b/core-web/libs/utils/src/lib/dot-utils.ts
@@ -4,6 +4,8 @@ import {
     DotPageToolUrlParams
 } from '@dotcms/dotcms-models';
 
+import { CD_PARAM_PREFIX } from './shared/const';
+
 /**
  * Generate an anchor element with a Blob file to eventually be click to force a download
  * This approach is needed because FF do not hear WS events while waiting for a request.
@@ -149,4 +151,36 @@ export function hasValidValue<T>(value: T | undefined | null): value is T {
     }
 
     return true;
+}
+
+/**
+ * Maps the query params to the CD params
+ * @param queryParams - The query params to map
+ * @returns The CD params
+ */
+export function mapQueryParamsToCDParams(queryParams: URLSearchParams): Record<string, string> {
+    return Array.from(queryParams.entries()).reduce(
+        (acc, [key, value]) => {
+            acc[`${CD_PARAM_PREFIX}${key}`] = value;
+            return acc;
+        },
+        {} as Record<string, string>
+    );
+}
+
+/**
+ * Maps the CD params to the query params
+ * @param cdParams - The CD params to map
+ * @returns The query params
+ */
+export function mapParamsFromEditContentlet(cdParams: URLSearchParams): Record<string, string> {
+    return Array.from(cdParams.entries())
+        .filter(([key]) => key.startsWith('CD_'))
+        .reduce(
+            (acc, [key, value]) => {
+                acc[key.replace(CD_PARAM_PREFIX, '')] = value;
+                return acc;
+            },
+            {} as Record<string, string>
+        );
 }

--- a/core-web/libs/utils/src/lib/shared/const.ts
+++ b/core-web/libs/utils/src/lib/shared/const.ts
@@ -1,3 +1,5 @@
 import { InjectionToken } from '@angular/core';
 
 export const WINDOW = new InjectionToken<Window>('WindowToken');
+
+export const CD_PARAM_PREFIX = 'CD_';

--- a/core-web/libs/utils/tsconfig.lib.json
+++ b/core-web/libs/utils/tsconfig.lib.json
@@ -7,7 +7,7 @@
         "declarationMap": true,
         "inlineSources": true,
         "types": [],
-        "lib": ["dom", "es2018"]
+        "lib": ["dom", "es2018", "dom.iterable"]
     },
     "angularCompilerOptions": {
         "skipTemplateCodegen": true,

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6129,6 +6129,8 @@ content-drive.toast.unlock-success-detail=You’ve unlocked this contentlet for 
 content-drive.toast.unlock-error=Couldn't unlock
 content-drive.toast.unlock-error-detail=Something went wrong. The contentlet wasn’t unlocked.
 
+content-drive.all-folder.label=All
+
 content-drive.toast.download-success=Downloading {0}
 content-drive.toast.download-success-detail=The download has started.
 


### PR DESCRIPTION
## Summary

This PR fixes the issue where Content Drive redirects to the old content search page after closing the edit content dialog. The fix ensures proper navigation back to Content Drive with the correct context preserved.

https://github.com/user-attachments/assets/81d5cb2b-0c36-45d2-9584-983dd70eccfd


**Key Changes:**

- **Content Drive Navigation**: Implemented redirect logic in `DotContentletWrapperComponent` to detect Content Drive context (via `CD_` query parameters) and navigate back to Content Drive instead of old content search
- **Query Parameter Mapping**: Added bidirectional parameter mapping utilities (`mapParamsFromEditContentlet` and `mapQueryParamsToCDParams`) to handle Content Drive context across edit flows
- **Navigation Service Updates**: Enhanced `DotContentDriveNavigationService` to include Content Drive query parameters when navigating to old content editor
- **Router Service Enhancement**: Updated `DotRouterService.gotoPortlet()` to support `queryParams` option for preserving navigation context
- **Localization**: Added "Root" folder label translation for better UX
- **Search Fixes**: Fixed special character handling in search with proper Lucene escaping (dash, plus, etc.)
- **Content Type Field**: Improved `linkedSignal` behavior to prevent unnecessary updates before content types are loaded

Closes #33722, #33528

This PR fixes: #33528