### PR TITLE
feat(dotcli): Added .dotcliignore to exclude files from push

### DIFF
--- a/tools/dotcms-cli/README.md
+++ b/tools/dotcms-cli/README.md
@@ -254,6 +254,60 @@ In the following table you can see the different directories and files that conf
 | `sites/`             | Dir  | Sites Directory         |
 | `.dot-workspace.yml` | File | CLI workspace marker    |
 
+## File Filtering with .dotcliignore
+
+When pushing files to dotCMS, you can exclude specific files and directories by creating a `.dotcliignore` file in your workspace. This file works similarly to `.gitignore` and supports standard glob patterns.
+
+### Pattern Syntax
+
+The `.dotcliignore` file supports the following glob patterns:
+
+- `*` - Matches any sequence of characters within a single directory level
+- `**` - Matches any sequence of characters across multiple directory levels
+- `?` - Matches any single character
+- `[]` - Matches a character class (e.g., `[abc]` or `[0-9]`)
+- `!` - Negates a pattern to re-include files that were previously excluded
+
+### Hierarchical Pattern Loading
+
+The CLI loads `.dotcliignore` files hierarchically from the current directory up to the workspace root. Patterns defined in child directories take precedence over parent directories, allowing you to override parent exclusions.
+
+### Usage Examples
+
+Create a `.dotcliignore` file in your workspace with patterns like:
+
+```
+# Ignore all log files
+*.log
+
+# Ignore build directories
+build/
+dist/
+target/
+
+# Ignore OS-specific files
+**/.DS_Store
+**/Thumbs.db
+
+# Ignore dependencies
+node_modules/
+vendor/
+
+# Re-include a specific log file (negation)
+!important.log
+```
+
+### Notes
+
+- Lines starting with `#` are treated as comments
+- Blank lines are ignored
+- Leading and trailing whitespace is automatically removed from patterns
+- To preserve trailing spaces in a pattern, escape them with a backslash: `pattern\ `
+- Patterns are evaluated relative to the workspace root
+- Directory patterns should end with `/`
+- Files matching ignore patterns will be excluded during `files push` operations
+- Pull operations are not affected by `.dotcliignore` files
+
 ## GitHub Actions Integration
 We provide support for GitHub Actions to be able to run the CLI as part of your CI/CD pipeline. 
 

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/files/traversal/LocalTraversalServiceImpl.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/files/traversal/LocalTraversalServiceImpl.java
@@ -12,10 +12,12 @@ import com.dotcms.api.client.files.traversal.task.PullTreeNodeTask;
 import com.dotcms.api.client.files.traversal.task.PullTreeNodeTaskParams;
 import com.dotcms.api.traversal.TreeNode;
 import com.dotcms.cli.common.ConsoleProgressBar;
+import com.dotcms.cli.common.DotCliIgnore;
 import com.dotcms.common.AssetsUtils;
 import com.dotcms.common.LocalPathStructure;
 import io.quarkus.arc.DefaultBean;
 import java.io.File;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CompletionException;
@@ -102,6 +104,13 @@ public class LocalTraversalServiceImpl implements LocalTraversalService {
                 fileHashCalculatorService
         );
 
