### PR TITLE
feat: add user information to bundle deletion logs (#33978)

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_unpushed_bundles.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_unpushed_bundles.jsp
@@ -28,8 +28,7 @@
 
 	if(null!=request.getParameter("delBundle")){
 		String id = request.getParameter("delBundle");
-		APILocator.getBundleAPI().deleteBundle(id);
-		
+		APILocator.getBundleAPI().deleteBundleAndDependencies(id,user);
 		String selectedBundleKey = com.dotmarketing.util.WebKeys.SELECTED_BUNDLE + request.getSession().getAttribute("USER_ID");
 		
 		Bundle lastSelectedBundle = (com.dotcms.publisher.bundle.bean.Bundle) request.getSession().getAttribute( selectedBundleKey ); 


### PR DESCRIPTION
Before

<img width="1712" height="923" alt="Screenshot 2025-12-08 at 3 38 33 PM" src="https://github.com/user-attachments/assets/0338e164-b05d-4a60-abe7-47ad6e43a913" />


After

<img width="1706" height="883" alt="Screenshot 2025-12-08 at 3 38 09 PM" src="https://github.com/user-attachments/assets/590faa0a-0f38-4a3e-a7cb-08cbfea9fb51" />

This PR fixes: #33978

This PR fixes: #33978