### PR TITLE
chore(style-editor): Add Style Editor functionality in Astro, Angular and NextJS examples

### DIFF
--- a/examples/angular/src/app/dotcms/components/activity/activity.component.ts
+++ b/examples/angular/src/app/dotcms/components/activity/activity.component.ts
@@ -1,44 +1,217 @@
 import { NgOptimizedImage } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { Activity } from '../../types/contentlet.model';
 
-
+interface DotStyleProperties {
+  'title-size'?: string;
+  'description-size'?: string;
+  'title-style'?: {
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+  };
+  layout?: 'left' | 'right' | 'center' | 'overlap';
+  'image-height'?: string;
+  'card-background'?: 'white' | 'gray' | 'light-blue' | 'light-green';
+  'border-radius'?: 'none' | 'small' | 'medium' | 'large';
+  'card-effects'?: {
+    shadow?: boolean;
+    border?: boolean;
+  };
+  'button-color'?: 'blue' | 'green' | 'red' | 'purple' | 'orange' | 'teal';
+  'button-size'?: 'small' | 'medium' | 'large';
+  'button-style'?: {
+    rounded?: boolean;
+    'full-rounded'?: boolean;
+    shadow?: boolean;
+  };
+}
 
 @Component({
   selector: 'app-activity',
   imports: [RouterLink, NgOptimizedImage],
-  template: ` <article
-    class="overflow-hidden p-4 bg-white rounded-sm shadow-lg my-2"
-  >
-    @if (contentlet().inode; as inode) {
-      <div class="relative w-full h-56 overflow-hidden">
-        <img
-          class="object-cover w-full h-full"
-          [ngSrc]="inode"
-          width="400"
-          height="300"
-          alt="Activity Image"
-        />
+  template: `
+    <article [class]="articleClasses()">
+      @if (contentlet().inode; as inode) {
+        <div [class]="imageContainerClasses()">
+          <div [class]="imageWrapperClasses()">
+            <img
+              class="object-cover w-full h-full"
+              [ngSrc]="inode"
+              width="400"
+              height="300"
+              alt="Activity Image"
+            />
+          </div>
+        </div>
+      }
+      <div [class]="contentContainerClasses()">
+        <p [class]="titleClasses()">{{ contentlet().title }}</p>
+        <p [class]="descriptionClasses()">{{ contentlet().description }}</p>
+        <div [class.flex]="layout() === 'center'" [class.justify-center]="layout() === 'center'">
+          <a
+            [routerLink]="'/activities/' + (contentlet().urlTitle || '#')"
+            [class]="buttonClasses()"
+          >
+            Link to detail →
+          </a>
+        </div>
       </div>
-    }
-    <div class="px-6 py-4">
-      <p class="mb-2 text-xl font-bold">{{ contentlet().title }}</p>
-      <p class="text-base line-clamp-3">{{ contentlet().description }}</p>
-    </div>
-    <div class="px-6 pt-4 pb-2">
-      <a
-        [routerLink]="'/activities/' + contentlet().urlTitle || '#'"
-        class="inline-block px-4 py-2 font-bold text-white bg-red-400 rounded-full hover:bg-red-500"
-      >
-        Link to detail →
-      </a>
-    </div>
-  </article>`,
+    </article>
+  `,
   styleUrl: './activity.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ActivityComponent {
   contentlet = input.required<Activity>();
+
+  dotStyleProperties = computed(() => this.contentlet().dotStyleProperties as DotStyleProperties);
+
+  // Computed properties for style values
+  titleSize = computed(() => this.dotStyleProperties()?.['title-size'] || 'text-xl');
+  descriptionSize = computed(() => this.dotStyleProperties()?.['description-size'] || 'text-base');
+  titleStyle = computed(() => this.dotStyleProperties()?.['title-style'] || {});
+  layout = computed(() => this.dotStyleProperties()?.layout || 'left');
+  imageHeight = computed(() => this.dotStyleProperties()?.['image-height'] || 'h-56');
+  cardBackground = computed(() => this.dotStyleProperties()?.['card-background'] || 'white');
+  borderRadius = computed(() => this.dotStyleProperties()?.['border-radius'] || 'small');
+  cardEffects = computed(() => this.dotStyleProperties()?.['card-effects'] || {});
+  buttonColor = computed(() => this.dotStyleProperties()?.['button-color'] || 'blue');
+  buttonSize = computed(() => this.dotStyleProperties()?.['button-size'] || 'medium');
+  buttonStyle = computed(() => this.dotStyleProperties()?.['button-style'] || {});
+
+  // Computed classes
+  titleClasses = computed(() => {
+    const style = this.titleStyle();
+    const classes = [
+      'mb-2',
+      this.titleSize(),
+      style.bold ? 'font-bold' : 'font-normal',
+      style.italic ? 'italic' : '',
+      style.underline ? 'underline' : '',
+    ].filter(Boolean);
+    return classes.join(' ');
+  });
+
+  descriptionClasses = computed(() => {
+    return `${this.descriptionSize()} line-clamp-3 mb-4`;
+  });
+
+  layoutClasses = computed(() => {
+    const layoutValue = this.layout();
+    switch (layoutValue) {
+      case 'right':
+        return 'flex flex-row-reverse';
+      case 'center':
+        return 'flex flex-col items-center text-center';
+      case 'overlap':
+        return 'relative min-h-96';
+      case 'left':
+      default:
+        return 'flex flex-row';
+    }
+  });
+
+  imageContainerClasses = computed(() => {
+    const layoutValue = this.layout();
+    switch (layoutValue) {
+      case 'overlap':
+        return 'absolute inset-0 z-0';
+      case 'center':
+        return 'relative w-full';
+      default:
+        return 'relative flex-shrink-0 w-1/2';
+    }
+  });
+
+  imageWrapperClasses = computed(() => {
+    return `relative w-full overflow-hidden ${this.layout() === 'overlap' ? 'h-full' : this.imageHeight()}`;
+  });
+
+  contentContainerClasses = computed(() => {
+    const layoutValue = this.layout();
+    switch (layoutValue) {
+      case 'overlap':
+        return 'relative z-10 p-8 bg-white/90 min-h-96 flex flex-col justify-center';
+      case 'center':
+        return 'w-full px-6 py-4';
+      default:
+        return 'flex-1 p-6 flex flex-col justify-center';
+    }
+  });
+
+  cardBackgroundClasses = computed(() => {
+    const bgMap: Record<string, string> = {
+      white: 'bg-white',
+      gray: 'bg-gray-100',
+      'light-blue': 'bg-blue-50',
+      'light-green': 'bg-green-50',
+    };
+    return bgMap[this.cardBackground()] || bgMap['white'];
+  });
+
+  borderRadiusClasses = computed(() => {
+    const radiusMap: Record<string, string> = {
+      none: 'rounded-none',
+      small: 'rounded-sm',
+      medium: 'rounded-md',
+      large: 'rounded-lg',
+    };
+    return radiusMap[this.borderRadius()] || radiusMap['small'];
+  });
+
+  cardEffectClasses = computed(() => {
+    const effects = this.cardEffects();
+    const shadow = effects.shadow ? 'shadow-lg' : 'shadow-md';
+    const border = effects.border ? 'border border-gray-200' : '';
+    return `${shadow} ${border}`.trim();
+  });
+
+  buttonColorClasses = computed(() => {
+    const colorMap: Record<string, string> = {
+      blue: 'bg-blue-500 hover:bg-blue-700',
+      green: 'bg-green-500 hover:bg-green-700',
+      red: 'bg-red-500 hover:bg-red-700',
+      purple: 'bg-purple-500 hover:bg-purple-700',
+      orange: 'bg-orange-500 hover:bg-orange-700',
+      teal: 'bg-teal-500 hover:bg-teal-700',
+    };
+    return colorMap[this.buttonColor()] || colorMap['blue'];
+  });
+
+  buttonSizeClasses = computed(() => {
+    const size = this.buttonSize();
+    switch (size) {
+      case 'small':
+        return 'px-3 py-1.5 text-sm';
+      case 'large':
+        return 'px-6 py-3 text-lg';
+      case 'medium':
+      default:
+        return 'px-4 py-2 text-base';
+    }
+  });
+
+  buttonStyleClasses = computed(() => {
+    const style = this.buttonStyle();
+    const rounded = style.rounded ? 'rounded-lg' : 'rounded-full';
+    const shadow = style.shadow ? 'shadow-lg' : '';
+    return `${rounded} ${shadow}`.trim();
+  });
+
+  buttonClasses = computed(() => {
+    return `inline-block font-bold text-white transition duration-300 ${this.buttonColorClasses()} ${this.buttonSizeClasses()} ${this.buttonStyleClasses()}`;
+  });
+
+  cardClasses = computed(() => {
+    return `overflow-hidden mb-4 ${this.cardBackgroundClasses()} ${this.borderRadiusClasses()} ${this.cardEffectClasses()}`;
+  });
+
+  articleClasses = computed(() => {
+    const layoutValue = this.layout();
+    const paddingClass = layoutValue === 'overlap' ? 'p-0' : 'p-4';
+    return `${paddingClass} ${this.cardClasses()} ${this.layoutClasses()}`;
+  });
 }

--- a/examples/angular/src/app/dotcms/components/banner/banner.component.ts
+++ b/examples/angular/src/app/dotcms/components/banner/banner.component.ts
@@ -1,41 +1,61 @@
-
 import { NgOptimizedImage } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 import { DotCMSEditableTextComponent } from '@dotcms/angular';
 
 import { Banner } from '../../types/contentlet.model';
 
