### PR TITLE
refactor(cachettl): Update cache TTL logic 

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/cachettl_custom_field_old.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/cachettl_custom_field_old.vtl
@@ -1,20 +1,17 @@
 <script type="application/javascript">
 	dojo.ready(function() {
-		DotCustomFieldApi.ready(() => {
-			const cachettlField = DotCustomFieldApi.getField('cachettl');
-			let currentValue = cachettlField.getValue() ?? '';
-			if(currentValue==="") {
-				currentValue=$config.getIntProperty("DEFAULT_PAGE_CACHE_SECONDS",15);
-				cachettlField.setValue(currentValue);
+		var currentValue=dojo.byId('cachettl').value;
+		if(currentValue==="") {
+			currentValue=$config.getIntProperty("DEFAULT_PAGE_CACHE_SECONDS",15);
+			dojo.byId('cachettl').value=currentValue;
+		}
+		new dijit.form.TextBox({
+			name: "cachettlbox",
+			value: currentValue,
+			onChange: function() {
+				dojo.byId('cachettl').value=this.get('value');
 			}
-			new dijit.form.TextBox({
-				name: "cachettlbox",
-				value: currentValue,
-				onChange: function() {
-					cachettlField.setValue(this.get('value'));
-				}
-			},"cachettlbox");
-		});
+		},"cachettlbox");
 	});
 </script>
 <input id="cachettlbox"/>


### PR DESCRIPTION
This pull request refactors the cache TTL custom field logic in the `cachettl_custom_field_old.vtl` file to remove dependencies on the `DotCustomFieldApi` and use direct DOM manipulation with Dojo instead.

Refactoring and simplification of cache TTL field logic:

* Removed usage of `DotCustomFieldApi` for getting and setting the `cachettl` field value, replacing it with direct access to the DOM element via `dojo.byId('cachettl')`.
* Updated the initialization and change handling of the cache TTL value to work directly with the input element, simplifying the code and reducing reliance on external APIs.

Related: #34029

This PR fixes: #34029