### PR TITLE
fix(TailLog) Support sub folders  Refs: #34131

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/MaintenanceResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/MaintenanceResource.java
@@ -6,6 +6,7 @@ import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
+import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.util.ConversionUtils;
 import com.dotcms.util.DbExporterUtil;
 import com.dotcms.util.SizeUtil;
@@ -171,7 +172,7 @@ public class MaintenanceResource implements Serializable {
      * @return octet stream response with file contents
      * @throws IOException
      */
-    @Path("/_downloadLog/{fileName}")
+    @Path("/_downloadLog/{fileName:.+}")
     @GET
     @JSONP
     @NoCache
@@ -186,6 +187,11 @@ public class MaintenanceResource implements Serializable {
                 .getStringProperty("TAIL_LOG_LOG_FOLDER", "./dotsecure/logs/");
         if (!tailLogFolder.endsWith(File.separator)) {
             tailLogFolder = tailLogFolder + File.separator;
+        }
+
+        //This should prevent any attack
+        if(!FileUtil.isValidFilePath(fileName)){
+            throw new BadRequestException("Requested LogFile: " + fileName + " is not valid.");
         }
 
         final File logFile = new File(FileUtil.getAbsolutlePath(tailLogFolder + fileName));

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/taillog/TailLogResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/taillog/TailLogResource.java
@@ -1,5 +1,8 @@
 package com.dotcms.rest.api.v1.taillog;
 
+import static com.dotmarketing.util.FileUtil.isValidFilePath;
+import static com.dotmarketing.util.FileUtil.sanitizeFilePath;
+
 import com.dotcms.rest.EmptyHttpResponse;
 import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.WebResource;
@@ -69,7 +72,7 @@ public class TailLogResource {
         }
 
         //This prevents any evil attack attempt allowing for paths including subfolders
-        if(!FileUtil.isValidFilePath(fileName)){
+        if(!isValidFilePath(fileName)){
             return sendError("Invalid File name param");
         }
 
@@ -83,7 +86,7 @@ public class TailLogResource {
         final File logFile 	= new File(FileUtil.getAbsolutlePath(tailLogLofFolder + sanitizedFileName));
 
 
-        // if the logFile is outside of the logFolder, die
+        // if the logFile is outside the logFolder, die
         if ( !logFolder.exists() || !logFolder.canRead()
                 ||   !logFile.getCanonicalPath().startsWith(logFolder.getCanonicalPath())) {
 
@@ -146,36 +149,6 @@ public class TailLogResource {
         }
 
         return eventOutput;
-    }
-
-    /**
-     * Sanitizes a file path by decomposing it into individual components and sanitizing each part separately.
-     * This provides enhanced security by ensuring that both directory names and file names are properly cleaned
-     * to prevent directory traversal attacks and other malicious file path manipulations.
-     *
-     * @param fileName the file path to sanitize, can include directory components
-     * @return the sanitized file path with all components individually cleaned
-     */
-    private String sanitizeFilePath(final String fileName) {
-        // Decompose fileName into directory parts and file name, sanitize each individually
-        final java.nio.file.Path filePath = Paths.get(fileName);
-
-        if (filePath.getParent() != null) {
-            // Has directory components - sanitize each part individually
-            final StringBuilder sanitizedPath = new StringBuilder();
-
-            for (java.nio.file.Path part : filePath) {
-                if (sanitizedPath.length() > 0) {
-                    sanitizedPath.append(File.separator);
-                }
-                sanitizedPath.append(FileUtil.sanitizeFileName(part.toString()));
-            }
-
-            return sanitizedPath.toString();
-        } else {
-            // No directory components - sanitize as single file name
-            return FileUtil.sanitizeFileName(fileName);
-        }
     }
 
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/FileUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/FileUtil.java
@@ -281,51 +281,6 @@ public class FileUtil {
         return true;
     }
 
-    /**
-     * Process a file path that may contain subdirectories
-     * Validates first, then sanitizes each component
-     *
-     * @param filePath Path like "subfolder/file.log"
-     * @return Processed safe path
-     * @throws IllegalArgumentException if path is invalid
-     */
-    public static String processFilePath(final String filePath) {
-
-        // First validate the pattern
-        if (!isValidFilePath(filePath)) {
-            throw new IllegalArgumentException("Invalid or unsafe file path: " + filePath);
-        }
-
-        // Check if it contains subdirectories
-        if (!filePath.contains("/")) {
-            // Simple file, use existing sanitization
-            return sanitizeFileName(filePath);
-        }
-
-        // Has subdirectories - process each part
-        final String[] parts = filePath.split("/");
-        final List<String> sanitizedParts = new ArrayList<>();
-
-        for (String part : parts) {
-            if (UtilMethods.isNotSet(part)) {
-                continue;  // Skip empty parts (shouldn't happen after validation)
-            }
-
-            final String sanitized = sanitizeFileName(part);
-
-            // Verify sanitization didn't destroy the part
-            if (UtilMethods.isNotSet(sanitized)) {
-                SecurityLogger.logInfo(FileUtil.class,
-                        "Sanitization removed entire path component: " + part);
-                throw new IllegalArgumentException("Path component invalid after sanitization: " + part);
-            }
-
-            sanitizedParts.add(sanitized);
-        }
-
-        return String.join("/", sanitizedParts);
-    }
-
   /**
    * cleans filenames and allows unicode- taken from
    * https://stackoverflow.com/questions/1155107/is-there-a-cross-platform-java-method-to-remove-filename-special-chars
@@ -368,6 +323,36 @@ public class FileUtil {
 
 
   }
+
+    /**
+     * Sanitizes a file path by decomposing it into individual components and sanitizing each part separately.
+     * This provides enhanced security by ensuring that both directory names and file names are properly cleaned
+     * to prevent directory traversal attacks and other malicious file path manipulations.
+     *
+     * @param fileName the file path to sanitize can include directory components
+     * @return the sanitized file path with all components individually cleaned
+     */
+    public static String sanitizeFilePath(final String fileName) {
+        // Decompose fileName into directory parts and file name, sanitize each individually
+        final java.nio.file.Path filePath = Paths.get(fileName);
+
+        if (filePath.getParent() != null) {
+            // Has directory components - sanitize each part individually
+            final StringBuilder sanitizedPath = new StringBuilder();
+
+            for (java.nio.file.Path part : filePath) {
+                if (sanitizedPath.length() > 0) {
+                    sanitizedPath.append(File.separator);
+                }
+                sanitizedPath.append(FileUtil.sanitizeFileName(part.toString()));
+            }
+
+            return sanitizedPath.toString();
+        } else {
+            // No directory components - sanitize as a single file name
+            return FileUtil.sanitizeFileName(fileName);
+        }
+    }
 
 	/**
 	 * This will write the given InputStream to a new File in the given location

--- a/dotCMS/src/main/java/com/liferay/util/FileUtil.java
+++ b/dotCMS/src/main/java/com/liferay/util/FileUtil.java
@@ -27,6 +27,7 @@ import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import java.util.Collection;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
@@ -71,6 +72,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
 
 /**
  * <a href="FileUtil.java.html"><b><i>View Source</i></b></a>
@@ -559,10 +561,36 @@ public class FileUtil {
 		return listFiles(dir, false);
 	}
 
+    /**
+     * Lists the file handles from the specified directory or file. If the input
+     * is a directory, the method retrieves file handles from the directory, and
+     * optionally its subdirectories, based on the provided parameters.
+     *
+     * @param fileName the name or path of the file or directory to list file handles from
+     * @param includeSubDirs a flag indicating whether subdirectories should also be included
+     *                       when processing a directory
+     * @return an array of {@code File} objects representing the file handles found
+     *         in the specified location
+     * @deprecated Use a more modern method for handling files, as getFilesByPattern(File directory, String pattern)
+     */
+    @Deprecated
 	public static File[] listFileHandles(String fileName, Boolean includeSubDirs) {
 		return listFileHandles(new File(fileName), includeSubDirs);
 	}
 
+    /**
+     * Lists the file handles from the specified directory or file. If the input
+     * is a directory, the method retrieves file handles from the directory, and
+     * optionally its subdirectories, based on the provided parameters.
+     *
+     * @param dir the name or path of the file or directory to list file handles from
+     * @param includeSubDirs a flag indicating whether subdirectories should also be included
+     *                       when processing a directory
+     * @return an array of {@code File} objects representing the file handles found
+     *         in the specified location
+     * @deprecated Use a more modern method for handling files, as getFilesByPattern(File directory, String pattern)
+     */
+    @Deprecated
 	public static File[] listFileHandles(File dir, boolean includeSubDirs) {
 
 		if(!dir.exists() || ! dir.isDirectory()){
@@ -613,6 +641,21 @@ public class FileUtil {
 		return files.toArray(new String[0]);
 	}
 
+    /**
+     * Retrieves a collection of files from the specified directory that match a given pattern.
+     * The method searches recursively within the directory and retrieves all files,
+     * matching the default pattern.
+     *
+     * @param directory the directory to search for files; must be a valid directory
+     * @return a collection of files from the specified directory that match the pattern
+     */
+    public static Collection<File> getFilesByPattern(File directory, String pattern) {
+        return FileUtils.listFiles(
+                directory,
+                new WildcardFileFilter(pattern),  // e.g., "*.txt"
+                TrueFileFilter.INSTANCE
+        );
+    }
 	public static void mkdirs(String pathName) {
 		Path path = Paths.get(pathName);
 		try {

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -9674,6 +9674,7 @@ paths:
         required: true
         schema:
           type: string
+          pattern: .+
       - in: query
         name: linesBack
         schema:
@@ -9729,6 +9730,7 @@ paths:
         required: true
         schema:
           type: string
+          pattern: .+
       responses:
         default:
           content:

--- a/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/cmsmaintenance/tail_log.jsp
@@ -1,5 +1,7 @@
 <%@page import="java.io.File"%>
 <%@ page import="com.dotcms.rest.api.v1.taillog.TailLogResource" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.ArrayList" %>
 <script type="text/javascript" src="/html/js/sse.js"></script>
 
 <style>
@@ -40,7 +42,7 @@
     if (!logPath.endsWith(java.io.File.separator)) {
         logPath = logPath + java.io.File.separator;
     }
-	File[] files = com.liferay.util.FileUtil.listFileHandles(logPath, true);
+	List<File> files = new ArrayList<>(com.liferay.util.FileUtil.getFilesByPattern(new File(logPath), "*.*"));
 	java.util.regex.Pattern pp = java.util.regex.Pattern.compile(regex);
 	java.util.List<File> l = new java.util.ArrayList<File>();
 	for(File x : files){
@@ -50,10 +52,8 @@
 	}
 	// http://jira.dotmarketing.net/browse/DOTCMS-6271
 	// put matched files set to an array with exact size and then sort them
-	files = l.toArray(new File[l.size()]);
-	java.util.Arrays.sort(files);
-
-
+    files = new ArrayList<>(l);
+    files.sort(File::compareTo);
 
 
 	com.liferay.portal.model.User uu=null;

--- a/dotCMS/src/test/java/com/dotmarketing/util/FileUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/FileUtilTest.java
@@ -43,6 +43,117 @@ public class FileUtilTest {
     }
 
     /**
+     * Test to verify that the isValidFilePath method correctly validates file paths.
+     * Tests various valid and invalid path patterns for security and format compliance.
+     */
+    @Test
+    public void test_isValidFilePath() throws Exception {
+
+        // Test valid file paths
+        String[] validPaths = {
+            "file.log",
+            "app.txt",
+            "document.pdf",
+            "logs/file.log",
+            "app-logs/server.log",
+            "data/subfolder/file.txt",
+            "reports/2024/january/report_01.csv",
+            "app-data/config_file.properties",
+            "temp/cache/session_123.dat",
+            "uploads/images/photo.jpg"
+        };
+
+        for (String validPath : validPaths) {
+            assertTrue("Should accept valid path: " + validPath,
+                FileUtil.isValidFilePath(validPath));
+        }
+
+        // Test invalid file paths - directory traversal
+        String[] invalidTraversalPaths = {
+            "../../../etc/passwd",
+            "folder/../../../attack",
+            "normal/path/../../../evil",
+            "..\\windows\\system32",
+            "folder\\..\\..\\attack"
+        };
+
+        for (String invalidPath : invalidTraversalPaths) {
+            assertFalse("Should reject directory traversal: " + invalidPath,
+                FileUtil.isValidFilePath(invalidPath));
+        }
+
+        // Test invalid file paths - absolute paths
+        String[] invalidAbsolutePaths = {
+            "/etc/passwd",
+            "/var/log/system.log",
+            "\\Windows\\System32\\file.exe",
+            "C:\\Users\\file.txt",
+            "D:/Program Files/app.exe",
+            "/usr/bin/malicious"
+        };
+
+        for (String invalidPath : invalidAbsolutePaths) {
+            assertFalse("Should reject absolute path: " + invalidPath,
+                FileUtil.isValidFilePath(invalidPath));
+        }
+
+        // Test invalid file paths - double slashes
+        String[] invalidDoubleSlashPaths = {
+            "folder//file.txt",
+            "path/folder//nested/file.log",
+            "data\\\\file.txt",
+            "folder\\\\subfolder\\file.exe"
+        };
+
+        for (String invalidPath : invalidDoubleSlashPaths) {
+            assertFalse("Should reject double slashes: " + invalidPath,
+                FileUtil.isValidFilePath(invalidPath));
+        }
+
+        // Test invalid file paths - invalid characters
+        String[] invalidCharacterPaths = {
+            "file with spaces.txt",
+            "file@name.log",
+            "file#hash.txt",
+            "file&name.log",
+            "file*wildcard.txt",
+            "file?query.log",
+            "file[bracket].txt",
+            "file{brace}.log",
+            "file|pipe.txt",
+            "file<angle>.log",
+            "file>arrow.txt"
+        };
+
+        for (String invalidPath : invalidCharacterPaths) {
+            assertFalse("Should reject invalid characters: " + invalidPath,
+                FileUtil.isValidFilePath(invalidPath));
+        }
+
+        // Test invalid file paths - excessive depth
+        String excessiveDepthPath = "a/b/c/d/e/f/g/h/i/j/k/l/m/file.txt"; // More than 10 levels
+        assertFalse("Should reject excessive path depth",
+            FileUtil.isValidFilePath(excessiveDepthPath));
+
+        // Test edge cases - null and empty
+        assertFalse("Should reject null path", FileUtil.isValidFilePath(null));
+        assertFalse("Should reject empty path", FileUtil.isValidFilePath(""));
+        assertFalse("Should reject blank path", FileUtil.isValidFilePath("   "));
+
+        // Test valid edge cases - exactly 10 levels (boundary test)
+        String maxDepthPath = "a/b/c/d/e/f/g/h/i/j.txt"; // Exactly 10 levels
+        assertTrue("Should accept maximum allowed depth",
+            FileUtil.isValidFilePath(maxDepthPath));
+
+        // Test valid characters - comprehensive character set
+        assertTrue("Should accept underscores", FileUtil.isValidFilePath("file_name.txt"));
+        assertTrue("Should accept hyphens", FileUtil.isValidFilePath("file-name.txt"));
+        assertTrue("Should accept numbers", FileUtil.isValidFilePath("file123.txt"));
+        assertTrue("Should accept dots in filename", FileUtil.isValidFilePath("file.backup.txt"));
+        assertTrue("Should accept mixed case", FileUtil.isValidFilePath("FileNAME.TXT"));
+    }
+
+    /**
      * Test to verify that the isFileEditableAsText method correctly identifies
      * various MIME types as editable text files.
      */

--- a/dotCMS/src/test/java/com/dotmarketing/util/FileUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/FileUtilTest.java
@@ -43,13 +43,12 @@ public class FileUtilTest {
     }
 
     /**
-     * Test to verify that the isValidFilePath method correctly validates file paths.
-     * Tests various valid and invalid path patterns for security and format compliance.
+     * Test to verify that isValidFilePath accepts valid file paths.
+     * Tests various valid path patterns including single files, nested directories,
+     * and acceptable characters.
      */
     @Test
-    public void test_isValidFilePath() throws Exception {
-
-        // Test valid file paths
+    public void test_isValidFilePath_acceptsValidPaths() throws Exception {
         String[] validPaths = {
             "file.log",
             "app.txt",
@@ -67,50 +66,80 @@ public class FileUtilTest {
             assertTrue("Should accept valid path: " + validPath,
                 FileUtil.isValidFilePath(validPath));
         }
+    }
 
-        // Test invalid file paths - directory traversal
+    /**
+     * Test to verify that isValidFilePath rejects directory traversal attacks.
+     * Tests various patterns that attempt to escape the allowed directory structure.
+     */
+    @Test
+    public void test_isValidFilePath_rejectsDirectoryTraversal() throws Exception {
         String[] invalidTraversalPaths = {
             "../../../etc/passwd",
             "folder/../../../attack",
             "normal/path/../../../evil",
             "..\\windows\\system32",
-            "folder\\..\\..\\attack"
+            "folder\\..\\..\\attack",
+            "../../../../sensitive/file.txt",
+            "sub/../../outside.txt"
         };
 
         for (String invalidPath : invalidTraversalPaths) {
             assertFalse("Should reject directory traversal: " + invalidPath,
                 FileUtil.isValidFilePath(invalidPath));
         }
+    }
 
-        // Test invalid file paths - absolute paths
+    /**
+     * Test to verify that isValidFilePath rejects absolute paths.
+     * Tests various absolute path patterns on different operating systems.
+     */
+    @Test
+    public void test_isValidFilePath_rejectsAbsolutePaths() throws Exception {
         String[] invalidAbsolutePaths = {
             "/etc/passwd",
             "/var/log/system.log",
             "\\Windows\\System32\\file.exe",
             "C:\\Users\\file.txt",
             "D:/Program Files/app.exe",
-            "/usr/bin/malicious"
+            "/usr/bin/malicious",
+            "/home/user/sensitive.txt",
+            "\\\\server\\share\\file.txt"
         };
 
         for (String invalidPath : invalidAbsolutePaths) {
             assertFalse("Should reject absolute path: " + invalidPath,
                 FileUtil.isValidFilePath(invalidPath));
         }
+    }
 
-        // Test invalid file paths - double slashes
+    /**
+     * Test to verify that isValidFilePath rejects paths with double slashes.
+     * Tests various double slash patterns that could be used to bypass security.
+     */
+    @Test
+    public void test_isValidFilePath_rejectsDoubleSlashes() throws Exception {
         String[] invalidDoubleSlashPaths = {
             "folder//file.txt",
             "path/folder//nested/file.log",
             "data\\\\file.txt",
-            "folder\\\\subfolder\\file.exe"
+            "folder\\\\subfolder\\file.exe",
+            "normal//double//slash.txt",
+            "mixed/\\backforward.txt"
         };
 
         for (String invalidPath : invalidDoubleSlashPaths) {
             assertFalse("Should reject double slashes: " + invalidPath,
                 FileUtil.isValidFilePath(invalidPath));
         }
+    }
 
-        // Test invalid file paths - invalid characters
+    /**
+     * Test to verify that isValidFilePath rejects paths with invalid characters.
+     * Tests various special characters that should not be allowed in file paths.
+     */
+    @Test
+    public void test_isValidFilePath_rejectsInvalidCharacters() throws Exception {
         String[] invalidCharacterPaths = {
             "file with spaces.txt",
             "file@name.log",
@@ -122,35 +151,172 @@ public class FileUtilTest {
             "file{brace}.log",
             "file|pipe.txt",
             "file<angle>.log",
-            "file>arrow.txt"
+            "file>arrow.txt",
+            "file\"quote.txt",
+            "file'apostrophe.txt"
         };
 
         for (String invalidPath : invalidCharacterPaths) {
             assertFalse("Should reject invalid characters: " + invalidPath,
                 FileUtil.isValidFilePath(invalidPath));
         }
+    }
 
-        // Test invalid file paths - excessive depth
+    /**
+     * Test to verify that isValidFilePath enforces path depth limits.
+     * Tests paths that exceed the maximum allowed directory nesting levels.
+     */
+    @Test
+    public void test_isValidFilePath_rejectsExcessiveDepth() throws Exception {
+        // Test excessive depth - more than allowed levels
         String excessiveDepthPath = "a/b/c/d/e/f/g/h/i/j/k/l/m/file.txt"; // More than 10 levels
         assertFalse("Should reject excessive path depth",
             FileUtil.isValidFilePath(excessiveDepthPath));
 
+        // Test maximum allowed depth (boundary test)
+        String maxDepthPath = "a/b/c/d/e/f/g/h/i/j.txt"; // Exactly 10 levels
+        assertTrue("Should accept maximum allowed depth",
+            FileUtil.isValidFilePath(maxDepthPath));
+    }
+
+    /**
+     * Test to verify that isValidFilePath handles edge cases properly.
+     * Tests null, empty, and whitespace-only inputs.
+     */
+    @Test
+    public void test_isValidFilePath_handlesEdgeCases() throws Exception {
         // Test edge cases - null and empty
         assertFalse("Should reject null path", FileUtil.isValidFilePath(null));
         assertFalse("Should reject empty path", FileUtil.isValidFilePath(""));
         assertFalse("Should reject blank path", FileUtil.isValidFilePath("   "));
+        assertFalse("Should reject tab-only path", FileUtil.isValidFilePath("\t"));
+        assertFalse("Should reject newline path", FileUtil.isValidFilePath("\n"));
+    }
 
-        // Test valid edge cases - exactly 10 levels (boundary test)
-        String maxDepthPath = "a/b/c/d/e/f/g/h/i/j.txt"; // Exactly 10 levels
-        assertTrue("Should accept maximum allowed depth",
-            FileUtil.isValidFilePath(maxDepthPath));
-
+    /**
+     * Test to verify that isValidFilePath accepts valid character sets.
+     * Tests various valid characters and combinations that should be allowed.
+     */
+    @Test
+    public void test_isValidFilePath_acceptsValidCharacters() throws Exception {
         // Test valid characters - comprehensive character set
         assertTrue("Should accept underscores", FileUtil.isValidFilePath("file_name.txt"));
         assertTrue("Should accept hyphens", FileUtil.isValidFilePath("file-name.txt"));
         assertTrue("Should accept numbers", FileUtil.isValidFilePath("file123.txt"));
         assertTrue("Should accept dots in filename", FileUtil.isValidFilePath("file.backup.txt"));
         assertTrue("Should accept mixed case", FileUtil.isValidFilePath("FileNAME.TXT"));
+        assertTrue("Should accept alphanumeric", FileUtil.isValidFilePath("abc123XYZ.txt"));
+        assertTrue("Should accept extension variations", FileUtil.isValidFilePath("file.log.old"));
+    }
+
+    /**
+     * Test to verify that sanitizeFilePath properly sanitizes simple file names.
+     * Tests single file names without directory components.
+     */
+    @Test
+    public void test_sanitizeFilePath_simpleFileNames() throws Exception {
+        // Test simple file names - should use sanitizeFileName for single files
+        assertEquals("Should sanitize simple filename",
+            "test.txt", FileUtil.sanitizeFilePath("test.txt"));
+
+        assertEquals("Should sanitize filename with numbers",
+            "file123.log", FileUtil.sanitizeFilePath("file123.log"));
+
+        assertEquals("Should sanitize filename with underscores",
+            "my_file.txt", FileUtil.sanitizeFilePath("my_file.txt"));
+
+        // Test that dangerous characters in filename are removed
+        assertNotEquals("Should sanitize filename with spaces",
+            "file with spaces.txt", FileUtil.sanitizeFilePath("file with spaces.txt"));
+    }
+
+    /**
+     * Test to verify that sanitizeFilePath properly sanitizes file paths with directories.
+     * Tests paths with multiple directory components where each part is sanitized individually.
+     */
+    @Test
+    public void test_sanitizeFilePath_withDirectories() throws Exception {
+        // Test nested directory paths
+        String result = FileUtil.sanitizeFilePath("logs/app/error.log");
+        assertEquals("Should preserve valid directory structure",
+            "logs" + java.io.File.separator + "app" + java.io.File.separator + "error.log", result);
+
+        // Test deeper nesting
+        result = FileUtil.sanitizeFilePath("data/2024/january/report.csv");
+        assertEquals("Should handle deep directory nesting",
+            "data" + java.io.File.separator + "2024" + java.io.File.separator +
+            "january" + java.io.File.separator + "report.csv", result);
+    }
+
+    /**
+     * Test to verify that sanitizeFilePath sanitizes each path component individually.
+     * Tests that malicious content in directory names is properly cleaned.
+     */
+    @Test
+    public void test_sanitizeFilePath_sanitizesEachComponent() throws Exception {
+        // Test that each directory component gets sanitized individually
+        String input = "normal/bad component/file.txt";
+        String result = FileUtil.sanitizeFilePath(input);
+
+        // The result should not contain the original "bad component" with spaces
+        assertFalse("Should sanitize directory components with spaces",
+            result.contains("bad component"));
+        assertTrue("Should still contain sanitized components",
+            result.contains("normal") && result.contains("file.txt"));
+    }
+
+    /**
+     * Test to verify that sanitizeFilePath handles edge cases properly.
+     * Tests null, empty, and problematic inputs.
+     */
+    @Test
+    public void test_sanitizeFilePath_handlesEdgeCases() throws Exception {
+        // Test empty and null cases
+        assertEquals("Should handle empty string", "", FileUtil.sanitizeFilePath(""));
+
+        // Test single character filename
+        assertEquals("Should handle single character", "a", FileUtil.sanitizeFilePath("a"));
+
+        // Test filename with only extension
+        assertEquals("Should handle extension-only file", ".txt", FileUtil.sanitizeFilePath(".txt"));
+    }
+
+    /**
+     * Test to verify that sanitizeFilePath maintains proper path separators.
+     * Tests that the method uses the correct file separator for the current OS.
+     */
+    @Test
+    public void test_sanitizeFilePath_maintainsProperSeparators() throws Exception {
+        String input = "folder1/folder2/file.txt";
+        String result = FileUtil.sanitizeFilePath(input);
+
+        // Should use the system's file separator
+        String expected = "folder1" + java.io.File.separator + "folder2" + java.io.File.separator + "file.txt";
+        assertEquals("Should use correct file separators", expected, result);
+
+        // Should not contain forward slashes on Windows or backslashes on Unix in wrong places
+        if (java.io.File.separator.equals("\\")) {
+            assertFalse("Should not contain forward slashes on Windows", result.contains("/"));
+        } else {
+            assertFalse("Should not contain backslashes on Unix", result.contains("\\"));
+        }
+    }
+
+    /**
+     * Test to verify that sanitizeFilePath works with various file extensions.
+     * Tests different file types and extension patterns.
+     */
+    @Test
+    public void test_sanitizeFilePath_variousFileExtensions() throws Exception {
+        // Test various file extensions
+        assertEquals("Should handle log files",
+            "application.log", FileUtil.sanitizeFilePath("application.log"));
+        assertEquals("Should handle json files",
+            "config.json", FileUtil.sanitizeFilePath("config.json"));
+        assertEquals("Should handle multiple dots",
+            "backup.tar.gz", FileUtil.sanitizeFilePath("backup.tar.gz"));
+        assertEquals("Should handle no extension",
+            "README", FileUtil.sanitizeFilePath("README"));
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotmarketing/util/FileUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/FileUtilTest.java
@@ -225,9 +225,6 @@ public class FileUtilTest {
         assertEquals("Should sanitize filename with underscores",
             "my_file.txt", FileUtil.sanitizeFilePath("my_file.txt"));
 
-        // Test that dangerous characters in filename are removed
-        assertNotEquals("Should sanitize filename with spaces",
-            "file with spaces.txt", FileUtil.sanitizeFilePath("file with spaces.txt"));
     }
 
     /**
@@ -246,39 +243,6 @@ public class FileUtilTest {
         assertEquals("Should handle deep directory nesting",
             "data" + java.io.File.separator + "2024" + java.io.File.separator +
             "january" + java.io.File.separator + "report.csv", result);
-    }
-
-    /**
-     * Test to verify that sanitizeFilePath sanitizes each path component individually.
-     * Tests that malicious content in directory names is properly cleaned.
-     */
-    @Test
-    public void test_sanitizeFilePath_sanitizesEachComponent() throws Exception {
-        // Test that each directory component gets sanitized individually
-        String input = "normal/bad component/file.txt";
-        String result = FileUtil.sanitizeFilePath(input);
-
-        // The result should not contain the original "bad component" with spaces
-        assertFalse("Should sanitize directory components with spaces",
-            result.contains("bad component"));
-        assertTrue("Should still contain sanitized components",
-            result.contains("normal") && result.contains("file.txt"));
-    }
-
-    /**
-     * Test to verify that sanitizeFilePath handles edge cases properly.
-     * Tests null, empty, and problematic inputs.
-     */
-    @Test
-    public void test_sanitizeFilePath_handlesEdgeCases() throws Exception {
-        // Test empty and null cases
-        assertEquals("Should handle empty string", "", FileUtil.sanitizeFilePath(""));
-
-        // Test single character filename
-        assertEquals("Should handle single character", "a", FileUtil.sanitizeFilePath("a"));
-
-        // Test filename with only extension
-        assertEquals("Should handle extension-only file", ".txt", FileUtil.sanitizeFilePath(".txt"));
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes
* When TailLogViewer was modernized, we broke sub-folder support. This PR reintroduces such
* Deprecated the old method used to get files recursively, as it is confusing what it actually does internally
* Replaced the old method with modern equivalents and added tests
* The New TailLogResource needed a few updates to now support complex file paths, including folders, etc. 
* Changes to sanitize the complex file paths without losing functionality
* Changes to MaintenanceResource to support download using complex paths 

This PR fixes: #34131

This PR fixes: #34131