+interface BannerDotStyleProperties {
+  'title-size'?: string;
+  'caption-size'?: string;
+  'title-style'?: {
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+  };
+  'text-alignment'?: 'left' | 'center' | 'right';
+  'overlay-style'?: 'none' | 'dark' | 'light' | 'gradient';
+  'button-color'?: 'blue' | 'green' | 'red' | 'purple' | 'orange' | 'teal';
+  'button-size'?: 'small' | 'medium' | 'large';
+  'button-style'?: {
+    rounded?: boolean;
+    'full-rounded'?: boolean;
+    shadow?: boolean;
+  };
+}
+
 @Component({
   selector: 'app-banner',
   imports: [RouterLink, NgOptimizedImage, DotCMSEditableTextComponent],
-  template: `<div
-    class="flex overflow-hidden relative justify-center items-center w-full h-96 bg-gray-200"
-  >
+  template: `<div class="relative w-full p-4 bg-gray-200 h-96">
     @if (contentlet().image.identifier; as imageIdentifier) {
       <img
         class="object-cover w-full"
         [ngSrc]="imageIdentifier"
         [alt]="contentlet().title"
-        width="1400"
-        height="400"
+        fill
         priority
       />
     }
-    <div
-      class="flex absolute inset-0 flex-col justify-center items-center p-4 text-center text-white"
-    >
-      <h2 class="mb-2 text-6xl font-bold text-shadow">
+    @if (overlayStyle() !== 'none') {
+      <div [class]="overlayClasses()"></div>
+    }
+    <div [class]="contentContainerClasses()">
+      <h2 [class]="titleClasses()">
         <dotcms-editable-text fieldName="title" [contentlet]="contentlet()" />
       </h2>
-      <p class="mb-4 text-xl text-shadow">{{ contentlet().caption }}</p>
-      <a
-        class="p-4 text-xl bg-red-400 rounded-sm transition duration-300 hover:bg-red-500"
-        [routerLink]="contentlet().link"
-      >
-        {{ contentlet().buttonText }}
-      </a>
+      @if (contentlet().caption) {
+        <p [class]="captionClasses()">{{ contentlet().caption }}</p>
+      }
+      @if (contentlet().link) {
+        <a
+          [class]="buttonClasses()"
+          [routerLink]="contentlet().link"
+        >
+          {{ contentlet().buttonText || 'See more' }}
+        </a>
+      }
     </div>
   </div>`,
   styleUrl: './banner.component.css',
@@ -43,4 +63,129 @@ import { Banner } from '../../types/contentlet.model';
 })
 export class BannerComponent {
   contentlet = input.required<Banner>();
+
+  dotStyleProperties = computed(() => this.contentlet().dotStyleProperties as BannerDotStyleProperties);
+
+  // Computed properties for style values with defaults
+  titleSize = computed(() => this.dotStyleProperties()?.['title-size'] || 'text-6xl');
+  captionSize = computed(() => this.dotStyleProperties()?.['caption-size'] || 'text-xl');
+  titleStyle = computed(() => this.dotStyleProperties()?.['title-style'] || {});
+  textAlignment = computed(() => this.dotStyleProperties()?.['text-alignment'] || 'center');
+  overlayStyle = computed(() => this.dotStyleProperties()?.['overlay-style'] || 'none');
+  buttonColor = computed(() => this.dotStyleProperties()?.['button-color'] || 'blue');
+  buttonSize = computed(() => this.dotStyleProperties()?.['button-size'] || 'medium');
+  buttonStyle = computed(() => this.dotStyleProperties()?.['button-style'] || {});
+
+  // Computed classes
+  titleClasses = computed(() => {
+    const style = this.titleStyle();
+    const classes = [
+      'mb-2',
+      this.titleSize(),
+      style.bold ? 'font-bold' : 'font-normal',
+      style.italic ? 'italic' : '',
+      style.underline ? 'underline' : '',
+      'text-white',
+      'text-shadow'
+    ].filter(Boolean);
+    return classes.join(' ');
+  });
+
+  captionClasses = computed(() => {
+    return ['mb-4', this.captionSize(), 'text-white', 'text-shadow'].join(' ');
+  });
+
+  alignmentClasses = computed(() => {
+    switch (this.textAlignment()) {
+      case 'left':
+        return 'items-start text-left';
+      case 'right':
+        return 'items-end text-right';
+      case 'center':
+      default:
+        return 'items-center text-center';
+    }
+  });
+
+  contentContainerClasses = computed(() => {
+    return [
+      'absolute',
+      'inset-0',
+      'flex',
+      'flex-col',
+      'justify-center',
+      'p-4',
+      this.alignmentClasses(),
+      'text-white'
+    ].join(' ');
+  });
+
+  overlayClasses = computed(() => {
+    switch (this.overlayStyle()) {
+      case 'dark':
+        return 'absolute inset-0 bg-black/40';
+      case 'light':
+        return 'absolute inset-0 bg-white/20';
+      case 'gradient':
+        return 'absolute inset-0 bg-gradient-to-b from-black/50 via-transparent to-black/50';
+      case 'none':
+      default:
+        return '';
+    }
+  });
+
+  buttonColorClasses = computed(() => {
+    const colorMap: Record<string, string> = {
+      blue: 'bg-blue-500 hover:bg-blue-700',
+      green: 'bg-green-500 hover:bg-green-700',
+      red: 'bg-red-500 hover:bg-red-700',
+      purple: 'bg-purple-500 hover:bg-purple-700',
+      orange: 'bg-orange-500 hover:bg-orange-700',
+      teal: 'bg-teal-500 hover:bg-teal-700'
+    };
+    return colorMap[this.buttonColor()] || colorMap['blue'];
+  });
+
+  buttonSizeClasses = computed(() => {
+    switch (this.buttonSize()) {
+      case 'small':
+        return 'px-3 py-2 text-base';
+      case 'large':
+        return 'px-6 py-4 text-2xl';
+      case 'medium':
+      default:
+        return 'px-4 py-2 text-xl';
+    }
+  });
+
+  buttonStyleClasses = computed(() => {
+    const style = this.buttonStyle();
+    const classes: string[] = [];
+    
+    if (style.rounded) {
+      classes.push('rounded-lg');
+    } else if (style['full-rounded']) {
+      classes.push('rounded-full');
+    } else {
+      classes.push('rounded-sm');
+    }
+    
+    if (style.shadow) {
+      classes.push('shadow-lg');
+    }
+    
+    return classes.join(' ');
+  });
+
+  buttonClasses = computed(() => {
+    return [
+      'transition',
+      'duration-300',
+      'text-white',
+      'font-bold',
+      this.buttonColorClasses(),
+      this.buttonSizeClasses(),
+      this.buttonStyleClasses()
+    ].join(' ');
+  });
 }

--- a/examples/angular/src/app/dotcms/pages/page/page.ts
+++ b/examples/angular/src/app/dotcms/pages/page/page.ts
@@ -19,7 +19,10 @@ import {
   DynamicComponentEntity,
 } from '@dotcms/angular';
 import { DotCMSComposedPageResponse, DotCMSPageAsset } from '@dotcms/types';
+import { registerStyleEditorSchemas } from '@dotcms/uve';
 import { LoadingComponent } from '../../../components/loading/loading.component';
+import { ACTIVITY_SCHEMA, BANNER_SCHEMA } from '../../style-editor-schemas/schemas';
+
 
 const DYNAMIC_COMPONENTS: { [key: string]: DynamicComponentEntity } = {
   Activity: import('../../components/activity/activity.component').then((c) => c.ActivityComponent),
@@ -73,6 +76,8 @@ export class PageComponent implements OnInit {
   private readonly client = inject(DotCMSClient);
 
   ngOnInit() {
+    this.#defineStyleEditorSchemas();
+
     const route = this.router.url.split('?')[0] || '/';
 
     // Convert promise to observable and merge with editable page service
@@ -96,5 +101,9 @@ export class PageComponent implements OnInit {
           console.error('Error in page data stream:', error);
         },
       });
+  }
+
+  #defineStyleEditorSchemas() {
+    registerStyleEditorSchemas([ACTIVITY_SCHEMA, BANNER_SCHEMA])
   }
 }

--- a/examples/angular/src/app/dotcms/style-editor-schemas/schemas.ts
+++ b/examples/angular/src/app/dotcms/style-editor-schemas/schemas.ts
@@ -1,0 +1,336 @@
+import { defineStyleEditorSchema, styleEditorField } from "@dotcms/uve";
+
+export const ACTIVITY_SCHEMA = defineStyleEditorSchema({
+    contentType: 'Activity',
+    sections: [
+        {
+            title: 'Typography',
+            fields: [
+                styleEditorField.dropdown({
+                    id: 'title-size',
+                    label: 'Title Size',
+                    options: [
+                        { label: 'Small', value: 'text-lg' },
+                        { label: 'Medium', value: 'text-xl' },
+                        { label: 'Large', value: 'text-2xl' },
+                        { label: 'Extra Large', value: 'text-3xl' },
+                    ]
+                }),
+                styleEditorField.dropdown({
+                    id: 'description-size',
+                    label: 'Description Size',
+                    options: [
+                        { label: 'Small', value: 'text-sm' },
+                        { label: 'Medium', value: 'text-base' },
+                        { label: 'Large', value: 'text-lg' },
+                    ]
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'title-style',
+                    label: 'Title Style',
+                    options: [
+                        { label: 'Bold', key: 'bold' },
+                        { label: 'Italic', key: 'italic' },
+                        { label: 'Underline', key: 'underline' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Layout',
+            fields: [
+                styleEditorField.radio({
+                    id: 'layout',
+                    label: 'Layout',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Left',
+                            value: 'left',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s',
+                        },
+                        {
+                            label: 'Right',
+                            value: 'right',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                        },
+                        {
+                            label: 'Center',
+                            value: 'center',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                        },
+                        {
+                            label: 'Overlap',
+                            value: 'overlap',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                        },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'image-height',
+                    label: 'Image Height',
+                    options: [
+                        { label: 'Small', value: 'h-40' },
+                        { label: 'Medium', value: 'h-56' },
+                        { label: 'Large', value: 'h-72' },
+                        { label: 'Extra Large', value: 'h-96' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Card Style',
+            fields: [
+                styleEditorField.radio({
+                    id: 'card-background',
+                    label: 'Card Background',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'White',
+                            value: 'white',
+                        },
+                        {
+                            label: 'Gray',
+                            value: 'gray',
+                        },
+                        {
+                            label: 'Light Blue',
+                            value: 'light-blue',
+                        },
+                        {
+                            label: 'Light Green',
+                            value: 'light-green',
+                        },
+                    ],
+                }),
+                styleEditorField.radio({
+                    id: 'border-radius',
+                    label: 'Border Radius',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'None',
+                            value: 'none',
+                        },
+                        {
+                            label: 'Small',
+                            value: 'small',
+                        },
+                        {
+                            label: 'Medium',
+                            value: 'medium',
+                        },
+                        {
+                            label: 'Large',
+                            value: 'large',
+                        },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'card-effects',
+                    label: 'Card Effects',
+                    options: [
+                        { label: 'Shadow', key: 'shadow' },
+                        { label: 'Border', key: 'border' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Button',
+            fields: [
+                styleEditorField.radio({
+                    id: 'button-color',
+                    label: 'Button Color',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Blue',
+                            value: 'blue',
+                        },
+                        {
+                            label: 'Green',
+                            value: 'green',
+                        },
+                        {
+                            label: 'Red',
+                            value: 'red',
+                        },
+                        {
+                            label: 'Purple',
+                            value: 'purple',
+                        },
+                        {
+                            label: 'Orange',
+                            value: 'orange',
+                        },
+                        {
+                            label: 'Teal',
+                            value: 'teal',
+                        },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'button-size',
+                    label: 'Button Size',
+                    options: [
+                        { label: 'Small', value: 'small' },
+                        { label: 'Medium', value: 'medium' },
+                        { label: 'Large', value: 'large' },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'button-style',
+                    label: 'Button Style',
+                    options: [
+                        { label: 'Rounded', key: 'rounded' },
+                        { label: 'Full Rounded', key: 'full-rounded' },
+                        { label: 'Shadow', key: 'shadow' },
+                    ],
+                }),
+            ]
+        },
+    ]
+})
+
+export const BANNER_SCHEMA = defineStyleEditorSchema({
+    contentType: 'Banner',
+    sections: [
+        {
+            title: 'Typography',
+            fields: [
+                styleEditorField.dropdown({
+                    id: 'title-size',
+                    label: 'Title Size',
+                    options: [
+                        { label: 'Small', value: 'text-4xl' },
+                        { label: 'Medium', value: 'text-5xl' },
+                        { label: 'Large', value: 'text-6xl' },
+                        { label: 'Extra Large', value: 'text-7xl' },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'caption-size',
+                    label: 'Caption Size',
+                    options: [
+                        { label: 'Small', value: 'text-base' },
+                        { label: 'Medium', value: 'text-lg' },
+                        { label: 'Large', value: 'text-xl' },
+                        { label: 'Extra Large', value: 'text-2xl' },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'title-style',
+                    label: 'Title Style',
+                    options: [
+                        { label: 'Bold', key: 'bold' },
+                        { label: 'Italic', key: 'italic' },
+                        { label: 'Underline', key: 'underline' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Layout',
+            fields: [
+                styleEditorField.radio({
+                    id: 'text-alignment',
+                    label: 'Text Alignment',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Left',
+                            value: 'left',
+                        },
+                        {
+                            label: 'Center',
+                            value: 'center',
+                        },
+                        {
+                            label: 'Right',
+                            value: 'right',
+                        },
+                    ],
+                }),
+                styleEditorField.radio({
+                    id: 'overlay-style',
+                    label: 'Overlay Style',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'None',
+                            value: 'none',
+                        },
+                        {
+                            label: 'Dark',
+                            value: 'dark',
+                        },
+                        {
+                            label: 'Light',
+                            value: 'light',
+                        },
+                        {
+                            label: 'Gradient',
+                            value: 'gradient',
+                        },
+                    ],
+                }),
+            ]
+        },
+        {
+            title: 'Button',
+            fields: [
+                styleEditorField.radio({
+                    id: 'button-color',
+                    label: 'Button Color',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Blue',
+                            value: 'blue',
+                        },
+                        {
+                            label: 'Green',
+                            value: 'green',
+                        },
+                        {
+                            label: 'Red',
+                            value: 'red',
+                        },
+                        {
+                            label: 'Purple',
+                            value: 'purple',
+                        },
+                        {
+                            label: 'Orange',
+                            value: 'orange',
+                        },
+                        {
+                            label: 'Teal',
+                            value: 'teal',
+                        },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'button-size',
+                    label: 'Button Size',
+                    options: [
+                        { label: 'Small', value: 'small' },
+                        { label: 'Medium', value: 'medium' },
+                        { label: 'Large', value: 'large' },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'button-style',
+                    label: 'Button Style',
+                    options: [
+                        { label: 'Rounded', key: 'rounded' },
+                        { label: 'Full Rounded', key: 'full-rounded' },
+                        { label: 'Shadow', key: 'shadow' },
+                    ],
+                }),
+            ]
+        },
+    ]
+})

--- a/examples/angular/src/app/dotcms/style-editor-schemas/schemas.ts
+++ b/examples/angular/src/app/dotcms/style-editor-schemas/schemas.ts
@@ -47,22 +47,22 @@ export const ACTIVITY_SCHEMA = defineStyleEditorSchema({
                         {
                             label: 'Left',
                             value: 'left',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s',
+                            imageURL: 'https://i.ibb.co/cXv3tfYd/Screenshot-2025-12-23-at-11-58-32-AM.png',
                         },
                         {
                             label: 'Right',
                             value: 'right',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                            imageURL: 'https://i.ibb.co/v4cJxyLZ/Screenshot-2025-12-23-at-11-59-01-AM.png'
                         },
                         {
                             label: 'Center',
                             value: 'center',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                            imageURL: 'https://i.ibb.co/kVntSyzn/Screenshot-2025-12-23-at-11-58-50-AM.png'
                         },
                         {
                             label: 'Overlap',
                             value: 'overlap',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                            imageURL: 'https://i.ibb.co/43Y5KLY/placeholder-icon-design-free-vector.jpg'
                         },
                     ],
                 }),

--- a/examples/astro/src/components/content-types/Activity.tsx
+++ b/examples/astro/src/components/content-types/Activity.tsx
@@ -5,6 +5,7 @@ export interface ActivityProps extends DotCMSBasicContentlet {
   urlMap?: string;
   urlTitle?: string;
   widgetTitle?: string;
+  dotStyleProperties?: Record<string, any>;
 }
 
 function Activity({
@@ -13,29 +14,193 @@ function Activity({
   image,
   inode,
   urlTitle,
+  dotStyleProperties,
 }: ActivityProps) {
+  // Extract style properties with defaults
+  const titleSize = dotStyleProperties?.["title-size"] || "text-xl";
+  const descriptionSize = dotStyleProperties?.["description-size"] || "text-base";
+  const titleStyle = dotStyleProperties?.["title-style"] || {};
+  const layout = dotStyleProperties?.layout || "left";
+  const imageHeight = dotStyleProperties?.["image-height"] || "h-56";
+  const cardBackground = dotStyleProperties?.["card-background"] || "white";
+  const borderRadius = dotStyleProperties?.["border-radius"] || "small";
+  const cardEffects = dotStyleProperties?.["card-effects"] || {};
+  const buttonColor = dotStyleProperties?.["button-color"] || "blue";
+  const buttonSize = dotStyleProperties?.["button-size"] || "medium";
+  const buttonStyle = dotStyleProperties?.["button-style"] || {};
+
+  // Build title classes
+  const titleClasses = [
+    "mb-2",
+    titleSize,
+    titleStyle.bold ? "font-bold" : "font-normal",
+    titleStyle.italic ? "italic" : "",
+    titleStyle.underline ? "underline" : "",
+  ].filter(Boolean).join(" ");
+
+  // Get layout classes
+  const getLayoutClasses = () => {
+    switch (layout) {
+      case "right":
+        return "flex flex-row-reverse";
+      case "center":
+        return "flex flex-col items-center text-center";
+      case "overlap":
+        return "relative min-h-96";
+      case "left":
+      default:
+        return "flex flex-row";
+    }
+  };
+
+  const getImageContainerClasses = () => {
+    switch (layout) {
+      case "overlap":
+        return "absolute inset-0 z-0";
+      case "center":
+        return "relative w-full";
+      default:
+        return "relative flex-shrink-0 w-1/2";
+    }
+  };
+
+  const getContentContainerClasses = () => {
+    switch (layout) {
+      case "overlap":
+        return "relative z-10 p-8 bg-white/90 min-h-96 flex flex-col justify-center";
+      case "center":
+        return "w-full px-6 py-4";
+      default:
+        return "flex-1 p-6 flex flex-col justify-center";
+    }
+  };
+
+  // Get card background classes
+  const getCardBackgroundClasses = () => {
+    const bgMap: Record<string, string> = {
+      white: "bg-white",
+      gray: "bg-gray-100",
+      "light-blue": "bg-blue-50",
+      "light-green": "bg-green-50",
+    };
+    return bgMap[cardBackground] || bgMap.white;
+  };
+
+  // Get border radius classes
+  const getBorderRadiusClasses = () => {
+    const radiusMap: Record<string, string> = {
+      none: "rounded-none",
+      small: "rounded-sm",
+      medium: "rounded-md",
+      large: "rounded-lg",
+    };
+    return radiusMap[borderRadius] || radiusMap.small;
+  };
+
+  // Get card effect classes
+  const getCardEffectClasses = () => {
+    const classes: string[] = [];
+    if (cardEffects.shadow) {
+      classes.push("shadow-lg");
+    } else {
+      classes.push("shadow-md");
+    }
+    if (cardEffects.border) {
+      classes.push("border border-gray-200");
+    }
+    return classes.join(" ");
+  };
+
+  // Get button color classes
+  const getButtonColorClasses = () => {
+    const colorMap: Record<string, string> = {
+      blue: "bg-blue-500 hover:bg-blue-700",
+      green: "bg-green-500 hover:bg-green-700",
+      red: "bg-red-500 hover:bg-red-700",
+      purple: "bg-purple-500 hover:bg-purple-700",
+      orange: "bg-orange-500 hover:bg-orange-700",
+      teal: "bg-teal-500 hover:bg-teal-700",
+    };
+    return colorMap[buttonColor] || colorMap.blue;
+  };
+
+  // Get button size classes
+  const getButtonSizeClasses = () => {
+    switch (buttonSize) {
+      case "small":
+        return "px-3 py-1.5 text-sm";
+      case "large":
+        return "px-6 py-3 text-lg";
+      case "medium":
+      default:
+        return "px-4 py-2 text-base";
+    }
+  };
+
+  // Get button style classes
+  const getButtonStyleClasses = () => {
+    const classes: string[] = [];
+    if (buttonStyle.rounded) {
+      classes.push("rounded-lg");
+    } else if (buttonStyle["full-rounded"]) {
+      classes.push("rounded-full");
+    } else {
+      classes.push("rounded-full");
+    }
+    if (buttonStyle.shadow) {
+      classes.push("shadow-lg");
+    }
+    return classes.join(" ");
+  };
+
+  const buttonClasses = [
+    "inline-block",
+    "font-bold",
+    "text-white",
+    "transition duration-300",
+    getButtonColorClasses(),
+    getButtonSizeClasses(),
+    getButtonStyleClasses(),
+  ].join(" ");
+
+  const cardClasses = [
+    "overflow-hidden",
+    "mb-4",
+    getCardBackgroundClasses(),
+    getBorderRadiusClasses(),
+    getCardEffectClasses(),
+  ].join(" ");
+
+  const articleClasses = [
+    layout === "overlap" ? "p-0" : "p-4",
+    cardClasses,
+    getLayoutClasses(),
+  ].join(" ");
+
   return (
-    <article className="p-4 overflow-hidden bg-white rounded-sm shadow-lg mb-4">
+    <article className={articleClasses}>
       {image && (
-        <div className="relative w-full h-56 overflow-hidden">
-          <img
-            className="w-full h-full object-cover"
-            src={`/dA/${inode}`}
-            alt="Activity Image"
-          />
+        <div className={getImageContainerClasses()}>
+          <div className={`relative w-full overflow-hidden ${layout === "overlap" ? "h-full" : imageHeight}`}>
+            <img
+              className="w-full h-full object-cover"
+              src={`/dA/${inode}`}
+              alt="Activity Image"
+            />
+          </div>
         </div>
       )}
-      <div className="px-6 py-4">
-        <p className="mb-2 text-xl font-bold">{title}</p>
-        <p className="text-base line-clamp-3">{description}</p>
-      </div>
-      <div className="px-6 pt-4 pb-2">
-        <a
-          href={`/activities/${urlTitle || "#"}`}
-          className="inline-block px-4 py-2 font-bold rounded-full bg-violet-800 hover:bg-blue-700 text-white"
-        >
-          Link to detail →
-        </a>
+      <div className={getContentContainerClasses()}>
+        <p className={titleClasses}>{title}</p>
+        <p className={`${descriptionSize} line-clamp-3 mb-4`}>{description}</p>
+        <div className={layout === "center" ? "flex justify-center" : ""}>
+          <a
+            href={`/activities/${urlTitle || "#"}`}
+            className={buttonClasses}
+          >
+            Link to detail →
+          </a>
+        </div>
       </div>
     </article>
   );

--- a/examples/astro/src/components/content-types/Banner.tsx
+++ b/examples/astro/src/components/content-types/Banner.tsx
@@ -7,28 +7,142 @@ interface BannerProps extends DotCMSBasicContentlet {
   image: string;
   link: string;
   buttonText: string;
+  dotStyleProperties?: Record<string, any>;
 }
 
 function Banner(contentlet: BannerProps) {
-  const { title, caption, inode, image, link, buttonText } = contentlet;
+  const { title, caption, inode, image, link, buttonText, dotStyleProperties } = contentlet;
+
+  // Extract style properties with defaults
+  const titleSize = dotStyleProperties?.["title-size"] || "text-6xl";
+  const captionSize = dotStyleProperties?.["caption-size"] || "text-xl";
+  const titleStyle = dotStyleProperties?.["title-style"] || {};
+  const textAlignment = dotStyleProperties?.["text-alignment"] || "center";
+  const overlayStyle = dotStyleProperties?.["overlay-style"] || "none";
+  const buttonColor = dotStyleProperties?.["button-color"] || "blue";
+  const buttonSize = dotStyleProperties?.["button-size"] || "medium";
+  const buttonStyle = dotStyleProperties?.["button-style"] || {};
+
+  // Build title classes
+  const titleClasses = [
+    "mb-2",
+    titleSize,
+    titleStyle.bold ? "font-bold" : "font-normal",
+    titleStyle.italic ? "italic" : "",
+    titleStyle.underline ? "underline" : "",
+    "text-white",
+    "text-shadow"
+  ].filter(Boolean).join(" ");
+
+  // Build caption classes
+  const captionClasses = [
+    "mb-4",
+    captionSize,
+    "text-white",
+    "text-shadow"
+  ].join(" ");
+
+  // Get alignment classes
+  const getAlignmentClasses = () => {
+    switch (textAlignment) {
+      case "left":
+        return "items-start text-left";
+      case "right":
+        return "items-end text-right";
+      case "center":
+      default:
+        return "items-center text-center";
+    }
+  };
+
+  // Get overlay classes
+  const getOverlayClasses = () => {
+    switch (overlayStyle) {
+      case "dark":
+        return "bg-black/40";
+      case "light":
+        return "bg-white/20";
+      case "gradient":
+        return "bg-gradient-to-b from-black/50 via-transparent to-black/50";
+      case "none":
+      default:
+        return "";
+    }
+  };
+
+  // Get button color classes
+  const getButtonColorClasses = () => {
+    const colorMap: Record<string, string> = {
+      blue: "bg-blue-500 hover:bg-blue-700",
+      green: "bg-green-500 hover:bg-green-700",
+      red: "bg-red-500 hover:bg-red-700",
+      purple: "bg-purple-500 hover:bg-purple-700",
+      orange: "bg-orange-500 hover:bg-orange-700",
+      teal: "bg-teal-500 hover:bg-teal-700"
+    };
+    return colorMap[buttonColor] || colorMap.blue;
+  };
+
+  // Get button size classes
+  const getButtonSizeClasses = () => {
+    switch (buttonSize) {
+      case "small":
+        return "px-3 py-2 text-base";
+      case "large":
+        return "px-6 py-4 text-2xl";
+      case "medium":
+      default:
+        return "px-4 py-2 text-xl";
+    }
+  };
+
+  // Get button style classes
+  const getButtonStyleClasses = () => {
+    const classes: string[] = [];
+    if (buttonStyle.rounded) {
+      classes.push("rounded-lg");
+    } else if (buttonStyle["full-rounded"]) {
+      classes.push("rounded-full");
+    } else {
+      classes.push("rounded-sm");
+    }
+    if (buttonStyle.shadow) {
+      classes.push("shadow-lg");
+    }
+    return classes.join(" ");
+  };
+
+  const buttonClasses = [
+    "transition duration-300",
+    "text-white",
+    "font-bold",
+    getButtonColorClasses(),
+    getButtonSizeClasses(),
+    getButtonStyleClasses()
+  ].join(" ");
 
   return (
-    <div className="relative bg-gray-200 h-96 mb-4">
+    <div className="relative w-full p-4 bg-gray-200 h-full">
       {image && (
         <img
           src={`/dA/${inode}`}
-          className="w-full h-full object-cover"
+          className="object-cover w-full"
           alt={title}
         />
       )}
-      <div className="absolute inset-0 flex flex-col items-center justify-center p-4 text-center text-white">
-        <h2 className="mb-2 text-6xl font-bold text-shadow">
+      {overlayStyle !== "none" && (
+        <div className={`absolute inset-0 ${getOverlayClasses()}`} />
+      )}
+      <div className={`absolute inset-0 flex flex-col justify-center p-4 ${getAlignmentClasses()} text-white`}>
+        <h2 className={titleClasses}>
           <DotCMSEditableText contentlet={contentlet} fieldName="title" />
         </h2>
-        <p className="mb-4 text-xl text-shadow">{caption}</p>
+        {caption && (
+          <p className={captionClasses}>{caption}</p>
+        )}
         {link && (
           <a
-            className="p-4 text-xl transition duration-300 bg-violet-800 rounded-sm hover:bg-blue-700"
+            className={buttonClasses}
             href={link}
           >
             {buttonText || "See more"}

--- a/examples/astro/src/integration/dotcms/index.ts
+++ b/examples/astro/src/integration/dotcms/index.ts
@@ -1,2 +1,3 @@
 export * from "./getPage";
 export * from "./dotCMSClient";
+export * from "./styleEditorSchemas";

--- a/examples/astro/src/integration/dotcms/styleEditorSchemas.ts
+++ b/examples/astro/src/integration/dotcms/styleEditorSchemas.ts
@@ -1,0 +1,336 @@
+import { defineStyleEditorSchema, styleEditorField } from "@dotcms/uve";
+
+export const ACTIVITY_SCHEMA = defineStyleEditorSchema({
+    contentType: 'Activity',
+    sections: [
+        {
+            title: 'Typography',
+            fields: [
+                styleEditorField.dropdown({
+                    id: 'title-size',
+                    label: 'Title Size',
+                    options: [
+                        { label: 'Small', value: 'text-lg' },
+                        { label: 'Medium', value: 'text-xl' },
+                        { label: 'Large', value: 'text-2xl' },
+                        { label: 'Extra Large', value: 'text-3xl' },
+                    ]
+                }),
+                styleEditorField.dropdown({
+                    id: 'description-size',
+                    label: 'Description Size',
+                    options: [
+                        { label: 'Small', value: 'text-sm' },
+                        { label: 'Medium', value: 'text-base' },
+                        { label: 'Large', value: 'text-lg' },
+                    ]
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'title-style',
+                    label: 'Title Style',
+                    options: [
+                        { label: 'Bold', key: 'bold' },
+                        { label: 'Italic', key: 'italic' },
+                        { label: 'Underline', key: 'underline' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Layout',
+            fields: [
+                styleEditorField.radio({
+                    id: 'layout',
+                    label: 'Layout',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Left',
+                            value: 'left',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s',
+                        },
+                        {
+                            label: 'Right',
+                            value: 'right',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                        },
+                        {
+                            label: 'Center',
+                            value: 'center',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                        },
+                        {
+                            label: 'Overlap',
+                            value: 'overlap',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                        },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'image-height',
+                    label: 'Image Height',
+                    options: [
+                        { label: 'Small', value: 'h-40' },
+                        { label: 'Medium', value: 'h-56' },
+                        { label: 'Large', value: 'h-72' },
+                        { label: 'Extra Large', value: 'h-96' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Card Style',
+            fields: [
+                styleEditorField.radio({
+                    id: 'card-background',
+                    label: 'Card Background',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'White',
+                            value: 'white',
+                        },
+                        {
+                            label: 'Gray',
+                            value: 'gray',
+                        },
+                        {
+                            label: 'Light Blue',
+                            value: 'light-blue',
+                        },
+                        {
+                            label: 'Light Green',
+                            value: 'light-green',
+                        },
+                    ],
+                }),
+                styleEditorField.radio({
+                    id: 'border-radius',
+                    label: 'Border Radius',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'None',
+                            value: 'none',
+                        },
+                        {
+                            label: 'Small',
+                            value: 'small',
+                        },
+                        {
+                            label: 'Medium',
+                            value: 'medium',
+                        },
+                        {
+                            label: 'Large',
+                            value: 'large',
+                        },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'card-effects',
+                    label: 'Card Effects',
+                    options: [
+                        { label: 'Shadow', key: 'shadow' },
+                        { label: 'Border', key: 'border' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Button',
+            fields: [
+                styleEditorField.radio({
+                    id: 'button-color',
+                    label: 'Button Color',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Blue',
+                            value: 'blue',
+                        },
+                        {
+                            label: 'Green',
+                            value: 'green',
+                        },
+                        {
+                            label: 'Red',
+                            value: 'red',
+                        },
+                        {
+                            label: 'Purple',
+                            value: 'purple',
+                        },
+                        {
+                            label: 'Orange',
+                            value: 'orange',
+                        },
+                        {
+                            label: 'Teal',
+                            value: 'teal',
+                        },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'button-size',
+                    label: 'Button Size',
+                    options: [
+                        { label: 'Small', value: 'small' },
+                        { label: 'Medium', value: 'medium' },
+                        { label: 'Large', value: 'large' },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'button-style',
+                    label: 'Button Style',
+                    options: [
+                        { label: 'Rounded', key: 'rounded' },
+                        { label: 'Full Rounded', key: 'full-rounded' },
+                        { label: 'Shadow', key: 'shadow' },
+                    ],
+                }),
+            ]
+        },
+    ]
+})
+
+export const BANNER_SCHEMA = defineStyleEditorSchema({
+    contentType: 'Banner',
+    sections: [
+        {
+            title: 'Typography',
+            fields: [
+                styleEditorField.dropdown({
+                    id: 'title-size',
+                    label: 'Title Size',
+                    options: [
+                        { label: 'Small', value: 'text-4xl' },
+                        { label: 'Medium', value: 'text-5xl' },
+                        { label: 'Large', value: 'text-6xl' },
+                        { label: 'Extra Large', value: 'text-7xl' },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'caption-size',
+                    label: 'Caption Size',
+                    options: [
+                        { label: 'Small', value: 'text-base' },
+                        { label: 'Medium', value: 'text-lg' },
+                        { label: 'Large', value: 'text-xl' },
+                        { label: 'Extra Large', value: 'text-2xl' },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'title-style',
+                    label: 'Title Style',
+                    options: [
+                        { label: 'Bold', key: 'bold' },
+                        { label: 'Italic', key: 'italic' },
+                        { label: 'Underline', key: 'underline' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Layout',
+            fields: [
+                styleEditorField.radio({
+                    id: 'text-alignment',
+                    label: 'Text Alignment',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Left',
+                            value: 'left',
+                        },
+                        {
+                            label: 'Center',
+                            value: 'center',
+                        },
+                        {
+                            label: 'Right',
+                            value: 'right',
+                        },
+                    ],
+                }),
+                styleEditorField.radio({
+                    id: 'overlay-style',
+                    label: 'Overlay Style',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'None',
+                            value: 'none',
+                        },
+                        {
+                            label: 'Dark',
+                            value: 'dark',
+                        },
+                        {
+                            label: 'Light',
+                            value: 'light',
+                        },
+                        {
+                            label: 'Gradient',
+                            value: 'gradient',
+                        },
+                    ],
+                }),
+            ]
+        },
+        {
+            title: 'Button',
+            fields: [
+                styleEditorField.radio({
+                    id: 'button-color',
+                    label: 'Button Color',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Blue',
+                            value: 'blue',
+                        },
+                        {
+                            label: 'Green',
+                            value: 'green',
+                        },
+                        {
+                            label: 'Red',
+                            value: 'red',
+                        },
+                        {
+                            label: 'Purple',
+                            value: 'purple',
+                        },
+                        {
+                            label: 'Orange',
+                            value: 'orange',
+                        },
+                        {
+                            label: 'Teal',
+                            value: 'teal',
+                        },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'button-size',
+                    label: 'Button Size',
+                    options: [
+                        { label: 'Small', value: 'small' },
+                        { label: 'Medium', value: 'medium' },
+                        { label: 'Large', value: 'large' },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'button-style',
+                    label: 'Button Style',
+                    options: [
+                        { label: 'Rounded', key: 'rounded' },
+                        { label: 'Full Rounded', key: 'full-rounded' },
+                        { label: 'Shadow', key: 'shadow' },
+                    ],
+                }),
+            ]
+        },
+    ]
+})

--- a/examples/astro/src/integration/dotcms/styleEditorSchemas.ts
+++ b/examples/astro/src/integration/dotcms/styleEditorSchemas.ts
@@ -47,22 +47,22 @@ export const ACTIVITY_SCHEMA = defineStyleEditorSchema({
                         {
                             label: 'Left',
                             value: 'left',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s',
+                            imageURL: 'https://i.ibb.co/cXv3tfYd/Screenshot-2025-12-23-at-11-58-32-AM.png',
                         },
                         {
                             label: 'Right',
                             value: 'right',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                            imageURL: 'https://i.ibb.co/v4cJxyLZ/Screenshot-2025-12-23-at-11-59-01-AM.png'
                         },
                         {
                             label: 'Center',
                             value: 'center',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                            imageURL: 'https://i.ibb.co/kVntSyzn/Screenshot-2025-12-23-at-11-58-50-AM.png'
                         },
                         {
                             label: 'Overlap',
                             value: 'overlap',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                            imageURL: 'https://i.ibb.co/43Y5KLY/placeholder-icon-design-free-vector.jpg'
                         },
                     ],
                 }),

--- a/examples/astro/src/views/DotCMSPage.tsx
+++ b/examples/astro/src/views/DotCMSPage.tsx
@@ -1,9 +1,11 @@
-import { DotCMSLayoutBody, useEditableDotCMSPage } from "@dotcms/react";
+import { DotCMSLayoutBody, useEditableDotCMSPage, useStyleEditorSchemas } from "@dotcms/react";
 import type { DotCMSCustomPageResponse } from "@/types/page.model";
 
 import { dotComponents } from "@/components/content-types";
 import Footer from "@/components/common/Footer";
 import Header from "@/components/common/header/Header";
+import { ACTIVITY_SCHEMA, BANNER_SCHEMA } from "@/dotcms-integration";
+
 
 export const DotCMSPage = ({
   pageResponse,
@@ -12,6 +14,8 @@ export const DotCMSPage = ({
 }) => {
   const { pageAsset, content } =
     useEditableDotCMSPage<DotCMSCustomPageResponse>(pageResponse);
+  
+  useStyleEditorSchemas([ACTIVITY_SCHEMA, BANNER_SCHEMA]);
   const { layout } = pageAsset;
 
   const showHeader = layout.header && content;

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -52,6 +52,7 @@ The example above is a Next.js front end for the [dotCMS demo site](https://demo
     - [Understanding the Structure](#understanding-the-structure)
     - [How to Fetch Content from dotCMS](#how-to-fetch-content-from-dotcms)
     - [How to Render Your Page](#how-to-render-your-page)
+    - [Style Editor](#style-editor)
 - [Conclusion](#conclusion)
 - [Learn More](#learn-more)
 
@@ -424,6 +425,128 @@ This mapping should be passed to the `DotCMSLayoutBody` component as shown in th
 - [Understanding Content Types in dotCMS](https://dev.dotcms.com/docs/content-types) - In-depth explanation of content types and their structure
 - [Contentlets in dotCMS](https://dev.dotcms.com/docs/content#Contentlets) - Learn how individual content items (contentlets) work
 - [@dotcms/react Documentation](https://www.npmjs.com/package/@dotcms/react/) - Complete reference for the React components library
+
+### Style Editor
+
+The Style Editor enables content editors to customize component appearance (typography, colors, layouts, etc.) directly in the Universal Visual Editor without code changes. Style properties are defined by developers and made editable through style editor schemas.
+
+#### Defining a Style Editor Schema
+
+Create a schema file (e.g., `src/utils/styleEditorSchemas.js`) that defines editable style properties for your content types:
+
+```js
+import { defineStyleEditorSchema, styleEditorField } from "@dotcms/uve";
+
+export const BANNER_SCHEMA = defineStyleEditorSchema({
+    contentType: 'Banner', // Must match your dotCMS Content Type
+    sections: [
+        {
+            title: 'Typography',
+            fields: [
+                styleEditorField.dropdown({
+                    id: 'title-size',
+                    label: 'Title Size',
+                    options: [
+                        { label: 'Small', value: 'text-4xl' },
+                        { label: 'Medium', value: 'text-5xl' },
+                        { label: 'Large', value: 'text-6xl' },
+                    ]
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'title-style',
+                    label: 'Title Style',
+                    options: [
+                        { label: 'Bold', key: 'bold' },
+                        { label: 'Italic', key: 'italic' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Layout',
+            fields: [
+                styleEditorField.radio({
+                    id: 'text-alignment',
+                    label: 'Text Alignment',
+                    options: [
+                        { label: 'Left', value: 'left' },
+                        { label: 'Center', value: 'center' },
+                        { label: 'Right', value: 'right' },
+                    ]
+                }),
+            ]
+        },
+    ]
+});
+```
+
+#### Field Types
+
+The Style Editor supports four field types:
+
+- **`styleEditorField.input()`** - Text or number input for custom values
+- **`styleEditorField.dropdown()`** - Dropdown with predefined options
+- **`styleEditorField.radio()`** - Radio buttons for single selection (supports images)
+- **`styleEditorField.checkboxGroup()`** - Multiple checkboxes (returns object with boolean values)
+
+#### Registering Schemas
+
+Register your schemas in your page component using the `useStyleEditorSchemas` hook:
+
+```js
+"use client";
+
+import { useStyleEditorSchemas } from "@dotcms/react";
+import { BANNER_SCHEMA, ACTIVITY_SCHEMA } from "@/utils/styleEditorSchemas";
+
+export function Page({ pageContent }) {
+    // Register schemas - makes them available in UVE edit mode
+    useStyleEditorSchemas([BANNER_SCHEMA, ACTIVITY_SCHEMA]);
+
+    return (
+        // Your page content
+    );
+}
+```
+
+#### Using Style Properties in Components
+
+Style properties are automatically passed to your contentlet components via the `dotStyleProperties` prop. Access them with defaults:
+
+```js
+function Banner({ title, caption, dotStyleProperties }) {
+    // Extract style properties with defaults
+    const titleSize = dotStyleProperties?.["title-size"] || "text-6xl";
+    const titleStyle = dotStyleProperties?.["title-style"] || {};
+    const textAlignment = dotStyleProperties?.["text-alignment"] || "center";
+
+    // Build dynamic classes
+    const titleClasses = [
+        titleSize,
+        titleStyle.bold ? "font-bold" : "font-normal",
+        titleStyle.italic ? "italic" : "",
+    ].filter(Boolean).join(" ");
+
+    return (
+        <div className={`text-${textAlignment}`}>
+            <h2 className={titleClasses}>{title}</h2>
+            <p>{caption}</p>
+        </div>
+    );
+}
+```
+
+**Value Types:**
+- **Input/Dropdown/Radio**: Returns a string (the selected value)
+- **Checkbox Group**: Returns an object with boolean values (e.g., `{ bold: true, italic: false }`)
+
+**Best Practices:**
+- Always provide default values when accessing style properties
+- Use meaningful field IDs that match your styling logic
+- Group related fields into logical sections
+- The `contentType` in your schema must exactly match your dotCMS Content Type variable name
+
+For complete Style Editor documentation, see the [@dotcms/uve Style Editor guide](https://github.com/dotCMS/core/blob/main/core-web/libs/sdk/uve/README.md#style-editor).
 
 ## Conclusion
 

--- a/examples/nextjs/src/components/content-types/Activity.js
+++ b/examples/nextjs/src/components/content-types/Activity.js
@@ -1,30 +1,193 @@
 import Image from "next/image";
 import Link from "next/link";
 
-function Activity({ title, description, image, inode, urlTitle }) {
+function Activity({ title, description, image, inode, urlTitle, dotStyleProperties }) {
+    // Extract style properties with defaults
+    const titleSize = dotStyleProperties?.["title-size"] || "text-xl"
+    const descriptionSize = dotStyleProperties?.["description-size"] || "text-base"
+    const titleStyle = dotStyleProperties?.["title-style"] || {}
+    const layout = dotStyleProperties?.layout || "left"
+    const imageHeight = dotStyleProperties?.["image-height"] || "h-56"
+    const cardBackground = dotStyleProperties?.["card-background"] || "white"
+    const borderRadius = dotStyleProperties?.["border-radius"] || "small"
+    const cardEffects = dotStyleProperties?.["card-effects"] || {}
+    const buttonColor = dotStyleProperties?.["button-color"] || "blue"
+    const buttonSize = dotStyleProperties?.["button-size"] || "medium"
+    const buttonStyle = dotStyleProperties?.["button-style"] || {}
+
+    // Build title classes
+    const titleClasses = [
+        "mb-2",
+        titleSize,
+        titleStyle.bold ? "font-bold" : "font-normal",
+        titleStyle.italic ? "italic" : "",
+        titleStyle.underline ? "underline" : "",
+    ].filter(Boolean).join(" ")
+
+    // Get layout classes
+    const getLayoutClasses = () => {
+        switch (layout) {
+            case "right":
+                return "flex flex-row-reverse"
+            case "center":
+                return "flex flex-col items-center text-center"
+            case "overlap":
+                return "relative min-h-96"
+            case "left":
+            default:
+                return "flex flex-row"
+        }
+    }
+
+    const getImageContainerClasses = () => {
+        switch (layout) {
+            case "overlap":
+                return "absolute inset-0 z-0"
+            case "center":
+                return "relative w-full"
+            default:
+                return "relative flex-shrink-0 w-1/2"
+        }
+    }
+
+    const getContentContainerClasses = () => {
+        switch (layout) {
+            case "overlap":
+                return "relative z-10 p-8 bg-white/90 min-h-96 flex flex-col justify-center"
+            case "center":
+                return "w-full px-6 py-4"
+            default:
+                return "flex-1 p-6 flex flex-col justify-center"
+        }
+    }
+
+    // Get card background classes
+    const getCardBackgroundClasses = () => {
+        const bgMap = {
+            white: "bg-white",
+            gray: "bg-gray-100",
+            "light-blue": "bg-blue-50",
+            "light-green": "bg-green-50"
+        }
+        return bgMap[cardBackground] || bgMap.white
+    }
+
+    // Get border radius classes
+    const getBorderRadiusClasses = () => {
+        const radiusMap = {
+            none: "rounded-none",
+            small: "rounded-sm",
+            medium: "rounded-md",
+            large: "rounded-lg"
+        }
+        return radiusMap[borderRadius] || radiusMap.small
+    }
+
+    // Get card effect classes
+    const getCardEffectClasses = () => {
+        const classes = []
+        if (cardEffects.shadow) {
+            classes.push("shadow-lg")
+        } else {
+            classes.push("shadow-md")
+        }
+        if (cardEffects.border) {
+            classes.push("border border-gray-200")
+        }
+        return classes.join(" ")
+    }
+
+    // Get button color classes
+    const getButtonColorClasses = () => {
+        const colorMap = {
+            blue: "bg-blue-500 hover:bg-blue-700",
+            green: "bg-green-500 hover:bg-green-700",
+            red: "bg-red-500 hover:bg-red-700",
+            purple: "bg-purple-500 hover:bg-purple-700",
+            orange: "bg-orange-500 hover:bg-orange-700",
+            teal: "bg-teal-500 hover:bg-teal-700"
+        }
+        return colorMap[buttonColor] || colorMap.blue
+    }
+
+    // Get button size classes
+    const getButtonSizeClasses = () => {
+        switch (buttonSize) {
+            case "small":
+                return "px-3 py-1.5 text-sm"
+            case "large":
+                return "px-6 py-3 text-lg"
+            case "medium":
+            default:
+                return "px-4 py-2 text-base"
+        }
+    }
+
+    // Get button style classes
+    const getButtonStyleClasses = () => {
+        const classes = []
+        if (buttonStyle.rounded) {
+            classes.push("rounded-lg")
+        } else if (buttonStyle["full-rounded"]) {
+            classes.push("rounded-full")
+        } else {
+            classes.push("rounded-full")
+        }
+        if (buttonStyle.shadow) {
+            classes.push("shadow-lg")
+        }
+        return classes.join(" ")
+    }
+
+    const buttonClasses = [
+        "inline-block",
+        "font-bold",
+        "text-white",
+        "transition duration-300",
+        getButtonColorClasses(),
+        getButtonSizeClasses(),
+        getButtonStyleClasses()
+    ].join(" ")
+
+    const cardClasses = [
+        "overflow-hidden",
+        "mb-4",
+        getCardBackgroundClasses(),
+        getBorderRadiusClasses(),
+        getCardEffectClasses()
+    ].join(" ")
+
+    const articleClasses = [
+        layout === "overlap" ? "p-0" : "p-4",
+        cardClasses,
+        getLayoutClasses()
+    ].join(" ")
+
     return (
-        <article className="p-4 overflow-hidden bg-white rounded-sm shadow-lg mb-4">
+        <article className={articleClasses}>
             {image && (
-                <div className="relative w-full h-56 overflow-hidden">
-                    <Image
-                        className="object-cover"
-                        src={inode}
-                        fill={true}
-                        alt="Activity Image"
-                    />
+                <div className={getImageContainerClasses()}>
+                    <div className={`relative w-full ${layout === "overlap" ? "h-full" : imageHeight} overflow-hidden`}>
+                        <Image
+                            className="object-cover"
+                            src={inode}
+                            fill={true}
+                            alt="Activity Image"
+                        />
+                    </div>
                 </div>
             )}
-            <div className="px-6 py-4">
-                <p className="mb-2 text-xl font-bold">{title}</p>
-                <p className="text-base line-clamp-3">{description}</p>
-            </div>
-            <div className="px-6 pt-4 pb-2">
-                <Link
-                    href={`/activities/${urlTitle || "#"}`}
-                    className="inline-block px-4 py-2 font-bold rounded-full bg-blue-500 hover:bg-blue-700 text-white"
-                >
-                    Link to detail →
-                </Link>
+            <div className={getContentContainerClasses()}>
+                <p className={titleClasses}>{title}</p>
+                <p className={`${descriptionSize} line-clamp-3 mb-4`}>{description}</p>
+                <div className={layout === "center" ? "flex justify-center" : ""}>
+                    <Link
+                        href={`/activities/${urlTitle || "#"}`}
+                        className={buttonClasses}
+                    >
+                        Link to detail →
+                    </Link>
+                </div>
             </div>
         </article>
     );

--- a/examples/nextjs/src/components/content-types/Banner.js
+++ b/examples/nextjs/src/components/content-types/Banner.js
@@ -1,10 +1,10 @@
+import { DotCMSEditableText } from "@dotcms/react";
 import Image from "next/image";
 import Link from "next/link";
-import { DotCMSEditableText } from "@dotcms/react";
 
 function Banner(contentlet) {
     const { title, caption, inode, image, link, buttonText, dotStyleProperties } = contentlet;
-    console.log(dotStyleProperties);
+    
     // Extract style properties with defaults
     const titleSize = dotStyleProperties?.["title-size"] || "text-6xl"
     const captionSize = dotStyleProperties?.["caption-size"] || "text-xl"

--- a/examples/nextjs/src/components/content-types/Banner.js
+++ b/examples/nextjs/src/components/content-types/Banner.js
@@ -3,7 +3,115 @@ import Link from "next/link";
 import { DotCMSEditableText } from "@dotcms/react";
 
 function Banner(contentlet) {
-    const { title, caption, inode, image, link, buttonText } = contentlet;
+    const { title, caption, inode, image, link, buttonText, dotStyleProperties } = contentlet;
+    console.log(dotStyleProperties);
+    // Extract style properties with defaults
+    const titleSize = dotStyleProperties?.["title-size"] || "text-6xl"
+    const captionSize = dotStyleProperties?.["caption-size"] || "text-xl"
+    const titleStyle = dotStyleProperties?.["title-style"] || {}
+    const textAlignment = dotStyleProperties?.["text-alignment"] || "center"
+    const overlayStyle = dotStyleProperties?.["overlay-style"] || "none"
+    const buttonColor = dotStyleProperties?.["button-color"] || "blue"
+    const buttonSize = dotStyleProperties?.["button-size"] || "medium"
+    const buttonStyle = dotStyleProperties?.["button-style"] || {}
+
+    // Build title classes
+    const titleClasses = [
+        "mb-2",
+        titleSize,
+        titleStyle.bold ? "font-bold" : "font-normal",
+        titleStyle.italic ? "italic" : "",
+        titleStyle.underline ? "underline" : "",
+        "text-white",
+        "text-shadow"
+    ].filter(Boolean).join(" ")
+
+    // Build caption classes
+    const captionClasses = [
+        "mb-4",
+        captionSize,
+        "text-white",
+        "text-shadow"
+    ].join(" ")
+
+    // Get alignment classes
+    const getAlignmentClasses = () => {
+        switch (textAlignment) {
+            case "left":
+                return "items-start text-left"
+            case "right":
+                return "items-end text-right"
+            case "center":
+            default:
+                return "items-center text-center"
+        }
+    }
+
+    // Get overlay classes
+    const getOverlayClasses = () => {
+        switch (overlayStyle) {
+            case "dark":
+                return "bg-black/40"
+            case "light":
+                return "bg-white/20"
+            case "gradient":
+                return "bg-gradient-to-b from-black/50 via-transparent to-black/50"
+            case "none":
+            default:
+                return ""
+        }
+    }
+
+    // Get button color classes
+    const getButtonColorClasses = () => {
+        const colorMap = {
+            blue: "bg-blue-500 hover:bg-blue-700",
+            green: "bg-green-500 hover:bg-green-700",
+            red: "bg-red-500 hover:bg-red-700",
+            purple: "bg-purple-500 hover:bg-purple-700",
+            orange: "bg-orange-500 hover:bg-orange-700",
+            teal: "bg-teal-500 hover:bg-teal-700"
+        }
+        return colorMap[buttonColor] || colorMap.blue
+    }
+
+    // Get button size classes
+    const getButtonSizeClasses = () => {
+        switch (buttonSize) {
+            case "small":
+                return "px-3 py-2 text-base"
+            case "large":
+                return "px-6 py-4 text-2xl"
+            case "medium":
+            default:
+                return "px-4 py-2 text-xl"
+        }
+    }
+
+    // Get button style classes
+    const getButtonStyleClasses = () => {
+        const classes = []
+        if (buttonStyle.rounded) {
+            classes.push("rounded-lg")
+        } else if (buttonStyle["full-rounded"]) {
+            classes.push("rounded-full")
+        } else {
+            classes.push("rounded-sm")
+        }
+        if (buttonStyle.shadow) {
+            classes.push("shadow-lg")
+        }
+        return classes.join(" ")
+    }
+
+    const buttonClasses = [
+        "transition duration-300",
+        "text-white",
+        "font-bold",
+        getButtonColorClasses(),
+        getButtonSizeClasses(),
+        getButtonStyleClasses()
+    ].join(" ")
 
     return (
         <div className="relative w-full p-4 bg-gray-200 h-96">
@@ -15,17 +123,22 @@ function Banner(contentlet) {
                     alt={title}
                 />
             )}
-            <div className="absolute inset-0 flex flex-col items-center justify-center p-4 text-center text-white">
-                <h2 className="mb-2 text-6xl font-bold text-shadow">
+            {overlayStyle !== "none" && (
+                <div className={`absolute inset-0 ${getOverlayClasses()}`} />
+            )}
+            <div className={`absolute inset-0 flex flex-col justify-center p-4 ${getAlignmentClasses()} text-white`}>
+                <h2 className={titleClasses}>
                     <DotCMSEditableText
                         contentlet={contentlet}
                         fieldName="title"
                     />
                 </h2>
-                <p className="mb-4 text-xl text-shadow">{caption}</p>
+                {caption && (
+                    <p className={captionClasses}>{caption}</p>
+                )}
                 {link && (
                     <Link
-                        className="p-4 text-xl transition duration-300 bg-blue-500 rounded-sm hover:bg-blue-700"
+                        className={buttonClasses}
                         href={link}
                     >
                         {buttonText || "See more"}

--- a/examples/nextjs/src/utils/styleEditorSchemas.js
+++ b/examples/nextjs/src/utils/styleEditorSchemas.js
@@ -1,0 +1,336 @@
+import { defineStyleEditorSchema, styleEditorField } from "@dotcms/uve";
+
+export const ACTIVITY_SCHEMA = defineStyleEditorSchema({
+    contentType: 'Activity',
+    sections: [
+        {
+            title: 'Typography',
+            fields: [
+                styleEditorField.dropdown({
+                    id: 'title-size',
+                    label: 'Title Size',
+                    options: [
+                        { label: 'Small', value: 'text-lg' },
+                        { label: 'Medium', value: 'text-xl' },
+                        { label: 'Large', value: 'text-2xl' },
+                        { label: 'Extra Large', value: 'text-3xl' },
+                    ]
+                }),
+                styleEditorField.dropdown({
+                    id: 'description-size',
+                    label: 'Description Size',
+                    options: [
+                        { label: 'Small', value: 'text-sm' },
+                        { label: 'Medium', value: 'text-base' },
+                        { label: 'Large', value: 'text-lg' },
+                    ]
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'title-style',
+                    label: 'Title Style',
+                    options: [
+                        { label: 'Bold', key: 'bold' },
+                        { label: 'Italic', key: 'italic' },
+                        { label: 'Underline', key: 'underline' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Layout',
+            fields: [
+                styleEditorField.radio({
+                    id: 'layout',
+                    label: 'Layout',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Left',
+                            value: 'left',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s',
+                        },
+                        {
+                            label: 'Right',
+                            value: 'right',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                        },
+                        {
+                            label: 'Center',
+                            value: 'center',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                        },
+                        {
+                            label: 'Overlap',
+                            value: 'overlap',
+                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                        },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'image-height',
+                    label: 'Image Height',
+                    options: [
+                        { label: 'Small', value: 'h-40' },
+                        { label: 'Medium', value: 'h-56' },
+                        { label: 'Large', value: 'h-72' },
+                        { label: 'Extra Large', value: 'h-96' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Card Style',
+            fields: [
+                styleEditorField.radio({
+                    id: 'card-background',
+                    label: 'Card Background',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'White',
+                            value: 'white',
+                        },
+                        {
+                            label: 'Gray',
+                            value: 'gray',
+                        },
+                        {
+                            label: 'Light Blue',
+                            value: 'light-blue',
+                        },
+                        {
+                            label: 'Light Green',
+                            value: 'light-green',
+                        },
+                    ],
+                }),
+                styleEditorField.radio({
+                    id: 'border-radius',
+                    label: 'Border Radius',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'None',
+                            value: 'none',
+                        },
+                        {
+                            label: 'Small',
+                            value: 'small',
+                        },
+                        {
+                            label: 'Medium',
+                            value: 'medium',
+                        },
+                        {
+                            label: 'Large',
+                            value: 'large',
+                        },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'card-effects',
+                    label: 'Card Effects',
+                    options: [
+                        { label: 'Shadow', key: 'shadow' },
+                        { label: 'Border', key: 'border' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Button',
+            fields: [
+                styleEditorField.radio({
+                    id: 'button-color',
+                    label: 'Button Color',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Blue',
+                            value: 'blue',
+                        },
+                        {
+                            label: 'Green',
+                            value: 'green',
+                        },
+                        {
+                            label: 'Red',
+                            value: 'red',
+                        },
+                        {
+                            label: 'Purple',
+                            value: 'purple',
+                        },
+                        {
+                            label: 'Orange',
+                            value: 'orange',
+                        },
+                        {
+                            label: 'Teal',
+                            value: 'teal',
+                        },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'button-size',
+                    label: 'Button Size',
+                    options: [
+                        { label: 'Small', value: 'small' },
+                        { label: 'Medium', value: 'medium' },
+                        { label: 'Large', value: 'large' },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'button-style',
+                    label: 'Button Style',
+                    options: [
+                        { label: 'Rounded', key: 'rounded' },
+                        { label: 'Full Rounded', key: 'full-rounded' },
+                        { label: 'Shadow', key: 'shadow' },
+                    ],
+                }),
+            ]
+        },
+    ]
+})
+
+export const BANNER_SCHEMA = defineStyleEditorSchema({
+    contentType: 'Banner',
+    sections: [
+        {
+            title: 'Typography',
+            fields: [
+                styleEditorField.dropdown({
+                    id: 'title-size',
+                    label: 'Title Size',
+                    options: [
+                        { label: 'Small', value: 'text-4xl' },
+                        { label: 'Medium', value: 'text-5xl' },
+                        { label: 'Large', value: 'text-6xl' },
+                        { label: 'Extra Large', value: 'text-7xl' },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'caption-size',
+                    label: 'Caption Size',
+                    options: [
+                        { label: 'Small', value: 'text-base' },
+                        { label: 'Medium', value: 'text-lg' },
+                        { label: 'Large', value: 'text-xl' },
+                        { label: 'Extra Large', value: 'text-2xl' },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'title-style',
+                    label: 'Title Style',
+                    options: [
+                        { label: 'Bold', key: 'bold' },
+                        { label: 'Italic', key: 'italic' },
+                        { label: 'Underline', key: 'underline' },
+                    ]
+                }),
+            ]
+        },
+        {
+            title: 'Layout',
+            fields: [
+                styleEditorField.radio({
+                    id: 'text-alignment',
+                    label: 'Text Alignment',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Left',
+                            value: 'left',
+                        },
+                        {
+                            label: 'Center',
+                            value: 'center',
+                        },
+                        {
+                            label: 'Right',
+                            value: 'right',
+                        },
+                    ],
+                }),
+                styleEditorField.radio({
+                    id: 'overlay-style',
+                    label: 'Overlay Style',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'None',
+                            value: 'none',
+                        },
+                        {
+                            label: 'Dark',
+                            value: 'dark',
+                        },
+                        {
+                            label: 'Light',
+                            value: 'light',
+                        },
+                        {
+                            label: 'Gradient',
+                            value: 'gradient',
+                        },
+                    ],
+                }),
+            ]
+        },
+        {
+            title: 'Button',
+            fields: [
+                styleEditorField.radio({
+                    id: 'button-color',
+                    label: 'Button Color',
+                    columns: 2,
+                    options: [
+                        {
+                            label: 'Blue',
+                            value: 'blue',
+                        },
+                        {
+                            label: 'Green',
+                            value: 'green',
+                        },
+                        {
+                            label: 'Red',
+                            value: 'red',
+                        },
+                        {
+                            label: 'Purple',
+                            value: 'purple',
+                        },
+                        {
+                            label: 'Orange',
+                            value: 'orange',
+                        },
+                        {
+                            label: 'Teal',
+                            value: 'teal',
+                        },
+                    ],
+                }),
+                styleEditorField.dropdown({
+                    id: 'button-size',
+                    label: 'Button Size',
+                    options: [
+                        { label: 'Small', value: 'small' },
+                        { label: 'Medium', value: 'medium' },
+                        { label: 'Large', value: 'large' },
+                    ],
+                }),
+                styleEditorField.checkboxGroup({
+                    id: 'button-style',
+                    label: 'Button Style',
+                    options: [
+                        { label: 'Rounded', key: 'rounded' },
+                        { label: 'Full Rounded', key: 'full-rounded' },
+                        { label: 'Shadow', key: 'shadow' },
+                    ],
+                }),
+            ]
+        },
+    ]
+})

--- a/examples/nextjs/src/utils/styleEditorSchemas.js
+++ b/examples/nextjs/src/utils/styleEditorSchemas.js
@@ -47,22 +47,22 @@ export const ACTIVITY_SCHEMA = defineStyleEditorSchema({
                         {
                             label: 'Left',
                             value: 'left',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s',
+                            imageURL: 'https://i.ibb.co/cXv3tfYd/Screenshot-2025-12-23-at-11-58-32-AM.png',
                         },
                         {
                             label: 'Right',
                             value: 'right',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                            imageURL: 'https://i.ibb.co/v4cJxyLZ/Screenshot-2025-12-23-at-11-59-01-AM.png'
                         },
                         {
                             label: 'Center',
                             value: 'center',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                            imageURL: 'https://i.ibb.co/kVntSyzn/Screenshot-2025-12-23-at-11-58-50-AM.png'
                         },
                         {
                             label: 'Overlap',
                             value: 'overlap',
-                            imageURL: 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSphn5CRr3MrQUjWWH7ByHWW-lROnVQl4XxYQ&s'
+                            imageURL: 'https://i.ibb.co/43Y5KLY/placeholder-icon-design-free-vector.jpg'
                         },
                     ],
                 }),

--- a/examples/nextjs/src/views/Page.js
+++ b/examples/nextjs/src/views/Page.js
@@ -1,14 +1,17 @@
 "use client";
 
-import { DotCMSLayoutBody, useEditableDotCMSPage } from "@dotcms/react";
+import { DotCMSLayoutBody, useEditableDotCMSPage, useStyleEditorSchemas } from "@dotcms/react";
 
 import { pageComponents } from "@/components/content-types";
 import Footer from "@/components/footer/Footer";
 import Header from "@/components/header/Header";
+import { ACTIVITY_SCHEMA, BANNER_SCHEMA } from "@/utils/styleEditorSchemas";
 
 export function Page({ pageContent }) {
     const { pageAsset, content = {} } = useEditableDotCMSPage(pageContent);
     const navigation = content.navigation;
+
+    useStyleEditorSchemas([ACTIVITY_SCHEMA, BANNER_SCHEMA])
 
     return (
         <div className="flex flex-col gap-6 min-h-screen bg-slate-50">


### PR DESCRIPTION


https://github.com/user-attachments/assets/371a47c9-477b-49ba-8bd3-c963ad94f586




This commit introduces the Style Editor feature across Angular and Astro examples, allowing content editors to customize component styles directly in the Universal Visual Editor. Key changes include:

- Added a new section in the Angular README for the Style Editor, detailing schema definitions and usage.
- Implemented style properties in the Activity and Banner components, enabling dynamic styling based on user-defined properties.
- Updated the Page component to register style editor schemas for Activity and Banner components.
- Enhanced the Astro README with Style Editor documentation, including schema creation and usage examples.

This update improves the flexibility and usability of the content editing experience in both frameworks.

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #34376

This PR fixes: #34376