### PR TITLE
fix(dot-nav-item): Correct chevron direction for open/close state

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.html
@@ -20,10 +20,10 @@
             class="dot-nav__item-toggle"
             data-testid="nav-item-toggle"
             (click)="toggleHandler($event, data)">
-            <dot-icon
-                class="dot-nav__item-arrow"
-                aria-hidden="true"
-                name="{{ data.isOpen ? 'arrow_drop_up' : 'arrow_drop_down' }}"></dot-icon>
+            <i
+                class="dot-nav__item-arrow pi"
+                [ngClass]="data.isOpen ? 'pi-chevron-up' : 'pi-chevron-down'"
+                aria-hidden="true"></i>
         </div>
     </div>
 </div>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.html
@@ -23,7 +23,7 @@
             <dot-icon
                 class="dot-nav__item-arrow"
                 aria-hidden="true"
-                name="{{ data.isOpen ? 'arrow_drop_down' : 'arrow_drop_up' }}"></dot-icon>
+                name="{{ data.isOpen ? 'arrow_drop_up' : 'arrow_drop_down' }}"></dot-icon>
         </div>
     </div>
 </div>

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.scss
@@ -100,13 +100,14 @@
     transition: opacity $basic-speed ease;
 }
 
-dot-icon {
+.dot-nav__item-arrow {
     opacity: 1;
     position: absolute;
-    right: $spacing-1;
+    right: $spacing-2;
     top: 50%;
     transform: translateY(-50%);
     transition: opacity $basic-speed ease;
+    font-size: $font-size-sm;
 }
 
 dot-nav-icon {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
@@ -179,8 +179,8 @@ describe('DotNavItemComponent', () => {
         const arrow: DebugElement = de.query(By.css('.dot-nav__item-arrow'));
 
         expect(icon.componentInstance.icon).toBe('icon');
-        // When menu.isOpen = true, arrow should be arrow_drop_down (see beforeEach)
-        expect(arrow.componentInstance.name).toBe('arrow_drop_down');
+        // When menu.isOpen = true, arrow should be arrow_drop_up (see beforeEach)
+        expect(arrow.componentInstance.name).toBe('arrow_drop_up');
     });
 
     it('should avoid label_important icon', () => {

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts
@@ -176,11 +176,11 @@ describe('DotNavItemComponent', () => {
 
     it('should have icons set', () => {
         const icon: DebugElement = de.query(By.css('dot-nav-icon'));
-        const arrow: DebugElement = de.query(By.css('.dot-nav__item-arrow'));
+        const arrow: DebugElement = de.query(By.css('[data-testid="nav-item-toggle"] i'));
 
         expect(icon.componentInstance.icon).toBe('icon');
-        // When menu.isOpen = true, arrow should be arrow_drop_up (see beforeEach)
-        expect(arrow.componentInstance.name).toBe('arrow_drop_up');
+        // When menu.isOpen = true, arrow should have pi-chevron-up class (see beforeEach)
+        expect(arrow.nativeElement.classList.contains('pi-chevron-up')).toBe(true);
     });
 
     it('should avoid label_important icon', () => {


### PR DESCRIPTION

Fixes incorrect chevron icon direction in the navigation accordion component. Previously, chevrons were facing up when the accordion panel was collapsed and down when expanded. This has been corrected to follow standard UI conventions where:
- **Collapsed state**: Chevron faces down (↓)
- **Expanded state**: Chevron faces up (↑)

This aligns with the behavior of PrimeNG Accordion and improves visual consistency across the application.

## Changes
- **File**: `core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.html`
  - Replaced `dot-icon` component with PrimeNG icon element (`<i>` with `pi-chevron-up`/`pi-chevron-down` classes)
  - Updated the ternary operator to display `pi-chevron-up` when `data.isOpen` is true and `pi-chevron-down` when false

- **File**: `core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.scss`
  - Updated `.dot-nav__item-arrow` selector to work with the new `<i>` element
  - Added `font-size: $font-size-sm` to maintain consistent icon sizing with PrimeNG icons
  - Removed the previous `dot-icon` selector that is no longer used

- **File**: `core-web/apps/dotcms-ui/src/app/view/components/dot-navigation/components/dot-nav-item/dot-nav-item.component.spec.ts`
  - Updated test selector to use `[data-testid="nav-item-toggle"] i` for better semantic selection
  - Updated test expectations to match the corrected icon direction logic

## Testing
- All `dot-nav-item.component.spec.ts` tests pass with the updated chevron direction and icon implementation

## Related Issue
Fixes #33752

This PR fixes: #33752