### PR TITLE
feat(render-mode): Enhance render mode selection UI 

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/new-render-mode-proptery/new-render-mode-property.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/new-render-mode-proptery/new-render-mode-property.component.html
@@ -2,33 +2,28 @@
     <label [for]="property.name" dotFieldRequired>
         {{ 'contenttypes.field.properties.newRenderMode.label' | dm }}
     </label>
-    <div class="flex flex-wrap gap-3">
-        <div class="flex align-items-center">
-            <p-radioButton
-                name="newRenderMode"
-                value="iframe"
-                [formControlName]="property.name"
-                inputId="iframe" />
-            <label
-                for="iframe"
-                class="ml-2"
-                [pTooltip]="'contenttypes.field.properties.newRenderMode.component.tooltip' | dm">
-                {{ 'contenttypes.field.properties.newRenderMode.component.label' | dm }}
-            </label>
-        </div>
-
-        <div class="flex align-items-center">
-            <p-radioButton
-                name="newRenderMode"
-                value="components"
-                [formControlName]="property.name"
-                inputId="components" />
-            <label
-                for="components"
-                class="ml-2"
-                [pTooltip]="'contenttypes.field.properties.newRenderMode.iframe.tooltip' | dm">
-                {{ 'contenttypes.field.properties.newRenderMode.iframe.label' | dm }}
-            </label>
-        </div>
+    <div class="flex flex-wrap gap-3 align-items-stretch">
+        @for (renderMode of $renderModes(); track renderMode.value) {
+            <p-card
+                class="render-mode-card flex-1 min-w-12rem cursor-pointer h-full"
+                [class.selected]="value === renderMode.value"
+                (click)="choose(renderMode.value)">
+                <div class="flex align-content-center gap-3 h-full">
+                    <p-radioButton
+                        name="newRenderMode"
+                        [value]="renderMode.value"
+                        [formControlName]="property.name"
+                        [inputId]="renderMode.value" />
+                    <div class="flex flex-column gap-1 flex-1">
+                        <div class="font-bold">
+                            {{ renderMode.label | dm }}
+                        </div>
+                        <div class="text-sm">
+                            {{ renderMode.tooltip | dm }}
+                        </div>
+                    </div>
+                </div>
+            </p-card>
+        }
     </div>
 </div>

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/new-render-mode-proptery/new-render-mode-property.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/new-render-mode-proptery/new-render-mode-property.component.html
@@ -7,6 +7,7 @@
             <p-card
                 class="render-mode-card flex-1 min-w-12rem cursor-pointer h-full"
                 [class.selected]="value === renderMode.value"
