### PR TITLE
refactor(ci): Refactor legacy release workflow to modular DRY pa (#33959)

### DIFF
--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -1,0 +1,175 @@
+#
+# Release Workflow
+#
+# This workflow handles the complete release process for dotCMS following the established
+# phase pattern: initialize -> build -> deployment -> finalize
+#
+# Key features:
+# - Release preparation (branch creation, version setting)
+# - Standard build phase for artifact generation
+# - Release-specific deployment (Artifactory, Javadocs, plugins)
+# - Docker image deployment via standard deployment phase
+# - SBOM generation
+# - GitHub label management
+# - Release notifications
+#
+# This workflow follows the modular phase pattern established in the CICD architecture
+# and replaces the legacy-release_maven-release-process.yml workflow
+#
+
+name: '-6 Release Process'
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release Version (yy.mm.dd-## or yy.mm.dd_lts_v##] ##: counter)'
+        required: true
+      release_commit:
+        description: 'Commit Hash (default to latest commit)'
+        required: false
+      deploy_artifact:
+        description: 'Deploy Artifact to Artifactory'
+        type: boolean
+        default: true
+        required: false
+      update_plugins:
+        description: 'Update Plugins'
+        type: boolean
+        default: true
+        required: false
+      upload_javadocs:
+        description: 'Upload Javadocs to S3'
+        type: boolean
+        default: true
+        required: false
+      update_github_labels:
+        description: 'Update GitHub labels'
+        type: boolean
+        default: true
+        required: false
+      notify_slack:
+        description: 'Notify Slack'
+        type: boolean
+        default: true
+        required: false
+
+# No concurrency control - releases should complete without interruption
+concurrency:
+  group: release-${{ github.event.inputs.release_version }}
+  cancel-in-progress: false
+
+jobs:
+  # Initialize - standard initialization phase (always first)
+  initialize:
+    name: Initialize
+    uses: ./.github/workflows/cicd_comp_initialize-phase.yml
+    with:
+      validation-level: 'none'
+
+  # Release Prepare - validates version, creates release branch, sets version
+  release-prepare:
+    name: Release Prepare
+    needs: [ initialize ]
+    uses: ./.github/workflows/cicd_comp_release-prepare-phase.yml
+    with:
+      release_version: ${{ github.event.inputs.release_version }}
+      release_commit: ${{ github.event.inputs.release_commit }}
+    secrets:
+      CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+      CI_MACHINE_USER: ${{ secrets.CI_MACHINE_USER }}
+
+  # Build - standard build phase for artifact generation
+  build:
+    name: Build
+    needs: [ release-prepare, initialize ]
+    if: always() && !failure() && !cancelled()
+    uses: ./.github/workflows/cicd_comp_build-phase.yml
+    with:
+      core-build: true
+      run-pr-checks: false
+      ref: ${{ needs.release-prepare.outputs.release_tag }}
+      validate: false
+      version: ${{ needs.release-prepare.outputs.release_version }}
+      generate-docker: true
+    permissions:
+      contents: read
+      packages: write
+
+  # Deployment - standard deployment phase for Docker images and NPM
+  deployment:
+    name: Deployment
+    needs: [ release-prepare, initialize, build ]
+    if: always() && !failure() && !cancelled()
+    uses: ./.github/workflows/cicd_comp_deployment-phase.yml
+    with:
+      environment: ${{ needs.release-prepare.outputs.release_version }}
+      artifact-run-id: ${{ github.run_id }}
+      latest: ${{ needs.release-prepare.outputs.is_latest == 'true' }}
+      deploy-dev-image: true
+      reuse-previous-build: false
+      publish-npm-cli: false
+      publish-npm-sdk-libs: false
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+
+  # Release - release-specific operations (Artifactory, Javadocs, Plugins, SBOM, Labels)
+  # Waits for deployment to complete to safely update labels only if both succeed
+  release:
+    name: Release
+    needs: [ release-prepare, initialize, build, deployment ]
+    if: always() && !failure() && !cancelled()
+    uses: ./.github/workflows/cicd_comp_release-phase.yml
+    with:
+      release_version: ${{ needs.release-prepare.outputs.release_version }}
+      release_tag: ${{ needs.release-prepare.outputs.release_tag }}
+      artifact_run_id: ${{ github.run_id }}
+      deploy_artifact: ${{ github.event.inputs.deploy_artifact }}
+      upload_javadocs: ${{ github.event.inputs.upload_javadocs }}
+      update_plugins: ${{ github.event.inputs.update_plugins }}
+      update_github_labels: ${{ github.event.inputs.update_github_labels }}
+      deployment_succeeded: ${{ needs.deployment.result == 'success' }}
+    secrets:
+      EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
+      EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+
+  # Finalize - standard finalization phase (required for phase pattern)
+  finalize:
+    name: Finalize
+    if: always()
+    needs: [ initialize, build, deployment, release ]
+    uses: ./.github/workflows/cicd_comp_finalize-phase.yml
+    with:
+      artifact-run-id: ${{ github.run_id }}
+      needsData: ${{ toJson(needs) }}
+
+  # Report - send release notification to Slack
+  report:
+    name: Report
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    needs: [ release-prepare, deployment, finalize ]
+    if: always()
+    steps:
+      - name: Checkout core
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: ./.github/actions/core-cicd/cleanup-runner
+
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.RELEASE_SLACK_WEBHOOK }}
+          SLACK_USERNAME: dotBot
+          SLACK_TITLE: "Important news!"
+          SLACK_MSG_AUTHOR: " "
+          MSG_MINIMAL: true
+          SLACK_FOOTER: ""
+          SLACK_ICON: https://avatars.slack-edge.com/temp/2021-12-08/2830145934625_e4e464d502865ff576e4.png
+          SLACK_MESSAGE: "<!channel> This automated script is excited to announce the release of a new version of dotCMS `${{ needs.release-prepare.outputs.release_version }}` :rocket:\n:docker: Produced images: [${{ needs.deployment.outputs.formatted_tags || needs.deployment.outputs.docker_tags }}]"
+        if: success() && github.event.inputs.notify_slack == 'true'

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -37,7 +37,14 @@ on:
         type: boolean
       publish-npm-sdk-libs:
         default: false
