### PR TITLE
fix(cicd):  #34363 convert workflow_dispatch boolean inputs to native boolean type

### DIFF
--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -129,10 +129,10 @@ jobs:
       release_version: ${{ needs.release-prepare.outputs.release_version }}
       release_tag: ${{ needs.release-prepare.outputs.release_tag }}
       artifact_run_id: ${{ github.run_id }}
-      deploy_artifact: ${{ github.event.inputs.deploy_artifact }}
-      upload_javadocs: ${{ github.event.inputs.upload_javadocs }}
-      update_plugins: ${{ github.event.inputs.update_plugins }}
-      update_github_labels: ${{ github.event.inputs.update_github_labels }}
+      deploy_artifact: ${{ github.event.inputs.deploy_artifact == 'true' }}
+      upload_javadocs: ${{ github.event.inputs.upload_javadocs == 'true' }}
+      update_plugins: ${{ github.event.inputs.update_plugins == 'true' }}
+      update_github_labels: ${{ github.event.inputs.update_github_labels == 'true' }}
     secrets:
       EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
       EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}


### PR DESCRIPTION
## Summary

Fixes #34363 - Release workflow fails due to boolean input type conversion

Converts `workflow_dispatch` boolean input strings to native boolean types when passing to reusable workflows. GitHub Actions stores workflow_dispatch boolean inputs as strings internally ("true"/"false"), but reusable workflows require native boolean types, which caused workflow evaluation errors.

## Changes

Updated `.github/workflows/cicd_6-release.yml` (lines 132-135) to convert string boolean inputs:

```yaml
# Before (broken)
deploy_artifact: ${{ github.event.inputs.deploy_artifact }}

# After (fixed)
deploy_artifact: ${{ github.event.inputs.deploy_artifact == 'true' }}
```

Applied to all four boolean parameters:
- `deploy_artifact` 
- `upload_javadocs`
- `update_plugins`
- `update_github_labels`

## Impact

This fix unblocks all release operations:
- ✅ Release artifact deployment to Artifactory
- ✅ Javadoc upload to S3
- ✅ Plugin repository updates  
- ✅ SBOM generation and GitHub release asset upload
- ✅ GitHub issue label updates for release tracking

## Technical Background

This is a known GitHub Actions behavior where:
- `workflow_dispatch` inputs are HTTP parameters (always strings)
- `type: boolean` in input definition affects GitHub UI display only  
- Reusable workflows require explicit type conversion for boolean inputs
- String comparison (`== 'true'`) is the recommended conversion pattern

## Test Plan

- [x] Apply fix to workflow file
- [ ] Trigger test release with non-production version
- [ ] Test with boolean inputs set to both `true` and `false`
- [ ] Verify release job executes successfully
- [ ] Confirm all release operations complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34363