### PR TITLE
chore(style-editor): Enhance style editor form to utilize contentlet style properties

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/dot-uve-style-editor-form.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/dot-uve-style-editor-form.component.ts
@@ -99,9 +99,8 @@ export class DotUveStyleEditorFormComponent {
     });
 
     $reloadSchemaEffect = effect(() => {
-        // This allow to preserve the current value on the form when the schema is reloaded.
-        // TODO: Remove untracked when we have the styleProperties in PageAPI response, also ensure that the form is rebuilt correctly.
         const schema = untracked(() => this.$schema());
+
         if (schema) {
             this.#buildForm(schema);
             this.#listenToFormChanges();
@@ -112,7 +111,12 @@ export class DotUveStyleEditorFormComponent {
      * Builds a form from the schema using the form builder service
      */
     #buildForm(schema: StyleEditorFormSchema): void {
-        const form = this.#formBuilder.buildForm(schema);
+        const activeContentlet = this.#uveStore.activeContentlet();
+
+        // Get styleProperties directly from the contentlet payload (already in the postMessage)
+        const initialValues = activeContentlet?.contentlet?.styleProperties;
+
+        const form = this.#formBuilder.buildForm(schema, initialValues);
         this.#form.set(form);
     }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/services/style-editor-form-builder.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/services/style-editor-form-builder.service.spec.ts
@@ -1,11 +1,9 @@
 import { TestBed } from '@angular/core/testing';
-import { FormGroup } from '@angular/forms';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import { StyleEditorFormSchema } from '@dotcms/uve';
 
 import { StyleEditorFormBuilderService } from './style-editor-form-builder.service';
-import { STYLE_EDITOR_FIELD_TYPES } from '../../../../../../shared/consts';
 
 const createMockSchema = (): StyleEditorFormSchema => ({
     contentType: 'test-content-type',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/services/style-editor-form-builder.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/services/style-editor-form-builder.service.spec.ts
@@ -1,0 +1,224 @@
+import { TestBed } from '@angular/core/testing';
+import { FormGroup } from '@angular/forms';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { StyleEditorFormSchema } from '@dotcms/uve';
+
+import { StyleEditorFormBuilderService } from './style-editor-form-builder.service';
+import { STYLE_EDITOR_FIELD_TYPES } from '../../../../../../shared/consts';
+
+const createMockSchema = (): StyleEditorFormSchema => ({
+    contentType: 'test-content-type',
+    sections: [
+        {
+            title: 'Typography',
+            fields: [
+                {
+                    id: 'font-size',
+                    label: 'Font Size',
+                    type: 'input',
+                    config: {
+                        inputType: 'number',
+                        defaultValue: 16
+                    }
+                },
+                {
+                    id: 'font-family',
+                    label: 'Font Family',
+                    type: 'dropdown',
+                    config: {
+                        options: [
+                            { label: 'Arial', value: 'Arial' },
+                            { label: 'Helvetica', value: 'Helvetica' }
+                        ],
+                        defaultValue: 'Arial'
+                    }
+                }
+            ]
+        },
+        {
+            title: 'Text Decoration',
+            fields: [
+                {
+                    id: 'text-decoration',
+                    label: 'Text Decoration',
+                    type: 'checkboxGroup',
+                    config: {
+                        options: [
+                            { label: 'Underline', value: 'underline' },
+                            { label: 'Overline', value: 'overline' }
+                        ],
+                        defaultValue: {
+                            underline: true,
+                            overline: false
+                        }
+                    }
+                },
+                {
+                    id: 'alignment',
+                    label: 'Alignment',
+                    type: 'radio',
+                    config: {
+                        options: [
+                            { label: 'Left', value: 'left' },
+                            { label: 'Right', value: 'right' }
+                        ],
+                        defaultValue: 'left'
+                    }
+                }
+            ]
+        }
+    ]
+});
+
+describe('StyleEditorFormBuilderService', () => {
+    let service: StyleEditorFormBuilderService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ReactiveFormsModule],
+            providers: [StyleEditorFormBuilderService]
+        });
+        service = TestBed.inject(StyleEditorFormBuilderService);
+    });
+
+    it('should be created', () => {
+        expect(service).toBeTruthy();
+    });
+
+    describe('buildForm', () => {
+        it('should build form with default values when initialValues is not provided', () => {
+            const schema = createMockSchema();
+            const form = service.buildForm(schema);
+
+            expect(form).toBeInstanceOf(FormGroup);
+            expect(form.get('font-size')?.value).toBe(16);
+            expect(form.get('font-family')?.value).toBe('Arial');
+            expect(form.get('alignment')?.value).toBe('left');
+
+            const textDecorationGroup = form.get('text-decoration') as FormGroup;
+            expect(textDecorationGroup.get('underline')?.value).toBe(true);
+            expect(textDecorationGroup.get('overline')?.value).toBe(false);
+        });
+
+        it('should use initial values when provided for input field', () => {
+            const schema = createMockSchema();
+            const initialValues = {
+                'font-size': 24
+            };
+
+            const form = service.buildForm(schema, initialValues);
+
+            expect(form.get('font-size')?.value).toBe(24);
+            expect(form.get('font-family')?.value).toBe('Arial'); // Should use default
+        });
+
+        it('should use initial values when provided for dropdown field', () => {
+            const schema = createMockSchema();
+            const initialValues = {
+                'font-family': 'Helvetica'
+            };
+
+            const form = service.buildForm(schema, initialValues);
+
+            expect(form.get('font-family')?.value).toBe('Helvetica');
+            expect(form.get('font-size')?.value).toBe(16); // Should use default
+        });
+
+        it('should use initial values when provided for radio field', () => {
+            const schema = createMockSchema();
+            const initialValues = {
+                alignment: 'right'
+            };
+
+            const form = service.buildForm(schema, initialValues);
+
+            expect(form.get('alignment')?.value).toBe('right');
+        });
+
+        it('should use initial values when provided for checkboxGroup field', () => {
+            const schema = createMockSchema();
+            const initialValues = {
+                'text-decoration': {
+                    underline: false,
+                    overline: true
+                }
+            };
+
+            const form = service.buildForm(schema, initialValues);
+            const textDecorationGroup = form.get('text-decoration') as FormGroup;
+
+            expect(textDecorationGroup.get('underline')?.value).toBe(false);
+            expect(textDecorationGroup.get('overline')?.value).toBe(true);
+        });
+
+        it('should use initial values for all fields when provided', () => {
+            const schema = createMockSchema();
+            const initialValues = {
+                'font-size': 20,
+                'font-family': 'Helvetica',
+                'text-decoration': {
+                    underline: false,
+                    overline: true
+                },
+                alignment: 'right'
+            };
+
+            const form = service.buildForm(schema, initialValues);
+
+            expect(form.get('font-size')?.value).toBe(20);
+            expect(form.get('font-family')?.value).toBe('Helvetica');
+            expect(form.get('alignment')?.value).toBe('right');
+
+            const textDecorationGroup = form.get('text-decoration') as FormGroup;
+            expect(textDecorationGroup.get('underline')?.value).toBe(false);
+            expect(textDecorationGroup.get('overline')?.value).toBe(true);
+        });
+
+        it('should use default values for fields not in initialValues', () => {
+            const schema = createMockSchema();
+            const initialValues = {
+                'font-size': 20
+                // Other fields should use defaults
+            };
+
+            const form = service.buildForm(schema, initialValues);
+
+            expect(form.get('font-size')?.value).toBe(20);
+            expect(form.get('font-family')?.value).toBe('Arial');
+            expect(form.get('alignment')?.value).toBe('left');
+
+            const textDecorationGroup = form.get('text-decoration') as FormGroup;
+            expect(textDecorationGroup.get('underline')?.value).toBe(true);
+            expect(textDecorationGroup.get('overline')?.value).toBe(false);
+        });
+
+        it('should handle empty initialValues object', () => {
+            const schema = createMockSchema();
+            const initialValues = {};
+
+            const form = service.buildForm(schema, initialValues);
+
+            // Should use all defaults
+            expect(form.get('font-size')?.value).toBe(16);
+            expect(form.get('font-family')?.value).toBe('Arial');
+            expect(form.get('alignment')?.value).toBe('left');
+        });
+
+        it('should handle partial checkboxGroup initial values', () => {
+            const schema = createMockSchema();
+            const initialValues = {
+                'text-decoration': {
+                    underline: false
+                    // overline not provided, should use default
+                }
+            };
+
+            const form = service.buildForm(schema, initialValues);
+            const textDecorationGroup = form.get('text-decoration') as FormGroup;
+
+            expect(textDecorationGroup.get('underline')?.value).toBe(false);
+            expect(textDecorationGroup.get('overline')?.value).toBe(false); // Default from schema
+        });
+    });
+});

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/services/style-editor-form-builder.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/services/style-editor-form-builder.service.ts
@@ -9,6 +9,7 @@ import {
 } from '@dotcms/uve';
 
 import { STYLE_EDITOR_FIELD_TYPES } from '../../../../../../shared/consts';
