### PR TITLE
Isssue 34122 fixing in conversion cube

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Conversion.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Conversion.js
@@ -32,6 +32,7 @@ cube('Conversion', {
                         'identifier', identifier,
                         'title', title,
                         'conversions', toString(total_conversion_count),
+                        'events', toString(total_events_count),
                         'event_type', event_type
                     )
                 ) as top_attributed_content
@@ -44,7 +45,8 @@ cube('Conversion', {
                         title,
                         context_site_id,
                         event_type,
-                        SUM(conversion_count) AS total_conversion_count
+                        SUM(conversion_count) AS total_conversion_count,
+                        SUM(events_count) AS total_events_count
                     FROM content_presents_in_conversion
                     WHERE ${FILTER_PARAMS.Conversion.customerId.filter('customer_id')} AND (
                         ${FILTER_PARAMS.Conversion.clusterId ? FILTER_PARAMS.Conversion.clusterId.filter('cluster_id') : '1=1'}
@@ -74,7 +76,7 @@ cube('Conversion', {
             ((total_conversion * 100)/ (SELECT total FROM total_conversion)) as conv_rate,
             day,
             arrayMap(
-                x -> mapUpdate(x, map('conv_rate', toString((total_conversion* 100) / toInt64(x['conversions'])))),
+                x -> mapUpdate(x, map('conv_rate', toString((toInt64(x['conversions']) * 100) / total_conversion))),
                 top_attributed_content
             ) as top_attributed_content
         FROM conversion INNER JOIN top_attributed_content

--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Conversion.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Conversion.js
@@ -74,7 +74,7 @@ cube('Conversion', {
             ((total_conversion * 100)/ (SELECT total FROM total_conversion)) as conv_rate,
             day,
             arrayMap(
-                x -> mapUpdate(x, map('conv_rate', toString((toInt64(x['conversions']) * 100) / total_conversion))),
+                x -> mapUpdate(x, map('conv_rate', toString((total_conversion* 100) / toInt64(x['conversions'])))),
                 top_attributed_content
             ) as top_attributed_content
         FROM conversion INNER JOIN top_attributed_content

--- a/docker/docker-compose-examples/analytics/setup/db/clickhouse/init-scripts/init.sql
+++ b/docker/docker-compose-examples/analytics/setup/db/clickhouse/init-scripts/init.sql
@@ -327,7 +327,8 @@ CREATE TABLE clickhouse_test_db.content_presents_in_conversion
     title String,
 
     conversion_name String,
-    conversion_count UInt32
+    conversion_count UInt32,
+    events_count UInt32
 )
     ENGINE = SummingMergeTree
         PARTITION BY (customer_id)
@@ -408,7 +409,8 @@ SELECT
     context_user_id,
     context_site_id,
     conversion.conversion_name as conversion_name,
-    count(*) AS conversion_count,
+    count(*) AS events_count,
+    count(DISTINCT identifier, title) AS conversion_count,
     max(conversion._timestamp) as last_timestamp,
     max(conversion.conversion_time) as last_conversion_time
 FROM clickhouse_test_db.events e


### PR DESCRIPTION
This PR fixes #34139

### Proposed Changes
* Calculate the conversion attribute right

before conversion count the number of events that happen before a conversion, so if we have


content_impression, content 1, 9:00 AM
content_impression, content 1, 9:01 AM
content_impression, content 1, 9:02 AM
conversion, 9:03 AM

Then conversion count 3, and this is wrong this number should be the number of conversion that this content contributed to reach so it must be 1 for this example, so now we take just distinct to not count duplicated.

Also I include a new attribute called events and this is what was conversions before

