### PR TITLE
#33795 Add contributing guide to MCP server

### DIFF
--- a/core-web/apps/mcp-server/CONTRIBUTING.md
+++ b/core-web/apps/mcp-server/CONTRIBUTING.md
@@ -1,0 +1,82 @@
+## Adding New Tools
+
+### Quick Start
+
+1. **Copy the example tool**:
+```bash
+   cp -r src/tools/_example-tool src/tools/your-tool-name
+```
+
+2. **Follow the TODOs** in each file
+
+3. **Register in `main.ts`**:
+```typescript
+   import { registerYourTools } from './tools/your-tool-name';
+   registerYourTools(server);
+```
+
+4. **Test it**:
+```bash
+   yarn nx test mcp-server
+```
+
+### Do I Need a New Service?
+
+**Use existing services if:**
+- You're working with content types → `ContentTypeService`
+- You're creating/publishing/archiving content → `WorkflowService`
+- You're searching content → `SearchService`
+- You need site information → `SiteService`
+
+**Create a new service if:**
+- You need a dotCMS API endpoint that doesn't have a service yet
+- You're integrating with an external system (not dotCMS)
+
+### Creating a New Service
+
+If you need a new service:
+
+1. **Create service file** in `src/services/your-service.ts`
+2. **Extend AgnosticClient**:
+```typescript
+   export class YourService extends AgnosticClient {
+       // Your service gets automatic auth, logging, error handling
+   }
+```
+3. **Add Zod schemas** in `src/types/your-types.ts`
+4. **Add tests** in `src/services/your-service.spec.ts`
+5. **Then create your tool** using the tool template
+
+See existing services for patterns to follow.
+
+### CONTEXT Framework Principles
+
+Every tool must follow the CONTEXT framework:
+
+- **C - Context First**: Ensure context is initialized (handled by middleware)
+- **O - One Intent Per Tool**: Each tool does ONE thing (verb-based names)
+- **N - Narrow Parameters**: Maximum 5 parameters
+- **T - Transform Responses**: Natural language, not JSON dumps
+- **E - Educate with Errors**: Helpful error messages with next steps
+- **X - eXplicit Orchestration**: Clear descriptions guide the LLM
+
+### Tool Naming Conventions
+
+✅ Good names:
+- `publish_content_by_tag`
+- `search_content_by_category`
+- `archive_expired_content`
+
+❌ Bad names:
+- `manage_content` (too broad, not one intent)
+- `contentAction` (not snake_case, not descriptive)
+- `process` (what does it process?)
+
+### Best Practices
+
+1. **One tool = One user intent** (not one API endpoint)
+2. **Reuse services** (don't duplicate HTTP calls)
+3. **Format responses** (prose > JSON)
+4. **Log everything** (use the Logger class)
+5. **Validate everything** (use Zod schemas)
+6. **Test everything** (follow existing test patterns)

--- a/core-web/apps/mcp-server/src/tools/_example-tool/formatters.ts
+++ b/core-web/apps/mcp-server/src/tools/_example-tool/formatters.ts
@@ -1,0 +1,47 @@
+/**
+ * Response formatters for example tool
+ *
+ * CRITICAL: Transform Responses (CONTEXT Framework)
+ *
+ * LLMs work best with natural language, not raw JSON.
+ * Your formatters should:
+ * - Use prose, not data dumps
+ * - Include actionable next steps
+ * - Provide context about what happened
+ * - Include relevant URLs (if DOTCMS_URL is set)
+ * - Be scannable (use line breaks, bullets when appropriate)
+ */
+
+/**
+ * Formats the example tool response
+ *
+ * TODO: Replace this with your actual formatting logic
+ *
+ * @param data - The raw data from services
+ * @returns Natural language response for the LLM
+ */
+export function formatExampleResponse(_data: unknown): string {
+    // TODO: Transform your service responses into natural language
+
+    // Example pattern:
+    // return `Successfully ${params.action}ed ${data.length} content items!
+    //
+    // Content Type: ${params.contentType}
+    // Items affected:
+    // ${data.map(item => `- ${item.title} (${item.identifier})`).join('\n')}
+    //
+    // Next steps:
+    // - View content in dotCMS: ${getDotCMSUrl()}/dotAdmin/#/c/content/${data[0].inode}
+    // - Search for more content using content_search tool`;
+
+    return 'TODO: Format your response here';
+}
+
+/**
+ * TODO: Add more formatters if needed
+ *
+ * Examples:
+ * - formatErrorDetails() - for tool-specific error formatting
+ * - formatSummary() - for bulk operation summaries
+ * - formatProgress() - for multi-step operation updates
+ */

--- a/core-web/apps/mcp-server/src/tools/_example-tool/handlers.ts
+++ b/core-web/apps/mcp-server/src/tools/_example-tool/handlers.ts
@@ -1,0 +1,76 @@
+import { Logger } from '../../utils/logger';
+import { executeWithErrorHandling, createSuccessResponse } from '../../utils/response';
+
+// TODO: Import the services you need
+// Examples:
+// import { ContentTypeService } from '../../services/contentType';
+// import { WorkflowService } from '../../services/workflow';
+// import { SearchService } from '../../services/search';
+
+// TODO: Import your input schema from index.ts and zod for validation
+// import { z } from 'zod';
+// const ExampleToolInputSchema = z.object({ ... });
+
+const logger = new Logger('EXAMPLE_TOOL'); // TODO: Update logger name
+
+// TODO: Create service instances you need
+// const workflowService = new WorkflowService();
+// const searchService = new SearchService();
+
+/**
+ * Handles the example tool execution
+ *
+ * This is where your tool logic lives. It should:
+ * 1. Log the execution start
+ * 2. Call one or more services to do the work
+ * 3. Format the response using formatters.ts
+ * 4. Return a success response
+ *
+ * Error handling is automatic via executeWithErrorHandling
+ */
+// Note: Using 'any' type here as a template - replace with your actual input schema type
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function exampleToolHandler(params: any) {
+    // TODO: Type this properly
+    return executeWithErrorHandling(async () => {
+        logger.log('Starting example tool execution', params);
+
+        // TODO: Implement your tool logic here
+        //
+        // Example pattern for multi-step operations:
+        //
+        // Step 1: Search for content
+        // const searchResults = await searchService.search({
+        //     query: `+contentType:${params.contentType} +tags:${params.tag}`
+        // });
+        //
+        // Step 2: Process each result
+        // const results = [];
+        // for (const content of searchResults.entity.jsonObjectView.contentlets) {
+        //     const result = await workflowService.performContentAction({
+        //         identifier: content.identifier,
+        //         action: params.action
+        //     });
+        //     results.push(result);
+        // }
+        //
+        // Step 3: Format response
+        // const formattedText = formatExampleResponse(results);
+
+        const formattedText = 'TODO: Implement tool logic and format response';
+
+        logger.log('Example tool executed successfully');
+
+        return createSuccessResponse(formattedText);
+    }, 'Error executing example tool'); // TODO: Update error prefix
+}
+
+/**
+ * Additional helper functions for this tool
+ *
+ * TODO: Add any tool-specific helpers here
+ * Examples:
+ * - Validation functions
+ * - Data transformation functions
+ * - Business logic functions
+ */

--- a/core-web/apps/mcp-server/src/tools/_example-tool/index.ts
+++ b/core-web/apps/mcp-server/src/tools/_example-tool/index.ts
@@ -1,0 +1,75 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import { exampleToolHandler } from './handlers';
+
+/**
+ * TODO: Define your input schema
+ *
+ * TIPS:
+ * - Keep it to 5 parameters max (Narrow Parameters principle)
+ * - Use descriptive names that match dotCMS terminology
+ * - Add .optional() for non-required fields
+ * - Add validation rules (max length, enums, etc.)
+ */
+const ExampleToolInputSchema = z.object({
+    // Example parameters - replace with your own
+    contentType: z.string().describe('Content type variable name'),
+    action: z.enum(['publish', 'unpublish', 'archive']).describe('Action to perform'),
+    limit: z.number().int().positive().max(100).optional().default(10)
+});
+
+/**
+ * Registers this tool with the MCP server
+ *
+ * TODO:
+ * 1. Update the tool name (use snake_case, verb-first)
+ * 2. Update the title and description
+ * 3. Update the annotations
+ * 4. Update the inputSchema
+ */
+export function registerExampleTools(server: McpServer) {
+    server.registerTool(
+        'example_tool_action', // TODO: Replace with your tool name (e.g., 'bulk_publish_by_tag')
+        {
+            title: 'Example Tool Action', // TODO: Human-readable title
+
+            // TODO: Write a clear description that explains:
+            // - What this tool does
+            // - When to use it
+            // - What parameters it needs
+            // - Any prerequisites (like specific content types existing)
+            description: `
+                TODO: Describe your tool here.
+
+                This tool does X by using Y service to accomplish Z.
+
+                Prerequisites:
+                - Context must be initialized first
+                - Content type must exist
+
+                Example usage: "Publish all blog posts tagged with 'featured'"
+            `.trim(),
+
+            annotations: {
+                title: 'Example Tool Action',
+
+                // TODO: Set to true if this tool only reads data (doesn't modify)
+                readOnlyHint: false,
+
+                // TODO: Set to true if calling this tool multiple times with same params is safe
+                idempotentHint: false,
+
+                // TODO: Set to true if parameters accept open-ended values
+                openWorldHint: true
+            },
+
+            inputSchema: ExampleToolInputSchema.shape
+        },
+        exampleToolHandler
+    );
+}
+
+// TODO: Don't forget to register this in src/main.ts:
+// import { registerExampleTools } from './tools/_example-tool';
+// registerExampleTools(server);


### PR DESCRIPTION
Closes #33795

Adds CONTRIBUTING.md with guidelines for creating new tools and an example tool template.

**Changes:**
- Added CONTRIBUTING.md with CONTEXT framework principles
- Created example tool template in src/tools/_example-tool/
- Includes best practices for tool development

This PR fixes: #33795