### PR TITLE
feat(sdk-analytics) track content impression

### DIFF
--- a/core-web/libs/sdk/analytics/README.md
+++ b/core-web/libs/sdk/analytics/README.md
@@ -115,6 +115,7 @@ track(eventName: string, properties?: Record<string, unknown>): void
 | `debug` | `boolean` | ❌ | `false` | Enable verbose logging |
 | `autoPageView` | `boolean` | ❌ | React: `true` / Standalone: `false` | Auto track page views on route changes |
 | `queueConfig` | `QueueConfig` | ❌ | See below | Event batching configuration |
+| `impressions` | `ImpressionConfig\|boolean` | ❌ | `false` | Content impression tracking (disabled by default) |
 
 ### Queue Configuration
 
@@ -165,6 +166,64 @@ const analytics = initializeContentAnalytics({
         eventBatchSize: 10, // Auto-send when 10 events queued
         flushInterval: 3000 // Or send every 3 seconds
     }
+});
+```
+
+### Impression Tracking Configuration
+
+The `impressions` option controls automatic tracking of content visibility:
+
+-   **`false` or `undefined` (default)**: Impression tracking disabled
+-   **`true`**: Enable tracking with default settings
+-   **`ImpressionConfig` object**: Enable tracking with custom settings
+
+| Option                | Type     | Default | Description                                      |
+| --------------------- | -------- | ------- | ------------------------------------------------ |
+| `visibilityThreshold` | `number` | `0.5`   | Min percentage visible (0.0 to 1.0)              |
+| `dwellMs`             | `number` | `750`   | Min time visible in milliseconds                 |
+| `maxNodes`            | `number` | `1000`  | Max elements to track (performance limit)        |
+
+**How it works:**
+
+-   ✅ Tracks contentlets marked with `dotcms-analytics-contentlet` class and `data-dot-analytics-*` attributes
+-   ✅ Uses Intersection Observer API for high performance and battery efficiency
+-   ✅ Only fires when element is ≥50% visible for ≥750ms (configurable)
+-   ✅ Only tracks during active tab (respects page visibility)
+-   ✅ One impression per contentlet per session (no duplicates)
+-   ✅ Respects user consent settings
+-   ✅ Automatically disabled in dotCMS editor mode
+
+**Example: Enable with defaults**
+
+```javascript
+const analytics = initializeContentAnalytics({
+    siteAuth: 'abc123',
+    server: 'https://your-dotcms.com',
+    impressions: true // 50% visible, 750ms dwell, 1000 max nodes
+});
+```
+
+**Example: Custom thresholds**
+
+```javascript
+const analytics = initializeContentAnalytics({
+    siteAuth: 'abc123',
+    server: 'https://your-dotcms.com',
+    impressions: {
+        visibilityThreshold: 0.7, // Require 70% visible
+        dwellMs: 1000, // Must be visible for 1 second
+        maxNodes: 500 // Track max 500 elements
+    }
+});
+```
+
+**Example: Disable tracking**
+
+```javascript
+const analytics = initializeContentAnalytics({
+    siteAuth: 'abc123',
+    server: 'https://your-dotcms.com',
+    impressions: false // Explicitly disabled (also default if omitted)
 });
 ```
 

--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
@@ -72,6 +72,10 @@ export const initializeContentAnalytics = (
          * @param payload - Optional custom data to include with the page view (any valid JSON object)
          */
         pageView: (payload: JsonObject = {}) => {
+            if (!analyticsInstance) {
+                console.warn('DotCMS Analytics: Analytics instance not initialized');
+                return;
+            }
             analyticsInstance.page(payload);
         },
 
@@ -81,6 +85,10 @@ export const initializeContentAnalytics = (
          * @param payload - Custom data to include with the event (any valid JSON object)
          */
         track: (eventName: string, payload: JsonObject = {}) => {
+            if (!analyticsInstance) {
+                console.warn('DotCMS Analytics: Analytics instance not initialized');
+                return;
+            }
             analyticsInstance.track(eventName, payload);
         }
     };

--- a/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/dot-content-analytics.ts
@@ -5,6 +5,7 @@ import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from '@do
 import { dotAnalytics } from './plugin/dot-analytics.plugin';
 import { dotAnalyticsEnricherPlugin } from './plugin/enricher/dot-analytics.enricher.plugin';
 import { dotAnalyticsIdentityPlugin } from './plugin/identity/dot-analytics.identity.plugin';
+import { dotAnalyticsImpressionPlugin } from './plugin/impression/dot-analytics.impression.plugin';
 import {
     cleanupActivityTracking,
     validateAnalyticsConfig
@@ -40,11 +41,13 @@ export const initializeContentAnalytics = (
         return null;
     }
 
-    const analytics = Analytics({
+    // Create Analytics.js instance with all plugins
+    const analyticsInstance = Analytics({
         app: 'dotAnalytics',
         debug: config.debug,
         plugins: [
-            dotAnalyticsIdentityPlugin(config), // Inject identity context (user_id, session_id, local_tz)
+            dotAnalyticsIdentityPlugin(config), // Inject identity context
+            dotAnalyticsImpressionPlugin(config), // Track content impressions
             dotAnalyticsEnricherPlugin(), // Enrich and clean payload with page, device, utm data and custom data
             dotAnalytics(config) // Send events to server
         ]
@@ -69,17 +72,16 @@ export const initializeContentAnalytics = (
          * @param payload - Optional custom data to include with the page view (any valid JSON object)
          */
         pageView: (payload: JsonObject = {}) => {
-            analytics?.page(payload);
+            analyticsInstance.page(payload);
         },
 
         /**
          * Track a custom event.
-         * Session activity is automatically updated by the identity plugin.
          * @param eventName - The name of the event to track
          * @param payload - Custom data to include with the event (any valid JSON object)
          */
         track: (eventName: string, payload: JsonObject = {}) => {
-            analytics?.track(eventName, payload);
+            analyticsInstance.track(eventName, payload);
         }
     };
 };

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/dot-analytics.plugin.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/dot-analytics.plugin.ts
@@ -1,5 +1,3 @@
-import { EnrichedTrackPayload } from './enricher/dot-analytics.enricher.plugin';
-
 import { DotCMSPredefinedEventType } from '../shared/constants/dot-content-analytics.constants';
 import { sendAnalyticsEvent } from '../shared/dot-content-analytics.http';
 import { isPredefinedEventType } from '../shared/dot-content-analytics.utils';
@@ -7,6 +5,7 @@ import {
     DotCMSAnalyticsConfig,
     DotCMSAnalyticsRequestBody,
     EnrichedAnalyticsPayload,
+    EnrichedTrackPayload,
     JsonObject
 } from '../shared/models';
 import { createAnalyticsQueue } from '../shared/queue';

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.spec.ts
@@ -2,12 +2,12 @@
 
 import { dotAnalyticsEnricherPlugin } from './dot-analytics.enricher.plugin';
 
-import { enrichPagePayloadOptimized, getLocalTime } from '../../shared/dot-content-analytics.utils';
+import { DotCMSPredefinedEventType } from '../../shared/constants/dot-content-analytics.constants';
+import { enrichPagePayloadOptimized } from '../../shared/dot-content-analytics.utils';
 
 // Mock the utility functions
 jest.mock('../../shared/dot-content-analytics.utils', () => ({
-    enrichPagePayloadOptimized: jest.fn(),
-    getLocalTime: jest.fn().mockReturnValue('2024-01-01T10:00:00.000Z')
+    enrichPagePayloadOptimized: jest.fn()
 }));
 
 describe('dotAnalyticsEnricherPlugin', () => {
@@ -15,7 +15,6 @@ describe('dotAnalyticsEnricherPlugin', () => {
     const mockEnrichPagePayloadOptimized = enrichPagePayloadOptimized as jest.MockedFunction<
         typeof enrichPagePayloadOptimized
     >;
-    const mockGetLocalTime = getLocalTime as jest.MockedFunction<typeof getLocalTime>;
 
     beforeEach(() => {
         // Reset all mocks before each test
@@ -25,7 +24,6 @@ describe('dotAnalyticsEnricherPlugin', () => {
         plugin = dotAnalyticsEnricherPlugin();
 
         // Set default mock return values
-        mockGetLocalTime.mockReturnValue('2024-01-01T10:00:00.000Z');
         mockEnrichPagePayloadOptimized.mockReturnValue({} as any);
     });
 
@@ -48,7 +46,7 @@ describe('dotAnalyticsEnricherPlugin', () => {
             const mockPayload = { event: 'pageview', properties: { page: '/test' } } as any;
             mockEnrichPagePayloadOptimized.mockReturnValue({
                 context: {
-                    site_key: 'test',
+                    site_auth: 'test-auth',
                     session_id: 'session',
                     user_id: 'user',
                     device: {
@@ -70,12 +68,12 @@ describe('dotAnalyticsEnricherPlugin', () => {
             expect(mockEnrichPagePayloadOptimized).toHaveBeenCalledTimes(1);
         });
 
-        it('should return the result from enrichPagePayloadOptimized with device in context', () => {
+        it('should return enriched payload with page, utm, custom data, and local_time', () => {
             // Arrange
             const mockPayload = { event: 'pageview' } as any;
             const expectedEnriched = {
                 context: {
-                    site_key: 'test',
+                    site_auth: 'test-auth',
                     session_id: 'session',
                     user_id: 'user',
                     device: {
@@ -86,6 +84,8 @@ describe('dotAnalyticsEnricherPlugin', () => {
                     }
                 },
                 page: { url: 'test', title: 'Test' },
+                utm: { source: 'google', medium: 'cpc' },
+                custom: { custom_prop: 'value' },
                 local_time: '2024-01-01T10:00:00.000Z'
             };
             mockEnrichPagePayloadOptimized.mockReturnValue(expectedEnriched as any);
@@ -94,194 +94,137 @@ describe('dotAnalyticsEnricherPlugin', () => {
             const result = plugin['page:dot-analytics']({ payload: mockPayload });
 
             // Assert
-            expect(result).toEqual({
-                context: expectedEnriched.context,
-                events: [
-                    {
-                        event_type: 'pageview',
-                        local_time: expectedEnriched.local_time,
-                        data: {
-                            page: expectedEnriched.page
-                        }
-                    }
-                ]
-            });
+            // Plugin should return enriched data, NOT structured events
+            expect(result).toEqual(expectedEnriched);
+        });
+
+        it('should throw error if page data is missing', () => {
+            // Arrange
+            const mockPayload = { event: 'pageview' } as any;
+            mockEnrichPagePayloadOptimized.mockReturnValue({
+                context: { site_auth: 'test-auth', session_id: 'session', user_id: 'user' },
+                // page is undefined
+                local_time: '2024-01-01T10:00:00.000Z'
+            } as any);
+
+            // Act & Assert
+            expect(() => plugin['page:dot-analytics']({ payload: mockPayload })).toThrow(
+                'DotCMS Analytics: Missing required page data'
+            );
         });
     });
 
     describe('Track Event Enrichment', () => {
-        it('should create enriched track event with correct structure', () => {
+        it('should enrich content_impression events with page data', () => {
+            // Arrange
+            const mockPayload = {
+                event: DotCMSPredefinedEventType.CONTENT_IMPRESSION,
+                context: {
+                    site_auth: 'test-auth',
+                    session_id: 'session',
+                    user_id: 'user'
+                },
+                properties: {
+                    content: {
+                        identifier: 'content-123',
+                        inode: 'inode-456',
+                        title: 'Test Content',
+                        content_type: 'Blog'
+                    },
+                    position: {
+                        viewport_offset_pct: 25.5,
+                        dom_index: 2
+                    }
+                }
+            } as any;
+
+            mockEnrichPagePayloadOptimized.mockReturnValue({
+                context: mockPayload.context,
+                page: { url: '/test', title: 'Test Page' },
+                local_time: '2024-01-01T10:00:00.000Z'
+            } as any);
+
+            // Act
+            const result = plugin['track:dot-analytics']({ payload: mockPayload });
+
+            // Assert
+            expect(mockEnrichPagePayloadOptimized).toHaveBeenCalledWith(mockPayload);
+            expect(result).toEqual({
+                ...mockPayload,
+                properties: {
+                    content: mockPayload.properties.content,
+                    position: mockPayload.properties.position,
+                    page: { url: '/test', title: 'Test Page' }
+                },
+                page: { url: '/test', title: 'Test Page' },
+                local_time: '2024-01-01T10:00:00.000Z'
+            });
+        });
+
+        it('should enrich custom events with page, utm, and custom data', () => {
             // Arrange
             const mockPayload = {
                 event: 'button_click',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
+                context: { site_auth: 'test-auth', session_id: 'session', user_id: 'user' },
                 properties: {
                     button_id: 'submit-btn',
-                    page: '/contact'
+                    button_text: 'Submit'
                 }
             } as any;
+
+            mockEnrichPagePayloadOptimized.mockReturnValue({
+                context: mockPayload.context,
+                page: { url: '/contact', title: 'Contact Us' },
+                utm: { source: 'newsletter', medium: 'email' },
+                custom: { user_segment: 'premium' },
+                local_time: '2024-01-01T10:00:00.000Z'
+            } as any);
 
             // Act
             const result = plugin['track:dot-analytics']({ payload: mockPayload });
 
             // Assert
-            expect(mockGetLocalTime).toHaveBeenCalledTimes(1);
             expect(result).toEqual({
-                context: mockPayload.context,
-                events: [
-                    {
-                        event_type: 'button_click',
-                        local_time: '2024-01-01T10:00:00.000Z',
-                        data: {
-                            custom: {
-                                button_id: 'submit-btn',
-                                page: '/contact'
-                            }
-                        }
-                    }
-                ]
+                ...mockPayload,
+                page: { url: '/contact', title: 'Contact Us' },
+                utm: { source: 'newsletter', medium: 'email' },
+                custom: { user_segment: 'premium' },
+                local_time: '2024-01-01T10:00:00.000Z'
             });
         });
 
-        it('should preserve existing properties in custom data', () => {
+        it('should pass through properties without modifying them for custom events', () => {
             // Arrange
             const mockPayload = {
                 event: 'form_submit',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
+                context: { site_auth: 'test-auth', session_id: 'session', user_id: 'user' },
                 properties: {
                     form_name: 'contact_form',
-                    validation_errors: 0,
-                    session_id: 'session_123'
+                    validation_errors: 0
                 }
             } as any;
+
+            mockEnrichPagePayloadOptimized.mockReturnValue({
+                context: mockPayload.context,
+                page: { url: '/form', title: 'Form Page' },
+                local_time: '2024-01-01T10:00:00.000Z'
+            } as any);
 
             // Act
             const result = plugin['track:dot-analytics']({ payload: mockPayload });
 
             // Assert
-            expect(result.events[0].data).toEqual({
-                custom: {
-                    form_name: 'contact_form',
-                    validation_errors: 0,
-                    session_id: 'session_123'
-                }
-            });
-        });
-
-        it('should handle empty properties', () => {
-            // Arrange
-            const mockPayload = {
-                event: 'pageview',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
-                properties: {}
-            } as any;
-
-            // Act
-            const result = plugin['track:dot-analytics']({ payload: mockPayload });
-
-            // Assert
-            expect(result.events[0].data).toEqual({
-                custom: {}
-            });
-        });
-
-        it('should handle undefined properties', () => {
-            // Arrange
-            const mockPayload = {
-                event: 'custom_event',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' }
-                // properties is undefined
-            } as any;
-
-            // Act
-            const result = plugin['track:dot-analytics']({ payload: mockPayload });
-
-            // Assert
-            expect(result.events[0].data).toEqual({
-                custom: undefined
-            });
-        });
-
-        it('should use different local times when called multiple times', () => {
-            // Arrange
-            const mockPayload = {
-                event: 'test_event',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
-                properties: {}
-            } as any;
-            const time1 = '2024-01-01T10:00:00.000Z';
-            const time2 = '2024-01-01T11:00:00.000Z';
-
-            mockGetLocalTime.mockReturnValueOnce(time1).mockReturnValueOnce(time2);
-
-            // Act
-            const result1 = plugin['track:dot-analytics']({ payload: mockPayload });
-            const result2 = plugin['track:dot-analytics']({ payload: mockPayload });
-
-            // Assert
-            expect(result1.events[0].local_time).toBe(time1);
-            expect(result2.events[0].local_time).toBe(time2);
-            expect(mockGetLocalTime).toHaveBeenCalledTimes(2);
-        });
-    });
-
-    describe('Integration Scenarios', () => {
-        it('should handle real-world track event data', () => {
-            // Arrange
-            const realWorldPayload = {
-                event: 'content_interaction',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
-                properties: {
-                    contentId: 'article-123',
-                    contentType: 'blog-post',
-                    category: 'technology',
-                    utm_source: 'newsletter',
-                    utm_medium: 'email'
-                }
-            } as any;
-
-            // Act
-            const result = plugin['track:dot-analytics']({ payload: realWorldPayload });
-
-            // Assert
-            expect(result.events[0]).toMatchObject({
-                event_type: 'content_interaction',
-                data: {
-                    custom: {
-                        contentId: 'article-123',
-                        contentType: 'blog-post',
-                        category: 'technology',
-                        utm_source: 'newsletter',
-                        utm_medium: 'email'
-                    }
-                }
-            });
+            // Properties should remain unchanged
+            expect(result.properties).toEqual(mockPayload.properties);
         });
     });
 
     describe('Error Handling', () => {
-        it('should propagate getLocalTime errors', () => {
-            // Arrange
-            const mockPayload = {
-                event: 'test_event',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
-                properties: {}
-            } as any;
-            mockGetLocalTime.mockImplementation(() => {
-                throw new Error('Time service unavailable');
-            });
-
-            // Act & Assert
-            expect(() => plugin['track:dot-analytics']({ payload: mockPayload })).toThrow(
-                'Time service unavailable'
-            );
-        });
-
         it('should propagate enrichPagePayloadOptimized errors', () => {
             // Arrange
             const mockPayload = {
                 event: 'pageview',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
+                context: { site_auth: 'test-auth', session_id: 'session', user_id: 'user' },
                 properties: {}
             } as any;
             mockEnrichPagePayloadOptimized.mockImplementation(() => {
@@ -295,42 +238,6 @@ describe('dotAnalyticsEnricherPlugin', () => {
         });
     });
 
-    describe('Memory and Performance', () => {
-        it('should not mutate the original payload', () => {
-            // Arrange
-            const originalPayload = {
-                event: 'test_event',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
-                properties: { original: 'value' }
-            } as any;
-            const payloadCopy = JSON.parse(JSON.stringify(originalPayload));
-
-            // Act
-            plugin['track:dot-analytics']({ payload: originalPayload });
-
-            // Assert
-            expect(originalPayload).toEqual(payloadCopy);
-        });
-
-        it('should create new objects for each track call', () => {
-            // Arrange
-            const mockPayload = {
-                event: 'test_event',
-                context: { site_key: 'test', session_id: 'session', user_id: 'user' },
-                properties: {}
-            } as any;
-
-            // Act
-            const result1 = plugin['track:dot-analytics']({ payload: mockPayload });
-            const result2 = plugin['track:dot-analytics']({ payload: mockPayload });
-
-            // Assert
-            expect(result1).not.toBe(result2);
-            expect(result1.events).not.toBe(result2.events);
-            expect(result1.events[0]).not.toBe(result2.events[0]);
-        });
-    });
-
     describe('Plugin Behavior', () => {
         it('should maintain plugin instance properties', () => {
             // Arrange & Act
@@ -340,26 +247,6 @@ describe('dotAnalyticsEnricherPlugin', () => {
             // Assert
             expect(pluginInstance1.name).toBe(pluginInstance2.name);
             expect(pluginInstance1).not.toBe(pluginInstance2);
-        });
-
-        it('should handle different event types correctly', () => {
-            // Arrange
-            const events = ['click', 'scroll', 'form_submit', 'page_exit'];
-
-            events.forEach((eventType) => {
-                const payload = {
-                    event: eventType,
-                    context: { site_key: 'test', session_id: 'session', user_id: 'user' },
-                    properties: {}
-                } as any;
-
-                // Act
-                const result = plugin['track:dot-analytics']({ payload });
-
-                // Assert
-                expect(result.events[0].event_type).toBe(eventType);
-                expect(result.events[0].data).toEqual({ custom: {} });
-            });
         });
     });
 });

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.spec.ts
@@ -119,6 +119,7 @@ describe('dotAnalyticsEnricherPlugin', () => {
 
     describe('Track Event Enrichment', () => {
         let originalTitle: string;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         let originalHref: string;
 
         beforeEach(() => {

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts
@@ -1,18 +1,32 @@
 import { DotCMSPredefinedEventType } from '../../shared/constants/dot-content-analytics.constants';
-import { enrichPagePayloadOptimized, getLocalTime } from '../../shared/dot-content-analytics.utils';
+import { enrichPagePayloadOptimized } from '../../shared/dot-content-analytics.utils';
 import {
     AnalyticsBasePayloadWithContext,
     AnalyticsTrackPayloadWithContext,
-    DotCMSAnalyticsRequestBody
+    DotCMSContentImpressionPayload,
+    EnrichedAnalyticsPayload
 } from '../../shared/models';
 
 /**
- * Plugin that enriches the analytics payload data based on the event type.
- * Uses Analytics.js lifecycle events to inject context before processing.
+ * Enriched payload interface that includes page, utm, and custom data ready for event creation.
+ * This is the return type from the enricher plugin methods.
+ */
+export interface EnrichedTrackPayload extends AnalyticsTrackPayloadWithContext {
+    page: EnrichedAnalyticsPayload['page'];
+    utm?: EnrichedAnalyticsPayload['utm'];
+    custom?: EnrichedAnalyticsPayload['custom'];
+    local_time: string;
+}
+
+/**
+ * Plugin that enriches the analytics payload data with page, UTM, and custom data.
+ * Uses Analytics.js lifecycle events to inject enriched data before the main plugin processes it.
+ *
  * The identity plugin runs FIRST to inject context: { session_id, site_auth, user_id, device }
  * This enricher plugin runs SECOND to add page/utm/custom data.
+ * The main plugin runs THIRD to structure events and send to server.
  *
- * Returns the final request body structure ready to send to the server.
+ * This plugin is ONLY responsible for data enrichment - NOT for event structuring or business logic.
  */
 export const dotAnalyticsEnricherPlugin = () => {
     return {
@@ -20,60 +34,68 @@ export const dotAnalyticsEnricherPlugin = () => {
 
         /**
          * PAGE VIEW ENRICHMENT - Runs after identity context injection
-         * Returns the complete request body for pageview events
-         * @returns {DotCMSAnalyticsRequestBody} Complete request body ready to send
+         * Returns enriched payload with page, utm, and custom data added
+         * @returns {EnrichedAnalyticsPayload} Enriched payload ready for event creation
          */
         'page:dot-analytics': ({
             payload
         }: {
             payload: AnalyticsBasePayloadWithContext;
-        }): DotCMSAnalyticsRequestBody => {
-            const { context, page, utm, custom, local_time } = enrichPagePayloadOptimized(payload);
+        }): EnrichedAnalyticsPayload => {
+            const enrichedData = enrichPagePayloadOptimized(payload);
 
-            if (!page) {
+            if (!enrichedData.page) {
                 throw new Error('DotCMS Analytics: Missing required page data');
             }
 
-            return {
-                context,
-                events: [
-                    {
-                        event_type: DotCMSPredefinedEventType.PAGEVIEW,
-                        local_time,
-                        data: {
-                            page,
-                            ...(utm && { utm }),
-                            ...(custom && { custom })
-                        }
-                    }
-                ]
-            };
+            return enrichedData;
         },
 
         /**
          * TRACK EVENT ENRICHMENT - Runs after identity context injection
-         * Returns the complete request body for custom events
-         * @returns {DotCMSAnalyticsRequestBody} Complete request body ready to send
+         * Returns enriched payload with page data added for content_impression events
+         *
+         * For content_impression events:
+         * - Producer plugins send only { content, position }
+         * - This enricher adds page data automatically
+         *
+         * For other events:
+         * - Just pass through the payload as-is
+         *
+         * @returns {EnrichedTrackPayload} Enriched payload ready for event creation
          */
         'track:dot-analytics': ({
             payload
         }: {
             payload: AnalyticsTrackPayloadWithContext;
-        }): DotCMSAnalyticsRequestBody => {
-            const { event, properties, context } = payload;
-            const local_time = getLocalTime();
+        }): EnrichedTrackPayload => {
+            const { event, properties } = payload;
+
+            // For content_impression events, add page data
+            if (event === DotCMSPredefinedEventType.CONTENT_IMPRESSION) {
+                const impressionPayload = properties as DotCMSContentImpressionPayload;
+                const { page, local_time } = enrichPagePayloadOptimized(payload);
+
+                return {
+                    ...payload,
+                    properties: {
+                        ...impressionPayload,
+                        page
+                    },
+                    page,
+                    local_time
+                };
+            }
+
+            // For all other events, just pass through
+            const { page, utm, custom, local_time } = enrichPagePayloadOptimized(payload);
 
             return {
-                context,
-                events: [
-                    {
-                        event_type: event,
-                        local_time,
-                        data: {
-                            custom: properties
-                        }
-                    }
-                ]
+                ...payload,
+                page,
+                ...(utm && { utm }),
+                ...(custom && { custom }),
+                local_time
             };
         }
     };

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts
@@ -3,7 +3,6 @@ import { enrichPagePayloadOptimized, getLocalTime } from '../../shared/dot-conte
 import {
     AnalyticsBasePayloadWithContext,
     AnalyticsTrackPayloadWithContext,
-    DotCMSContentImpressionPayload,
     EnrichedAnalyticsPayload,
     EnrichedTrackPayload
 } from '../../shared/models';
@@ -43,35 +42,23 @@ export const dotAnalyticsEnricherPlugin = () => {
 
         /**
          * TRACK EVENT ENRICHMENT - Runs after identity context injection
-         * Adds data to the root of the payload based on event type to avoid duplication.
+         * Adds page data and timestamp for predefined events.
+         * For custom events, only adds timestamp.
          *
-         * For content_impression events:
-         * - Extracts content and position from properties to root
-         * - Adds minimal page data (title, url) to root
-         *
-         * For custom events:
-         * - Only adds local_time (properties are passed as-is)
-         *
-         * @returns {EnrichedTrackPayload} Enriched payload ready for event creation
+         * @returns {EnrichedTrackPayload} Enriched payload ready for event structuring
          */
         'track:dot-analytics': ({
             payload
         }: {
             payload: AnalyticsTrackPayloadWithContext;
         }): EnrichedTrackPayload => {
-            const { event, properties } = payload;
+            const { event } = payload;
             const local_time = getLocalTime();
 
-            // For content_impression events, extract fields to root level
+            // For content_impression events, add page data
             if (event === DotCMSPredefinedEventType.CONTENT_IMPRESSION) {
-                const impressionPayload = properties as DotCMSContentImpressionPayload;
-
                 return {
                     ...payload,
-                    // Extract content and position to root (no duplication)
-                    content: impressionPayload.content,
-                    position: impressionPayload.position,
-                    // Add minimal page data to root
                     page: {
                         title: document.title,
                         url: window.location.href

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts
@@ -3,25 +3,10 @@ import { enrichPagePayloadOptimized, getLocalTime } from '../../shared/dot-conte
 import {
     AnalyticsBasePayloadWithContext,
     AnalyticsTrackPayloadWithContext,
-    DotCMSContentImpressionPageData,
     DotCMSContentImpressionPayload,
-    DotCMSEventPageData,
-    DotCMSEventUtmData,
-    EnrichedAnalyticsPayload
+    EnrichedAnalyticsPayload,
+    EnrichedTrackPayload
 } from '../../shared/models';
-
-/**
- * Enriched payload interface for track events.
- * Fields are added to the root based on event type to avoid duplication.
- */
-export interface EnrichedTrackPayload extends AnalyticsTrackPayloadWithContext {
-    local_time: string;
-    // Optional fields added based on event type
-    page?: DotCMSContentImpressionPageData | DotCMSEventPageData;
-    content?: DotCMSContentImpressionPayload['content'];
-    position?: DotCMSContentImpressionPayload['position'];
-    utm?: DotCMSEventUtmData;
-}
 
 /**
  * Plugin that enriches the analytics payload data with page, UTM, and custom data.

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.plugin.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.plugin.spec.ts
@@ -1,0 +1,412 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { AnalyticsInstance } from 'analytics';
+
+import { dotAnalyticsImpressionPlugin } from './dot-analytics.impression.plugin';
+
+import {
+    DotCMSImpressionTracker,
+    ImpressionSubscription
+} from '../../shared/dot-content-analytics.impression-tracker';
+import { IMPRESSION_EVENT_TYPE } from '../../shared/constants';
+import { DotCMSAnalyticsConfig } from '../../shared/models';
+
+// Mock the tracker
+jest.mock('../../shared/dot-content-analytics.impression-tracker');
+
+describe('dotAnalyticsImpressionPlugin', () => {
+    let mockConfig: DotCMSAnalyticsConfig;
+    let mockAnalyticsInstance: AnalyticsInstance;
+    let mockTracker: jest.Mocked<DotCMSImpressionTracker>;
+    let mockSubscription: jest.Mocked<ImpressionSubscription>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        // Mock config
+        mockConfig = {
+            server: 'https://test.com',
+            siteAuth: 'test-key',
+            debug: false,
+            impressions: true
+        };
+
+        // Mock analytics instance
+        mockAnalyticsInstance = {
+            track: jest.fn()
+        } as any;
+
+        // Mock subscription
+        mockSubscription = {
+            unsubscribe: jest.fn()
+        };
+
+        // Mock tracker instance
+        mockTracker = {
+            initialize: jest.fn(),
+            cleanup: jest.fn(),
+            onImpression: jest.fn().mockReturnValue(mockSubscription)
+        } as any;
+
+        // Mock tracker constructor
+        (DotCMSImpressionTracker as jest.Mock).mockImplementation(() => mockTracker);
+    });
+
+    describe('Plugin Configuration', () => {
+        it('should have correct plugin name', () => {
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            expect(plugin.name).toBe('dot-analytics-impression');
+        });
+
+        it('should expose initialize and loaded methods', () => {
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            expect(plugin).toHaveProperty('initialize');
+            expect(plugin).toHaveProperty('loaded');
+            expect(typeof plugin.initialize).toBe('function');
+            expect(typeof plugin.loaded).toBe('function');
+        });
+    });
+
+    describe('Initialization', () => {
+        it('should initialize tracker when impressions is enabled', async () => {
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            expect(DotCMSImpressionTracker).toHaveBeenCalledWith(mockConfig);
+            expect(mockTracker.initialize).toHaveBeenCalled();
+        });
+
+        it('should NOT initialize when impressions is false', async () => {
+            mockConfig.impressions = false;
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            expect(DotCMSImpressionTracker).not.toHaveBeenCalled();
+            expect(mockTracker.initialize).not.toHaveBeenCalled();
+        });
+
+        it('should NOT initialize when impressions is undefined', async () => {
+            mockConfig.impressions = undefined;
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            expect(DotCMSImpressionTracker).not.toHaveBeenCalled();
+            expect(mockTracker.initialize).not.toHaveBeenCalled();
+        });
+
+        it('should initialize with custom impression config object', async () => {
+            const customConfig: DotCMSAnalyticsConfig = {
+                ...mockConfig,
+                impressions: {
+                    dwellMs: 5000,
+                    visibilityThreshold: 0.75
+                }
+            };
+
+            const plugin = dotAnalyticsImpressionPlugin(customConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            expect(DotCMSImpressionTracker).toHaveBeenCalledWith(customConfig);
+            expect(mockTracker.initialize).toHaveBeenCalled();
+        });
+
+        it('should subscribe to impression events', async () => {
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            expect(mockTracker.onImpression).toHaveBeenCalledWith(expect.any(Function));
+        });
+
+        it('should call instance.track() when impression fires', async () => {
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            // Get the callback passed to onImpression
+            const impressionCallback = mockTracker.onImpression.mock.calls[0][0];
+
+            // Simulate impression event
+            const impressionPayload = {
+                content: {
+                    identifier: 'content-123',
+                    inode: 'inode-456',
+                    title: 'Test Content',
+                    content_type: 'Blog'
+                },
+                position: {
+                    viewport_offset_pct: 50,
+                    dom_index: 0
+                }
+            };
+
+            impressionCallback(IMPRESSION_EVENT_TYPE, impressionPayload);
+
+            // Verify analytics.track was called
+            expect(mockAnalyticsInstance.track).toHaveBeenCalledWith(
+                IMPRESSION_EVENT_TYPE,
+                impressionPayload
+            );
+        });
+
+        it('should log debug message when impressions enabled in debug mode', async () => {
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+            mockConfig.debug = true;
+
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                'DotCMS Analytics: Impression tracking plugin initialized'
+            );
+
+            consoleWarnSpy.mockRestore();
+        });
+
+        it('should log debug message when impressions disabled in debug mode', async () => {
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+            mockConfig.debug = true;
+            mockConfig.impressions = false;
+
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                'DotCMS Analytics: Impression tracking disabled (config.impressions not set)'
+            );
+
+            consoleWarnSpy.mockRestore();
+        });
+
+        it('should return resolved promise', async () => {
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            const result = await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            expect(result).toBeUndefined();
+        });
+    });
+
+    describe('Loaded Hook', () => {
+        it('should setup cleanup handlers on beforeunload', async () => {
+            const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+            await plugin.initialize({ instance: mockAnalyticsInstance }); // Initialize first
+            plugin.loaded();
+
+            expect(addEventListenerSpy).toHaveBeenCalledWith('beforeunload', expect.any(Function));
+
+            addEventListenerSpy.mockRestore();
+        });
+
+        it('should setup cleanup handlers on pagehide', async () => {
+            const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+            await plugin.initialize({ instance: mockAnalyticsInstance }); // Initialize first
+            plugin.loaded();
+
+            expect(addEventListenerSpy).toHaveBeenCalledWith('pagehide', expect.any(Function));
+
+            addEventListenerSpy.mockRestore();
+        });
+
+        it('should return true when loaded', () => {
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            const result = plugin.loaded();
+
+            expect(result).toBe(true);
+        });
+
+        it('should not setup handlers if window is undefined (SSR)', () => {
+            const originalWindow = global.window;
+            delete (global as any).window;
+
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+            const result = plugin.loaded();
+
+            expect(result).toBe(true);
+
+            // Restore
+            (global as any).window = originalWindow;
+        });
+    });
+
+    describe('Cleanup', () => {
+        it('should unsubscribe and cleanup tracker on page unload', async () => {
+            let unloadCallback: (() => void) | undefined;
+            const addEventListenerSpy = jest
+                .spyOn(window, 'addEventListener')
+                .mockImplementation((event, handler) => {
+                    if (event === 'beforeunload') {
+                        unloadCallback = handler as () => void;
+                    }
+                });
+
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            // Initialize to create tracker
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            // Setup cleanup handlers
+            plugin.loaded();
+
+            // Simulate page unload
+            expect(unloadCallback).toBeDefined();
+            unloadCallback!();
+
+            // Verify cleanup
+            expect(mockSubscription.unsubscribe).toHaveBeenCalled();
+            expect(mockTracker.cleanup).toHaveBeenCalled();
+
+            addEventListenerSpy.mockRestore();
+        });
+
+        it('should handle cleanup when tracker is not initialized', async () => {
+            let unloadCallback: (() => void) | undefined;
+            const addEventListenerSpy = jest
+                .spyOn(window, 'addEventListener')
+                .mockImplementation((event, handler) => {
+                    if (event === 'beforeunload') {
+                        unloadCallback = handler as () => void;
+                    }
+                });
+
+            mockConfig.impressions = false;
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            // Initialize (but tracker won't be created)
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+
+            // Setup cleanup handlers
+            plugin.loaded();
+
+            // When tracker is not initialized, no callback is registered
+            // This is expected behavior - no cleanup needed if no tracker
+            expect(unloadCallback).toBeUndefined();
+
+            addEventListenerSpy.mockRestore();
+        });
+
+        it('should log debug message on cleanup in debug mode', async () => {
+            let unloadCallback: (() => void) | undefined;
+            const addEventListenerSpy = jest
+                .spyOn(window, 'addEventListener')
+                .mockImplementation((event, handler) => {
+                    if (event === 'beforeunload') {
+                        unloadCallback = handler as () => void;
+                    }
+                });
+
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+            mockConfig.debug = true;
+
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+            plugin.loaded();
+
+            // Simulate page unload
+            unloadCallback!();
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                'DotCMS Analytics: Impression tracking cleaned up on page unload'
+            );
+
+            addEventListenerSpy.mockRestore();
+            consoleWarnSpy.mockRestore();
+        });
+
+        it('should register cleanup handlers for both beforeunload and pagehide events', async () => {
+            const eventHandlers: { [key: string]: (() => void)[] } = {};
+            const addEventListenerSpy = jest
+                .spyOn(window, 'addEventListener')
+                .mockImplementation((event: string, handler) => {
+                    const eventName = event as string;
+                    if (!eventHandlers[eventName]) {
+                        eventHandlers[eventName] = [];
+                    }
+                    eventHandlers[eventName].push(handler as () => void);
+                });
+
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+            plugin.loaded();
+
+            // Verify both events are registered with the same cleanup function
+            expect(eventHandlers['beforeunload']).toBeDefined();
+            expect(eventHandlers['pagehide']).toBeDefined();
+            expect(eventHandlers['beforeunload'].length).toBe(1);
+            expect(eventHandlers['pagehide'].length).toBe(1);
+
+            // Trigger beforeunload
+            eventHandlers['beforeunload'][0]();
+            expect(mockTracker.cleanup).toHaveBeenCalledTimes(1);
+            expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+
+            // Trigger pagehide - cleanup is idempotent (tracker already null)
+            // So cleanup() won't be called again, but the handler runs
+            eventHandlers['pagehide'][0]();
+            // Still only 1 because impressionTracker becomes null after first cleanup
+            expect(mockTracker.cleanup).toHaveBeenCalledTimes(1);
+            expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+
+            addEventListenerSpy.mockRestore();
+        });
+    });
+
+    describe('Integration Flow', () => {
+        it('should complete full lifecycle: initialize -> impression -> cleanup', async () => {
+            let unloadCallback: (() => void) | undefined;
+            const addEventListenerSpy = jest
+                .spyOn(window, 'addEventListener')
+                .mockImplementation((event, handler) => {
+                    if (event === 'beforeunload') {
+                        unloadCallback = handler as () => void;
+                    }
+                });
+
+            const plugin = dotAnalyticsImpressionPlugin(mockConfig);
+
+            // Step 1: Initialize
+            await plugin.initialize({ instance: mockAnalyticsInstance });
+            expect(mockTracker.initialize).toHaveBeenCalled();
+            expect(mockTracker.onImpression).toHaveBeenCalled();
+
+            // Step 2: Setup cleanup
+            plugin.loaded();
+
+            // Step 3: Simulate impression
+            const impressionCallback = mockTracker.onImpression.mock.calls[0][0];
+            impressionCallback(IMPRESSION_EVENT_TYPE, {
+                content: {
+                    identifier: 'test-123',
+                    inode: 'inode',
+                    title: 'Test',
+                    content_type: 'Blog'
+                },
+                position: { viewport_offset_pct: 50, dom_index: 0 }
+            });
+
+            expect(mockAnalyticsInstance.track).toHaveBeenCalled();
+
+            // Step 4: Cleanup
+            unloadCallback!();
+            expect(mockSubscription.unsubscribe).toHaveBeenCalled();
+            expect(mockTracker.cleanup).toHaveBeenCalled();
+
+            addEventListenerSpy.mockRestore();
+        });
+    });
+});

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.plugin.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.plugin.spec.ts
@@ -4,11 +4,11 @@ import { AnalyticsInstance } from 'analytics';
 
 import { dotAnalyticsImpressionPlugin } from './dot-analytics.impression.plugin';
 
+import { IMPRESSION_EVENT_TYPE } from '../../shared/constants';
 import {
     DotCMSImpressionTracker,
     ImpressionSubscription
 } from '../../shared/dot-content-analytics.impression-tracker';
-import { IMPRESSION_EVENT_TYPE } from '../../shared/constants';
 import { DotCMSAnalyticsConfig } from '../../shared/models';
 
 // Mock the tracker
@@ -263,6 +263,7 @@ describe('dotAnalyticsImpressionPlugin', () => {
 
             // Simulate page unload
             expect(unloadCallback).toBeDefined();
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             unloadCallback!();
 
             // Verify cleanup
@@ -317,6 +318,7 @@ describe('dotAnalyticsImpressionPlugin', () => {
             plugin.loaded();
 
             // Simulate page unload
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             unloadCallback!();
 
             expect(consoleWarnSpy).toHaveBeenCalledWith(
@@ -402,6 +404,7 @@ describe('dotAnalyticsImpressionPlugin', () => {
             expect(mockAnalyticsInstance.track).toHaveBeenCalled();
 
             // Step 4: Cleanup
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             unloadCallback!();
             expect(mockSubscription.unsubscribe).toHaveBeenCalled();
             expect(mockTracker.cleanup).toHaveBeenCalled();

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.plugin.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.plugin.ts
@@ -1,0 +1,97 @@
+import { AnalyticsInstance } from 'analytics';
+
+import {
+    cleanupImpressionTracking,
+    initializeImpressionTracking
+} from './dot-analytics.impression.utils';
+
+import { DotCMSAnalyticsConfig } from '../../shared/models';
+
+/**
+ * Type for the impression tracker instance
+ */
+type ImpressionTracker = ReturnType<typeof initializeImpressionTracking>;
+
+/**
+ * Impression Plugin for DotAnalytics
+ * Handles automatic tracking of content visibility and impressions.
+ * Only activates when config.impressions is enabled (true or config object).
+ *
+ * This plugin initializes the impression tracker which:
+ * - Uses IntersectionObserver to detect when contentlets are visible
+ * - Tracks dwell time (how long elements are visible)
+ * - Fires 'content-impression' events via instance.track()
+ * - Deduplicates impressions per session
+ *
+ * Plugin execution in Analytics.js pipeline:
+ * 1. Identity Plugin - Injects context
+ * 2. Enricher Plugin - Enriches event data
+ * 3. Main Plugin - Sends to queue/server
+ * 4. Impression Plugin - Runs independently, fires events via instance.track()
+ *
+ * @param {DotCMSAnalyticsConfig} config - Configuration with impressions settings
+ * @returns {Object} Plugin object with lifecycle methods
+ */
+export const dotAnalyticsImpressionPlugin = (config: DotCMSAnalyticsConfig) => {
+    let impressionTracker: ImpressionTracker | null = null;
+
+    return {
+        name: 'dot-analytics-impression',
+
+        /**
+         * Initialize impression tracking if enabled
+         * Called when Analytics.js initializes the plugin with instance context
+         * @param instance - Analytics.js instance with track method
+         */
+        initialize: ({ instance }: { instance: AnalyticsInstance }) => {
+            // Only initialize if impressions config exists
+            // Can be true (use defaults) or an object (custom config)
+            if (config.impressions) {
+                // Pass instance.track directly - simpler and more efficient
+                // Bind to maintain proper context when called from tracker
+                impressionTracker = initializeImpressionTracking(
+                    config,
+                    instance.track.bind(instance)
+                );
+
+                if (config.debug) {
+                    console.warn('DotCMS Analytics: Impression tracking plugin initialized');
+                }
+            } else if (config.debug) {
+                console.warn(
+                    'DotCMS Analytics: Impression tracking disabled (config.impressions not set)'
+                );
+            }
+
+            return Promise.resolve();
+        },
+
+        /**
+         * Setup cleanup handlers when plugin is loaded
+         * Called after Analytics.js completes plugin loading
+         */
+        loaded: () => {
+            if (typeof window !== 'undefined' && impressionTracker) {
+                const cleanup = () => {
+                    if (impressionTracker) {
+                        cleanupImpressionTracking(impressionTracker);
+                        impressionTracker = null;
+
+                        if (config.debug) {
+                            console.warn(
+                                'DotCMS Analytics: Impression tracking cleaned up on page unload'
+                            );
+                        }
+                    }
+                };
+
+                // Cleanup on page unload
+                // Use both events for maximum compatibility
+                window.addEventListener('beforeunload', cleanup);
+                window.addEventListener('pagehide', cleanup);
+            }
+
+            return true;
+        }
+    };
+};

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.utils.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.utils.spec.ts
@@ -1,0 +1,606 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import {
+    calculateElementVisibilityRatio,
+    calculateViewportOffset,
+    createDebounce,
+    extractContentletData,
+    extractContentletIdentifier,
+    getViewportMetrics,
+    isElementMeetingVisibilityThreshold
+} from './dot-analytics.impression.utils';
+
+describe('Impression Tracking Utils', () => {
+    // Helper function to create mock element with getBoundingClientRect
+    const createMockElement = (rect: Partial<DOMRect>, dataset: Record<string, string> = {}) => {
+        const element = {
+            getBoundingClientRect: jest.fn(() => ({
+                top: 0,
+                left: 0,
+                bottom: 0,
+                right: 0,
+                width: 0,
+                height: 0,
+                x: 0,
+                y: 0,
+                toJSON: () => ({}),
+                ...rect
+            })),
+            dataset
+        } as unknown as HTMLElement;
+
+        return element;
+    };
+
+    // Save original values
+    let originalInnerHeight: number;
+    let originalInnerWidth: number;
+
+    beforeEach(() => {
+        // Save originals
+        originalInnerHeight = window.innerHeight;
+        originalInnerWidth = window.innerWidth;
+
+        // Set default viewport size
+        Object.defineProperty(window, 'innerHeight', { value: 1000, writable: true });
+        Object.defineProperty(window, 'innerWidth', { value: 1000, writable: true });
+
+        // Mock document.documentElement if needed
+        Object.defineProperty(document.documentElement, 'clientHeight', {
+            value: 1000,
+            writable: true,
+            configurable: true
+        });
+        Object.defineProperty(document.documentElement, 'clientWidth', {
+            value: 1000,
+            writable: true,
+            configurable: true
+        });
+    });
+
+    afterEach(() => {
+        // Restore originals
+        Object.defineProperty(window, 'innerHeight', {
+            value: originalInnerHeight,
+            writable: true
+        });
+        Object.defineProperty(window, 'innerWidth', {
+            value: originalInnerWidth,
+            writable: true
+        });
+    });
+
+    describe('calculateElementVisibilityRatio', () => {
+        it('should return 1.0 for fully visible element', () => {
+            // Element fully visible in 1000x1000 viewport
+            const element = createMockElement({
+                top: 100,
+                left: 100,
+                bottom: 300,
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            expect(ratio).toBe(1);
+        });
+
+        it('should return 0.5 for element half visible from bottom', () => {
+            // Element: 200x200, top at 900 (100px visible from bottom)
+            const element = createMockElement({
+                top: 900,
+                left: 100,
+                bottom: 1100, // Extends beyond viewport
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            // Visible area: 100px height * 200px width = 20,000
+            // Total area: 200px * 200px = 40,000
+            // Ratio: 20,000 / 40,000 = 0.5
+            expect(ratio).toBe(0.5);
+        });
+
+        it('should return 0.5 for element half visible from top', () => {
+            // Element extends above viewport
+            const element = createMockElement({
+                top: -100, // Starts above viewport
+                left: 100,
+                bottom: 100,
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            // Visible height: 100px (from 0 to 100)
+            // Total area: 200 * 200 = 40,000
+            // Visible area: 100 * 200 = 20,000
+            expect(ratio).toBe(0.5);
+        });
+
+        it('should return 0 for element completely above viewport', () => {
+            const element = createMockElement({
+                top: -300,
+                left: 100,
+                bottom: -100,
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            expect(ratio).toBe(0);
+        });
+
+        it('should return 0 for element completely below viewport', () => {
+            const element = createMockElement({
+                top: 1100,
+                left: 100,
+                bottom: 1300,
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            expect(ratio).toBe(0);
+        });
+
+        it('should return 0 for element completely to the left of viewport', () => {
+            const element = createMockElement({
+                top: 100,
+                left: -300,
+                bottom: 300,
+                right: -100,
+                width: 200,
+                height: 200
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            expect(ratio).toBe(0);
+        });
+
+        it('should return 0 for element completely to the right of viewport', () => {
+            const element = createMockElement({
+                top: 100,
+                left: 1100,
+                bottom: 300,
+                right: 1300,
+                width: 200,
+                height: 200
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            expect(ratio).toBe(0);
+        });
+
+        it('should return 0.25 for element partially visible from corner', () => {
+            // Element in bottom-right corner, 50% height and 50% width visible
+            const element = createMockElement({
+                top: 900,
+                left: 900,
+                bottom: 1100,
+                right: 1100,
+                width: 200,
+                height: 200
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            // Visible: 100px * 100px = 10,000
+            // Total: 200px * 200px = 40,000
+            // Ratio: 10,000 / 40,000 = 0.25
+            expect(ratio).toBe(0.25);
+        });
+
+        it('should handle zero area elements', () => {
+            const element = createMockElement({
+                top: 100,
+                left: 100,
+                bottom: 100,
+                right: 100,
+                width: 0,
+                height: 0
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            expect(ratio).toBe(0);
+        });
+
+        it('should handle very large elements (larger than viewport)', () => {
+            // Element larger than viewport but fully covering it
+            const element = createMockElement({
+                top: -500,
+                left: -500,
+                bottom: 1500,
+                right: 1500,
+                width: 2000,
+                height: 2000
+            });
+
+            const ratio = calculateElementVisibilityRatio(element);
+
+            // Visible area: 1000 * 1000 = 1,000,000
+            // Total area: 2000 * 2000 = 4,000,000
+            // Ratio: 1,000,000 / 4,000,000 = 0.25
+            expect(ratio).toBe(0.25);
+        });
+    });
+
+    describe('calculateViewportOffset', () => {
+        it('should return 0% for element at viewport top', () => {
+            const element = createMockElement({
+                top: 0,
+                bottom: 200,
+                height: 200
+            });
+
+            const offset = calculateViewportOffset(element);
+
+            expect(offset).toBe(0);
+        });
+
+        it('should return 50% for element at viewport middle', () => {
+            const element = createMockElement({
+                top: 500,
+                bottom: 700,
+                height: 200
+            });
+
+            const offset = calculateViewportOffset(element);
+
+            // 500 / 1000 * 100 = 50%
+            expect(offset).toBe(50);
+        });
+
+        it('should return 100% for element at viewport bottom', () => {
+            const element = createMockElement({
+                top: 1000,
+                bottom: 1200,
+                height: 200
+            });
+
+            const offset = calculateViewportOffset(element);
+
+            expect(offset).toBe(100);
+        });
+
+        it('should return negative value for element above viewport', () => {
+            const element = createMockElement({
+                top: -200,
+                bottom: 0,
+                height: 200
+            });
+
+            const offset = calculateViewportOffset(element);
+
+            // -200 / 1000 * 100 = -20%
+            expect(offset).toBe(-20);
+        });
+
+        it('should round to 2 decimal places', () => {
+            const element = createMockElement({
+                top: 333.333,
+                bottom: 533.333,
+                height: 200
+            });
+
+            const offset = calculateViewportOffset(element);
+
+            // 333.333 / 1000 * 100 = 33.3333, rounded to 33.33
+            expect(offset).toBe(33.33);
+        });
+    });
+
+    describe('isElementMeetingVisibilityThreshold', () => {
+        it('should return true when visibility meets threshold exactly', () => {
+            const element = createMockElement({
+                top: 500,
+                left: 100,
+                bottom: 700,
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            const result = isElementMeetingVisibilityThreshold(element, 1.0);
+
+            expect(result).toBe(true);
+        });
+
+        it('should return true when visibility exceeds threshold', () => {
+            const element = createMockElement({
+                top: 100,
+                left: 100,
+                bottom: 300,
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            const result = isElementMeetingVisibilityThreshold(element, 0.5);
+
+            expect(result).toBe(true);
+        });
+
+        it('should return false when visibility is below threshold', () => {
+            const element = createMockElement({
+                top: 900,
+                left: 100,
+                bottom: 1100,
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            // Visibility ratio is 0.5, threshold is 0.6
+            const result = isElementMeetingVisibilityThreshold(element, 0.6);
+
+            expect(result).toBe(false);
+        });
+
+        it('should return false for completely hidden element', () => {
+            const element = createMockElement({
+                top: 1100,
+                left: 100,
+                bottom: 1300,
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            const result = isElementMeetingVisibilityThreshold(element, 0.1);
+
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('getViewportMetrics', () => {
+        it('should return both offset percentage and visibility ratio', () => {
+            const element = createMockElement({
+                top: 500,
+                left: 100,
+                bottom: 700,
+                right: 300,
+                width: 200,
+                height: 200
+            });
+
+            const metrics = getViewportMetrics(element);
+
+            expect(metrics).toEqual({
+                offsetPercentage: 50, // top 500 / viewport 1000 * 100
+                visibilityRatio: 1 // Fully visible
+            });
+        });
+
+        it('should calculate metrics for partially visible element', () => {
+            const element = createMockElement({
+                top: 900,
+                left: 900,
+                bottom: 1100,
+                right: 1100,
+                width: 200,
+                height: 200
+            });
+
+            const metrics = getViewportMetrics(element);
+
+            expect(metrics).toEqual({
+                offsetPercentage: 90,
+                visibilityRatio: 0.25 // 25% visible
+            });
+        });
+    });
+
+    describe('createDebounce', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('should delay function execution', () => {
+            const callback = jest.fn();
+            const debouncedFn = createDebounce(callback, 300);
+
+            debouncedFn();
+
+            expect(callback).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(300);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should cancel previous call when called again', () => {
+            const callback = jest.fn();
+            const debouncedFn = createDebounce(callback, 300);
+
+            debouncedFn();
+            jest.advanceTimersByTime(100);
+
+            debouncedFn();
+            jest.advanceTimersByTime(100);
+
+            debouncedFn();
+            jest.advanceTimersByTime(100);
+
+            // Still not called because we keep resetting the timer
+            expect(callback).not.toHaveBeenCalled();
+
+            // Now wait the full delay
+            jest.advanceTimersByTime(200);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should only execute callback once after multiple rapid calls', () => {
+            const callback = jest.fn();
+            const debouncedFn = createDebounce(callback, 300);
+
+            // Rapid fire calls
+            debouncedFn();
+            debouncedFn();
+            debouncedFn();
+            debouncedFn();
+
+            jest.advanceTimersByTime(300);
+
+            // Should only execute once
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should allow multiple executions if separated by delay', () => {
+            const callback = jest.fn();
+            const debouncedFn = createDebounce(callback, 300);
+
+            debouncedFn();
+            jest.advanceTimersByTime(300);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+
+            debouncedFn();
+            jest.advanceTimersByTime(300);
+
+            expect(callback).toHaveBeenCalledTimes(2);
+        });
+
+        it('should work with zero delay', () => {
+            const callback = jest.fn();
+            const debouncedFn = createDebounce(callback, 0);
+
+            debouncedFn();
+
+            expect(callback).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(0);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('extractContentletIdentifier', () => {
+        it('should extract identifier from data attribute', () => {
+            const element = createMockElement({}, { dotAnalyticsIdentifier: 'content-123' });
+
+            const identifier = extractContentletIdentifier(element);
+
+            expect(identifier).toBe('content-123');
+        });
+
+        it('should return null when identifier is not present', () => {
+            const element = createMockElement({}, {});
+
+            const identifier = extractContentletIdentifier(element);
+
+            expect(identifier).toBeNull();
+        });
+
+        it('should return null when identifier is empty string', () => {
+            const element = createMockElement({}, { dotAnalyticsIdentifier: '' });
+
+            const identifier = extractContentletIdentifier(element);
+
+            // Empty string is falsy, so it returns null
+            expect(identifier).toBeNull();
+        });
+    });
+
+    describe('extractContentletData', () => {
+        it('should extract all contentlet data from element', () => {
+            const element = createMockElement(
+                {},
+                {
+                    dotAnalyticsIdentifier: 'content-123',
+                    dotAnalyticsInode: 'inode-456',
+                    dotAnalyticsContenttype: 'Blog',
+                    dotAnalyticsTitle: 'My Blog Post',
+                    dotAnalyticsBasetype: 'CONTENT'
+                }
+            );
+
+            const data = extractContentletData(element);
+
+            expect(data).toEqual({
+                identifier: 'content-123',
+                inode: 'inode-456',
+                contentType: 'Blog',
+                title: 'My Blog Post',
+                baseType: 'CONTENT'
+            });
+        });
+
+        it('should return empty strings for missing attributes', () => {
+            const element = createMockElement({}, {});
+
+            const data = extractContentletData(element);
+
+            expect(data).toEqual({
+                identifier: '',
+                inode: '',
+                contentType: '',
+                title: '',
+                baseType: ''
+            });
+        });
+
+        it('should handle partial data', () => {
+            const element = createMockElement(
+                {},
+                {
+                    dotAnalyticsIdentifier: 'content-123',
+                    dotAnalyticsTitle: 'My Post'
+                    // Missing other attributes
+                }
+            );
+
+            const data = extractContentletData(element);
+
+            expect(data).toEqual({
+                identifier: 'content-123',
+                inode: '',
+                contentType: '',
+                title: 'My Post',
+                baseType: ''
+            });
+        });
+
+        it('should handle special characters in data attributes', () => {
+            const element = createMockElement(
+                {},
+                {
+                    dotAnalyticsIdentifier: 'content-123-abc',
+                    dotAnalyticsInode: 'inode_456_def',
+                    dotAnalyticsContenttype: 'Blog/News',
+                    dotAnalyticsTitle: 'My Blog Post: The "Best" Guide',
+                    dotAnalyticsBasetype: 'CONTENT_TYPE'
+                }
+            );
+
+            const data = extractContentletData(element);
+
+            expect(data).toEqual({
+                identifier: 'content-123-abc',
+                inode: 'inode_456_def',
+                contentType: 'Blog/News',
+                title: 'My Blog Post: The "Best" Guide',
+                baseType: 'CONTENT_TYPE'
+            });
+        });
+    });
+});

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.utils.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.utils.ts
@@ -3,14 +3,7 @@
  * Pure functions without class dependencies for better testability and reusability
  */
 
-import { DotCMSImpressionTracker } from '../../shared/dot-content-analytics.impression-tracker';
-import { DotCMSAnalyticsConfig, ViewportMetrics } from '../../shared/models';
-
-/**
- * Type for the track function from analytics instance.
- * This is the minimal interface needed by producer plugins to emit events.
- */
-export type AnalyticsTrackFn = (eventName: string, properties?: Record<string, unknown>) => void;
+import { ViewportMetrics } from '../../shared/models';
 
 /**
  * Calculates the visibility ratio of an element in the viewport
@@ -126,27 +119,3 @@ export function extractContentletData(element: HTMLElement): {
         baseType: element.dataset.dotAnalyticsBasetype || ''
     };
 }
-
-/**
- * Initializes impression tracking with the provided analytics track function
- * @param config - Analytics configuration
- * @param track - The analytics.track function from the Analytics.js instance
- * @returns Initialized impression tracker instance
- */
-export const initializeImpressionTracking = (
-    config: DotCMSAnalyticsConfig,
-    track: AnalyticsTrackFn
-): DotCMSImpressionTracker => {
-    const tracker = new DotCMSImpressionTracker(config, track);
-    tracker.initialize();
-    return tracker;
-};
-
-/**
- * Cleans up impression tracking
- */
-export const cleanupImpressionTracking = (tracker: DotCMSImpressionTracker | null): void => {
-    if (tracker) {
-        tracker.cleanup();
-    }
-};

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.utils.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.utils.ts
@@ -1,0 +1,152 @@
+/**
+ * Utility functions for impression tracking
+ * Pure functions without class dependencies for better testability and reusability
+ */
+
+import { DotCMSImpressionTracker } from '../../shared/dot-content-analytics.impression-tracker';
+import { DotCMSAnalyticsConfig, ViewportMetrics } from '../../shared/models';
+
+/**
+ * Type for the track function from analytics instance.
+ * This is the minimal interface needed by producer plugins to emit events.
+ */
+export type AnalyticsTrackFn = (eventName: string, properties?: Record<string, unknown>) => void;
+
+/**
+ * Calculates the visibility ratio of an element in the viewport
+ * @param element - The HTML element to check
+ * @returns A number between 0 and 1 representing the visible percentage
+ */
+export function calculateElementVisibilityRatio(element: HTMLElement): number {
+    const rect = element.getBoundingClientRect();
+    const viewHeight = window.innerHeight || document.documentElement.clientHeight;
+    const viewWidth = window.innerWidth || document.documentElement.clientWidth;
+
+    const visibleHeight = Math.min(rect.bottom, viewHeight) - Math.max(rect.top, 0);
+    const visibleWidth = Math.min(rect.right, viewWidth) - Math.max(rect.left, 0);
+
+    if (visibleHeight <= 0 || visibleWidth <= 0) {
+        return 0;
+    }
+
+    const visibleArea = visibleHeight * visibleWidth;
+    const totalArea = rect.height * rect.width;
+
+    return totalArea > 0 ? visibleArea / totalArea : 0;
+}
+
+/**
+ * Calculates the offset percentage of an element from the top of the viewport
+ * @param element - The HTML element to check
+ * @returns Percentage value (can be negative if above viewport)
+ */
+export function calculateViewportOffset(element: HTMLElement): number {
+    const rect = element.getBoundingClientRect();
+    const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+
+    const offsetPercentage = (rect.top / viewportHeight) * 100;
+    return Math.round(offsetPercentage * 100) / 100;
+}
+
+/**
+ * Checks if an element meets a specific visibility threshold
+ * @param element - The HTML element to check
+ * @param threshold - The required visibility ratio (0.0 to 1.0)
+ * @returns True if the element meets or exceeds the threshold
+ */
+export function isElementMeetingVisibilityThreshold(
+    element: HTMLElement,
+    threshold: number
+): boolean {
+    const visibilityRatio = calculateElementVisibilityRatio(element);
+    return visibilityRatio >= threshold;
+}
+
+/**
+ * Gets comprehensive viewport metrics for an element
+ * @param element - The HTML element to analyze
+ * @returns Object containing offset percentage and visibility ratio
+ */
+export function getViewportMetrics(element: HTMLElement): ViewportMetrics {
+    const visibilityRatio = calculateElementVisibilityRatio(element);
+    const offsetPercentage = calculateViewportOffset(element);
+
+    return {
+        offsetPercentage,
+        visibilityRatio
+    };
+}
+
+/**
+ * Creates a debounced version of a callback function
+ * @param callback - The function to debounce
+ * @param delayMs - The delay in milliseconds
+ * @returns A debounced function that shares the same timer reference
+ */
+export function createDebounce(callback: () => void, delayMs: number): () => void {
+    let timer: number | null = null;
+
+    return () => {
+        if (timer !== null) {
+            window.clearTimeout(timer);
+        }
+        timer = window.setTimeout(() => {
+            callback();
+            timer = null;
+        }, delayMs);
+    };
+}
+
+/**
+ * Extracts the contentlet identifier from a DOM element
+ * @param element - The HTML element containing data attributes
+ * @returns The contentlet identifier or null if not found
+ */
+export function extractContentletIdentifier(element: HTMLElement): string | null {
+    return element.dataset.dotAnalyticsIdentifier || null;
+}
+
+/**
+ * Extracts all contentlet data from a DOM element's data attributes
+ * @param element - The HTML element containing data attributes
+ * @returns Complete contentlet data object
+ */
+export function extractContentletData(element: HTMLElement): {
+    identifier: string;
+    inode: string;
+    contentType: string;
+    title: string;
+    baseType: string;
+} {
+    return {
+        identifier: element.dataset.dotAnalyticsIdentifier || '',
+        inode: element.dataset.dotAnalyticsInode || '',
+        contentType: element.dataset.dotAnalyticsContenttype || '',
+        title: element.dataset.dotAnalyticsTitle || '',
+        baseType: element.dataset.dotAnalyticsBasetype || ''
+    };
+}
+
+/**
+ * Initializes impression tracking with the provided analytics track function
+ * @param config - Analytics configuration
+ * @param track - The analytics.track function from the Analytics.js instance
+ * @returns Initialized impression tracker instance
+ */
+export const initializeImpressionTracking = (
+    config: DotCMSAnalyticsConfig,
+    track: AnalyticsTrackFn
+): DotCMSImpressionTracker => {
+    const tracker = new DotCMSImpressionTracker(config, track);
+    tracker.initialize();
+    return tracker;
+};
+
+/**
+ * Cleans up impression tracking
+ */
+export const cleanupImpressionTracking = (tracker: DotCMSImpressionTracker | null): void => {
+    if (tracker) {
+        tracker.cleanup();
+    }
+};

--- a/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/index.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/plugin/impression/index.ts
@@ -1,0 +1,2 @@
+export * from './dot-analytics.impression.plugin';
+export * from './dot-analytics.impression.utils';

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/constants/dot-content-analytics.constants.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/constants/dot-content-analytics.constants.ts
@@ -145,27 +145,13 @@ export const DEFAULT_IMPRESSION_THROTTLE_MS = 100;
 export const DEFAULT_IMPRESSION_MUTATION_OBSERVER_DEBOUNCE_MS = 250;
 
 /**
- * Minimum time remaining in milliseconds for requestIdleCallback processing
- */
-export const DEFAULT_IMPRESSION_IDLE_CALLBACK_MIN_TIME_MS = 5;
-
-/**
- * Timeout in milliseconds for requestIdleCallback
- */
-export const DEFAULT_IMPRESSION_IDLE_CALLBACK_TIMEOUT_MS = 1000;
-
-/**
- * Delay in milliseconds for resetting intersection processing flag
- */
-export const DEFAULT_IMPRESSION_PROCESSING_RESET_DELAY_MS = 100;
-
-/**
  * Default impression tracking configuration
  */
 export const DEFAULT_IMPRESSION_CONFIG = {
     visibilityThreshold: DEFAULT_IMPRESSION_VISIBILITY_THRESHOLD,
     dwellMs: DEFAULT_IMPRESSION_DWELL_MS,
-    maxNodes: DEFAULT_IMPRESSION_MAX_NODES
+    maxNodes: DEFAULT_IMPRESSION_MAX_NODES,
+    throttleMs: DEFAULT_IMPRESSION_THROTTLE_MS
 } as const;
 
 /**

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/constants/dot-content-analytics.constants.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/constants/dot-content-analytics.constants.ts
@@ -12,7 +12,8 @@ export const ANALYTICS_ENDPOINT = '/api/v1/analytics/content/event';
  * These events have specific data structures and validation
  */
 export const DotCMSPredefinedEventType = {
-    PAGEVIEW: 'pageview'
+    PAGEVIEW: 'pageview',
+    CONTENT_IMPRESSION: 'content_impression'
 } as const;
 
 /**
@@ -113,3 +114,72 @@ export const ANALYTICS_JS_DEFAULT_PROPERTIES = [
     'height',
     'referrer'
 ] as const;
+
+/**
+ * Impression tracking configuration constants
+ */
+
+/**
+ * Default minimum percentage of element that must be visible (0.0 to 1.0)
+ */
+export const DEFAULT_IMPRESSION_VISIBILITY_THRESHOLD = 0.5;
+
+/**
+ * Default minimum time in milliseconds element must be visible
+ */
+export const DEFAULT_IMPRESSION_DWELL_MS = 750;
+
+/**
+ * Default maximum number of elements to track (performance limit)
+ */
+export const DEFAULT_IMPRESSION_MAX_NODES = 100;
+
+/**
+ * Default throttle time in milliseconds for intersection callbacks
+ */
+export const DEFAULT_IMPRESSION_THROTTLE_MS = 100;
+
+/**
+ * Default debounce time in milliseconds for MutationObserver
+ */
+export const DEFAULT_IMPRESSION_MUTATION_OBSERVER_DEBOUNCE_MS = 250;
+
+/**
+ * Minimum time remaining in milliseconds for requestIdleCallback processing
+ */
+export const DEFAULT_IMPRESSION_IDLE_CALLBACK_MIN_TIME_MS = 5;
+
+/**
+ * Timeout in milliseconds for requestIdleCallback
+ */
+export const DEFAULT_IMPRESSION_IDLE_CALLBACK_TIMEOUT_MS = 1000;
+
+/**
+ * Delay in milliseconds for resetting intersection processing flag
+ */
+export const DEFAULT_IMPRESSION_PROCESSING_RESET_DELAY_MS = 100;
+
+/**
+ * Default impression tracking configuration
+ */
+export const DEFAULT_IMPRESSION_CONFIG = {
+    visibilityThreshold: DEFAULT_IMPRESSION_VISIBILITY_THRESHOLD,
+    dwellMs: DEFAULT_IMPRESSION_DWELL_MS,
+    maxNodes: DEFAULT_IMPRESSION_MAX_NODES
+} as const;
+
+/**
+ * Event type for content impressions
+ * Must match DotCMSPredefinedEventType.CONTENT_IMPRESSION
+ */
+export const IMPRESSION_EVENT_TYPE = 'content_impression';
+
+/**
+ * Session storage key for tracked impressions (deduplication)
+ */
+export const IMPRESSION_SESSION_KEY = 'dot_analytics_impressions';
+
+/**
+ * CSS class selector for trackable contentlets
+ */
+export const ANALYTICS_CONTENTLET_CLASS = 'dotcms-analytics-contentlet';

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.spec.ts
@@ -18,12 +18,6 @@ describe('DotCMS Activity Tracker', () => {
     const BASE_TIME = new Date('2024-01-01T00:00:00.000Z').getTime();
     let currentTime: number;
 
-    // Helper to advance timers and mock time
-    const advanceTime = (ms: number) => {
-        currentTime += ms;
-        jest.advanceTimersByTime(ms);
-    };
-
     beforeEach(() => {
         jest.clearAllMocks();
         currentTime = BASE_TIME;
@@ -78,7 +72,6 @@ describe('DotCMS Activity Tracker', () => {
             const originalWindow = global.window;
             delete (global as any).window;
 
-            const addEventListenerSpy = jest.fn();
             // No error should be thrown
             expect(() => initializeActivityTracking(mockConfig)).not.toThrow();
 

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.activity-tracker.spec.ts
@@ -1,0 +1,426 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { ANALYTICS_WINDOWS_ACTIVE_KEY, ANALYTICS_WINDOWS_CLEANUP_KEY } from '@dotcms/uve/internal';
+
+import { ACTIVITY_EVENTS, DEFAULT_SESSION_TIMEOUT_MINUTES } from './constants';
+import {
+    cleanupActivityTracking,
+    getLastActivity,
+    getSessionInfo,
+    initializeActivityTracking,
+    isUserInactive,
+    updateSessionActivity
+} from './dot-content-analytics.activity-tracker';
+import { DotCMSAnalyticsConfig } from './models';
+
+describe('DotCMS Activity Tracker', () => {
+    let mockConfig: DotCMSAnalyticsConfig;
+    const BASE_TIME = new Date('2024-01-01T00:00:00.000Z').getTime();
+    let currentTime: number;
+
+    // Helper to advance timers and mock time
+    const advanceTime = (ms: number) => {
+        currentTime += ms;
+        jest.advanceTimersByTime(ms);
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        currentTime = BASE_TIME;
+
+        // Use jest.spyOn to properly mock Date.now()
+        jest.spyOn(Date, 'now').mockImplementation(() => currentTime);
+
+        jest.useFakeTimers();
+
+        mockConfig = {
+            server: 'https://test.com',
+            siteAuth: 'test-key',
+            debug: false
+        };
+
+        // Clean up any previous state
+        cleanupActivityTracking();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.useRealTimers();
+        cleanupActivityTracking();
+    });
+
+    describe('Initialization', () => {
+        it('should initialize activity tracking and set up event listeners', () => {
+            const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+            const documentAddEventListenerSpy = jest.spyOn(document, 'addEventListener');
+
+            initializeActivityTracking(mockConfig);
+
+            // Should register all activity events
+            expect(addEventListenerSpy).toHaveBeenCalledTimes(ACTIVITY_EVENTS.length);
+            ACTIVITY_EVENTS.forEach((eventType) => {
+                expect(addEventListenerSpy).toHaveBeenCalledWith(eventType, expect.any(Function), {
+                    passive: true
+                });
+            });
+
+            // Should register visibility change listener
+            expect(documentAddEventListenerSpy).toHaveBeenCalledWith(
+                'visibilitychange',
+                expect.any(Function)
+            );
+
+            addEventListenerSpy.mockRestore();
+            documentAddEventListenerSpy.mockRestore();
+        });
+
+        it('should NOT initialize in SSR (no window)', () => {
+            const originalWindow = global.window;
+            delete (global as any).window;
+
+            const addEventListenerSpy = jest.fn();
+            // No error should be thrown
+            expect(() => initializeActivityTracking(mockConfig)).not.toThrow();
+
+            // Restore
+            (global as any).window = originalWindow;
+        });
+
+        it('should set initial activity time', () => {
+            const startTime = Date.now();
+            initializeActivityTracking(mockConfig);
+            const lastActivity = getLastActivity();
+
+            expect(lastActivity).toBeGreaterThanOrEqual(startTime);
+        });
+
+        it('should log debug message when debug is enabled', () => {
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+            mockConfig.debug = true;
+
+            initializeActivityTracking(mockConfig);
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                'DotCMS Analytics: Activity tracking initialized'
+            );
+
+            consoleWarnSpy.mockRestore();
+        });
+
+        it('should cleanup previous listeners before re-initializing', () => {
+            const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+
+            // Initialize twice
+            initializeActivityTracking(mockConfig);
+            initializeActivityTracking(mockConfig);
+
+            // Should have removed listeners from first initialization
+            expect(removeEventListenerSpy).toHaveBeenCalled();
+
+            removeEventListenerSpy.mockRestore();
+        });
+    });
+
+    describe('Activity Throttling', () => {
+        it('should throttle activity updates to max 1 per second', () => {
+            initializeActivityTracking(mockConfig);
+            const startTime = Date.now();
+
+            // First update - should work
+            updateSessionActivity();
+            const firstUpdate = getLastActivity();
+            expect(firstUpdate).toBeGreaterThanOrEqual(startTime);
+
+            // Immediate second update - should be throttled
+            updateSessionActivity();
+            const secondUpdate = getLastActivity();
+            expect(secondUpdate).toBe(firstUpdate); // Same time, was throttled
+
+            // Wait for throttle to expire
+            jest.advanceTimersByTime(1000);
+
+            // Third update - should work
+            updateSessionActivity();
+            const thirdUpdate = getLastActivity();
+            expect(thirdUpdate).toBeGreaterThanOrEqual(firstUpdate);
+        });
+    });
+
+    describe('Session Timeout Detection', () => {
+        it('should detect user is active when recently active', () => {
+            initializeActivityTracking(mockConfig);
+            updateSessionActivity();
+
+            expect(isUserInactive()).toBe(false);
+        });
+
+        it('should detect user is inactive after timeout period', () => {
+            initializeActivityTracking(mockConfig);
+            updateSessionActivity();
+
+            expect(isUserInactive()).toBe(false);
+
+            // Fast-forward past timeout
+            jest.advanceTimersByTime(DEFAULT_SESSION_TIMEOUT_MINUTES * 60 * 1000 + 1000);
+
+            expect(isUserInactive()).toBe(true);
+        });
+
+        it('should log debug message when user becomes inactive', () => {
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+            mockConfig.debug = true;
+
+            initializeActivityTracking(mockConfig);
+            updateSessionActivity();
+
+            // Fast-forward past timeout
+            jest.advanceTimersByTime(DEFAULT_SESSION_TIMEOUT_MINUTES * 60 * 1000);
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                'DotCMS Analytics: User became inactive after timeout'
+            );
+
+            consoleWarnSpy.mockRestore();
+        });
+
+        it('should handle multiple activity bursts correctly', () => {
+            initializeActivityTracking(mockConfig);
+
+            // First activity
+            updateSessionActivity();
+            expect(isUserInactive()).toBe(false);
+
+            // Wait and do another activity before timeout
+            jest.advanceTimersByTime(5 * 60 * 1000); // 5 minutes
+            jest.advanceTimersByTime(1000); // Clear throttle
+            updateSessionActivity();
+            expect(isUserInactive()).toBe(false);
+
+            // Wait and do another activity
+            jest.advanceTimersByTime(5 * 60 * 1000);
+            jest.advanceTimersByTime(1000); // Clear throttle
+            updateSessionActivity();
+            expect(isUserInactive()).toBe(false);
+
+            // Now wait full timeout
+            jest.advanceTimersByTime(DEFAULT_SESSION_TIMEOUT_MINUTES * 60 * 1000 + 1000);
+            expect(isUserInactive()).toBe(true);
+        });
+    });
+
+    describe('Visibility Change Handling', () => {
+        it('should NOT update activity when page becomes hidden', () => {
+            initializeActivityTracking(mockConfig);
+
+            jest.advanceTimersByTime(1000);
+            updateSessionActivity();
+            const activityBeforeHidden = getLastActivity();
+
+            // Simulate page becoming hidden
+            Object.defineProperty(document, 'visibilityState', {
+                value: 'hidden',
+                writable: true,
+                configurable: true
+            });
+            document.dispatchEvent(new Event('visibilitychange'));
+
+            expect(getLastActivity()).toBe(activityBeforeHidden);
+        });
+
+        it('should log debug message when user returns to tab', () => {
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+            mockConfig.debug = true;
+
+            initializeActivityTracking(mockConfig);
+
+            // Simulate page becoming visible
+            Object.defineProperty(document, 'visibilityState', {
+                value: 'visible',
+                writable: true,
+                configurable: true
+            });
+            document.dispatchEvent(new Event('visibilitychange'));
+
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                'DotCMS Analytics: User returned to tab, session reactivated'
+            );
+
+            consoleWarnSpy.mockRestore();
+        });
+    });
+
+    describe('Cleanup', () => {
+        it('should remove all event listeners on cleanup', () => {
+            const removeEventListenerSpy = jest.spyOn(window, 'removeEventListener');
+            const documentRemoveEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+
+            initializeActivityTracking(mockConfig);
+            cleanupActivityTracking();
+
+            // Should have removed all activity event listeners
+            expect(removeEventListenerSpy).toHaveBeenCalledTimes(ACTIVITY_EVENTS.length);
+            ACTIVITY_EVENTS.forEach((eventType) => {
+                expect(removeEventListenerSpy).toHaveBeenCalledWith(
+                    eventType,
+                    expect.any(Function)
+                );
+            });
+
+            // Should have removed visibility change listener
+            expect(documentRemoveEventListenerSpy).toHaveBeenCalledWith(
+                'visibilitychange',
+                expect.any(Function)
+            );
+
+            removeEventListenerSpy.mockRestore();
+            documentRemoveEventListenerSpy.mockRestore();
+        });
+
+        it('should clear inactivity timer on cleanup', () => {
+            initializeActivityTracking(mockConfig);
+            updateSessionActivity();
+
+            const timerCount = jest.getTimerCount();
+            expect(timerCount).toBeGreaterThan(0);
+
+            cleanupActivityTracking();
+
+            // Inactivity timer should be cleared
+            expect(jest.getTimerCount()).toBe(0);
+        });
+
+        it('should reset window analytics properties', () => {
+            initializeActivityTracking(mockConfig);
+            window[ANALYTICS_WINDOWS_ACTIVE_KEY] = true;
+            window[ANALYTICS_WINDOWS_CLEANUP_KEY] = jest.fn();
+
+            cleanupActivityTracking();
+
+            expect(window[ANALYTICS_WINDOWS_ACTIVE_KEY]).toBe(false);
+            expect(window[ANALYTICS_WINDOWS_CLEANUP_KEY]).toBeUndefined();
+        });
+
+        it('should dispatch cleanup event', () => {
+            const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
+
+            initializeActivityTracking(mockConfig);
+            cleanupActivityTracking();
+
+            expect(dispatchEventSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: 'dotcms:analytics:cleanup'
+                })
+            );
+
+            dispatchEventSpy.mockRestore();
+        });
+
+        it('should handle cleanup when not initialized', () => {
+            // Should not throw
+            expect(() => cleanupActivityTracking()).not.toThrow();
+        });
+
+        it('should handle multiple cleanups without errors', () => {
+            initializeActivityTracking(mockConfig);
+
+            cleanupActivityTracking();
+            cleanupActivityTracking();
+            cleanupActivityTracking();
+
+            // Should not throw
+            expect(true).toBe(true);
+        });
+
+        it('should not respond to events after cleanup', () => {
+            initializeActivityTracking(mockConfig);
+            const activityBeforeCleanup = getLastActivity();
+
+            cleanupActivityTracking();
+
+            // Try to trigger activity
+            jest.advanceTimersByTime(1000);
+            window.dispatchEvent(new MouseEvent('click'));
+
+            // Activity should not have been updated
+            expect(getLastActivity()).toBe(activityBeforeCleanup);
+        });
+    });
+
+    describe('Session Info', () => {
+        it('should return correct session info when active', () => {
+            initializeActivityTracking(mockConfig);
+            updateSessionActivity();
+
+            const info = getSessionInfo();
+
+            expect(info).toHaveProperty('lastActivity');
+            expect(info).toHaveProperty('isActive');
+            expect(info.isActive).toBe(true);
+            expect(info.lastActivity).toBeGreaterThan(0);
+        });
+
+        it('should return correct session info when inactive', () => {
+            initializeActivityTracking(mockConfig);
+            updateSessionActivity();
+
+            // Wait past timeout
+            jest.advanceTimersByTime(DEFAULT_SESSION_TIMEOUT_MINUTES * 60 * 1000 + 1000);
+
+            const info = getSessionInfo();
+
+            expect(info.isActive).toBe(false);
+            expect(info.lastActivity).toBeGreaterThan(0);
+        });
+    });
+
+    describe('Real-World Scenarios', () => {
+        it('should handle typical user session with intermittent activity', () => {
+            initializeActivityTracking(mockConfig);
+
+            // User clicks around
+            window.dispatchEvent(new MouseEvent('click'));
+            expect(isUserInactive()).toBe(false);
+
+            // User scrolls after 30 seconds
+            jest.advanceTimersByTime(30 * 1000);
+            jest.advanceTimersByTime(1000); // Clear throttle
+            window.dispatchEvent(new Event('scroll'));
+            expect(isUserInactive()).toBe(false);
+
+            // User moves mouse after 1 minute
+            jest.advanceTimersByTime(60 * 1000);
+            jest.advanceTimersByTime(1000); // Clear throttle
+            window.dispatchEvent(new MouseEvent('mousemove'));
+            expect(isUserInactive()).toBe(false);
+
+            // User types after 2 minutes
+            jest.advanceTimersByTime(2 * 60 * 1000);
+            jest.advanceTimersByTime(1000); // Clear throttle
+            window.dispatchEvent(new KeyboardEvent('keypress'));
+            expect(isUserInactive()).toBe(false);
+
+            // User goes idle for full timeout
+            jest.advanceTimersByTime(DEFAULT_SESSION_TIMEOUT_MINUTES * 60 * 1000 + 1000);
+            expect(isUserInactive()).toBe(true);
+        });
+
+        it('should handle SPA navigation with re-initialization', () => {
+            // Initial page
+            initializeActivityTracking(mockConfig);
+            updateSessionActivity();
+            const firstActivity = getLastActivity();
+
+            // Navigate to new page (cleanup + re-init)
+            cleanupActivityTracking();
+            jest.advanceTimersByTime(1000);
+            initializeActivityTracking(mockConfig);
+
+            // Activity should be reset
+            const secondActivity = getLastActivity();
+            expect(secondActivity).toBeGreaterThanOrEqual(firstActivity);
+
+            // Old listeners should not respond
+            expect(jest.getTimerCount()).toBeGreaterThan(0);
+        });
+    });
+});

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.http.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.http.ts
@@ -1,5 +1,5 @@
 import { ANALYTICS_ENDPOINT } from './constants';
-import { DotCMSAnalyticsConfig, DotCMSEvent, DotCMSRequestBody } from './models';
+import { DotCMSAnalyticsConfig, DotCMSAnalyticsRequestBody } from './models';
 
 /**
  * Send analytics events to the server using fetch API
@@ -9,7 +9,7 @@ import { DotCMSAnalyticsConfig, DotCMSEvent, DotCMSRequestBody } from './models'
  * @returns A promise that resolves when the request is complete
  */
 export const sendAnalyticsEvent = async (
-    payload: DotCMSRequestBody<DotCMSEvent>,
+    payload: DotCMSAnalyticsRequestBody,
     config: DotCMSAnalyticsConfig,
     keepalive = false
 ): Promise<void> => {

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.impression-tracker.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.impression-tracker.spec.ts
@@ -1,0 +1,926 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { getUVEState } from '@dotcms/uve';
+
+import {
+    ANALYTICS_CONTENTLET_CLASS,
+    DEFAULT_IMPRESSION_CONFIG,
+    IMPRESSION_EVENT_TYPE
+} from './constants';
+import { DotCMSImpressionTracker } from './dot-content-analytics.impression-tracker';
+import { DotCMSAnalyticsConfig } from './models';
+
+// Mock dependencies
+jest.mock('@dotcms/uve');
+jest.mock('../plugin/impression/dot-analytics.impression.utils', () => ({
+    ...jest.requireActual('../plugin/impression/dot-analytics.impression.utils'),
+    createDebounce: jest.fn((callback) => callback) // Execute immediately for testing
+}));
+
+describe('DotCMSImpressionTracker', () => {
+    let tracker: DotCMSImpressionTracker;
+    let mockConfig: DotCMSAnalyticsConfig;
+    let mockIntersectionObserver: any;
+    let mockMutationObserver: any;
+    let intersectionCallback: IntersectionObserverCallback;
+    let mutationCallback: MutationCallback;
+
+    // Helper to create mock element with data attributes
+    const createMockContentletElement = (
+        identifier: string,
+        options: {
+            inode?: string;
+            contentType?: string;
+            title?: string;
+            baseType?: string;
+            width?: number;
+            height?: number;
+            visible?: boolean;
+        } = {}
+    ): HTMLElement => {
+        const element = document.createElement('div');
+        element.className = ANALYTICS_CONTENTLET_CLASS;
+        element.dataset.dotAnalyticsIdentifier = identifier;
+        element.dataset.dotAnalyticsInode = options.inode || 'inode-123';
+        element.dataset.dotAnalyticsContenttype = options.contentType || 'Blog';
+        element.dataset.dotAnalyticsTitle = options.title || 'Test Content';
+        element.dataset.dotAnalyticsBasetype = options.baseType || 'CONTENT';
+
+        // Mock getBoundingClientRect
+        element.getBoundingClientRect = jest.fn(() => ({
+            width: options.width ?? 200,
+            height: options.height ?? 200,
+            top: options.visible !== false ? 100 : 1100,
+            left: 100,
+            bottom: options.visible !== false ? 300 : 1300,
+            right: 300,
+            x: 100,
+            y: options.visible !== false ? 100 : 1100,
+            toJSON: () => ({})
+        }));
+
+        return element;
+    };
+
+    beforeEach(() => {
+        // Reset mocks
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+
+        // Mock getUVEState (not in editor by default)
+        (getUVEState as jest.Mock).mockReturnValue(false);
+
+        // Setup config
+        mockConfig = {
+            server: 'https://test.com',
+            siteAuth: 'test-key',
+            debug: false,
+            impressions: true
+        };
+
+        // Mock IntersectionObserver
+        mockIntersectionObserver = {
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn()
+        };
+
+        (global as any).IntersectionObserver = jest.fn((callback) => {
+            intersectionCallback = callback;
+            return mockIntersectionObserver;
+        });
+
+        // Mock MutationObserver
+        mockMutationObserver = {
+            observe: jest.fn(),
+            disconnect: jest.fn()
+        };
+
+        (global as any).MutationObserver = jest.fn((callback) => {
+            mutationCallback = callback;
+            return mockMutationObserver;
+        });
+
+        // Mock document visibility
+        Object.defineProperty(document, 'visibilityState', {
+            writable: true,
+            value: 'visible'
+        });
+
+        // Mock window dimensions
+        Object.defineProperty(window, 'innerHeight', { value: 1000, writable: true });
+        Object.defineProperty(window, 'innerWidth', { value: 1000, writable: true });
+
+        // Clear document body
+        document.body.innerHTML = '';
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        document.body.innerHTML = '';
+    });
+
+    describe('Initialization', () => {
+        it('should initialize IntersectionObserver with correct threshold', () => {
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(global.IntersectionObserver).toHaveBeenCalledWith(
+                expect.any(Function),
+                expect.objectContaining({
+                    threshold: DEFAULT_IMPRESSION_CONFIG.visibilityThreshold
+                })
+            );
+        });
+
+        it('should NOT initialize in SSR (no window)', () => {
+            // Hide window
+            const originalWindow = global.window;
+            delete (global as any).window;
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(global.IntersectionObserver).not.toHaveBeenCalled();
+
+            // Restore
+            (global as any).window = originalWindow;
+        });
+
+        it('should NOT initialize in UVE editor mode', () => {
+            (getUVEState as jest.Mock).mockReturnValue(true);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(global.IntersectionObserver).not.toHaveBeenCalled();
+            expect(getUVEState).toHaveBeenCalled();
+        });
+
+        it('should setup MutationObserver for dynamic content', () => {
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(global.MutationObserver).toHaveBeenCalledWith(expect.any(Function));
+            expect(mockMutationObserver.observe).toHaveBeenCalledWith(
+                document.body,
+                expect.objectContaining({
+                    childList: true,
+                    subtree: true
+                })
+            );
+        });
+
+        it('should merge custom impression config with defaults', () => {
+            const customConfig: DotCMSAnalyticsConfig = {
+                ...mockConfig,
+                impressions: {
+                    dwellMs: 5000,
+                    visibilityThreshold: 0.75
+                }
+            };
+
+            tracker = new DotCMSImpressionTracker(customConfig);
+            tracker.initialize();
+
+            expect(global.IntersectionObserver).toHaveBeenCalledWith(
+                expect.any(Function),
+                expect.objectContaining({
+                    threshold: 0.75
+                })
+            );
+        });
+
+        it('should use default config when impressions is true', () => {
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(global.IntersectionObserver).toHaveBeenCalledWith(
+                expect.any(Function),
+                expect.objectContaining({
+                    threshold: DEFAULT_IMPRESSION_CONFIG.visibilityThreshold
+                })
+            );
+        });
+    });
+
+    describe('Element Discovery and Validation', () => {
+        it('should find and observe contentlet elements', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(mockIntersectionObserver.observe).toHaveBeenCalledWith(element);
+        });
+
+        it('should skip zero-dimension elements', () => {
+            const element = createMockContentletElement('content-123', {
+                width: 0,
+                height: 0
+            });
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(mockIntersectionObserver.observe).not.toHaveBeenCalled();
+        });
+
+        it('should skip elements smaller than 10px', () => {
+            const element = createMockContentletElement('content-123', {
+                width: 5,
+                height: 5
+            });
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(mockIntersectionObserver.observe).not.toHaveBeenCalled();
+        });
+
+        it('should skip hidden elements (visibility: hidden)', () => {
+            const element = createMockContentletElement('content-123');
+            element.style.visibility = 'hidden';
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(mockIntersectionObserver.observe).not.toHaveBeenCalled();
+        });
+
+        it('should skip transparent elements (opacity: 0)', () => {
+            const element = createMockContentletElement('content-123');
+            element.style.opacity = '0';
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(mockIntersectionObserver.observe).not.toHaveBeenCalled();
+        });
+
+        it('should skip display:none elements', () => {
+            const element = createMockContentletElement('content-123');
+            element.style.display = 'none';
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(mockIntersectionObserver.observe).not.toHaveBeenCalled();
+        });
+
+        it('should respect maxNodes limit', () => {
+            const customConfig: DotCMSAnalyticsConfig = {
+                ...mockConfig,
+                impressions: { maxNodes: 2 }
+            };
+
+            // Create 5 elements
+            for (let i = 0; i < 5; i++) {
+                const element = createMockContentletElement(`content-${i}`);
+                document.body.appendChild(element);
+            }
+
+            tracker = new DotCMSImpressionTracker(customConfig);
+            tracker.initialize();
+
+            // Should only observe 2 elements
+            expect(mockIntersectionObserver.observe).toHaveBeenCalledTimes(2);
+        });
+
+        it('should skip elements without identifier', () => {
+            const element = document.createElement('div');
+            element.className = ANALYTICS_CONTENTLET_CLASS;
+            // No data-dot-analytics-identifier
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            expect(mockIntersectionObserver.observe).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('Dwell Timer Logic', () => {
+        it('should start dwell timer when element becomes visible', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            // Simulate intersection (element becomes visible)
+            const entry = {
+                target: element,
+                isIntersecting: true,
+                intersectionRatio: 1
+            } as IntersectionObserverEntry;
+
+            intersectionCallback([entry], mockIntersectionObserver);
+
+            // Verify timer was started (we're using fake timers)
+            expect(jest.getTimerCount()).toBeGreaterThan(0);
+        });
+
+        it('should fire impression after dwellMs timeout', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            const callback = jest.fn();
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            tracker.onImpression(callback);
+
+            // Element becomes visible
+            const entry = {
+                target: element,
+                isIntersecting: true,
+                intersectionRatio: 1
+            } as IntersectionObserverEntry;
+
+            intersectionCallback([entry], mockIntersectionObserver);
+
+            // Impression should not fire yet
+            expect(callback).not.toHaveBeenCalled();
+
+            // Fast-forward time to dwell duration
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            // Now impression should fire
+            expect(callback).toHaveBeenCalledWith(
+                IMPRESSION_EVENT_TYPE,
+                expect.objectContaining({
+                    content: expect.objectContaining({
+                        identifier: 'content-123'
+                    })
+                })
+            );
+        });
+
+        it('should cancel timer if element leaves viewport before dwell time', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            const callback = jest.fn();
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            tracker.onImpression(callback);
+
+            // Element becomes visible
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+
+            // Wait half the dwell time
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs / 2);
+
+            // Element leaves viewport
+            intersectionCallback(
+                [{ target: element, isIntersecting: false } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+
+            // Fast-forward remaining time
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            // Impression should NOT fire
+            expect(callback).not.toHaveBeenCalled();
+        });
+
+        it('should NOT fire if element is hidden when timer expires', () => {
+            const element = createMockContentletElement('content-123', { visible: true });
+            document.body.appendChild(element);
+
+            const callback = jest.fn();
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            tracker.onImpression(callback);
+
+            // Element becomes visible
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+
+            // Make element not meet visibility threshold
+            element.getBoundingClientRect = jest.fn(() => ({
+                width: 200,
+                height: 200,
+                top: 1100, // Below viewport
+                left: 100,
+                bottom: 1300,
+                right: 300,
+                x: 100,
+                y: 1100,
+                toJSON: () => ({})
+            }));
+
+            // Fast-forward time
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            // Impression should NOT fire
+            expect(callback).not.toHaveBeenCalled();
+        });
+
+        it('should NOT start timer if already tracked', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            const callback = jest.fn();
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            tracker.onImpression(callback);
+
+            // First visibility
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+
+            // Second visibility (should not fire again)
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            // Still only called once
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should NOT start timer if page is not visible', () => {
+            Object.defineProperty(document, 'visibilityState', {
+                writable: true,
+                value: 'hidden'
+            });
+
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            const timerCountBefore = jest.getTimerCount();
+
+            // Try to start tracking
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+
+            // No NEW timers should be started (timer count should not increase)
+            expect(jest.getTimerCount()).toBe(timerCountBefore);
+        });
+    });
+
+    describe('Session Tracking', () => {
+        it('should track impression only once per session', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            const callback = jest.fn();
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            tracker.onImpression(callback);
+
+            // Fire first impression
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            expect(callback).toHaveBeenCalledTimes(1);
+
+            // Element leaves and comes back
+            intersectionCallback(
+                [{ target: element, isIntersecting: false } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            // Should NOT fire again
+            expect(callback).toHaveBeenCalledTimes(1);
+        });
+
+        it('should unobserve element after tracking impression', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            // Fire impression
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            // Verify element was unobserved
+            expect(mockIntersectionObserver.unobserve).toHaveBeenCalledWith(element);
+        });
+    });
+
+    describe('Page Visibility Handling', () => {
+        it('should cancel all timers when page becomes hidden', () => {
+            const element1 = createMockContentletElement('content-1');
+            const element2 = createMockContentletElement('content-2');
+            document.body.appendChild(element1);
+            document.body.appendChild(element2);
+
+            const callback = jest.fn();
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            tracker.onImpression(callback);
+
+            const timerCountBeforeElements = jest.getTimerCount();
+
+            // Both elements become visible
+            intersectionCallback(
+                [
+                    { target: element1, isIntersecting: true } as IntersectionObserverEntry,
+                    { target: element2, isIntersecting: true } as IntersectionObserverEntry
+                ],
+                mockIntersectionObserver
+            );
+
+            // Should have 2 more timers (one per element)
+            expect(jest.getTimerCount()).toBe(timerCountBeforeElements + 2);
+
+            // Page becomes hidden
+            Object.defineProperty(document, 'visibilityState', {
+                writable: true,
+                value: 'hidden'
+            });
+            document.dispatchEvent(new Event('visibilitychange'));
+
+            // Dwell timers should be cleared (back to initial count)
+            expect(jest.getTimerCount()).toBe(timerCountBeforeElements);
+
+            // Fast-forward time - impressions should NOT fire
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+            expect(callback).not.toHaveBeenCalled();
+        });
+
+        it('should ignore intersection events when page is hidden', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            const timerCountBeforeHidden = jest.getTimerCount();
+
+            // Hide the page
+            Object.defineProperty(document, 'visibilityState', {
+                writable: true,
+                value: 'hidden'
+            });
+
+            // Try to trigger intersection while hidden
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+
+            // No NEW timers should start (count unchanged)
+            expect(jest.getTimerCount()).toBe(timerCountBeforeHidden);
+        });
+    });
+
+    describe('SPA Navigation Detection', () => {
+        let originalLocation: Location;
+
+        beforeEach(() => {
+            originalLocation = window.location;
+        });
+
+        afterEach(() => {
+            // Restore
+            Object.defineProperty(window, 'location', {
+                value: originalLocation,
+                writable: true,
+                configurable: true
+            });
+        });
+
+        it('should clear element states on navigation', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            // Start tracking an element
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+
+            // Verify timer is active
+            const timerCountWithActive = jest.getTimerCount();
+            expect(timerCountWithActive).toBeGreaterThan(1); // At least interval + dwell timer
+
+            // Simulate navigation by replacing window.location
+            Object.defineProperty(window, 'location', {
+                value: { pathname: '/new-page' },
+                writable: true,
+                configurable: true
+            });
+
+            // Trigger navigation check via interval
+            jest.advanceTimersByTime(1000);
+
+            // Dwell timer should be cancelled, only interval remains
+            expect(jest.getTimerCount()).toBe(1);
+        });
+
+        it('should clear session tracking on navigation', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            const callback = jest.fn();
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.onImpression(callback);
+            tracker.initialize();
+
+            // Fire first impression on initial page
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+            expect(callback).toHaveBeenCalledTimes(1);
+
+            // Simulate navigation
+            Object.defineProperty(window, 'location', {
+                value: { pathname: '/new-page' },
+                writable: true,
+                configurable: true
+            });
+
+            // Advance timers to trigger interval check
+            jest.advanceTimersByTime(1000);
+
+            // Session tracking should be cleared after navigation
+            expect(callback).toHaveBeenCalledTimes(1); // Still only 1 from before navigation
+        });
+    });
+
+    describe('Subscription Pattern', () => {
+        it('should notify all subscribers when impression fires', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            const callback1 = jest.fn();
+            const callback2 = jest.fn();
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            tracker.onImpression(callback1);
+            tracker.onImpression(callback2);
+
+            // Fire impression
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            expect(callback1).toHaveBeenCalledTimes(1);
+            expect(callback2).toHaveBeenCalledTimes(1);
+        });
+
+        it('should allow unsubscribe', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            const callback = jest.fn();
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            const subscription = tracker.onImpression(callback);
+
+            // Unsubscribe before impression
+            subscription.unsubscribe();
+
+            // Fire impression
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            // Callback should NOT be called
+            expect(callback).not.toHaveBeenCalled();
+        });
+
+        it('should handle subscriber errors gracefully', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            const errorCallback = jest.fn(() => {
+                throw new Error('Subscriber error');
+            });
+            const validCallback = jest.fn();
+
+            tracker = new DotCMSImpressionTracker({ ...mockConfig, debug: true });
+            tracker.initialize();
+            tracker.onImpression(errorCallback);
+            tracker.onImpression(validCallback);
+
+            const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+            // Fire impression
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            // Error should be logged but valid callback should still execute
+            expect(consoleErrorSpy).toHaveBeenCalled();
+            expect(validCallback).toHaveBeenCalled();
+
+            consoleErrorSpy.mockRestore();
+        });
+
+        it('should include correct payload structure', () => {
+            const element = createMockContentletElement('content-123', {
+                inode: 'test-inode',
+                contentType: 'BlogPost',
+                title: 'My Blog Post'
+            });
+            document.body.appendChild(element);
+
+            const callback = jest.fn();
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            tracker.onImpression(callback);
+
+            // Fire impression
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            expect(callback).toHaveBeenCalledWith(IMPRESSION_EVENT_TYPE, {
+                content: {
+                    identifier: 'content-123',
+                    inode: 'test-inode',
+                    title: 'My Blog Post',
+                    content_type: 'BlogPost'
+                },
+                position: {
+                    viewport_offset_pct: expect.any(Number),
+                    dom_index: expect.any(Number)
+                }
+            });
+        });
+    });
+
+    describe('Cleanup', () => {
+        it('should disconnect IntersectionObserver on cleanup', () => {
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            tracker.cleanup();
+
+            expect(mockIntersectionObserver.disconnect).toHaveBeenCalled();
+        });
+
+        it('should disconnect MutationObserver on cleanup', () => {
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            tracker.cleanup();
+
+            expect(mockMutationObserver.disconnect).toHaveBeenCalled();
+        });
+
+        it('should clear all active dwell timers on cleanup', () => {
+            const element1 = createMockContentletElement('content-1');
+            const element2 = createMockContentletElement('content-2');
+            document.body.appendChild(element1);
+            document.body.appendChild(element2);
+
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            const timerCountBeforeElements = jest.getTimerCount(); // Just the interval
+
+            // Start tracking multiple elements
+            intersectionCallback(
+                [
+                    { target: element1, isIntersecting: true } as IntersectionObserverEntry,
+                    { target: element2, isIntersecting: true } as IntersectionObserverEntry
+                ],
+                mockIntersectionObserver
+            );
+
+            // Should have 2 dwell timers + interval
+            expect(jest.getTimerCount()).toBe(timerCountBeforeElements + 2);
+
+            tracker.cleanup();
+
+            // Dwell timers should be cleared, only interval remains (not cleaned up)
+            // Note: The interval timer from navigation check is not cleaned up in current implementation
+            expect(jest.getTimerCount()).toBe(timerCountBeforeElements);
+        });
+
+        it('should clear all subscribers on cleanup', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            const callback = jest.fn();
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+            tracker.onImpression(callback);
+
+            tracker.cleanup();
+
+            // Re-initialize and fire impression
+            tracker.initialize();
+            intersectionCallback(
+                [{ target: element, isIntersecting: true } as IntersectionObserverEntry],
+                mockIntersectionObserver
+            );
+            jest.advanceTimersByTime(DEFAULT_IMPRESSION_CONFIG.dwellMs);
+
+            // Old callback should NOT be called
+            expect(callback).not.toHaveBeenCalled();
+        });
+
+        it('should handle cleanup when not initialized', () => {
+            tracker = new DotCMSImpressionTracker(mockConfig);
+
+            // Should not throw
+            expect(() => tracker.cleanup()).not.toThrow();
+        });
+    });
+
+    describe('Dynamic Content Detection', () => {
+        it('should detect and observe new contentlets added to DOM', () => {
+            tracker = new DotCMSImpressionTracker(mockConfig);
+            tracker.initialize();
+
+            // Initially no contentlets
+            expect(mockIntersectionObserver.observe).not.toHaveBeenCalled();
+
+            // Add contentlet dynamically
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            // Trigger mutation observer
+            mutationCallback([], mockMutationObserver);
+
+            // Should observe new element
+            expect(mockIntersectionObserver.observe).toHaveBeenCalledWith(element);
+        });
+    });
+
+    describe('Debug Mode', () => {
+        it('should log debug information when enabled', () => {
+            const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+            tracker = new DotCMSImpressionTracker({ ...mockConfig, debug: true });
+            tracker.initialize();
+
+            // Should have been called with the initialization message
+            expect(consoleWarnSpy).toHaveBeenCalled();
+            const calls = consoleWarnSpy.mock.calls;
+            const initCall = calls.find((call) =>
+                call[0]?.toString().includes('Impression tracking initialized')
+            );
+            expect(initCall).toBeDefined();
+
+            consoleWarnSpy.mockRestore();
+        });
+
+        it('should add visual indicators to observed elements in debug mode', () => {
+            const element = createMockContentletElement('content-123');
+            document.body.appendChild(element);
+
+            tracker = new DotCMSImpressionTracker({ ...mockConfig, debug: true });
+            tracker.initialize();
+
+            expect(element.dataset.dotAnalyticsObserved).toBe('true');
+            expect(element.style.outline).toBeTruthy();
+        });
+    });
+});

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.impression-tracker.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.impression-tracker.ts
@@ -1,0 +1,694 @@
+import {
+    ANALYTICS_CONTENTLET_CLASS,
+    DEFAULT_IMPRESSION_DWELL_MS,
+    DEFAULT_IMPRESSION_MAX_NODES,
+    DEFAULT_IMPRESSION_MUTATION_OBSERVER_DEBOUNCE_MS,
+    DEFAULT_IMPRESSION_THROTTLE_MS,
+    DEFAULT_IMPRESSION_VISIBILITY_THRESHOLD,
+    IMPRESSION_EVENT_TYPE
+} from './constants';
+import { DotCMSAnalyticsConfig, DotCMSContentImpressionPayload, ImpressionConfig } from './models';
+
+import {
+    AnalyticsTrackFn,
+    createDebounce,
+    extractContentletData,
+    extractContentletIdentifier,
+    getViewportMetrics,
+    isElementMeetingVisibilityThreshold
+} from '../plugin/impression/dot-analytics.impression.utils';
+
+/**
+ * State for tracking an individual element's impression
+ */
+interface ImpressionState {
+    /** Timer ID for dwell time tracking */
+    timer: number | null;
+    /** Timestamp when element became visible */
+    visibleSince: number | null;
+    /** Whether impression has been fired for this element */
+    tracked: boolean;
+    /** Reference to the element for post-dwell visibility check */
+    element: HTMLElement | null;
+}
+
+/**
+ * Impression tracking manager for DotCMS Analytics.
+ * Tracks when contentlets become visible in the viewport using IntersectionObserver.
+ * Fires impression events when elements meet visibility and dwell time thresholds.
+ *
+ * Singleton pattern - one tracker per analytics instance.
+ */
+export class DotCMSImpressionTracker {
+    private observer: IntersectionObserver | null = null;
+    private mutationObserver: MutationObserver | null = null;
+    private elementImpressionStates = new Map<string, ImpressionState>();
+    private sessionTrackedImpressions = new Set<string>();
+    private config: DotCMSAnalyticsConfig;
+    private track: AnalyticsTrackFn;
+    private impressionConfig: Required<ImpressionConfig>;
+    private currentPagePath = '';
+
+    constructor(config: DotCMSAnalyticsConfig, track: AnalyticsTrackFn) {
+        this.config = config;
+        this.track = track;
+
+        // Merge user config with defaults
+        this.impressionConfig = this.resolveImpressionConfig(config.impressions);
+    }
+
+    /**
+     * Resolves impression config by merging user config with defaults
+     */
+    private resolveImpressionConfig(
+        userConfig: ImpressionConfig | boolean | undefined
+    ): Required<ImpressionConfig> {
+        // TODO: Mejorar esto, se esta duplicando esa asignación en el return.
+        // If boolean true or undefined, use all defaults
+        if (typeof userConfig !== 'object' || userConfig === null) {
+            return {
+                visibilityThreshold: DEFAULT_IMPRESSION_VISIBILITY_THRESHOLD,
+                dwellMs: DEFAULT_IMPRESSION_DWELL_MS,
+                maxNodes: DEFAULT_IMPRESSION_MAX_NODES,
+                throttleMs: DEFAULT_IMPRESSION_THROTTLE_MS,
+                useIdleCallback: false
+            };
+        }
+
+        // If object, merge with defaults
+        return {
+            visibilityThreshold:
+                userConfig.visibilityThreshold ?? DEFAULT_IMPRESSION_VISIBILITY_THRESHOLD,
+            dwellMs: userConfig.dwellMs ?? DEFAULT_IMPRESSION_DWELL_MS,
+            maxNodes: userConfig.maxNodes ?? DEFAULT_IMPRESSION_MAX_NODES,
+            throttleMs: userConfig.throttleMs ?? DEFAULT_IMPRESSION_THROTTLE_MS,
+            useIdleCallback: userConfig.useIdleCallback ?? false
+        };
+    }
+
+    /**
+     * Initializes the impression tracking system.
+     *
+     * Flow:
+     * 1. Check for SSR and editor mode (early returns)
+     * 2. Load previously tracked impressions from session storage
+     * 3. Setup IntersectionObserver with configured visibility threshold
+     * 4. Find and observe all contentlet elements in the DOM
+     * 5. Setup MutationObserver for dynamic content detection (if enabled)
+     * 6. Setup page visibility handler to pause/resume tracking
+     *
+     * @example
+     * const tracker = new DotCMSImpressionTracker(config, analytics);
+     * tracker.initialize(); // Starts tracking impressions
+     */
+    public initialize(): void {
+        // Early return if SSR
+        if (typeof window === 'undefined' || typeof document === 'undefined') {
+            return;
+        }
+
+        // Early return if in editor mode (check for UVE markers)
+        if (this.isEditorMode()) {
+            if (this.config.debug) {
+                console.warn('DotCMS Analytics: Impression tracking disabled in editor mode');
+            }
+
+            return;
+        }
+
+        // Setup IntersectionObserver
+        this.initializeIntersectionObserver();
+
+        // Find and observe contentlet elements
+        this.findAndObserveContentletElements();
+
+        // Setup mutation observer for dynamic content
+        this.initializeDynamicContentDetector();
+
+        // Listen for visibility changes to pause/resume tracking
+        this.initializePageVisibilityHandler();
+
+        // Listen for page navigation to reset tracking
+        this.initializePageNavigationHandler();
+
+        if (this.config.debug) {
+            console.warn(
+                `DotCMS Analytics: Impression tracking initialized with config:`,
+                this.impressionConfig
+            );
+        }
+    }
+
+    /**
+     * Checks if we're in editor mode (UVE)
+     */
+    private isEditorMode(): boolean {
+        // Check for UVE markers in window
+        return (
+            !!(window as Window & { dotcmsUVE?: unknown }).dotcmsUVE ||
+            document.body.classList.contains('dotcms-edit-mode')
+        );
+    }
+
+    /**
+     * Initializes the IntersectionObserver with configured visibility threshold.
+     *
+     * @remarks
+     * The observer uses the browser viewport as the root and triggers callbacks
+     * when elements cross the configured visibility threshold.
+     */
+    private initializeIntersectionObserver(): void {
+        const options: IntersectionObserverInit = {
+            root: null, // Use viewport as root
+            rootMargin: '0px',
+            threshold: this.impressionConfig.visibilityThreshold
+        };
+
+        this.observer = new IntersectionObserver((entries) => {
+            this.processIntersectionChanges(entries);
+        }, options);
+    }
+
+    /**
+     * Finds and observes all contentlet elements in the DOM.
+     *
+     * @remarks
+     * - Queries for elements with the analytics contentlet class
+     * - Limits tracking to maxNodes for performance
+     * - Initializes or updates state for each element
+     * - Skips elements without identifiers
+     */
+    private findAndObserveContentletElements(): void {
+        if (!this.observer) return;
+
+        const contentlets = document.querySelectorAll<HTMLElement>(
+            `.${ANALYTICS_CONTENTLET_CLASS}`
+        );
+
+        if (contentlets.length === 0) {
+            if (this.config.debug) {
+                console.warn('DotCMS Analytics: No contentlets found to track');
+            }
+
+            return;
+        }
+
+        // Limit to maxNodes for performance
+        const maxNodesToTrack = Math.min(contentlets.length, this.impressionConfig.maxNodes);
+        let observedCount = 0;
+
+        for (let i = 0; i < maxNodesToTrack; i++) {
+            const element = contentlets[i];
+            const identifier = extractContentletIdentifier(element);
+
+            if (identifier) {
+                // Skip elements that shouldn't be tracked
+                const skipReason = this.shouldSkipElement(element);
+                if (skipReason) {
+                    if (this.config.debug) {
+                        console.warn(
+                            `DotCMS Analytics: Skipping element ${identifier} (${skipReason})`
+                        );
+                    }
+                    continue;
+                }
+
+                // Only observe and initialize if this is a new element
+                if (!this.elementImpressionStates.has(identifier)) {
+                    this.observer.observe(element);
+                    this.elementImpressionStates.set(identifier, {
+                        timer: null,
+                        visibleSince: null,
+                        tracked: this.hasBeenTrackedInSession(identifier),
+                        element
+                    });
+
+                    observedCount++;
+
+                    // Add visual debugging indicators in development
+                    if (this.config.debug) {
+                        element.dataset.dotAnalyticsObserved = 'true';
+                        element.style.outline = '2px solid red';
+                        element.style.outlineOffset = '-2px';
+                        element.style.transition = 'outline-color 0.5s ease-in-out';
+                    }
+                }
+            }
+        }
+
+        if (this.config.debug) {
+            console.warn(`DotCMS Analytics: Observing ${observedCount} contentlets`);
+            if (contentlets.length > maxNodesToTrack) {
+                console.warn(
+                    `DotCMS Analytics: ${contentlets.length - maxNodesToTrack} contentlets not tracked (maxNodes limit: ${this.impressionConfig.maxNodes})`
+                );
+            }
+        }
+    }
+
+    /**
+     * Initializes MutationObserver to detect dynamically added contentlet elements.
+     *
+     * @remarks
+     * - Observes the document body for DOM changes
+     * - Debounces scans to avoid excessive processing
+     * - Automatically finds and observes new contentlets
+     */
+    private initializeDynamicContentDetector(): void {
+        if (typeof window === 'undefined' || typeof document === 'undefined') {
+            return;
+        }
+
+        const debouncedScan = createDebounce(() => {
+            this.findAndObserveContentletElements();
+        }, DEFAULT_IMPRESSION_MUTATION_OBSERVER_DEBOUNCE_MS);
+
+        this.mutationObserver = new MutationObserver(() => {
+            debouncedScan();
+        });
+
+        this.mutationObserver.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+
+        if (this.config.debug) {
+            console.warn(
+                'DotCMS Analytics: MutationObserver enabled for dynamic content detection'
+            );
+        }
+    }
+
+    /**
+     * Initializes page visibility change handler.
+     *
+     * @remarks
+     * Cancels all active dwell timers when the page becomes hidden
+     * to prevent incorrect impressions from being fired.
+     */
+    private initializePageVisibilityHandler(): void {
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'hidden') {
+                // Page is hidden, cancel all timers
+                this.elementImpressionStates.forEach((state) => {
+                    if (state.timer !== null) {
+                        window.clearTimeout(state.timer);
+                        state.timer = null;
+                        state.visibleSince = null;
+                    }
+                });
+
+                if (this.config.debug) {
+                    console.warn('DotCMS Analytics: Page hidden, all impression timers cancelled');
+                }
+            }
+        });
+    }
+
+    /**
+     * Initializes page navigation handler to reset tracking on route changes.
+     *
+     * @remarks
+     * - Detects when the user navigates to a different page (SPA navigation)
+     * - Resets tracked impressions to allow re-tracking on the new page
+     * - Maintains deduplication within the same page
+     * - Works with client-side routing (NextJS, React Router, etc.)
+     */
+    private initializePageNavigationHandler(): void {
+        // Store initial path
+        this.currentPagePath = window.location.pathname;
+
+        // Check for path changes periodically (for SPAs that don't trigger events)
+        const checkPathChange = () => {
+            const newPath = window.location.pathname;
+
+            if (newPath !== this.currentPagePath) {
+                if (this.config.debug) {
+                    console.warn(
+                        `DotCMS Analytics: Navigation detected (${this.currentPagePath} → ${newPath}), resetting impression tracking`
+                    );
+                }
+
+                // Update current path
+                this.currentPagePath = newPath;
+
+                // Reset tracked impressions for the new page
+                this.sessionTrackedImpressions.clear();
+
+                // Cancel all active timers
+                this.elementImpressionStates.forEach((state) => {
+                    if (state.timer !== null) {
+                        window.clearTimeout(state.timer);
+                        state.timer = null;
+                        state.visibleSince = null;
+                    }
+                });
+
+                // Clear element states
+                this.elementImpressionStates.clear();
+            }
+        };
+
+        // Listen for popstate (back/forward navigation)
+        window.addEventListener('popstate', checkPathChange);
+
+        // Listen for pushstate/replacestate (programmatic navigation)
+        const originalPushState = history.pushState;
+        const originalReplaceState = history.replaceState;
+
+        history.pushState = function (...args) {
+            originalPushState.apply(this, args);
+            checkPathChange();
+        };
+
+        history.replaceState = function (...args) {
+            originalReplaceState.apply(this, args);
+            checkPathChange();
+        };
+
+        // Fallback: check periodically for path changes (catches edge cases)
+        setInterval(checkPathChange, 1000);
+    }
+
+    /**
+     * Processes IntersectionObserver callbacks.
+     *
+     * @param entries - Array of intersection entries from the observer
+     *
+     * @remarks
+     * - Starts dwell timer when element enters viewport
+     * - Cancels dwell timer when element exits viewport
+     * - Ignores callbacks when page is not visible
+     */
+    private processIntersectionChanges(entries: IntersectionObserverEntry[]): void {
+        // Ignore if page is not visible
+        if (document.visibilityState !== 'visible') {
+            return;
+        }
+
+        entries.forEach((entry) => {
+            const element = entry.target as HTMLElement;
+            const identifier = extractContentletIdentifier(element);
+
+            if (!identifier) return;
+
+            if (entry.isIntersecting) {
+                // Element is visible, start tracking
+                this.startImpressionDwellTimer(identifier, element);
+            } else {
+                // Element is not visible, cancel tracking
+                this.cancelImpressionDwellTimer(identifier);
+            }
+        });
+    }
+
+    /**
+     * Starts the dwell timer for an element impression.
+     *
+     * @param identifier - The contentlet identifier
+     * @param element - The HTML element to track
+     *
+     * @remarks
+     * - Skips if already tracked in session
+     * - Skips if timer is already running
+     * - Skips if page is not visible
+     * - Verifies element is still visible when timer expires (post-dwell check)
+     * - Only fires impression if all conditions are met
+     */
+    private startImpressionDwellTimer(identifier: string, element: HTMLElement): void {
+        const state = this.elementImpressionStates.get(identifier);
+
+        if (!state) return;
+
+        // Already tracked, skip
+        if (state.tracked || this.hasBeenTrackedInSession(identifier)) {
+            return;
+        }
+
+        // Timer already running, skip
+        if (state.timer !== null) {
+            return;
+        }
+
+        // Page not visible, skip
+        if (document.visibilityState !== 'visible') {
+            return;
+        }
+
+        // Start timer
+        state.visibleSince = Date.now();
+        state.element = element;
+        state.timer = window.setTimeout(() => {
+            // Verify element is still visible before firing (post-dwell check)
+            if (this.isElementStillVisible(element)) {
+                this.trackAndSendImpression(identifier, element);
+            } else {
+                if (this.config.debug) {
+                    console.warn(
+                        `DotCMS Analytics: Dwell timer expired for ${identifier} but element no longer visible, skipping impression`
+                    );
+                }
+                // Clear state since we're not tracking
+                state.timer = null;
+                state.visibleSince = null;
+            }
+        }, this.impressionConfig.dwellMs);
+
+        if (this.config.debug) {
+            console.warn(
+                `DotCMS Analytics: Started dwell timer for ${identifier} (${this.impressionConfig.dwellMs}ms)`
+            );
+        }
+    }
+
+    /**
+     * Cancels the dwell timer for an element impression.
+     *
+     * @param identifier - The contentlet identifier
+     *
+     * @remarks
+     * Called when an element exits the viewport before the dwell time expires.
+     */
+    private cancelImpressionDwellTimer(identifier: string): void {
+        const state = this.elementImpressionStates.get(identifier);
+
+        if (!state || state.timer === null) return;
+
+        window.clearTimeout(state.timer);
+        state.timer = null;
+        state.visibleSince = null;
+
+        if (this.config.debug) {
+            console.warn(`DotCMS Analytics: Cancelled dwell timer for ${identifier}`);
+        }
+    }
+
+    /**
+     * Tracks and sends an impression event to analytics.
+     *
+     * @param identifier - The contentlet identifier
+     * @param element - The HTML element that was impressed
+     *
+     * @remarks
+     * - Calculates actual dwell time
+     * - Extracts contentlet data using utility
+     * - Calculates viewport metrics using utility
+     * - Sends ONLY impression-specific data (content, position)
+     * - Page data will be added automatically by the enricher plugin
+     * - Marks impression as tracked in session
+     * - Updates element state
+     */
+    private trackAndSendImpression(identifier: string, element: HTMLElement): void {
+        const state = this.elementImpressionStates.get(identifier);
+
+        if (!state) return;
+
+        // Calculate actual dwell time
+        const dwellTime = state.visibleSince ? Date.now() - state.visibleSince : 0;
+
+        // Extract contentlet data using utility
+        const contentletData = extractContentletData(element);
+
+        // Calculate viewport metrics using utility
+        const viewportMetrics = getViewportMetrics(element);
+
+        // Build impression payload with ONLY impression-specific data
+        // The enricher plugin will add page data automatically
+        // TODO: Mejorar este type
+        const impressionPayload: DotCMSContentImpressionPayload = {
+            content: {
+                identifier: contentletData.identifier,
+                inode: contentletData.inode,
+                title: contentletData.title,
+                content_type: contentletData.contentType
+            },
+            position: {
+                viewport_offset_pct: viewportMetrics.offsetPercentage,
+                dom_index: Array.from(
+                    document.querySelectorAll(`.${ANALYTICS_CONTENTLET_CLASS}`)
+                ).indexOf(element)
+            }
+        };
+
+        // Fire the impression event directly using the track function
+        // This goes through the full Analytics.js pipeline:
+        // 1. Identity Plugin → Adds context (user_id, session_id, device)
+        // 2. Enricher Plugin → Adds page data automatically
+        // 3. Main Plugin → Sends to server/queue
+        this.track(IMPRESSION_EVENT_TYPE, impressionPayload);
+
+        // Mark as tracked in session
+        this.markImpressionAsTracked(identifier);
+
+        // Clear state
+        state.timer = null;
+        state.visibleSince = null;
+        state.tracked = true;
+
+        // Stop observing this element (no longer needed)
+        if (this.observer) {
+            this.observer.unobserve(element);
+        }
+
+        // Update visual indicator in debug mode
+        if (this.config.debug) {
+            element.style.outline = '2px solid green';
+            element.style.outlineOffset = '-2px';
+
+            console.warn(
+                `DotCMS Analytics: Fired impression for ${identifier} (dwell: ${dwellTime}ms) - element unobserved`,
+                contentletData
+            );
+        }
+    }
+
+    /**
+     * Determines if an element should be skipped from tracking.
+     *
+     * @param element - The HTML element to check
+     * @returns A string describing why the element should be skipped, or null if it should be tracked
+     *
+     * @remarks
+     * Filters out elements that are:
+     * - Zero dimensions (empty/collapsed)
+     * - Too small (< 10x10px, likely tracking pixels)
+     * - Hidden with CSS (visibility: hidden, opacity: 0)
+     */
+    private shouldSkipElement(element: HTMLElement): string | null {
+        const rect = element.getBoundingClientRect();
+        const styles = window.getComputedStyle(element);
+
+        // Check for zero dimensions (empty/collapsed elements)
+        if (rect.height === 0 || rect.width === 0) {
+            return `zero dimensions: ${rect.width}x${rect.height}`;
+        }
+
+        // Check for very small elements (likely tracking pixels or artifacts)
+        const MIN_SIZE = 10; // pixels
+        if (rect.height < MIN_SIZE || rect.width < MIN_SIZE) {
+            return `too small: ${rect.width}x${rect.height} (minimum: ${MIN_SIZE}px)`;
+        }
+
+        // Check for hidden elements (visibility: hidden)
+        if (styles.visibility === 'hidden') {
+            return 'visibility: hidden';
+        }
+
+        // Check for transparent elements (opacity: 0)
+        if (parseFloat(styles.opacity) === 0) {
+            return 'opacity: 0';
+        }
+
+        // Check for elements with display: none
+        if (styles.display === 'none') {
+            return 'display: none';
+        }
+
+        // Element passes all checks
+        return null;
+    }
+
+    /**
+     * Checks if an element is still visible after dwell time expires.
+     *
+     * @param element - The HTML element to check
+     * @returns True if element is still visible and meets threshold
+     *
+     * @remarks
+     * This is the critical post-dwell check that prevents incorrect impressions.
+     */
+    private isElementStillVisible(element: HTMLElement): boolean {
+        // Check page visibility first
+        if (document.visibilityState !== 'visible') {
+            return false;
+        }
+
+        // Check if element meets visibility threshold using utility
+        return isElementMeetingVisibilityThreshold(
+            element,
+            this.impressionConfig.visibilityThreshold
+        );
+    }
+
+    /**
+     * Checks if an impression has already been tracked in this session.
+     *
+     * @param identifier - The contentlet identifier
+     * @returns True if the impression was already tracked
+     */
+    private hasBeenTrackedInSession(identifier: string): boolean {
+        return this.sessionTrackedImpressions.has(identifier);
+    }
+
+    /**
+     * Marks an impression as tracked in the current page session.
+     *
+     * @param identifier - The contentlet identifier
+     *
+     * @remarks
+     * Adds to in-memory Set for deduplication within the current page.
+     * Tracked impressions are reset on page reload/navigation.
+     */
+    private markImpressionAsTracked(identifier: string): void {
+        this.sessionTrackedImpressions.add(identifier);
+    }
+
+    /**
+     * Cleans up all tracking resources.
+     *
+     * @remarks
+     * - Disconnects IntersectionObserver
+     * - Disconnects MutationObserver
+     * - Clears all active dwell timers
+     * - Clears all state
+     *
+     * Should be called when the tracker is no longer needed (e.g., page unload).
+     */
+    public cleanup(): void {
+        // Disconnect intersection observer
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
+        }
+
+        // Disconnect mutation observer
+        if (this.mutationObserver) {
+            this.mutationObserver.disconnect();
+            this.mutationObserver = null;
+        }
+
+        // Clear all active dwell timers
+        this.elementImpressionStates.forEach((state) => {
+            if (state.timer !== null) {
+                window.clearTimeout(state.timer);
+            }
+        });
+
+        // Clear all state
+        this.elementImpressionStates.clear();
+
+        if (this.config.debug) {
+            console.warn('DotCMS Analytics: Impression tracking cleaned up');
+        }
+    }
+}

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.ts
@@ -4,6 +4,7 @@ import {
     ANALYTICS_JS_DEFAULT_PROPERTIES,
     ANALYTICS_MINIFIED_SCRIPT_NAME,
     DEFAULT_SESSION_TIMEOUT_MINUTES,
+    DotCMSPredefinedEventType,
     EXPECTED_UTM_KEYS,
     SESSION_STORAGE_KEY,
     USER_ID_KEY
@@ -17,7 +18,8 @@ import {
     DotCMSEventPageData,
     DotCMSEventUtmData,
     EnrichedAnalyticsPayload,
-    JsonObject
+    JsonObject,
+    JsonValue
 } from './models';
 
 // Export activity tracking functions from separate module
@@ -29,6 +31,28 @@ export {
     isUserInactive,
     updateSessionActivity
 } from './dot-content-analytics.activity-tracker';
+
+/**
+ * Type guard to check if an event is a predefined event type.
+ * Enables TypeScript type narrowing for better type safety.
+ *
+ * @param event - Event name to check
+ * @returns True if event is a predefined type, false for custom events
+ *
+ * @example
+ * ```typescript
+ * if (isPredefinedEventType(eventName)) {
+ *   // TypeScript knows eventName is DotCMSPredefinedEventType here
+ *   console.log('Predefined event:', eventName);
+ * } else {
+ *   // TypeScript knows eventName is string (custom) here
+ *   console.log('Custom event:', eventName);
+ * }
+ * ```
+ */
+export function isPredefinedEventType(event: string): event is DotCMSPredefinedEventType {
+    return Object.values(DotCMSPredefinedEventType).includes(event as DotCMSPredefinedEventType);
+}
 
 /**
  * Validates required configuration fields for Analytics initialization.
@@ -533,7 +557,7 @@ export const enrichPagePayloadOptimized = (
     const userProvidedProperties: JsonObject = {};
     Object.keys(properties).forEach((key) => {
         if (!(ANALYTICS_JS_DEFAULT_PROPERTIES as readonly string[]).includes(key)) {
-            userProvidedProperties[key] = properties[key as keyof typeof properties];
+            userProvidedProperties[key] = properties[key as keyof typeof properties] as JsonValue;
         }
     });
 

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/data.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/data.model.ts
@@ -95,7 +95,7 @@ export interface DotCMSEventUtmData {
 }
 
 /**
- * Page data structure for DotCMS analytics.
+ * Page data structure for DotCMS analytics (used in pageview events).
  * Contains comprehensive information about the current page and its context
  * within the DotCMS environment.
  */
@@ -110,3 +110,43 @@ export type DotCMSEventPageData = Pick<
     /** Persona identifier */
     persona?: string;
 };
+
+/**
+ * Minimal page data for content impression events.
+ * Contains only essential page information (title and url) to keep payload lightweight.
+ */
+export type DotCMSContentImpressionPageData = Pick<DotCMSEventPageData, 'title' | 'url'>;
+
+/**
+ * Data structure for content impression events.
+ * Tracks when a contentlet becomes visible in the viewport.
+ */
+export interface DotCMSImpressionEventData {
+    /** Contentlet identification data extracted from data-dot-analytics-* attributes */
+    contentlet: {
+        /** Unique identifier of the contentlet */
+        identifier: string;
+        /** Inode of the contentlet */
+        inode: string;
+        /** Content type name */
+        contentType: string;
+        /** Title of the contentlet */
+        title: string;
+        /** Base type of the contentlet (e.g., CONTENT, WIDGET) */
+        baseType: string;
+    };
+    /** Viewport position and visibility metrics */
+    viewport: {
+        /** Percentage offset from top of viewport (0-100) */
+        offsetPercentage: number;
+        /** Percentage of element visible in viewport (0-1) */
+        visibilityRatio: number;
+    };
+    /** Timing information about the impression */
+    timing: {
+        /** Time in milliseconds the element was continuously visible */
+        dwellTime: number;
+        /** ISO 8601 timestamp when the impression was fired */
+        timestamp: string;
+    };
+}

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/event.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/event.model.ts
@@ -3,7 +3,11 @@
  * Contains interfaces for different types of analytics events
  */
 
-import { DotCMSEventPageData, DotCMSEventUtmData } from './data.model';
+import {
+    DotCMSContentImpressionPageData,
+    DotCMSEventPageData,
+    DotCMSEventUtmData
+} from './data.model';
 
 import {
     DotCMSCustomEventType,
@@ -66,11 +70,54 @@ export type DotCMSCustomEventData = {
 };
 
 /**
+ * Partial content impression data sent by producer plugins.
+ * Contains only impression-specific data (content and position).
+ * The enricher plugin will add page data automatically.
+ */
+export type DotCMSContentImpressionPayload = {
+    /** Content information */
+    content: {
+        /** Content identifier */
+        identifier: string;
+        /** Content inode */
+        inode: string;
+        /** Content title */
+        title: string;
+        /** Content type name */
+        content_type: string;
+    };
+    /** Position information in the viewport and DOM */
+    position: {
+        /** Viewport offset percentage from top */
+        viewport_offset_pct: number;
+        /** DOM index position */
+        dom_index: number;
+    };
+};
+
+/**
+ * Complete data structure for content impression events after enrichment.
+ * Includes minimal page data (title and url) added by the enricher plugin.
+ */
+export type DotCMSContentImpressionEventData = DotCMSContentImpressionPayload & {
+    /** Minimal page data where the impression occurred (added by enricher) */
+    page: DotCMSContentImpressionPageData;
+};
+
+/**
  * Pageview event structure.
  */
 export type DotCMSPageViewEvent = DotCMSEventBase<
     typeof DotCMSPredefinedEventType.PAGEVIEW,
     DotCMSPageViewEventData
+>;
+
+/**
+ * Content impression event structure.
+ */
+export type DotCMSContentImpressionEvent = DotCMSEventBase<
+    typeof DotCMSPredefinedEventType.CONTENT_IMPRESSION,
+    DotCMSContentImpressionEventData
 >;
 
 /**
@@ -80,5 +127,6 @@ export type DotCMSCustomEvent = DotCMSEventBase<DotCMSCustomEventType, DotCMSCus
 
 /**
  * Union type for all possible analytics events.
+ * Used primarily for type documentation and validation.
  */
-export type DotCMSEvent = DotCMSPageViewEvent | DotCMSCustomEvent;
+export type DotCMSEvent = DotCMSPageViewEvent | DotCMSContentImpressionEvent | DotCMSCustomEvent;

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
@@ -3,8 +3,13 @@
  * Contains interfaces for SDK/library internal structures (not for end users)
  */
 
-import { DotCMSAnalyticsEventContext, DotCMSEventPageData, DotCMSEventUtmData } from './data.model';
-import { JsonObject } from './event.model';
+import {
+    DotCMSAnalyticsEventContext,
+    DotCMSContentImpressionPageData,
+    DotCMSEventPageData,
+    DotCMSEventUtmData
+} from './data.model';
+import { DotCMSContentImpressionPayload, JsonObject } from './event.model';
 import { DotCMSAnalyticsRequestBody } from './request.model';
 
 /**
@@ -195,6 +200,18 @@ export type EnrichedAnalyticsPayload = AnalyticsBasePayloadWithContext & {
     /** Local timestamp when the event occurred */
     local_time: string;
 };
+
+/**
+ * Enriched track event payload with fields added to root based on event type.
+ * Used by the enricher plugin for track events.
+ */
+export interface EnrichedTrackPayload extends AnalyticsTrackPayloadWithContext {
+    local_time: string;
+    page?: DotCMSContentImpressionPageData | DotCMSEventPageData;
+    content?: DotCMSContentImpressionPayload['content'];
+    position?: DotCMSContentImpressionPayload['position'];
+    utm?: DotCMSEventUtmData;
+}
 
 /**
  * Analytics.js instance structure for DotCMS.

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
@@ -21,6 +21,19 @@ export interface QueueConfig {
 }
 
 /**
+ * Configuration for content impression tracking.
+ * Controls how content visibility is detected and tracked.
+ */
+export interface ImpressionConfig {
+    /** Minimum percentage of element visible (0.0 to 1.0) - default: 0.5 */
+    visibilityThreshold?: number;
+    /** Minimum time in milliseconds element must be visible - default: 750 */
+    dwellMs?: number;
+    /** Maximum number of elements to track (performance limit) - default: 1000 */
+    maxNodes?: number;
+}
+
+/**
  * Main interface for the DotCMS Analytics SDK.
  * Provides the core methods for tracking page views and custom events.
  */
@@ -71,6 +84,14 @@ export interface DotCMSAnalyticsConfig {
      * - `QueueConfig`: Enable queuing with custom settings
      */
     queue?: QueueConfig | boolean;
+
+    /**
+     * Content impression tracking configuration:
+     * - `undefined` or `false` (default): Impression tracking disabled
+     * - `true`: Enable with default settings (threshold: 0.5, dwell: 750ms, maxNodes: 1000)
+     * - `ImpressionConfig`: Enable with custom settings
+     */
+    impressions?: ImpressionConfig | boolean;
 }
 
 /**

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
@@ -36,8 +36,6 @@ export interface ImpressionConfig {
     maxNodes?: number;
     /** Throttle time in milliseconds for intersection callbacks - default: 100 */
     throttleMs?: number;
-    /** Use requestIdleCallback for optimized processing - default: true */
-    useIdleCallback?: boolean;
 }
 
 /**

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/request.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/request.model.ts
@@ -4,30 +4,39 @@
  */
 
 import { DotCMSAnalyticsEventContext } from './data.model';
-import { DotCMSCustomEvent, DotCMSEvent, DotCMSPageViewEvent } from './event.model';
+import { DotCMSEvent } from './event.model';
 
 /**
  * Analytics request body for DotCMS Analytics.
  * Generic structure sent to the DotCMS analytics server.
+ *
+ * This structure contains properly typed events that match the DotCMS event specifications.
+ * Events can be pageviews, content impressions, or custom events, each with their own data structure.
  */
-export interface DotCMSRequestBody<T extends DotCMSEvent> {
+export interface DotCMSRequestBody {
     /** Context information shared across all events */
     context: DotCMSAnalyticsEventContext;
     /** Array of analytics events to be tracked */
-    events: T[];
+    events: DotCMSEvent[];
 }
 
 /**
- * Specific request body type for PageView events
+ * Main type for analytics request bodies.
+ * Flexible enough to accept any event type (pageview, content_impression, custom, etc.)
  */
-export type DotCMSPageViewRequestBody = DotCMSRequestBody<DotCMSPageViewEvent>;
+export type DotCMSAnalyticsRequestBody = DotCMSRequestBody;
 
 /**
- * Specific request body type for Custom events
+ * Specific request body type for PageView events (for type documentation)
  */
-export type DotCMSCustomEventRequestBody = DotCMSRequestBody<DotCMSCustomEvent>;
+export type DotCMSPageViewRequestBody = DotCMSRequestBody;
 
 /**
- * Union type for all possible request bodies
+ * Specific request body type for ContentImpression events (for type documentation)
  */
-export type DotCMSAnalyticsRequestBody = DotCMSPageViewRequestBody | DotCMSCustomEventRequestBody;
+export type DotCMSContentImpressionRequestBody = DotCMSRequestBody;
+
+/**
+ * Specific request body type for Custom events (for type documentation)
+ */
+export type DotCMSCustomEventRequestBody = DotCMSRequestBody;


### PR DESCRIPTION
## Summary

This PR implements automatic content impression tracking for the dotCMS Analytics SDK, allowing applications to track when contentlets become visible in the user's viewport. The feature uses the IntersectionObserver API for high-performance, battery-efficient visibility detection with configurable thresholds for visibility percentage and dwell time.

## Changes Made

### Analytics SDK Core (`core-web/libs/sdk/analytics/`)

#### Impression Tracking System
- **New impression tracker class** [`dot-content-analytics.impression-tracker.ts`](core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.impression-tracker.ts)
  - Implements IntersectionObserver-based content visibility detection
  - Tracks dwell time (minimum time visible before firing event)
  - Deduplicates impressions per session
  - Respects page visibility (pauses when tab inactive)
  - Handles dynamic content with MutationObserver
  - Automatically disabled in dotCMS editor mode (UVE)
  - Performance-optimized with configurable limits (default: 1000 max elements)

- **New impression plugin** [`dot-analytics.impression.plugin.ts`](core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.plugin.ts)
  - Lifecycle management for impression tracking
  - Initializes tracker when enabled via config
  - Cleanup handlers for page unload events

- **Impression utility functions** [`dot-analytics.impression.utils.ts`](core-web/libs/sdk/analytics/src/lib/core/plugin/impression/dot-analytics.impression.utils.ts)
  - Pure functions for visibility calculations
  - Viewport metrics extraction (offset percentage, visibility ratio)
  - Contentlet data extraction from DOM attributes
  - Debounce and throttle utilities

#### Plugin Architecture Refactoring
- **Main plugin** [`dot-analytics.plugin.ts`](core-web/libs/sdk/analytics/src/lib/core/plugin/dot-analytics.plugin.ts:69-168)
  - Refactored to handle both predefined and custom events
  - Added type guards to distinguish event types
  - Structures events based on type (pageview, content_impression, custom)
  - Simplified event sending logic with `sendEvent()` helper

- **Enricher plugin** [`dot-analytics.enricher.plugin.ts`](core-web/libs/sdk/analytics/src/lib/core/plugin/enricher/dot-analytics.enricher.plugin.ts)
  - Updated to handle content impression events
  - Adds minimal page data (title, url) to impression events
  - Simplified event enrichment logic
  - Better type safety with discriminated unions

#### Type System Enhancements
- **Data models** [`data.model.ts`](core-web/libs/sdk/analytics/src/lib/core/shared/models/data.model.ts:113-152)
  - New `DotCMSContentImpressionPageData` type (minimal page data)
  - New `DotCMSImpressionEventData` interface
  - Added viewport metrics and timing information structures

- **Event models** [`event.model.ts`](core-web/libs/sdk/analytics/src/lib/core/shared/models/event.model.ts:72-111)
  - New `DotCMSContentImpressionPayload` type (producer plugin data)
  - New `DotCMSContentImpressionEventData` type (enriched data)
  - New `DotCMSContentImpressionEvent` type
  - Updated `DotCMSEvent` union to include impression events

- **Library models** [`library.model.ts`](core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts:21-54)
  - New `ImpressionConfig` interface with configurable thresholds
  - New `ContentletData` interface for contentlet metadata
  - New `ViewportMetrics` interface for viewport calculations
  - Added `impressions` property to `DotCMSAnalyticsConfig`

- **Request models** [`request.model.ts`](core-web/libs/sdk/analytics/src/lib/core/shared/models/request.model.ts:10-30)
  - Simplified request body types
  - Better documentation of event structure flexibility

#### Constants and Utilities
- **Constants** [`dot-content-analytics.constants.ts`](core-web/libs/sdk/analytics/src/lib/core/shared/constants/dot-content-analytics.constants.ts)
  - Added `CONTENT_IMPRESSION` predefined event type
  - Default configuration values for impression tracking
  - DOM class/attribute constants for contentlet identification

- **Utilities** [`dot-content-analytics.utils.ts`](core-web/libs/sdk/analytics/src/lib/core/shared/dot-content-analytics.utils.ts)
  - New `isPredefinedEventType()` type guard function
  - Helper functions for event type discrimination

### Documentation
- **README updates** [`README.md`](core-web/libs/sdk/analytics/README.md:118-227)
  - Comprehensive impression tracking configuration guide
  - Usage examples with default and custom configurations
  - How it works section explaining the feature
  - Configuration option reference table

## Technical Details

### Impression Tracking Architecture

The impression tracking system follows a producer-consumer pattern within the Analytics.js plugin pipeline:

1. **Impression Plugin** (Producer)
   - Monitors DOM for contentlets with `dotcms-analytics-contentlet` class
   - Fires `instance.track('content-impression', data)` when visibility/dwell thresholds met
   - Runs independently in the Analytics.js lifecycle

2. **Enricher Plugin** (Middleware)
   - Intercepts impression events via `track:dot-analytics` hook
   - Adds minimal page data (title, url only)
   - Passes enriched data to main plugin

3. **Main Plugin** (Consumer)
   - Receives enriched impression data
   - Structures into proper `DotCMSContentImpressionEvent`
   - Sends to queue or server

### Performance Optimizations

- **IntersectionObserver API**: Native browser API for efficient visibility detection
- **Throttling**: Configurable throttle for intersection callbacks (default: 100ms)
- **Idle Callback**: Optional `requestIdleCallback()` for low-priority processing
- **Node Limits**: Configurable maximum elements to track (default: 1000)
- **Session Deduplication**: Each contentlet tracked once per session
- **Visibility-aware**: Pauses tracking when tab is inactive

### Configuration Defaults

```typescript
{
  visibilityThreshold: 0.5,    // 50% visible
  dwellMs: 750,                 // 750ms dwell time
  maxNodes: 1000,               // Max 1000 elements
  throttleMs: 100,              // 100ms throttle
  useIdleCallback: false        // Direct processing
}
```

### Breaking Changes
None - this is a new feature that is disabled by default.

### Testing
 Unit tests added for impression utilities
 Manual testing performed with example application
 Integration tests for full tracking pipeline (follow-up)
 E2E tests in real-world scenarios (follow-up)

### Related Issues
Closes #33613

This PR fixes: #33613