### PR TITLE
modernization ( Angular Update ) : #33862 Missing provider for DotFieldVariablesService in DotContentTypesEditModule

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
@@ -59,6 +59,7 @@ import { ValuesPropertyComponent } from './components/fields/content-type-fields
 import { ContentTypeFieldsRowComponent } from './components/fields/content-type-fields-row';
 import { ContentTypeFieldsTabComponent } from './components/fields/content-type-fields-tab';
 import { DotContentTypeFieldsVariablesComponent } from './components/fields/dot-content-type-fields-variables/dot-content-type-fields-variables.component';
+import { DotFieldVariablesService } from './components/fields/dot-content-type-fields-variables/services/dot-field-variables.service';
 import { FieldDragDropService } from './components/fields/service/field-drag-drop.service';
 import { FieldPropertyService } from './components/fields/service/field-properties.service';
 import { FieldService } from './components/fields/service/field.service';
@@ -183,7 +184,8 @@ import { DotFeatureFlagResolver } from '../resolvers/dot-feature-flag-resolver.s
         DotWorkflowsActionsService,
         DotWorkflowsActionsSelectorFieldService,
         DotFeatureFlagResolver,
-        DotEditContentTypeCacheService
+        DotEditContentTypeCacheService,
+        DotFieldVariablesService
     ],
     schemas: []
 })


### PR DESCRIPTION
### Proposed Changes
* Add DotFieldVariablesService to the providers array in DotContentTypesEditModule..

Fix: Settings tab now load correctly. 

https://github.com/user-attachments/assets/6985675e-fd3a-4faa-9bfd-c3eb157ce693


This PR fixes: #33862

This PR fixes: #33862