### PR TITLE
fix(mcp): Enhance search tests for content handling and date validation

### DIFF
--- a/core-web/apps/mcp-server/src/services/search.spec.ts
+++ b/core-web/apps/mcp-server/src/services/search.spec.ts
@@ -10,7 +10,7 @@ describe('ContentSearchService', () => {
     });
 
     describe('search', () => {
-        it('should search content successfully', async () => {
+        it('should search content successfully with published content', async () => {
             const mockResponse = {
                 json: jest.fn().mockResolvedValue({
                     entity: {
@@ -19,11 +19,10 @@ describe('ContentSearchService', () => {
                         jsonObjectView: {
                             contentlets: [
                                 {
-                                    id: '1',
                                     title: 'Test Result',
                                     hostName: 'localhost',
-                                    modDate: '20240101',
-                                    publishDate: '20240101',
+                                    modDate: '1764284834965',
+                                    publishDate: '1764284834994',
                                     baseType: 'CONTENT',
                                     inode: 'inode1',
                                     archived: false,
@@ -39,10 +38,10 @@ describe('ContentSearchService', () => {
                                     publishUserName: 'admin',
                                     publishUser: 'admin',
                                     languageId: 1,
-                                    creationDate: '20240101',
+                                    creationDate: '1764284749322',
                                     shortyId: 'shorty1',
                                     url: '/test',
-                                    titleImage: '',
+                                    titleImage: 'TITLE_IMAGE_NOT_FOUND',
                                     modUserName: 'admin',
                                     hasLiveVersion: true,
                                     folder: '/test',
@@ -83,6 +82,223 @@ describe('ContentSearchService', () => {
             );
             expect(result.entity?.jsonObjectView?.contentlets).toHaveLength(1);
             expect(result.entity?.jsonObjectView?.contentlets?.[0].title).toBe('Test Result');
+            // Verify dates are converted to numbers
+            expect(typeof result.entity?.jsonObjectView?.contentlets?.[0].modDate).toBe('number');
+            expect(typeof result.entity?.jsonObjectView?.contentlets?.[0].creationDate).toBe(
+                'number'
+            );
+            expect(typeof result.entity?.jsonObjectView?.contentlets?.[0].publishDate).toBe(
+                'number'
+            );
+        });
+
+        it('should search content successfully with unpublished content', async () => {
+            const mockResponse = {
+                json: jest.fn().mockResolvedValue({
+                    entity: {
+                        contentTook: 1,
+                        resultsSize: 1,
+                        jsonObjectView: {
+                            contentlets: [
+                                {
+                                    title: 'Unpublished Result',
+                                    hostName: 'localhost',
+                                    modDate: '1764284834965',
+                                    baseType: 'CONTENT',
+                                    inode: 'inode2',
+                                    archived: false,
+                                    host: 'host1',
+                                    ownerUserName: 'admin',
+                                    working: true,
+                                    locked: false,
+                                    stInode: 'stinode1',
+                                    contentType: 'Blog',
+                                    live: false,
+                                    owner: 'admin',
+                                    identifier: 'id2',
+                                    languageId: 1,
+                                    creationDate: '1764284749322',
+                                    shortyId: 'shorty2',
+                                    url: '/test2',
+                                    titleImage: 'TITLE_IMAGE_NOT_FOUND',
+                                    modUserName: 'admin',
+                                    hasLiveVersion: false,
+                                    folder: '/test',
+                                    hasTitleImage: false,
+                                    sortOrder: 0,
+                                    modUser: 'admin',
+                                    __icon__: 'icon',
+                                    contentTypeIcon: 'icon',
+                                    variant: 'default'
+                                }
+                            ]
+                        },
+                        queryTook: 1
+                    },
+                    errors: [],
+                    messages: [],
+                    i18nMessagesMap: {},
+                    permissions: []
+                })
+            };
+            mockFetch.mockResolvedValue(mockResponse);
+
+            const params = {
+                query: '+title:Unpublished',
+                limit: 1,
+                languageId: 1,
+                depth: 1,
+                allCategoriesInfo: false
+            };
+            const result = await service.search(params);
+
+            expect(result.entity?.jsonObjectView?.contentlets).toHaveLength(1);
+            expect(result.entity?.jsonObjectView?.contentlets?.[0].title).toBe(
+                'Unpublished Result'
+            );
+            // Verify publishDate is null/undefined for unpublished content
+            expect(result.entity?.jsonObjectView?.contentlets?.[0].publishDate).toBeUndefined();
+            // Verify dates are converted to numbers
+            expect(typeof result.entity?.jsonObjectView?.contentlets?.[0].modDate).toBe('number');
+            expect(typeof result.entity?.jsonObjectView?.contentlets?.[0].creationDate).toBe(
+                'number'
+            );
+        });
+
+        it('should handle numeric date values', async () => {
+            const mockResponse = {
+                json: jest.fn().mockResolvedValue({
+                    entity: {
+                        contentTook: 1,
+                        resultsSize: 1,
+                        jsonObjectView: {
+                            contentlets: [
+                                {
+                                    title: 'Numeric Dates',
+                                    hostName: 'localhost',
+                                    modDate: 1764284834965,
+                                    publishDate: 1764284834994,
+                                    baseType: 'CONTENT',
+                                    inode: 'inode3',
+                                    archived: false,
+                                    host: 'host1',
+                                    ownerUserName: 'admin',
+                                    working: true,
+                                    locked: false,
+                                    stInode: 'stinode1',
+                                    contentType: 'Blog',
+                                    live: true,
+                                    owner: 'admin',
+                                    identifier: 'id3',
+                                    publishUserName: 'admin',
+                                    publishUser: 'admin',
+                                    languageId: 1,
+                                    creationDate: 1764284749322,
+                                    shortyId: 'shorty3',
+                                    url: '/test3',
+                                    titleImage: 'TITLE_IMAGE_NOT_FOUND',
+                                    modUserName: 'admin',
+                                    hasLiveVersion: true,
+                                    folder: '/test',
+                                    hasTitleImage: false,
+                                    sortOrder: 0,
+                                    modUser: 'admin',
+                                    __icon__: 'icon',
+                                    contentTypeIcon: 'icon',
+                                    variant: 'default'
+                                }
+                            ]
+                        },
+                        queryTook: 1
+                    },
+                    errors: [],
+                    messages: [],
+                    i18nMessagesMap: {},
+                    permissions: []
+                })
+            };
+            mockFetch.mockResolvedValue(mockResponse);
+
+            const params = {
+                query: '+title:Numeric',
+                limit: 1,
+                languageId: 1,
+                depth: 1,
+                allCategoriesInfo: false
+            };
+            const result = await service.search(params);
+
+            expect(result.entity?.jsonObjectView?.contentlets).toHaveLength(1);
+            expect(result.entity?.jsonObjectView?.contentlets?.[0].modDate).toBe(1764284834965);
+            expect(result.entity?.jsonObjectView?.contentlets?.[0].creationDate).toBe(
+                1764284749322
+            );
+            expect(result.entity?.jsonObjectView?.contentlets?.[0].publishDate).toBe(1764284834994);
+        });
+
+        it('should handle null publishDate', async () => {
+            const mockResponse = {
+                json: jest.fn().mockResolvedValue({
+                    entity: {
+                        contentTook: 1,
+                        resultsSize: 1,
+                        jsonObjectView: {
+                            contentlets: [
+                                {
+                                    title: 'Null Publish Date',
+                                    hostName: 'localhost',
+                                    modDate: '1764284834965',
+                                    publishDate: null,
+                                    baseType: 'CONTENT',
+                                    inode: 'inode4',
+                                    archived: false,
+                                    host: 'host1',
+                                    ownerUserName: 'admin',
+                                    working: true,
+                                    locked: false,
+                                    stInode: 'stinode1',
+                                    contentType: 'Blog',
+                                    live: false,
+                                    owner: 'admin',
+                                    identifier: 'id4',
+                                    languageId: 1,
+                                    creationDate: '1764284749322',
+                                    shortyId: 'shorty4',
+                                    url: '/test4',
+                                    titleImage: 'TITLE_IMAGE_NOT_FOUND',
+                                    modUserName: 'admin',
+                                    hasLiveVersion: false,
+                                    folder: '/test',
+                                    hasTitleImage: false,
+                                    sortOrder: 0,
+                                    modUser: 'admin',
+                                    __icon__: 'icon',
+                                    contentTypeIcon: 'icon',
+                                    variant: 'default'
+                                }
+                            ]
+                        },
+                        queryTook: 1
+                    },
+                    errors: [],
+                    messages: [],
+                    i18nMessagesMap: {},
+                    permissions: []
+                })
+            };
+            mockFetch.mockResolvedValue(mockResponse);
+
+            const params = {
+                query: '+title:Null',
+                limit: 1,
+                languageId: 1,
+                depth: 1,
+                allCategoriesInfo: false
+            };
+            const result = await service.search(params);
+
+            expect(result.entity?.jsonObjectView?.contentlets).toHaveLength(1);
+            expect(result.entity?.jsonObjectView?.contentlets?.[0].publishDate).toBeNull();
         });
 
         it('should handle invalid search parameters', async () => {

--- a/core-web/apps/mcp-server/src/services/site.spec.ts
+++ b/core-web/apps/mcp-server/src/services/site.spec.ts
@@ -97,6 +97,135 @@ describe('SiteService', () => {
             await expect(service.getCurrentSite()).rejects.toThrow('Network error');
         });
 
+        it('should handle null aliases', async () => {
+            const mockResponse = {
+                json: jest.fn().mockResolvedValue({
+                    entity: {
+                        aliases: null,
+                        archived: false,
+                        categoryId: 'cat123',
+                        contentTypeId: 'ct123',
+                        default: true,
+                        dotAsset: false,
+                        fileAsset: false,
+                        folder: 'folder123',
+                        form: false,
+                        host: 'host123',
+                        hostThumbnail: null,
+                        hostname: 'localhost',
+                        htmlpage: false,
+                        identifier: 'id123',
+                        indexPolicyDependencies: 'deps',
+                        inode: 'inode123',
+                        keyValue: false,
+                        languageId: 1,
+                        languageVariable: false,
+                        live: true,
+                        locked: false,
+                        lowIndexPriority: false,
+                        modDate: 123456789,
+                        modUser: 'admin',
+                        name: 'Default Site',
+                        new: false,
+                        owner: 'admin',
+                        parent: false,
+                        permissionId: 'perm123',
+                        permissionType: 'host',
+                        persona: false,
+                        sortOrder: 1,
+                        structureInode: 'struct123',
+                        systemHost: false,
+                        tagStorage: 'tag123',
+                        title: 'Default Site',
+                        titleImage: null,
+                        type: 'host',
+                        vanityUrl: false,
+                        variantId: 'var123',
+                        versionId: 'ver123',
+                        working: true
+                    },
+                    errors: [],
+                    i18nMessagesMap: {},
+                    messages: [],
+                    pagination: null,
+                    permissions: []
+                })
+            };
+
+            mockFetch.mockResolvedValue(mockResponse);
+
+            const result = await service.getCurrentSite();
+
+            expect(mockFetch).toHaveBeenCalledWith('/api/v1/site/currentSite', { method: 'GET' });
+            expect(result.name).toBe('Default Site');
+            expect(result.hostname).toBe('localhost');
+            expect((result as Record<string, unknown>).aliases).toBeNull();
+        });
+
+        it('should handle missing aliases field', async () => {
+            const mockResponse = {
+                json: jest.fn().mockResolvedValue({
+                    entity: {
+                        archived: false,
+                        categoryId: 'cat123',
+                        contentTypeId: 'ct123',
+                        default: true,
+                        dotAsset: false,
+                        fileAsset: false,
+                        folder: 'folder123',
+                        form: false,
+                        host: 'host123',
+                        hostThumbnail: null,
+                        hostname: 'localhost',
+                        htmlpage: false,
+                        identifier: 'id123',
+                        indexPolicyDependencies: 'deps',
+                        inode: 'inode123',
+                        keyValue: false,
+                        languageId: 1,
+                        languageVariable: false,
+                        live: true,
+                        locked: false,
+                        lowIndexPriority: false,
+                        modDate: 123456789,
+                        modUser: 'admin',
+                        name: 'Default Site',
+                        new: false,
+                        owner: 'admin',
+                        parent: false,
+                        permissionId: 'perm123',
+                        permissionType: 'host',
+                        persona: false,
+                        sortOrder: 1,
+                        structureInode: 'struct123',
+                        systemHost: false,
+                        tagStorage: 'tag123',
+                        title: 'Default Site',
+                        titleImage: null,
+                        type: 'host',
+                        vanityUrl: false,
+                        variantId: 'var123',
+                        versionId: 'ver123',
+                        working: true
+                    },
+                    errors: [],
+                    i18nMessagesMap: {},
+                    messages: [],
+                    pagination: null,
+                    permissions: []
+                })
+            };
+
+            mockFetch.mockResolvedValue(mockResponse);
+
+            const result = await service.getCurrentSite();
+
+            expect(result.name).toBe('Default Site');
+            expect(result.hostname).toBe('localhost');
+            // aliases should be undefined when not provided
+            expect((result as Record<string, unknown>).aliases).toBeUndefined();
+        });
+
         it('should allow custom fields defined by users', async () => {
             const mockResponse = {
                 json: jest.fn().mockResolvedValue({

--- a/core-web/apps/mcp-server/src/types/search.ts
+++ b/core-web/apps/mcp-server/src/types/search.ts
@@ -4,8 +4,23 @@ import { z } from 'zod';
 export const ContentletSchema = z
     .object({
         hostName: z.string(),
-        modDate: z.string(),
-        publishDate: z.string(),
+        modDate: z.preprocess((val) => {
+            if (typeof val === 'number') return val;
+            if (typeof val === 'string' && val) {
+                const num = Number(val);
+                return isNaN(num) ? 0 : num;
+            }
+            return 0;
+        }, z.number()),
+        publishDate: z.preprocess((val) => {
+            if (val === null || val === undefined) return val;
+            if (typeof val === 'number') return val;
+            if (typeof val === 'string' && val) {
+                const num = Number(val);
+                return isNaN(num) ? null : num;
+            }
+            return null;
+        }, z.number().nullish()),
         title: z.string(),
         baseType: z.string(),
         inode: z.string(),
@@ -19,10 +34,17 @@ export const ContentletSchema = z
         live: z.boolean(),
         owner: z.string(),
         identifier: z.string(),
-        publishUserName: z.string(),
-        publishUser: z.string(),
+        publishUserName: z.string().nullish(),
+        publishUser: z.string().nullish(),
         languageId: z.number(),
-        creationDate: z.string(),
+        creationDate: z.preprocess((val) => {
+            if (typeof val === 'number') return val;
+            if (typeof val === 'string' && val) {
+                const num = Number(val);
+                return isNaN(num) ? 0 : num;
+            }
+            return 0;
+        }, z.number()),
         shortyId: z.string(),
         url: z.string(),
         titleImage: z.string(),

--- a/core-web/apps/mcp-server/src/types/site.ts
+++ b/core-web/apps/mcp-server/src/types/site.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const SiteSchema = z
     .object({
-        aliases: z.string().optional(),
+        aliases: z.string().nullable().optional(),
         archived: z.boolean(),
         categoryId: z.string(),
         contentTypeId: z.string(),


### PR DESCRIPTION
### Summary
This commit improves the search functionality tests by adding scenarios for both published and unpublished content, ensuring proper handling of numeric date values and null publish dates.

### Changes Made
- Updated existing test for published content to clarify the description and validate date types.
- Added new tests for:
  - Unpublished content, verifying that `publishDate` is undefined.
  - Numeric date values, ensuring they are correctly processed as numbers.
  - Handling of null `publishDate` values in search results.

### Type Validation
- Adjusted the `ContentletSchema` to preprocess date fields, allowing for both string and number inputs, enhancing robustness in data handling.

This PR fixes: #33942
