### PR TITLE
Fix: Migrate from deprecated macos-13 to macos-15-intel runner

### DIFF
--- a/.github/workflows/cicd_comp_cli-native-build-phase.yml
+++ b/.github/workflows/cicd_comp_cli-native-build-phase.yml
@@ -64,7 +64,7 @@ jobs:
         id: set-os
         run: |
           if [[ "${{ inputs.buildNativeImage }}" == "true" ]]; then
-            RUNNERS='[{ "os": "ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}", "label": "Linux", "platform": "linux-x86_64" }, { "os": "macos-13", "label": "macOS-Intel", "platform": "osx-x86_64" }, { "os": "macos-14", "label": "macOS-Silicon", "platform": "osx-aarch_64" }]'
+            RUNNERS='[{ "os": "ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}", "label": "Linux", "platform": "linux-x86_64" }, { "os": "macos-${{ vars.MACOS_INTEL_RUNNER_VERSION || '15-intel' }}", "label": "macOS-Intel", "platform": "osx-x86_64" }, { "os": "macos-${{ vars.MACOS_SILICON_RUNNER_VERSION || '14' }}", "label": "macOS-Silicon", "platform": "osx-aarch_64" }]'
           else
             RUNNERS='[{ "os": "ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}", "label": "Linux", "platform": "linux-x86_64" }]'
           fi


### PR DESCRIPTION
## Description

This PR resolves issue #33802 by migrating from the deprecated `macos-13` runner to the new `macos-15-intel` runner for macOS Intel builds.

## Changes

- ✅ Replaced deprecated `macos-13` runner with `macos-15-intel` (available until August 2027)
- ✅ Implemented variable-based runner version configuration similar to Ubuntu pattern
- ✅ Added support for `MACOS_INTEL_RUNNER_VERSION` and `MACOS_SILICON_RUNNER_VERSION` repository variables
- ✅ Set default values: `macos-15-intel` for Intel, `macos-14` for Silicon

## Solution Approach

Following the same pattern used for Ubuntu runners (`UBUNTU_RUNNER_VERSION`), this change:
- Provides flexibility to configure macOS runner versions via repository variables
- Uses safe default values that align with GitHub's recommendations
- Maintains consistency with existing workflow patterns

## Testing

The workflow should now successfully build native images for macOS Intel using the supported `macos-15-intel` runner.

## Related Issue

Resolves #33802

This PR fixes: #33802