### PR TITLE
Defect update headless examples to render block editor contenlets correctly

### DIFF
--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/blog-post.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/blog-post.component.ts
@@ -38,6 +38,12 @@ export class BlogPostComponent implements OnChanges {
     Activity: import('./customRenderers/activity/activity.component').then(
       (c) => c.ActivityComponent,
     ),
+    Product: import('./customRenderers/product/product.component').then(
+      (c) => c.ProductComponent,
+    ),
+    Destination: import('./customRenderers/destination/destination.component').then(
+      (c) => c.DestinationComponent,
+    )
   };
 
   editPost() {

--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/activity/activity.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/activity/activity.component.ts
@@ -8,7 +8,7 @@ import { Activity } from '../../../../../types/contentlet.model';
   template: `
     <div class="w-full p-4 my-2 bg-white rounded-lg border border-slate-400">
         <h4 class="text-lg font-bold">{{ contentlet().title }}</h4>
-        <span class="text-sm text-slate-500">{{ contentlet().contentType }}</span>
+        <span class="text-sm text-cyan-700">{{ contentlet().contentType }}</span>
     </div>
   `,
   standalone: true,

--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/activity/activity.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/activity/activity.component.ts
@@ -8,6 +8,7 @@ import { Activity } from '../../../../../types/contentlet.model';
   template: `
     <div class="w-full p-4 my-2 bg-white rounded-lg border border-slate-400">
         <h4 class="text-lg font-bold">{{ contentlet().title }}</h4>
+        <p class="line-clamp-2">{{ contentlet().description }}</p>
         <span class="text-sm text-cyan-700">{{ contentlet().contentType }}</span>
     </div>
   `,

--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/destination/destination.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/destination/destination.component.ts
@@ -9,7 +9,7 @@ import { Destination } from '../../../../../types/contentlet.model';
     template: `
     <div class="w-full p-4 my-2 bg-white rounded-lg border border-slate-400">
         <h4 class="text-lg font-bold">{{ contentlet().title }}</h4>
-        <span class="text-sm text-slate-500">{{ contentlet().contentType }}</span>
+        <span class="text-sm text-blue-500">{{ contentlet().contentType }}</span>
     </div>
   `,
 })

--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/destination/destination.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/destination/destination.component.ts
@@ -1,22 +1,23 @@
 import { Component, computed, Input } from '@angular/core';
 import { BlockEditorNode } from '@dotcms/types';
 
