### PR TITLE
feat(content analytics) #34041 : Create metric for `Traffic vs Conversions` metric

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/EventSummary.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/EventSummary.js
@@ -1,6 +1,8 @@
-
+/**
+ * This model is used for calculating basic metrics related to events of type `conversion`.
+ */
 cube(`EventSummary`, {
-  // 1) Source table in ClickHouse
+
   sql: `
     SELECT day, cluster_id, customer_id, context_site_id, event_type, context_user_id, identifier, title, daily_total
     FROM content_events_counter
@@ -12,12 +14,14 @@ cube(`EventSummary`, {
 
   // 2) Measures
   measures: {
-    totalUsers: {
+
+    uniqueVisitors: {
       sql: `context_user_id`,
       type: `countDistinct`,
       title: 'Unique Users',
       description: 'Total number of unique users across all sessions'
     },
+
     // Generic measure: total events across all event types
     totalEvents: {
       sql: `daily_total`,
@@ -41,6 +45,7 @@ cube(`EventSummary`, {
       filters: [
         { sql: `${CUBE}.event_type = 'conversion'` }
       ],
+      description: 'Total of events of type `conversion`',
       drillMembers: [
         day,
         customerId,
@@ -49,91 +54,78 @@ cube(`EventSummary`, {
         contextUserId,
         identifier,
         title
-      ],
-      description: 'Total of events'
+      ]
     },
 
     // Filtered measure: Converting visitors
-    convertingVisitors: {
-      sql: `daily_total`,
-      type: `sum`,
+    uniqueConvertingVisitors: {
+      sql: `context_user_id`,
+      type: `countDistinct`,
       filters: [
         { sql: `${CUBE}.event_type = 'conversion'` }
       ],
-      drillMembers: [
-        day,
-        customerId,
-        clusterId,
-        contextSiteId,
-        contextUserId,
-        identifier,
-        title
-      ],
-      description: 'Total of conversion'
-    },
+      description: 'Total number of unique User IDs -- visitors -- who triggered a conversion event at some point'
+    }
 
-    // (optional) If you later want a generic "by event type" measure:
-    // you can just use `totalEvents` + a filter at query time.
   },
 
   // 3) Dimensions
   dimensions: {
     day: {
       sql: `day`,
-      type: `time`
+      type: `time`,
+      title: 'Day',
+      description: 'The day when the event was created.'
     },
 
     clusterId: {
       sql: `cluster_id`,
-      type: `string`
+      type: `string`,
+      title: 'Cluster ID',
+      description: 'The ID or type of customer environment where the event was created.'
     },
 
     customerId: {
       sql: `customer_id`,
-      type: `string`
+      type: `string`,
+      title: 'Customer ID',
+      description: 'The ID or name of the customer environment where the event was created.'
     },
 
     contextSiteId: {
       sql: `context_site_id`,
-      type: `string`
+      type: `string`,
+      title: 'Site ID',
+      description: 'The ID of the Site that the event was created for.'
     },
 
     eventType: {
       sql: `event_type`,
-      type: `string`
+      type: `string`,
+      title: 'Event Type',
+      description: 'Type of tracked event (pageview, content_impression, content_click, etc.).'
     },
 
     contextUserId: {
       sql: `context_user_id`,
-      type: `string`
+      type: `string`,
+      title: 'User ID',
+      description: 'The ID of the User tha triggered the creation of the event.'
     },
 
     identifier: {
       sql: `identifier`,
-      type: `string`
+      type: `string`,
+      title: 'Identifier',
+      description: 'The Identifier of the Contentlet that the event is related to.'
     },
 
     title: {
       sql: `title`,
-      type: `string`
+      type: `string`,
+      title: 'Title',
+      description: 'The title of the Contentlet that the event is related to.'
     }
   },
 
-  // 4) (Optional) Pre-aggregations – you can add these later if needed
-  //    Right now your table is already daily-aggregated, so you may not
-  //    need extra rollups immediately.
-  /*
-  preAggregations: {
-    byDayCustomerSite: {
-      type: `rollup`,
-      measureReferences: [totalEvents],
-      dimensionReferences: [customerId, clusterId, contextSiteId, eventType],
-      timeDimensionReference: day,
-      granularity: `day`,
-      refreshKey: {
-        every: `5 minutes`
-      }
-    }
-  }
-  */
 });


### PR DESCRIPTION
### Proposed Changes
* This metric provides a visual representation of the metric exposed here:
  * #33870
* The CubeJS query that exposes the data for a specified time range is:
```json
{
    "measures": [
        "EventSummary.uniqueVisitors",
        "EventSummary.uniqueConvertingVisitors"
    ],
    "timeDimensions": [
        {
            "dimension": "EventSummary.day",
            "dateRange": [
                "2025-12-01",
                "2025-12-08"
            ],
            "granularity": "day"
        }
    ]
}
```

This PR fixes: #34041