### PR TITLE
fix(PP): update `deleteAllCategories` to use `DotConnect`

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/CategoryFullHandler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/remote/handler/CategoryFullHandler.java
@@ -172,8 +172,7 @@ public class CategoryFullHandler implements IHandler {
 
     @WrapInTransaction
     private void deleteAllCategories() throws DotDataException {
-        HibernateUtil
-                .delete("from category in class com.dotmarketing.portlets.categories.model.Category");
+        new DotConnect().setSQL("DELETE FROM category").loadResult();
     }
 
     @WrapInTransaction


### PR DESCRIPTION
### Changes:
- Replaced Hibernate deletion logic with `DotConnect` SQL execution in `deleteAllCategories`.

fixes: #33909 

This PR fixes: #33909