### PR TITLE
fix(References Tab): fix redirect issue with custom language (#33096)

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_references.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet_references.jsp
@@ -42,11 +42,12 @@
 			str_style2 = "class=alternate_2";
 		}
 		Cmod++;
+		String urlWithLang = htmlpageRef.getURI() + "&language_id=" + htmlpageRef.getLanguageId();
 %>
 	<tr <%= str_style2 %> >
 		<td><%= host.getName() %></td>
 		<td>
-			<a href="/dotAdmin/#/edit-page/content?url=<%=htmlpageRef.getURI()%>" class="beta" target="_top">
+			<a href="/dotAdmin/#/edit-page/content?url=<%=urlWithLang%>" class="beta" target="_top">
 				<%= UtilMethods.escapeHTMLSpecialChars(htmlpageRef.getTitle()) %>
 			</a>
 		</td>


### PR DESCRIPTION
Added the languageId parameter to the redirect URL to ensure the frontend loads the correct language and avoids invalid fallbacks.

This PR fixes: #33096

This PR fixes: #33096