### PR TITLE
fix(ci): Remove needs.deployment.result from release phase with block

### DIFF
--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -133,7 +133,6 @@ jobs:
       upload_javadocs: ${{ github.event.inputs.upload_javadocs }}
       update_plugins: ${{ github.event.inputs.update_plugins }}
       update_github_labels: ${{ github.event.inputs.update_github_labels }}
-      deployment_succeeded: ${{ needs.deployment.result == 'success' }}
     secrets:
       EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
       EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}

--- a/.github/workflows/cicd_comp_release-phase.yml
+++ b/.github/workflows/cicd_comp_release-phase.yml
@@ -50,10 +50,6 @@ on:
         description: 'Update GitHub labels'
         type: boolean
         default: true
-      deployment_succeeded:
-        description: 'Whether the deployment phase succeeded (required for safe label updates)'
-        type: boolean
-        required: true
     secrets:
       EE_REPO_USERNAME:
         required: false
@@ -206,13 +202,12 @@ jobs:
           echo "::endgroup::"
 
   # Update GitHub labels for release tracking
-  # CRITICAL SAFETY: Only updates labels if BOTH deployment phase (Docker Hub) AND
-  # release-artifacts (Artifactory/Javadocs) succeeded. This prevents partial releases
-  # from being marked as complete.
+  # Only updates labels if release-artifacts (Artifactory/Javadocs) succeeded.
+  # The calling workflow's dependency chain ensures deployment also succeeded.
   release-labeling:
     name: Release Labeling
     needs: [ release-artifacts ]
-    if: success() && inputs.deployment_succeeded && inputs.update_github_labels == true
+    if: success() && inputs.update_github_labels == true
     uses: ./.github/workflows/issue_comp_release-labeling.yml
     with:
       new_label: 'Release : ${{ inputs.release_version }}'


### PR DESCRIPTION
## Summary
Fixes the release workflow by removing the redundant `deployment_succeeded` parameter that caused syntax validation errors and skipped the entire release phase during workflow run [#20043196360](https://github.com/dotCMS/core/actions/runs/20043196360).

## Root Cause
The `deployment_succeeded` parameter had two critical problems:

1. **GitHub Actions Syntax Error**: GitHub Actions does **NOT** support using `needs.<job>.result` in the `with:` block of reusable workflow calls. The `needs.*.result` context is **only available in `if:` conditions**.

2. **Redundant Logic**: The parameter was unnecessary because:
   - The release job already has `needs: [deployment]` with `if: !failure()`, ensuring deployment succeeded
   - The release-labeling job uses `if: success()`, which already checks that release-artifacts succeeded
   - GitHub Actions' native dependency chain already enforces the safety requirement

When GitHub Actions validated the workflow and found:
```yaml
deployment_succeeded: ${{ needs.deployment.result == 'success' }}
```

It rejected this with "Unexpected value" errors and skipped the entire release phase, marking it as "failure" without ever executing it.

## Impact
This caused **critical partial release failures**:
- ✅ Docker images deployed successfully  
- ❌ Maven artifacts NOT deployed to Artifactory
- ❌ Javadocs NOT uploaded to S3
- ❌ SBOM NOT generated
- ❌ GitHub labels NOT updated
- ❌ Plugins NOT notified

## The Fix
Removed the `deployment_succeeded` parameter entirely from:
1. **cicd_6-release.yml** (line 132) - Removed the problematic input
2. **cicd_comp_release-phase.yml** (lines 53-56) - Removed the input definition
3. **cicd_comp_release-phase.yml** (line 211) - Removed from release-labeling condition

The workflow now relies on GitHub Actions' native job dependency checking:
- The `release` job only runs if `deployment` succeeds (via `needs` + `if: !failure()`)
- The `release-labeling` job only runs if `release-artifacts` succeeds (via `if: success()`)
- This properly ensures both deployment and release-artifacts succeed before updating labels

**Changes**: 2 files, -6 lines (removed redundancy)

## Test Plan
- [ ] Trigger a test release workflow run
- [ ] Verify the release phase actually executes (no annotations)
- [ ] Verify all release steps complete successfully (Artifactory, Javadocs, SBOM, labels)
- [ ] Confirm release-labeling only runs when both deployment and release-artifacts succeed

## Related Issues
Fixes #34051  
References: https://github.com/dotCMS/core/actions/runs/20043196360

## Documentation
See complete root cause analysis: `.claude/diagnostics/run-20043196360/DIAGNOSIS-FINAL.md`

This PR fixes: #34051