### PR TITLE
Implement new styleProperties endpoint in the frontend and fix containerId issue

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.spec.ts
@@ -211,7 +211,7 @@ describe('DotPageApiService', () => {
     });
 
     describe('saveStyleProperties', () => {
-        it('should send a POST request with correct payload structure', () => {
+        it('should send a PUT request with correct payload structure', () => {
             const payload = {
                 pageId: 'test-page-123',
                 containerIdentifier: 'container-id-456',
@@ -226,20 +226,17 @@ describe('DotPageApiService', () => {
             spectator.service.saveStyleProperties(payload).subscribe();
 
             const { request } = spectator.expectOne(
-                '/api/v1/page/test-page-123/content',
-                HttpMethod.POST
+                '/api/v1/page/test-page-123/styles',
+                HttpMethod.PUT
             );
 
             expect(request.body).toEqual([
                 {
                     identifier: 'container-id-456',
                     uuid: 'container-uuid-789',
-                    contentletsId: ['contentlet-id-abc'],
-                    styleProperties: {
-                        'contentlet-id-abc': {
-                            'font-size': '16px',
-                            color: '#000000'
-                        }
+                    'contentlet-id-abc': {
+                        'font-size': '16px',
+                        color: '#000000'
                     }
                 }
             ]);

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api.service.ts
@@ -112,14 +112,11 @@ export class DotPageApiService {
         const payload = {
             identifier: containerIdentifier,
             uuid: containerUUID,
-            contentletsId: [contentletIdentifier],
-            styleProperties: {
-                [contentletIdentifier]: styleProperties
-            }
+            [contentletIdentifier]: styleProperties
         };
 
         return this.http
-            .post(`/api/v1/page/${pageId}/content`, [payload])
+            .put(`/api/v1/page/${pageId}/styles`, [payload])
             .pipe(catchError(() => EMPTY));
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -1551,7 +1551,7 @@ public class PageResource {
 
             // Update style properties in database
             final List<ContentView> updatedStyles =
-                pageResourceHelper.saveContentletStyles(pageId, reducedContainerEntries);
+                pageResourceHelper.saveContentletStyles(pageId, reducedContainerEntries, user);
 
             return Response.ok(new ResponseEntityContentView(updatedStyles)).build();
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResource.java
@@ -802,7 +802,7 @@ public class PageResource {
 
             // Save content and Get the saved contentlets
             final List<ContentView> savedContent = pageResourceHelper.saveContent(
-                    pageId, this.reduce(pageContainerForm.getContainerEntries()), language, variantName);
+                    pageId, this.reduce(pageContainerForm.getContainerEntries()), language, variantName, user);
 
             return Response.ok(new ResponseEntityContentView(savedContent)).build();
         } catch(HTMLPageAssetNotFoundException e) {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -496,22 +496,13 @@ public class PageResourceHelper implements Serializable {
         final Contentlet copiedContentlet   = tuple2._1();
         final Contentlet originalContentlet = tuple2._2();
         final String htmlPage   = copyContentletForm.getPageId();
-        String container        = copyContentletForm.getContainerId();
+        final String container  = castToOriginalContainerId(copyContentletForm.getContainerId(), user, pageMode.respectAnonPerms);
         final String contentId  = copyContentletForm.getContentId();
         final String instanceId = copyContentletForm.getRelationType();
         final String variant    = copyContentletForm.getVariantId();
         final int treeOrder     = copyContentletForm.getTreeOrder();
         final String personalization = copyContentletForm.getPersonalization();
         final Map<String, Object> styleProperties = copyContentletForm.getStyleProperties();
-
-        if (FileAssetContainerUtil.getInstance().isFolderAssetContainerId(container)) {
-
-            final Container containerObject = APILocator.getContainerAPI().getLiveContainerByFolderPath(container, user, pageMode.respectAnonPerms,
-                    ()-> Try.of(()->APILocator.getHostAPI().findDefaultHost(user, pageMode.respectAnonPerms)).getOrNull());
-            if (null != containerObject) {
-                container =containerObject.getIdentifier();
-            }
-        }
 
         Logger.debug(this, ()-> "Deleting current contentlet multi tree: " + copyContentletForm);
         final MultiTree currentMultitree = getMultiTree(htmlPage, container, contentId, instanceId, personalization, variant);
@@ -598,6 +589,34 @@ public class PageResourceHelper implements Serializable {
     }
 
     /**
+     * Converts a folder asset container ID to its actual container identifier.
+     * If the container ID is a folder path (e.g., "/application/containers/mycontainer/"),
+     * this method retrieves the actual container object and returns its identifier.
+     * If it's already a regular container ID, it returns it unchanged.
+     *
+     * @param containerId The container ID (could be folder path or actual identifier)
+     * @param user The user performing the action
+     * @param respectAnonPerms Whether to respect anonymous permissions
+     * @return The actual container identifier
+     */
+    private String castToOriginalContainerId(final String containerId, final User user, final boolean respectAnonPerms) {
+        if (FileAssetContainerUtil.getInstance().isFolderAssetContainerId(containerId)) {
+            try {
+                final Container containerObject = APILocator.getContainerAPI().getLiveContainerByFolderPath(containerId, user, respectAnonPerms,
+                        () -> Try.of(() -> APILocator.getHostAPI().findDefaultHost(user, respectAnonPerms)).getOrNull());
+                if (null != containerObject) {
+                    return containerObject.getIdentifier();
+                }
+            } catch (DotDataException | DotSecurityException e) {
+                Logger.warn(this, String.format(
+                        "Could not resolve folder asset container ID '%s': %s", containerId,
+                        e.getMessage()));
+            }
+        }
+        return containerId;
+    }
+
+    /**
      * Returns a list of ALL languages in dotCMS and, for each of them, adds a boolean indicating
      * whether the specified HTML Page Identifier is available in such a language or not. This is
      * particularly useful for the UI layer to be able to easily check what languages a page is
@@ -663,13 +682,13 @@ public class PageResourceHelper implements Serializable {
      * @param pageId The identifier of the HTML Page whose contentlet styles are being updated.
      * @param containerEntries The list of container entries with contentlet style updates.
      *                        Must be already validated and reduced (deduplicated).
+     * @param user The user performing the action
      * @return A list of ContentView objects representing the updated contentlets with their new styles.
      * @throws DotDataException If there's an error accessing or updating the database.
      */
     @WrapInTransaction
     public List<ContentView> saveContentletStyles(final String pageId,
-                                                           final List<ContainerEntry> containerEntries)
-            throws DotDataException{
+            final List<ContainerEntry> containerEntries, final User user) throws DotDataException {
 
         // Fetch all existing MultiTree entries for this page from database
         final List<MultiTree> existingMultiTrees = multiTreeAPI.getMultiTrees(pageId);
@@ -690,7 +709,8 @@ public class PageResourceHelper implements Serializable {
                         mt.getRelationType(),
                         mt.getContentlet(),
                         mt.getPersonalization(),
-                        mt.getVariantId()
+                        mt.getVariantId(),
+                        user
                     ),
                     mt -> mt,
                     // In case of duplicate keys (shouldn't happen), keep the first one
@@ -719,7 +739,7 @@ public class PageResourceHelper implements Serializable {
             for (final String contentletId : containerEntry.getContentIds()) {
                 this.updateContentletStyles(pageId, contentletId, containerId, containerUuid,
                         personalization, currentVariantId, multiTreeLookup, contentletStylesMap,
-                        multiTreesToUpdate, responseViews);
+                        multiTreesToUpdate, responseViews, user);
             }
         }
 
@@ -745,16 +765,17 @@ public class PageResourceHelper implements Serializable {
      * @param contentletStylesMap The map of contentlet styles.
      * @param multiTreesToUpdate The list of MultiTree entries to update.
      * @param responseViews The list of ContentView objects representing the updated contentlets with their new styles.
+     * @param user The user performing the action
      */
     private void updateContentletStyles(final String pageId, final String contentletId, final String containerId,
             final String containerUuid, final String personalization, final String currentVariantId,
             final Map<String, MultiTree> multiTreeLookup,
             final Map<String, Map<String, Object>> contentletStylesMap,
-            final List<MultiTree> multiTreesToUpdate, final List<ContentView> responseViews) {
+            final List<MultiTree> multiTreesToUpdate, final List<ContentView> responseViews, final User user) {
 
         // Find the existing MultiTree entry searching in the multiTreeLookup map
         final MultiTree existingMultiTree = multiTreeLookup.get(
-                buildMultiTreeLookupKey(containerId, containerUuid, contentletId, personalization, currentVariantId));
+                buildMultiTreeLookupKey(containerId, containerUuid, contentletId, personalization, currentVariantId, user));
 
         if (existingMultiTree == null) {
             String message = String.format(
@@ -796,12 +817,17 @@ public class PageResourceHelper implements Serializable {
      * @param contentlet      The contentlet identifier
      * @param personalization The personalization tag (persona)
      * @param variantId       The variant identifier
+     * @param user            The user performing the action
      * @return A unique string key combining all parameters
      */
     private String buildMultiTreeLookupKey(final String container, final String instanceId,
-            final String contentlet, final String personalization, final String variantId) {
+            final String contentlet, final String personalization, final String variantId, final User user) {
+
+        // Resolve folder asset container IDs to actual identifiers for consistent lookups
+        final String originalContainerID = castToOriginalContainerId(container, user, false);
+
         return String.format("%s|%s|%s|%s|%s",
-            container,
+            originalContainerID,
             instanceId,
             contentlet,
             personalization != null ? personalization : MultiTree.DOT_PERSONALIZATION_DEFAULT,

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -155,7 +155,7 @@ public class PageResourceHelper implements Serializable {
     @WrapInTransaction
     public List<ContentView> saveContent(final String pageId,
             final List<ContainerEntry> containerEntries,
-            final Language language, String variantName) throws DotDataException {
+            final Language language, String variantName, User user) throws DotDataException {
 
         final Map<String, List<MultiTree>> multiTreesMap = new HashMap<>();
         final List<ContentView> responseViews = new ArrayList<>();
@@ -169,7 +169,8 @@ public class PageResourceHelper implements Serializable {
 
             if (UtilMethods.isSet(contentIds)) {
                 for (final String contentletId : contentIds) {
-                    final MultiTree multiTree = new MultiTree().setContainer(containerEntry.getContainerId())
+                    final MultiTree multiTree = new MultiTree()
+                            .setContainer(castToOriginalContainerId(containerEntry.getContainerId(), user, false))
                             .setContentlet(contentletId)
                             .setInstanceId(containerEntry.getContainerUUID())
                             .setTreeOrder(i++)


### PR DESCRIPTION
This PR updates the endpoint used for `styleProperties` definition in the FE. Plus a fix was added in the BE to extend the support of **containerIds**, now you can use container IDs like this:
```json
"identifier": "83baa82257cb262c122b3a6ea032ea7f"
"identifier": "/application/containers/mycontainer/"
```


### Proposed Changes
* `dot-page-api.service.spec.ts`: Update test to use the new endpoint to define styleProperties.
* `dot-page-api.service.ts`: Update endpoint for styleProperties definition.
* `PageResource.java`: Send user to `pageResourceHelper` specifically to the **saveContent** and **saveContentletStyles** methods.
* `pageResourceHelper.java`: Extract and reuse method for convert a folder asset container ID to its Container identifier


This PR fixes: #33699

This PR fixes: #33699