### PR TITLE
fix(build): Fix nonreproducible builds vite configs referencin (#34010)

### DIFF
--- a/core-web/libs/edit-content-bridge/vite.config.ts
+++ b/core-web/libs/edit-content-bridge/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig(() => {
     // __dirname points to core-web/libs/edit-content-bridge
     // So ../../dist/libs/edit-content-bridge resolves to core-web/dist/libs/edit-content-bridge
     const outDir = resolve(__dirname, '../../dist/libs/edit-content-bridge');
-    
+
     return {
         build: {
             // Explicitly set outDir to prevent Vite from resolving paths incorrectly

--- a/core-web/libs/edit-content-bridge/vite.config.ts
+++ b/core-web/libs/edit-content-bridge/vite.config.ts
@@ -2,14 +2,27 @@ import { defineConfig } from 'vite';
 
 import { resolve } from 'path';
 
-export default defineConfig({
-    build: {
-        lib: {
-            entry: resolve(__dirname, 'src/iife.ts'),
-            name: 'DotCustomFieldApi',
-            formats: ['iife'],
-            fileName: () => 'edit-content-bridge.js'
-        },
-        minify: true
-    }
+export default defineConfig(() => {
+    // Explicitly resolve outDir relative to this config file's location
+    // This ensures output always goes to core-web/dist/libs/edit-content-bridge
+    // regardless of current working directory or presence of external dist folders
+    // __dirname points to core-web/libs/edit-content-bridge
+    // So ../../dist/libs/edit-content-bridge resolves to core-web/dist/libs/edit-content-bridge
+    const outDir = resolve(__dirname, '../../dist/libs/edit-content-bridge');
+    
+    return {
+        build: {
+            // Explicitly set outDir to prevent Vite from resolving paths incorrectly
+            // This is critical for reproducible builds, especially when dist folders
+            // exist outside the repository root (e.g., at repo root level)
+            outDir: outDir,
+            lib: {
+                entry: resolve(__dirname, 'src/iife.ts'),
+                name: 'DotCustomFieldApi',
+                formats: ['iife'],
+                fileName: () => 'edit-content-bridge.js'
+            },
+            minify: true
+        }
+    };
 });

--- a/core-web/libs/sdk/analytics/vite.config.mts
+++ b/core-web/libs/sdk/analytics/vite.config.mts
@@ -44,7 +44,9 @@ export default defineConfig({
     ],
 
     build: {
-        outDir: '../../../dist/libs/sdk/analytics',
+        // Explicitly resolve outDir to prevent output from going to external dist folders
+        // This ensures reproducible builds regardless of current working directory
+        outDir: path.resolve(__dirname, '../../../dist/libs/sdk/analytics'),
         emptyOutDir: true,
         reportCompressedSize: true,
         commonjsOptions: {

--- a/core-web/libs/sdk/analytics/vite.standalone.config.mts
+++ b/core-web/libs/sdk/analytics/vite.standalone.config.mts
@@ -9,7 +9,9 @@ export default defineConfig({
     cacheDir: '../../../node_modules/.vite/libs/sdk/analytics',
     plugins: [nxViteTsPaths()],
     build: {
-        outDir: '../../../dist/libs/sdk/analytics',
+        // Explicitly resolve outDir to prevent output from going to external dist folders
+        // This ensures reproducible builds regardless of current working directory
+        outDir: resolve(__dirname, '../../../dist/libs/sdk/analytics'),
         emptyOutDir: false,
         reportCompressedSize: true,
         lib: {

--- a/core-web/libs/sdk/experiments/vite.config.ts
+++ b/core-web/libs/sdk/experiments/vite.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
     // Configuration for building the DotExperiment as IIFE file to use in
     // plain HTML or other projects.
     build: {
-        outDir: '../../../dist/libs/sdk/experiments',
+        // Explicitly resolve outDir to prevent output from going to external dist folders
+        // This ensures reproducible builds regardless of current working directory
+        outDir: path.resolve(__dirname, '../../../dist/libs/sdk/experiments'),
         reportCompressedSize: true,
         emptyOutDir: true,
         commonjsOptions: {

--- a/core-web/pom.xml
+++ b/core-web/pom.xml
@@ -40,7 +40,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>dist</directory>
+                            <directory>${project.basedir}/dist</directory>
                             <includes>
                                 <include>**/*</include>
                             </includes>
@@ -62,6 +62,41 @@
                                 <filter token="node.js.version" value="${node.js.version}"/>
                                 <copy file="${basedir}/version-template.txt" tofile="${basedir}/.nvmrc" overwrite="true" filtering="true"/>
                                 -->
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>validate-dist-paths</id>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <target>
+                                <!-- Validate that dist paths resolve correctly within core-web -->
+                                <!-- This prevents referencing dist folders outside the repository, ensuring reproducible builds -->
+                                <property name="core.web.basedir" value="${project.basedir}"/>
+                                
+                                <!-- Verify that dist path resolves to within core-web directory -->
+                                <!-- Using project.basedir ensures paths are relative to pom.xml location -->
+                                <property name="dist.path" value="${core.web.basedir}/dist"/>
+                                
+                                <!-- Ensure dist path is a subdirectory of core-web (basic sanity check) -->
+                                <condition property="dist.path.valid">
+                                    <contains string="${dist.path}" substring="${core.web.basedir}"/>
+                                </condition>
+                                <fail unless="dist.path.valid" message="ERROR: dist path (${dist.path}) does not resolve within core-web (${core.web.basedir}). This could cause non-reproducible builds by referencing external folders."/>
+                                
+                                <!-- If multi-module project directory is available, validate core-web is within repo -->
+                                <condition property="repo.root.available">
+                                    <isset property="maven.multiModuleProjectDirectory"/>
+                                </condition>
+                                <condition property="path.within.repo" if="repo.root.available">
+                                    <contains string="${core.web.basedir}" substring="${maven.multiModuleProjectDirectory}"/>
+                                </condition>
+                                <fail if="repo.root.available" unless="path.within.repo" message="ERROR: core-web project.basedir (${core.web.basedir}) is outside repository root (${maven.multiModuleProjectDirectory}). This indicates a path resolution issue that could cause non-reproducible builds."/>
+                                
+                                <echo message="Validated dist paths are scoped to core-web: ${core.web.basedir}"/>
                             </target>
                         </configuration>
                         <goals>
@@ -180,12 +215,14 @@
                 <configuration>
                     <webResources>
                         <resource>
-                            <!-- this is relative to the pom.xml directory -->
+                            <!-- Explicitly scoped to core-web directory to prevent referencing external folders -->
+                            <!-- This ensures reproducible builds by failing if dist is outside core-web -->
                             <directory>${project.basedir}/dist/apps/dotcms-ui</directory>
                             <filtering>false</filtering>
                             <targetPath>dotAdmin</targetPath>
                         </resource>
                         <resource>
+                            <!-- Explicitly scoped to core-web directory to prevent referencing external folders -->
                             <directory>${project.basedir}/dist/libs/dotcms-webcomponents/dist</directory>
                             <filtering>false</filtering>
                             <includes>
@@ -194,18 +231,21 @@
                         </resource>
 
                         <resource>
+                            <!-- Explicitly scoped to core-web directory to prevent referencing external folders -->
                             <directory>${project.basedir}/dist/apps/dotcms-binary-field-builder</directory>
                             <filtering>false</filtering>
                             <targetPath>dotcms-binary-field-builder</targetPath>
                         </resource>
 
                         <resource>
+                            <!-- Explicitly scoped to core-web directory to prevent referencing external folders -->
                             <directory>${project.basedir}/dist/apps/dotcms-block-editor</directory>
                             <filtering>false</filtering>
                             <targetPath>dotcms-block-editor</targetPath>
                         </resource>
 
                         <resource>
+                            <!-- Explicitly scoped to core-web directory to prevent referencing external folders -->
                             <directory>${project.basedir}/dist/libs/sdk/analytics-standalone</directory>
                             <filtering>false</filtering>
                             <targetPath>ext/analytics</targetPath>
@@ -214,6 +254,7 @@
                             </includes>
                         </resource>
                         <resource>
+                            <!-- Explicitly scoped to core-web directory to prevent referencing external folders -->
                             <directory>${project.basedir}/dist/libs/edit-content-bridge</directory>
                             <filtering>false</filtering>
                             <targetPath>html/js/legacy_custom_field_bridge</targetPath>

--- a/core-web/pom.xml
+++ b/core-web/pom.xml
@@ -91,10 +91,21 @@
                                 <condition property="repo.root.available">
                                     <isset property="maven.multiModuleProjectDirectory"/>
                                 </condition>
-                                <condition property="path.within.repo" if="repo.root.available">
-                                    <contains string="${core.web.basedir}" substring="${maven.multiModuleProjectDirectory}"/>
+                                <!-- Only validate if repo root is available -->
+                                <condition property="path.within.repo">
+                                    <and>
+                                        <isset property="repo.root.available"/>
+                                        <contains string="${core.web.basedir}" substring="${maven.multiModuleProjectDirectory}"/>
+                                    </and>
                                 </condition>
-                                <fail if="repo.root.available" unless="path.within.repo" message="ERROR: core-web project.basedir (${core.web.basedir}) is outside repository root (${maven.multiModuleProjectDirectory}). This indicates a path resolution issue that could cause non-reproducible builds."/>
+                                <!-- Only fail if repo root is available but path is not within repo -->
+                                <condition property="should.fail.repo.check">
+                                    <and>
+                                        <isset property="repo.root.available"/>
+                                        <not><isset property="path.within.repo"/></not>
+                                    </and>
+                                </condition>
+                                <fail if="should.fail.repo.check" message="ERROR: core-web project.basedir (${core.web.basedir}) is outside repository root (${maven.multiModuleProjectDirectory}). This indicates a path resolution issue that could cause non-reproducible builds."/>
                                 
                                 <echo message="Validated dist paths are scoped to core-web: ${core.web.basedir}"/>
                             </target>


### PR DESCRIPTION
## Description

Fixed vite configurations to use absolute paths resolved from __dirname instead of relative paths. This ensures builds are reproducible and prevents references to dist folders outside the repository root. Fixes issues in worktrees and regular repositories where relative paths could resolve incorrectly based on current working directory.

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #34010

**Issue:** Fix nonreproducible builds vite configs referencin

This PR fixes: #34010