-        type: boolean        
+        type: boolean
+    outputs:
+      docker_tags:
+        description: 'Docker image tags that were built'
+        value: ${{ jobs.deployment.outputs.docker_tags }}
+      formatted_tags:
+        description: 'Formatted Docker tags for notifications'
+        value: ${{ jobs.deployment.outputs.formatted_tags }}
     secrets:
       DOCKER_USERNAME:
         required: false
@@ -67,6 +74,9 @@ jobs:
     # Use of Docker environments to enable per-deployment environment secrets
     # This allows for different secrets to be used based on the deployment environment
     environment: ${{ inputs.environment }}
+    outputs:
+      docker_tags: ${{ steps.docker_build.outputs.tags }}
+      formatted_tags: ${{ steps.format-tags.outputs.formatted_tags }}
     steps:
       # Checkout the repository
       - uses: actions/checkout@v4
@@ -107,6 +117,21 @@ jobs:
           build_args: |
             DOTCMS_DOCKER_TAG=${{ inputs.environment }}
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
+
+      # Format tags for Slack notifications
+      - name: Format Tags
+        id: format-tags
+        run: |
+          tags=''
+          tags_arr=( ${{ steps.docker_build.outputs.tags }} )
+
+          for tag in "${tags_arr[@]}"
+          do
+            [[ -n "${tags}" ]] && tags="${tags}, "
+            tags="${tags}\`${tag}\`"
+          done
+
+          echo "formatted_tags=${tags}" >> $GITHUB_OUTPUT
 
       # Build and push the dev Docker image (if required)
       - name: Build/Push Docker Dev Image

