### PR TITLE
Move to use the jitsu batch endpoints

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/app/AnalyticsApp.java
@@ -87,7 +87,7 @@ public class AnalyticsApp {
         final Optional<Secret> secret = AppsUtil.paramSecret(
                 ANALYTICS_APP_KEY,
                 name,
-                analyticsKey.jsKey().toCharArray(),
+                analyticsKey.m2mKey().toCharArray(),
                 paramDescriptor);
 
         APILocator.getAppsAPI().saveSecret(

--- a/dotCMS/src/main/java/com/dotcms/jitsu/AnalyticsEventsPayload.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/AnalyticsEventsPayload.java
@@ -4,6 +4,7 @@ import com.dotmarketing.util.json.JSONObject;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -21,7 +22,7 @@ public class AnalyticsEventsPayload extends EventsPayload {
     }
 
     @Override
-    public Iterable<EventPayload> payloads() {
+    public Collection<EventPayload> payloads() {
 
         final List<EventPayload> eventPayloads = new ArrayList<>();
 

--- a/dotCMS/src/main/java/com/dotcms/jitsu/EventsPayload.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/EventsPayload.java
@@ -3,6 +3,7 @@ package com.dotcms.jitsu;
 import com.dotcms.util.JsonUtil;
 import com.dotmarketing.util.json.JSONObject;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -27,7 +28,7 @@ public abstract class EventsPayload {
     }
 
 
-    public abstract Iterable<EventPayload> payloads();
+    public abstract Collection<EventPayload> payloads();
 
     public static class EventPayload {
         private JSONObject jsonObject;

--- a/dotCMS/src/main/java/com/dotcms/jitsu/ExperimentEventsPayload.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/ExperimentEventsPayload.java
@@ -3,6 +3,7 @@ package com.dotcms.jitsu;
 import com.dotmarketing.util.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public class ExperimentEventsPayload extends EventsPayload {
     }
 
     @Override
-    public Iterable<EventPayload> payloads() {
+    public Collection<EventPayload> payloads() {
         final String jsonObjectString = jsonObject.toString();
         final List<EventPayload> eventPayloads = new ArrayList<>();
 

--- a/dotCMS/src/main/java/com/dotcms/jitsu/ValidAnalyticsEventPayload.java
+++ b/dotCMS/src/main/java/com/dotcms/jitsu/ValidAnalyticsEventPayload.java
@@ -4,6 +4,8 @@ package com.dotcms.jitsu;
 import com.dotmarketing.util.json.JSONObject;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -105,7 +107,7 @@ public class ValidAnalyticsEventPayload extends EventsPayload {
      * @return a collection of {@link EventsPayload} objects to be sent to Jitsu.
      */
     @Override
-    public Iterable<EventPayload> payloads() {
+    public Collection<EventPayload> payloads() {
         return ValidAnalyticsEventPayloadTransformer.INSTANCE.transform(jsonObject);
     }
 }


### PR DESCRIPTION
We need to support bath in dotCMs to send the event to jitsu, for this we need to use a different key and a different endpoint, the endpoint is going to be set in the App, for now this batch is really simple it just take the batch of events send by the FE and send it as a batch to jitsu.

### Proposed Changes

* Use the m2 key instead of the jskey
https://github.com/dotCMS/core/pull/34059/files#diff-29cacbde2fe6ea160809f524ffd80ffc8526f8d2f60cff0339996965c0e36b90R90

* Not send a request for each event in the payload, now we are going to send just one Request for all the events

https://github.com/dotCMS/core/pull/34059/files#diff-c6b552720dcdd032d58c9b299fd4c5aba7a5f3b233c6ae1d7a1528e94bfe51c7R102-R131


This PR fixes: #34048