### PR TITLE
add styleProperties as a top level field

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/graphql/ContentFields.java
+++ b/dotCMS/src/main/java/com/dotcms/graphql/ContentFields.java
@@ -42,6 +42,7 @@ import static com.dotmarketing.portlets.contentlet.model.Contentlet.OWNER_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.PUBLISH_DATE_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.PUBLISH_USER_KEY;
 import static com.dotmarketing.portlets.contentlet.model.Contentlet.TITLE_IMAGE_KEY;
+import static com.dotmarketing.portlets.contentlet.model.Contentlet.STYLE_PROPERTIES_KEY;
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.Scalars.GraphQLID;
 import static graphql.Scalars.GraphQLInt;
@@ -97,6 +98,13 @@ public final class ContentFields {
                                 : "")));
         contentFields.put(PUBLISH_USER_KEY, new TypeFetcher(GraphQLTypeReference.typeRef(USER.getTypeName()),
                 new UserDataFetcher()));
+
+        contentFields.put(STYLE_PROPERTIES_KEY, new TypeFetcher(ExtendedScalars.Json, PropertyDataFetcher
+                .fetching((Function<Contentlet, Object>) contentlet ->
+                        UtilMethods.isSet(contentlet.get(STYLE_PROPERTIES_KEY))
+                                ? contentlet.get(STYLE_PROPERTIES_KEY)
+                                : null)));
+
         return contentFields;
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -537,6 +537,10 @@ public class PageRenderUtil implements Serializable {
      *                               properties from the MultiTree relationship
      */
     private void addStyles(Contentlet contentlet, PersonalizedContentlet personalizedContentlet) {
+        // NOTE: Safe to modify contentlet.getMap() here because the contentlet is a COPY
+        // created by hydrate(), not the cached original instance.
+        // See: DotContentletTransformerImpl.hydrate() and copy()
+
         if (!Config.getBooleanProperty("FEATURE_FLAG_UVE_STYLE_EDITOR", false)) {
             return;
         }

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -544,7 +544,7 @@ public class PageRenderUtil implements Serializable {
         final Map<String, Object> styleProperties = personalizedContentlet.getStyleProperties();
 
         if (UtilMethods.isSet(styleProperties) && !styleProperties.isEmpty()) {
-            contentlet.getMap().put("styleProperties", styleProperties);
+            contentlet.getMap().put(Contentlet.STYLE_PROPERTIES_KEY, styleProperties);
         }
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -155,6 +155,7 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
   public static final String DONT_VALIDATE_ME = "_dont_validate_me";
   public static final String DISABLE_WORKFLOW = "__disable_workflow__";
   public static final String VALIDATE_EMPTY_FILE = "_validateEmptyFile_";
+  public static final String STYLE_PROPERTIES_KEY = "styleProperties";
 
   // means the contentlet is being used on unit test mode.
   // this is only for unit test. do not use on production.

--- a/dotcms-postman/src/main/resources/postman/GraphQLTests.json
+++ b/dotcms-postman/src/main/resources/postman/GraphQLTests.json
@@ -4660,12 +4660,7 @@
 											"pm.test(\"Status code is 200\", function () {",
 											"    pm.response.to.have.status(200);",
 											"});",
-											"",
-											"pm.test(\"FEATURE_FLAG_UVE_STYLE_EDITOR is enabled\", function () {",
-											"    const entity = pm.response.json().entity;",
-											"    pm.expect(entity).to.exist;",
-											"    pm.expect(entity).to.eql('FEATURE_FLAG_UVE_STYLE_EDITOR saved/updated');",
-											"});"
+											""
 										],
 										"type": "text/javascript",
 										"packages": {},
@@ -4686,7 +4681,7 @@
 									}
 								},
 								"url": {
-									"raw": "{{serverURL}}/api/v1/system-table/",
+									"raw": "{{serverURL}}/api/v1/system-table",
 									"host": [
 										"{{serverURL}}"
 									],
@@ -4724,13 +4719,13 @@
 											"    pm.expect(response.data.page).to.exist;",
 											"});",
 											"",
-											"// Finding the Container (Logic adjusted for nested structure)",
+											"// Finding the Container",
 											"let targetContainerWrapper = null;",
 											"",
 											"pm.test(\"Target Container exists\", function () {",
 											"    const containers = response.data.page.containers;",
 											"    ",
-											"    // We have to look inside the 'containerContentlets' array of each container to find the UUID 'uuid-1'",
+											"    // Look inside the 'containerContentlets' array to find the UUID 'uuid-1'",
 											"    containers.forEach(container => {",
 											"        if(container.containerContentlets) {",
 											"             const found = container.containerContentlets.find(c => c.uuid === 'uuid-1');",
@@ -4752,14 +4747,21 @@
 											"    pm.expect(targetContentlet, \"Contentlet not found\").to.exist;",
 											"});",
 											"",
-											"// Checking Style Values",
-											"pm.test(\"Styles have correct width\", function () {",
+											"// Checking Style Values inside _map Object",
+											"pm.test(\"_map Styles have correct width\", function () {",
 											"    pm.expect(targetContentlet.styles).to.not.be.null;",
 											"    pm.expect(targetContentlet.styles.width).to.eql('100px');",
 											"    pm.expect(targetContentlet.styles.color).to.eql('#FF0000');",
 											"    pm.expect(targetContentlet.styles.margin).to.eql('10px');",
 											"});",
-											""
+											"",
+											"// Checking Style Values as a top level field",
+											"pm.test(\"Top level Styles have correct width\", function () {",
+											"    pm.expect(targetContentlet.styleProperties).to.not.be.null;",
+											"    pm.expect(targetContentlet.styleProperties.width).to.eql('100px');",
+											"    pm.expect(targetContentlet.styleProperties.color).to.eql('#FF0000');",
+											"    pm.expect(targetContentlet.styleProperties.margin).to.eql('10px');",
+											"});"
 										],
 										"type": "text/javascript",
 										"packages": {},
