### PR TITLE
fix(jobs): changed copy host job to use scroll API for host with large content volume

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -124,6 +124,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.core.CountResponse;
 import org.elasticsearch.common.unit.TimeValue;
@@ -154,6 +155,10 @@ public class ESContentFactoryImpl extends ContentletFactory {
     private static final String[] ES_FIELDS = {"inode", "identifier"};
     public static final int ES_TRACK_TOTAL_HITS_DEFAULT = 10000000;
     public static final String ES_TRACK_TOTAL_HITS = "ES_TRACK_TOTAL_HITS";
+    private static final Lazy<Integer> SCROLL_KEEP_ALIVE_MINUTES = Lazy.of(() ->
+            Config.getIntProperty("ES_SCROLL_KEEP_ALIVE_MINUTES", 5));
+    private static final Lazy<Integer> SCROLL_BATCH_SIZE = Lazy.of(() ->
+            Config.getIntProperty("ES_SCROLL_BATCH_SIZE", 1000));
     private static final String[] UPSERT_INODE_EXTRA_COLUMNS = {"owner", "idate", "type"};
 
     private static final String[] UPSERT_EXTRA_COLUMNS = {"show_on_menu", "title", "mod_date", "mod_user",
@@ -1960,112 +1965,110 @@ public class ESContentFactoryImpl extends ContentletFactory {
 
     }
 
+    /**
+     * Performs a scroll-based search to retrieve all results matching the query.
+     * <p>
+     * Results are fetched in batches using the ElasticSearch Scroll API. The batch size
+     * is configurable via the {@code ES_SCROLL_BATCH_SIZE} property (default: 1000).
+     * This helps manage memory usage when dealing with large result sets.
+     * </p>
+     *
+     * @param query Lucene query string
+     * @param sortBy Sort criteria (e.g., "title asc", "moddate desc")
+     * @return PaginatedArrayList containing all search results
+     */
     PaginatedArrayList<ContentletSearch> indexSearchScroll(final String query, String sortBy) {
-
-        final String formattedQuery = LuceneQueryDateTimeFormatter
-                .findAndReplaceQueryDates(translateQuery(query, sortBy).getQuery());
-
-        // we check the query to figure out which indexes to hit
-        final String indexToHit;
-        try {
-            indexToHit = inferIndexToHit(query);
-        } catch (Exception e) {
-            Logger.fatal(this, "Can't get indices information.", e);
-            return null;
-        }
-
-        final SearchRequest searchRequest = new SearchRequest();
-        final SearchSourceBuilder searchSourceBuilder = createSearchSourceBuilder(formattedQuery, sortBy);
-        searchSourceBuilder.timeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
-        searchRequest.indices(indexToHit);
-
-        if(UtilMethods.isSet(sortBy) ) {
-            sortBy = sortBy.toLowerCase();
-
-            if(sortBy.startsWith("score")){
-                String[] sortByCriteria = sortBy.split("[,|\\s+]");
-                String defaultSecondarySort = "moddate";
-                SortOrder defaultSecondardOrder = SortOrder.DESC;
-
-                if(sortByCriteria.length>2){
-                    if(sortByCriteria[2].equalsIgnoreCase("desc")) {
-                        defaultSecondardOrder = SortOrder.DESC;
-                    } else {
-                        defaultSecondardOrder = SortOrder.ASC;
-                    }
-                }
-                if(sortByCriteria.length>1){
-                    defaultSecondarySort= sortByCriteria[1];
-                }
-
-                searchSourceBuilder.sort("_score", SortOrder.DESC);
-                searchSourceBuilder.sort(defaultSecondarySort, defaultSecondardOrder);
-            } else if(!sortBy.startsWith("undefined") && !sortBy.startsWith("undefined_dotraw") && !sortBy.equals("random")) {
-                addBuilderSort(sortBy, searchSourceBuilder);
-            }
-        }else{
-            searchSourceBuilder.sort("moddate", SortOrder.DESC);
-        }
-
-        searchSourceBuilder.size(MAX_LIMIT);
-        searchRequest.source(searchSourceBuilder);
-        final Scroll scroll = new Scroll(TimeValue.timeValueMinutes(1L));
-        searchRequest.scroll(scroll);
-
         PaginatedArrayList<ContentletSearch> contentletSearchList = new PaginatedArrayList<>();
 
-        try {
-            SearchResponse searchResponse = RestHighLevelClientProvider.getInstance().getClient()
-                    .search(searchRequest, RequestOptions.DEFAULT);
-            String scrollId = searchResponse.getScrollId();
-            SearchHits searchHits = searchResponse.getHits();
+        // Use the ESContentletScrollImpl inner class to handle all scroll logic
+        // Using configurable batch size instead of MAX_LIMIT for better memory management
+        try (ESContentletScroll contentletScroll = createScrollQuery(query, APILocator.systemUser(),
+                false, SCROLL_BATCH_SIZE.get(), sortBy)) {
 
-            contentletSearchList.addAll(getContentletSearchFromSearchHits(searchHits));
-            contentletSearchList.setTotalResults(searchHits.getTotalHits().value);
+            contentletSearchList.setTotalResults(contentletScroll.getTotalHits());
 
-            while (searchHits.getHits() != null && searchHits.getHits().length > 0) {
-
-                SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId);
-                scrollRequest.scroll(scroll);
-                searchResponse = RestHighLevelClientProvider.getInstance().getClient()
-                        .scroll(scrollRequest, RequestOptions.DEFAULT);
-                scrollId = searchResponse.getScrollId();
-                searchHits = searchResponse.getHits();
-
-                contentletSearchList.addAll(getContentletSearchFromSearchHits(searchHits));
+            // Fetch all batches (first batch is returned on first nextBatch() call)
+            List<ContentletSearch> batch;
+            while ((batch = contentletScroll.nextBatch()) != null && !batch.isEmpty()) {
+                contentletSearchList.addAll(batch);
             }
 
-            ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
-            clearScrollRequest.addScrollId(scrollId);
-            ClearScrollResponse clearScrollResponse = RestHighLevelClientProvider.getInstance()
-                    .getClient().clearScroll(clearScrollRequest, RequestOptions.DEFAULT);
-            boolean succeeded = clearScrollResponse.isSucceeded();
+            Logger.debug(this.getClass(),
+                    () -> String.format("indexSearchScroll completed: totalResults=%d, query=%s",
+                            contentletSearchList.getTotalResults(), query));
 
         } catch (final ElasticsearchStatusException | IndexNotFoundException | SearchPhaseExecutionException e) {
             final String exceptionMsg = (null != e.getCause() ? e.getCause().getMessage() : e.getMessage());
             Logger.warn(this.getClass(), "----------------------------------------------");
-            Logger.warn(this.getClass(), String.format("Elasticsearch error in index '%s'", (searchRequest.indices()!=null) ? String.join(",", searchRequest.indices()): "unknown"));
-            Logger.warn(this.getClass(), String.format("ES Query: %s", String.valueOf(searchRequest.source()) ));
+            Logger.warn(this.getClass(), String.format("Elasticsearch error for query: %s", query));
             Logger.warn(this.getClass(), String.format("Class %s: %s", e.getClass().getName(), exceptionMsg));
             Logger.warn(this.getClass(), "----------------------------------------------");
             return new PaginatedArrayList<>();
-        } catch(final IllegalStateException e) {
+        } catch (final IllegalStateException e) {
             rebuildRestHighLevelClientIfNeeded(e);
             Logger.warnAndDebug(ESContentFactoryImpl.class, e);
             throw new DotRuntimeException(e);
         } catch (final Exception e) {
-            if(ExceptionUtil.causedBy(e, IllegalStateException.class)) {
+            if (ExceptionUtil.causedBy(e, IllegalStateException.class)) {
                 rebuildRestHighLevelClientIfNeeded(e);
             }
             final String errorMsg = String.format("An error occurred when executing the Lucene Query [ %s ] : %s",
-                    searchRequest.source().toString(), e.getMessage());
+                    query, e.getMessage());
             Logger.warnAndDebug(ESContentFactoryImpl.class, errorMsg, e);
             throw new DotRuntimeException(errorMsg, e);
         }
 
         return contentletSearchList;
+    }
 
+    /**
+     * Creates an ESContentletScroll instance for scroll-based queries.
+     * <p>
+     * The Scroll API is designed for efficiently retrieving large result sets that exceed
+     * ElasticSearch's max_result_window limit. Use this when you need to iterate through
+     * thousands of results.
+     * </p>
+     * <p>
+     * <strong>IMPORTANT:</strong> Always use try-with-resources to ensure scroll contexts
+     * are properly cleaned up:
+     * </p>
+     * <pre>
+     * try (ESContentletScroll scroll = factory.createScrollQuery(query, user, false, 100)) {
+     *     List&lt;ContentletSearch&gt; batch = scroll.initialize();
+     *     while (!batch.isEmpty()) {
+     *         // process batch
+     *         batch = scroll.nextBatch();
+     *     }
+     * }
+     * </pre>
+     *
+     * @param luceneQuery Lucene query string to search for contentlets
+     * @param user User for permission checking
+     * @param respectFrontendRoles Whether to respect frontend roles
+     * @param batchSize Number of results to retrieve per batch (page size)
+     * @param sortBy Sort criteria (e.g., "title asc", "moddate desc")
+     * @return ESContentletScroll instance for iterating through results
+     */
+    @Override
+    public ESContentletScroll createScrollQuery(final String luceneQuery, final User user,
+                                                  final boolean respectFrontendRoles, final int batchSize,
+                                                  final String sortBy) {
+        return new ESContentletScrollImpl(luceneQuery, user, respectFrontendRoles, batchSize, sortBy);
+    }
 
+    /**
+     * Creates an ESContentletScroll instance with default sort by "title asc".
+     *
+     * @param luceneQuery Lucene query string to search for contentlets
+     * @param user User for permission checking
+     * @param respectFrontendRoles Whether to respect frontend roles
+     * @param batchSize Number of results to retrieve per batch (page size)
+     * @return ESContentletScroll instance for iterating through results
+     */
+    @Override
+    public ESContentletScroll createScrollQuery(final String luceneQuery, final User user,
+                                                  final boolean respectFrontendRoles, final int batchSize) {
+        return createScrollQuery(luceneQuery, user, respectFrontendRoles, batchSize, "title asc");
     }
 
     private List<ContentletSearch> getContentletSearchFromSearchHits(final SearchHits searchHits) {
@@ -2576,11 +2579,188 @@ public class ESContentFactoryImpl extends ContentletFactory {
         }
 	}
 
-	///////////////////////////////////////////////////////
-	////////// imported from old LuceneUtils //////////////
-	///////////////////////////////////////////////////////
+	/**
+	 * Private implementation of ESContentletScroll that encapsulates all ElasticSearch
+	 * Scroll API logic in one place.
+	 */
+	private class ESContentletScrollImpl implements ESContentletScroll {
 
-	   public static class TranslatedQuery implements Serializable {
+		// State fields
+		private String scrollId;
+		private long totalHits = 0;
+		private boolean hasMoreResults = false;
+		private boolean firstBatchReturned = false;
+		private List<ContentletSearch> firstBatch;
+		private RestHighLevelClient esClient;
+
+		/**
+		 * Creates a new scroll query instance and initializes the scroll context.
+		 * The first batch is fetched immediately and cached for the first {@link #nextBatch()} call.
+		 *
+		 * @param luceneQuery Lucene query string
+		 * @param user User for permission checking (only used during initialization)
+		 * @param respectFrontendRoles Whether to respect frontend roles (only used during initialization)
+		 * @param batchSize Number of results to retrieve per batch
+		 * @param sortBy Sort criteria (e.g., "title asc", "moddate desc")
+		 * @throws DotRuntimeException if scroll initialization fails
+		 */
+		ESContentletScrollImpl(final String luceneQuery, final User user, final boolean respectFrontendRoles,
+					  final int batchSize, final String sortBy) {
+			this.esClient = RestHighLevelClientProvider.getInstance().getClient();
+
+			// Initialize scroll and fetch first batch
+			this.firstBatch = Try.of(() -> {
+				// Translate query to ES format
+				final String formattedQuery = LuceneQueryDateTimeFormatter
+						.findAndReplaceQueryDates(translateQuery(luceneQuery, sortBy).getQuery());
+
+				// Determine which index to query
+				final String indexToHit = inferIndexToHit(luceneQuery);
+
+				// Build search request
+				final SearchSourceBuilder sourceBuilder = createSearchSourceBuilder(formattedQuery, sortBy);
+				sourceBuilder.timeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
+				sourceBuilder.size(batchSize);
+
+				// Apply sorting
+				applySorting(sortBy, sourceBuilder);
+
+				final SearchRequest searchRequest = new SearchRequest()
+						.indices(indexToHit)
+						.source(sourceBuilder)
+						.scroll(TimeValue.timeValueMinutes(SCROLL_KEEP_ALIVE_MINUTES.get()));
+
+				// Execute initial search
+				final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
+				this.scrollId = response.getScrollId();
+				final SearchHits searchHits = response.getHits();
+
+				this.totalHits = searchHits.getTotalHits().value;
+
+				// Convert hits to ContentletSearch
+				final List<ContentletSearch> results = getContentletSearchFromSearchHits(searchHits);
+				this.hasMoreResults = (searchHits.getHits() != null && searchHits.getHits().length > 0);
+
+				Logger.debug(this.getClass(),
+						() -> String.format("Scroll initialized: scrollId=%s, totalHits=%d, firstBatchSize=%d",
+								scrollId, totalHits, results.size()));
+
+				return results;
+
+			}).getOrElseThrow(e -> {
+				if (e instanceof DotRuntimeException) {
+					return (DotRuntimeException) e;
+				}
+				return new DotRuntimeException("Error initializing scroll API: " + e.getMessage(), e);
+			});
+		}
+
+		@Override
+		public List<ContentletSearch> nextBatch() throws DotDataException {
+			// On first call, return the cached first batch
+			if (!firstBatchReturned) {
+				firstBatchReturned = true;
+				Logger.debug(this.getClass(),
+						() -> String.format("Returning first batch: size=%d", firstBatch.size()));
+				return firstBatch;
+			}
+
+			// No more results
+			if (!hasMoreResults) {
+				return new ArrayList<>();
+			}
+
+			// Fetch next batch from scroll
+			return Try.of(() -> {
+				final SearchScrollRequest scrollRequest = new SearchScrollRequest(scrollId)
+						.scroll(TimeValue.timeValueMinutes(SCROLL_KEEP_ALIVE_MINUTES.get()));
+
+				final SearchResponse response = esClient.scroll(scrollRequest, RequestOptions.DEFAULT);
+				final SearchHits searchHits = response.getHits();
+
+				final List<ContentletSearch> results = getContentletSearchFromSearchHits(searchHits);
+				this.hasMoreResults = (searchHits.getHits() != null && searchHits.getHits().length > 0);
+
+				Logger.debug(this.getClass(),
+						() -> String.format("Scroll next batch: batchSize=%d, hasMore=%b",
+								results.size(), hasMoreResults));
+
+				return results;
+
+			}).getOrElseThrow(e -> {
+				if (e instanceof DotDataException) {
+					return (DotDataException) e;
+				}
+				return new DotDataException("Error continuing scroll API: " + e.getMessage(), e);
+			});
+		}
+
+		@Override
+		public long getTotalHits() {
+			return totalHits;
+		}
+
+		@Override
+		public boolean hasMoreResults() {
+			// If we haven't returned the first batch yet and it has results, there are more
+			if (!firstBatchReturned && firstBatch != null && !firstBatch.isEmpty()) {
+				return true;
+			}
+			return hasMoreResults;
+		}
+
+		@Override
+		public void close() {
+			if (scrollId != null && esClient != null) {
+				Try.run(() -> {
+					final ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
+					clearScrollRequest.addScrollId(scrollId);
+					esClient.clearScroll(clearScrollRequest, RequestOptions.DEFAULT);
+					Logger.debug(this.getClass(), () -> "Cleared scroll context: " + scrollId);
+				}).onFailure(e ->
+						Logger.error(this.getClass(), "Error clearing scroll context: " + e.getMessage(), e)
+				);
+				scrollId = null;
+			}
+		}
+
+		/**
+		 * Applies sorting to the search source builder based on sortBy parameter.
+		 */
+		private void applySorting(String sortBy, SearchSourceBuilder searchSourceBuilder) {
+			if (UtilMethods.isSet(sortBy)) {
+				sortBy = sortBy.toLowerCase();
+
+				if (sortBy.startsWith("score")) {
+					String[] sortByCriteria = sortBy.split("[,|\\s+]");
+					String defaultSecondarySort = "moddate";
+					SortOrder defaultSecondaryOrder = SortOrder.DESC;
+
+					if (sortByCriteria.length > 2) {
+						defaultSecondaryOrder = sortByCriteria[2].equalsIgnoreCase("desc")
+								? SortOrder.DESC : SortOrder.ASC;
+					}
+					if (sortByCriteria.length > 1) {
+						defaultSecondarySort = sortByCriteria[1];
+					}
+
+					searchSourceBuilder.sort("_score", SortOrder.DESC);
+					searchSourceBuilder.sort(defaultSecondarySort, defaultSecondaryOrder);
+				} else if (!sortBy.startsWith("undefined") && !sortBy.startsWith("undefined_dotraw")
+						&& !sortBy.equals("random")) {
+					addBuilderSort(sortBy, searchSourceBuilder);
+				}
+			} else {
+				searchSourceBuilder.sort("moddate", SortOrder.DESC);
+			}
+		}
+	}
+
+    ///////////////////////////////////////////////////////
+    ////////// imported from old LuceneUtils //////////////
+    ///////////////////////////////////////////////////////
+
+    public static class TranslatedQuery implements Serializable {
 
 	        private static final long serialVersionUID = 1L;
 	        private String query;

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -988,6 +988,18 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 .build();
     }
 
+    @Override
+    public ESContentletScroll createScrollQuery(final String luceneQuery, final User user,
+            final boolean respectFrontendRoles, final int batchSize, final String sortBy)
+            throws DotSecurityException, DotDataException {
+
+        // Apply permissions to query
+        final String queryWithPermissions = applyPermissionsToQuery(luceneQuery, user, respectFrontendRoles);
+
+        // Delegate to factory with the permission-filtered query
+        return contentFactory.createScrollQuery(queryWithPermissions, user, respectFrontendRoles, batchSize, sortBy);
+    }
+
     @CloseDBIfOpened
     @Override
     public List<Contentlet> findContentletsByHost(Host parentHost,
@@ -1561,16 +1573,33 @@ public class ESContentletAPIImpl implements ContentletAPI {
 
     }
 
-    @Override
-    public List<ContentletSearch> searchIndex(String luceneQuery, int limit, int offset,
-            String sortBy, User user, boolean respectFrontendRoles)
-            throws DotSecurityException, DotDataException {
-        boolean isAdmin = false;
-        List<Role> roles = new ArrayList<>();
+    /**
+     * Applies permissions and category permissions to a lucene query string.
+     * This method handles admin checks, role loading, and permission clauses.
+     * <p>
+     * <strong>SECURITY NOTE:</strong> This method MUST be called on any query before
+     * passing it to Elasticsearch to ensure proper permission filtering.
+     * </p>
+     *
+     * @param luceneQuery The original lucene query string
+     * @param user The user making the request (required if not respecting frontend roles)
+     * @param respectFrontendRoles Whether to respect frontend roles
+     * @return The query with permissions clauses added
+     * @throws DotSecurityException If user is null and not respecting frontend roles
+     * @throws DotDataException If there's an error loading roles
+     */
+    protected String applyPermissionsToQuery(final String luceneQuery, final User user,
+            final boolean respectFrontendRoles) throws DotSecurityException, DotDataException {
+
+        // Validate user requirement
         if (user == null && !respectFrontendRoles) {
             throw new DotSecurityException(
                     "You must specify a user if you are not respecting frontend roles");
         }
+
+        // Check if user is admin
+        boolean isAdmin = false;
+        List<Role> roles = new ArrayList<>();
         if (user != null) {
             if (!APILocator.getRoleAPI()
                     .doesUserHaveRole(user, APILocator.getRoleAPI().loadCMSAdminRole())) {
@@ -1579,13 +1608,27 @@ public class ESContentletAPIImpl implements ContentletAPI {
                 isAdmin = true;
             }
         }
-        final StringBuffer buffy = new StringBuffer(luceneQuery);
 
-        // Permissions in the query
-        if (!isAdmin) {
-            addPermissionsToQuery(buffy, user, roles, respectFrontendRoles);
-            addCategoryPermissionsToQuery(buffy, user, roles, respectFrontendRoles);
+        // If admin, return query unchanged
+        if (isAdmin) {
+            return luceneQuery;
         }
+
+        // Apply permissions
+        final StringBuffer buffy = new StringBuffer(luceneQuery);
+        addPermissionsToQuery(buffy, user, roles, respectFrontendRoles);
+        addCategoryPermissionsToQuery(buffy, user, roles, respectFrontendRoles);
+
+        return buffy.toString();
+    }
+
+    @Override
+    public List<ContentletSearch> searchIndex(String luceneQuery, int limit, int offset,
+            String sortBy, User user, boolean respectFrontendRoles)
+            throws DotSecurityException, DotDataException {
+
+        // Apply permissions to query
+        final String queryWithPermissions = applyPermissionsToQuery(luceneQuery, user, respectFrontendRoles);
 
         if (UtilMethods.isSet(sortBy) && sortBy.trim().equalsIgnoreCase("random")) {
             sortBy = "random";
@@ -1596,7 +1639,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
 
         if (limit <= MAX_LIMIT) {
-            final SearchHits searchHits = contentFactory.indexSearch(buffy.toString(), limit,
+            final SearchHits searchHits = contentFactory.indexSearch(queryWithPermissions, limit,
                     offset, sortBy);
             final PaginatedArrayList<ContentletSearch> list = new PaginatedArrayList<>();
             list.setTotalResults(searchHits.getTotalHits().value);
@@ -1618,7 +1661,7 @@ public class ESContentletAPIImpl implements ContentletAPI {
             }
             return list;
         } else {
-            return contentFactory.indexSearchScroll(buffy.toString(), sortBy);
+            return contentFactory.indexSearchScroll(queryWithPermissions, sortBy);
         }
 
     }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletScroll.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletScroll.java
@@ -1,0 +1,69 @@
+package com.dotcms.content.elasticsearch.business;
+
+import com.dotmarketing.common.model.ContentletSearch;
+import com.dotmarketing.exception.DotDataException;
+
+import java.util.List;
+
+/**
+ * API for performing scroll-based queries on contentlets in ElasticSearch.
+ * <p>
+ * The Scroll API is designed for efficiently retrieving large result sets that exceed
+ * ElasticSearch's max_result_window limit. Unlike offset-based pagination, scroll maintains
+ * a search context and retrieves results in batches.
+ * </p>
+ * <p>
+ * The scroll context is initialized automatically upon instantiation, and the first batch
+ * is fetched and cached. Use {@link #nextBatch()} to retrieve batches sequentially.
+ * </p>
+ * <p>
+ * <strong>IMPORTANT:</strong> Always close the scroll context when done to free server resources.
+ * Use try-with-resources pattern:
+ * </p>
+ * <pre>
+ * try (ESContentletScroll scroll = factory.createScrollQuery(query, user, false, 100)) {
+ *     List&lt;ContentletSearch&gt; batch;
+ *     while ((batch = scroll.nextBatch()) != null && !batch.isEmpty()) {
+ *         // process batch
+ *     }
+ * }
+ * </pre>
+ *
+ * @see ContentletFactory#createScrollQuery(String, com.liferay.portal.model.User, boolean, int)
+ */
+public interface ESContentletScroll extends AutoCloseable {
+
+    /**
+     * Retrieves the next batch of results from the scroll context.
+     * On the first call, returns the initial batch fetched during construction.
+     * Subsequent calls fetch and return the next batch.
+     * Returns an empty list when there are no more results.
+     *
+     * @return List of ContentletSearch objects from the next batch (empty if no more results)
+     * @throws DotDataException if fetching the next batch fails
+     */
+    List<ContentletSearch> nextBatch() throws DotDataException;
+
+    /**
+     * Returns the total number of hits for the query.
+     * Available immediately after construction.
+     *
+     * @return Total number of matching documents
+     */
+    long getTotalHits();
+
+    /**
+     * Checks if there are more results available.
+     *
+     * @return true if more results are available, false otherwise
+     */
+    boolean hasMoreResults();
+
+    /**
+     * Clears the scroll context and frees server resources.
+     * This is called automatically when using try-with-resources.
+     * Safe to call multiple times.
+     */
+    @Override
+    void close();
+}

--- a/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
@@ -189,11 +189,12 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
                     .forEach(fileContainer -> dependencyProcessor.addAsset(fileContainer,
                             PusheableAsset.CONTAINER));
 
-            PaginatedContentlets contentletsPaginatedByHost = this.contentletAPI.get().findContentletsPaginatedByHost(site,
-                    APILocator.systemUser(), false);
-            // Content dependencies
-            tryToAddAllAndProcessDependencies(PusheableAsset.CONTENTLET, contentletsPaginatedByHost,
-                    ManifestReason.INCLUDE_DEPENDENCY_FROM.getMessage(site));
+            // Content dependencies - use try-with-resources to ensure Scroll context cleanup
+            try (PaginatedContentlets contentletsPaginatedByHost = this.contentletAPI.get().findContentletsPaginatedByHost(site,
+                    APILocator.systemUser(), false)) {
+                tryToAddAllAndProcessDependencies(PusheableAsset.CONTENTLET, contentletsPaginatedByHost,
+                        ManifestReason.INCLUDE_DEPENDENCY_FROM.getMessage(site));
+            }
 
             // Structure dependencies
             tryToAddAllAndProcessDependencies(PusheableAsset.CONTENT_TYPE,

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPI.java
@@ -402,6 +402,39 @@ public interface ContentletAPI {
 	public PaginatedContentlets findContentletsPaginatedByHost(Host parentHost, List<Integer> includingContentTypes, List<Integer> excludingContentTypes, User user, boolean respectFrontendRoles) throws DotDataException, DotSecurityException;
 
 	/**
+	 * Creates an ElasticSearch Scroll API query with proper permissions applied.
+	 * <p>
+	 * This method should be used instead of directly accessing the factory when you need
+	 * scroll functionality for large result sets. It ensures that permissions are properly
+	 * applied to the query before creating the scroll context.
+	 * </p>
+	 * <p>
+	 * <strong>IMPORTANT:</strong> Always use try-with-resources to ensure the scroll
+	 * context is properly cleaned up:
+	 * </p>
+	 * <pre>
+	 * try (ESContentletScroll scroll = contentletAPI.createScrollQuery(query, user, false, 100, "title asc")) {
+	 *     List&lt;ContentletSearch&gt; batch;
+	 *     while ((batch = scroll.nextBatch()) != null && !batch.isEmpty()) {
+	 *         // process batch
+	 *     }
+	 * }
+	 * </pre>
+	 *
+	 * @param luceneQuery The base lucene query (permissions will be added automatically)
+	 * @param user The user making the request (required if not respecting frontend roles)
+	 * @param respectFrontendRoles Whether to respect frontend roles
+	 * @param batchSize Number of results to retrieve per batch
+	 * @param sortBy Sort criteria (e.g., "title asc", "moddate desc")
+	 * @return ESContentletScroll instance for iterating through results
+	 * @throws DotSecurityException If user is null and not respecting frontend roles
+	 * @throws DotDataException If there's an error creating the scroll query
+	 */
+	public com.dotcms.content.elasticsearch.business.ESContentletScroll createScrollQuery(
+			String luceneQuery, User user, boolean respectFrontendRoles, int batchSize, String sortBy)
+			throws DotSecurityException, DotDataException;
+
+	/**
 	 *
 	 * Returns a list of {@link Contentlet} whose parent host matches the given host and whose base-type
 	 * (See {@link Structure.Type}) matches any of the given base types. .

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPostHook.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.portlets.contentlet.business;
 
+import com.dotcms.content.elasticsearch.business.ESContentletScroll;
 import com.dotcms.content.elasticsearch.business.SearchCriteria;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.variant.model.Variant;
@@ -1839,4 +1840,16 @@ public interface ContentletAPIPostHook {
 	}
 
 	default void findContentletByIdentifierOrFallback(String identifier, boolean live, long incomingLangId, User user, boolean respectFrontendRoles, String variantName) {}
+
+	/**
+	 * Creates an ElasticSearch Scroll API query with proper permissions applied.
+	 *
+	 * @param luceneQuery The lucene query string
+	 * @param user The user executing the query
+	 * @param respectFrontendRoles Whether to respect frontend roles
+	 * @param batchSize The size of each batch returned by the scroll
+	 * @param sortBy The sort criteria
+	 * @param returnValue The ESContentletScroll object returned by the API
+	 */
+	default void createScrollQuery(String luceneQuery, User user, boolean respectFrontendRoles, int batchSize, String sortBy, ESContentletScroll returnValue) {}
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletAPIPreHook.java
@@ -2144,4 +2144,18 @@ public interface ContentletAPIPreHook {
     default boolean findContentletByIdentifierOrFallback(String identifier, boolean live, long incomingLangId, User user, boolean respectFrontendRoles, String variantName) {
 		return true;
 	}
+
+	/**
+	 * Creates an ElasticSearch Scroll API query with proper permissions applied.
+	 *
+	 * @param luceneQuery The lucene query string
+	 * @param user The user executing the query
+	 * @param respectFrontendRoles Whether to respect frontend roles
+	 * @param batchSize The size of each batch returned by the scroll
+	 * @param sortBy The sort criteria
+	 * @return false if the hook should stop the transaction
+	 */
+	default boolean createScrollQuery(String luceneQuery, User user, boolean respectFrontendRoles, int batchSize, String sortBy) {
+		return true;
+	}
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/ContentletFactory.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.portlets.contentlet.business; 
 
+import com.dotcms.content.elasticsearch.business.ESContentletScroll;
 import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.repackage.net.sf.hibernate.ObjectNotFoundException;
@@ -638,6 +639,49 @@ public abstract class ContentletFactory {
 	public abstract int updateModDate(final Set<String> inodes, User user) throws DotDataException;
 
     public abstract Optional<Contentlet> findInDb(String inode) ;
+
+	/**
+	 * Creates an ESContentletScroll instance for scroll-based queries.
+	 * <p>
+	 * The Scroll API is designed for efficiently retrieving large result sets that exceed
+	 * ElasticSearch's max_result_window limit. Use this when you need to iterate through
+	 * thousands of results without hitting deep pagination limits.
+	 * </p>
+	 * <p>
+	 * <strong>IMPORTANT:</strong> Always use try-with-resources to ensure scroll contexts
+	 * are properly cleaned up:
+	 * </p>
+	 * <pre>
+	 * try (ESContentletScroll scroll = factory.createScrollQuery(query, user, false, 100, "title asc")) {
+	 *     List&lt;ContentletSearch&gt; batch = scroll.initialize();
+	 *     while (!batch.isEmpty()) {
+	 *         // process batch
+	 *         batch = scroll.nextBatch();
+	 *     }
+	 * }
+	 * </pre>
+	 *
+	 * @param luceneQuery Lucene query string to search for contentlets
+	 * @param user User for permission checking
+	 * @param respectFrontendRoles Whether to respect frontend roles
+	 * @param batchSize Number of results to retrieve per batch (page size)
+	 * @param sortBy Sort criteria (e.g., "title asc", "moddate desc")
+	 * @return ESContentletScroll instance for iterating through results
+	 */
+	public abstract ESContentletScroll createScrollQuery(
+			String luceneQuery, User user, boolean respectFrontendRoles, int batchSize, String sortBy);
+
+	/**
+	 * Creates an ESContentletScroll instance with default sort by "title asc".
+	 *
+	 * @param luceneQuery Lucene query string to search for contentlets
+	 * @param user User for permission checking
+	 * @param respectFrontendRoles Whether to respect frontend roles
+	 * @param batchSize Number of results to retrieve per batch (page size)
+	 * @return ESContentletScroll instance for iterating through results
+	 */
+	public abstract ESContentletScroll createScrollQuery(
+			String luceneQuery, User user, boolean respectFrontendRoles, int batchSize);
 
 	public static void rebuildRestHighLevelClientIfNeeded(final Exception e) {
 		if(e != null && e.getMessage().contains("reactor status: STOPPED")) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
@@ -85,7 +85,7 @@ public class HostFactoryImpl implements HostFactory {
     private static final String SELECT_SYSTEM_HOST = "SELECT id FROM identifier WHERE id = '"+ Host.SYSTEM_HOST+"' ";
 
     private static final String FROM_JOINED_TABLES = "INNER JOIN identifier i " +
-            "ON c.identifier = i.id AND i.asset_type = '" + Host.HOST_VELOCITY_VAR_NAME + "' " +
+            "ON c.identifier = i.id " +
             "INNER JOIN contentlet_version_info cvi " +
             "ON c.inode = cvi.working_inode " +
             "LEFT JOIN contentlet clive " +

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
@@ -85,7 +85,7 @@ public class HostFactoryImpl implements HostFactory {
     private static final String SELECT_SYSTEM_HOST = "SELECT id FROM identifier WHERE id = '"+ Host.SYSTEM_HOST+"' ";
 
     private static final String FROM_JOINED_TABLES = "INNER JOIN identifier i " +
-            "ON c.identifier = i.id " +
+            "ON c.identifier = i.id AND i.asset_subtype = '" + Host.HOST_VELOCITY_VAR_NAME + "' " +
             "INNER JOIN contentlet_version_info cvi " +
             "ON c.inode = cvi.working_inode " +
             "LEFT JOIN contentlet clive " +

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/business/HostFactoryImpl.java
@@ -85,7 +85,7 @@ public class HostFactoryImpl implements HostFactory {
     private static final String SELECT_SYSTEM_HOST = "SELECT id FROM identifier WHERE id = '"+ Host.SYSTEM_HOST+"' ";
 
     private static final String FROM_JOINED_TABLES = "INNER JOIN identifier i " +
-            "ON c.identifier = i.id " +
+            "ON c.identifier = i.id AND i.asset_type = '" + Host.HOST_VELOCITY_VAR_NAME + "' " +
             "INNER JOIN contentlet_version_info cvi " +
             "ON c.inode = cvi.working_inode " +
             "LEFT JOIN contentlet clive " +

--- a/dotCMS/src/main/java/com/dotmarketing/util/contentet/pagination/PaginatedContentletBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/contentet/pagination/PaginatedContentletBuilder.java
@@ -18,6 +18,7 @@ public class PaginatedContentletBuilder {
     private boolean respectFrontendRoles;
     private ContentletAPI contentletAPI;
     private int perPage = -1;
+    private int scrollApiThreshold = -1;
     private Lazy<Integer> perPageDefaultValue = Lazy.of(() -> Config.getIntProperty("CONTENTLET_PER_PAGE", 1000));
 
     public PaginatedContentletBuilder setLuceneQuery(String luceneQuery) {
@@ -46,6 +47,12 @@ public class PaginatedContentletBuilder {
         return this;
     }
 
+    @VisibleForTesting
+    public PaginatedContentletBuilder setScrollApiThreshold(int scrollApiThreshold) {
+        this.scrollApiThreshold = scrollApiThreshold;
+        return this;
+    }
+
     public PaginatedContentlets build(){
         if (!UtilMethods.isSet(contentletAPI)) {
             contentletAPI = APILocator.getContentletAPI();
@@ -55,6 +62,6 @@ public class PaginatedContentletBuilder {
             perPage = perPageDefaultValue.get();
         }
 
-        return new PaginatedContentlets(luceneQuery, user, respectFrontendRoles, perPage, contentletAPI);
+        return new PaginatedContentlets(luceneQuery, user, respectFrontendRoles, perPage, contentletAPI, scrollApiThreshold);
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/util/contentet/pagination/PaginatedContentlets.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/contentet/pagination/PaginatedContentlets.java
@@ -1,14 +1,20 @@
 package com.dotmarketing.util.contentet.pagination;
 
+import com.dotcms.content.elasticsearch.business.ESContentletScroll;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.common.model.ContentletSearch;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PaginatedArrayList;
 import com.liferay.portal.model.User;
+import io.vavr.Lazy;
+import io.vavr.control.Try;
+
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -20,19 +26,45 @@ import java.util.stream.Collectors;
  * the size of each page can be set by {@link PaginatedContentlets#perPage} attribute.
  * Just the {@link Contentlet}'s Inode are storage into memory and before return each of them the
  * {@link Contentlet} object is load from cache or database.
+ *
+ * <p>For large result sets (configurable via ES_SCROLL_API_THRESHOLD), this class automatically
+ * switches to ElasticSearch Scroll API to avoid deep pagination issues.</p>
+ *
+ * <p><strong>IMPORTANT:</strong> This class implements {@link AutoCloseable}. Always use
+ * try-with-resources to ensure Scroll contexts are properly cleaned up:</p>
+ * <pre>
+ * try (PaginatedContentlets contentlets = APILocator.getContentletAPI().findContentletsPaginatedByHost(host, user, false)) {
+ *     for (Contentlet contentlet : contentlets) {
+ *         // process contentlet
+ *     }
+ * }
+ * </pre>
  */
-public class PaginatedContentlets implements Iterable<Contentlet> {
+public class PaginatedContentlets implements Iterable<Contentlet>, AutoCloseable {
 
-    private static int NOT_LOAD = -1;
-    private User user;
-    private ContentletAPI contentletAPI;
-    private String luceneQuery;
-    private boolean respectFrontendRoles;
+    /**
+     * Configuration property to control when to use Scroll API instead of offset pagination.
+     * If the total result count exceeds this threshold, Scroll API will be used automatically.
+     * Default: 10000
+     */
+    private static final Lazy<Integer> SCROLL_API_THRESHOLD = Lazy.of(() ->
+            Config.getIntProperty("ES_SCROLL_API_THRESHOLD", 10000));
 
-    private String SORT_BY = "title asc";
-    private int perPage;
+    private static final int NOT_LOAD = -1;
+    private final User user;
+    private final ContentletAPI contentletAPI;
+    private final String luceneQuery;
+    private final boolean respectFrontendRoles;
+
+    private final String SORT_BY = "title asc";
+    private final int perPage;
+
     private long totalHits = NOT_LOAD;
     private List<String> currentPageContentletInodes = null;
+
+    // Scroll API state
+    private boolean useScrollApi = false;
+    private ESContentletScroll esContentletScroll = null;
 
     /**
      * Create a PaginatedContentlet
@@ -41,7 +73,7 @@ public class PaginatedContentlets implements Iterable<Contentlet> {
      * @param user User to check permission
      * @param respectFrontendRoles true if you want to respect Front end roles
      * @param perPage Page size limit
-     * @param contentletAPI
+     * @param contentletAPI ContentletAPI instance
      */
     PaginatedContentlets(final String luceneQuery, final User user, final boolean respectFrontendRoles,
             final int perPage, final ContentletAPI contentletAPI) {
@@ -52,9 +84,42 @@ public class PaginatedContentlets implements Iterable<Contentlet> {
         this.perPage = perPage;
 
         try {
-            currentPageContentletInodes = loadNextPage(0);
+            currentPageContentletInodes = loadFirstPage();
+
+            if (currentPageContentletInodes == null || currentPageContentletInodes.isEmpty()) {
+                if (totalHits > 0) {
+                    Logger.error(this.getClass(),
+                        String.format("First page is empty but totalHits is %d! useScrollApi: %b, query: %s. " +
+                            "This indicates a Scroll API query issue. Resetting totalHits to 0 to prevent iteration.",
+                            totalHits, useScrollApi, luceneQuery));
+                    // Reset totalHits to prevent iterator from trying to access empty list
+                    totalHits = 0;
+                }
+                currentPageContentletInodes = new ArrayList<>();
+
+                if (totalHits == 0) {
+                    Logger.debug(this.getClass(), () -> "Query returned no results or first batch was empty");
+                }
+
+                // Clear scroll if it was created but returned no results
+                if (esContentletScroll != null && totalHits == 0) {
+                    Logger.debug(this.getClass(), "Clearing unused scroll context since no results were returned");
+                    Try.run(this::close);
+                }
+            }
+
+            Logger.debug(this.getClass(),
+                () -> String.format("PaginatedContentlets initialized: %d total hits, %d in first page, useScrollApi: %b",
+                    totalHits, currentPageContentletInodes.size(), useScrollApi));
+
         } catch (DotSecurityException | DotDataException e) {
-            Logger.error(ContentletIterator.class, e.getMessage());
+            Logger.error(this.getClass(), "Error initializing PaginatedContentlets: " + e.getMessage(), e);
+            currentPageContentletInodes = new ArrayList<>();
+            totalHits = 0; // CRITICAL: Reset totalHits so iterator won't try to iterate
+            // Clear scroll if it was created before failure
+            if (esContentletScroll != null) {
+                Try.run(this::close);
+            }
         }
     }
 
@@ -67,26 +132,117 @@ public class PaginatedContentlets implements Iterable<Contentlet> {
         return new ContentletIterator();
     }
 
+    /**
+     * Loads the first page and determines whether to use Scroll API based on total results.
+     * Uses indexCount for efficient count retrieval before deciding on pagination strategy.
+     */
+    private List<String> loadFirstPage() throws DotSecurityException, DotDataException {
+        // First, get the total count efficiently using indexCount (no need to fetch documents)
+        totalHits = this.contentletAPI.indexCount(this.luceneQuery, this.user, this.respectFrontendRoles);
+
+        Logger.debug(this.getClass(),
+            () -> String.format("Query result count: %d (threshold: %d)", totalHits, SCROLL_API_THRESHOLD.get()));
+
+        // Decide whether to use Scroll API based on total hits
+        if (totalHits > SCROLL_API_THRESHOLD.get()) {
+            Logger.debug(this.getClass(),
+                String.format("Result set size (%d) exceeds threshold (%d). Using Scroll API for query: %s",
+                    totalHits, SCROLL_API_THRESHOLD.get(), luceneQuery));
+            useScrollApi = true;
+
+            // CRITICAL: Use ContentletAPI to create scroll query with proper permissions applied
+            // DO NOT bypass the API by going directly to the factory, as that would skip
+            // permission checks and create a security vulnerability
+            this.esContentletScroll = this.contentletAPI.createScrollQuery(
+                    luceneQuery, user, respectFrontendRoles, perPage, SORT_BY);
+
+            return initializeScrollAndLoadFirstPage();
+        } else {
+            Logger.debug(this.getClass(),
+                () -> String.format("Using standard pagination for %d results (threshold: %d)",
+                    totalHits, SCROLL_API_THRESHOLD.get()));
+            // Load first page using standard pagination
+            return loadNextPageWithOffset(0);
+        }
+    }
+
+    /**
+     * Loads next page using standard offset pagination.
+     */
+    private List<String> loadNextPageWithOffset(final int offset) throws DotSecurityException, DotDataException {
+        final PaginatedArrayList<ContentletSearch> paginatedArrayList = (PaginatedArrayList) this.contentletAPI
+                .searchIndex(this.luceneQuery, perPage, offset, SORT_BY, this.user, this.respectFrontendRoles);
+
+        return paginatedArrayList.stream()
+                .map(ContentletSearch::getInode)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Loads the first page from the Scroll context (already initialized in constructor).
+     * Delegates to ESContentletScroll.
+     */
+    private List<String> initializeScrollAndLoadFirstPage() throws DotDataException {
+        // Scroll is already initialized in constructor, just get first batch
+        final List<ContentletSearch> batch = esContentletScroll.nextBatch();
+
+        Logger.debug(this.getClass(),
+                String.format("Scroll API ready: totalHits=%d, firstBatchSize=%d",
+                        esContentletScroll.getTotalHits(), batch.size()));
+
+        return batch.stream()
+                .map(ContentletSearch::getInode)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Continues an existing Scroll and loads the next page.
+     * Delegates to ESContentletScroll.
+     */
+    private List<String> loadNextPageWithScroll() throws DotDataException {
+        final List<ContentletSearch> batch = esContentletScroll.nextBatch();
+
+        Logger.debug(this.getClass(),
+                () -> String.format("Scroll API next batch: size=%d", batch.size()));
+
+        return batch.stream()
+                .map(ContentletSearch::getInode)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Loads the next page using the appropriate method (offset or scroll).
+     */
     private List<String> loadNextPage(final int offset) throws DotSecurityException, DotDataException {
-         final PaginatedArrayList<ContentletSearch> paginatedArrayList = (PaginatedArrayList) this.contentletAPI
-                .searchIndex(this.luceneQuery,
-                        perPage,
-                        offset,
-                        SORT_BY,
-                        this.user,
-                        this.respectFrontendRoles);
-
-         if (totalHits == NOT_LOAD) {
-             totalHits  = paginatedArrayList.getTotalResults();
-         }
-
-         return paginatedArrayList.stream()
-                 .map(contentletSearch -> contentletSearch.getInode())
-                 .collect(Collectors.toList());
+        if (useScrollApi) {
+            return loadNextPageWithScroll();
+        } else {
+            return loadNextPageWithOffset(offset);
+        }
     }
 
     public long size(){
         return totalHits;
+    }
+
+    /**
+     * Returns whether this instance is using Scroll API.
+     */
+    public boolean isUsingScrollApi() {
+        return useScrollApi;
+    }
+
+    /**
+     * Clears the Scroll context if one exists. This should always be called when done
+     * processing results to free server resources.
+     * Delegates to ContentletScrollAPI.
+     */
+    @Override
+    public void close() {
+        if (esContentletScroll != null) {
+            esContentletScroll.close();
+            esContentletScroll = null;
+        }
     }
 
     private class ContentletIterator implements Iterator<Contentlet> {
@@ -107,6 +263,15 @@ public class PaginatedContentlets implements Iterable<Contentlet> {
                 if (currentIndex >= currentPageContentletInodes.size()) {
                     currentPageContentletInodes = loadNextPage(totalIndex);
                     currentIndex = 0;
+
+                    // Check if loaded page is empty when we expected results
+                    if (currentPageContentletInodes.isEmpty()) {
+                        Logger.error(PaginatedContentlets.this.getClass(),
+                            String.format("CRITICAL: loadNextPage returned empty list but hasNext was true! " +
+                                "totalIndex=%d, totalHits=%d, useScrollApi=%b, query=%s",
+                                totalIndex, totalHits, useScrollApi, luceneQuery));
+                        throw new NoSuchElementException("Pagination returned empty batch when results were expected");
+                    }
                 }
 
                 final String inode = currentPageContentletInodes.get(currentIndex);

--- a/dotcms-integration/src/test/java/com/dotmarketing/util/contentlet/pagination/PaginatedContentletsIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/util/contentlet/pagination/PaginatedContentletsIntegrationTest.java
@@ -252,6 +252,10 @@ public class PaginatedContentletsIntegrationTest {
         final ContentletAPI contentletAPIMock = mock(ContentletAPI.class);
         final String luceneQuery = "+conHost:" + host.getIdentifier();
 
+        // Mock indexCount to return total results (used to determine pagination strategy)
+        when(contentletAPIMock.indexCount(luceneQuery, APILocator.systemUser(), false))
+                .thenReturn(4L);
+
         when(contentletAPIMock.searchIndex(luceneQuery, 2, 0, "title asc",
                         APILocator.systemUser(), false))
                 .thenReturn(expectedFirstCall);

--- a/dotcms-integration/src/test/java/com/dotmarketing/util/contentlet/pagination/PaginatedContentletsIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/util/contentlet/pagination/PaginatedContentletsIntegrationTest.java
@@ -18,6 +18,7 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.PaginatedArrayList;
 import com.dotmarketing.util.contentet.pagination.PaginatedContentletBuilder;
 import com.dotmarketing.util.contentet.pagination.PaginatedContentlets;
@@ -25,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 public class PaginatedContentletsIntegrationTest {
@@ -328,5 +330,164 @@ public class PaginatedContentletsIntegrationTest {
 
         assertEquals("Should not return any Contentlets", 0, paginatedContentlets.size());
 
+    }
+
+    /**
+     * Method to test: {@link PaginatedContentlets} with Scroll API enabled
+     * When:
+     * - Create 3 contentlets in the same Host
+     * - Temporarily set ES_SCROLL_API_THRESHOLD to 1 to force scroll API usage
+     * - Create PaginatedContentlets with the query
+     * Should:
+     * - Use Scroll API (isUsingScrollApi() should return true)
+     * - Return all 3 contentlets correctly
+     * - Maintain proper order
+     */
+    @Test
+    public void testScrollApiWithForcedThreshold() {
+        // Store original threshold value to restore later
+        final String originalThreshold = Config.getStringProperty("ES_SCROLL_API_THRESHOLD", "10000");
+
+        try {
+            // Create test data
+            final Host host = new SiteDataGen().nextPersisted();
+            final ContentType contentType = new ContentTypeDataGen().nextPersisted();
+
+            final long currentTimeMillis = System.currentTimeMillis();
+            final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                    .host(host)
+                    .setProperty("title", "ScrollTest_A_" + currentTimeMillis)
+                    .nextPersisted();
+
+            final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                    .host(host)
+                    .setProperty("title", "ScrollTest_B_" + currentTimeMillis)
+                    .nextPersisted();
+
+            final Contentlet contentlet3 = new ContentletDataGen(contentType)
+                    .host(host)
+                    .setProperty("title", "ScrollTest_C_" + currentTimeMillis)
+                    .nextPersisted();
+
+            final List<Contentlet> expected = list(contentlet1, contentlet2, contentlet3);
+
+            // Temporarily lower threshold to force scroll API usage
+            // Setting to 1 means any query with more than 1 result will use scroll
+            Config.setProperty("ES_SCROLL_API_THRESHOLD", "1");
+
+            // Create PaginatedContentlets with try-with-resources to ensure cleanup
+            try (final PaginatedContentlets paginatedContentlets = new PaginatedContentletBuilder()
+                    .setLuceneQuery("+conHost:" + host.getIdentifier())
+                    .setUser(APILocator.systemUser())
+                    .setRespectFrontendRoles(false)
+                    .build()) {
+
+                // Verify that Scroll API is being used
+                assertTrue("Scroll API should be used when threshold is exceeded",
+                        paginatedContentlets.isUsingScrollApi());
+
+                // Verify total count
+                assertEquals("Should return all 3 contentlets", expected.size(),
+                        paginatedContentlets.size());
+
+                // Verify all contentlets are returned in correct order
+                int i = 0;
+                for (Contentlet contentlet : paginatedContentlets) {
+                    final Contentlet contentletExpected = expected.get(i++);
+
+                    assertEquals("Contentlet identifiers should match in order",
+                            contentletExpected.getIdentifier(), contentlet.getIdentifier());
+                    assertEquals("Contentlet titles should match in order",
+                            contentletExpected.getTitle(), contentlet.getTitle());
+                }
+
+                // Verify we iterated through all contentlets
+                assertEquals("Should have iterated through all contentlets", expected.size(), i);
+            }
+            // try-with-resources ensures scroll context is cleaned up
+
+        } finally {
+            // Always restore original configuration
+            Config.setProperty("ES_SCROLL_API_THRESHOLD", originalThreshold);
+        }
+    }
+
+    /**
+     * Method to test: {@link PaginatedContentlets} with Scroll API and pagination
+     * When:
+     * - Create 3 contentlets in the same Host
+     * - Temporarily set ES_SCROLL_API_THRESHOLD to 1 to force scroll API usage
+     * - Set perPage to 2 to force multiple batches
+     * Should:
+     * - Use Scroll API
+     * - Return all 3 contentlets correctly across multiple batches
+     * - Maintain proper order
+     */
+    @Test
+    public void testScrollApiWithMultipleBatches() {
+        final String originalThreshold = Config.getStringProperty("ES_SCROLL_API_THRESHOLD", "10000");
+
+        try {
+            // Create test data
+            final Host host = new SiteDataGen().nextPersisted();
+            final ContentType contentType = new ContentTypeDataGen().nextPersisted();
+
+            final long currentTimeMillis = System.currentTimeMillis();
+            final Contentlet contentlet1 = new ContentletDataGen(contentType)
+                    .host(host)
+                    .setProperty("title", "ScrollBatch_A_" + currentTimeMillis)
+                    .nextPersisted();
+
+            final Contentlet contentlet2 = new ContentletDataGen(contentType)
+                    .host(host)
+                    .setProperty("title", "ScrollBatch_B_" + currentTimeMillis)
+                    .nextPersisted();
+
+            final Contentlet contentlet3 = new ContentletDataGen(contentType)
+                    .host(host)
+                    .setProperty("title", "ScrollBatch_C_" + currentTimeMillis)
+                    .nextPersisted();
+
+            final List<Contentlet> expected = list(contentlet1, contentlet2, contentlet3);
+
+            // Force scroll API usage with low threshold
+            Config.setProperty("ES_SCROLL_API_THRESHOLD", "1");
+
+            // Create PaginatedContentlets with small batch size to test pagination
+            try (final PaginatedContentlets paginatedContentlets = new PaginatedContentletBuilder()
+                    .setLuceneQuery("+conHost:" + host.getIdentifier())
+                    .setUser(APILocator.systemUser())
+                    .setRespectFrontendRoles(false)
+                    .setPerPage(2) // Small batch size to force multiple scroll batches
+                    .build()) {
+
+                // Verify that Scroll API is being used
+                assertTrue("Scroll API should be used when threshold is exceeded",
+                        paginatedContentlets.isUsingScrollApi());
+
+                // Verify total count
+                assertEquals("Should return all 3 contentlets", expected.size(),
+                        paginatedContentlets.size());
+
+                // Verify all contentlets are returned correctly across batches
+                int i = 0;
+                for (Contentlet contentlet : paginatedContentlets) {
+                    final Contentlet contentletExpected = expected.get(i++);
+
+                    assertEquals("Contentlet identifiers should match in order (batch " + ((i-1)/2 + 1) + ")",
+                            contentletExpected.getIdentifier(), contentlet.getIdentifier());
+                    assertEquals("Contentlet titles should match in order (batch " + ((i-1)/2 + 1) + ")",
+                            contentletExpected.getTitle(), contentlet.getTitle());
+                }
+
+                // Verify we iterated through all contentlets
+                assertEquals("Should have iterated through all contentlets across batches",
+                        expected.size(), i);
+            }
+
+        } finally {
+            // Always restore original configuration
+            Config.setProperty("ES_SCROLL_API_THRESHOLD", originalThreshold);
+        }
     }
 }


### PR DESCRIPTION
Closes #33661

This PR addresses performance issues and pagination errors in the site copy job by implementing ElasticSearch Scroll API for a large result set.

### Proposed Changes
* When copying sites with large numbers of contentlets, the copy host job was encountering deep pagination errors when the offset exceeded ElasticSearch's max_result_window (100,000), and also performance degradation with offset-based pagination for large result sets.
* A refactoring was done on the `indexSearchScroll` method from the `ESContentFactoryImp` class to expose the ES scroll API in a new wrapper interface `ESContentletScroll`. The `PaginatedContentlets` class uses this new interface to iterate on results using the ES scroll API.
* SQL queries in `HostFactoryImpl` were optimized to use `structure_inode` field from `contentlet` table to filter hosts, and also to use the ILIKE clause in SQL conditions to match case insensitive values.

### Checklist
- [x] Tests

This PR fixes: #33661