### PR TITLE
fix(dwr): make DWRSESSIONID cookie atts configurable

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/application/myaccount/edit_user_organization.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/application/myaccount/edit_user_organization.vtl
@@ -4,6 +4,14 @@
 #end
 
 <script type='text/javascript' src='/dwr/interface/OrganizationAjax.js'></script>
+<!-- DWR Cookie Security Configuration -->
+<script type="text/javascript">
+	window.dwrCookieSecurityConfig = {
+		secure: $config.getBooleanProperty("DWRSESSIONID_SECURE", false),
+		sameSite: '$config.getStringProperty("DWRSESSIONID_SAMESITE", "")'
+	};
+</script>
+<script type='text/javascript' src='/html/js/dwr-cookie-security.js'></script>
 <script type='text/javascript' src='/dwr/engine.js'></script>
 <script type='text/javascript' src='/dwr/util.js'></script>
 

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/application/registration/registration.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/application/registration/registration.vtl
@@ -2,6 +2,14 @@
 #set($theCategories = $categories.getCategoriesByEntityName("category","Preferences","$!{dotRegistrationForm.category}",true,true,3,false))
 <!-- SCRIPT FOR AJAX MANAGEMENT -->
 <script language="javascript" type="text/javascript" src='/html/js/states_and_countries.js'></script>
+<!-- DWR Cookie Security Configuration -->
+<script type="text/javascript">
+	window.dwrCookieSecurityConfig = {
+		secure: $config.getBooleanProperty("DWRSESSIONID_SECURE", false),
+		sameSite: '$config.getStringProperty("DWRSESSIONID_SAMESITE", "")'
+	};
+</script>
+<script type='text/javascript' src='/html/js/dwr-cookie-security.js'></script>
 <script type='text/javascript' src='/dwr/engine.js'></script>
 <script type='text/javascript' src='/dwr/util.js'></script>
 <!-- END SCRIPT FOR AJAX MANAGEMENT -->

--- a/dotCMS/src/main/webapp/html/common/top_inc.jsp
+++ b/dotCMS/src/main/webapp/html/common/top_inc.jsp
@@ -91,6 +91,19 @@ THIS FILE AND ITS INCLUDES
 	<script type="text/javascript" src="/html/js/dojo/custom-build/dojo/dojo.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/html/js/dojo/custom-build/build/build.js?b=<%= ReleaseInfo.getVersion() %>"></script>
   	<script type="text/javascript" src="/html/common/javascript.jsp?b=<%= ReleaseInfo.getVersion() %>"></script>
+
+	<!-- DWR Cookie Security Configuration -->
+	<script type="text/javascript">
+		// Configuration for DWR cookie security enhancement
+		// Set via dotmarketing-config.properties:
+		//   DWRSESSIONID_SECURE=true/false (default: false)
+		//   DWRSESSIONID_SAMESITE=Strict|Lax|None (default: empty/disabled)
+		window.dwrCookieSecurityConfig = {
+			secure: <%= Config.getBooleanProperty("DWRSESSIONID_SECURE", false) %>,
+			sameSite: '<%= Config.getStringProperty("DWRSESSIONID_SAMESITE", "") %>'
+		};
+	</script>
+	<script type="text/javascript" src="/html/js/dwr-cookie-security.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/dwr/engine.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/dwr/util.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/dwr/interface/HostAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>

