### PR TITLE
feat(ci): add support for custom Docker image tags in workflows

### DIFF
--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -25,6 +25,9 @@ on:
         required: false
         type: boolean
         default: false
+      custom_tag:
+        description: 'Custom Docker Image Tag'
+        required: false
     secrets:
       docker_io_username:
         description: 'Docker.io username'
@@ -248,6 +251,7 @@ jobs:
             type=raw,value=${{ steps.set-common-vars.outputs.version }},enable=${{ steps.set-common-vars.outputs.is_release }}
             type=raw,value=latest,enable=${{ steps.set-common-vars.outputs.is_latest }}
             type=raw,value={{sha}},enable=${{ steps.set-common-vars.outputs.is_custom }}
+            type=raw,value=${{ inputs.custom_tag }},enable=${{ inputs.custom_tag != '' }}
         if: success()
 
       - name: Debug Docker Metadata

--- a/.github/workflows/legacy-release_publish-dotcms-docker-image.yml
+++ b/.github/workflows/legacy-release_publish-dotcms-docker-image.yml
@@ -16,6 +16,9 @@ on:
           - 'GHCR.IO'
           - 'BOTH'
         default: 'DOCKER.IO'
+        custom_tag:
+          description: 'Custom Docker Image Tag'
+          required: false
 jobs:
   prepare-build:
     name: Prepare build
@@ -45,6 +48,7 @@ jobs:
       ref: ${{ needs.prepare-build.outputs.ref }}
       docker_platforms: ${{ needs.prepare-build.outputs.docker_platforms }}
       docker_registry: ${{ inputs.docker_registry }}
+      custom_tag: ${{ inputs.custom_tag }}
     secrets:
       docker_io_username: ${{ secrets.DOCKER_USERNAME }}
       docker_io_token: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
### Changes:
- Introduced `custom_tag` input to specify a custom Docker image tag in `legacy-release_publish-dotcms-docker-image.yml` and `legacy-release_comp_maven-build-docker-image.yml` workflows.
- Updated workflows to utilize the new input where applicable.

ref: #33737

This PR fixes: #33737