+import { StyleEditorProperties } from '../../../../../../shared/models';
 
 /**
  * Service responsible for building reactive forms from style editor schemas.
@@ -27,7 +28,7 @@ export class StyleEditorFormBuilderService {
      * @param initialValues - Optional initial values to populate the form with
      * @returns A FormGroup with controls for all fields in the schema
      */
-    buildForm(schema: StyleEditorFormSchema, initialValues?: Record<string, unknown>): FormGroup {
+    buildForm(schema: StyleEditorFormSchema, initialValues?: StyleEditorProperties): FormGroup {
         const formControls: Record<string, AbstractControl> = {};
 
         schema.sections.forEach((section: StyleEditorSectionSchema) => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/services/style-editor-form-builder.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/services/style-editor-form-builder.service.ts
@@ -24,15 +24,17 @@ export class StyleEditorFormBuilderService {
      * Builds a FormGroup from a StyleEditorFormSchema
      *
      * @param schema - The style editor form schema
+     * @param initialValues - Optional initial values to populate the form with
      * @returns A FormGroup with controls for all fields in the schema
      */
-    buildForm(schema: StyleEditorFormSchema): FormGroup {
+    buildForm(schema: StyleEditorFormSchema, initialValues?: Record<string, unknown>): FormGroup {
         const formControls: Record<string, AbstractControl> = {};
 
         schema.sections.forEach((section: StyleEditorSectionSchema) => {
             section.fields.forEach((field: StyleEditorFieldSchema) => {
                 const fieldKey = field.id;
-                const defaultValue = this.getDefaultValue(field);
+                // Use initial value if available, otherwise use default value
+                const defaultValue = initialValues?.[fieldKey] ?? this.getDefaultValue(field);
 
                 switch (field.type) {
                     case STYLE_EDITOR_FIELD_TYPES.DROPDOWN:
@@ -41,7 +43,11 @@ export class StyleEditorFormBuilderService {
 
                     case STYLE_EDITOR_FIELD_TYPES.CHECKBOX_GROUP: {
                         const options = field.config?.options || [];
-                        const checkboxDefaults = this.getCheckboxGroupDefaultValue(field.config);
+                        // For checkbox groups, merge initial values with defaults
+                        const checkboxDefaults =
+                            (initialValues?.[fieldKey] as
+                                | StyleEditorCheckboxDefaultValue
+                                | undefined) ?? this.getCheckboxGroupDefaultValue(field.config);
                         const checkboxGroupControls: Record<string, FormControl> = {};
 
                         options.forEach((option) => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/utils/style-editor-graphql.utils.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/utils/style-editor-graphql.utils.ts
@@ -1,6 +1,6 @@
 import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageResponse } from '@dotcms/types';
 
-import { ActionPayload } from '../../../../../../shared/models';
+import { ActionPayload, StyleEditorProperties } from '../../../../../../shared/models';
 
 /**
  * Type representing a GraphQL response that can be either:
@@ -34,7 +34,7 @@ function extractPageAsset(response: GraphQLResponse): DotCMSPageAsset {
 export function updateStylePropertiesInGraphQL(
     graphqlResponse: GraphQLResponse,
     payload: ActionPayload,
-    styleProperties: Record<string, unknown>
+    styleProperties: StyleEditorProperties
 ): GraphQLResponse {
     const pageAsset = extractPageAsset(graphqlResponse);
     const containerId = payload.container.identifier;
@@ -75,7 +75,7 @@ export function updateStylePropertiesInGraphQL(
 export function extractStylePropertiesFromGraphQL(
     graphqlResponse: GraphQLResponse,
     payload: ActionPayload
-): Record<string, unknown> | null {
+): StyleEditorProperties | null {
     const pageAsset = extractPageAsset(graphqlResponse);
     const containerId = payload.container.identifier;
     const contentletId = payload.contentlet.identifier;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/models.ts
@@ -92,6 +92,7 @@ export interface ContentletPayload {
     contentType: string;
     baseType?: string;
     onNumberOfPages?: number;
+    styleProperties?: StyleEditorProperties;
 }
 
 export interface SetUrlPayload {

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/contentlet/contentlet.component.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/contentlet/contentlet.component.spec.ts
@@ -106,6 +106,44 @@ describe('ContentletComponent', () => {
         expect(component.containerAttribute).not.toBeNull();
     });
 
+    it('should set styleProperties attribute when contentlet has styleProperties', () => {
+        // Set development mode to true
+        dotcmsStore.$isDevMode.mockReturnValue(true);
+
+        const contentletWithStyleProperties = {
+            ...mockContentlet,
+            styleProperties: {
+                'font-size': 20,
+                'font-family': 'Arial'
+            }
+        };
+
+        spectator.setInput('contentlet', contentletWithStyleProperties);
+        spectator.detectChanges();
+
+        expect(component.styleProperties).toBeTruthy();
+        expect(component.styleProperties).toBe(
+            JSON.stringify(contentletWithStyleProperties.styleProperties)
+        );
+
+        const hostElement = spectator.debugElement.nativeElement;
+        expect(hostElement.getAttribute('data-dot-style-properties')).toBe(
+            JSON.stringify(contentletWithStyleProperties.styleProperties)
+        );
+    });
+
+    it('should set styleProperties to null when contentlet has no styleProperties', () => {
+        // Set development mode to true
+        dotcmsStore.$isDevMode.mockReturnValue(true);
+
+        spectator.detectChanges();
+
+        expect(component.styleProperties).toBeNull();
+
+        const hostElement = spectator.debugElement.nativeElement;
+        expect(hostElement.getAttribute('data-dot-style-properties')).toBeNull();
+    });
+
     it('should set user component in ngOnChanges', async () => {
         component.ngOnChanges();
         const resolvedComponent = await component.$UserComponent();

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/contentlet/contentlet.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-layout-body/components/contentlet/contentlet.component.ts
@@ -76,6 +76,7 @@ export class ContentletComponent implements OnChanges {
     @HostBinding('attr.data-dot-type') type: string | null = null;
     @HostBinding('attr.data-dot-container') containerAttribute: string | null = null;
     @HostBinding('attr.data-dot-on-number-of-pages') onNumberOfPages: string | null = null;
+    @HostBinding('attr.data-dot-style-properties') styleProperties: string | null = null;
     @HostBinding('style') styleAttribute: { [key: string]: unknown } | null = null;
 
     ngOnChanges() {
@@ -89,6 +90,7 @@ export class ContentletComponent implements OnChanges {
         this.type = this.$dotAttributes()['data-dot-type'];
         this.containerAttribute = JSON.stringify(this.containerData);
         this.onNumberOfPages = this.$dotAttributes()['data-dot-on-number-of-pages'];
+        this.styleProperties = this.$dotAttributes()['data-dot-style-properties'] || null;
         this.styleAttribute = this.$style();
     }
 

--- a/core-web/libs/sdk/types/src/lib/editor/internal.ts
+++ b/core-web/libs/sdk/types/src/lib/editor/internal.ts
@@ -110,4 +110,5 @@ export interface DotContentletAttributes {
     'data-dot-type': string;
     'data-dot-container': string;
     'data-dot-on-number-of-pages': string;
+    'data-dot-style-properties'?: string;
 }

--- a/core-web/libs/sdk/uve/src/internal/events.ts
+++ b/core-web/libs/sdk/uve/src/internal/events.ts
@@ -155,7 +155,10 @@ export function onContentletHovered(callback: UVEEventHandler) {
             contentType: foundElement.dataset?.['dotType'],
             baseType: foundElement.dataset?.['dotBasetype'],
             widgetTitle: foundElement.dataset?.['dotWidgetTitle'],
-            onNumberOfPages: foundElement.dataset?.['dotOnNumberOfPages']
+            onNumberOfPages: foundElement.dataset?.['dotOnNumberOfPages'],
+            ...(foundElement.dataset?.['dotStyleProperties'] && {
+                styleProperties: JSON.parse(foundElement.dataset['dotStyleProperties'])
+            })
         };
 
         const vtlFiles = findDotCMSVTLData(foundElement);

--- a/core-web/libs/sdk/uve/src/lib/dom/dom.spec.ts
+++ b/core-web/libs/sdk/uve/src/lib/dom/dom.spec.ts
@@ -282,6 +282,78 @@ describe('getDotContentletAttributes', () => {
         const result = getDotContentletAttributes(contentlet as any, 'container');
         expect(result['data-dot-title']).toBe('Widget Title');
     });
+
+    it('should include data-dot-style-properties when styleProperties exist', () => {
+        const styleProperties = {
+            'font-size': 20,
+            'font-family': 'Arial',
+            alignment: 'center'
+        };
+
+        const contentlet = {
+            identifier: 'test-id',
+            baseType: 'test-base',
+            title: 'Test Title',
+            inode: 'test-inode',
+            contentType: 'test-type',
+            styleProperties
+        } as unknown as DotCMSBasicContentlet;
+
+        const result = getDotContentletAttributes(contentlet, 'test-container');
+
+        expect(result['data-dot-style-properties']).toBe(JSON.stringify(styleProperties));
+    });
+
+    it('should not include data-dot-style-properties when styleProperties do not exist', () => {
+        const contentlet = {
+            identifier: 'test-id',
+            baseType: 'test-base',
+            title: 'Test Title',
+            inode: 'test-inode',
+            contentType: 'test-type'
+        } as unknown as DotCMSBasicContentlet;
+
+        const result = getDotContentletAttributes(contentlet, 'test-container');
+
+        expect(result['data-dot-style-properties']).toBeUndefined();
+    });
+
+    it('should not include data-dot-style-properties when styleProperties is null', () => {
+        const contentlet = {
+            identifier: 'test-id',
+            baseType: 'test-base',
+            title: 'Test Title',
+            inode: 'test-inode',
+            contentType: 'test-type',
+            styleProperties: null
+        } as unknown as DotCMSBasicContentlet;
+
+        const result = getDotContentletAttributes(contentlet, 'test-container');
+
+        expect(result['data-dot-style-properties']).toBeUndefined();
+    });
+
+    it('should stringify styleProperties correctly', () => {
+        const styleProperties = {
+            'font-size': 20,
+            'font-family': 'Arial',
+            'text-decoration': {
+                underline: true,
+                overline: false
+            }
+        };
+
+        const contentlet = {
+            identifier: 'test-id',
+            contentType: 'test-type',
+            styleProperties
+        } as unknown as DotCMSBasicContentlet;
+
+        const result = getDotContentletAttributes(contentlet, 'test-container');
+
+        expect(result['data-dot-style-properties']).toBe(JSON.stringify(styleProperties));
+        expect(JSON.parse(result['data-dot-style-properties']!)).toEqual(styleProperties);
+    });
 });
 
 describe('getContainersData', () => {

--- a/core-web/libs/sdk/uve/src/lib/dom/dom.utils.ts
+++ b/core-web/libs/sdk/uve/src/lib/dom/dom.utils.ts
@@ -279,7 +279,10 @@ export function getDotContentletAttributes(
         'data-dot-inode': contentlet?.inode,
         'data-dot-type': contentlet?.contentType,
         'data-dot-container': container,
-        'data-dot-on-number-of-pages': contentlet?.['onNumberOfPages'] || '1'
+        'data-dot-on-number-of-pages': contentlet?.['onNumberOfPages'] || '1',
+        ...(contentlet?.styleProperties && {
+            'data-dot-style-properties': JSON.stringify(contentlet.styleProperties)
+        })
     };
 }
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/9b73b263-4cb0-4e5d-96ad-0c5931580b76



- Updated DotUveStyleEditorFormComponent to pull initial values from  when available.
- Implemented default values for form fields when activeContentlet is null or lacks style properties.
- Added unit tests to verify correct form behavior based on contentlet style properties.
- Introduced StyleEditorFormBuilderService to handle initial values for form fields, ensuring defaults are applied correctly.

This change improves the user experience by ensuring that the style editor reflects the current contentlet's styling options accurately.

This PR fixes: #34220

This PR fixes: #34220