### PR TITLE
Fixing error calculating the conv rate by Content

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Conversion.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Conversion.js
@@ -74,7 +74,7 @@ cube('Conversion', {
             ((total_conversion * 100)/ (SELECT total FROM total_conversion)) as conv_rate,
             day,
             arrayMap(
-                x -> mapUpdate(x, map('conv_rate', toString((toInt64(x['conversions']) * 100) / total_conversion))),
+                x -> mapUpdate(x, map('conv_rate', toString((total_conversion* 100) / toInt64(x['conversions'])))),
                 top_attributed_content
             ) as top_attributed_content
         FROM conversion INNER JOIN top_attributed_content


### PR DESCRIPTION
This PR fixes #34122

### Proposed Changes
* We have an error calculating the conv rate by content
currently we are doing: (100 * total_events)/ total_conversions

it should be: (100 * total_conversions)/ total_events