@@ -4778,7 +4780,7 @@
 								"body": {
 									"mode": "graphql",
 									"graphql": {
-										"query": "query getPageData($url: String!) {\n  page(url: $url) {\n    containers {\n      containerContentlets {\n        uuid\n        contentlets {\n          identifier\n          title\n          styles: _map(key: \"styleProperties\")\n        }\n      }\n    }\n  }\n}\n",
+										"query": "query getPageData($url: String!) {\n  page(url: $url) {\n    containers {\n      containerContentlets {\n        uuid\n        contentlets {\n          identifier\n          title\n          styles: _map(key: \"styleProperties\")\n          styleProperties\n        }\n      }\n    }\n  }\n}\n",
 										"variables": "{\n  \"url\": \"{{pageUrl}}\"\n}"
 									}
 								},
@@ -4806,12 +4808,7 @@
 											"pm.test(\"Status code is 200\", function () {",
 											"    pm.response.to.have.status(200);",
 											"});",
-											"",
-											"pm.test(\"FEATURE_FLAG_UVE_STYLE_EDITOR is disabled\", function () {",
-											"    const entity = pm.response.json().entity;",
-											"    pm.expect(entity).to.exist;",
-											"    pm.expect(entity).to.eql('FEATURE_FLAG_UVE_STYLE_EDITOR Deleted');",
-											"});"
+											""
 										],
 										"type": "text/javascript",
 										"packages": {},
@@ -4824,7 +4821,7 @@
 								"header": [],
 								"body": {
 									"mode": "raw",
-									"raw": "{\"key\":\"FEATURE_FLAG_UVE_STYLE_EDITOR\"}",
+									"raw": "",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -4832,7 +4829,7 @@
 									}
 								},
 								"url": {
-									"raw": "{{serverURL}}/api/v1/system-table/_delete",
+									"raw": "{{serverURL}}/api/v1/system-table/FEATURE_FLAG_UVE_STYLE_EDITOR",
 									"host": [
 										"{{serverURL}}"
 									],
@@ -4840,7 +4837,7 @@
 										"api",
 										"v1",
 										"system-table",
-										"_delete"
+										"FEATURE_FLAG_UVE_STYLE_EDITOR"
 									]
 								}
 							},


### PR DESCRIPTION
### Proposed Changes
This PR add the styleProperties field to be queried outside the `_map` object of the contentlet like this:

``` graphql
query getPageData($url: String!) {
  page(url: $url) {
    containers {
      containerContentlets {
        contentlets {
          identifier
          title
          styleProperties # outside map field
        }
      }
    }
  }
}
```

### Checklist
* `GraphQLTests.json‎`: add test for top level style properties in graphql request.
* `ContentFields.java:` Include StyleProperties in the contentFields of the `Contentlets`.
* `Contentlet.java`: Create new constant for the name "styleProperties"


This PR fixes: #33696

This PR fixes: #33696