### PR TITLE
modernization ( Angular Update ) : #33806 [BUG] App Deletion Action Fail Silently on Main Branch 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/app.component.html
+++ b/core-web/apps/dotcms-ui/src/app/app.component.html
@@ -1,1 +1,2 @@
 <router-outlet></router-outlet>
+<dot-alert-confirm />

--- a/core-web/apps/dotcms-ui/src/app/app.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/app.component.spec.ts
@@ -8,7 +8,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { DotLicenseService, DotMessageService, DotUiColorsService } from '@dotcms/data-access';
+import { ConfirmationService } from 'primeng/api';
+
+import {
+    DotAlertConfirmService,
+    DotLicenseService,
+    DotMessageService,
+    DotUiColorsService
+} from '@dotcms/data-access';
 import {
     CoreWebService,
     CoreWebServiceMock,
@@ -40,7 +47,9 @@ describe('AppComponent', () => {
                 LoggerService,
                 StringUtils,
                 DotLicenseService,
-                DotMessageService
+                DotMessageService,
+                DotAlertConfirmService,
+                ConfirmationService
             ]
         });
 
@@ -50,7 +59,7 @@ describe('AppComponent', () => {
         dotLicenseService = TestBed.inject(DotLicenseService);
         dotNavLogoService = TestBed.inject(DotNavLogoService);
 
-        jest.spyOn<any>(dotCmsConfigService, 'getConfig').mockReturnValue(
+        jest.spyOn(dotCmsConfigService, 'getConfig').mockReturnValue(
             of({
                 colors: {
                     primary: '#123',
@@ -66,7 +75,7 @@ describe('AppComponent', () => {
                     level: 200,
                     levelName: 'test level'
                 }
-            })
+            }) as any
         );
         jest.spyOn(dotUiColorsService, 'setColors');
         jest.spyOn(dotMessageService, 'init');
@@ -86,6 +95,11 @@ describe('AppComponent', () => {
     it('should have router-outlet', () => {
         fixture.detectChanges();
         expect(de.query(By.css('router-outlet')) !== null).toBe(true);
+    });
+
+    it('should have dot-alert-confirm component', () => {
+        fixture.detectChanges();
+        expect(de.query(By.css('dot-alert-confirm')) !== null).toBe(true);
     });
 
     it('should set ui colors', () => {

--- a/core-web/apps/dotcms-ui/src/app/app.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/app.component.ts
@@ -8,12 +8,13 @@ import { ConfigParams, DotcmsConfigService, DotUiColors } from '@dotcms/dotcms-j
 import { DotLicense } from '@dotcms/dotcms-models';
 
 import { DotNavLogoService } from './api/services/dot-nav-logo/dot-nav-logo.service';
+import { DotAlertConfirmComponent } from './view/components/_common/dot-alert-confirm/dot-alert-confirm';
 
 @Component({
     selector: 'dot-root',
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.scss'],
-    imports: [RouterOutlet]
+    imports: [RouterOutlet, DotAlertConfirmComponent]
 })
 export class AppComponent implements OnInit {
     private dotCmsConfigService = inject(DotcmsConfigService);


### PR DESCRIPTION
## Fix: DotAlertConfirmService dialogs not displaying

After the Angular standalone migration, confirmation dialogs were not showing because `dot-alert-confirm` wasn't available in all component hierarchies.

**Solution:** Moved `dot-alert-confirm` to the root `AppComponent` level for global availability.

**Changes:**
- Removed redundant instances from individual components

**Affected:** Content Types and Apps Configuration delete dialogs now work correctly.

This PR fixes: #33806