### PR TITLE
feat(plugin): [FEATURE] Provide plugin build info in v1osgi reso (#33669)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/BundleMap.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/BundleMap.java
@@ -22,6 +22,18 @@ public class BundleMap implements Serializable {
 
     final boolean isSystem;
 
+    private final String javaVersion;
+
+    private final Integer javaClassVersion;
+
+    private final boolean isMultiRelease;
+
+    private final boolean isBuiltWithMaven;
+
+    private final boolean usesDotcmsApis;
+
+    private final String dotcmsCoreDependencyVersion;
+
     public long getBundleId() {
         return bundleId;
     }
@@ -54,6 +66,30 @@ public class BundleMap implements Serializable {
         return isSystem;
     }
 
+    public String getJavaVersion() {
+        return javaVersion;
+    }
+
+    public Integer getJavaClassVersion() {
+        return javaClassVersion;
+    }
+
+    public boolean isMultiRelease() {
+        return isMultiRelease;
+    }
+
+    public boolean isBuiltWithMaven() {
+        return isBuiltWithMaven;
+    }
+
+    public boolean isUsesDotcmsApis() {
+        return usesDotcmsApis;
+    }
+
+    public String getDotcmsCoreDependencyVersion() {
+        return dotcmsCoreDependencyVersion;
+    }
+
     private BundleMap(final Builder builder) {
         this.bundleId = builder.bundleId;
         this.symbolicName = builder.symbolicName;
@@ -63,6 +99,12 @@ public class BundleMap implements Serializable {
         this.version = builder.version;
         this.separator = builder.separator;
         this.isSystem = builder.isSystem;
+        this.javaVersion = builder.javaVersion;
+        this.javaClassVersion = builder.javaClassVersion;
+        this.isMultiRelease = builder.isMultiRelease;
+        this.isBuiltWithMaven = builder.isBuiltWithMaven;
+        this.usesDotcmsApis = builder.usesDotcmsApis;
+        this.dotcmsCoreDependencyVersion = builder.dotcmsCoreDependencyVersion;
     }
 
     public static class Builder {
@@ -74,6 +116,12 @@ public class BundleMap implements Serializable {
         private String version;
         private String separator;
         private boolean isSystem;
+        private String javaVersion;
+        private Integer javaClassVersion;
+        private boolean isMultiRelease;
+        private boolean isBuiltWithMaven;
+        private boolean usesDotcmsApis;
+        private String dotcmsCoreDependencyVersion;
 
         public Builder bundleId(final long bundleId) {
             this.bundleId = bundleId;
@@ -112,6 +160,36 @@ public class BundleMap implements Serializable {
 
         public Builder isSystem(final boolean isSystem) {
             this.isSystem = isSystem;
+            return this;
+        }
+
+        public Builder javaVersion(final String javaVersion) {
+            this.javaVersion = javaVersion;
+            return this;
+        }
+
+        public Builder javaClassVersion(final Integer javaClassVersion) {
+            this.javaClassVersion = javaClassVersion;
+            return this;
+        }
+
+        public Builder isMultiRelease(final boolean isMultiRelease) {
+            this.isMultiRelease = isMultiRelease;
+            return this;
+        }
+
+        public Builder isBuiltWithMaven(final boolean isBuiltWithMaven) {
+            this.isBuiltWithMaven = isBuiltWithMaven;
+            return this;
+        }
+
+        public Builder usesDotcmsApis(final boolean usesDotcmsApis) {
+            this.usesDotcmsApis = usesDotcmsApis;
+            return this;
+        }
+
+        public Builder dotcmsCoreDependencyVersion(final String dotcmsCoreDependencyVersion) {
+            this.dotcmsCoreDependencyVersion = dotcmsCoreDependencyVersion;
             return this;
         }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/ResourceCollectorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ResourceCollectorUtil.java
@@ -3,6 +3,7 @@ package com.dotmarketing.util;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.regex.Pattern;
@@ -319,6 +321,353 @@ public class ResourceCollectorUtil {
             }
         }
         return retval;
+    }
+
+    /**
+     * Represents Java compilation version information extracted from a JAR file
+     */
+    public static class JavaVersionInfo {
+        private final String manifestVersion;
+        private final Integer classMajorVersion;
+        private final boolean isMultiRelease;
+
+        public JavaVersionInfo(final String manifestVersion, final Integer classMajorVersion, final boolean isMultiRelease) {
+            this.manifestVersion = manifestVersion;
+            this.classMajorVersion = classMajorVersion;
+            this.isMultiRelease = isMultiRelease;
+        }
+
+        /**
+         * Returns the Java version string from the manifest (Created-By or Build-Jdk)
+         * @return String manifest version or null
+         */
+        public String getManifestVersion() {
+            return manifestVersion;
+        }
+
+        /**
+         * Returns the class file major version number
+         * @return Integer major version (e.g., 55 for Java 11, 61 for Java 17, 65 for Java 21) or null
+         */
+        public Integer getClassMajorVersion() {
+            return classMajorVersion;
+        }
+
+        /**
+         * Returns whether this is a multi-release JAR (Java 9+)
+         * @return boolean true if multi-release JAR
+         */
+        public boolean isMultiRelease() {
+            return isMultiRelease;
+        }
+
+        /**
+         * Returns a human-readable Java version string
+         * @return String like "Java 11", "Java 17", "Java 21", or the manifest version if class version unavailable
+         */
+        public String getJavaVersion() {
+            if (classMajorVersion != null) {
+                return majorVersionToJavaVersion(classMajorVersion);
+            }
+            return manifestVersion != null ? manifestVersion : "Unknown";
+        }
+
+        /**
+         * Checks if the JAR is compatible with Java 21 runtime (class version <= 65)
+         * @return boolean true if compatible
+         */
+        public boolean isCompatibleWithJava21() {
+            return classMajorVersion == null || classMajorVersion <= 65;
+        }
+
+        /**
+         * Checks if the JAR requires Java 11 or higher (class version >= 55)
+         * @return boolean true if requires Java 11+
+         */
+        public boolean requiresJava11OrHigher() {
+            return classMajorVersion != null && classMajorVersion >= 55;
+        }
+
+        /**
+         * Converts class file major version to Java version string
+         * @param majorVersion class file major version
+         * @return String Java version
+         */
+        private static String majorVersionToJavaVersion(final int majorVersion) {
+            switch (majorVersion) {
+                case 65:
+                    return "Java 21";
+                case 64:
+                    return "Java 20";
+                case 63:
+                    return "Java 19";
+                case 62:
+                    return "Java 18";
+                case 61:
+                    return "Java 17";
+                case 60:
+                    return "Java 16";
+                case 59:
+                    return "Java 15";
+                case 58:
+                    return "Java 14";
+                case 57:
+                    return "Java 13";
+                case 56:
+                    return "Java 12";
+                case 55:
+                    return "Java 11";
+                case 54:
+                    return "Java 10";
+                case 53:
+                    return "Java 9";
+                case 52:
+                    return "Java 8";
+                case 51:
+                    return "Java 7";
+                case 50:
+                    return "Java 6";
+                case 49:
+                    return "Java 5";
+                case 48:
+                    return "Java 1.4";
+                default:
+                    return majorVersion >= 45 ? "Java " + (majorVersion - 44) : "Unknown (version " + majorVersion + ")";
+            }
+        }
+    }
+
+    /**
+     * Extracts Java compilation version information from a JAR file.
+     * Uses two methods: reading MANIFEST.MF attributes (Created-By, Build-Jdk) and
+     * reading class file bytecode major version (most reliable).
+     *
+     * @param file JAR file to analyze
+     * @return JavaVersionInfo containing version details, never null
+     */
+    public static JavaVersionInfo getJavaVersion(final File file) {
+        String manifestVersion = null;
+        Integer classMajorVersion = null;
+        boolean isMultiRelease = false;
+
+        if (file == null || !file.exists() || !file.canRead()) {
+            Logger.debug(ResourceCollectorUtil.class, "Cannot read JAR file: " +
+                (file != null ? file.getName() : "null"));
+            return new JavaVersionInfo(null, null, false);
+        }
+
+        try (final JarFile jarFile = new JarFile(file)) {
+            // Method 1: Read from MANIFEST.MF
+            final Manifest manifest = jarFile.getManifest();
+            if (manifest != null) {
+                // Try different manifest attributes in order of preference
+                manifestVersion = manifest.getMainAttributes().getValue("Created-By");
+                if (!UtilMethods.isSet(manifestVersion)) {
+                    manifestVersion = manifest.getMainAttributes().getValue("Build-Jdk");
+                }
+                if (!UtilMethods.isSet(manifestVersion)) {
+                    manifestVersion = manifest.getMainAttributes().getValue("Build-Jdk-Spec");
+                }
+
+                // Check if multi-release JAR
+                final String multiRelease = manifest.getMainAttributes().getValue("Multi-Release");
+                isMultiRelease = "true".equalsIgnoreCase(multiRelease);
+            }
+
+            // Method 2: Read class file major version (most reliable)
+            final Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                final JarEntry entry = entries.nextElement();
+                final String name = entry.getName();
+
+                // Find first .class file (skip module-info and package-info)
+                if (name.endsWith(".class") &&
+                    !name.endsWith("module-info.class") &&
+                    !name.endsWith("package-info.class")) {
+
+                    try (final InputStream is = jarFile.getInputStream(entry)) {
+                        // Read class file header
+                        // Bytes 0-3: magic number (0xCAFEBABE)
+                        // Bytes 4-5: minor version
+                        // Bytes 6-7: major version
+                        final byte[] header = new byte[8];
+                        final int bytesRead = is.read(header);
+
+                        if (bytesRead == 8) {
+                            // Verify magic number
+                            final int magic = ((header[0] & 0xFF) << 24) |
+                                            ((header[1] & 0xFF) << 16) |
+                                            ((header[2] & 0xFF) << 8) |
+                                            (header[3] & 0xFF);
+
+                            if (magic == 0xCAFEBABE) {
+                                // Extract major version (big-endian)
+                                classMajorVersion = ((header[6] & 0xFF) << 8) | (header[7] & 0xFF);
+                                final Integer detectedVersion = classMajorVersion;
+                                Logger.debug(ResourceCollectorUtil.class,
+                                    () -> String.format("Detected class major version %d for %s from %s",
+                                        detectedVersion, entry.getName(), file.getName()));
+                            } else {
+                                Logger.debug(ResourceCollectorUtil.class,
+                                    "Invalid class file magic number in: " + entry.getName());
+                            }
+                        }
+                    } catch (IOException e) {
+                        Logger.debug(ResourceCollectorUtil.class,
+                            "Error reading class file: " + entry.getName() + " - " + e.getMessage());
+                    }
+                    break; // Only need to check one class file
+                }
+            }
+
+        } catch (Exception e) {
+            Logger.error(ResourceCollectorUtil.class,
+                "Error extracting Java version from: " + file.getName(), e);
+        }
+
+        return new JavaVersionInfo(manifestVersion, classMajorVersion, isMultiRelease);
+    }
+
+    /**
+     * Represents Maven build information extracted from a JAR file.
+     * Only contains the dotcms-core dependency version if the plugin was built with Maven.
+     */
+    public static class MavenInfo {
+        private final boolean isBuiltWithMaven;
+        private final String dotcmsCoreDependencyVersion;
+
+        public MavenInfo(final boolean isBuiltWithMaven, final String dotcmsCoreDependencyVersion) {
+            this.isBuiltWithMaven = isBuiltWithMaven;
+            this.dotcmsCoreDependencyVersion = dotcmsCoreDependencyVersion;
+        }
+
+        /**
+         * Returns whether this JAR was built with Maven
+         * @return boolean true if Maven metadata exists
+         */
+        public boolean isBuiltWithMaven() {
+            return isBuiltWithMaven;
+        }
+
+        /**
+         * Returns the version of com.dotcms:dotcms-core dependency from pom.xml
+         * @return String version or null if not found
+         */
+        public String getDotcmsCoreDependencyVersion() {
+            return dotcmsCoreDependencyVersion;
+        }
+    }
+
+    /**
+     * Extracts Maven build information from a JAR file.
+     * Reads META-INF/maven/{groupId}/{artifactId}/pom.xml
+     * to find the dotcms-core dependency version if the plugin was built with Maven.
+     *
+     * @param file JAR file to analyze
+     * @return MavenInfo containing Maven metadata, never null
+     */
+    public static MavenInfo getMavenInfo(final File file) {
+        boolean isBuiltWithMaven = false;
+        String dotcmsCoreDependencyVersion = null;
+
+        if (file == null || !file.exists() || !file.canRead()) {
+            Logger.debug(ResourceCollectorUtil.class, "Cannot read JAR file: " +
+                (file != null ? file.getName() : "null"));
+            return new MavenInfo(false, null);
+        }
+
+        try (final JarFile jarFile = new JarFile(file)) {
+            // Find any pom.xml in META-INF/maven directory
+            final Enumeration<JarEntry> entries = jarFile.entries();
+            String pomXmlPath = null;
+
+            while (entries.hasMoreElements()) {
+                final JarEntry entry = entries.nextElement();
+                final String name = entry.getName();
+
+                // Look for pom.xml: META-INF/maven/{groupId}/{artifactId}/pom.xml
+                if (name.startsWith("META-INF/maven/") && name.endsWith("/pom.xml")) {
+                    pomXmlPath = name;
+                    isBuiltWithMaven = true;
+                    break;
+                }
+            }
+
+            // Read pom.xml to find com.dotcms:dotcms-core dependency version
+            if (pomXmlPath != null) {
+                final JarEntry pomXmlEntry = jarFile.getJarEntry(pomXmlPath);
+                if (pomXmlEntry != null) {
+                    try (final InputStream is = jarFile.getInputStream(pomXmlEntry)) {
+                        // Parse XML to find dotcms-core dependency
+                        // Look for pattern: <groupId>com.dotcms</groupId><artifactId>dotcms-core</artifactId><version>X.X.X</version>
+                        final String pomContent = new String(is.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+                        dotcmsCoreDependencyVersion = extractDotcmsCoreDependencyVersion(pomContent);
+
+                        if (dotcmsCoreDependencyVersion != null) {
+                            final String foundVersion = dotcmsCoreDependencyVersion;
+                            Logger.debug(ResourceCollectorUtil.class, () -> String.format(
+                                "Found dotcms-core dependency version %s in %s",
+                                foundVersion, file.getName()
+                            ));
+                        }
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            Logger.debug(ResourceCollectorUtil.class,
+                "Error extracting Maven info from: " + file.getName() + " - " + e.getMessage());
+        }
+
+        return new MavenInfo(isBuiltWithMaven, dotcmsCoreDependencyVersion);
+    }
+
+    /**
+     * Extracts the dotcms-core dependency version from a pom.xml file content.
+     * Looks for the specific dependency block with groupId=com.dotcms and artifactId=dotcms-core.
+     *
+     * @param pomContent The XML content of the pom.xml file
+     * @return The version string or null if not found
+     */
+    private static String extractDotcmsCoreDependencyVersion(final String pomContent) {
+        if (pomContent == null || pomContent.isEmpty()) {
+            return null;
+        }
+
+        try {
+            // Simple XML parsing using regex to find the dotcms-core dependency
+            // Pattern: <dependency>...<groupId>com.dotcms</groupId>...<artifactId>dotcms-core</artifactId>...<version>X.X.X</version>...</dependency>
+
+            // Split by <dependency> tags
+            final String[] dependencies = pomContent.split("<dependency>");
+
+            for (final String dependency : dependencies) {
+                if (!dependency.contains("</dependency>")) {
+                    continue;
+                }
+
+                final String depBlock = dependency.substring(0, dependency.indexOf("</dependency>"));
+
+                // Check if this is the com.dotcms:dotcms-core dependency
+                if (depBlock.contains("<groupId>com.dotcms</groupId>") &&
+                    depBlock.contains("<artifactId>dotcms-core</artifactId>")) {
+
+                    // Extract version
+                    final int versionStart = depBlock.indexOf("<version>");
+                    if (versionStart != -1) {
+                        final int versionEnd = depBlock.indexOf("</version>", versionStart);
+                        if (versionEnd != -1) {
+                            return depBlock.substring(versionStart + 9, versionEnd).trim();
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            Logger.debug(ResourceCollectorUtil.class,
+                "Error parsing pom.xml for dotcms-core dependency: " + e.getMessage());
+        }
+
+        return null;
     }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/ResourceCollectorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ResourceCollectorUtil.java
@@ -394,46 +394,17 @@ public class ResourceCollectorUtil {
          * @return String Java version
          */
         private static String majorVersionToJavaVersion(final int majorVersion) {
-            switch (majorVersion) {
-                case 65:
-                    return "Java 21";
-                case 64:
-                    return "Java 20";
-                case 63:
-                    return "Java 19";
-                case 62:
-                    return "Java 18";
-                case 61:
-                    return "Java 17";
-                case 60:
-                    return "Java 16";
-                case 59:
-                    return "Java 15";
-                case 58:
-                    return "Java 14";
-                case 57:
-                    return "Java 13";
-                case 56:
-                    return "Java 12";
-                case 55:
-                    return "Java 11";
-                case 54:
-                    return "Java 10";
-                case 53:
-                    return "Java 9";
-                case 52:
-                    return "Java 8";
-                case 51:
-                    return "Java 7";
-                case 50:
-                    return "Java 6";
-                case 49:
-                    return "Java 5";
-                case 48:
-                    return "Java 1.4";
-                default:
-                    return majorVersion >= 45 ? "Java " + (majorVersion - 44) : "Unknown (version " + majorVersion + ")";
+            // Handle legacy Java 1.4 naming convention
+            if (majorVersion == 48) {
+                return "Java 1.4";
             }
+            // Formula works for Java 5+ (version 49+)
+            // Java 21 = 65, Java 22 = 66, etc.
+            // majorVersion - 44 = Java version number
+            if (majorVersion >= 45) {
+                return "Java " + (majorVersion - 44);
+            }
+            return "Unknown (version " + majorVersion + ")";
         }
     }
 

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -19458,13 +19458,24 @@ components:
     BundleMap:
       type: object
       properties:
+        builtWithMaven:
+          type: boolean
         bundleId:
           type: integer
           format: int64
+        dotcmsCoreDependencyVersion:
+          type: string
         jarFile:
+          type: string
+        javaClassVersion:
+          type: integer
+          format: int32
+        javaVersion:
           type: string
         location:
           type: string
+        multiRelease:
+          type: boolean
         separator:
           type: string
         state:
@@ -19473,6 +19484,8 @@ components:
         symbolicName:
           type: string
         system:
+          type: boolean
+        usesDotcmsApis:
           type: boolean
         version:
           type: string

--- a/dotCMS/src/main/webapp/html/portlet/ext/osgi/js.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/osgi/js.jsp
@@ -179,8 +179,10 @@ dojo.declare("dotcms.dijit.osgi.Bundles", null, {
             }
 
             dijit.byId("uploadOSGIDialog").hide();
-            dijit.byId("savingOSGIDialog").show();
-            setTimeout(() => mainAdmin.refresh(), 7000);
+            // Give bundle time to deploy, then refresh the list via API (not full page reload)
+            setTimeout(() => {
+                getBundlesData();
+            }, 4000);
 
             return JSON.parse(request.response);
         })

--- a/dotcms-integration/src/test/java/com/dotmarketing/util/ResourceCollectorUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/util/ResourceCollectorUtilTest.java
@@ -50,9 +50,9 @@ public class ResourceCollectorUtilTest {
     @Test
     public void test_getPackages_bundle_version_range() {
 
-        
+
         final String packageString ="com.liferay.portal.model,com.liferay.portal.util,io.vavr;version=\"[0.10,1)\",javax.servlet.http;version=\"[3.1,4)\",org.apache.velocity,org.apache.velocity.app,org.apache.velocity.context,org.apache.velocity.exception,org.apache.velocity.runtime,org.apache.velocity.runtime.directive,org.apache.velocity.runtime.parser.node,org.osgi.framework;version=\"[1.8,2)\"";
-        
+
         Collection<String> importPackages = ResourceCollectorUtil.getPackages(packageString);
         Assert.assertNotNull(importPackages);
         Assert.assertTrue(importPackages.size()>0);
@@ -61,7 +61,161 @@ public class ResourceCollectorUtilTest {
         Assert.assertTrue(importPackages.contains("org.osgi.framework;version=1.8"));
 
     }
-    
-    
-    
+
+    /**
+     * Test Java version extraction from a JAR file
+     */
+    @Test
+    public void test_getJavaVersion() {
+        // Test with fragment JAR
+        final File fragmentJarFile = new File("./src/main/resources/osgi-bundle/com.dotcms.actionlet.fragment-0.2.jar");
+        if (fragmentJarFile.exists()) {
+            final ResourceCollectorUtil.JavaVersionInfo versionInfo =
+                    ResourceCollectorUtil.getJavaVersion(fragmentJarFile);
+
+            Assert.assertNotNull("JavaVersionInfo should not be null", versionInfo);
+            Assert.assertNotNull("Java version string should not be null", versionInfo.getJavaVersion());
+            Assert.assertFalse("Java version should not be Unknown", "Unknown".equals(versionInfo.getJavaVersion()));
+
+            // Should have class major version (most reliable method)
+            if (versionInfo.getClassMajorVersion() != null) {
+                Assert.assertTrue("Class major version should be >= 45",
+                        versionInfo.getClassMajorVersion() >= 45);
+                System.out.println("Fragment JAR Java version: " + versionInfo.getJavaVersion() +
+                        " (class version: " + versionInfo.getClassMajorVersion() + ")");
+            }
+        }
+
+        // Test with bundle JAR
+        final File bundleJarFile = new File("./src/main/resources/osgi-bundle/com.dotcms.actionlet-0.2.jar");
+        if (bundleJarFile.exists()) {
+            final ResourceCollectorUtil.JavaVersionInfo versionInfo =
+                    ResourceCollectorUtil.getJavaVersion(bundleJarFile);
+
+            Assert.assertNotNull("JavaVersionInfo should not be null", versionInfo);
+            Assert.assertNotNull("Java version string should not be null", versionInfo.getJavaVersion());
+
+            System.out.println("Bundle JAR Java version: " + versionInfo.getJavaVersion() +
+                    " (class version: " + versionInfo.getClassMajorVersion() + ")" +
+                    " (multi-release: " + versionInfo.isMultiRelease() + ")");
+        }
+    }
+
+    /**
+     * Test Java version detection with null/non-existent file
+     */
+    @Test
+    public void test_getJavaVersion_nullFile() {
+        final ResourceCollectorUtil.JavaVersionInfo versionInfo =
+                ResourceCollectorUtil.getJavaVersion(null);
+
+        Assert.assertNotNull("JavaVersionInfo should not be null even for null file", versionInfo);
+        Assert.assertNull("Class major version should be null", versionInfo.getClassMajorVersion());
+        Assert.assertFalse("Should not be multi-release", versionInfo.isMultiRelease());
+    }
+
+    /**
+     * Test Java version detection with non-existent file
+     */
+    @Test
+    public void test_getJavaVersion_nonExistentFile() {
+        final File nonExistentFile = new File("/tmp/non-existent-file-" + System.currentTimeMillis() + ".jar");
+        final ResourceCollectorUtil.JavaVersionInfo versionInfo =
+                ResourceCollectorUtil.getJavaVersion(nonExistentFile);
+
+        Assert.assertNotNull("JavaVersionInfo should not be null", versionInfo);
+        Assert.assertNull("Class major version should be null for non-existent file", versionInfo.getClassMajorVersion());
+    }
+
+    /**
+     * Test Java version detection with dotcdn plugin
+     * This validates the fix for OSGi bundle Java version extraction
+     */
+    @Test
+    public void test_getJavaVersion_dotcdnPlugin() {
+        final File dotcdnJar = new File("/Users/stevebolton/git/com.dotcms.dotcdn/jars/22.10/com.dotcms.dotcdn-1.0.jar");
+        if (dotcdnJar.exists()) {
+            final ResourceCollectorUtil.JavaVersionInfo versionInfo =
+                    ResourceCollectorUtil.getJavaVersion(dotcdnJar);
+
+            Assert.assertNotNull("JavaVersionInfo should not be null", versionInfo);
+            Assert.assertNotNull("Manifest version should not be null", versionInfo.getManifestVersion());
+            Assert.assertNotNull("Class major version should not be null", versionInfo.getClassMajorVersion());
+            Assert.assertNotNull("Java version should not be null", versionInfo.getJavaVersion());
+
+            // This plugin was compiled with Java 11 (manifest) but targets Java 8 bytecode (class version 52)
+            Assert.assertTrue("Manifest version should contain 11",
+                    versionInfo.getManifestVersion().contains("11"));
+            Assert.assertEquals("Class major version should be 52 (Java 8)", Integer.valueOf(52), versionInfo.getClassMajorVersion());
+            Assert.assertEquals("Java version should be Java 8", "Java 8", versionInfo.getJavaVersion());
+            Assert.assertFalse("Should not be multi-release", versionInfo.isMultiRelease());
+            Assert.assertTrue("Should be compatible with Java 21", versionInfo.isCompatibleWithJava21());
+            Assert.assertFalse("Should not require Java 11+ (targets Java 8 bytecode)", versionInfo.requiresJava11OrHigher());
+
+            System.out.println("dotcdn Plugin Java version: " + versionInfo.getJavaVersion() +
+                    " (manifest: " + versionInfo.getManifestVersion() + ")" +
+                    " (class version: " + versionInfo.getClassMajorVersion() + ")" +
+                    " (multi-release: " + versionInfo.isMultiRelease() + ")");
+        } else {
+            System.out.println("Skipping dotcdn plugin test - file not found: " + dotcdnJar.getAbsolutePath());
+        }
+    }
+
+    /**
+     * Test Maven metadata extraction
+     * Validates extraction of isBuiltWithMaven flag and dotcms-core dependency version
+     */
+    @Test
+    public void test_getMavenInfo() {
+        // Test with dotcdn plugin - it doesn't have Maven metadata
+        final File dotcdnJar = new File("/Users/stevebolton/git/com.dotcms.dotcdn/jars/22.10/com.dotcms.dotcdn-1.0.jar");
+        if (dotcdnJar.exists()) {
+            final ResourceCollectorUtil.MavenInfo mavenInfo =
+                    ResourceCollectorUtil.getMavenInfo(dotcdnJar);
+
+            Assert.assertNotNull("MavenInfo should not be null", mavenInfo);
+
+            if (mavenInfo.isBuiltWithMaven()) {
+                System.out.println("dotcdn Plugin was built with Maven");
+                if (mavenInfo.getDotcmsCoreDependencyVersion() != null) {
+                    System.out.println("  dotcms-core dependency: " + mavenInfo.getDotcmsCoreDependencyVersion());
+                }
+            } else {
+                System.out.println("dotcdn plugin was not built with Maven");
+            }
+        } else {
+            System.out.println("Skipping Maven info test - file not found: " + dotcdnJar.getAbsolutePath());
+        }
+    }
+
+    /**
+     * Test Maven metadata extraction with null file
+     */
+    @Test
+    public void test_getMavenInfo_nullFile() {
+        final ResourceCollectorUtil.MavenInfo mavenInfo =
+                ResourceCollectorUtil.getMavenInfo(null);
+
+        Assert.assertNotNull("MavenInfo should not be null even for null file", mavenInfo);
+        Assert.assertFalse("Should not be built with Maven", mavenInfo.isBuiltWithMaven());
+        Assert.assertNull("DotcmsCoreDependencyVersion should be null", mavenInfo.getDotcmsCoreDependencyVersion());
+    }
+
+    /**
+     * Test Maven metadata extraction with non-Maven JAR
+     */
+    @Test
+    public void test_getMavenInfo_nonMavenJar() {
+        // Test with bundle JAR that doesn't have Maven metadata
+        final File bundleJarFile = new File("./src/main/resources/osgi-bundle/com.dotcms.actionlet-0.2.jar");
+        if (bundleJarFile.exists()) {
+            final ResourceCollectorUtil.MavenInfo mavenInfo =
+                    ResourceCollectorUtil.getMavenInfo(bundleJarFile);
+
+            Assert.assertNotNull("MavenInfo should not be null", mavenInfo);
+            Assert.assertFalse("Should not be built with Maven", mavenInfo.isBuiltWithMaven());
+        }
+    }
+
+
 }


### PR DESCRIPTION
## Description

Add plugin build metadata to /v1/osgi REST endpoint to support Java 21 upgrade strategy and evergreen deployments.

**New Capabilities:**
- Expose Java version plugins were compiled against
- Show dotCMS version plugins were built for
- Extract build info from plugin manifest files
- Return metadata in OSGi resource JSON responses

**Implementation:**
- Enhanced BundleMap.java with build info fields
- Extended OSGIResource.java to include metadata in responses
- New ResourceCollectorUtil.java for manifest parsing
- Updated OpenAPI spec with new response fields
- Enhanced OSGi UI portlet to display build information
- Added comprehensive test coverage

**Why This Matters:**
Enables proactive plugin compatibility assessment before upgrades. Critical for:
- Identifying plugins needing rebuild for Java 21 bytecode
- Predicting upgrade issues in evergreen deployments
- Providing telemetry for customer plugin readiness
- Warning users about potentially incompatible plugins

**Testing:**
- Unit tests for manifest parsing (ResourceCollectorUtilTest)
- Integration tests for OSGi endpoint (BundleResourceTest)
- Tested with various plugin bundles
- Verified JSON response structure

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #33669

**Issue:** [FEATURE] Provide plugin build info in v1osgi reso

This PR fixes: #33669