### PR TITLE
Update Glowroot agent to version 0.14.4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -217,7 +217,7 @@
         <environment.properties.folder>${maven.multiModuleProjectDirectory}/environments</environment.properties.folder>
         <environment.properties.defaults>${environment.properties.folder}/environment.properties</environment.properties.defaults>
         <spotless.skip>true</spotless.skip>
-        <glowroot.version>0.14.0-beta.3</glowroot.version>
+        <glowroot.version>0.14.4</glowroot.version>
         <jmeter.test.skip>true</jmeter.test.skip>
     </properties>
 


### PR DESCRIPTION
## Summary
Update the Glowroot agent version from 0.14.0-beta.3 to 0.14.4 to use the latest stable release.

## Changes
- Updated `glowroot.version` property in `parent/pom.xml` from 0.14.0-beta.3 to 0.14.4

## Test plan
- [x] Build completes successfully with `just build`
- [ ] Verify Glowroot agent loads correctly when running dotCMS with `just dev-run`
- [ ] Confirm Glowroot web UI is accessible at http://localhost:4000

## Related Issue
Closes #34294

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34294