### PR TITLE
Rename sdk package from sdk-create-app to @dotcms/create-app #34185

### DIFF
--- a/core-web/libs/sdk/create-app/package.json
+++ b/core-web/libs/sdk/create-app/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "sdk-create-app",
+    "name": "@dotcms/create-app",
     "version": "1.0.0",
     "type": "commonjs",
     "main": "./src/index.js",


### PR DESCRIPTION
This pull request makes a small but important change to the package name in the `core-web/libs/sdk/create-app/package.json` file. The package is now properly scoped under the `@dotcms` namespace, which helps with organization and publishing to npm.

* Changed the package name from `sdk-create-app` to `@dotcms/create-app` in `package.json`.

This PR fixes: #34185

This PR fixes: #34185