### PR TITLE
fix(Site search): fix site search files error

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/sitesearch/ESSiteSearchPublisher.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/sitesearch/ESSiteSearchPublisher.java
@@ -332,7 +332,7 @@ public class ESSiteSearchPublisher extends Publisher {
                     res.setUri(asset.getPath() + asset.getFileName());
                     res.setUrl(host.getHostname() + res.getUri());
                     res.setFileName(asset.getFileName());
-
+                    res.setTitle(asset.getTitle());
                     res.setMimeType(fileAssetAPI
                             .getMimeType(asset.getUnderlyingFileName()));
                     res.setModified(asset.getModDate());


### PR DESCRIPTION
The title of the file asset was never being set.
Now is added and the expected title is present on the site search portlet.


This PR fixes: #33745

This PR fixes: #33745