+        // Create DotCliIgnore instance with hierarchical loading
+        // Load patterns from the source path up to the workspace root
+        final File sourceFile = new File(params.sourcePath());
+        final Path sourcePath = sourceFile.isDirectory() ? sourceFile.toPath() : sourceFile.getParentFile().toPath();
+        final Path workspaceRoot = workspace.toPath();
+        final DotCliIgnore dotCliIgnore = DotCliIgnore.create(sourcePath, workspaceRoot);
+
         task.setTaskParams(LocalFolderTraversalTaskParams.builder()
                 .siteExists(siteExists)
                 .sourcePath(params.sourcePath())
@@ -110,6 +119,7 @@ public class LocalTraversalServiceImpl implements LocalTraversalService {
                 .removeFolders(params.removeFolders())
                 .ignoreEmptyFolders(params.ignoreEmptyFolders())
                 .failFast(params.failFast())
+                .dotCliIgnore(dotCliIgnore)
                 .build()
         );
 

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/files/traversal/task/AbstractLocalFolderTraversalTaskParams.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/api/client/files/traversal/task/AbstractLocalFolderTraversalTaskParams.java
@@ -1,8 +1,10 @@
 package com.dotcms.api.client.files.traversal.task;
 
+import com.dotcms.cli.common.DotCliIgnore;
 import com.dotcms.model.annotation.ValueType;
 import java.io.File;
 import java.io.Serializable;
+import java.util.Optional;
 import org.immutables.value.Value;
 import org.immutables.value.Value.Default;
 
@@ -66,6 +68,13 @@ public interface AbstractLocalFolderTraversalTaskParams extends Serializable {
      * @return true if the operation should fail fast, false otherwise.
      */
     boolean failFast();
+
+    /**
+     * Returns the DotCliIgnore instance for filtering files and directories based on .dotcliignore patterns.
+     *
+     * @return Optional containing the DotCliIgnore instance, or empty if not set.
+     */
+    Optional<DotCliIgnore> dotCliIgnore();
 
     // END-NOSCAN
 

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/DotCliIgnore.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/DotCliIgnore.java
@@ -1,0 +1,384 @@
+package com.dotcms.cli.common;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.List;
+import org.jboss.logging.Logger;
+
+/**
+ * Parses and manages .dotcliignore files for filtering files and directories during push operations.
+ * Supports standard glob patterns similar to .gitignore:
+ * <ul>
+ *   <li>'*' - matches any sequence of characters within a path segment</li>
+ *   <li>'**' - matches any sequence of characters across path segments</li>
+ *   <li>'?' - matches any single character</li>
+ *   <li>'[]' - matches a character class</li>
+ *   <li>'!' - negates a pattern (includes files that were previously excluded)</li>
+ * </ul>
+ * <p>
+ * Patterns are evaluated relative to the .dotcliignore file location.
+ * Comments (lines starting with '#') and blank lines are ignored.
+ * </p>
+ */
+public class DotCliIgnore {
+
+    private static final Logger logger = Logger.getLogger(DotCliIgnore.class);
+    private static final String DOTCLIIGNORE_FILE = ".dotcliignore";
+
+    private final List<PatternRule> rules;
+    private final Path basePath;
+
+    /**
+     * Pattern rule representing a single line from .dotcliignore file.
+     */
+    private static class PatternRule {
+        final PathMatcher matcher;
+        final boolean negated;
+        final String originalPattern;
+
+        PatternRule(PathMatcher matcher, boolean negated, String originalPattern) {
+            this.matcher = matcher;
+            this.negated = negated;
+            this.originalPattern = originalPattern;
+        }
+    }
+
+    /**
+     * Creates a DotCliIgnore instance with patterns loaded from the .dotcliignore file
+     * located in the specified base directory.
+     *
+     * @param basePath the base directory containing the .dotcliignore file
+     * @param workspaceRoot the workspace root directory for hierarchical pattern loading
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    public DotCliIgnore(Path basePath, Path workspaceRoot) throws IOException {
+        this.basePath = basePath;
+        this.rules = new ArrayList<>();
+        loadIgnoreFilesHierarchically(basePath, workspaceRoot);
+    }
+
+    /**
+     * Creates an empty DotCliIgnore without loading any patterns.
+     * Used when error occurs during file loading.
+     *
+     * @param basePath the base directory for pattern matching
+     */
+    private DotCliIgnore(Path basePath) {
+        this.basePath = basePath;
+        this.rules = new ArrayList<>();
+    }
+
+    /**
+     * Creates a DotCliIgnore instance. Loads patterns hierarchically from the base directory
+     * up to the workspace root, merging all .dotcliignore files found along the way.
+     * Patterns closer to the base directory take precedence over patterns from parent directories.
+     *
+     * @param basePath the base directory to start loading patterns from
+     * @return a new DotCliIgnore instance
+     */
+    public static DotCliIgnore create(Path basePath) {
+        return create(basePath, basePath);
+    }
+
+    /**
+     * Creates a DotCliIgnore instance with hierarchical pattern loading.
+     * Loads patterns from .dotcliignore files starting from basePath up to workspaceRoot.
+     *
+     * @param basePath the base directory to start loading patterns from
+     * @param workspaceRoot the workspace root directory (top-level boundary for pattern search)
+     * @return a new DotCliIgnore instance
+     */
+    public static DotCliIgnore create(Path basePath, Path workspaceRoot) {
+        try {
+            // Normalize paths for comparison
+            Path normalizedBase = basePath.toAbsolutePath().normalize();
+            Path normalizedRoot = workspaceRoot.toAbsolutePath().normalize();
+
+            logger.debug(String.format("Creating DotCliIgnore with hierarchical loading from %s to %s",
+                                      normalizedBase, normalizedRoot));
+
+            return new DotCliIgnore(normalizedBase, normalizedRoot);
+        } catch (IOException e) {
+            logger.warn("Error reading .dotcliignore files: " + e.getMessage());
+            return new DotCliIgnore(basePath);
+        }
+    }
+
+    /**
+     * Loads patterns hierarchically from .dotcliignore files starting from startPath
+     * up to workspaceRoot. Patterns are loaded from child to parent, so patterns
+     * closer to the file being checked have higher precedence.
+     *
+     * @param startPath the starting directory to load patterns from
+     * @param workspaceRoot the workspace root directory (top boundary)
+     * @throws IOException if an I/O error occurs while reading files
+     */
+    private void loadIgnoreFilesHierarchically(Path startPath, Path workspaceRoot) throws IOException {
+        // Normalize paths for proper comparison
+        Path currentPath = startPath.toAbsolutePath().normalize();
+        final Path rootPath = workspaceRoot.toAbsolutePath().normalize();
+
+        int filesLoaded = 0;
+
+        // Walk up the directory tree from startPath to workspaceRoot
+        while (currentPath != null) {
+
+            final Path ignoreFile = currentPath.resolve(DOTCLIIGNORE_FILE);
+
+            if (Files.exists(ignoreFile) && Files.isRegularFile(ignoreFile)) {
+                logger.debug("Loading .dotcliignore from: " + ignoreFile);
+                loadIgnoreFile(ignoreFile);
+                filesLoaded++;
+            }
+
+            // Stop if we've reached the workspace root or can't go higher
+            if (currentPath.equals(rootPath)) {
+                break;
+            }
+
+            // Move up to parent directory
+            currentPath = currentPath.getParent();
+        }
+
+        if (filesLoaded > 0) {
+            logger.debug(String.format("Loaded %d .dotcliignore file(s) hierarchically", filesLoaded));
+        } else {
+            logger.debug("No .dotcliignore files found in hierarchy");
+        }
+    }
+
+    /**
+     * Loads patterns from a specific .dotcliignore file.
+     *
+     * @param ignoreFile the path to the .dotcliignore file
+     * @throws IOException if an I/O error occurs while reading the file
+     */
+    private void loadIgnoreFile(Path ignoreFile) throws IOException {
+        try (BufferedReader reader = Files.newBufferedReader(ignoreFile)) {
+            String line;
+            int lineNumber = 0;
+
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                try {
+                    processLine(trimIgnoreLine(line), lineNumber);
+                } catch (IllegalArgumentException e) {
+                    logger.error(String.format("Invalid pattern at line %d in %s: %s",
+                                              lineNumber, ignoreFile, e.getMessage()));
+                    throw e;
+                }
+            }
+        }
+    }
+
+    /**
+     * Trims a line from .dotcliignore file, preserving escaped trailing spaces.
+     * Leading whitespace is always removed. Trailing whitespace is removed unless
+     * preceded by a backslash (escaped).
+     *
+     * @param line the line to trim
+     * @return the trimmed line with escaped spaces preserved
+     */
+    private String trimIgnoreLine(String line) {
+        if (line == null) {
+            return "";
+        }
+
+        // Remove leading whitespace
+        String trimmedLeft = line.replaceFirst("^\\s+", "");
+
+        // Handle trailing spaces: remove unless escaped with backslash
+        // We need to check if trailing spaces are escaped
+        StringBuilder result = new StringBuilder(trimmedLeft);
+
+        // Remove trailing whitespace working backwards
+        int lastNonSpace = result.length() - 1;
+        while (lastNonSpace >= 0 && Character.isWhitespace(result.charAt(lastNonSpace))) {
+            lastNonSpace--;
+        }
+
+        // Check if the last non-space character is a backslash (escape)
+        if (lastNonSpace >= 0 && result.charAt(lastNonSpace) == '\\') {
+            // Count consecutive backslashes before the trailing spaces
+            int backslashCount = 0;
+            int pos = lastNonSpace;
+            while (pos >= 0 && result.charAt(pos) == '\\') {
+                backslashCount++;
+                pos--;
+            }
+
+            // If odd number of backslashes, the last one escapes the trailing space
+            if (backslashCount % 2 == 1) {
+                // Keep one trailing space and remove the escape backslash
+                result.delete(lastNonSpace + 1, result.length()); // Remove trailing spaces
+                result.setCharAt(lastNonSpace, ' '); // Replace last backslash with space
+                return result.toString();
+            }
+        }
+
+        // No escaped space, remove all trailing whitespace
+        return result.substring(0, lastNonSpace + 1);
+    }
+
+
+    /**
+     * Processes a single line from the .dotcliignore file.
+     *
+     * @param line the line to process
+     * @param lineNumber the line number (for error reporting)
+     */
+    private void processLine(String line, int lineNumber) {
+        // Skip empty lines and comments
+        if (line.isEmpty() || line.startsWith("#")) {
+            return;
+        }
+
+        // Check for negation pattern
+        boolean negated = false;
+        if (line.startsWith("!")) {
+            negated = true;
+            line = line.substring(1).trim();
+
+            if (line.isEmpty()) {
+                throw new IllegalArgumentException(
+                    "Invalid negation pattern at line " + lineNumber + ": pattern cannot be empty after '!'"
+                );
+            }
+        }
+
+        addPattern(line, negated);
+    }
+
+    /**
+     * Adds a pattern to the rules list.
+     *
+     * @param pattern the glob pattern to add
+     * @param negated whether this is a negation pattern
+     * @throws IllegalArgumentException if the pattern is invalid
+     */
+    private void addPattern(String pattern, boolean negated) {
+        try {
+            // Convert .gitignore-style patterns to glob patterns
+            String globPattern = convertToGlobPattern(pattern);
+
+            FileSystem fileSystem = FileSystems.getDefault();
+            PathMatcher matcher = fileSystem.getPathMatcher("glob:" + globPattern);
+
+            rules.add(new PatternRule(matcher, negated, pattern));
+            logger.debug("Added " + (negated ? "negation " : "") + "pattern: " + pattern + " (glob: " + globPattern + ")");
+
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                "Invalid glob pattern: '" + pattern + "'. " +
+                "Supported patterns: *, **, ?, [], and ! for negation. Error: " + e.getMessage()
+            );
+        }
+    }
+
+    /**
+     * Converts a .gitignore-style pattern to a Java glob pattern.
+     *
+     * @param pattern the .gitignore-style pattern
+     * @return the equivalent glob pattern
+     */
+    private String convertToGlobPattern(String pattern) {
+        // Handle directory patterns (ending with /)
+        if (pattern.endsWith("/")) {
+            // Match directory and everything inside it
+            // Remove trailing slash and add patterns for both directory and contents
+            String dirPattern = pattern.substring(0, pattern.length() - 1);
+            return "**/" + dirPattern + "{,/**}";
+        }
+
+        // Handle patterns starting with /
+        if (pattern.startsWith("/")) {
+            // Absolute path from workspace root
+            return pattern.substring(1);
+        }
+
+        // Handle patterns already containing ** (full path wildcards)
+        if (pattern.startsWith("**/")) {
+            return pattern;
+        }
+
+        // Handle patterns containing /
+        if (pattern.contains("/")) {
+            // If it contains /, it's a path pattern
+            return "**/" + pattern;
+        }
+
+        // Simple filename patterns
+        return "**/" + pattern;
+    }
+
+    /**
+     * Checks if a file or directory should be ignored based on the loaded patterns.
+     * Patterns are evaluated in order, with later patterns overriding earlier ones.
+     * Negation patterns (starting with !) can re-include files that were previously excluded.
+     *
+     * @param file the file to check
+     * @return true if the file should be ignored, false otherwise
+     */
+    public boolean shouldIgnore(File file) {
+        return shouldIgnore(file.toPath());
+    }
+
+    /**
+     * Checks if a path should be ignored based on the loaded patterns.
+     *
+     * @param path the path to check
+     * @return true if the path should be ignored, false otherwise
+     */
+    public boolean shouldIgnore(Path path) {
+        // Calculate relative path from base path
+        Path relativePath;
+        try {
+            if (path.isAbsolute()) {
+                relativePath = basePath.relativize(path);
+            } else {
+                relativePath = path;
+            }
+        } catch (IllegalArgumentException e) {
+            // Path is outside the base path, don't ignore it
+            logger.debug("Path outside base path, not ignoring: " + path);
+            return false;
+        }
+
+        // Evaluate patterns in order
+        boolean ignored = false;
+        for (PatternRule rule : rules) {
+            if (rule.matcher.matches(relativePath)) {
+                ignored = !rule.negated; // Negation flips the result
+                logger.debug("Pattern '" + rule.originalPattern + "' matched path: " + relativePath +
+                           " (ignored=" + ignored + ")");
+            }
+        }
+
+        return ignored;
+    }
+
+    /**
+     * Gets the base path for this DotCliIgnore instance.
+     *
+     * @return the base path
+     */
+    public Path getBasePath() {
+        return basePath;
+    }
+
+    /**
+     * Gets the number of loaded patterns (including default patterns).
+     *
+     * @return the number of patterns
+     */
+    public int getPatternCount() {
+        return rules.size();
+    }
+}

