### PR TITLE
fix(ci): Release workflow artifact deployment fails due to  (#34370)

### DIFF
--- a/.github/workflows/cicd_comp_release-phase.yml
+++ b/.github/workflows/cicd_comp_release-phase.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Deploy Release Artifacts to Artifactory
         run: |
           ./mvnw -ntp \
-            "${JVM_TEST_MAVEN_OPTS}" \
+            ${JVM_TEST_MAVEN_OPTS} \
             -Dprod=true \
             -DskipTests=true \
             deploy
@@ -118,7 +118,7 @@ jobs:
       - name: Generate and Upload Javadocs
         run: |
           ./mvnw -ntp \
-            "${JVM_TEST_MAVEN_OPTS}" \
+            ${JVM_TEST_MAVEN_OPTS} \
             javadoc:javadoc \
             -pl :dotcms-core
           rc=$?


### PR DESCRIPTION
## Description

Remove quotes from JVM_TEST_MAVEN_OPTS variable expansion in Maven commands to fix shell argument parsing. The quoted variable was treated as a single argument, causing Maven to interpret command-line options as a lifecycle phase name. This blocked artifact deployment to Artifactory and Javadoc uploads. Verified the fix is secure - variable is statically defined, not user-controllable.

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #34370

**Issue:** Release workflow artifact deployment fails due to 

This PR fixes: #34370