### PR TITLE
refactor(edit-content): migrate field error handling to Angular signals

### DIFF
--- a/.claude/skills/sdk-analytics/SKILL.md
+++ b/.claude/skills/sdk-analytics/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: SDK Analytics Installer
+description: Use this skill when the user asks to install, configure, or set up @dotcms/analytics, sdk-analytics, analytics SDK, add analytics tracking, or mentions installing analytics in Next.js or React projects
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+version: 1.0.0
+---
+
 # DotCMS SDK Analytics Installation Guide
 
 This skill provides step-by-step instructions for installing and configuring the `@dotcms/analytics` SDK in the Next.js example project at `/core/examples/nextjs`.

--- a/core-web/AGENTS.md
+++ b/core-web/AGENTS.md
@@ -1,0 +1,13 @@
+<!-- nx configuration start-->
+<!-- Leave the start & end comments to automatically receive updates. -->
+
+# General Guidelines for working with Nx
+
+-   When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
+-   You have access to the Nx MCP server and its tools, use them to help the user
+-   When answering questions about the repository, use the `nx_workspace` tool first to gain an understanding of the workspace architecture where applicable.
+-   When working in individual projects, use the `nx_project_details` mcp tool to analyze and understand the specific project structure and dependencies
+-   For questions around nx configuration, best practices or if you're unsure, use the `nx_docs` tool to get relevant, up-to-date docs. Always use this instead of assuming things about nx configuration
+-   If the user needs help with an Nx configuration or project graph error, use the `nx_workspace` tool to get any errors
+
+<!-- nx configuration end-->

--- a/core-web/CLAUDE.md
+++ b/core-web/CLAUDE.md
@@ -9,6 +9,7 @@ This is the **DotCMS Core-Web** monorepo - the frontend infrastructure for the D
 ## Key Development Commands
 
 ### Development Server
+
 ```bash
 # Start main admin UI with backend proxy
 nx serve dotcms-ui
@@ -21,6 +22,7 @@ nx serve dotcms-ui --configuration=development
 ```
 
 ### Building
+
 ```bash
 # Build main application
 nx build dotcms-ui
@@ -35,6 +37,7 @@ nx affected:build
 ```
 
 ### Testing
+
 ```bash
 # Run all tests
 yarn run test:dotcms
@@ -55,6 +58,7 @@ nx test dotcms-ui --coverage
 ```
 
 ### Code Quality
+
 ```bash
 # Lint all projects
 yarn run lint:dotcms
@@ -71,6 +75,7 @@ nx affected:lint
 ```
 
 ### Monorepo Management
+
 ```bash
 # Visualize project dependencies
 nx dep-graph
@@ -85,33 +90,37 @@ nx run-many --target=test --projects=sdk-client,sdk-react
 ## Architecture & Structure
 
 ### Monorepo Organization
-- **apps/** - Main applications (dotcms-ui, dotcms-block-editor, dotcms-binary-field-builder, mcp-server)
-- **libs/sdk/** - External-facing SDKs (client, react, angular, analytics, experiments, uve)
-- **libs/data-access/** - Angular services for API communication
-- **libs/ui/** - Shared UI components and patterns
-- **libs/portlets/** - Feature-specific portlets (analytics, experiments, locales, etc.)
-- **libs/dotcms-models/** - TypeScript interfaces and types
-- **libs/block-editor/** - TipTap-based rich text editor
-- **libs/template-builder/** - Template construction utilities
+
+-   **apps/** - Main applications (dotcms-ui, dotcms-block-editor, dotcms-binary-field-builder, mcp-server)
+-   **libs/sdk/** - External-facing SDKs (client, react, angular, analytics, experiments, uve)
+-   **libs/data-access/** - Angular services for API communication
+-   **libs/ui/** - Shared UI components and patterns
+-   **libs/portlets/** - Feature-specific portlets (analytics, experiments, locales, etc.)
+-   **libs/dotcms-models/** - TypeScript interfaces and types
+-   **libs/block-editor/** - TipTap-based rich text editor
+-   **libs/template-builder/** - Template construction utilities
 
 ### Technology Stack
-- **Angular 19.2.9** with standalone components
-- **Nx 20.5.1** for monorepo management
-- **PrimeNG 17.18.11** UI components
-- **TipTap 2.14.0** for rich text editing
-- **NgRx 19.2.1** for state management
-- **Jest 29.7.0** for testing
-- **Playwright** for E2E testing
-- **Node.js >=v22.15.0** requirement
+
+-   **Angular 19.2.9** with standalone components
+-   **Nx 20.5.1** for monorepo management
+-   **PrimeNG 17.18.11** UI components
+-   **TipTap 2.14.0** for rich text editing
+-   **NgRx 19.2.1** for state management
+-   **Jest 29.7.0** for testing
+-   **Playwright** for E2E testing
+-   **Node.js >=v22.15.0** requirement
 
 ### Component Conventions
-- **Prefix**: All Angular components use `dot-` prefix
-- **Naming**: Follow Angular style guide with kebab-case
-- **Architecture**: Feature modules with lazy loading
-- **State**: Component-store pattern with NgRx signals
-- **Testing**: Jest unit tests + Playwright E2E
+
+-   **Prefix**: All Angular components use `dot-` prefix
+-   **Naming**: Follow Angular style guide with kebab-case
+-   **Architecture**: Feature modules with lazy loading
+-   **State**: Component-store pattern with NgRx signals
+-   **Testing**: Jest unit tests + Playwright E2E
 
 ### Modern Angular Syntax (REQUIRED)
+
 ```typescript
 // ✅ CORRECT: Modern control flow syntax
 @if (condition()) { <content /> }      // NOT *ngIf
