### PR TITLE
refactor: remove FEATURE_FLAG_UVE_STYLE_EDITOR feature flag

### DIFF
--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -859,9 +859,6 @@ LOCALIZATION_ENHANCEMENTS_ENABLED=false
 ## UVE Toggle Lock
 FEATURE_FLAG_UVE_TOGGLE_LOCK=false
 
-## UVE Style Editor
-FEATURE_FLAG_UVE_STYLE_EDITOR=false
-
 STARTER_BUILD_VERSION=${starter.deploy.version}
 
 ##LTS properties to show EOL message


### PR DESCRIPTION
## Summary
Removes the deprecated FEATURE_FLAG_UVE_STYLE_EDITOR feature flag from dotmarketing-config.properties.

## Changes
- Removed `FEATURE_FLAG_UVE_STYLE_EDITOR=false` from dotmarketing-config.properties

## Motivation
The Style Editor functionality is now turned on by default, making this feature flag obsolete.

## Related Issue
Fixes #34446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34446