### PR TITLE
fix(edit-field): Replace jQuery with direct DOM manipulation 

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -1099,7 +1099,7 @@
 
         function change<%=field.getFieldContentlet()%>ThumbnailSize(newValue) {
             <%=field.getFieldContentlet()%>ThumbSize = newValue;
-            $('<%=field.getFieldContentlet()%>Thumbnail').src =
+            document.getElementById('<%=field.getFieldContentlet()%>Thumbnail').src =
                 "/contentAsset/image-thumbnail/<%=inode+"/"+field.getVelocityVarName()%>?w=" + newValue + "&rand=" + Math.random();
             dojo.cookie('<%=field.getStructureInode()%>-<%=field.getFieldContentlet()%>ThumbSize', new String(newValue));
         }
@@ -1258,7 +1258,7 @@
         <script type="text/javascript">
         function update<%=field.getVelocityVarName()%>MultiSelect() {
             var valuesList = "";
-            var multiselect = $('<%=field.getVelocityVarName()%>MultiSelect');
+            var multiselect = document.getElementById('<%=field.getVelocityVarName()%>MultiSelect');
             for(var i = 0; i < multiselect.options.length; i++) {
                 if(multiselect.options[i].selected) {
                     if (valuesList != ""){
@@ -1267,7 +1267,7 @@
                     valuesList += multiselect.options[i].value;
                 }
             }
-            $('<%=field.getVelocityVarName()%>MultiSelectHF').value = valuesList;
+            document.getElementById('<%=field.getVelocityVarName()%>MultiSelectHF').value = valuesList;
         }
 
         update<%=field.getVelocityVarName()%>MultiSelect();
@@ -1325,7 +1325,7 @@
             checkedInputs.forEach(function(checkedInput) {
                 valuesList.push(checkedInput.value);
             });
-            $("<%=field.getVelocityVarName()%>Checkbox").value = valuesList.join(",");
+            document.getElementById("<%=field.getVelocityVarName()%>Checkbox").value = valuesList.join(",");
         }
 
         update<%=field.getVelocityVarName()%>Checkbox();

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
@@ -90,7 +90,7 @@ var cmsfile=null;
 
 	//Date/Time fields
 	function updateDate(varName) {
-		var field = $(varName);
+		var field = document.getElementById(varName);
 		var dateValue ="";
 		var datePart=dijit.byId(varName + "Date");
 		var timePart=dijit.byId(varName + 'Time');
@@ -206,10 +206,11 @@ var cmsfile=null;
 
 	function updateAmPm(varName) {
 		var hour = dijit.byId(varName + 'Hour').value;
+		var ampmElement = document.getElementById(varName + 'AMPM');
 		if(hour > 11) {
-			$(varName + 'AMPM').update("PM");
+			ampmElement.textContent = "PM";
 		} else {
-			$(varName + 'AMPM').update("AM");
+			ampmElement.textContent = "AM";
 		}
 	}
 


### PR DESCRIPTION
This pull request updates the way DOM elements are selected in the `edit_field.jsp` file, replacing the use of the `$()` selector (which is likely a jQuery-style or custom selector) with the native JavaScript `document.getElementById` method. This change improves code clarity and performance by relying on standard, modern JavaScript APIs.

**Refactoring DOM element selection:**

* Replaced `$()` selector with `document.getElementById` for updating the image thumbnail source in the `change<%=field.getFieldContentlet()%>ThumbnailSize` function.
* Updated the `update<%=field.getVelocityVarName()%>MultiSelect` function to use `document.getElementById` instead of `$()` for accessing the multi-select element and its hidden field. [[1]](diffhunk://#diff-56d86f13aa386cb1827964028808b975ede83f83670e89874ab7afa4207ed103L1261-R1261) [[2]](diffhunk://#diff-56d86f13aa386cb1827964028808b975ede83f83670e89874ab7afa4207ed103L1270-R1270)
* Changed the code that updates the value of the checkbox hidden field to use `document.getElementById` instead of `$()`.

This PR fixes: #34288

This PR fixes: #34288