### PR TITLE
Issue 34144 webp images failing to render

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/image/filter/WebPImageFilter.java
+++ b/dotCMS/src/main/java/com/dotmarketing/image/filter/WebPImageFilter.java
@@ -10,6 +10,8 @@ import javax.imageio.stream.FileImageOutputStream;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.luciad.imageio.webp.WebPWriteParam;
 
+import static com.dotmarketing.image.filter.ImageFilterAPI.WEBP;
+
 public class WebPImageFilter extends ImageFilter {
 	public String[] getAcceptedParameters(){
 		return  new String[] {
@@ -17,6 +19,10 @@ public class WebPImageFilter extends ImageFilter {
 		};
 	}
 	public File runFilter(final File file, final Map<String, String[]> parameters) {
+
+        if(file!=null && file.getName().contains(WEBP)){
+            return file;
+        }
 
 	    final int qualityParam = parameters.get(getPrefix() +"q") != null?Integer.parseInt(parameters.get(getPrefix() +"q")[0]):85;
 
@@ -46,8 +52,8 @@ public class WebPImageFilter extends ImageFilter {
 
             final File tempResultFile = new File(resultFile.getAbsoluteFile() + "_" + System.currentTimeMillis() +".tmp");
 
-	        
-	        
+
+
 	        writer.setOutput(new FileImageOutputStream(tempResultFile));
 	        writer.write(null, new IIOImage(ImageIO.read(file), null, null), writeParam);
 	        writer.dispose();

--- a/dotCMS/src/main/java/com/dotmarketing/image/filter/WebPImageFilter.java
+++ b/dotCMS/src/main/java/com/dotmarketing/image/filter/WebPImageFilter.java
@@ -8,7 +8,6 @@ import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.stream.FileImageOutputStream;
 import com.dotmarketing.exception.DotRuntimeException;
-import com.dotmarketing.util.Config;
 import com.luciad.imageio.webp.WebPWriteParam;
 
 public class WebPImageFilter extends ImageFilter {

--- a/dotCMS/src/main/java/com/dotmarketing/image/filter/WebPImageFilter.java
+++ b/dotCMS/src/main/java/com/dotmarketing/image/filter/WebPImageFilter.java
@@ -11,8 +11,6 @@ import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
 import com.luciad.imageio.webp.WebPWriteParam;
 
-import static com.dotmarketing.image.filter.ImageFilterAPI.WEBP;
-
 public class WebPImageFilter extends ImageFilter {
 	public String[] getAcceptedParameters(){
 		return  new String[] {

--- a/dotCMS/src/main/java/com/dotmarketing/image/filter/WebPImageFilter.java
+++ b/dotCMS/src/main/java/com/dotmarketing/image/filter/WebPImageFilter.java
@@ -8,6 +8,7 @@ import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.stream.FileImageOutputStream;
 import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.util.Config;
 import com.luciad.imageio.webp.WebPWriteParam;
 
 import static com.dotmarketing.image.filter.ImageFilterAPI.WEBP;
@@ -19,11 +20,7 @@ public class WebPImageFilter extends ImageFilter {
 		};
 	}
 	public File runFilter(final File file, final Map<String, String[]> parameters) {
-
-        if(file!=null && file.getName().contains(WEBP)){
-            return file;
-        }
-
+        
 	    final int qualityParam = parameters.get(getPrefix() +"q") != null?Integer.parseInt(parameters.get(getPrefix() +"q")[0]):85;
 
 	    Float quality = Float.valueOf(qualityParam);

--- a/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/servlets/ShortyServlet.java
@@ -66,9 +66,9 @@ public class ShortyServlet extends HttpServlet {
   private final ShortyIdAPI    shortyIdAPI    = APILocator.getShortyAPI();
   private final WebResource    webResource    = new WebResource();
 
-  private static final String  JPEG                        = ".jpeg";
-  private static final String  JPEGP                       = ".jpegp";
-  private static final String  WEBP                        = ".webp";
+  private static final String  JPEG                        = "/jpeg";
+  private static final String  JPEGP                       = "/jpegp";
+  private static final String  WEBP                        = "/webp";
   private static final String  FILE_ASSET_DEFAULT          = FileAssetAPI.BINARY_FIELD;
   public  static final String  SHORTY_SERVLET_FORWARD_PATH = "shorty.servlet.forward.path";
   private static final Pattern widthPattern                = Pattern.compile("/(\\d+)w\\b");


### PR DESCRIPTION
Fix syntax for converting images to the JPEG, JPEGP and WEBP, to match what we have in our documentation

https://dev.dotcms.com/docs/image-resizing-and-processing#simpleFilters

This PR fixes: #34144

This PR fixes: #34144