@@ -131,14 +140,16 @@ const button = spectator.query('[data-testid="submit-button"]');
 ```
 
 ### Backend Integration
-- **Development Proxy**: `proxy-dev.conf.mjs` routes `/api/*` to port 8080
-- **API Services**: Centralized in `libs/data-access`
-- **Authentication**: Bearer token-based with `DotcmsConfigService`
-- **Content Management**: Full CRUD through `DotHttpService`
+
+-   **Development Proxy**: `proxy-dev.conf.mjs` routes `/api/*` to port 8080
+-   **API Services**: Centralized in `libs/data-access`
+-   **Authentication**: Bearer token-based with `DotcmsConfigService`
+-   **Content Management**: Full CRUD through `DotHttpService`
 
 ## Development Workflows
 
 ### Local Development Setup
+
 1. Ensure Node.js >=v22.15.0
 2. Run `yarn install` to install dependencies
 3. Run `node prepare.js` to set up Husky git hooks
@@ -146,6 +157,7 @@ const button = spectator.query('[data-testid="submit-button"]');
 5. Run `nx serve dotcms-ui` for frontend development
 
 ### Adding New Features
+
 1. Create feature branch following naming convention
 2. Add libraries in `libs/` for reusable code
 3. Use existing patterns from similar features
@@ -154,75 +166,100 @@ const button = spectator.query('[data-testid="submit-button"]');
 6. Update TypeScript paths in `tsconfig.base.json` if adding new libraries
 
 ### SDK Development
-- **Client SDK**: Core API client in `libs/sdk/client`
-- **React SDK**: React components in `libs/sdk/react`
-- **Angular SDK**: Angular services in `libs/sdk/angular`
-- **Publishing**: Automated via npm with proper versioning
+
+-   **Client SDK**: Core API client in `libs/sdk/client`
+-   **React SDK**: React components in `libs/sdk/react`
+-   **Angular SDK**: Angular services in `libs/sdk/angular`
+-   **Publishing**: Automated via npm with proper versioning
 
 ### Testing Strategy
-- **Unit Tests**: Jest with comprehensive mocking utilities
-- **E2E Tests**: Playwright for critical user workflows
-- **Coverage**: Reports generated to `../../../target/core-web-reports/`
-- **Mock Data**: Extensive mock utilities in `libs/utils-testing`
+
+-   **Unit Tests**: Jest with comprehensive mocking utilities
+-   **E2E Tests**: Playwright for critical user workflows
+-   **Coverage**: Reports generated to `../../../target/core-web-reports/`
+-   **Mock Data**: Extensive mock utilities in `libs/utils-testing`
 
 ### Build Targets & Configurations
-- **Development**: Proxy configuration with source maps
-- **Production**: Optimized builds with tree shaking
-- **Library**: Rollup/Vite builds for SDK packages
-- **Web Components**: Stencil.js compilation for `dotcms-webcomponents`
+
+-   **Development**: Proxy configuration with source maps
+-   **Production**: Optimized builds with tree shaking
+-   **Library**: Rollup/Vite builds for SDK packages
+-   **Web Components**: Stencil.js compilation for `dotcms-webcomponents`
 
 ## Important Notes
 
 ### TypeScript Configuration
-- **Strict Mode**: Enabled across all projects
-- **Path Mapping**: Extensive use of `@dotcms/*` barrel exports
-- **Types**: Centralized in `libs/dotcms-models` and `libs/sdk/types`
+
+-   **Strict Mode**: Enabled across all projects
+-   **Path Mapping**: Extensive use of `@dotcms/*` barrel exports
+-   **Types**: Centralized in `libs/dotcms-models` and `libs/sdk/types`
 
 ### State Management
-- **NgRx**: Component stores with signals pattern
-- **Global Store**: Centralized state in `libs/global-store`
-- **Services**: Angular services for data access and business logic
+
+-   **NgRx**: Component stores with signals pattern
+-   **Global Store**: Centralized state in `libs/global-store`
+-   **Services**: Angular services for data access and business logic
 
 ### Web Components
-- **Stencil.js**: Framework-agnostic components in `libs/dotcms-webcomponents`
-- **Legacy**: `libs/dotcms-field-elements` (deprecated, use Stencil components)
-- **Integration**: Used across Angular, React, and vanilla JS contexts
+
+-   **Stencil.js**: Framework-agnostic components in `libs/dotcms-webcomponents`
+-   **Legacy**: `libs/dotcms-field-elements` (deprecated, use Stencil components)
+-   **Integration**: Used across Angular, React, and vanilla JS contexts
 
 ### Performance Considerations
-- **Lazy Loading**: Feature modules loaded on demand
-- **Tree Shaking**: Proper barrel exports for optimal bundles
-- **Caching**: Nx task caching for faster builds
-- **Affected**: Only build/test changed projects in CI
+
+-   **Lazy Loading**: Feature modules loaded on demand
+-   **Tree Shaking**: Proper barrel exports for optimal bundles
+-   **Caching**: Nx task caching for faster builds
+-   **Affected**: Only build/test changed projects in CI
 
 ## Debugging & Troubleshooting
 
 ### Common Issues
-- **Proxy Errors**: Ensure backend is running on port 8080
-- **Build Failures**: Check TypeScript paths and circular dependencies
-- **Test Failures**: Verify mock data and async handling
-- **Linting**: Follow component naming conventions with `dot-` prefix
+
+-   **Proxy Errors**: Ensure backend is running on port 8080
+-   **Build Failures**: Check TypeScript paths and circular dependencies
+-   **Test Failures**: Verify mock data and async handling
+-   **Linting**: Follow component naming conventions with `dot-` prefix
 
 ### Development Tools
-- **Nx Console**: VS Code extension for Nx commands
-- **Angular DevTools**: Browser extension for debugging
-- **Coverage Reports**: Check `target/core-web-reports/` for test coverage
-- **Dependency Graph**: Use `nx dep-graph` to visualize project relationships
+
+-   **Nx Console**: VS Code extension for Nx commands
+-   **Angular DevTools**: Browser extension for debugging
+-   **Coverage Reports**: Check `target/core-web-reports/` for test coverage
+-   **Dependency Graph**: Use `nx dep-graph` to visualize project relationships
 
 This codebase emphasizes consistency, testability, and maintainability through its monorepo architecture and established patterns.
 
 ## Summary Checklist
 
 ### Angular/TypeScript Development
-- ✅ Use modern control flow: `@if`, `@for` (NOT `*ngIf`, `*ngFor`)
-- ✅ Use modern inputs/outputs: `input<T>()`, `output<T>()` (NOT `@Input()`, `@Output()`)
-- ✅ Use `data-testid` attributes for all testable elements
-- ✅ Use `spectator.setInput()` for testing component inputs
-- ✅ Follow `dot-` prefix convention for all components
-- ✅ Use standalone components with lazy loading
-- ✅ Use NgRx signals for state management
-- ❌ Avoid legacy Angular syntax (`*ngIf`, `@Input()`, etc.)
-- ❌ Avoid direct DOM queries without `data-testid`
-- ❌ Never skip unit tests for new components
+
+-   ✅ Use modern control flow: `@if`, `@for` (NOT `*ngIf`, `*ngFor`)
+-   ✅ Use modern inputs/outputs: `input<T>()`, `output<T>()` (NOT `@Input()`, `@Output()`)
+-   ✅ Use `data-testid` attributes for all testable elements
+-   ✅ Use `spectator.setInput()` for testing component inputs
+-   ✅ Follow `dot-` prefix convention for all components
+-   ✅ Use standalone components with lazy loading
+-   ✅ Use NgRx signals for state management
+-   ❌ Avoid legacy Angular syntax (`*ngIf`, `@Input()`, etc.)
+-   ❌ Avoid direct DOM queries without `data-testid`
+-   ❌ Never skip unit tests for new components
 
 ### For Backend/Java Development
-- See **[../CLAUDE.md](../CLAUDE.md)** for Java, Maven, REST API, and Git workflow standards
+
+-   See **[../CLAUDE.md](../CLAUDE.md)** for Java, Maven, REST API, and Git workflow standards
+
+<!-- nx configuration start-->
+<!-- Leave the start & end comments to automatically receive updates. -->
+
+# General Guidelines for working with Nx
+
+-   When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
+-   You have access to the Nx MCP server and its tools, use them to help the user
+-   When answering questions about the repository, use the `nx_workspace` tool first to gain an understanding of the workspace architecture where applicable.
+-   When working in individual projects, use the `nx_project_details` mcp tool to analyze and understand the specific project structure and dependencies
+-   For questions around nx configuration, best practices or if you're unsure, use the `nx_docs` tool to get relevant, up-to-date docs. Always use this instead of assuming things about nx configuration
+-   If the user needs help with an Nx configuration or project graph error, use the `nx_workspace` tool to get any errors
+
+<!-- nx configuration end-->

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-wrapper/dot-binary-field-wrapper.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/components/dot-binary-field-wrapper/dot-binary-field-wrapper.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -16,7 +17,7 @@
             [attr.data-testId]="'field-' + field.variable" />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -24,7 +25,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-block-editor/dot-edit-content-block-editor.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-block-editor/dot-edit-content-block-editor.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -15,7 +16,7 @@
             [field]="field" />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -23,7 +24,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.html
@@ -4,8 +4,9 @@
 @let showTimezoneInfo = $showTimezoneInfo();
 @let hasTimezone = showTimezoneInfo && systemTimezone;
 @let hasHint = field.hint;
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label
             [variableName]="field.variable"
@@ -17,7 +18,7 @@
     <dot-card-field-content>
         <dot-calendar-field
             [field]="field"
-            [hasError]="hasError"
+            [hasError]="fieldHasError"
             [formControlName]="field.variable"
             [utcTimezone]="systemTimezone"
             [contentType]="$contentType()" />
@@ -25,7 +26,7 @@
     <dot-card-field-footer>
         <div class="flex justify-content-between align-items-center">
             <div class="flex-grow-1">
-                @if (hasError) {
+                @if (fieldHasError) {
                     <div class="error-message">
                         @if (isRequired) {
                             <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -33,7 +34,7 @@
                     </div>
                 }
 
-                @if (!hasError && !hasTimezone && hasHint) {
+                @if (!fieldHasError && !hasTimezone && hasHint) {
                     <div class="hint-message" data-testid="calendar-field-hints">
                         <small
                             [attr.data-testId]="'hint-' + field.variable"
@@ -42,7 +43,7 @@
                         </small>
                     </div>
                 }
-                @if (!hasError && hasTimezone && hasHint) {
+                @if (!fieldHasError && hasTimezone && hasHint) {
                     <div class="hint-message">
                         <small
                             data-testid="calendar-field-timezone"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/dot-edit-content-category-field.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -12,18 +13,20 @@
             [field]="field"
             [contentlet]="$contentlet()"
             [formControlName]="field.variable"
-            [hasError]="hasError" />
+            [hasError]="fieldHasError" />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
-                    <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
+                    <small data-testId="category-field-required">
+                        {{ 'dot.edit.content.form.field.required' | dm }}
+                    </small>
                 }
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-checkbox-field/dot-edit-content-checkbox-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-checkbox-field/dot-edit-content-checkbox-field.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -11,8 +12,8 @@
         <div class="flex flex-column gap-2">
             @for (option of $options(); track $index) {
                 <p-checkbox
-                    [class.ng-invalid]="hasError"
-                    [class.ng-dirty]="hasError"
+                    [class.ng-invalid]="fieldHasError"
+                    [class.ng-dirty]="fieldHasError"
                     [name]="field.variable"
                     [formControlName]="field.variable"
                     [value]="option.value"
@@ -23,14 +24,14 @@
         </div>
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
                 }
             </div>
         }
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.html
@@ -3,8 +3,9 @@
 @let showAsModal = fieldConfig.showAsModal;
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/dot-edit-content-file-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/dot-edit-content-file-field.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -12,10 +13,10 @@
             [field]="field"
             [contentlet]="$contentlet()"
             [formControlName]="field.variable"
-            [hasError]="hasError" />
+            [hasError]="fieldHasError" />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -23,7 +24,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-host-folder-field/dot-edit-content-host-folder-field.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -10,11 +11,11 @@
     <dot-card-field-content>
         <dot-host-folder-field
             [formControlName]="field.variable"
-            [hasError]="hasError"
+            [hasError]="fieldHasError"
             [isRequired]="isRequired" />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -22,7 +23,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-json-field/dot-edit-content-json-field.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -24,13 +25,13 @@
                     #monaco
                     data-testid="json-field-monaco-editor"
                     [field]="field"
-                    [hasError]="hasError"
+                    [hasError]="fieldHasError"
                     [forceLanguage]="languages.Json" />
             </div>
         </div>
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -38,7 +39,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-key-value/dot-edit-content-key-value.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-key-value/dot-edit-content-key-value.component.html
@@ -1,17 +1,18 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
         </dot-card-field-label>
     }
     <dot-card-field-content>
-        <dot-key-value-field [hasError]="hasError" [formControlName]="field.variable" />
+        <dot-key-value-field [hasError]="fieldHasError" [formControlName]="field.variable" />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -19,7 +20,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-multi-select-field/dot-edit-content-multi-select-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-multi-select-field/dot-edit-content-multi-select-field.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -9,15 +10,15 @@
     }
     <dot-card-field-content>
         <p-multiSelect
-            [class.ng-invalid]="hasError"
-            [class.ng-dirty]="hasError"
+            [class.ng-invalid]="fieldHasError"
+            [class.ng-dirty]="fieldHasError"
             [options]="$options()"
             [formControlName]="field.variable"
             optionLabel="label"
             optionValue="value" />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -25,7 +26,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-radio-field/dot-edit-content-radio-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-radio-field/dot-edit-content-radio-field.component.html
@@ -1,8 +1,9 @@
 @let options = $options();
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -14,8 +15,8 @@
                 <p-radioButton
                     [inputId]="field.variable + '_' + option.value"
                     [name]="field.variable"
-                    [class.ng-invalid]="hasError"
-                    [class.ng-dirty]="hasError"
+                    [class.ng-invalid]="fieldHasError"
+                    [class.ng-dirty]="fieldHasError"
                     [value]="option.value"
                     [label]="option.label"
                     [formControlName]="field.variable" />
@@ -23,7 +24,7 @@
         </div>
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -31,7 +32,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.html
@@ -1,8 +1,9 @@
 @let field = $field();
 @let contentlet = $contentlet();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -13,7 +14,7 @@
             [field]="field"
             [formControlName]="field.variable"
             [contentlet]="contentlet"
-            [hasError]="hasError"
+            [hasError]="fieldHasError"
             [isRequired]="isRequired" />
     </dot-card-field-content>
 </dot-card-field>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-select-field/dot-edit-content-select-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-select-field/dot-edit-content-select-field.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -12,21 +13,21 @@
             [formControlName]="field.variable"
             [name]="field.variable"
             [options]="$options()"
-            [class.ng-invalid]="hasError"
-            [class.ng-dirty]="hasError"
+            [class.ng-invalid]="fieldHasError"
+            [class.ng-dirty]="fieldHasError"
             [attr.aria-labelledby]="'field-' + $field().variable"
             optionLabel="label"
             optionValue="value" />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
                 }
             </div>
         }
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -11,10 +12,10 @@
         <dot-tag-field
             [formControlName]="field.variable"
             [variableName]="field.variable"
-            [hasError]="hasError" />
+            [hasError]="fieldHasError" />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -22,7 +23,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-area/dot-edit-content-text-area.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -11,8 +12,8 @@
         <div class="dot-textarea__container flex flex-column gap-2">
             <div class="dot-textarea__controls flex flex-wrap gap-2 justify-content-between">
                 <p-dropdown
-                    [class.ng-invalid]="hasError"
-                    [class.ng-dirty]="hasError"
+                    [class.ng-invalid]="fieldHasError"
+                    [class.ng-dirty]="fieldHasError"
                     [options]="textAreaEditorOptions"
                     [(ngModel)]="$selectedEditorDropdown"
                     [ngModelOptions]="{ standalone: true }"
@@ -28,8 +29,8 @@
                         #textarea
                         [id]="field.variable"
                         [formControlName]="field.variable"
-                        [class.ng-invalid]="hasError"
-                        [class.ng-dirty]="hasError"
+                        [class.ng-invalid]="fieldHasError"
+                        [class.ng-dirty]="fieldHasError"
                         [attr.data-testId]="field.variable"
                         [style]="{
                             'min-height': '9.375rem',
@@ -39,21 +40,21 @@
                 } @else {
                     <dot-edit-content-monaco-editor-control
                         #monaco
-                        [hasError]="hasError"
+                        [hasError]="fieldHasError"
                         [field]="field" />
                 }
             </div>
         </div>
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
                 }
             </div>
         }
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-field/dot-edit-content-text-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-text-field/dot-edit-content-text-field.component.html
@@ -1,8 +1,9 @@
 @let field = $field();
 @let showLabel = $showLabel();
 @let dataType = field.dataType;
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -13,8 +14,8 @@
             [id]="field.variable"
             [name]="field.variable"
             [formControlName]="field.variable"
-            [class.ng-invalid]="hasError"
-            [class.ng-dirty]="hasError"
+            [class.ng-invalid]="fieldHasError"
+            [class.ng-dirty]="fieldHasError"
             [attr.data-testId]="field.variable"
             [type]="inputTextOptions[dataType].type"
             [attr.inputmode]="inputTextOptions[dataType].inputMode"
@@ -22,7 +23,7 @@
             pInputText />
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -30,7 +31,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-edit-content-wysiwyg-field.component.html
@@ -1,7 +1,8 @@
 @let field = $field();
 @let showLabel = $showLabel();
+@let fieldHasError = $hasError();
 
-<dot-card-field [hasError]="hasError">
+<dot-card-field [hasError]="fieldHasError">
     @if (showLabel) {
         <dot-card-field-label [variableName]="field.variable" [isRequired]="isRequired">
             {{ field.name }}
@@ -24,15 +25,17 @@
 
             <div class="dot-wysiwyg__editor">
                 @if ($displayedEditor() === editorTypes.TinyMCE) {
-                    <dot-wysiwyg-tinymce [field]="field" [hasError]="hasError" />
+                    <dot-wysiwyg-tinymce [field]="field" [hasError]="fieldHasError" />
                 } @else {
-                    <dot-edit-content-monaco-editor-control [field]="field" [hasError]="hasError" />
+                    <dot-edit-content-monaco-editor-control
+                        [field]="field"
+                        [hasError]="fieldHasError" />
                 }
             </div>
         </div>
     </dot-card-field-content>
     <dot-card-field-footer>
-        @if (hasError) {
+        @if (fieldHasError) {
             <div class="error-message">
                 @if (isRequired) {
                     <small>{{ 'dot.edit.content.form.field.required' | dm }}</small>
@@ -40,7 +43,7 @@
             </div>
         }
 
-        @if (!hasError && field.hint) {
+        @if (!fieldHasError && field.hint) {
             <div class="hint-message">
                 <small [attr.data-testId]="'hint-' + field.variable">
                     {{ field.hint }}

--- a/core-web/libs/edit-content/src/lib/fields/shared/base-wrapper-field.ts
+++ b/core-web/libs/edit-content/src/lib/fields/shared/base-wrapper-field.ts
@@ -1,10 +1,12 @@
-import { computed, DestroyRef, inject, InputSignal } from '@angular/core';
+import { merge } from 'rxjs';
+
+import { afterNextRender, computed, DestroyRef, inject, InputSignal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormControl, Validators, TouchedChangeEvent, ControlContainer } from '@angular/forms';
+import { ControlContainer, FormControl, TouchedChangeEvent, Validators } from '@angular/forms';
 
 import { filter } from 'rxjs/operators';
 
-import { DotCMSContentTypeField, DotCMSContentlet } from '@dotcms/dotcms-models';
+import { DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
 
 /**
  * Base class for all wrapper field components that provides common functionality
@@ -18,20 +20,38 @@ export abstract class BaseWrapperField {
     abstract $field: InputSignal<DotCMSContentTypeField>;
     abstract $contentlet: InputSignal<DotCMSContentlet>;
 
+    /**
+     * A signal that holds the error state of the field.
+     * It is used to display the error state in the field component.
+     */
+    $hasError = signal(false);
+
+    constructor() {
+        afterNextRender(() => {
+            const control = this.formControl;
+            if (!control) return;
+
+            const updateState = () => {
+                this.$hasError.set(!!(control.invalid && control.touched));
+            };
+
+            // Initial state
+            updateState();
+
+            merge(control.valueChanges, control.statusChanges, control.events)
+                .pipe(takeUntilDestroyed(this.destroyRef))
+                .subscribe(() => {
+                    updateState();
+                });
+        });
+    }
+
     $showLabel = computed(() => {
         const field = this.$field();
         if (!field) return true;
 
         return field.fieldVariables.find(({ key }) => key === 'hideLabel')?.value !== 'true';
     });
