### PR TITLE
#33742 Add Title Case requirement for MCP server content type field labels

### DIFF
--- a/core-web/apps/mcp-server/src/tools/content-types/index.ts
+++ b/core-web/apps/mcp-server/src/tools/content-types/index.ts
@@ -32,7 +32,7 @@ export function registerContentTypeTools(server: McpServer) {
         {
             title: 'Create Content Type',
             description:
-                'Creates a content type in dotCMS. Content types are used to define the structure of content in dotCMS, you can think of them as schemas for content. NOTE: For field types Checkbox, Multi-Select, Radio, and Select, the "values" property is required. The value should be a string with one option per line, each formatted as "Label|value". Example: Pizza|pizza\nChicken|chicken This will create two options for the field.',
+                'Creates a content type in dotCMS. Content types are used to define the structure of content in dotCMS, you can think of them as schemas for content. IMPORTANT: Field names must be in Title Case format (e.g., "Page Title" not "pageTitle", "First Name" not "firstName"). NOTE: For field types Checkbox, Multi-Select, Radio, and Select, the "values" property is required. The value should be a string with one option per line, each formatted as "Label|value". Example: Pizza|pizza\nChicken|chicken This will create two options for the field.',
             annotations: {
                 title: 'Create Content Type',
                 readOnlyHint: false,


### PR DESCRIPTION
## Description
Updates the MCP server content type creation tool to enforce Title Case formatting for field labels, ensuring human-readable and properly formatted field names.

## What Changed
- Added IMPORTANT note in the content type creation description requiring field names to be in Title Case format
- Provides clear examples: "Page Title" not "pageTitle", "First Name" not "firstName"

## Why
When the MCP server creates content types, field labels should be human-readable and follow consistent formatting conventions. Title Case formatting improves readability and maintains professional standards across content type definitions.

## Related Issue
Closes #33742