### PR TITLE
refactor(java): Replace Jersey internal Base64 (#33857)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1614,6 +1614,13 @@
             </dependency>
 
             <dependency>
+                <groupId>com.tngtech.archunit</groupId>
+                <artifactId>archunit-junit5</artifactId>
+                <version>1.4.1</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
                 <groupId>org.wiremock</groupId>
                 <artifactId>wiremock</artifactId>
                 <version>3.5.3</version>

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -1324,6 +1324,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- Jandex for test annotation scanning -->
         <dependency>

--- a/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
@@ -30,7 +30,7 @@ import com.liferay.util.StringPool;
 import io.vavr.control.Try;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.glassfish.jersey.server.ContainerRequest;
 
 import javax.servlet.http.HttpServletRequest;
@@ -603,7 +603,7 @@ public  class WebResource {
             // @todo ggranum: this should be a split limit 1.
             // "username:SomePass:word".split(":") ==> ["username", "SomePass", "word"]
             // "username:SomePass:word".split(":", 1) ==> ["username", "SomePass:word"]
-            String[] values = Base64.decodeAsString(authentication).split(":");
+            String[] values = new String(Base64.getDecoder().decode(authentication), java.nio.charset.StandardCharsets.UTF_8).split(":");
             if(values.length < 2) {
                 // "Invalid syntax for username and password"
                 throw new SecurityException("Invalid syntax for username and password", Response.Status.BAD_REQUEST);
@@ -622,7 +622,7 @@ public  class WebResource {
             // @todo ggranum: this should be a split limit 1.
             // "username:SomePass:word".split(":") ==> ["username", "SomePass", "word"]
             // "username:SomePass:word".split(":", 1) ==> ["username", "SomePass:word"]
-            String[] values = Base64.decodeAsString(authentication).split(":");
+            String[] values = new String(Base64.getDecoder().decode(authentication), java.nio.charset.StandardCharsets.UTF_8).split(":");
             if(values.length < 2) {
                 throw new SecurityException("Invalid syntax for username and password", Response.Status.BAD_REQUEST);
             }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
@@ -37,7 +37,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.vavr.control.Try;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.glassfish.jersey.server.JSONP;
 
 import javax.servlet.http.HttpServletRequest;
@@ -662,11 +662,11 @@ public class ApiTokenResource implements Serializable {
             String password = "";
 
             if (UtilMethods.isSet(formData.password())) {
-                password = Base64.decodeAsString(formData.password());
+                password = new String(Base64.getDecoder().decode(formData.password()), java.nio.charset.StandardCharsets.UTF_8);
             }
 
             final Response response = webTarget.request(MediaType.APPLICATION_JSON)
-                    .header("Authorization", "Basic " + Base64.encodeAsString(formData.login() + ":" + password))
+                    .header("Authorization", "Basic " + Base64.getEncoder().encodeToString((formData.login() + ":" + password).getBytes(java.nio.charset.StandardCharsets.UTF_8)))
                     .post(Entity.entity(formData.getTokenInfo(), MediaType.APPLICATION_JSON));
 
             if (response.getStatus() != HttpStatus.SC_OK) {

--- a/dotCMS/src/test/java/com/dotcms/architecture/CodingStandardsArchTest.java
+++ b/dotCMS/src/test/java/com/dotcms/architecture/CodingStandardsArchTest.java
@@ -1,0 +1,70 @@
+package com.dotcms.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * ArchUnit tests to enforce coding standards and architectural rules across the dotCMS codebase.
+ *
+ * These tests run at compile time and fail the build if any violations are detected.
+ * They help maintain code quality and prevent the introduction of problematic patterns.
+ */
+public class CodingStandardsArchTest {
+
+    /**
+     * Import all production classes from com.dotcms and com.dotmarketing packages.
+     * Excludes test classes to focus on production code.
+     * Note: Classes are loaded lazily - only analyzed when rules are checked.
+     */
+    private JavaClasses getProductionClasses() {
+        return new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_JARS)
+                .importPackages("com.dotcms..", "com.dotmarketing..");
+    }
+
+    /**
+     * Verifies that no code uses internal Jersey APIs from org.glassfish.jersey.internal package.
+     *
+     * <p>Rationale: Jersey internal APIs are implementation details that:
+     * <ul>
+     *   <li>May change without notice between versions</li>
+     *   <li>Are not part of the public API contract</li>
+     *   <li>Can cause runtime issues after Jersey upgrades</li>
+     * </ul>
+     *
+     * <p>Instead, use:
+     * <ul>
+     *   <li>Public Jersey APIs from org.glassfish.jersey.* (excluding .internal)</li>
+     *   <li>Standard Java APIs like java.util.Base64 instead of org.glassfish.jersey.internal.util.Base64</li>
+     *   <li>JAX-RS standard APIs from javax.ws.rs.*</li>
+     * </ul>
+     *
+     * <p>Example violation and fix:
+     * <pre>
+     * // ❌ WRONG - uses internal API
+     * import org.glassfish.jersey.internal.util.Base64;
+     * String encoded = Base64.encodeAsString("data");
+     *
+     * // ✅ CORRECT - uses standard Java API
+     * import java.util.Base64;
+     * String encoded = Base64.getEncoder().encodeToString("data".getBytes());
+     * </pre>
+     *
+     * @see <a href="https://github.com/dotCMS/core/issues/33857">Issue #33857</a>
+     */
+    @Test
+    public void shouldNotUseJerseyInternalAPIs() {
+        ArchRule rule = noClasses()
+                .should().dependOnClassesThat().resideInAPackage("org.glassfish.jersey.internal..")
+                .because("Jersey internal APIs are not part of the public contract and may change without notice. "
+                        + "Use public Jersey APIs (org.glassfish.jersey.*) or standard Java APIs instead. "
+                        + "For example, replace org.glassfish.jersey.internal.util.Base64 with java.util.Base64.");
+
+        rule.check(getProductionClasses());
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/DotAssetBaseTypeToContentTypeStrategyImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/DotAssetBaseTypeToContentTypeStrategyImplTest.java
@@ -24,7 +24,7 @@ import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.util.FileUtil;
 import com.dotmarketing.util.UUIDGenerator;
 import com.liferay.portal.util.WebKeys;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -98,7 +98,7 @@ public class DotAssetBaseTypeToContentTypeStrategyImplTest  extends IntegrationT
                 ).request()
         );
 
-        request.setHeader("Authorization", "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+        request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
         request.setHeader("User-Agent", "Fake-Agent");
         request.setHeader("Host", "localhost");
         request.setHeader("Origin", "localhost");

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/test/ContentResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/test/ContentResourceTest.java
@@ -49,7 +49,7 @@ import com.liferay.util.StringPool;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import io.vavr.Tuple2;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -1366,10 +1366,10 @@ public class ContentResourceTest extends IntegrationTestBase {
         );
 
         if (user == null){
-            request.setHeader("Authorization", "Basic " + new String(Base64.encode(("admin@dotcms.com:admin").getBytes())));
+            request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(("admin@dotcms.com:admin").getBytes()));
 
         } else if (!user.equals(userAPI.getAnonymousUser())){
-            request.setHeader("Authorization", "Basic " + new String(Base64.encode((user.getEmailAddress() + ":" + user.getPassword()).getBytes())));
+            request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString((user.getEmailAddress() + ":" + user.getPassword()).getBytes()));
         }
 
         if (jsonPayload != null) {

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/test/ContentTypeResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/test/ContentTypeResourceTest.java
@@ -33,7 +33,7 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import org.apache.commons.io.IOUtils;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -151,7 +151,7 @@ public class ContentTypeResourceTest extends ContentTypeBaseTest {
 				new MockSessionRequest(new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
 				.request());
 
-		request.setHeader("Authorization", "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+		request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
 		return request;
 	}

--- a/dotcms-integration/src/test/java/com/dotcms/rest/BundleResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/BundleResourceTest.java
@@ -27,7 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.WebKeys;
 import io.vavr.control.Try;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.glassfish.jersey.media.multipart.BodyPart;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
@@ -157,7 +157,7 @@ public class BundleResourceTest {
                         .request());
 
         request.setHeader("Authorization",
-                "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+                "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
         return request;
     }

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/asset/WebAssetHelperIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/asset/WebAssetHelperIntegrationTest.java
@@ -55,7 +55,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
@@ -488,7 +488,7 @@ public class WebAssetHelperIntegrationTest {
                 ).request()
         );
 
-        request.setHeader("Authorization", "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+        request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
         request.setHeader("User-Agent", "Fake-Agent");
         request.setHeader("Host", "localhost");
         request.setHeader("Origin", "localhost");

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResourceTest.java
@@ -53,7 +53,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.Response;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -363,7 +363,7 @@ public class ContentTypeResourceTest {
 				).request()
 		);
 
-		request.setHeader("Authorization", "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+		request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
 		return request;
 	}

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/contenttype/FieldResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/contenttype/FieldResourceTest.java
@@ -52,7 +52,7 @@ import java.util.List;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -2393,7 +2393,7 @@ public class FieldResourceTest {
 			).request()
 		);
 
-		request.setHeader("Authorization", "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+		request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
 		return request;
 	}

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/NavResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/page/NavResourceTest.java
@@ -20,7 +20,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -87,7 +87,7 @@ public class NavResourceTest{
                         .request());
 
         request.setHeader("Authorization",
-                "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+                "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
         Mockito.when(request.getParameter("host_id")).thenReturn(site.getIdentifier());
 

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/pushpublish/PushPublishFilterResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/pushpublish/PushPublishFilterResourceTest.java
@@ -14,7 +14,7 @@ import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.google.common.collect.ImmutableMap;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -67,7 +67,7 @@ public class PushPublishFilterResourceTest {
 
         if(authorization) {
             request.setHeader("Authorization",
-                    "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+                    "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
         }
 

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/relationships/RelationshipsResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/relationships/RelationshipsResourceTest.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -121,7 +121,7 @@ public class RelationshipsResourceTest {
         );
 
         request.setHeader("Authorization",
-                "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+                "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
         return request;
     }

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/user/UserResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/user/UserResourceIntegrationTest.java
@@ -29,7 +29,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import static org.junit.Assert.*;
 import java.util.List;
 import java.util.Map;
@@ -150,7 +150,7 @@ public class UserResourceIntegrationTest {
                         .request());
 
         request.setHeader("Authorization",
-                "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+                "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
         request.getSession().setAttribute(com.dotmarketing.util.WebKeys.CURRENT_HOST,host);
         request.getSession().setAttribute(com.dotmarketing.util.WebKeys.CMS_SELECTED_HOST_ID,host.getIdentifier());
@@ -219,7 +219,7 @@ public class UserResourceIntegrationTest {
         
         // Authenticate as permissionTestUser
         String auth = permissionTestUser.getEmailAddress() + ":" + "password";
-        request.setHeader("Authorization", "Basic " + new String(Base64.encode(auth.getBytes())));
+        request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(auth.getBytes()));
         request.getSession().setAttribute(WebKeys.USER_ID, permissionTestUser.getUserId());
         
         ResponseEntityUserPermissionsView responseEntity = resource.getUserPermissions(request, this.response, permissionTestUser.getUserId());

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceIntegrationTest.java
@@ -138,7 +138,7 @@ import com.liferay.portal.util.WebKeys;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.commons.lang.RandomStringUtils;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.glassfish.jersey.media.multipart.BodyPart;
 import org.glassfish.jersey.media.multipart.ContentDisposition;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
@@ -2674,7 +2674,7 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         );
 
         request.setHeader("Authorization",
-                "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+                "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
         return request;
     }

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v2/contenttype/FieldResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v2/contenttype/FieldResourceTest.java
@@ -61,7 +61,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -2585,7 +2585,7 @@ public class FieldResourceTest {
                 ).request()
         );
 
-        request.setHeader("Authorization", "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+        request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
         return request;
     }

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v3/contenttype/FieldResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v3/contenttype/FieldResourceTest.java
@@ -32,7 +32,7 @@ import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.WebKeys.Relationship.RELATIONSHIP_CARDINALITY;
 import com.dotmarketing.util.json.JSONException;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.jetbrains.annotations.NotNull;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -1054,7 +1054,7 @@ public class FieldResourceTest {
                 ).request()
         );
 
-        request.setHeader("Authorization", "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+        request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
 
         return request;
     }

--- a/dotcms-integration/src/test/java/com/dotcms/rest/elasticsearch/ESContentResourcePortletTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/elasticsearch/ESContentResourcePortletTest.java
@@ -49,7 +49,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -276,7 +276,7 @@ public class ESContentResourcePortletTest extends IntegrationTestBase {
 
         if (!anonymous){
             request.setHeader("Authorization",
-                    "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+                    "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
         }
 
         when(request.getContentType()).thenReturn(MediaType.APPLICATION_JSON);

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -95,7 +95,7 @@ import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.apache.commons.io.FileUtils;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -2362,7 +2362,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
                 new MockSessionRequest(new MockAttributeRequest(new MockHttpRequestIntegrationTest("localhost", "/").request()).request())
                         .request());
 
-        request.setHeader("Authorization", "Basic " + new String(Base64.encode("admin@dotcms.com:admin".getBytes())));
+        request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
         request.setHeader("Origin", "localhost");
         request.setAttribute(WebKeys.USER,user);
         request.setAttribute(WebKeys.USER_ID,user.getUserId());

--- a/dotcms-integration/src/test/java/com/dotmarketing/servlets/BinaryExporterServletTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/servlets/BinaryExporterServletTest.java
@@ -52,7 +52,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import org.apache.commons.lang.RandomStringUtils;
-import org.glassfish.jersey.internal.util.Base64;
+import java.util.Base64;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -239,7 +239,7 @@ public class BinaryExporterServletTest {
             final MockHeaderRequest request = new MockHeaderRequest(mockServletRequest(fileURI));
             if (AUTH_WITH_CREDENTIALS.equals(authType)) {
                 request.setHeader("Authorization",
-                        "Basic " + new String(Base64.encode(userEmailAndPassword.getBytes())));
+                        "Basic " + Base64.getEncoder().encodeToString(userEmailAndPassword.getBytes()));
             } else if (AUTH_WITH_TOKEN.equals(authType)) {
                 request.setHeader("Authorization",
                         "Bearer " + APILocator.getApiTokenAPI().getJWT(apiToken, user));


### PR DESCRIPTION
## Description

Replace Jersey internal Base64 API (org.glassfish.jersey.internal.util.Base64) with Java standard Base64 (java.util.Base64) in WebResource authentication and API token handling.

**Files Changed:**
- WebResource.java - Core authentication Base64 encoding
- ApiTokenResource.java - API token Base64 handling
- 16 integration test files - Updated test authentication helpers

**Why This Matters:**
This is Phase 1 of the Jersey upgrade path. Jersey internal APIs are not public and will break when upgrading from Jersey 2.28 to 2.43 for Java 21/25 support. Using java.util.Base64 (available since Java 8) ensures compatibility with future Jersey versions.

**Testing:**
- All authentication flows tested
- API token generation/validation verified
- Integration test suite updated and passing

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #33857

**Issue:** Upgrade Jersey and ASM to support Java 21 and 25

This PR fixes: #33857