+                tabindex="0"
                 (click)="choose(renderMode.value)">
                 <div class="flex align-content-center gap-3 h-full">
                     <p-radioButton

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/new-render-mode-proptery/new-render-mode-property.component.scss
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/new-render-mode-proptery/new-render-mode-property.component.scss
@@ -1,0 +1,68 @@
+@use "variables" as *;
+
+.render-mode-card {
+    transition:
+        border-color $basic-speed ease,
+        background-color $basic-speed ease;
+    display: flex;
+    flex-direction: column;
+
+    ::ng-deep .p-card {
+        border: 1px solid $color-palette-gray-300;
+        padding: 0;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        transition:
+            border-color $basic-speed ease,
+            background-color $basic-speed ease;
+    }
+
+    ::ng-deep .p-card-body {
+        padding: $spacing-3;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+    }
+
+    p-radiobutton {
+        flex-shrink: 0;
+        margin-top: 2px;
+
+        ::ng-deep .p-radiobutton {
+            border-color: $color-palette-gray-400;
+        }
+    }
+
+    &:hover {
+        ::ng-deep .p-card {
+            border-color: $color-palette-primary-400;
+        }
+    }
+
+    &.selected {
+        ::ng-deep .p-card {
+            border: 1px solid $color-palette-primary-500;
+            background-color: $color-palette-primary-op-10;
+        }
+
+        p-radiobutton {
+            ::ng-deep .p-radiobutton {
+                border-color: $color-palette-primary-500;
+
+                .p-radiobutton-box.p-highlight {
+                    .p-radiobutton-icon {
+                        background-color: $color-palette-primary-500;
+                    }
+                }
+            }
+        }
+    }
+}
+
+@media (max-width: 768px) {
+    .render-mode-card {
+        width: 100%;
+        min-width: 100%;
+    }
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/new-render-mode-proptery/new-render-mode-property.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/new-render-mode-proptery/new-render-mode-property.component.ts
@@ -1,14 +1,64 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 
+import { DotRenderModes } from '@dotcms/dotcms-models';
+
 import { FieldProperty } from '../field-properties.model';
+
+interface RenderMode {
+    value: typeof DotRenderModes.COMPONENT | typeof DotRenderModes.IFRAME;
+    label: string;
+    tooltip: string;
+}
 
 @Component({
     selector: 'dot-new-render-mode-property',
     templateUrl: './new-render-mode-property.component.html',
+    styleUrls: ['./new-render-mode-property.component.scss'],
     standalone: false
 })
 export class NewRenderModePropertyComponent {
     property: FieldProperty;
     group: UntypedFormGroup;
+
+    /**
+     * Signals the render modes available for the field
+     * @type {Signal<RenderMode[]>}
+     */
+    $renderModes = signal<RenderMode[]>([
+        {
+            value: DotRenderModes.COMPONENT,
+            label: 'contenttypes.field.properties.newRenderMode.component.label',
+            tooltip: 'contenttypes.field.properties.newRenderMode.component.tooltip'
+        },
+        {
+            value: DotRenderModes.IFRAME,
+            label: 'contenttypes.field.properties.newRenderMode.iframe.label',
+            tooltip: 'contenttypes.field.properties.newRenderMode.iframe.tooltip'
+        }
+    ]);
+
+    /**
+     * Returns the field control from the form group
+     * @type {FormControl}
+     */
+    get field() {
+        return this.group.get(this.property.name);
+    }
+
+    /**
+     * Returns the value of the field control
+     * @type {unknown}
+     */
+    get value() {
+        return this.field?.value;
+    }
+
+    /**
+     * Sets the value of the field control
+     * @param value {RenderMode['value']}
+     */
+    choose(value: RenderMode['value']) {
+        this.field?.setValue(value);
+    }
 }

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-properties.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/service/field-properties.service.spec.ts
@@ -146,7 +146,7 @@ describe('FieldPropertyService', () => {
                     {
                         id: 'var1',
                         key: 'newRenderMode',
-                        value: DotRenderModes.COMPONENTS,
+                        value: DotRenderModes.COMPONENT,
                         fieldId: '123',
                         clazz: 'com.dotcms.contenttype.model.field.ImmutableFieldVariable'
                     }
@@ -165,7 +165,7 @@ describe('FieldPropertyService', () => {
             };
 
             const result = fieldPropertiesService.getValue(field, 'newRenderMode');
-            expect(result).toEqual(DotRenderModes.COMPONENTS);
+            expect(result).toEqual(DotRenderModes.COMPONENT);
         });
 
         it('should return DotRenderModes.IFRAME when propertyName is newRenderMode and fieldVariable does not exist', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
@@ -6,6 +6,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
 import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
 import { CheckboxModule } from 'primeng/checkbox';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogModule } from 'primeng/dialog';
@@ -121,6 +122,7 @@ import { DotFeatureFlagResolver } from '../resolvers/dot-feature-flag-resolver.s
         ContentTypesLayoutComponent,
         ContentTypesFormComponent,
         ButtonModule,
+        CardModule,
         CheckboxModule,
         ConfirmDialogModule,
         CommonModule,

--- a/core-web/libs/dotcms-models/src/lib/dot-content-types.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-content-types.model.ts
@@ -47,7 +47,7 @@ export const DotCMSClazzes = {
  */
 export const DotRenderModes = {
     IFRAME: 'iframe',
-    COMPONENTS: 'components'
+    COMPONENT: 'component'
 } as const;
 
 /**

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/cachettl_custom_field.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/cachettl_custom_field.vtl
@@ -15,3 +15,4 @@ dojo.ready(function() {
 });
 </script>
 <input id="cachettlbox"/>
+<p>Is new Mode enabled? = $structures.isNewEditModeEnabled()</p>


### PR DESCRIPTION
### Proposed Changes
This pull request refactors the "Render Mode" property field in the content type fields properties form to improve its UI/UX and code maintainability. The main changes include switching from basic radio buttons to a card-based selection interface, updating the render mode enum, and introducing better styling and structure for the selection options.

**UI/UX Improvements:**

- The render mode selection is now displayed as selectable cards, each with a label and tooltip, providing a clearer and more interactive way for users to choose between modes.
- The new card-based UI is styled for improved accessibility and responsiveness, including visual feedback for selection and hover states.

**Codebase and Structure Updates:**

- Updated the `DotRenderModes` enum: renamed `COMPONENTS` to `COMPONENT` for consistency and correctness.
- Refactored the component logic to use Angular signals for managing render modes, encapsulated render mode metadata, and added utility getters for cleaner code.
- Added the required PrimeNG `CardModule` to the module imports to support the new card UI. [[1]](diffhunk://#diff-0f3ec14af7770b7e5376a79d0ebe9857b53fd3a61a4afb3725d1f5f515e95753R9) [[2]](diffhunk://#diff-0f3ec14af7770b7e5376a79d0ebe9857b53fd3a61a4afb3725d1f5f515e95753R125)

### Checklist
- [x] Tests
- [x] Translations
- [x] Security Implications Contemplated (add notes if applicable)

| Before | After |
|--------|--------|
| <img width="629" height="770" alt="Screenshot 2025-12-05 at 8 02 49 AM" src="https://github.com/user-attachments/assets/a78c67bb-0b88-4cc7-9fab-2510f5892700" /> | <img width="628" height="772" alt="Screenshot 2025-12-05 at 8 03 20 AM" src="https://github.com/user-attachments/assets/394b7827-1b7c-465c-83e1-db09f649fd24" /> |



