### PR TITLE
fix(ci): add `type: string` to `custom_tag` input in workflows

### DIFF
--- a/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
+++ b/.github/workflows/legacy-release_comp_maven-build-docker-image.yml
@@ -28,6 +28,7 @@ on:
       custom_tag:
         description: 'Custom Docker Image Tag'
         required: false
+        type: string
     secrets:
       docker_io_username:
         description: 'Docker.io username'

--- a/.github/workflows/legacy-release_publish-dotcms-docker-image.yml
+++ b/.github/workflows/legacy-release_publish-dotcms-docker-image.yml
@@ -16,9 +16,10 @@ on:
           - 'GHCR.IO'
           - 'BOTH'
         default: 'DOCKER.IO'
-        custom_tag:
-          description: 'Custom Docker Image Tag'
-          required: false
+      custom_tag:
+        description: 'Custom Docker Image Tag'
+        required: false
+        type: string
 jobs:
   prepare-build:
     name: Prepare build


### PR DESCRIPTION
Updated `custom_tag` input in `legacy-release_publish-dotcms-docker-image.yml` and `legacy-release_comp_maven-build-docker-image.yml` to include `type: string` for better input validation.

ref: #33737

This PR fixes: #33737