### PR TITLE
34029 rollback

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -7,11 +7,11 @@ import {
     Component,
     computed,
     DestroyRef,
+    DOCUMENT,
     effect,
     inject,
     OnInit,
-    output,
-    DOCUMENT
+    output
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/components/iframe-field/iframe-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/components/iframe-field/iframe-field.component.ts
@@ -123,7 +123,9 @@ export class IframeFieldComponent implements OnDestroy {
             params.set('modal', 'true');
         }
 
-        return `/html/legacy_custom_field/legacy-custom-field.jsp?${params}`;
+        const url = `/html/legacy_custom_field/legacy-custom-field.jsp?${params}`;
+
+        return url;
     });
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/components/native-field/native-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/components/native-field/native-field.component.ts
@@ -3,18 +3,18 @@ import { signalMethod } from '@ngrx/signals';
 import {
     ChangeDetectionStrategy,
     Component,
+    computed,
     ElementRef,
     inject,
     input,
-    viewChild,
-    computed,
     NgZone,
-    OnInit,
-    signal,
     OnDestroy,
-    SecurityContext
+    OnInit,
+    SecurityContext,
+    signal,
+    viewChild
 } from '@angular/core';
-import { ControlContainer, ReactiveFormsModule, FormGroupDirective } from '@angular/forms';
+import { ControlContainer, FormGroupDirective, ReactiveFormsModule } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
 
 import { ButtonModule } from 'primeng/button';
@@ -22,7 +22,7 @@ import { DialogModule } from 'primeng/dialog';
 import { DialogService } from 'primeng/dynamicdialog';
 import { InputTextModule } from 'primeng/inputtext';
 
-import { DotCMSContentTypeField, DotCMSContentlet } from '@dotcms/dotcms-models';
+import { DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
 import { createFormBridge, FormBridge } from '@dotcms/edit-content-bridge';
 import { WINDOW } from '@dotcms/utils';
 

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/cachettl_custom_field_old.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/cachettl_custom_field_old.vtl
@@ -1,17 +1,20 @@
 <script type="application/javascript">
 	dojo.ready(function() {
-		var currentValue=dojo.byId('cachettl').value;
-		if(currentValue==="") {
-			currentValue=$config.getIntProperty("DEFAULT_PAGE_CACHE_SECONDS",15);
-			dojo.byId('cachettl').value=currentValue;
-		}
-		new dijit.form.TextBox({
-			name: "cachettlbox",
-			value: currentValue,
-			onChange: function() {
-				dojo.byId('cachettl').value=this.get('value');
+		DotCustomFieldApi.ready(() => {
+			const cachettlField = DotCustomFieldApi.getField('cachettl');
+			let currentValue = cachettlField.getValue() ?? '';
+			if(currentValue==="") {
+				currentValue=$config.getIntProperty("DEFAULT_PAGE_CACHE_SECONDS",15);
+				cachettlField.setValue(currentValue);
 			}
-		},"cachettlbox");
+			new dijit.form.TextBox({
+				name: "cachettlbox",
+				value: currentValue,
+				onChange: function() {
+					cachettlField.setValue(this.get('value'));
+				}
+			},"cachettlbox");
+		});
 	});
 </script>
 <input id="cachettlbox"/>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/cachettl_custom_field_old.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/cachettl_custom_field_old.vtl
@@ -1,20 +1,17 @@
 <script type="application/javascript">
 	dojo.ready(function() {
-		DotCustomFieldApi.ready(() => {
-			const cachettlField = DotCustomFieldApi.getField('cachettl');
-			let currentValue = cachettlField.getValue() ?? '';
-			if(currentValue==="") {
-				currentValue=$config.getIntProperty("DEFAULT_PAGE_CACHE_SECONDS",15);
-				cachettlField.setValue(currentValue);
+		var currentValue=dojo.byId('cachettl').value;
+		if(currentValue==="") {
+			currentValue=$config.getIntProperty("DEFAULT_PAGE_CACHE_SECONDS",15);
+			dojo.byId('cachettl').value=currentValue;
+		}
+		new dijit.form.TextBox({
+			name: "cachettlbox",
+			value: currentValue,
+			onChange: function() {
+				dojo.byId('cachettl').value=this.get('value');
 			}
-			new dijit.form.TextBox({
-				name: "cachettlbox",
-				value: currentValue,
-				onChange: function() {
-					cachettlField.setValue(this.get('value'));
-				}
-			},"cachettlbox");
-		});
+		},"cachettlbox");
 	});
 </script>
 <input id="cachettlbox"/>


### PR DESCRIPTION
This pull request primarily updates and cleans up import statements across several Angular component files in the `core-web/libs/edit-content` library. The changes focus on improving code consistency, readability, and organization by reordering and correcting imports.

**Import statement cleanup and organization:**

* In `dot-edit-content-form.component.ts`, moved the `DOCUMENT` import to the correct alphabetical position and removed its duplicate, ensuring consistent import ordering.
* In `native-field.component.ts`, reordered Angular core imports for clarity, swapped the order of `ReactiveFormsModule` and `FormGroupDirective` imports, and alphabetized custom model imports.

**Minor code style improvement:**

* In `iframe-field.component.ts`, refactored the URL construction for clarity by assigning the result to a variable before returning it.

This PR fixes: #34029
