### PR TITLE
refactor(telemetry): Refactor telemetry API to use CDI dependency injec (#33979)

### DIFF
--- a/docs/backend/TELEMETRY_IMPLEMENTATION.md
+++ b/docs/backend/TELEMETRY_IMPLEMENTATION.md
@@ -1,0 +1,301 @@
+# Telemetry Implementation Design
+
+## Overview
+
+The dotCMS telemetry system collects and reports metrics about system usage, configuration, and features. The system has been refactored to use CDI (Contexts and Dependency Injection) for automatic discovery and management of metrics, replacing static factory patterns.
+
+## Architecture
+
+### Core Components
+
+#### `MetricType` Interface
+The base interface for all metrics. Implementations must provide:
+- **Metadata**: Name, description, category, and feature
+- **Value Calculation**: Logic to compute the metric value
+
+All concrete `MetricType` implementations must be annotated with `@ApplicationScoped` to be discovered by CDI.
+
+#### `MetricStatsCollector`
+CDI-managed service (`@ApplicationScoped`) that collects all metrics and generates `MetricsSnapshot` objects.
+
+**Key Features:**
+- Automatically discovers all `@ApplicationScoped MetricType` implementations via `@Inject Instance<MetricType>`
+- Aggregates metrics into `MetricsSnapshot` for reporting
+- Handles errors gracefully, collecting failed metrics separately
+- Used by telemetry endpoints and scheduled jobs
+
+**Usage:**
+```java
+@Inject
+private MetricStatsCollector collector;
+
+MetricsSnapshot snapshot = collector.getStats();
+```
+
+#### `DashboardMetricsProvider`
+CDI-managed service that provides dashboard-specific metrics. Only metrics annotated with `@DashboardMetric` are included.
+
+**Key Features:**
+- Filters metrics by `@DashboardMetric` annotation
+- Sorts metrics by priority (from annotation)
+- Supports category-based filtering
+- Used by `UsageResource` for dashboard display
+
+**Usage:**
+```java
+@Inject
+private DashboardMetricsProvider provider;
+
+List<MetricType> dashboardMetrics = provider.getDashboardMetrics();
+List<MetricType> contentMetrics = provider.getDashboardMetricsByCategory("content");
+```
+
+### Dashboard Metrics
+
+#### `@DashboardMetric` Annotation
+Marker annotation to include metrics in the Usage API dashboard endpoint (`/v1/usage/summary`).
+
+**Attributes:**
+- `category` (String): Optional grouping for organizing metrics (e.g., "content", "site", "user", "system")
+- `priority` (int): Display order (lower values appear first, default: 0)
+
+**Example:**
+```java
+@ApplicationScoped
+@DashboardMetric(category = "content", priority = 1)
+public class TotalContentsDatabaseMetricType implements DBMetricType {
+    // ...
+}
+```
+
+**Benefits:**
+- Declarative configuration (no code changes needed to add/remove metrics from dashboard)
+- Automatic discovery via CDI
+- No hardcoded metric lists in API code
+
+## Creating New Metrics
+
+### Step 1: Implement MetricType
+
+```java
+package com.dotcms.telemetry.collectors.example;
+
+import com.dotcms.telemetry.MetricCategory;
+import com.dotcms.telemetry.MetricFeature;
+import com.dotcms.telemetry.MetricType;
+import com.dotcms.telemetry.MetricValue;
+import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Optional;
+
+@ApplicationScoped
+public class MyNewMetricType implements DBMetricType {
+    
+    @Override
+    public String getName() {
+        return "MY_NEW_METRIC";
+    }
+    
+    @Override
+    public String getDescription() {
+        return "Description of my new metric";
+    }
+    
+    @Override
+    public MetricCategory getCategory() {
+        return MetricCategory.DIFFERENTIATING_FEATURES;
+    }
+    
+    @Override
+    public MetricFeature getFeature() {
+        return MetricFeature.CONTENTLETS;
+    }
+    
+    @Override
+    public String getSqlQuery() {
+        return "SELECT COUNT(*) AS value FROM my_table";
+    }
+}
+```
+
+### Step 2: Add to Dashboard (Optional)
+
+To include the metric in the Usage API dashboard, add the `@DashboardMetric` annotation:
+
+```java
+@ApplicationScoped
+@DashboardMetric(category = "content", priority = 5)
+public class MyNewMetricType implements DBMetricType {
+    // ...
+}
+```
+
+The metric will automatically:
+- Be discovered by `MetricStatsCollector` for general telemetry
+- Be included in dashboard via `DashboardMetricsProvider`
+- Appear in `/v1/usage/summary` endpoint response
+- Be sorted by priority within its category
+
+### Base Classes
+
+For common patterns, extend base classes:
+
+- **`DBMetricType`**: For database query-based metrics
+- **`ApiMetricType`**: For API call count metrics
+- **Abstract classes**: Various abstract base classes for specific metric families (see package structure)
+
+## Configuration
+
+### Adding Metrics to Dashboard
+
+1. Annotate the metric class with `@DashboardMetric`
+2. Optionally set `category` and `priority`
+3. No code changes needed in `UsageResource` or other API classes
+
+### Removing Metrics from Dashboard
+
+Remove the `@DashboardMetric` annotation. The metric will still be available via general telemetry endpoints but won't appear in the dashboard.
+
+### Organizing Metrics
+
+Use the `category` attribute to group related metrics:
+- `"content"`: Content-related metrics
+- `"site"`: Site-related metrics
+- `"user"`: User-related metrics
+- `"system"`: System configuration metrics
+
+Use `priority` to control display order within categories (lower = first).
+
+## API Endpoints
+
+### General Telemetry
+- **`/api/v1/telemetry/stats`**: Returns all metrics (filtered by optional `metricNames` query parameter)
+- Uses `MetricStatsCollector` to collect all discovered metrics
+- Returns `MetricsSnapshot` with all collected metrics
+
+### Dashboard Metrics
+- **`/api/v1/usage/summary`**: Returns dashboard-specific metrics
+- Uses `DashboardMetricsProvider` to collect only `@DashboardMetric` annotated metrics
+- Returns `UsageSummary` optimized for dashboard consumption
+- Includes content, site, user, and system metrics
+
+## CDI Discovery
+
+### How It Works
+
+1. All `@ApplicationScoped` beans implementing `MetricType` are automatically discovered by CDI
+2. `MetricStatsCollector` injects `Instance<MetricType>` to access all metrics
+3. `DashboardMetricsProvider` filters the collection for `@DashboardMetric` annotated types
+4. No manual registration or factory methods required
+
+### Requirements
+
+- **Concrete implementations**: Must be annotated with `@ApplicationScoped`
+- **Abstract classes**: Should NOT be annotated (they're not instantiated)
+- **Interface implementations**: Must be concrete classes (interfaces can't be CDI beans)
+
+## Migration Notes
+
+### From Static Factory Pattern
+
+The refactoring moved from:
+- Static factory methods with hardcoded metric lists
+- Manual instantiation with `new`
+- Required code changes to add/remove metrics
+
+To:
+- CDI-based automatic discovery
+- Declarative configuration via annotations
+- No code changes needed to add/remove metrics
+
+### Call Sites
+
+All call sites have been updated to use CDI:
+- `TelemetryResource`: Uses `CDIUtils.getBeanThrows(MetricStatsCollector.class)`
+- `MetricsStatsJob`: Uses `CDIUtils.getBeanThrows(MetricStatsCollector.class)`
+- `UsageResource`: Uses `CDIUtils.getBeanThrows(DashboardMetricsProvider.class)`
+
+### Backward Compatibility
+
+No static method wrappers are needed - all call sites have been migrated to CDI.
+
+## Package Structure
+
+```
+com.dotcms.telemetry/
+├── MetricType.java                    # Base interface
+├── Metric.java                        # Metric metadata
+├── MetricValue.java                   # Metric value wrapper
+├── MetricsSnapshot.java               # Collection of metrics
+├── DashboardMetric.java               # Dashboard marker annotation
+├── MetricCategory.java                # Metric categories enum
+├── MetricFeature.java                 # Feature enums
+├── collectors/
+│   ├── MetricStatsCollector.java      # Main collector (CDI)
+│   ├── DashboardMetricsProvider.java  # Dashboard provider (CDI)
+│   ├── DBMetricType.java              # Database metric base class
+│   ├── ApiMetricType.java             # API metric base class
+│   ├── ai/                            # AI metrics
+│   ├── container/                     # Container metrics
+│   ├── content/                       # Content metrics
+│   ├── experiment/                    # Experiment metrics
+│   ├── image/                         # Image API metrics
+│   ├── language/                      # Language metrics
+│   ├── site/                          # Site metrics
+│   ├── template/                      # Template metrics
+│   ├── theme/                         # Theme metrics
+│   ├── user/                          # User metrics
+│   └── workflow/                      # Workflow metrics
+├── rest/
+│   └── TelemetryResource.java         # Telemetry REST endpoint
+└── job/
+    └── MetricsStatsJob.java           # Scheduled metric collection job
+```
+
+## Best Practices
+
+### Creating Metrics
+
+1. **Use appropriate base classes**: Extend `DBMetricType` or `ApiMetricType` when applicable
+2. **Provide clear descriptions**: Help users understand what the metric measures
+3. **Choose correct category/feature**: Ensures proper classification
+4. **Handle errors gracefully**: Return `Optional.empty()` on failure rather than throwing
+
+### Dashboard Metrics
+
+1. **Use meaningful categories**: Group related metrics together
+2. **Set appropriate priorities**: Lower numbers for more important metrics
+3. **Keep dashboard focused**: Only annotate metrics relevant to dashboard users
+4. **Document categories**: Use consistent category names across metrics
+
+### CDI Usage
+
+1. **Always annotate concrete classes**: `@ApplicationScoped` is required for discovery
+2. **Don't annotate abstract classes**: They're not instantiated by CDI
+3. **Use `Instance<T>` for collections**: Allows iteration over all beans of a type
+4. **Handle empty collections**: CDI injects empty `Instance` if no beans found (never null)
+
+## Related Documentation
+
+- **JavaDoc**: All classes have comprehensive JavaDoc with usage examples
+- **REST API Patterns**: See `docs/backend/REST_API_PATTERNS.md` for API design guidelines
+
+## Discovering Available Metrics
+
+All metrics are defined in the codebase under `com.dotcms.telemetry.collectors.*`. To discover available metrics:
+
+1. **Programmatically**: Use `MetricStatsCollector` or `DashboardMetricsProvider` to get all discovered metrics
+2. **In Code**: Browse the `com.dotcms.telemetry.collectors` package structure
+3. **At Runtime**: Query the `/api/v1/telemetry/stats` endpoint to see all collected metrics
+
+The code is the source of truth for metric definitions. Each `MetricType` implementation provides:
+- `getName()`: The metric identifier
+- `getDescription()`: What the metric measures
+- `getFeature()`: The feature category
+- `getCategory()`: The metric category
+
+---
+
+*Last Updated: 2024*  
+*Issue: #33979 - Refactor telemetry API to use CDI dependency injection*
+

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/usage/UsageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/usage/UsageResource.java
@@ -1,25 +1,11 @@
 package com.dotcms.rest.api.v1.usage;
 
-import com.dotcms.rest.InitDataObject;
+import com.dotcms.cdi.CDIUtils;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
+import com.dotcms.telemetry.MetricType;
 import com.dotcms.telemetry.MetricValue;
-import com.dotcms.telemetry.collectors.content.LastContentEditedDatabaseMetricType;
-import com.dotcms.telemetry.collectors.content.RecentlyEditedContentDatabaseMetricType;
-import com.dotcms.telemetry.collectors.content.TotalContentsDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.TotalActiveSitesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.TotalSitesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.TotalAliasesAllSitesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.template.TotalBuilderTemplatesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.template.TotalTemplatesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.theme.TotalLiveContainerDatabaseMetricType;
-import com.dotcms.telemetry.collectors.user.ActiveUsersDatabaseMetricType;
-import com.dotcms.telemetry.collectors.user.LastLoginDatabaseMetricType;
-import com.dotcms.telemetry.collectors.user.TotalUsersDatabaseMetricType;
-import com.dotcms.telemetry.collectors.workflow.ContentTypesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.workflow.SchemesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.workflow.StepsDatabaseMetricType;
-import com.dotcms.telemetry.collectors.language.TotalLanguagesDatabaseMetricType;
+import com.dotcms.telemetry.collectors.DashboardMetricsProvider;
 import com.dotmarketing.util.Logger;
 import com.fasterxml.jackson.jaxrs.json.annotation.JSONP;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,7 +23,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -45,7 +30,11 @@ import java.util.Optional;
 
 /**
  * REST resource for usage dashboard data.
- * Provides optimized business metrics for dashboard consumption.
+ * 
+ * <p>Collects metrics via {@link com.dotcms.telemetry.collectors.DashboardMetricsProvider},
+ * which automatically discovers all {@link com.dotcms.telemetry.DashboardMetric}-annotated
+ * MetricType implementations. To include a metric in the dashboard, annotate it with
+ * {@code @DashboardMetric}.</p>
  */
 @Tag(name = "Usage", 
      description = "Provides business intelligence metrics for dashboard usage")
@@ -92,7 +81,8 @@ public class UsageResource {
 
         Logger.debug(this, "Generating usage dashboard summary");
         
-        final InitDataObject initData = new WebResource.InitBuilder(webResource)
+        // Initialize and validate user authentication/authorization
+        new WebResource.InitBuilder(webResource)
                 .requestAndResponse(request, response)
                 .requiredBackendUser(true)
                 .rejectWhenNoUser(true)
@@ -109,56 +99,56 @@ public class UsageResource {
     }
 
     /**
-     * Collect and process business metrics for dashboard display
+     * Collects metrics for dashboard display using {@link DashboardMetricsProvider}
+     * to discover metrics annotated with {@link com.dotcms.telemetry.DashboardMetric}.
      */
     private UsageSummary collectUsageSummary() {
-        Logger.debug(this, "Collecting business metrics for usage dashboard");
+        Logger.info(this, "Collecting business metrics for usage dashboard");
 
-        // Define key metric collectors we need
-        final Collection<com.dotcms.telemetry.MetricType> keyMetrics = Arrays.asList(
-            new TotalContentsDatabaseMetricType(),
-            new RecentlyEditedContentDatabaseMetricType(),
-            new ContentTypesDatabaseMetricType(),
-            new TotalSitesDatabaseMetricType(), 
-            new TotalActiveSitesDatabaseMetricType(),
-            new TotalAliasesAllSitesDatabaseMetricType(),
-            new ActiveUsersDatabaseMetricType(),
-            new TotalUsersDatabaseMetricType(),
-            new LastLoginDatabaseMetricType(),
-            new LastContentEditedDatabaseMetricType(),
-            new TotalTemplatesDatabaseMetricType(),
-            new TotalBuilderTemplatesDatabaseMetricType(),
-            new TotalLiveContainerDatabaseMetricType(),
-            new TotalLanguagesDatabaseMetricType(),
-            new SchemesDatabaseMetricType(),
-            new StepsDatabaseMetricType()
-        );
+        final DashboardMetricsProvider metricsProvider = CDIUtils.getBeanThrows(DashboardMetricsProvider.class);
+        final Collection<MetricType> keyMetrics = metricsProvider.getDashboardMetrics();
+        
+        Logger.info(this, () -> String.format("Found %d dashboard metrics to collect", keyMetrics.size()));
 
-        // Collect metric values - handle duplicate keys by using metric type to create unique keys
+        // Collect metric values - use metricType.getName() as the map key
         final Map<String, MetricValue> metricMap = new HashMap<>();
-        for (com.dotcms.telemetry.MetricType metricType : keyMetrics) {
+        for (MetricType metricType : keyMetrics) {
             try {
+                final String metricName = metricType.getName();
                 final Optional<MetricValue> metricValueOpt = metricType.getStat();
                 if (metricValueOpt.isPresent()) {
                     final MetricValue metricValue = metricValueOpt.get();
-                    final String baseName = metricValue.getMetric().getName();
                     
-                    // Handle duplicate "COUNT" keys by using metric type class name
-                    String mapKey = baseName;
-                    if ("COUNT".equals(baseName)) {
-                        if (metricType instanceof TotalContentsDatabaseMetricType) {
-                            mapKey = "COUNT_CONTENT";
-                        } else if (metricType instanceof TotalLanguagesDatabaseMetricType) {
-                            mapKey = "COUNT_LANGUAGES";
+                    // Handle duplicate "COUNT" keys by mapping to specific names based on feature
+                    final String mapKey;
+                    if ("COUNT".equals(metricName)) {
+                        // Use feature to disambiguate generic "COUNT" metric
+                        switch (metricType.getFeature()) {
+                            case CONTENTLETS:
+                                mapKey = "COUNT_CONTENT";
+                                break;
+                            case LANGUAGES:
+                                mapKey = "COUNT_LANGUAGES";
+                                break;
+                            default:
+                                mapKey = metricName;
                         }
+                    } else {
+                        mapKey = metricName;
                     }
                     
                     metricMap.put(mapKey, metricValue);
+                    Logger.debug(this, () -> String.format("Collected metric: %s = %s (mapped to: %s)", 
+                            metricName, metricValue.getValue(), mapKey));
+                } else {
+                    Logger.info(this, () -> String.format("Metric %s returned empty value", metricName));
                 }
             } catch (Exception e) {
                 Logger.warn(this, "Failed to collect metric: " + metricType.getName(), e);
             }
         }
+        
+        Logger.info(this, () -> String.format("Collected %d metric values from %d dashboard metrics", metricMap.size(), keyMetrics.size()));
 
         // Build summary from collected metrics
         return UsageSummary.builder()
@@ -179,6 +169,9 @@ public class UsageResource {
         // For now, using totalContent as contentTypes placeholder - can be enhanced later
         final long contentTypes = totalContent > 0 ? 1 : 0;
         
+        Logger.info(this, () -> String.format("Content metrics - totalContent: %d, recentlyEdited: %d, contentTypesWithWorkflows: %d", 
+                totalContent, recentlyEdited, contentTypesWithWorkflows));
+        
         return new UsageSummary.ContentMetrics(totalContent, contentTypes, recentlyEdited, contentTypesWithWorkflows, lastContentEdited);
     }
 
@@ -187,6 +180,9 @@ public class UsageResource {
         final long activeSites = getMetricValueAsLong(metricMap, "COUNT_OF_ACTIVE_SITES", totalSites);
         final long templates = getMetricValueAsLong(metricMap, "COUNT_OF_TEMPLATES", 0L);
         final long siteAliases = getMetricValueAsLong(metricMap, "ALIASES_SITES_COUNT", 0L);
+        
+        Logger.info(this, () -> String.format("Site metrics - totalSites: %d, activeSites: %d, templates: %d, aliases: %d", 
+                totalSites, activeSites, templates, siteAliases));
         
         return new UsageSummary.SiteMetrics(totalSites, activeSites, templates, siteAliases);
     }
@@ -198,6 +194,9 @@ public class UsageResource {
         final long recentLogins = 0L;
         final String lastLogin = getMetricValueAsString(metricMap, "LAST_LOGIN", "N/A");
         
+        Logger.info(this, () -> String.format("User metrics - activeUsers: %d, totalUsers: %d, lastLogin: %s", 
+                activeUsers, totalUsers, lastLogin));
+        
         return new UsageSummary.UserMetrics(activeUsers, totalUsers, recentLogins, lastLogin);
     }
 
@@ -207,6 +206,9 @@ public class UsageResource {
         final long workflowSteps = getMetricValueAsLong(metricMap, "STEPS_COUNT", 0L);
         final long liveContainers = getMetricValueAsLong(metricMap, "COUNT_OF_LIVE_CONTAINERS", 0L);
         final long builderTemplates = getMetricValueAsLong(metricMap, "COUNT_OF_TEMPLATE_BUILDER_TEMPLATES", 0L);
+        
+        Logger.info(this, () -> String.format("System metrics - languages: %d, workflowSchemes: %d, workflowSteps: %d, liveContainers: %d, builderTemplates: %d", 
+                languages, workflowSchemes, workflowSteps, liveContainers, builderTemplates));
         
         return new UsageSummary.SystemMetrics(languages, workflowSchemes, workflowSteps, liveContainers, builderTemplates);
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/usage/UsageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/usage/UsageResource.java
@@ -103,12 +103,12 @@ public class UsageResource {
      * to discover metrics annotated with {@link com.dotcms.telemetry.DashboardMetric}.
      */
     private UsageSummary collectUsageSummary() {
-        Logger.info(this, "Collecting business metrics for usage dashboard");
+        Logger.debug(this, "Collecting business metrics for usage dashboard");
 
         final DashboardMetricsProvider metricsProvider = CDIUtils.getBeanThrows(DashboardMetricsProvider.class);
         final Collection<MetricType> keyMetrics = metricsProvider.getDashboardMetrics();
-        
-        Logger.info(this, () -> String.format("Found %d dashboard metrics to collect", keyMetrics.size()));
+
+        Logger.debug(this, () -> String.format("Found %d dashboard metrics to collect", keyMetrics.size()));
 
         // Collect metric values - use metricType.getName() as the map key
         final Map<String, MetricValue> metricMap = new HashMap<>();
@@ -138,17 +138,17 @@ public class UsageResource {
                     }
                     
                     metricMap.put(mapKey, metricValue);
-                    Logger.debug(this, () -> String.format("Collected metric: %s = %s (mapped to: %s)", 
+                    Logger.debug(this, () -> String.format("Collected metric: %s = %s (mapped to: %s)",
                             metricName, metricValue.getValue(), mapKey));
                 } else {
-                    Logger.info(this, () -> String.format("Metric %s returned empty value", metricName));
+                    Logger.debug(this, () -> String.format("Metric %s returned empty value", metricName));
                 }
             } catch (Exception e) {
                 Logger.warn(this, "Failed to collect metric: " + metricType.getName(), e);
             }
         }
-        
-        Logger.info(this, () -> String.format("Collected %d metric values from %d dashboard metrics", metricMap.size(), keyMetrics.size()));
+
+        Logger.debug(this, () -> String.format("Collected %d metric values from %d dashboard metrics", metricMap.size(), keyMetrics.size()));
 
         // Build summary from collected metrics
         return UsageSummary.builder()
@@ -168,10 +168,10 @@ public class UsageResource {
         
         // For now, using totalContent as contentTypes placeholder - can be enhanced later
         final long contentTypes = totalContent > 0 ? 1 : 0;
-        
-        Logger.info(this, () -> String.format("Content metrics - totalContent: %d, recentlyEdited: %d, contentTypesWithWorkflows: %d", 
+
+        Logger.debug(this, () -> String.format("Content metrics - totalContent: %d, recentlyEdited: %d, contentTypesWithWorkflows: %d",
                 totalContent, recentlyEdited, contentTypesWithWorkflows));
-        
+
         return new UsageSummary.ContentMetrics(totalContent, contentTypes, recentlyEdited, contentTypesWithWorkflows, lastContentEdited);
     }
 
@@ -180,10 +180,10 @@ public class UsageResource {
         final long activeSites = getMetricValueAsLong(metricMap, "COUNT_OF_ACTIVE_SITES", totalSites);
         final long templates = getMetricValueAsLong(metricMap, "COUNT_OF_TEMPLATES", 0L);
         final long siteAliases = getMetricValueAsLong(metricMap, "ALIASES_SITES_COUNT", 0L);
-        
-        Logger.info(this, () -> String.format("Site metrics - totalSites: %d, activeSites: %d, templates: %d, aliases: %d", 
+
+        Logger.debug(this, () -> String.format("Site metrics - totalSites: %d, activeSites: %d, templates: %d, aliases: %d",
                 totalSites, activeSites, templates, siteAliases));
-        
+
         return new UsageSummary.SiteMetrics(totalSites, activeSites, templates, siteAliases);
     }
 
@@ -193,10 +193,10 @@ public class UsageResource {
         // LAST_LOGIN_COUNT metric doesn't exist, using 0 as default
         final long recentLogins = 0L;
         final String lastLogin = getMetricValueAsString(metricMap, "LAST_LOGIN", "N/A");
-        
-        Logger.info(this, () -> String.format("User metrics - activeUsers: %d, totalUsers: %d, lastLogin: %s", 
+
+        Logger.debug(this, () -> String.format("User metrics - activeUsers: %d, totalUsers: %d, lastLogin: %s",
                 activeUsers, totalUsers, lastLogin));
-        
+
         return new UsageSummary.UserMetrics(activeUsers, totalUsers, recentLogins, lastLogin);
     }
 
@@ -206,10 +206,10 @@ public class UsageResource {
         final long workflowSteps = getMetricValueAsLong(metricMap, "STEPS_COUNT", 0L);
         final long liveContainers = getMetricValueAsLong(metricMap, "COUNT_OF_LIVE_CONTAINERS", 0L);
         final long builderTemplates = getMetricValueAsLong(metricMap, "COUNT_OF_TEMPLATE_BUILDER_TEMPLATES", 0L);
-        
-        Logger.info(this, () -> String.format("System metrics - languages: %d, workflowSchemes: %d, workflowSteps: %d, liveContainers: %d, builderTemplates: %d", 
+
+        Logger.debug(this, () -> String.format("System metrics - languages: %d, workflowSchemes: %d, workflowSteps: %d, liveContainers: %d, builderTemplates: %d",
                 languages, workflowSchemes, workflowSteps, liveContainers, builderTemplates));
-        
+
         return new UsageSummary.SystemMetrics(languages, workflowSchemes, workflowSteps, liveContainers, builderTemplates);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/usage/UsageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/usage/UsageResource.java
@@ -120,6 +120,8 @@ public class UsageResource {
                     final MetricValue metricValue = metricValueOpt.get();
                     
                     // Handle duplicate "COUNT" keys by mapping to specific names based on feature
+                    // TODO: Remove this workaround once MetricType naming is standardized
+                    // See: https://github.com/dotCMS/core/issues/34042
                     final String mapKey;
                     if ("COUNT".equals(metricName)) {
                         // Use feature to disambiguate generic "COUNT" metric

--- a/dotCMS/src/main/java/com/dotcms/telemetry/DashboardMetric.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/DashboardMetric.java
@@ -1,0 +1,55 @@
+package com.dotcms.telemetry;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a MetricType implementation for inclusion in the Usage API dashboard.
+ * 
+ * <p>Metrics annotated with this marker are automatically discovered by
+ * {@link com.dotcms.telemetry.collectors.DashboardMetricsProvider} and included
+ * in the {@code /v1/usage/summary} endpoint response. Without this annotation,
+ * metrics are still available via the general telemetry API but not included
+ * in the dashboard summary.</p>
+ * 
+ * <p>Example:</p>
+ * <pre>
+ * {@code
+ * @ApplicationScoped
+ * @DashboardMetric(category = "site", priority = 1)
+ * public class TotalSitesDatabaseMetricType implements DBMetricType {
+ *     // ...
+ * }
+ * }
+ * </pre>
+ * 
+ * @see com.dotcms.telemetry.collectors.DashboardMetricsProvider
+ * @see com.dotcms.rest.api.v1.usage.UsageResource
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface DashboardMetric {
+    
+    /**
+     * Category for grouping related metrics. Used by
+     * {@link com.dotcms.telemetry.collectors.DashboardMetricsProvider#getDashboardMetricsByCategory(String)}
+     * to filter metrics. Common categories: "content", "site", "user", "system".
+     * 
+     * @return the category name, or empty string if not categorized
+     */
+    String category() default "";
+    
+    /**
+     * Display order priority. Metrics are sorted by this value (ascending) when
+     * retrieved via {@link com.dotcms.telemetry.collectors.DashboardMetricsProvider#getDashboardMetrics()}.
+     * Lower values appear first.
+     * 
+     * @return the priority value
+     */
+    int priority() default 0;
+}
+

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/DashboardMetricsProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/DashboardMetricsProvider.java
@@ -1,0 +1,201 @@
+package com.dotcms.telemetry.collectors;
+
+import com.dotcms.telemetry.DashboardMetric;
+import com.dotcms.telemetry.MetricType;
+import com.dotmarketing.util.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Discovers and provides dashboard-available metrics via CDI.
+ * 
+ * <p>Used by {@link com.dotcms.rest.api.v1.usage.UsageResource} to collect
+ * metrics for the dashboard endpoint. Only metrics annotated with
+ * {@link DashboardMetric} are included.</p>
+ * 
+ * <p>Discovery is automatic - all {@code @ApplicationScoped MetricType} beans
+ * are scanned at runtime. Metrics are sorted by {@link DashboardMetric#priority()}
+ * before being returned.</p>
+ * 
+ * @see DashboardMetric
+ * @see com.dotcms.rest.api.v1.usage.UsageResource
+ */
+@ApplicationScoped
+public class DashboardMetricsProvider {
+    
+    @Inject
+    private BeanManager beanManager;
+    
+    @Inject
+    private Instance<MetricType> allMetrics;
+    
+    /**
+     * Returns all metrics annotated with {@link DashboardMetric}, sorted by priority.
+     * 
+     * <p>Uses CDI's {@link BeanManager} to query for beans with the annotation,
+     * which is the proper CDI way to discover annotated beans. This avoids
+     * issues with proxy classes and leverages CDI's built-in capabilities.</p>
+     * 
+     * <p>This method is called by {@link com.dotcms.rest.api.v1.usage.UsageResource}
+     * to collect metrics for the dashboard. The returned list is sorted by
+     * {@link DashboardMetric#priority()} in ascending order.</p>
+     * 
+     * @return list of dashboard-available metrics, sorted by priority (lowest first)
+     */
+    public List<MetricType> getDashboardMetrics() {
+        Logger.info(this, "Starting dashboard metrics discovery via CDI BeanManager");
+        
+        try {
+            // Use BeanManager to get all MetricType beans - this gives us Bean objects
+            // which contain the actual class information (not proxies)
+            final Set<Bean<?>> allBeans = beanManager.getBeans(MetricType.class, Any.Literal.INSTANCE);
+            
+            Logger.info(this, () -> String.format("BeanManager found %d MetricType beans", allBeans.size()));
+            
+            // Use a list that stores both the metric and its annotation for efficient sorting
+            final List<MetricWithAnnotation> dashboardMetricsWithAnnotation = new ArrayList<>();
+            
+            // Iterate through Bean objects to check annotations on actual classes
+            for (Bean<?> bean : allBeans) {
+                final Class<?> beanClass = bean.getBeanClass();
+                
+                // Check if the bean class has @DashboardMetric annotation
+                // bean.getBeanClass() returns the actual class, not the proxy
+                if (beanClass.isAnnotationPresent(DashboardMetric.class)) {
+                    final DashboardMetric annotation = beanClass.getAnnotation(DashboardMetric.class);
+                    
+                    // Get the actual bean instance from CDI
+                    final MetricType metric = (MetricType) beanManager.getReference(
+                            bean, MetricType.class, beanManager.createCreationalContext(bean));
+                    
+                    dashboardMetricsWithAnnotation.add(new MetricWithAnnotation(metric, annotation));
+                    Logger.info(this, () -> String.format("Found dashboard metric: %s (category: %s, priority: %d)", 
+                            beanClass.getName(), annotation.category(), annotation.priority()));
+                }
+            }
+            
+            Logger.info(this, () -> String.format("CDI discovered %d total MetricType beans, %d annotated with @DashboardMetric", 
+                    allBeans.size(), dashboardMetricsWithAnnotation.size()));
+            
+            // Sort by priority (from @DashboardMetric annotation)
+            dashboardMetricsWithAnnotation.sort(Comparator.comparingInt(m -> m.annotation.priority()));
+            
+            // Extract just the metrics
+            return dashboardMetricsWithAnnotation.stream()
+                    .map(m -> m.metric)
+                    .collect(Collectors.toList());
+            
+        } catch (Exception e) {
+            Logger.error(this, "Error discovering dashboard metrics via BeanManager", e);
+            // Fallback to Instance-based discovery if BeanManager fails
+            return getDashboardMetricsFallback();
+        }
+    }
+    
+    /**
+     * Fallback method using Instance injection if BeanManager approach fails.
+     * This method handles proxy classes by checking superclasses.
+     */
+    private List<MetricType> getDashboardMetricsFallback() {
+        Logger.warn(this, "Falling back to Instance-based discovery");
+        final List<MetricType> dashboardMetrics = new ArrayList<>();
+        
+        for (MetricType metric : allMetrics) {
+            final Class<?> actualClass = getBeanClass(metric);
+            if (actualClass.isAnnotationPresent(DashboardMetric.class)) {
+                dashboardMetrics.add(metric);
+            }
+        }
+        
+        dashboardMetrics.sort(Comparator.comparingInt(metric -> {
+            final Class<?> metricClass = getBeanClass(metric);
+            final DashboardMetric annotation = metricClass.getAnnotation(DashboardMetric.class);
+            return annotation != null ? annotation.priority() : 0;
+        }));
+        
+        return dashboardMetrics;
+    }
+    
+    /**
+     * Gets the actual bean class, handling CDI proxy classes.
+     * For BeanManager-discovered beans, this should not be needed, but kept
+     * as a fallback for Instance-based discovery.
+     */
+    private Class<?> getBeanClass(final MetricType metric) {
+        Class<?> clazz = metric.getClass();
+        
+        // CDI proxies often have names like "TotalSitesDatabaseMetricType$Proxy$..." 
+        // or extend the actual class. Check superclass if this looks like a proxy.
+        if (clazz.getName().contains("$Proxy") || clazz.getName().contains("$$")) {
+            Class<?> superclass = clazz.getSuperclass();
+            // If superclass is not Object and is assignable to MetricType, use it
+            if (superclass != null && !superclass.equals(Object.class) && MetricType.class.isAssignableFrom(superclass)) {
+                return superclass;
+            }
+        }
+        
+        return clazz;
+    }
+    
+    /**
+     * Returns dashboard metrics filtered by {@link DashboardMetric#category()}.
+     * 
+     * @param category the category to filter by (case-insensitive)
+     * @return list of metrics in the specified category, sorted by priority
+     */
+    public List<MetricType> getDashboardMetricsByCategory(final String category) {
+        return getDashboardMetrics().stream()
+                .filter(metric -> {
+                    final String metricCategory = getCategory(metric);
+                    return metricCategory != null && metricCategory.equalsIgnoreCase(category);
+                })
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Finds a dashboard metric by its {@link MetricType#getName()} value.
+     * 
+     * @param metricName the metric name to find
+     * @return the metric if found, null otherwise
+     */
+    public MetricType getDashboardMetricByName(final String metricName) {
+        return getDashboardMetrics().stream()
+                .filter(metric -> metricName.equals(metric.getName()))
+                .findFirst()
+                .orElse(null);
+    }
+    
+    private String getCategory(final MetricType metric) {
+        final Class<?> metricClass = getBeanClass(metric);
+        final DashboardMetric annotation = metricClass.getAnnotation(DashboardMetric.class);
+        if (annotation != null) {
+            final String category = annotation.category();
+            return category != null && !category.isEmpty() ? category : null;
+        }
+        return null;
+    }
+    
+    /**
+     * Helper class to hold a metric and its annotation together for efficient sorting.
+     */
+    private static class MetricWithAnnotation {
+        final MetricType metric;
+        final DashboardMetric annotation;
+        
+        MetricWithAnnotation(final MetricType metric, final DashboardMetric annotation) {
+            this.metric = metric;
+            this.annotation = annotation;
+        }
+    }
+}
+

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/DashboardMetricsProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/DashboardMetricsProvider.java
@@ -53,14 +53,14 @@ public class DashboardMetricsProvider {
      * @return list of dashboard-available metrics, sorted by priority (lowest first)
      */
     public List<MetricType> getDashboardMetrics() {
-        Logger.info(this, "Starting dashboard metrics discovery via CDI BeanManager");
-        
+        Logger.debug(this, "Starting dashboard metrics discovery via CDI BeanManager");
+
         try {
             // Use BeanManager to get all MetricType beans - this gives us Bean objects
             // which contain the actual class information (not proxies)
             final Set<Bean<?>> allBeans = beanManager.getBeans(MetricType.class, Any.Literal.INSTANCE);
-            
-            Logger.info(this, () -> String.format("BeanManager found %d MetricType beans", allBeans.size()));
+
+            Logger.debug(this, () -> String.format("BeanManager found %d MetricType beans", allBeans.size()));
             
             // Use a list that stores both the metric and its annotation for efficient sorting
             final List<MetricWithAnnotation> dashboardMetricsWithAnnotation = new ArrayList<>();
@@ -79,12 +79,12 @@ public class DashboardMetricsProvider {
                             bean, MetricType.class, beanManager.createCreationalContext(bean));
                     
                     dashboardMetricsWithAnnotation.add(new MetricWithAnnotation(metric, annotation));
-                    Logger.info(this, () -> String.format("Found dashboard metric: %s (category: %s, priority: %d)", 
+                    Logger.debug(this, () -> String.format("Found dashboard metric: %s (category: %s, priority: %d)",
                             beanClass.getName(), annotation.category(), annotation.priority()));
                 }
             }
-            
-            Logger.info(this, () -> String.format("CDI discovered %d total MetricType beans, %d annotated with @DashboardMetric", 
+
+            Logger.debug(this, () -> String.format("CDI discovered %d total MetricType beans, %d annotated with @DashboardMetric",
                     allBeans.size(), dashboardMetricsWithAnnotation.size()));
             
             // Sort by priority (from @DashboardMetric annotation)

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/MetricStatsCollector.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/MetricStatsCollector.java
@@ -108,21 +108,21 @@ public class MetricStatsCollector {
      */
     private Collection<MetricType> getMetricCollectors() {
         final Collection<MetricType> collectors = new ArrayList<>();
-        
-        Logger.info(this, "Starting MetricType discovery via CDI Instance<MetricType>");
-        
+
+        Logger.debug(this, "Starting MetricType discovery via CDI Instance<MetricType>");
+
         // CDI guarantees metricTypes is never null - it injects an empty Instance if no beans found
         for (MetricType metricType : metricTypes) {
             collectors.add(metricType);
             Logger.debug(this, () -> String.format("MetricStatsCollector discovered: %s", metricType.getClass().getName()));
         }
-        
+
         if (collectors.isEmpty()) {
             Logger.warn(this, "MetricStatsCollector discovered 0 MetricType implementations via CDI! This indicates a CDI scanning/configuration issue.");
         } else {
-            Logger.info(this, () -> String.format("MetricStatsCollector discovered %d MetricType implementations via CDI", collectors.size()));
+            Logger.debug(this, () -> String.format("MetricStatsCollector discovered %d MetricType implementations via CDI", collectors.size()));
         }
-        
+
         return collectors;
     }
 

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/MetricStatsCollector.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/MetricStatsCollector.java
@@ -1,290 +1,60 @@
 package com.dotcms.telemetry.collectors;
 
-import com.dotcms.cdi.CDIUtils;
 import com.dotcms.telemetry.MetricCalculationError;
 import com.dotcms.telemetry.MetricType;
 import com.dotcms.telemetry.MetricValue;
 import com.dotcms.telemetry.MetricsSnapshot;
-import com.dotcms.telemetry.business.MetricsAPI;
-import com.dotcms.telemetry.collectors.ai.TotalEmbeddingsIndexesMetricType;
-import com.dotcms.telemetry.collectors.ai.TotalSitesUsingDotaiMetricType;
-import com.dotcms.telemetry.collectors.ai.TotalSitesWithAutoIndexContentConfigMetricType;
 import com.dotcms.telemetry.collectors.api.ApiMetricAPI;
-import com.dotcms.telemetry.collectors.container.TotalFileContainersInLivePageDatabaseMetricType;
-import com.dotcms.telemetry.collectors.container.TotalFileContainersInLiveTemplatesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.container.TotalFileContainersInWorkingPageDatabaseMetricType;
-import com.dotcms.telemetry.collectors.container.TotalStandardContainersInLivePageDatabaseMetricType;
-import com.dotcms.telemetry.collectors.container.TotalStandardContainersInLiveTemplatesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.container.TotalStandardContainersInWorkingPageDatabaseMetricType;
-import com.dotcms.telemetry.collectors.content.*;
-import com.dotcms.telemetry.collectors.contenttype.CountOfBinaryFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfBlockEditorFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfCategoryFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfCheckboxFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfColumnsFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfConstantFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfDateFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfDateTimeFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfFileFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfHiddenFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfImageFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfJSONFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfKeyValueFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfLineDividersFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfMultiselectFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfPermissionsFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfRadioFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfRelationshipFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfRowsFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfSelectFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfSiteOrFolderFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfTabFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfTagFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfTextAreaFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfTextFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfTimeFieldsMetricType;
-import com.dotcms.telemetry.collectors.contenttype.CountOfWYSIWYGFieldsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountExperimentsEditedInThePast30DaysMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountExperimentsWithBounceRateGoalMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountExperimentsWithExitRateGoalMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountExperimentsWithReachPageGoalMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountExperimentsWithURLParameterGoalMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountPagesWithAllEndedExperimentsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountPagesWithArchivedExperimentsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountPagesWithDraftExperimentsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountPagesWithRunningExperimentsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountPagesWithScheduledExperimentsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountVariantsInAllArchivedExperimentsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountVariantsInAllDraftExperimentsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountVariantsInAllEndedExperimentsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountVariantsInAllRunningExperimentsMetricType;
-import com.dotcms.telemetry.collectors.experiment.CountVariantsInAllScheduledExperimentsMetricType;
-import com.dotcms.telemetry.collectors.language.HasChangeDefaultLanguagesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.language.OldStyleLanguagesVarialeMetricType;
-import com.dotcms.telemetry.collectors.language.TotalLanguagesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.language.TotalLiveLanguagesVariablesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.language.TotalUniqueLanguagesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.language.TotalWorkingLanguagesVariablesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.CountOfLiveSitesWithSiteVariablesMetricType;
-import com.dotcms.telemetry.collectors.site.CountOfSitesWithIndividualPermissionsMetricType;
-import com.dotcms.telemetry.collectors.site.CountOfSitesWithThumbnailsMetricType;
-import com.dotcms.telemetry.collectors.site.CountOfWorkingSitesWithSiteVariablesMetricType;
-import com.dotcms.telemetry.collectors.site.SitesWithNoDefaultTagStorageDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.SitesWithNoSystemFieldsDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.SitesWithRunDashboardDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.TotalActiveSitesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.TotalAliasesActiveSitesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.TotalAliasesAllSitesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.site.TotalSitesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.sitesearch.CountSiteSearchDocumentMetricType;
-import com.dotcms.telemetry.collectors.sitesearch.CountSiteSearchIndicesMetricType;
-import com.dotcms.telemetry.collectors.sitesearch.TotalSizeSiteSearchIndicesMetricType;
-import com.dotcms.telemetry.collectors.template.TotalAdvancedTemplatesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.template.TotalBuilderTemplatesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.template.TotalTemplatesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.template.TotalTemplatesInLivePagesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.template.TotalTemplatesInWorkingPagesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.theme.TotalFilesInThemeMetricType;
-import com.dotcms.telemetry.collectors.theme.TotalLiveContainerDatabaseMetricType;
-import com.dotcms.telemetry.collectors.theme.TotalLiveFilesInThemeMetricType;
-import com.dotcms.telemetry.collectors.theme.TotalSizeOfFilesPerThemeMetricType;
-import com.dotcms.telemetry.collectors.theme.TotalThemeMetricType;
-import com.dotcms.telemetry.collectors.theme.TotalThemeUsedInLiveTemplatesMetricType;
-import com.dotcms.telemetry.collectors.theme.TotalThemeUsedInWorkingTemplatesMetricType;
-import com.dotcms.telemetry.collectors.theme.TotalWorkingContainerDatabaseMetricType;
-import com.dotcms.telemetry.collectors.urlmap.ContentTypesWithUrlMapDatabaseMetricType;
-import com.dotcms.telemetry.collectors.urlmap.LiveContentInUrlMapDatabaseMetricType;
-import com.dotcms.telemetry.collectors.urlmap.UrlMapPatterWithTwoVariablesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.urlmap.WorkingContentInUrlMapDatabaseMetricType;
-import com.dotcms.telemetry.collectors.user.ActiveUsersDatabaseMetricType;
-import com.dotcms.telemetry.collectors.user.LastLoginDatabaseMetricType;
-import com.dotcms.telemetry.collectors.user.LastLoginUserDatabaseMetric;
-import com.dotcms.telemetry.collectors.workflow.ActionsDatabaseMetricType;
-import com.dotcms.telemetry.collectors.workflow.ContentTypesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.workflow.SchemesDatabaseMetricType;
-import com.dotcms.telemetry.collectors.workflow.StepsDatabaseMetricType;
-import com.dotcms.telemetry.collectors.workflow.SubActionsDatabaseMetricType;
-import com.dotcms.telemetry.collectors.workflow.UniqueSubActionsDatabaseMetricType;
 import com.dotcms.telemetry.util.MetricCaches;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Logger;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
 /**
- * This class collects and generates all the different Metrics that will be reported to a User or
- * any other application/client.
+ * Collects and generates all metrics for telemetry reporting.
+ * 
+ * <p>Automatically discovers all {@code @ApplicationScoped MetricType} implementations
+ * via CDI's {@link Instance} injection. Metrics are collected and aggregated into
+ * a {@link MetricsSnapshot} for reporting.</p>
+ * 
+ * <p>For dashboard-specific metrics, see {@link DashboardMetricsProvider}.</p>
  *
  * @author Freddy Rodriguez
  * @since Jan 8th, 2024
  */
-public final class MetricStatsCollector {
-
-    public static final ApiMetricAPI apiStatAPI = CDIUtils.getBeanThrows(ApiMetricAPI.class);
-    static final Collection<MetricType> metricStatsCollectors;
-
-    private MetricStatsCollector() {
-
-    }
-
-    static {
-        metricStatsCollectors = new HashSet<>();
-
-        metricStatsCollectors.add(new LastContentEditedDatabaseMetricType());
-        metricStatsCollectors.add(new RecentlyEditedContentDatabaseMetricType());
-        metricStatsCollectors.add(new LastLoginDatabaseMetricType());
-        metricStatsCollectors.add(new LastLoginUserDatabaseMetric());
-
-        metricStatsCollectors.add(new SchemesDatabaseMetricType());
-        metricStatsCollectors.add(new ContentTypesDatabaseMetricType());
-        metricStatsCollectors.add(new StepsDatabaseMetricType());
-        metricStatsCollectors.add(new ActionsDatabaseMetricType());
-        metricStatsCollectors.add(new SubActionsDatabaseMetricType());
-        metricStatsCollectors.add(new UniqueSubActionsDatabaseMetricType());
-
-        metricStatsCollectors.add(new TotalContentsDatabaseMetricType());
-        metricStatsCollectors.add(new WorkingNotDefaultLanguageContentsDatabaseMetricType());
-        metricStatsCollectors.add(new LiveNotDefaultLanguageContentsDatabaseMetricType());
-        metricStatsCollectors.add(new OldStyleLanguagesVarialeMetricType());
-
-        metricStatsCollectors.add(new ActiveUsersDatabaseMetricType());
-        metricStatsCollectors.add(new ContentTypesWithUrlMapDatabaseMetricType());
-        metricStatsCollectors.add(new LiveContentInUrlMapDatabaseMetricType());
-        metricStatsCollectors.add(new UrlMapPatterWithTwoVariablesDatabaseMetricType());
-        metricStatsCollectors.add(new WorkingContentInUrlMapDatabaseMetricType());
-
-        metricStatsCollectors.add(new HasChangeDefaultLanguagesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalLanguagesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalLiveLanguagesVariablesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalUniqueLanguagesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalWorkingLanguagesVariablesDatabaseMetricType());
-
-        metricStatsCollectors.add(new CountOfSitesWithIndividualPermissionsMetricType());
-        metricStatsCollectors.add(new CountOfSitesWithThumbnailsMetricType());
-        metricStatsCollectors.add(new CountOfWorkingSitesWithSiteVariablesMetricType());
-        metricStatsCollectors.add(new CountOfLiveSitesWithSiteVariablesMetricType());
-
-        metricStatsCollectors.add(new SitesWithNoSystemFieldsDatabaseMetricType());
-        metricStatsCollectors.add(new SitesWithNoDefaultTagStorageDatabaseMetricType());
-        metricStatsCollectors.add(new SitesWithRunDashboardDatabaseMetricType());
-        metricStatsCollectors.add(new TotalAliasesAllSitesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalAliasesActiveSitesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalSitesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalActiveSitesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalAdvancedTemplatesDatabaseMetricType());
-
-        metricStatsCollectors.add(new CountSiteSearchDocumentMetricType());
-        metricStatsCollectors.add(new CountSiteSearchIndicesMetricType());
-        metricStatsCollectors.add(new TotalSizeSiteSearchIndicesMetricType());
-
-        metricStatsCollectors.add(new TotalTemplatesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalTemplatesInLivePagesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalTemplatesInWorkingPagesDatabaseMetricType());
-        metricStatsCollectors.add(new TotalBuilderTemplatesDatabaseMetricType());
-
-        metricStatsCollectors.add(new TotalThemeUsedInLiveTemplatesMetricType());
-        metricStatsCollectors.add(new TotalThemeUsedInWorkingTemplatesMetricType());
-
-        metricStatsCollectors.add(new TotalLiveFilesInThemeMetricType());
-        metricStatsCollectors.add(new TotalFilesInThemeMetricType());
-        metricStatsCollectors.add(new TotalThemeMetricType());
-        metricStatsCollectors.add(new TotalSizeOfFilesPerThemeMetricType());
-
-        metricStatsCollectors.add(new TotalLiveContainerDatabaseMetricType());
-        metricStatsCollectors.add(new TotalWorkingContainerDatabaseMetricType());
-
-        if (CDIUtils.getBean(MetricsAPI.class).isPresent()) {
-            final MetricsAPI metricsAPI = CDIUtils.getBean(MetricsAPI.class).get();
-            metricStatsCollectors.add(new TotalStandardContainersInLivePageDatabaseMetricType(metricsAPI));
-            metricStatsCollectors.add(new TotalFileContainersInLivePageDatabaseMetricType(metricsAPI));
-            metricStatsCollectors.add(new TotalStandardContainersInWorkingPageDatabaseMetricType(metricsAPI));
-            metricStatsCollectors.add(new TotalFileContainersInWorkingPageDatabaseMetricType(metricsAPI));
-
-            metricStatsCollectors.add(new TotalFileContainersInLiveTemplatesDatabaseMetricType(metricsAPI));
-            metricStatsCollectors.add(new TotalStandardContainersInLiveTemplatesDatabaseMetricType(metricsAPI));
-        } else {
-            Logger.debug(MetricStatsCollector.class, () -> "MetricsAPI could not be injected via CDI");
-        }
-
-        metricStatsCollectors.add(new CountOfCategoryFieldsMetricType());
-        metricStatsCollectors.add(new CountOfConstantFieldsMetricType());
-        metricStatsCollectors.add(new CountOfDateFieldsMetricType());
-        metricStatsCollectors.add(new CountOfDateTimeFieldsMetricType());
-        metricStatsCollectors.add(new CountOfBinaryFieldsMetricType());
-        metricStatsCollectors.add(new CountOfBlockEditorFieldsMetricType());
-        metricStatsCollectors.add(new CountOfCheckboxFieldsMetricType());
-        metricStatsCollectors.add(new CountOfColumnsFieldsMetricType());
-        metricStatsCollectors.add(new CountOfFileFieldsMetricType());
-        metricStatsCollectors.add(new CountOfImageFieldsMetricType());
-        metricStatsCollectors.add(new CountOfJSONFieldsMetricType());
-        metricStatsCollectors.add(new CountOfKeyValueFieldsMetricType());
-        metricStatsCollectors.add(new CountOfLineDividersFieldsMetricType());
-        metricStatsCollectors.add(new CountOfMultiselectFieldsMetricType());
-        metricStatsCollectors.add(new CountOfRadioFieldsMetricType());
-        metricStatsCollectors.add(new CountOfRowsFieldsMetricType());
-        metricStatsCollectors.add(new CountOfSelectFieldsMetricType());
-        metricStatsCollectors.add(new CountOfTabFieldsMetricType());
-        metricStatsCollectors.add(new CountOfHiddenFieldsMetricType());
-        metricStatsCollectors.add(new CountOfPermissionsFieldsMetricType());
-        metricStatsCollectors.add(new CountOfRelationshipFieldsMetricType());
-        metricStatsCollectors.add(new CountOfSiteOrFolderFieldsMetricType());
-        metricStatsCollectors.add(new CountOfTagFieldsMetricType());
-        metricStatsCollectors.add(new CountOfTextAreaFieldsMetricType());
-        metricStatsCollectors.add(new CountOfTextFieldsMetricType());
-        metricStatsCollectors.add(new CountOfTimeFieldsMetricType());
-        metricStatsCollectors.add(new CountOfWYSIWYGFieldsMetricType());
-
-        metricStatsCollectors.add(new TotalSitesUsingDotaiMetricType());
-        metricStatsCollectors.add(new TotalEmbeddingsIndexesMetricType());
-        metricStatsCollectors.add(new TotalSitesWithAutoIndexContentConfigMetricType());
-
-        // adding experiments metrics
-        metricStatsCollectors.add(new CountVariantsInAllScheduledExperimentsMetricType());
-        metricStatsCollectors.add(new CountVariantsInAllRunningExperimentsMetricType());
-        metricStatsCollectors.add(new CountVariantsInAllEndedExperimentsMetricType());
-        metricStatsCollectors.add(new CountVariantsInAllDraftExperimentsMetricType());
-        metricStatsCollectors.add(new CountVariantsInAllArchivedExperimentsMetricType());
-        metricStatsCollectors.add(new CountPagesWithScheduledExperimentsMetricType());
-        metricStatsCollectors.add(new CountPagesWithRunningExperimentsMetricType());
-        metricStatsCollectors.add(new CountPagesWithDraftExperimentsMetricType());
-        metricStatsCollectors.add(new CountPagesWithArchivedExperimentsMetricType());
-        metricStatsCollectors.add(new CountPagesWithAllEndedExperimentsMetricType());
-        metricStatsCollectors.add(new CountExperimentsWithURLParameterGoalMetricType());
-        metricStatsCollectors.add(new CountExperimentsWithReachPageGoalMetricType());
-        metricStatsCollectors.add(new CountExperimentsWithExitRateGoalMetricType());
-        metricStatsCollectors.add(new CountExperimentsWithBounceRateGoalMetricType());
-        metricStatsCollectors.add(new CountExperimentsEditedInThePast30DaysMetricType());
-
-        metricStatsCollectors.add(new ImportContentletsJobTriggeredMetricType());
-    }
-
-    public static MetricsSnapshot getStatsAndCleanUp() {
-        final MetricsSnapshot stats = getStats();
-
-        apiStatAPI.flushTemporaryTable();
-        return stats;
-    }
+@ApplicationScoped
+public class MetricStatsCollector {
+    
+    @Inject
+    private Instance<MetricType> metricTypes;
+    
+    @Inject
+    private ApiMetricAPI apiStatAPI;
 
     /**
      * Calculate a MetricSnapshot by iterating through all the MetricType collections.
      *
      * @return the {@link MetricsSnapshot} with all the calculated metrics.
      */
-    public static MetricsSnapshot getStats() {
+    public MetricsSnapshot getStats() {
         return getStats(Set.of());
     }
+    
     /**
      * Calculate a MetricSnapshot by iterating through all the MetricType collections.
      *
+     * @param metricNameSet the set of metric names to filter by (empty set means all metrics)
      * @return the {@link MetricsSnapshot} with all the calculated metrics.
      */
-    public static MetricsSnapshot getStats(final Set<String> metricNameSet) {
-
+    public MetricsSnapshot getStats(final Set<String> metricNameSet) {
         final Collection<MetricValue> stats = new ArrayList<>();
         final Collection<MetricValue> noNumberStats = new ArrayList<>();
         Collection<MetricCalculationError> errors = new ArrayList<>();
@@ -292,8 +62,10 @@ public final class MetricStatsCollector {
         try {
             openDBConnection();
 
-            for (final MetricType metricType : metricStatsCollectors) {
+            // Use CDI-discovered metrics if available, otherwise fall back to static collection
+            final Collection<MetricType> collectors = getMetricCollectors();
 
+            for (final MetricType metricType : collectors) {
                 // If the metricNameSet is not empty and the metricNameSet does not contain the metricType name, skip it
                 if (!metricNameSet.isEmpty() && !metricNameSet.contains(metricType.getName())) {
                     continue;
@@ -325,7 +97,47 @@ public final class MetricStatsCollector {
                 .build();
     }
 
-    private static Optional<MetricValue> getMetricValue(final MetricType metricType) throws DotDataException {
+    /**
+     * Get all metric collectors via CDI discovery.
+     * 
+     * <p>CDI guarantees that {@code @Inject Instance<T>} fields are never null.
+     * If no beans are found, CDI injects an empty {@code Instance} that iterates to nothing.
+     * This method iterates over all discovered MetricType implementations.</p>
+     * 
+     * @return collection of all MetricType implementations discovered by CDI
+     */
+    private Collection<MetricType> getMetricCollectors() {
+        final Collection<MetricType> collectors = new ArrayList<>();
+        
+        Logger.info(this, "Starting MetricType discovery via CDI Instance<MetricType>");
+        
+        // CDI guarantees metricTypes is never null - it injects an empty Instance if no beans found
+        for (MetricType metricType : metricTypes) {
+            collectors.add(metricType);
+            Logger.debug(this, () -> String.format("MetricStatsCollector discovered: %s", metricType.getClass().getName()));
+        }
+        
+        if (collectors.isEmpty()) {
+            Logger.warn(this, "MetricStatsCollector discovered 0 MetricType implementations via CDI! This indicates a CDI scanning/configuration issue.");
+        } else {
+            Logger.info(this, () -> String.format("MetricStatsCollector discovered %d MetricType implementations via CDI", collectors.size()));
+        }
+        
+        return collectors;
+    }
+
+    /**
+     * Get stats and clean up temporary API table.
+     *
+     * @return the {@link MetricsSnapshot} with all the calculated metrics.
+     */
+    public MetricsSnapshot getStatsAndCleanUp() {
+        final MetricsSnapshot stats = getStats();
+        apiStatAPI.flushTemporaryTable();
+        return stats;
+    }
+
+    private Optional<MetricValue> getMetricValue(final MetricType metricType) throws DotDataException {
         final Optional<MetricValue> metricStatsOptional = metricType.getStat();
 
         if (metricStatsOptional.isPresent()) {
@@ -340,7 +152,7 @@ public final class MetricStatsCollector {
         return metricStatsOptional;
     }
 
-    private static void openDBConnection() {
+    private void openDBConnection() {
         DbConnectionFactory.getConnection();
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/ai/TotalEmbeddingsIndexesMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/ai/TotalEmbeddingsIndexesMetricType.java
@@ -8,7 +8,9 @@ import com.dotmarketing.util.UtilMethods;
 
 import java.util.Map;
 import java.util.Optional;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class TotalEmbeddingsIndexesMetricType implements MetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/ai/TotalSitesUsingDotaiMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/ai/TotalSitesUsingDotaiMetricType.java
@@ -17,7 +17,9 @@ import javax.ws.rs.NotSupportedException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class TotalSitesUsingDotaiMetricType implements MetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/ai/TotalSitesWithAutoIndexContentConfigMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/ai/TotalSitesWithAutoIndexContentConfigMetricType.java
@@ -19,7 +19,9 @@ import javax.ws.rs.NotSupportedException;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class TotalSitesWithAutoIndexContentConfigMetricType implements MetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/container/TotalFileContainersInLivePageDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/container/TotalFileContainersInLivePageDatabaseMetricType.java
@@ -4,10 +4,12 @@ import com.dotcms.telemetry.business.MetricsAPI;
 import com.dotmarketing.portlets.containers.business.FileAssetContainerUtil;
 
 import javax.inject.Inject;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Total of FILE containers used in LIVE pages
  */
+@ApplicationScoped
 public class TotalFileContainersInLivePageDatabaseMetricType extends TotalContainersInLivePageDatabaseMetricType {
 
     @Inject

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/container/TotalFileContainersInWorkingPageDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/container/TotalFileContainersInWorkingPageDatabaseMetricType.java
@@ -4,10 +4,12 @@ import com.dotcms.telemetry.business.MetricsAPI;
 import com.dotmarketing.portlets.containers.business.FileAssetContainerUtil;
 
 import javax.inject.Inject;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Total of FILE containers used in LIVE pages
  */
+@ApplicationScoped
 public class TotalFileContainersInWorkingPageDatabaseMetricType extends TotalContainersInWorkingPageDatabaseMetricType {
 
     @Inject

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/container/TotalStandardContainersInLivePageDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/container/TotalStandardContainersInLivePageDatabaseMetricType.java
@@ -3,11 +3,13 @@ package com.dotcms.telemetry.collectors.container;
 import com.dotcms.telemetry.business.MetricsAPI;
 import com.dotmarketing.portlets.containers.business.FileAssetContainerUtil;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 /**
  * Total of STANDARD containers used in LIVE pages
  */
+@ApplicationScoped
 public class TotalStandardContainersInLivePageDatabaseMetricType extends TotalContainersInLivePageDatabaseMetricType {
 
     @Inject

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/container/TotalStandardContainersInWorkingPageDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/container/TotalStandardContainersInWorkingPageDatabaseMetricType.java
@@ -4,10 +4,12 @@ import com.dotcms.telemetry.business.MetricsAPI;
 import com.dotmarketing.portlets.containers.business.FileAssetContainerUtil;
 
 import javax.inject.Inject;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Total of STANDARD containers used in WORKING pages
  */
+@ApplicationScoped
 public class TotalStandardContainersInWorkingPageDatabaseMetricType extends TotalContainersInWorkingPageDatabaseMetricType {
 
     @Inject

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/ImportContentletsJobTriggeredMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/ImportContentletsJobTriggeredMetricType.java
@@ -3,7 +3,9 @@ package com.dotcms.telemetry.collectors.content;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class ImportContentletsJobTriggeredMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/LastContentEditedDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/LastContentEditedDatabaseMetricType.java
@@ -1,12 +1,17 @@
 package com.dotcms.telemetry.collectors.content;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
 
+import javax.enterprise.context.ApplicationScoped;
+
 /**
  * Collects the modification date of the most recently edited Contentlet
  */
+@ApplicationScoped
+@DashboardMetric(category = "content", priority = 3)
 public class LastContentEditedDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/LiveNotDefaultLanguageContentsDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/LiveNotDefaultLanguageContentsDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.content;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of contentlets which have at least one live version in a non-default Language
  */
+@ApplicationScoped
 public class LiveNotDefaultLanguageContentsDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/RecentlyEditedContentDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/RecentlyEditedContentDatabaseMetricType.java
@@ -1,12 +1,17 @@
 package com.dotcms.telemetry.collectors.content;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
 
+import javax.enterprise.context.ApplicationScoped;
+
 /**
  * Collect the count of Contentlets that were edited less than a month ago
  */
+@ApplicationScoped
+@DashboardMetric(category = "content", priority = 2)
 public class RecentlyEditedContentDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/TotalContentsDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/TotalContentsDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.content;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total number of contentlets
  */
+@ApplicationScoped
+@DashboardMetric(category = "content", priority = 1)
 public class TotalContentsDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/WorkingNotDefaultLanguageContentsDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/WorkingNotDefaultLanguageContentsDatabaseMetricType.java
@@ -3,11 +3,13 @@ package com.dotcms.telemetry.collectors.content;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of Contentlets that has at least one working version on any non-default language and that
  * also don't have live version on any non-default language
  */
+@ApplicationScoped
 public class WorkingNotDefaultLanguageContentsDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfBinaryFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfBinaryFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfBinaryFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.BinaryField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfBlockEditorFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfBlockEditorFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfBlockEditorFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.StoryBlockField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfCategoryFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfCategoryFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfCategoryFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.CategoryField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfCheckboxFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfCheckboxFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfCheckboxFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.CheckboxField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfColumnsFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfColumnsFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfColumnsFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.ColumnField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfConstantFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfConstantFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfConstantFieldsMetricType extends ContentTypeFieldsMetricType {
     @Override
     boolean filterCondition(Map<String, Object> map) {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfDateFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfDateFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfDateFieldsMetricType extends ContentTypeFieldsMetricType {
     @Override
     boolean filterCondition(Map<String, Object> map) {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfDateTimeFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfDateTimeFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfDateTimeFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.DateTimeField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfFileFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfFileFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfFileFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.FileField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfHiddenFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfHiddenFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfHiddenFieldsMetricType extends ContentTypeFieldsMetricType {
     @Override
     boolean filterCondition(Map<String, Object> map) {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfImageFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfImageFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfImageFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.ImageField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfJSONFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfJSONFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfJSONFieldsMetricType extends ContentTypeFieldsMetricType {
     @Override
     boolean filterCondition(Map<String, Object> map) {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfKeyValueFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfKeyValueFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfKeyValueFieldsMetricType extends ContentTypeFieldsMetricType {
     @Override
     boolean filterCondition(Map<String, Object> map) {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfLineDividersFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfLineDividersFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfLineDividersFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.LineDividerField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfMultiselectFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfMultiselectFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfMultiselectFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.MultiSelectField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfPermissionsFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfPermissionsFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfPermissionsFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.PermissionTabField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfRadioFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfRadioFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfRadioFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.RadioField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfRelationshipFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfRelationshipFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfRelationshipFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.RelationshipField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfRowsFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfRowsFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfRowsFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.RowField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfSelectFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfSelectFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfSelectFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.SelectField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfSiteOrFolderFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfSiteOrFolderFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfSiteOrFolderFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.HostFolderField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTabFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTabFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfTabFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.TabDividerField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTagFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTagFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfTagFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.TagField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTextAreaFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTextAreaFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfTextAreaFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.TextAreaField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTextFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTextFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfTextFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.TextField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTimeFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfTimeFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfTimeFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.TimeField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfWYSIWYGFieldsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/contenttype/CountOfWYSIWYGFieldsMetricType.java
@@ -1,7 +1,9 @@
 package com.dotcms.telemetry.collectors.contenttype;
 
 import java.util.Map;
+import javax.enterprise.context.ApplicationScoped;
 
+@ApplicationScoped
 public class CountOfWYSIWYGFieldsMetricType extends ContentTypeFieldsMetricType {
     boolean filterCondition(Map<String, Object> map) {
         return "com.dotcms.contenttype.model.field.WysiwygField".equals(map.get("field_type"));

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsEditedInThePast30DaysMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsEditedInThePast30DaysMetricType.java
@@ -3,11 +3,13 @@ package com.dotcms.telemetry.collectors.experiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count the experiments edited in the past 30 days
  * @author jsanca
  */
+@ApplicationScoped
 public class CountExperimentsEditedInThePast30DaysMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsWithBounceRateGoalMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsWithBounceRateGoalMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.analytics.metrics.MetricType;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count the experiments with bounce rate goal
  * @author jsanca
  */
+@ApplicationScoped
 public class CountExperimentsWithBounceRateGoalMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsWithExitRateGoalMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsWithExitRateGoalMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.analytics.metrics.MetricType;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count the experiments with exit rate goal
  * @author jsanca
  */
+@ApplicationScoped
 public class CountExperimentsWithExitRateGoalMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsWithReachPageGoalMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsWithReachPageGoalMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.analytics.metrics.MetricType;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count the experiments with reach page goal
  * @author jsanca
  */
+@ApplicationScoped
 public class CountExperimentsWithReachPageGoalMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsWithURLParameterGoalMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountExperimentsWithURLParameterGoalMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.analytics.metrics.MetricType;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count the experiments with url parameter goal
  * @author jsanca
  */
+@ApplicationScoped
 public class CountExperimentsWithURLParameterGoalMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithAllEndedExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithAllEndedExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count pages with ended experiments
  * @author jsanca
  */
+@ApplicationScoped
 public class CountPagesWithAllEndedExperimentsMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithArchivedExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithArchivedExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count pages with archived experiments
  * @author jsanca
  */
+@ApplicationScoped
 public class CountPagesWithArchivedExperimentsMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithDraftExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithDraftExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count pages with draft experiments
  * @author jsanca
  */
+@ApplicationScoped
 public class CountPagesWithDraftExperimentsMetricType  implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithRunningExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithRunningExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count pages with running experiments
  * @author jsanca
  */
+@ApplicationScoped
 public class CountPagesWithRunningExperimentsMetricType  implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithScheduledExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountPagesWithScheduledExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count pages with scheduled experiments
  * @author jsanca
  */
+@ApplicationScoped
 public class CountPagesWithScheduledExperimentsMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllArchivedExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllArchivedExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count the variants on all archived experiments
  * @author jsanca
  */
+@ApplicationScoped
 public class CountVariantsInAllArchivedExperimentsMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllDraftExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllDraftExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count the variants on draft experiments
  * @author jsanca
  */
+@ApplicationScoped
 public class CountVariantsInAllDraftExperimentsMetricType   implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllEndedExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllEndedExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count variants with ended experiments
  * @author jsanca
  */
+@ApplicationScoped
 public class CountVariantsInAllEndedExperimentsMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllRunningExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllRunningExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Metric type to count variants with running experiments
  * @author jsanca
  */
+@ApplicationScoped
 public class CountVariantsInAllRunningExperimentsMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllScheduledExperimentsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/experiment/CountVariantsInAllScheduledExperimentsMetricType.java
@@ -4,11 +4,13 @@ import com.dotcms.experiments.model.AbstractExperiment;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Count Variants in All Scheduled Experiments Metric Type
  * @author jsanca
  */
+@ApplicationScoped
 public class CountVariantsInAllScheduledExperimentsMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/image/CountOfContentAssetImageBEAPICalls.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/image/CountOfContentAssetImageBEAPICalls.java
@@ -7,6 +7,7 @@ import com.dotcms.rest.api.v1.HTTPMethod;
 import com.dotmarketing.util.PageMode;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -14,6 +15,7 @@ import javax.servlet.http.HttpServletResponse;
  * Represents a Metric to count how many times the Endpoint '/contentAsset/image/' is called from
  * Back End.
  */
+@ApplicationScoped
 public class CountOfContentAssetImageBEAPICalls extends ApiMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/image/CountOfContentAssetImageFEAPICalls.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/image/CountOfContentAssetImageFEAPICalls.java
@@ -7,6 +7,7 @@ import com.dotcms.rest.api.v1.HTTPMethod;
 import com.dotmarketing.util.PageMode;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -14,6 +15,7 @@ import javax.servlet.http.HttpServletResponse;
  * Represents a Metric to count how many times the Endpoint '/contentAsset/image/' is called from
  * Front End.
  */
+@ApplicationScoped
 public class CountOfContentAssetImageFEAPICalls extends ApiMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/image/CountOfDAImageBEAPICalls.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/image/CountOfDAImageBEAPICalls.java
@@ -7,12 +7,14 @@ import com.dotcms.rest.api.v1.HTTPMethod;
 import com.dotmarketing.util.PageMode;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
  * Represents a Metric to count how many times the Endpoint '/dA' is called From Back End.
  */
+@ApplicationScoped
 public class CountOfDAImageBEAPICalls extends ApiMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/image/CountOfDAImageFEAPICalls.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/image/CountOfDAImageFEAPICalls.java
@@ -7,12 +7,14 @@ import com.dotcms.rest.api.v1.HTTPMethod;
 import com.dotmarketing.util.PageMode;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
  * Represents a Metric to count how many times the Endpoint '/dA' is called from Front End.
  */
+@ApplicationScoped
 public class CountOfDAImageFEAPICalls extends ApiMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/HasChangeDefaultLanguagesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/HasChangeDefaultLanguagesDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.language;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Checks if the default language was changed from English
  */
+@ApplicationScoped
 public class HasChangeDefaultLanguagesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/OldStyleLanguagesVarialeMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/OldStyleLanguagesVarialeMetricType.java
@@ -11,11 +11,13 @@ import com.dotmarketing.portlets.languagesmanager.model.LanguageKey;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of old style Language Variables
  */
 
+@ApplicationScoped
 public class OldStyleLanguagesVarialeMetricType implements MetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/TotalLanguagesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/TotalLanguagesDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.language;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of languages
  */
+@ApplicationScoped
+@DashboardMetric(category = "system", priority = 1)
 public class TotalLanguagesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/TotalLiveLanguagesVariablesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/TotalLiveLanguagesVariablesDatabaseMetricType.java
@@ -4,10 +4,12 @@ import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of Language Variables that have a live version.
  */
+@ApplicationScoped
 public class TotalLiveLanguagesVariablesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/TotalUniqueLanguagesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/TotalUniqueLanguagesDatabaseMetricType.java
@@ -3,11 +3,13 @@ package com.dotcms.telemetry.collectors.language;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of unique configured dotCMS Languages, it means that if two o more Countries use the same
  * language then it just count as one
  */
+@ApplicationScoped
 public class TotalUniqueLanguagesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/TotalWorkingLanguagesVariablesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/language/TotalWorkingLanguagesVariablesDatabaseMetricType.java
@@ -4,10 +4,12 @@ import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the count of Language Variable that does not have Live Version.
  */
+@ApplicationScoped
 public class TotalWorkingLanguagesVariablesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfLiveSitesWithSiteVariablesMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfLiveSitesWithSiteVariablesMetricType.java
@@ -1,4 +1,5 @@
 package com.dotcms.telemetry.collectors.site;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of started (live) Sites that have Site Variables.
@@ -6,6 +7,7 @@ package com.dotcms.telemetry.collectors.site;
  * @author Jose Castro
  * @since Oct 4th, 2024
  */
+@ApplicationScoped
 public class CountOfLiveSitesWithSiteVariablesMetricType extends CountOfSitesWithSiteVariablesMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfSitesWithIndividualPermissionsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfSitesWithIndividualPermissionsMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.site;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of sites with permissions not inheriting from System Host
  */
+@ApplicationScoped
 public class CountOfSitesWithIndividualPermissionsMetricType implements DBMetricType {
 
 

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfSitesWithThumbnailsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfSitesWithThumbnailsMetricType.java
@@ -15,10 +15,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of sites with thumbnails set
  */
+@ApplicationScoped
 public class CountOfSitesWithThumbnailsMetricType implements MetricType {
 
     private static final String ALL_SITES_INODES = "SELECT c.inode AS inode \n" +

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfWorkingSitesWithSiteVariablesMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfWorkingSitesWithSiteVariablesMetricType.java
@@ -1,4 +1,5 @@
 package com.dotcms.telemetry.collectors.site;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of stopped (working) Sites that have Site Variables.
@@ -6,6 +7,7 @@ package com.dotcms.telemetry.collectors.site;
  * @author Jose Castro
  * @since Oct 4th, 2024
  */
+@ApplicationScoped
 public class CountOfWorkingSitesWithSiteVariablesMetricType extends CountOfSitesWithSiteVariablesMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/SitesWithNoDefaultTagStorageDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/SitesWithNoDefaultTagStorageDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.site;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of sites With non-default value on the tagStorage attribute
  */
+@ApplicationScoped
 public class SitesWithNoDefaultTagStorageDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/SitesWithNoSystemFieldsDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/SitesWithNoSystemFieldsDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.site;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of non-system fields in Host content type
  */
+@ApplicationScoped
 public class SitesWithNoSystemFieldsDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/SitesWithRunDashboardDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/SitesWithRunDashboardDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.site;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of sites with 'Run Dashboard' enabled
  */
+@ApplicationScoped
 public class SitesWithRunDashboardDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/TotalActiveSitesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/TotalActiveSitesDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.site;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of active sites
  */
+@ApplicationScoped
+@DashboardMetric(category = "site", priority = 2)
 public class TotalActiveSitesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/TotalAliasesActiveSitesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/TotalAliasesActiveSitesDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.site;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of aliases on all active sites
  */
+@ApplicationScoped
 public class TotalAliasesActiveSitesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/TotalAliasesAllSitesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/TotalAliasesAllSitesDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.site;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of aliases on all sites
  */
+@ApplicationScoped
+@DashboardMetric(category = "site", priority = 3)
 public class TotalAliasesAllSitesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/TotalSitesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/TotalSitesDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.site;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of sites
  */
+@ApplicationScoped
+@DashboardMetric(category = "site", priority = 1)
 public class TotalSitesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/sitesearch/CountSiteSearchDocumentMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/sitesearch/CountSiteSearchDocumentMetricType.java
@@ -6,10 +6,12 @@ import com.dotmarketing.exception.DotDataException;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the number of documents in all site search indexes.
  */
+@ApplicationScoped
 public class CountSiteSearchDocumentMetricType extends IndicesSiteSearchMetricType {
 
 

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/sitesearch/CountSiteSearchIndicesMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/sitesearch/CountSiteSearchIndicesMetricType.java
@@ -5,10 +5,12 @@ import com.dotmarketing.exception.DotDataException;
 
 import java.util.Collection;
 import java.util.Optional;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the count of Site Search indices
  */
+@ApplicationScoped
 public class CountSiteSearchIndicesMetricType extends IndicesSiteSearchMetricType {
 
 

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/sitesearch/TotalSizeSiteSearchIndicesMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/sitesearch/TotalSizeSiteSearchIndicesMetricType.java
@@ -7,10 +7,12 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the total size in Mb of all the Site Search indices.
  */
+@ApplicationScoped
 public class TotalSizeSiteSearchIndicesMetricType extends IndicesSiteSearchMetricType {
 
 

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalAdvancedTemplatesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalAdvancedTemplatesDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.template;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of advanced templates
  */
+@ApplicationScoped
 public class TotalAdvancedTemplatesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalBuilderTemplatesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalBuilderTemplatesDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.template;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of builder templates, it means excluding File, Advanced, and Layout templates
  */
+@ApplicationScoped
+@DashboardMetric(category = "system", priority = 5)
 public class TotalBuilderTemplatesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalTemplatesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalTemplatesDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.template;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of templates
  */
+@ApplicationScoped
+@DashboardMetric(category = "site", priority = 4)
 public class TotalTemplatesDatabaseMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalTemplatesInLivePagesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalTemplatesInLivePagesDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.template;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total all templates used in LIVE pages
  */
+@ApplicationScoped
 public class TotalTemplatesInLivePagesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalTemplatesInWorkingPagesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/template/TotalTemplatesInWorkingPagesDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.template;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total all templates used in Working pages
  */
+@ApplicationScoped
 public class TotalTemplatesInWorkingPagesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalFilesInThemeMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalFilesInThemeMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.theme;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total of Number of LIVE/WORKING files in themes
  */
+@ApplicationScoped
 public class TotalFilesInThemeMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalLiveContainerDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalLiveContainerDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.theme;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of Live containers
  */
+@ApplicationScoped
+@DashboardMetric(category = "system", priority = 4)
 public class TotalLiveContainerDatabaseMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalLiveFilesInThemeMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalLiveFilesInThemeMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.theme;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total of Number of LIVE files in themes
  */
+@ApplicationScoped
 public class TotalLiveFilesInThemeMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalSizeOfFilesPerThemeMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalSizeOfFilesPerThemeMetricType.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * This Metric collects the total size -- in bytes -- of all files that live under every Theme in
@@ -24,6 +25,7 @@ import java.util.stream.Collectors;
  * @author Jose Castro
  * @since Mar 25th, 2025
  */
+@ApplicationScoped
 public class TotalSizeOfFilesPerThemeMetricType extends ThemeDataMetricType {
 
     private static final String GET_FILE_INODES_UNDER_THEME_QUERY =

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalThemeMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalThemeMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.theme;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total of themes
  */
+@ApplicationScoped
 public class TotalThemeMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalThemeUsedInLiveTemplatesMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalThemeUsedInLiveTemplatesMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.theme;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of themes used by LIVE templates
  */
+@ApplicationScoped
 public class TotalThemeUsedInLiveTemplatesMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalThemeUsedInWorkingTemplatesMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalThemeUsedInWorkingTemplatesMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.theme;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of themes used by WORKING templates
  */
+@ApplicationScoped
 public class TotalThemeUsedInWorkingTemplatesMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalWorkingContainerDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/theme/TotalWorkingContainerDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.theme;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of Working containers
  */
+@ApplicationScoped
 public class TotalWorkingContainerDatabaseMetricType implements DBMetricType {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/urlmap/ContentTypesWithUrlMapDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/urlmap/ContentTypesWithUrlMapDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.urlmap;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of content types with a non-null detail page.
  */
+@ApplicationScoped
 public class ContentTypesWithUrlMapDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/urlmap/LiveContentInUrlMapDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/urlmap/LiveContentInUrlMapDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.urlmap;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the count of all the Contentlets in content types with URL maps that have LIVE Version
  */
+@ApplicationScoped
 public class LiveContentInUrlMapDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/urlmap/UrlMapPatterWithTwoVariablesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/urlmap/UrlMapPatterWithTwoVariablesDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.urlmap;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the count of Content Types that are using a detail page with 2 or more variables.
  */
+@ApplicationScoped
 public class UrlMapPatterWithTwoVariablesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/urlmap/WorkingContentInUrlMapDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/urlmap/WorkingContentInUrlMapDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.urlmap;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the count of all the Contentlets in content types with URL maps that does not have LIVE Version
  */
+@ApplicationScoped
 public class WorkingContentInUrlMapDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/user/ActiveUsersDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/user/ActiveUsersDatabaseMetricType.java
@@ -1,11 +1,15 @@
 package com.dotcms.telemetry.collectors.user;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the count of Active User
  */
+@ApplicationScoped
+@DashboardMetric(category = "user", priority = 1)
 public class ActiveUsersDatabaseMetricType implements UsersDatabaseMetricType  {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/user/LastLoginDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/user/LastLoginDatabaseMetricType.java
@@ -1,11 +1,15 @@
 package com.dotcms.telemetry.collectors.user;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the date of the last login.
  */
+@ApplicationScoped
+@DashboardMetric(category = "user", priority = 3)
 public class LastLoginDatabaseMetricType implements UsersDatabaseMetricType  {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/user/LastLoginUserDatabaseMetric.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/user/LastLoginUserDatabaseMetric.java
@@ -3,9 +3,12 @@ package com.dotcms.telemetry.collectors.user;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 
+import javax.enterprise.context.ApplicationScoped;
+
 /**
  * Email address of the last logged-in user
  */
+@ApplicationScoped
 public class LastLoginUserDatabaseMetric implements UsersDatabaseMetricType  {
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/user/TotalUsersDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/user/TotalUsersDatabaseMetricType.java
@@ -1,11 +1,15 @@
 package com.dotcms.telemetry.collectors.user;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the total count of all users (excluding system users)
  */
+@ApplicationScoped
+@DashboardMetric(category = "user", priority = 2)
 public class TotalUsersDatabaseMetricType implements UsersDatabaseMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/ActionsDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/ActionsDatabaseMetricType.java
@@ -3,10 +3,12 @@ package com.dotcms.telemetry.collectors.workflow;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the count of Workflow Actions
  */
+@ApplicationScoped
 public class ActionsDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/ContentTypesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/ContentTypesDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.workflow;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the count of Content Types that are NOT using 'System Workflow'
  */
+@ApplicationScoped
+@DashboardMetric(category = "content", priority = 4)
 public class ContentTypesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/SchemesDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/SchemesDatabaseMetricType.java
@@ -1,13 +1,17 @@
 package com.dotcms.telemetry.collectors.workflow;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 
 /**
  * Collect the count of Workflow Schemes
  */
+@ApplicationScoped
+@DashboardMetric(category = "system", priority = 2)
 public class SchemesDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/StepsDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/StepsDatabaseMetricType.java
@@ -1,12 +1,16 @@
 package com.dotcms.telemetry.collectors.workflow;
 
+import com.dotcms.telemetry.DashboardMetric;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collect the count of Workflow Steps
  */
+@ApplicationScoped
+@DashboardMetric(category = "system", priority = 3)
 public class StepsDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/SubActionsDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/SubActionsDatabaseMetricType.java
@@ -3,12 +3,14 @@ package com.dotcms.telemetry.collectors.workflow;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 
 /**
  * Collect the count of Workflow SubActions, no matter if the same Sub Action is use for more than one Action
  * in this case it count several times.
  */
+@ApplicationScoped
 public class SubActionsDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/UniqueSubActionsDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/workflow/UniqueSubActionsDatabaseMetricType.java
@@ -3,12 +3,14 @@ package com.dotcms.telemetry.collectors.workflow;
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.collectors.DBMetricType;
+import javax.enterprise.context.ApplicationScoped;
 
 
 /**
  * Collect the count of Unique Workflow SubActions, it means if the same Sub Action is use by several
  * Workflow Action then it count as 1
  */
+@ApplicationScoped
 public class UniqueSubActionsDatabaseMetricType implements DBMetricType {
     @Override
     public String getName() {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/job/MetricsStatsJob.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/job/MetricsStatsJob.java
@@ -1,5 +1,6 @@
 package com.dotcms.telemetry.job;
 
+import com.dotcms.cdi.CDIUtils;
 import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.telemetry.MetricsSnapshot;
 import com.dotcms.telemetry.collectors.MetricStatsCollector;
@@ -32,7 +33,8 @@ public class MetricsStatsJob implements StatefulJob {
     public void execute(final JobExecutionContext jobExecutionContext) throws JobExecutionException {
         final MetricsSnapshot metricsSnapshot;
         try {
-            metricsSnapshot = MetricStatsCollector.getStatsAndCleanUp();
+            final MetricStatsCollector collector = CDIUtils.getBeanThrows(MetricStatsCollector.class);
+            metricsSnapshot = collector.getStatsAndCleanUp();
             APILocator.getMetricsAPI().persistMetricsSnapshot(metricsSnapshot);
         } catch (final Throwable e) {
             Logger.debug(this, String.format("An error occurred during job execution: %s",

--- a/dotCMS/src/main/java/com/dotcms/telemetry/rest/TelemetryResource.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/rest/TelemetryResource.java
@@ -1,5 +1,6 @@
 package com.dotcms.telemetry.rest;
 
+import com.dotcms.cdi.CDIUtils;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.telemetry.collectors.MetricStatsCollector;
@@ -63,7 +64,8 @@ public class TelemetryResource {
         final Set<String> metricNameSet = UtilMethods.isSet(metricNames)?
                 Stream.of(metricNames.split(StringPool.COMMA)).collect(Collectors.toSet()) : Set.of();
 
-        return Response.ok(new ResponseEntityMetricsSnapshotView(MetricStatsCollector.getStats(metricNameSet)))
+        final MetricStatsCollector collector = CDIUtils.getBeanThrows(MetricStatsCollector.class);
+        return Response.ok(new ResponseEntityMetricsSnapshotView(collector.getStats(metricNameSet)))
                 .build();
     }
 


### PR DESCRIPTION
## Description

Implements CDI-based metric discovery to replace static factory pattern in the telemetry system. This refactoring modernizes the architecture while maintaining full backward compatibility.

### Core Changes
- **MetricStatsCollector**: Converted to `@ApplicationScoped` CDI bean with automatic metric discovery via `@Inject Instance<MetricType>`
- **MetricType implementations**: Added `@ApplicationScoped` annotation to all 110 implementations for CDI discovery
- **DashboardMetricsProvider**: New CDI service for dashboard-specific metrics with filtering by `@DashboardMetric` annotation
- **UsageResource**: Updated to use `DashboardMetricsProvider` for cleaner metric collection

### New Components
- `@DashboardMetric` annotation - Declarative configuration for dashboard inclusion (category + priority)
- `DashboardMetricsProvider` - CDI-managed service providing dashboard-specific metric filtering
- `TELEMETRY_IMPLEMENTATION.md` - Comprehensive architecture documentation

### Benefits
- Removed 130+ lines of static initialization code
- Improved testability through dependency injection
- Declarative metric configuration (no code changes needed to add/remove dashboard metrics)
- Better separation of concerns (general telemetry vs dashboard-specific)
- Foundation for future enhancements (caching, consolidation)

## Changes

- [x] Convert MetricStatsCollector to @ApplicationScoped CDI bean
- [x] Add @Inject Instance<MetricType> for automatic metric discovery
- [x] Add @ApplicationScoped to all 110 MetricType implementations
- [x] Create DashboardMetricsProvider for dashboard metrics
- [x] Create @DashboardMetric annotation for declarative configuration
- [x] Update UsageResource to use DashboardMetricsProvider
- [x] Update MetricsStatsJob and TelemetryResource to use CDI lookup
- [x] Remove static initialization block (130+ lines)
- [x] Add comprehensive documentation (TELEMETRY_IMPLEMENTATION.md)

## Testing

- [x] Manual verification of CDI discovery logging
- [x] Validated all 110 MetricType implementations have @ApplicationScoped
- [x] Confirmed /api/v1/telemetry/stats endpoint returns same results
- [x] Confirmed /api/v1/usage/summary endpoint returns same results
- [x] Verified MetricsStatsJob executes successfully with CDI lookup
- [x] Confirmed no regression in metric collection accuracy
- [x] Validated dashboard metrics filtered correctly by @DashboardMetric annotation

### Validation Commands
```bash
# Verify all MetricTypes have @ApplicationScoped
grep -r "@ApplicationScoped" dotCMS/src/main/java/com/dotcms/telemetry/collectors/ | wc -l

# Test telemetry endpoint
curl -u admin@dotcms.com:admin http://localhost:8080/api/v1/telemetry/stats

# Test usage dashboard endpoint  
curl -u admin@dotcms.com:admin http://localhost:8080/api/v1/usage/summary
```

## Additional Notes

### Architecture Impact
- **No breaking changes**: Maintains full backward compatibility
- **Foundation for future work**: Enables metric caching and consolidation
- **Aligns with dotCMS patterns**: Uses existing CDI infrastructure

### Discovered Issues
During implementation, identified MetricType naming ambiguity issue where multiple metrics return the same generic name "COUNT", requiring fragile disambiguation logic in UsageResource. This is tracked separately in issue #34042 and should be addressed in a future PR to avoid breaking existing external telemetry reports.

### Related Issues
- Closes #33979 (this PR)
- Related: #34042 (MetricType naming ambiguity - separate concern, not addressed here)

Closes #33979

**Issue:** Refactor telemetry API to use CDI dependency injection

This PR fixes: #33979