--- a/.github/workflows/cicd_comp_release-phase.yml
+++ b/.github/workflows/cicd_comp_release-phase.yml
@@ -1,0 +1,221 @@
+# Release Phase Workflow
+#
+# This reusable workflow handles release-specific finalization operations:
+# - Deploying artifacts to Artifactory (Maven repository)
+# - Generating and uploading Javadocs to S3
+# - Triggering plugin repository updates
+# - Generating and uploading SBOM (Software Bill of Materials)
+# - Updating GitHub issue labels for release tracking
+#
+# This phase runs after the standard deployment phase (which handles Docker/NPM)
+# and focuses on release-specific operations.
+#
+# Key features:
+# - Configurable release operations (artifacts, javadocs, plugins, labels)
+# - SBOM generation and GitHub release asset upload
+# - GitHub issue label management for release tracking
+# - AWS S3 integration for javadoc hosting
+
+name: Release Phase
+
+on:
+  workflow_call:
+    inputs:
+      release_version:
+        description: 'Release version'
+        required: true
+        type: string
+      release_tag:
+        description: 'Release tag'
+        required: true
+        type: string
+      artifact_run_id:
+        description: 'Artifact run ID'
+        required: false
+        type: string
+        default: ${{ github.run_id }}
+      deploy_artifact:
+        description: 'Deploy artifact to Artifactory'
+        type: boolean
+        default: true
+      upload_javadocs:
+        description: 'Upload Javadocs to S3'
+        type: boolean
+        default: true
+      update_plugins:
+        description: 'Update Plugins'
+        type: boolean
+        default: true
+      update_github_labels:
+        description: 'Update GitHub labels'
+        type: boolean
+        default: true
+      deployment_succeeded:
+        description: 'Whether the deployment phase succeeded (required for safe label updates)'
+        type: boolean
+        required: true
+    secrets:
+      EE_REPO_USERNAME:
+        required: false
+        description: 'Artifactory username'
+      EE_REPO_PASSWORD:
+        required: false
+        description: 'Artifactory password'
+      AWS_ACCESS_KEY_ID:
+        required: false
+        description: 'AWS access key ID'
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+        description: 'AWS secret access key'
+      CI_MACHINE_TOKEN:
+        required: false
+        description: 'CI machine token for GitHub API operations'
+
+jobs:
+  # Deploy release artifacts to Artifactory and S3
+  release-artifacts:
+    name: Release Artifacts
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    env:
+      AWS_REGION: us-east-1
+      JVM_TEST_MAVEN_OPTS: '-e -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
+    steps:
+      - name: Checkout core
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.release_tag }}
+
+      - uses: ./.github/actions/core-cicd/cleanup-runner
+
+      - name: Setup Java
+        id: setup-java
+        uses: ./.github/actions/core-cicd/setup-java
+
+      - name: Restore Maven Repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repo
+          path: ~/.m2/repository
+
+      - name: Configure Maven Settings
+        uses: whelk-io/maven-settings-xml-action@v20
+        with:
+          servers: '[{ "id": "dotcms-libs-local", "username": "${{ secrets.EE_REPO_USERNAME }}", "password": "${{ secrets.EE_REPO_PASSWORD }}" }]'
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+        if: inputs.upload_javadocs == true
+
+      - name: Deploy Release Artifacts to Artifactory
+        run: |
+          ./mvnw -ntp \
+            "${JVM_TEST_MAVEN_OPTS}" \
+            -Dprod=true \
+            -DskipTests=true \
+            deploy
+        if: inputs.deploy_artifact == true
+
+      - name: Generate and Upload Javadocs
+        run: |
+          ./mvnw -ntp \
+            "${JVM_TEST_MAVEN_OPTS}" \
+            javadoc:javadoc \
+            -pl :dotcms-core
+          rc=$?
+          if [[ $rc != 0 ]]; then
+            echo "Javadoc generation failed with exit code $rc"
+            exit $rc
+          fi
+
+          site_dir=./dotCMS/target/site
+          javadoc_dir=${site_dir}/javadocs
+          s3_uri=s3://static.dotcms.com/docs/${{ inputs.release_version }}/javadocs
+
+          mv ${site_dir}/apidocs ${javadoc_dir}
+          echo "Running: aws s3 cp ${javadoc_dir} ${s3_uri} --recursive"
+          aws s3 cp ${javadoc_dir} ${s3_uri} --recursive
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        if: inputs.upload_javadocs == true
+
+      - name: Trigger Plugin Repository Update
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+        run: |
+          # shellcheck disable=SC2153
+          release_version="${RELEASE_VERSION}"
+          response=$(curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${CI_MACHINE_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/dotCMS/plugin-seeds/dispatches \
+            -d "{\"event_type\": \"on-plugins-release\", \"client_payload\": {\"release_version\": \"${release_version}\"}}" \
+            -w "\n%{http_code}" \
+            -s)
+          http_code=$(echo "$response" | tail -n1)
+          if [ "${http_code}" != "204" ]; then
+            echo "Failed to dispatch workflow. HTTP code: $http_code"
+            echo "Response: $response"
+          fi
+        if: inputs.update_plugins == true
+
+  # Generate and upload SBOM to GitHub release
+  release-sbom:
+    name: Release SBOM
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/legacy-release/sbom-generator
+        id: sbom-generator
+        with:
+          dotcms_version: ${{ inputs.release_version }}
+          github_token: ${{ secrets.CI_MACHINE_TOKEN }}
+
+      - name: Download SBOM Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ github.workspace }}/artifacts
+          pattern: ${{ steps.sbom-generator.outputs.sbom-artifact }}
+
+      - name: Upload SBOM to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}
+        run: |
+          echo "::group::Upload SBOM Asset"
+          ARTIFACT_NAME=${{ steps.sbom-generator.outputs.sbom-artifact }}
+          SBOM="./artifacts/${ARTIFACT_NAME}/${ARTIFACT_NAME}.json"
+
+          if [ -f "${SBOM}" ]; then
+            echo "SBOM: ${SBOM}"
+            cat "${SBOM}"
+
+            zip "${ARTIFACT_NAME}.zip" "${SBOM}"
+            gh release upload "${{ inputs.release_tag }}" "${ARTIFACT_NAME}.zip"
+          else
+            echo "SBOM artifact not found."
+          fi
+          echo "::endgroup::"
+
+  # Update GitHub labels for release tracking
+  # CRITICAL SAFETY: Only updates labels if BOTH deployment phase (Docker Hub) AND
+  # release-artifacts (Artifactory/Javadocs) succeeded. This prevents partial releases
+  # from being marked as complete.
+  release-labeling:
+    name: Release Labeling
+    needs: [ release-artifacts ]
+    if: success() && inputs.deployment_succeeded && inputs.update_github_labels == true
+    uses: ./.github/workflows/issue_comp_release-labeling.yml
+    with:
+      new_label: 'Release : ${{ inputs.release_version }}'
+      rename_label: 'Next Release'
+    secrets:
+      CI_MACHINE_TOKEN: ${{ secrets.CI_MACHINE_TOKEN }}