--- a/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/DotCliIgnoreFileFilter.java
+++ b/tools/dotcms-cli/cli/src/main/java/com/dotcms/cli/common/DotCliIgnoreFileFilter.java
@@ -1,0 +1,48 @@
+package com.dotcms.cli.common;
+
+import java.io.File;
+import java.io.FileFilter;
+
+/**
+ * FileFilter implementation that combines hidden file filtering with .dotcliignore pattern
+ * matching. This filter blocks:
+ * <ul>
+ *   <li>Hidden files (files starting with '.' on Unix systems or with hidden attribute on Windows)</li>
+ *   <li>Files and directories matching patterns in .dotcliignore file</li>
+ * </ul>
+ */
+public class DotCliIgnoreFileFilter implements FileFilter {
+
+    private final DotCliIgnore dotCliIgnore;
+
+    /**
+     * Creates a new DotCliIgnoreFileFilter with the specified DotCliIgnore instance.
+     *
+     * @param dotCliIgnore the DotCliIgnore instance to use for pattern matching
+     */
+    public DotCliIgnoreFileFilter(DotCliIgnore dotCliIgnore) {
+        this.dotCliIgnore = dotCliIgnore;
+    }
+
+    /**
+     * Tests whether the specified file should be accepted (not filtered out).
+     * A file is accepted if it is NOT:
+     * <ul>
+     *   <li>A hidden file</li>
+     *   <li>Matching any ignore pattern in .dotcliignore</li>
+     * </ul>
+     *
+     * @param file the file to test
+     * @return true if the file should be accepted, false otherwise
+     */
+    @Override
+    public boolean accept(File file) {
+        // First check if it's a hidden file (original HiddenFileFilter logic)
+        if (file.isFile() && file.isHidden()) {
+            return false;
+        }
+
+        // Then check if it matches any ignore pattern
+        return !dotCliIgnore.shouldIgnore(file);
+    }
+}