--- a/dotCMS/src/main/webapp/html/js/dwr-cookie-security.js
+++ b/dotCMS/src/main/webapp/html/js/dwr-cookie-security.js
@@ -1,0 +1,71 @@
+/**
+ * DWR Cookie Security Enhancement
+ * Configurable security attributes for DWRSESSIONID cookie
+ * for enhanced security compliance (banking/enterprise requirements).
+ *
+ * Configuration is provided via window.dwrCookieSecurityConfig object set by JSP.
+ * Defaults to disabled (no changes) to avoid affecting existing customers.
+ *
+ * This script must be loaded BEFORE dwr/engine.js
+ */
+(function() {
+    'use strict';
+
+    // Read configuration from window object (set by JSP)
+    var config = window.dwrCookieSecurityConfig || {};
+    var enableSecure = config.secure === true;
+    var sameSiteValue = config.sameSite || '';
+
+    // If both disabled, don't intercept at all
+    if (!enableSecure && !sameSiteValue) {
+        if (console && console.debug) {
+            console.debug('DWR Cookie Security: Disabled via configuration (DWRSESSIONID_SECURE=false, DWRSESSIONID_SAMESITE empty)');
+        }
+        return;
+    }
+
+    // Store the original cookie descriptor
+    var cookieDesc = Object.getOwnPropertyDescriptor(Document.prototype, 'cookie') ||
+                     Object.getOwnPropertyDescriptor(HTMLDocument.prototype, 'cookie');
+
+    if (!cookieDesc || !cookieDesc.configurable) {
+        console.warn('DWR Cookie Security: Unable to intercept document.cookie - descriptor not configurable');
+        return;
+    }
+
+    // Override document.cookie setter to intercept DWRSESSIONID
+    Object.defineProperty(document, 'cookie', {
+        get: function() {
+            return cookieDesc.get.call(document);
+        },
+        set: function(val) {
+            // Intercept DWRSESSIONID cookie setting
+            if (val && typeof val === 'string' && val.indexOf('DWRSESSIONID=') === 0) {
+                var attributesAdded = [];
+
+                // Add Secure attribute if enabled and not already present
+                if (enableSecure && val.indexOf('Secure') === -1) {
+                    val += '; Secure';
+                    attributesAdded.push('Secure');
+                }
+
+                // Add SameSite attribute if configured and not already present
+                if (sameSiteValue && val.indexOf('SameSite') === -1) {
+                    val += '; SameSite=' + sameSiteValue;
+                    attributesAdded.push('SameSite=' + sameSiteValue);
+                }
+
+                if (console && console.info && attributesAdded.length > 0) {
+                    console.info('DWR Cookie Security: Enhanced DWRSESSIONID cookie with: ' + attributesAdded.join(', '));
+                }
+            }
+            return cookieDesc.set.call(document, val);
+        },
+        enumerable: true,
+        configurable: true
+    });
+
+    if (console && console.info) {
+        console.info('DWR Cookie Security: Interceptor initialized (Secure=' + enableSecure + ', SameSite=' + sameSiteValue + ')');
+    }
+})();

--- a/dotCMS/src/main/webapp/html/legacy_custom_field/legacy-custom-field.jsp
+++ b/dotCMS/src/main/webapp/html/legacy_custom_field/legacy-custom-field.jsp
@@ -98,6 +98,14 @@
 <script type="text/javascript" src="/html/js/dojo/custom-build/dojo/dojo.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/html/js/dojo/custom-build/build/build.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 
+<!-- DWR Cookie Security Configuration -->
+<script type="text/javascript">
+	window.dwrCookieSecurityConfig = {
+		secure: <%= Config.getBooleanProperty("DWRSESSIONID_SECURE", false) %>,
+		sameSite: '<%= Config.getStringProperty("DWRSESSIONID_SAMESITE", "") %>'
+	};
+</script>
+<script type="text/javascript" src="/html/js/dwr-cookie-security.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/dwr/engine.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/dwr/util.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/dwr/interface/HostAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>

--- a/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
+++ b/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
@@ -233,6 +233,14 @@
     <script type="text/javascript" src="/html/js/dojo/custom-build/dojo/dojo.js"></script>
     <script type="text/javascript" src="/html/js/dojo/custom-build/build/build.js"></script>
     <script type="text/javascript" src="/html/common/javascript.jsp"></script>
+    <!-- DWR Cookie Security Configuration -->
+    <script type="text/javascript">
+        window.dwrCookieSecurityConfig = {
+            secure: <%= Config.getBooleanProperty("DWRSESSIONID_SECURE", false) %>,
+            sameSite: '<%= Config.getStringProperty("DWRSESSIONID_SAMESITE", "") %>'
+        };
+    </script>
+    <script type="text/javascript" src="/html/js/dwr-cookie-security.js"></script>
     <script type="text/javascript" src="/dwr/engine.js"></script>
     <script type="text/javascript" src="/dwr/util.js"></script>
     <script type="text/javascript" src="/dwr/interface/LanguageAjax.js"></script>


### PR DESCRIPTION
Introduce ability to change the values for DWRSESSIONID cookie attributes. 

Now Secure and SameSite attributes can be changed via config properties:
* DWRSESSIONID_SECURE=true|false (defaults to 'false')
* DWRSESSIONID_SAMESITE=Strict|Lax  (defaults to empty)


This PR fixes: #34417

This PR fixes: #34417