-import { Activity } from '../../../../../types/contentlet.model';
+import { Destination } from '../../../../../types/contentlet.model';
 
 @Component({
-  selector: 'app-activity',
-  template: `
+    selector: 'app-destination',
+    standalone: true,
+    template: `
     <div class="w-full p-4 my-2 bg-white rounded-lg border border-slate-400">
         <h4 class="text-lg font-bold">{{ contentlet().title }}</h4>
         <span class="text-sm text-slate-500">{{ contentlet().contentType }}</span>
     </div>
   `,
-  standalone: true,
 })
-export class ActivityComponent {
-  @Input() node!: BlockEditorNode;
+export class DestinationComponent {
+    @Input() node!: BlockEditorNode;
 
-  contentlet = computed(() => {
-    return this.node.attrs?.['data'] as Activity;
-  });
+    contentlet = computed(() => {
+        return this.node.attrs?.['data'] as Destination;
+    });
 }
+

--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/destination/destination.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/destination/destination.component.ts
@@ -9,6 +9,7 @@ import { Destination } from '../../../../../types/contentlet.model';
     template: `
     <div class="w-full p-4 my-2 bg-white rounded-lg border border-slate-400">
         <h4 class="text-lg font-bold">{{ contentlet().title }}</h4>
+        <p class="line-clamp-2">{{ contentlet().shortDescription }}</p>
         <span class="text-sm text-indigo-700">{{ contentlet().contentType }}</span>
     </div>
   `,

--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/destination/destination.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/destination/destination.component.ts
@@ -9,7 +9,7 @@ import { Destination } from '../../../../../types/contentlet.model';
     template: `
     <div class="w-full p-4 my-2 bg-white rounded-lg border border-slate-400">
         <h4 class="text-lg font-bold">{{ contentlet().title }}</h4>
-        <span class="text-sm text-blue-500">{{ contentlet().contentType }}</span>
+        <span class="text-sm text-indigo-700">{{ contentlet().contentType }}</span>
     </div>
   `,
 })
@@ -20,4 +20,3 @@ export class DestinationComponent {
         return this.node.attrs?.['data'] as Destination;
     });
 }
-

--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/product/product.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/product/product.component.ts
@@ -8,7 +8,8 @@ import { Product } from '../../../../../types/contentlet.model';
   template: `
     <div class="w-full p-4 my-2 bg-white rounded-lg border border-slate-400">
         <h4 class="text-lg font-bold">{{ contentlet().title }}</h4>
-        <span class="text-sm text-indigo-700">{{ contentlet().contentType }}</span>
+        <div class="line-clamp-2" [innerHTML]="contentlet().description"></div>
+        <span class="text-sm text-blue-500">{{ contentlet().contentType }}</span>
     </div>
   `,
   standalone: true,

--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/product/product.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/product/product.component.ts
@@ -1,10 +1,10 @@
 import { Component, computed, Input } from '@angular/core';
 import { BlockEditorNode } from '@dotcms/types';
 
-import { Activity } from '../../../../../types/contentlet.model';
+import { Product } from '../../../../../types/contentlet.model';
 
 @Component({
-  selector: 'app-activity',
+  selector: 'app-product',
   template: `
     <div class="w-full p-4 my-2 bg-white rounded-lg border border-slate-400">
         <h4 class="text-lg font-bold">{{ contentlet().title }}</h4>
@@ -13,10 +13,10 @@ import { Activity } from '../../../../../types/contentlet.model';
   `,
   standalone: true,
 })
-export class ActivityComponent {
+export class ProductComponent {
   @Input() node!: BlockEditorNode;
 
   contentlet = computed(() => {
-    return this.node.attrs?.['data'] as Activity;
+    return this.node.attrs?.['data'] as Product;
   });
 }

--- a/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/product/product.component.ts
+++ b/examples/angular/src/app/dotcms/pages/blog/blog-post/customRenderers/product/product.component.ts
@@ -8,7 +8,7 @@ import { Product } from '../../../../../types/contentlet.model';
   template: `
     <div class="w-full p-4 my-2 bg-white rounded-lg border border-slate-400">
         <h4 class="text-lg font-bold">{{ contentlet().title }}</h4>
-        <span class="text-sm text-slate-500">{{ contentlet().contentType }}</span>
+        <span class="text-sm text-indigo-700">{{ contentlet().contentType }}</span>
     </div>
   `,
   standalone: true,

--- a/examples/angular/src/app/dotcms/types/contentlet.model.ts
+++ b/examples/angular/src/app/dotcms/types/contentlet.model.ts
@@ -58,7 +58,7 @@ export interface Destination extends Contentlet {
   modDate: string;
   url: string;
   shortDescription?: string;
-  activities?: string[];
+  activities?: Activity[];
   selectValue?: string;
 }
 

--- a/examples/angular/src/app/dotcms/types/contentlet.model.ts
+++ b/examples/angular/src/app/dotcms/types/contentlet.model.ts
@@ -66,6 +66,7 @@ export interface Product extends Contentlet {
   salePrice: number;
   retailPrice: number;
   urlTitle: string;
+  description?: string;
 }
 
 export interface Activity extends Contentlet {

--- a/examples/astro/src/views/DetailPage.tsx
+++ b/examples/astro/src/views/DetailPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 
-import type { BlockEditorNode } from "@dotcms/types";
 import { enableBlockEditorInline } from "@dotcms/uve";
 import {
     DotCMSBlockEditorRenderer,
@@ -68,22 +67,33 @@ export function DetailPage({ pageResponse }: { pageResponse: DotCMSCustomDetailP
 const customRenderers = {
     Activity: (props: CustomRendererProps) => {
         const { node } = props;
-        const { title, description } = node.attrs?.data || {};
+        const { title, contentType } = node.attrs?.data || {};
 
         return (
-            <div>
-                <h1>{title}</h1>
-                <p>{description}</p>
+            <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
+                <h2 className="text-2xl font-bold">{title}</h2>
+                <p className="text-sm text-cyan-700">{contentType}</p>
             </div>
         );
     },
     Product: (props: CustomRendererProps) => {
-        const { title, description } = props.node.attrs?.data || {};
+        const { title, contentType } = props.node.attrs?.data || {};
 
         return (
-            <div>
-                <h1>{title}</h1>
-                <div dangerouslySetInnerHTML={{ __html: description }} />
+            <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
+                <h2 className="text-2xl font-bold">{title}</h2>
+                <p className="text-sm text-blue-500">{contentType}</p>
+            </div>
+        );
+    },
+    Destination: (props: CustomRendererProps) => {
+        const { title, shortDescription, contentType } = props.node.attrs?.data || {};
+
+        return (
+            <div className="p-6 mb-4 rounded-2xl bg-white shadow-lg">
+                <h2 className="text-2xl font-bold">{title}</h2>
+                <p className="line-clamp-2">{shortDescription}</p>
+                <p className="text-sm text-indigo-700">{contentType}</p>
             </div>
         );
     }

--- a/examples/astro/src/views/DetailPage.tsx
+++ b/examples/astro/src/views/DetailPage.tsx
@@ -67,21 +67,23 @@ export function DetailPage({ pageResponse }: { pageResponse: DotCMSCustomDetailP
 const customRenderers = {
     Activity: (props: CustomRendererProps) => {
         const { node } = props;
-        const { title, contentType } = node.attrs?.data || {};
+        const { title, description, contentType } = node.attrs?.data || {};
 
         return (
             <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
                 <h2 className="text-2xl font-bold">{title}</h2>
+                <p className="line-clamp-2">{description}</p>
                 <p className="text-sm text-cyan-700">{contentType}</p>
             </div>
         );
     },
     Product: (props: CustomRendererProps) => {
-        const { title, contentType } = props.node.attrs?.data || {};
+        const { title, description, contentType } = props.node.attrs?.data || {};
 
         return (
             <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
                 <h2 className="text-2xl font-bold">{title}</h2>
+                <div className="line-clamp-2" dangerouslySetInnerHTML={{ __html: description }} />
                 <p className="text-sm text-blue-500">{contentType}</p>
             </div>
         );

--- a/examples/nextjs/src/views/DetailPage.js
+++ b/examples/nextjs/src/views/DetailPage.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { Activity, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 
 import { enableBlockEditorInline } from "@dotcms/uve";

--- a/examples/nextjs/src/views/DetailPage.js
+++ b/examples/nextjs/src/views/DetailPage.js
@@ -78,11 +78,12 @@ export function DetailPage({ pageContent }) {
 
 const customRenderers = {
     Activity: (props) => {
-        const { title, contentType } = props.node.attrs?.data || {};
+        const { title, description, contentType } = props.node.attrs?.data || {};
 
         return (
             <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
                 <h2 className="text-2xl font-bold">{title}</h2>
+                <p className="line-clamp-2">{description}</p>
                 <p className="text-sm text-cyan-700">{contentType}</p>
             </div>
         );
@@ -93,6 +94,7 @@ const customRenderers = {
         return (
             <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
                 <h2 className="text-2xl font-bold">{title}</h2>
+                <div className="line-clamp-2" dangerouslySetInnerHTML={{ __html: description }} />
                 <p className="text-sm text-blue-500">{contentType}</p>
             </div>
         );

--- a/examples/nextjs/src/views/DetailPage.js
+++ b/examples/nextjs/src/views/DetailPage.js
@@ -77,23 +77,34 @@ export function DetailPage({ pageContent }) {
 }
 
 const customRenderers = {
-    Activity: (props) => {
-        const { title, description } = props.attrs?.data || {};
+    Destination: (props) => {
+        const { title, shortDescription, activities } = props.node.attrs?.data || {};
 
         return (
-            <div>
-                <h1>{title}</h1>
-                <p>{description}</p>
+            <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
+                <h2 className="text-2xl font-bold">{title}</h2>
+                <p className="line-clamp-2">{shortDescription}</p>
+                <h3 className="text-lg font-semibold mb-4">Activities</h3>
+                <ul>
+                    {activities.map((activity) => (
+                        <li key={activity.identifier}>{activity.title}</li>
+                    ))}
+                </ul>
             </div>
         );
     },
     Product: (props) => {
-        const { title, description } = props.attrs?.data || {};
+        const { title, description } = props.node.attrs?.data || {};
 
         return (
-            <div>
-                <h1>{title}</h1>
-                <div dangerouslySetInnerHTML={{ __html: description }} />
+            <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
+                <h2 className="mb-3 text-xl font-bold text-slate-800 line-clamp-2">
+                    {title}
+                </h2>
+                <div
+                    className="text-sm text-slate-600 line-clamp-4"
+                    dangerouslySetInnerHTML={{ __html: description }}
+                />
             </div>
         );
     },

--- a/examples/nextjs/src/views/DetailPage.js
+++ b/examples/nextjs/src/views/DetailPage.js
@@ -89,7 +89,7 @@ const customRenderers = {
         );
     },
     Product: (props) => {
-        const { title, contentType } = props.node.attrs?.data || {};
+        const { title, description, contentType } = props.node.attrs?.data || {};
 
         return (
             <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">

--- a/examples/nextjs/src/views/DetailPage.js
+++ b/examples/nextjs/src/views/DetailPage.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Activity, useEffect, useState } from "react";
 import Image from "next/image";
 
 import { enableBlockEditorInline } from "@dotcms/uve";
@@ -77,35 +77,35 @@ export function DetailPage({ pageContent }) {
 }
 
 const customRenderers = {
-    Destination: (props) => {
-        const { title, shortDescription, activities } = props.node.attrs?.data || {};
+    Activity: (props) => {
+        const { title, contentType } = props.node.attrs?.data || {};
 
         return (
             <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
                 <h2 className="text-2xl font-bold">{title}</h2>
-                <p className="line-clamp-2">{shortDescription}</p>
-                <h3 className="text-lg font-semibold mb-4">Activities</h3>
-                <ul>
-                    {activities.map((activity) => (
-                        <li key={activity.identifier}>{activity.title}</li>
-                    ))}
-                </ul>
+                <p className="text-sm text-cyan-700">{contentType}</p>
             </div>
         );
     },
     Product: (props) => {
-        const { title, description } = props.node.attrs?.data || {};
+        const { title, contentType } = props.node.attrs?.data || {};
 
         return (
             <div className="p-6 mb-4 overflow-hidden rounded-2xl bg-white shadow-lg">
-                <h2 className="mb-3 text-xl font-bold text-slate-800 line-clamp-2">
-                    {title}
-                </h2>
-                <div
-                    className="text-sm text-slate-600 line-clamp-4"
-                    dangerouslySetInnerHTML={{ __html: description }}
-                />
+                <h2 className="text-2xl font-bold">{title}</h2>
+                <p className="text-sm text-blue-500">{contentType}</p>
             </div>
         );
     },
+    Destination: (props) => {
+        const { title, shortDescription, contentType } = props.node.attrs?.data || {};
+
+        return (
+            <div className="p-6 mb-4 rounded-2xl bg-white shadow-lg">
+                <h2 className="text-2xl font-bold">{title}</h2>
+                <p className="line-clamp-2">{shortDescription}</p>
+                <p className="text-sm text-indigo-700">{contentType}</p>
+            </div>
+        );
+    }
 };


### PR DESCRIPTION
### Proposed Changes
Update SDK examples (Next.js, Angular, Astro) adding styles and retrieve the contentlet information by using.
```ts
props.node.attrs?.data
```

### Changes made
- [ ] Added styles to the custom render Activities, Products.
- [ ] Create a custom render for Destinations
- [ ] update `props.attrs?.data` data to `props.node.attrs?.data` where need it.

This PR fixes: #34061

This PR fixes: #34061