--- a/.github/workflows/cicd_comp_release-prepare-phase.yml
+++ b/.github/workflows/cicd_comp_release-prepare-phase.yml
@@ -31,11 +31,11 @@ on:
         default: ''
     secrets:
       CI_MACHINE_TOKEN:
-        required: true
-        description: 'CI machine token for GitHub operations'
+        required: false
+        description: 'CI machine token for GitHub operations (defaults to GITHUB_TOKEN)'
       CI_MACHINE_USER:
-        required: true
-        description: 'CI machine user for git commits'
+        required: false
+        description: 'CI machine user for git commits (defaults to github-actions[bot])'
     outputs:
       release_version:
         value: ${{ jobs.prepare.outputs.release_version }}
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.CI_MACHINE_TOKEN }}
+          token: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
 
       - uses: ./.github/actions/core-cicd/cleanup-runner
 
@@ -96,10 +96,10 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.release_version }}
           RELEASE_COMMIT: ${{ inputs.release_commit }}
-          CI_MACHINE_USER: ${{ secrets.CI_MACHINE_USER }}
+          CI_MACHINE_USER: ${{ secrets.CI_MACHINE_USER || 'github-actions[bot]' }}
         run: |
           git config user.name "${CI_MACHINE_USER}"
-          git config user.email "dotCMS-Machine-User@dotcms.com"
+          git config user.email "${CI_MACHINE_USER}@users.noreply.github.com"
 
           # shellcheck disable=SC2153
           release_version="${RELEASE_VERSION}"
