### PR TITLE
fix(ci): Fix notification issue with new cicd_6release.yml (#34030)

### DIFF
--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -113,6 +113,9 @@ jobs:
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+      EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
+      EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
   # Release - release-specific operations (Artifactory, Javadocs, Plugins, SBOM, Labels)
   # Waits for deployment to complete to safely update labels only if both succeed

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -116,6 +116,7 @@ jobs:
       EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
       EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      DEV_REQUEST_TOKEN: ${{ secrets.DEV_REQUEST_TOKEN }}
 
   # Release - release-specific operations (Artifactory, Javadocs, Plugins, SBOM, Labels)
   # Waits for deployment to complete to safely update labels only if both succeed


### PR DESCRIPTION
## Description

Fix missing secrets in release workflow deployment phase.

The refactored cicd_6-release.yml workflow was missing three critical secrets in the deployment job:
- EE_REPO_USERNAME and EE_REPO_PASSWORD for Artifactory deployment
- SLACK_BOT_TOKEN for deployment notifications

This caused two failures in run 19939365273:
1. Artifact deployment: 'Credentials not provided'
2. Slack notification: 'Need to provide at least one botToken or webhookUrl'

The fix adds these secrets to match the pattern used in cicd_3-trunk.yml and cicd_4-nightly.yml.

## Changes
- [x] Add EE_REPO_USERNAME and EE_REPO_PASSWORD secrets to deployment job
- [x] Add SLACK_BOT_TOKEN secret to deployment job
- [x] Align with working workflow patterns (cicd_3-trunk.yml, cicd_4-nightly.yml)

## Testing
- [x] Verified secrets match deployment phase component requirements
- [x] Verified pattern matches other working workflows
- [ ] Test with new release run to confirm artifact deployment succeeds
- [ ] Verify Slack notifications are sent correctly

Diagnostic details: .claude/diagnostics/run-19939365273/

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #34030

**Issue:** Fix notification issue with new cicd_6release.yml

This PR fixes: #34030