### PR TITLE
Issue-34257: Add required Links field to Defect template

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yaml
+++ b/.github/ISSUE_TEMPLATE/defect.yaml
@@ -69,3 +69,15 @@ body:
         - Low - Minor issue or cosmetic
     validations:
       required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Links
+      description: Related Freshdesk tickets and Slack channels
+      placeholder: |
+        - [Freshdesk ticket #XXXXX](url)
+        - [Slack channel #XXXXX](url)
+        - Or enter "NA" if no Freshdesk ticket exists
+    validations:
+      required: true


### PR DESCRIPTION
Added the Links Field to the Defect Template

This PR fixes: #34257

This PR fixes: #34257