### PR TITLE
fix(webp): this fixes webp encoding when there is alpha transparency.

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -15,7 +15,7 @@
         <maven.deploy.skip>false</maven.deploy.skip>
         <flatten.mode>bom</flatten.mode>
         <aws-java-sdk.version>1.12.488</aws-java-sdk.version>
-        <twelvemonkeys.version>3.10.1</twelvemonkeys.version>
+        <twelvemonkeys.version>3.13.1-fixed</twelvemonkeys.version>
         <swagger.version>2.2.34</swagger.version>
         <bytebuddy.version>1.18.1</bytebuddy.version>
         <batik.version>1.17</batik.version>


### PR DESCRIPTION
Hit by existing customers and prospects as well - the library is broken (actually all the VP8 java impls based on the old sourceforge code are broken).  

Put in a PR for this in the upstream [TwelveMonkeys library here](https://github.com/haraldk/TwelveMonkeys/pull/1243) but will also update our libs.


ref: #34144

This PR fixes: #34144