### PR TITLE
Migrate Containers Portlet Feedback

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.html
@@ -15,6 +15,8 @@
                 <button
                     pButton
                     icon="pi pi-plus"
+                    aria-label="{{ 'message.containers.create.add_content_type' | dm }}"
+                    data-testId="add-content-type-button"
                     (click)="handleTabClick($event, 0); actionsMenu.toggle($event)"></button>
                 <p-menu
                     [model]="menuItems"

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.html
@@ -11,20 +11,19 @@
         [scrollable]="true"
         [@contentCodeAnimation]>
         <p-tablist>
-            <p-tab [value]="0" (click)="handleTabClick($event, 0); actionsMenu.toggle($event)">
-                @if (contentTypes.length > 0) {
-                    <i class="pi pi-plus"></i>
-                } @else {
-                    <p-skeleton borderRadius="0px" height="3.9rem" width="4rem"></p-skeleton>
-                }
-
+            <div class="flex">
+                <button
+                    pButton
+                    icon="pi pi-plus"
+                    (click)="handleTabClick($event, 0); actionsMenu.toggle($event)"></button>
                 <p-menu
                     [model]="menuItems"
                     [popup]="true"
                     styleClass="max-h-64 overflow-auto"
                     #actionsMenu
                     appendTo="body" />
-            </p-tab>
+            </div>
+
             @for (
                 containerContent of getcontainerStructures.controls;
                 track containerContent;

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-code/dot-container-code.component.spec.ts
@@ -367,13 +367,13 @@ describe('DotContentEditorComponent', () => {
             expect(hostComponent.form.valid).toEqual(true);
         });
 
-        it('shoud have add loader on content types', () => {
+        it('should disable add content type button when content types is empty', () => {
             // remove all content types
             comp.contentTypes = [];
             // Use detectChanges(false) to skip checkNoChanges which causes ExpressionChangedAfterItHasBeenCheckedError
             hostFixture.detectChanges(false);
-            const loader = de.query(By.css('p-skeleton'));
-            expect(loader).toBeDefined();
+            const addButton = de.query(By.css('[data-testId="add-content-type-button"]'));
+            expect(addButton).toBeDefined();
         });
 
         it('should have a menu with max height in 200px and overflow auto using Tailwind classes', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-create.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-containers/dot-container-create/dot-container-create.component.html
@@ -1,16 +1,16 @@
 <dot-portlet-base [boxed]="false">
     <p-tabs class="h-full flex flex-col" [(value)]="activeTab">
         <p-tablist class="shrink-0">
-            <p-tab class="flex-1 text-center" [value]="0">
+            <p-tab [value]="0">
                 {{ 'message.containers.tab.properties' | dm }}
             </p-tab>
             @if (containerId) {
-                <p-tab class="flex-1 text-center" [value]="1">
+                <p-tab [value]="1">
                     {{ 'message.containers.tab.permissions' | dm }}
                 </p-tab>
             }
             @if (containerId) {
-                <p-tab class="flex-1 text-center" [value]="2">
+                <p-tab [value]="2">
                     {{ 'message.containers.tab.history' | dm }}
                 </p-tab>
             }


### PR DESCRIPTION
- Tabs are now aligned to the left.

- Added a button instead of a `p-tab` to prevent the default navigation

<img width="3442" height="2146" alt="image" src="https://github.com/user-attachments/assets/7415f3c8-91c0-4462-8678-f40a1842ecc4" />

This PR fixes: #34140

This PR fixes: #34140