### PR TITLE
add find(identifier) method to FolderWebAPI viewtool (#34033)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/FolderWebAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/FolderWebAPI.java
@@ -47,4 +47,8 @@ public class FolderWebAPI implements ViewTool{
 	public Folder findCurrentFolder(String path, Host host) throws DotStateException, DotDataException, DotSecurityException{
 		return folderAPI.findFolderByPath(path, host.getIdentifier(), APILocator.getUserAPI().getSystemUser(), true);
 	}
+
+	public Folder find(String folderIdOrInode) throws DotSecurityException,DotDataException{
+		return folderAPI.find(folderIdOrInode, APILocator.getUserAPI().getSystemUser(),true);
+	}
 }


### PR DESCRIPTION
Before 


<img width="1722" height="748" alt="Screenshot 2025-12-08 at 2 53 58 PM" src="https://github.com/user-attachments/assets/ef26b32b-37cb-4f21-9b3c-835d58f3375b" />



After

<img width="1422" height="606" alt="Screenshot 2025-12-08 at 2 53 38 PM" src="https://github.com/user-attachments/assets/ed2e03c4-4f49-40d5-8874-9e16a9e7ebd6" />


This PR fixes: #34033

This PR fixes: #34033