--- a/tools/dotcms-cli/cli/src/main/resources/.dotcliignore.example
+++ b/tools/dotcms-cli/cli/src/main/resources/.dotcliignore.example
@@ -1,0 +1,66 @@
+# .dotcliignore - Patterns for files and directories to exclude from push/pull operations
+#
+# This file uses glob patterns similar to .gitignore:
+#   *       - matches any sequence of characters within a path segment
+#   **      - matches any sequence of characters across path segments
+#   ?       - matches any single character
+#   []      - matches a character class
+#   !       - negates a pattern (includes files that were previously excluded)
+#
+# Lines starting with # are comments and are ignored.
+# Blank lines are also ignored.
+# Patterns are evaluated relative to the workspace root.
+
+# Version control directories
+.git/
+.svn/
+.hg/
+
+# Dependency directories
+node_modules/
+vendor/
+bower_components/
+
+# Build outputs
+dist/
+build/
+target/
+*.class
+*.jar
+*.war
+
+# IDE and editor files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.project
+.classpath
+.settings/
+
+# Operating system files
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Log files
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.temp
+.cache/
+tmp/
+
+# Environment and configuration files (containing secrets)
+.env
+.env.local
+.env.*.local
+*.key
+*.pem
+credentials.json
+
+# Example of negation: Include a specific file even if its extension is excluded
+# !important.log