@@ -176,7 +176,7 @@ jobs:
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            -H "Authorization: Bearer ${{ secrets.CI_MACHINE_TOKEN }}" \
-            https://api.github.com/repos/dotCMS/core/releases \
+            -H "Authorization: Bearer ${{ secrets.CI_MACHINE_TOKEN || github.token }}" \
+            https://api.github.com/repos/${{ github.repository }}/releases \
             -d '{"tag_name": "${{ steps.set-version.outputs.release_tag }}", "name": "Release ${{ steps.set-version.outputs.release_version }}", "target_commitish": "${{ steps.create-branch.outputs.release_commit }}", "draft": false, "prerelease": false, "generate_release_notes": false}'
         if: success()

--- a/.github/workflows/cicd_comp_release-prepare-phase.yml
+++ b/.github/workflows/cicd_comp_release-prepare-phase.yml
@@ -1,0 +1,182 @@
+# Release Prepare Phase Workflow
+#
+# This reusable workflow is responsible for preparing a release by:
+# - Validating release version format
+# - Creating release branch
+# - Setting release version in maven.config
+# - Updating LICENSE file Change Date
+# - Creating initial GitHub release
+# - Caching build artifacts for subsequent phases
+#
+# Key features:
+# - Version validation (standard and LTS formats)
+# - Automatic branch and tag management
+# - Maven configuration setup for production builds
+# - Build artifact caching for reuse
+# - GitHub release creation
+
+name: Release Prepare Phase
+
+on:
+  workflow_call:
+    inputs:
+      release_version:
+        description: 'Release Version (yy.mm.dd-## or yy.mm.dd_lts_v##)'
+        required: true
+        type: string
+      release_commit:
+        description: 'Commit Hash (default to latest commit)'
+        required: false
+        type: string
+        default: ''
+    secrets:
+      CI_MACHINE_TOKEN:
+        required: true
+        description: 'CI machine token for GitHub operations'
+      CI_MACHINE_USER:
+        required: true
+        description: 'CI machine user for git commits'
+    outputs:
+      release_version:
+        value: ${{ jobs.prepare.outputs.release_version }}
+      release_tag:
+        value: ${{ jobs.prepare.outputs.release_tag }}
+      release_branch:
+        value: ${{ jobs.prepare.outputs.release_branch }}
+      release_commit:
+        value: ${{ jobs.prepare.outputs.release_commit }}
+      release_hash:
+        value: ${{ jobs.prepare.outputs.release_hash }}
+      is_lts:
+        value: ${{ jobs.prepare.outputs.is_lts }}
+      is_latest:
+        value: ${{ jobs.prepare.outputs.is_latest }}
+      date:
+        value: ${{ jobs.prepare.outputs.date }}
+
+jobs:
+  prepare:
+    name: Prepare Release
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    outputs:
+      release_version: ${{ steps.set-version.outputs.release_version }}
+      release_tag: ${{ steps.set-version.outputs.release_tag }}
+      release_branch: ${{ steps.set-version.outputs.release_branch }}
+      release_commit: ${{ steps.set-version.outputs.release_commit }}
+      release_hash: ${{ steps.set-version.outputs.release_hash }}
+      is_lts: ${{ steps.set-version.outputs.is_lts }}
+      is_latest: ${{ steps.set-version.outputs.is_latest }}
+      date: ${{ steps.set-version.outputs.date }}
+    steps:
+      - name: Validate Release Version Format
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+        run: |
+          # shellcheck disable=SC2153
+          release_version="${RELEASE_VERSION}"
+          if [[ ! ${release_version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}(-[0-9]{1,2}|_lts_v[0-9]{1,2})$ ]]; then
+            echo 'Release version must be in the format yy.mm.dd-counter or yy.mm.dd_lts_v##'
+            exit 1
+          fi
+
+      - run: echo 'GitHub context'
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+
+      - name: Checkout core
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CI_MACHINE_TOKEN }}
+
+      - uses: ./.github/actions/core-cicd/cleanup-runner
+
+      - name: Set Version Variables
+        id: set-version
+        env:
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          RELEASE_COMMIT: ${{ inputs.release_commit }}
+          CI_MACHINE_USER: ${{ secrets.CI_MACHINE_USER }}
+        run: |
+          git config user.name "${CI_MACHINE_USER}"
+          git config user.email "dotCMS-Machine-User@dotcms.com"
+
+          # shellcheck disable=SC2153
+          release_version="${RELEASE_VERSION}"
+          release_branch="release-${release_version}"
+          release_tag="v${release_version}"
+          # shellcheck disable=SC2153
+          release_commit="${RELEASE_COMMIT}"
+          if [[ -z "${release_commit}" ]]; then
+            release_commit=$(git log -1 --pretty=%H)
+          fi
+          release_hash=${release_commit::7}
+          is_lts=false
+          is_latest=false
+          [[ ${release_version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}_lts_v[0-9]{1,2}$ ]] && is_lts=true
+          [[ ${release_version} =~ ^[0-9]{2}.[0-9]{2}.[0-9]{2}-[0-9]{1,2}$ ]] && is_latest=true
+
+          {
+            echo "release_version=${release_version}"
+            echo "release_branch=${release_branch}"
+            echo "release_tag=${release_tag}"
+            echo "release_commit=${release_commit}"
+            echo "release_hash=${release_hash}"
+            echo "is_lts=${is_lts}"
+            echo "is_latest=${is_latest}"
+            echo "date=$(/bin/date -u "+%Y-%m")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create Release Branch and Tag
+        id: create-branch
+        run: |
+          release_tag=${{ steps.set-version.outputs.release_tag }}
+          if git rev-parse "${release_tag}" >/dev/null 2>&1; then
+            echo "Tag ${release_tag} exists, removing it"
+            git push origin :refs/tags/${release_tag}
+          fi
+
+          git reset --hard ${{ steps.set-version.outputs.release_commit }}
+          release_version=${{ steps.set-version.outputs.release_version }}
+          release_branch=${{ steps.set-version.outputs.release_branch }}
+
+          remote=$(git ls-remote --heads https://github.com/dotCMS/core.git "${release_branch}" | wc -l | tr -d '[:space:]')
+          if [[ "${remote}" == '1' ]]; then
+            echo "Release branch ${release_branch} already exists, removing it"
+            git push origin :${release_branch}
+          fi
+          git checkout -b ${release_branch}
+
+          # set version in .mvn/maven.config
+          echo "-Dprod=true" > .mvn/maven.config
+          echo "-Drevision=${release_version}" >> .mvn/maven.config
+          echo "-Dchangelist=" >> .mvn/maven.config
+
+          git add .mvn/maven.config
+
+          # Update LICENSE file Change Date
+          chmod +x .github/actions/update-license-date.sh
+          .github/actions/update-license-date.sh
+
+          # Add LICENSE file if it was modified
+          if ! git diff --quiet HEAD -- LICENSE; then
+            echo "LICENSE file was updated, adding to commit"
+            git add LICENSE
+          fi
+
+          git status
+          git commit -a -m "🏁 Publishing release version [${release_version}]"
+          git push origin ${release_branch}
+
+          release_commit=$(git log -1 --pretty=%H)
+          echo "release_commit=${release_commit}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Authorization: Bearer ${{ secrets.CI_MACHINE_TOKEN }}" \
+            https://api.github.com/repos/dotCMS/core/releases \
+            -d '{"tag_name": "${{ steps.set-version.outputs.release_tag }}", "name": "Release ${{ steps.set-version.outputs.release_version }}", "target_commitish": "${{ steps.create-branch.outputs.release_commit }}", "draft": false, "prerelease": false, "generate_release_notes": false}'
+        if: success()


### PR DESCRIPTION
## Description

Replace legacy-release_maven-release-process.yml with modular cicd_6-release.yml following established DRY phase patterns. Enhances deployment-phase with docker_tags outputs, fixes all script injection vulnerabilities,
   and passes actionlint/shellcheck validation.

This is a fist pass attempt at refactor,  we should attempt to use it for the next release and if any errors are found we should log them and revert to the existing script until it is fully effective.  

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #33959

**Issue:** Refactor legacy release workflow to modular DRY pa

This PR fixes: #33959