### PR TITLE
feat(content analytics) #33380 : Improve error messaging when typos in CubeJS query are present

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/analytics/helper/AnalyticsHelper.java
@@ -20,6 +20,7 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.language.LanguageUtil;
 import com.liferay.portal.model.User;
 import com.liferay.util.StringPool;
@@ -175,17 +176,25 @@ public class AnalyticsHelper implements EventSubscriber<SystemTableUpdatedKeyEve
     }
 
     /**
-     * Given an {@link AccessToken} instance based on some checks evaluates if access token can be used.
+     * Given an {@link AccessToken} instance, and based on some checks, this method evaluates if the
+     * access token can be used.
      *
-     * @param accessToken provided access token
+     * @param accessToken The provided {@link AccessToken}.
+     *
+     * @throws AnalyticsException The specified access token is not valid. This may be related to a
+     *                            misconfiguration in the Experiments App.
      */
     public void checkAccessToken(final AccessToken accessToken) throws AnalyticsException {
         final TokenStatus tokenStatus = resolveTokenStatus(accessToken);
 
         if (!canUseToken(tokenStatus)) {
+            if (null != accessToken.status() && UtilMethods.isSet(accessToken.status().reason())) {
+                Logger.error(this, accessToken.status().reason());
+            }
             throw new AnalyticsException(
                 String.format(
-                    "ACCESS_TOKEN for clientId %s is %s",
+                    "ACCESS_TOKEN for Analytics Client ID %s is %s" +
+                            ". Please check that the Analytics Client ID value is correct.",
                     accessToken.clientId(),
                     tokenStatus.name()));
         }

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5399,6 +5399,7 @@ error.form.validator.required=This field is required
 error.form.validator.pattern=This field must match the pattern {0}
 analytics.app.override.not.allowed=dotAnalytics is configured using environmental variables - any configuration done within the App screen will be ignored
 analytics.app.not.configured=The Analytics App is not fully configured. Please open the Apps tool, and provide values for the following missing properties in the Analytics Integration: {0}
+analytics.app.cubejs.response.failed=CubeJS Server is not available. Please check that the parameters in the Experiments App and the current configuration in the Content Analytics Infrastructure are correct.
 content.has.change=Content has changed, proceed?
 experimentspage.not.experiments.founds=No experiments were found for this page. Do you want to add a new one now?
 experimentspage.add.new.experiment=Create a new Experiment


### PR DESCRIPTION
### Proposed Changes
* Improved error messaging from the back-end in order to point out more details related to potential errors with CubeJS queries. This PR is meant to handle as many error situations as possible.
* The main goal is to get to the root cause of the problem as fast as possible, without having to dive into the logs when something goes wrong.
* For now, the Angular layer is truncating the error messages as soon as it finds a `:` character in any error message. We'll take care of that in a separate ticket:
  * #34094

This PR fixes: #33380

This PR fixes: #33380