--- a/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/DotCliIgnoreTest.java
+++ b/tools/dotcms-cli/cli/src/test/java/com/dotcms/cli/common/DotCliIgnoreTest.java
@@ -1,0 +1,317 @@
+package com.dotcms.cli.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DotCliIgnoreTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testNoPatternsWhenNoFileExists() {
+        // Arrange & Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert - verify no patterns are loaded when no .dotcliignore file exists
+        assertEquals(0, dotCliIgnore.getPatternCount(), "Should have no patterns loaded");
+
+        // Nothing should be ignored
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve(".git").resolve("config")));
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve("node_modules").resolve("package.json")));
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve("test.log")));
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve("subdir").resolve(".DS_Store")));
+    }
+
+    @Test
+    void testSimpleFilePatterns() throws IOException {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+        Files.writeString(ignoreFile,
+                "*.log\n" +
+                "*.tmp\n" +
+                "test.txt\n"
+        );
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("error.log")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("temp.tmp")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("test.txt")));
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve("readme.md")));
+    }
+
+    @Test
+    void testDirectoryPatterns() throws IOException {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+        Files.writeString(ignoreFile,
+                "build/\n" +
+                "dist/\n" +
+                "target/\n"
+        );
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("build")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("build").resolve("output.jar")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("dist").resolve("bundle.js")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("target").resolve("classes").resolve("Main.class")));
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve("src").resolve("Main.java")));
+    }
+
+    @Test
+    void testDoubleStarPattern() throws IOException {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+        Files.writeString(ignoreFile,
+                "**/.DS_Store\n" +
+                "**/node_modules/\n"
+        );
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve(".DS_Store")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("src").resolve(".DS_Store")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("src").resolve("main").resolve("java").resolve(".DS_Store")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("node_modules").resolve("package.json")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("project").resolve("node_modules").resolve("lib.js")));
+    }
+
+    @Test
+    void testNegationPattern() throws IOException {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+        Files.writeString(ignoreFile,
+                "*.log\n" +
+                "!important.log\n"
+        );
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("error.log")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("debug.log")));
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve("important.log")),
+                   "important.log should not be ignored due to negation pattern");
+    }
+
+    @Test
+    void testCommentsAndBlankLines() throws IOException {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+        Files.writeString(ignoreFile,
+                "# This is a comment\n" +
+                "\n" +
+                "*.log\n" +
+                "  \n" +
+                "# Another comment\n" +
+                "*.tmp\n"
+        );
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("test.log")));
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("temp.tmp")));
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve("readme.md")));
+    }
+
+    @Test
+    void testInvalidPatternThrowsException() {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+
+        // Act & Assert
+        assertThrows(IllegalArgumentException.class, () -> {
+            Files.writeString(ignoreFile, "!\n"); // Negation with no pattern
+            DotCliIgnore.create(tempDir);
+        });
+    }
+
+    @Test
+    void testEmptyIgnoreFile() throws IOException {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+        Files.writeString(ignoreFile, "");
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert - should have no patterns since file is empty
+        assertEquals(0, dotCliIgnore.getPatternCount(), "Should have no patterns for empty file");
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve(".git").resolve("config")));
+    }
+
+    @Test
+    void testGetBasePath() {
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert
+        assertEquals(tempDir.toAbsolutePath().normalize(),
+                    dotCliIgnore.getBasePath().toAbsolutePath().normalize());
+    }
+
+    @Test
+    void testFileFilter() throws IOException {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+        Files.writeString(ignoreFile, "*.log\n");
+
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Create test files
+        Path logFile = tempDir.resolve("test.log");
+        Path txtFile = tempDir.resolve("test.txt");
+        Files.createFile(logFile);
+        Files.createFile(txtFile);
+
+        // Act
+        boolean logIgnored = dotCliIgnore.shouldIgnore(logFile.toFile());
+        boolean txtIgnored = dotCliIgnore.shouldIgnore(txtFile.toFile());
+
+        // Assert
+        assertTrue(logIgnored);
+        assertFalse(txtIgnored);
+    }
+
+    @Test
+    void testHierarchicalPatternLoading() throws IOException {
+        // Arrange - create nested directory structure with multiple .dotcliignore files
+        Path rootDir = tempDir;
+        Path subDir1 = rootDir.resolve("project");
+        Path subDir2 = subDir1.resolve("src");
+        Path subDir3 = subDir2.resolve("main");
+
+        Files.createDirectories(subDir3);
+
+        // Root .dotcliignore - ignores all .log files
+        Files.writeString(rootDir.resolve(".dotcliignore"), "*.log\n");
+
+        // Subdirectory .dotcliignore - ignores .tmp files and re-includes important.log
+        Files.writeString(subDir1.resolve(".dotcliignore"), "*.tmp\n!important.log\n");
+
+        // Deep subdirectory .dotcliignore - ignores .bak files
+        Files.writeString(subDir3.resolve(".dotcliignore"), "*.bak\n");
+
+        // Act - create DotCliIgnore from the deepest directory
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(subDir3, rootDir);
+
+        // Assert - patterns from all levels should be active
+        assertTrue(dotCliIgnore.shouldIgnore(subDir3.resolve("error.log")),
+                  "Should ignore .log from root");
+        assertTrue(dotCliIgnore.shouldIgnore(subDir3.resolve("temp.tmp")),
+                  "Should ignore .tmp from project/");
+        assertTrue(dotCliIgnore.shouldIgnore(subDir3.resolve("backup.bak")),
+                  "Should ignore .bak from main/");
+        assertFalse(dotCliIgnore.shouldIgnore(subDir3.resolve("important.log")),
+                   "Should not ignore important.log due to negation in project/");
+        assertFalse(dotCliIgnore.shouldIgnore(subDir3.resolve("readme.md")),
+                   "Should not ignore unmatched files");
+    }
+
+    @Test
+    void testHierarchicalPatternPrecedence() throws IOException {
+        // Arrange - test that closer patterns override parent patterns
+        Path rootDir = tempDir;
+        Path subDir = rootDir.resolve("src");
+        Files.createDirectories(subDir);
+
+        // Root ignores all .txt files
+        Files.writeString(rootDir.resolve(".dotcliignore"), "*.txt\n");
+
+        // Subdirectory re-includes specific .txt file
+        Files.writeString(subDir.resolve(".dotcliignore"), "!important.txt\n");
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(subDir, rootDir);
+
+        // Assert - negation in child should override parent ignore
+        assertTrue(dotCliIgnore.shouldIgnore(subDir.resolve("readme.txt")),
+                  "Should ignore regular .txt files");
+        assertFalse(dotCliIgnore.shouldIgnore(subDir.resolve("important.txt")),
+                   "Should not ignore important.txt due to child negation");
+    }
+
+    @Test
+    void testNoPatternsInHierarchy() throws IOException {
+        // Arrange - no .dotcliignore files in hierarchy
+        Path rootDir = tempDir;
+        Path subDir = rootDir.resolve("project").resolve("src");
+        Files.createDirectories(subDir);
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(subDir, rootDir);
+
+        // Assert - should have no patterns when no .dotcliignore files exist
+        assertEquals(0, dotCliIgnore.getPatternCount(), "Should have no patterns");
+        assertFalse(dotCliIgnore.shouldIgnore(subDir.resolve(".git").resolve("config")));
+        assertFalse(dotCliIgnore.shouldIgnore(subDir.resolve("test.log")));
+    }
+
+    @Test
+    void testTrailingSpaceTrimming() throws IOException {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+        // Pattern with trailing spaces (should be trimmed)
+        // Pattern with escaped trailing space (should be preserved)
+        Files.writeString(ignoreFile,
+                "*.log   \n" +  // Trailing spaces should be removed
+                "*.tmp\\ \n" +  // Escaped trailing space should be preserved
+                "test.txt    \n" +  // Multiple trailing spaces should be removed
+                "   *.bak\n"  // Leading spaces should be removed
+        );
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert
+        // Patterns with trimmed trailing spaces should still match
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("error.log")),
+                  "Pattern with trailing spaces should work after trimming");
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("test.txt")),
+                  "Pattern with multiple trailing spaces should work after trimming");
+
+        // Pattern with escaped space should preserve the space
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("file.tmp ")),
+                  "Pattern with escaped trailing space should match filename with trailing space");
+
+        // Pattern with leading spaces should match after trimming
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("backup.bak")),
+                  "Pattern with leading spaces should work after trimming");
+    }
+
+    @Test
+    void testEscapedBackslashBeforeTrailingSpace() throws IOException {
+        // Arrange
+        Path ignoreFile = tempDir.resolve(".dotcliignore");
+        // Test escaped backslash (\\) followed by trailing space
+        Files.writeString(ignoreFile,
+                "pattern\\\\   \n"  // Escaped backslash, trailing spaces should be removed
+        );
+
+        // Act
+        DotCliIgnore dotCliIgnore = DotCliIgnore.create(tempDir);
+
+        // Assert
+        // The pattern should have the backslash but trailing spaces removed
+        assertTrue(dotCliIgnore.shouldIgnore(tempDir.resolve("pattern\\")),
+                  "Pattern with escaped backslash should work");
+        assertFalse(dotCliIgnore.shouldIgnore(tempDir.resolve("pattern\\ ")),
+                   "Pattern should not match with trailing space when backslash is escaped");
+    }
+}


### PR DESCRIPTION
#Closes #30138

### Proposed Changes
* Implemented .dotcliignore file support to exclude files and directories from push operations, similar to how .gitignore works for Git. 

The `.dotcliignore` file supports the following glob patterns:

- `*` - Matches any sequence of characters within a single directory level
- `**` - Matches any sequence of characters across multiple directory levels
- `?` - Matches any single character
- `[]` - Matches a character class (e.g., `[abc]` or `[0-9]`)
- `!` - Negates a pattern to re-include files that were previously excluded

### Checklist
- [x] Tests

This PR fixes: #30138