-
-    get hasError(): boolean {
-        const control = this.formControl;
-        if (!control) {
-            return false;
-        }
-        return !!(control.invalid && control.touched);
-    }
 
     get isRequired(): boolean {
         const control = this.formControl;


### PR DESCRIPTION
## Summary

This PR refactors form field error handling across the edit-content library to use Angular signals for better reactivity and consistency. Additionally, it adds documentation for the SDK Analytics Installer skill.

## Changes Made

https://github.com/user-attachments/assets/6e2070f2-02ce-472b-8bcd-031f7463a08d

### Frontend

#### Error Handling Refactor
- **Unified error state management** across 20+ form field components ([base-wrapper-field.ts:20-46](core-web/libs/edit-content/src/lib/fields/shared/base-wrapper-field.ts#L20-L46))
  - Replaced `hasError` getter with `$hasError` signal for reactive error state tracking
  - Added automatic error state synchronization via `merge()` of `valueChanges`, `statusChanges`, and `events` streams
  - Introduced `afterNextRender()` lifecycle hook to ensure control initialization before subscribing
- **Template standardization** - Updated all field component templates to use `fieldHasError` local variable:
  - Binary field, Block editor, Calendar, Category, Checkbox
  - Custom field, File field, Host/Folder, JSON, Key-Value
  - Multi-select, Radio, Relationship, Select, Tag
  - Text area, Text field, WYSIWYG

#### Pattern Changes
```typescript
// Before: Getter-based approach
get hasError(): boolean {
    return !!(this.formControl?.invalid && this.formControl?.touched);
}

// After: Signal-based reactive approach
$hasError = signal(false);
// Auto-updates via merged control streams in constructor
```
#### Breaking Changes
None - This is an internal refactor that maintains the same external API and behavior.

#### Testing
- [ ] Manual testing performed on all affected field components

#### Related Issues
Closes #33654

This PR fixes: #33654