### PR TITLE
fix(ContentDrive) modernize Folders transformer  Refs: 34016

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/browser/BrowserAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/browser/BrowserAPIImpl.java
@@ -1163,7 +1163,7 @@ public class BrowserAPIImpl implements BrowserAPI {
 
         // 1. Folders
         if (browserQuery.showFolders) {
-            final List<Map<String, Object>> folders = getFolders(browserQuery, roles);
+            final List<Map<String, Object>> folders = foldersDefaultView(browserQuery, roles);
             folderCount = folders.size();
 
             // Calculate if the offset still falls within folders
@@ -1756,38 +1756,74 @@ public class BrowserAPIImpl implements BrowserAPI {
     }
 
 
-
-    private  List<Map<String, Object>> getFolders(final BrowserQuery browserQuery, final Role[] roles) throws DotDataException, DotSecurityException {
+    /**
+     * Retrieves a list of folders transformed into a list of maps based on the specified browser query
+     * and roles. If the `directParent` property of the browser query is not null, it processes the folders
+     * using a transformer. If `directParent` is null, it returns an empty list.
+     *
+     * @param browserQuery an instance of BrowserQuery containing query details and user information.
+     *                      The `directParent` field is checked to determine whether to process folders.
+     * @param roles an array of Role instances associated with the user, used in the folder transformation process.
+     * @return a list of maps where each map represents a folder and its attributes, or an empty list
+     *         if `directParent` is null.
+     */
+    private  List<Map<String, Object>> getFolders(final BrowserQuery browserQuery, final Role[] roles) {
 
         if (browserQuery.directParent != null) {
-
-            List<Folder> folders = Collections.emptyList();
-            try {
-
-                folders = folderAPI.findSubFoldersByParent(browserQuery.directParent, userAPI.getSystemUser(),false).stream()
-                        .sorted(Comparator.comparing(Folder::getName)).collect(Collectors.toList());
-
-            } catch (Exception e1) {
-
-                Logger.error(this, "Could not load folders : ", e1);
-            }
-
-
-            if(browserQuery.showMenuItemsOnly) {
-                folders.removeIf(f->!f.isShowOnMenu());
-            }
-
-            if(browserQuery.filterFolderNames){
-                folders.removeIf(f->!f.getName().toLowerCase().contains(browserQuery.filter.toLowerCase()));
-            }
-
+            final List<Folder> folders = getFolders(browserQuery);
             final DotMapViewTransformer transformer = new DotFolderTransformerBuilder().withFolders(folders)
                     .withUserAndRoles(browserQuery.user, roles).build();
             return transformer.toMaps();
-
         }
         return List.of();
     } // getFolders.
+
+    /**
+     * Generates a default view of folders based on the given browser query and roles.
+     *
+     * @param browserQuery an object containing the query parameters related to folders
+     * @param roles an array of roles associated with the user to determine access and visibility
+     * @return a list of maps representing the default view of folders; returns an empty list if no direct parent exists in the browser query
+     */
+    private List<Map<String, Object>> foldersDefaultView(final BrowserQuery browserQuery, final Role[] roles) {
+        if (browserQuery.directParent != null) {
+            final List<Folder> folders = getFolders(browserQuery);
+            final DotMapViewTransformer transformer = new DotFolderTransformerBuilder()
+                    .withFolders(folders)
+                    .withDefaultView(browserQuery.user, roles).build();
+            return transformer.toMaps();
+        }
+        return List.of();
+    }
+
+    /**
+     * Retrieves the list of subfolders based on the specified browser query parameters.
+     *
+     * @param browserQuery the query object containing filtering parameters, parent folder information,
+     *                     and other flags used to retrieve and filter the subfolders
+     * @return a list of folders that match the filtering criteria specified in the browser query
+     */
+    private List<Folder> getFolders(BrowserQuery browserQuery) {
+        List<Folder> folders = Collections.emptyList();
+        try {
+
+            folders = folderAPI.findSubFoldersByParent(browserQuery.directParent, userAPI.getSystemUser(),false).stream()
+                    .sorted(Comparator.comparing(Folder::getName)).collect(Collectors.toList());
+
+        } catch (Exception e1) {
+
+            Logger.error(this, "Could not load folders : ", e1);
+        }
+
+        if(browserQuery.showMenuItemsOnly) {
+            folders.removeIf(f->!f.isShowOnMenu());
+        }
+
+        if(browserQuery.filterFolderNames){
+            folders.removeIf(f->!f.getName().toLowerCase().contains(browserQuery.filter.toLowerCase()));
+        }
+        return folders;
+    }
 
     private Map<String,Object> htmlPageMap(final HTMLPageAsset page) throws DotStateException {
         return new DotTransformerBuilder().webAssetOptions().content(page).build().toMaps().get(0);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotFolderTransformerBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotFolderTransformerBuilder.java
@@ -20,6 +20,7 @@ public class DotFolderTransformerBuilder {
 
     private final FolderAPI folderAPI = APILocator.getFolderAPI();
 
+    private boolean defaultView = false;
     private User user;
     private Role[] roles;
     private List<String> folderIds;
@@ -68,18 +69,35 @@ public class DotFolderTransformerBuilder {
     }
 
     /**
+     * Content-Drive is the default view for Folders
+     * @param user
+     * @param roles
+     * @return
+     */
+    public DotFolderTransformerBuilder withDefaultView(final User user, final Role... roles){
+        this.user = user;
+        this.roles = Arrays.copyOf(roles, roles.length);
+        this.defaultView = true;
+        return this;
+    }
+
+    /**
      * Given the different param This Will get you the instance of  DotMapViewTransformer
      * @return
      */
     public DotMapViewTransformer build() {
-        List<Folder> folders = this.folders;
-        if (null == folders) {
-            folders = resolveFoldersFromIds(folderIds);
+        List<Folder> resolvedFolders = this.folders;
+        if (null == resolvedFolders) {
+            resolvedFolders = resolveFoldersFromIds(folderIds);
+        }
+        //Content-Drive Default View
+        if (defaultView && null != user && roles != null) {
+            return DotFolderTransformerImpl.defaultInstance(user, roles, resolvedFolders);
         }
         if (null != user && roles != null) {
-            return new DotFolderTransformerImpl(user, roles, folders);
+            return new DotFolderTransformerImpl(user, roles, resolvedFolders);
         }
-        return new DotFolderTransformerImpl(folders);
+        return new DotFolderTransformerImpl(resolvedFolders);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotFolderTransformerImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotFolderTransformerImpl.java
@@ -14,6 +14,7 @@ import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.Logger;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.liferay.portal.ejb.UserLocalManagerUtil;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
 import io.vavr.control.Try;
@@ -182,6 +183,15 @@ public class DotFolderTransformerImpl implements DotMapViewTransformer {
         final Map<String, Object> map = new HashMap<>(folder.getMap());
         map.put("permissions", stringPermissions);
         map.remove("inode");
+        final String ownerId = folder.getOwner();
+        if(null != ownerId){
+            final User owner = Try.of(()->UserLocalManagerUtil.getUserById(ownerId)).getOrNull();
+            if (null != owner) {
+                map.put("owner", owner.getFullName());
+            } else {
+                map.put("owner", "unknown");
+            }
+        }
         return map;
 
     }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotFolderTransformerImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/DotFolderTransformerImpl.java
@@ -184,12 +184,17 @@ public class DotFolderTransformerImpl implements DotMapViewTransformer {
         map.put("permissions", stringPermissions);
         map.remove("inode");
         final String ownerId = folder.getOwner();
-        if(null != ownerId){
-            final User owner = Try.of(()->UserLocalManagerUtil.getUserById(ownerId)).getOrNull();
-            if (null != owner) {
-                map.put("owner", owner.getFullName());
+        if (null != ownerId) {
+            if ("system".equalsIgnoreCase(ownerId)) {
+                map.put("owner", "System");
             } else {
-                map.put("owner", "unknown");
+                final User owner = Try.of(() -> UserLocalManagerUtil.getUserById(ownerId))
+                        .getOrNull();
+                if (null != owner) {
+                    map.put("owner", owner.getFullName());
+                } else {
+                    map.put("owner", "unknown");
+                }
             }
         }
         return map;

--- a/dotcms-integration/src/test/java/com/dotcms/browser/BrowserAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/browser/BrowserAPITest.java
@@ -19,6 +19,7 @@ import com.dotcms.datagen.LanguageDataGen;
 import com.dotcms.datagen.LinkDataGen;
 import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.TestDataUtils;
+import com.dotcms.datagen.UserDataGen;
 import com.dotcms.datagen.VariantDataGen;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.variant.model.Variant;
@@ -1387,6 +1388,7 @@ public class BrowserAPITest extends IntegrationTestBase {
      */
     @Test
     public void test_SmartPaginationPage1_25Folders1Contentlet() throws Exception {
+        final User owner = new UserDataGen().nextPersisted();
         // Create a test environment
         final Host host = new SiteDataGen().nextPersisted();
         final Folder parentFolder = new FolderDataGen().site(host).nextPersisted();
@@ -1397,6 +1399,7 @@ public class BrowserAPITest extends IntegrationTestBase {
             final Folder subFolder = new FolderDataGen()
                     .name(String.format("folder_%02d", i))
                     .parent(parentFolder)
+                    .owner(owner)
                     .nextPersisted();
             subFolders.add(subFolder);
         }
@@ -1441,6 +1444,8 @@ public class BrowserAPITest extends IntegrationTestBase {
             assertNotNull("Item should have name", item.get("name"));
             assertTrue("First 25 items should be folders",
                 item.get("name").toString().startsWith("folder_"));
+            assertEquals("Owner should be the same as parent folder",
+                owner.getFullName(), item.get("owner"));
         }
 
         // Verify the last item is a contentlet

--- a/dotcms-integration/src/test/java/com/dotcms/datagen/FolderDataGen.java
+++ b/dotcms-integration/src/test/java/com/dotcms/datagen/FolderDataGen.java
@@ -11,6 +11,7 @@ import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import com.liferay.portal.model.User;
 
 public class FolderDataGen extends AbstractDataGen<Folder> {
     private long currentTime = System.currentTimeMillis();
@@ -21,6 +22,7 @@ public class FolderDataGen extends AbstractDataGen<Folder> {
     private String fileMasks = "";
     private Folder parent;
     private Host site = host;
+    private User owner;
     private String defaultFileType = CacheLocator.getContentTypeCache()
                     .getStructureByVelocityVarName(FileAssetAPI.DEFAULT_FILE_ASSET_STRUCTURE_VELOCITY_VAR_NAME)
                     .getInode();
@@ -70,6 +72,13 @@ public class FolderDataGen extends AbstractDataGen<Folder> {
     }
 
     @SuppressWarnings("unused")
+    public FolderDataGen owner(User owner) {
+        this.owner = owner;
+        return this;
+    }
+
+
+    @SuppressWarnings("unused")
     public FolderDataGen parent(Folder parent) {
         this.parent = parent;
         try {
@@ -94,6 +103,11 @@ public class FolderDataGen extends AbstractDataGen<Folder> {
         f.setFilesMasks(fileMasks);
         f.setHostId(site.getIdentifier());
         f.setDefaultFileType(defaultFileType);
+        if(null!= owner ) {
+            f.setOwner(owner.getUserId());
+        } else {
+            f.setOwner(user.getUserId());
+        }
         return f;
     }
 


### PR DESCRIPTION
### Proposed Changes
* Trying to isolate a race condition in a smaller PR
* This PR contains changes that modernize the folder info returned by the new content-drive endpoint 
* Previously, the returned folder info was getting mapped using the old BrowerAPI Transformer 
* ContentDrive is the new default view in DotFolderTransformer 

This PR fixes: #34016

This PR fixes: #34016