### PR TITLE
task(sql): Improved query performance for relationships and telemetry queries

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/RelationshipFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/RelationshipFactoryImpl.java
@@ -579,7 +579,9 @@ public class RelationshipFactoryImpl implements RelationshipFactory{
         String liveOrWorking = live ? "cvi.live_inode" : "cvi.working_inode";
         String orderBy = SQLUtil.sanitizeSortBy(orderByIn);
         // we only include contentlet for sorting
-        boolean includeContentlet = !("sort_order".equalsIgnoreCase(orderBy) || "tree_order".equalsIgnoreCase(orderBy));
+        boolean includeContentlet =
+                UtilMethods.isSet(orderBy) && !("sort_order".equalsIgnoreCase(orderBy) || "tree_order".equalsIgnoreCase(
+                        orderBy));
 
         final StringBuilder query = new StringBuilder("select " + liveOrWorking + " as inode ")
                 .append(" from contentlet_version_info cvi, tree t ");
@@ -643,7 +645,9 @@ public class RelationshipFactoryImpl implements RelationshipFactory{
         String liveOrWorking = live ? "cvi.live_inode" : "cvi.working_inode";
 
         // we only include contentlet for sorting
-        boolean includeContentlet = !("sort_order".equalsIgnoreCase(orderBy) || "tree_order".equalsIgnoreCase(orderBy));
+        boolean includeContentlet =
+                UtilMethods.isSet(orderBy) && !("sort_order".equalsIgnoreCase(orderBy) || "tree_order".equalsIgnoreCase(
+                        orderBy));
 
         final StringBuilder query = new StringBuilder();
 

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/ProfileFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/ProfileFilter.java
@@ -35,7 +35,7 @@ public class ProfileFilter {
         
         // If no annotation, exclude (annotation is required)
         if (annotation == null) {
-            Logger.warn(ProfileFilter.class, 
+            Logger.debug(ProfileFilter.class,
                 String.format("Metric %s is missing required @MetricsProfile annotation. " +
                     "This metric will be excluded from collection. " +
                     "Please add @MetricsProfile annotation to the metric class.",
@@ -84,5 +84,3 @@ public class ProfileFilter {
         return clazz;
     }
 }
-
-

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/LiveNotDefaultLanguageContentsDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/LiveNotDefaultLanguageContentsDatabaseMetricType.java
@@ -2,10 +2,11 @@ package com.dotcms.telemetry.collectors.content;
 
 import com.dotcms.telemetry.MetricCategory;
 import com.dotcms.telemetry.MetricFeature;
-import com.dotcms.telemetry.collectors.DBMetricType;
-import javax.enterprise.context.ApplicationScoped;
 import com.dotcms.telemetry.MetricsProfile;
 import com.dotcms.telemetry.ProfileType;
+import com.dotcms.telemetry.collectors.DBMetricType;
+import com.dotmarketing.business.APILocator;
+import javax.enterprise.context.ApplicationScoped;
 
 /**
  * Collects the count of contentlets which have at least one live version in a non-default Language
@@ -35,9 +36,10 @@ public class LiveNotDefaultLanguageContentsDatabaseMetricType implements DBMetri
 
     @Override
     public String getSqlQuery() {
-        return "SELECT COUNT(DISTINCT identifier) AS value " +
+        long langId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+        return "SELECT COUNT(identifier) AS value " +
                 "FROM contentlet_version_info " +
                 "WHERE live_inode IS NOT null " +
-                    "AND lang NOT IN (SELECT default_language_id FROM company)";
+                "AND lang = " + langId;
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/RecentlyEditedContentDatabaseMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/content/RecentlyEditedContentDatabaseMetricType.java
@@ -6,7 +6,6 @@ import com.dotcms.telemetry.MetricFeature;
 import com.dotcms.telemetry.MetricsProfile;
 import com.dotcms.telemetry.ProfileType;
 import com.dotcms.telemetry.collectors.DBMetricType;
-
 import javax.enterprise.context.ApplicationScoped;
 
 /**
@@ -38,8 +37,7 @@ public class RecentlyEditedContentDatabaseMetricType implements DBMetricType {
 
     @Override
     public String getSqlQuery() {
-        return "SELECT COUNT(working_inode) AS value FROM contentlet_version_info, contentlet " +
-                "WHERE contentlet.inode = contentlet_version_info.working_inode AND " +
-                "contentlet.mod_date  > now() - interval '1 month'";
+        return "SELECT COUNT(working_inode) AS value FROM contentlet_version_info " +
+                "WHERE version_ts > now() - interval '1 month'";
     }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/common/util/SQLUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/util/SQLUtil.java
@@ -1,5 +1,7 @@
 package com.dotmarketing.common.util;
 
+import static com.liferay.util.StringPool.SPACE;
+
 import com.dotcms.contenttype.business.ContentTypeFactory;
 import com.dotcms.repackage.com.google.common.collect.ImmutableSet;
 import com.dotcms.util.SecurityLoggerServiceAPI;
@@ -13,9 +15,15 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.SecurityLogger;
 import com.dotmarketing.util.SecurityThreatLogger;
 import com.dotmarketing.util.UtilMethods;
-import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.liferay.util.StringPool;
 import com.liferay.util.StringUtil;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
 import net.sourceforge.squirrel_sql.fw.preferences.BaseQueryTokenizerPreferenceBean;
 import net.sourceforge.squirrel_sql.fw.preferences.IQueryTokenizerPreferenceBean;
 import net.sourceforge.squirrel_sql.fw.sql.QueryTokenizer;
@@ -26,18 +34,6 @@ import net.sourceforge.squirrel_sql.plugins.oracle.prefs.OraclePreferenceBean;
 import net.sourceforge.squirrel_sql.plugins.oracle.tokenizer.OracleQueryTokenizer;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
-
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.regex.Pattern;
-
-import static com.liferay.util.StringPool.SPACE;
 
 
 
@@ -133,7 +129,7 @@ public class SQLUtil {
 			"title","upper(title)","filename", "moddate", "tagname","pageUrl",
 			"category_name","category_velocity_var_name","status","workflow_step.name","assigned_to",
 			"mod_date","structuretype,upper(name)","upper(name)",
-			"category_key", "page_url","name","velocity_var_name",
+			"category_key", "page_url", "name", "velocity_var_name", "tree_order",
 			"description","category_","sort_order","hostName", "keywords",
 			"mod_date,upper(name)", "relation_type_value", "child_relation_name",
 			"parent_relation_name","inode");


### PR DESCRIPTION
ref: #34454

**BEFORE:**
```                
prod_1_db=> explain SELECT COUNT(working_inode) AS value 
FROM contentlet_version_info, contentlet
WHERE contentlet.inode = contentlet_version_info.working_inode AND
contentlet.mod_date  > now() - interval '1 month';
                                                          QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=11170340.22..11170340.23 rows=1 width=8)
   ->  Gather  (cost=11170340.01..11170340.22 rows=2 width=8)
         Workers Planned: 2
         ->  Partial Aggregate  (cost=11169340.01..11169340.02 rows=1 width=8)
               ->  Parallel Hash Join  (cost=10954188.47..11168776.29 rows=225487 width=37)
                     Hash Cond: ((contentlet_version_info.working_inode)::text = (contentlet.inode)::text)
                     ->  Parallel Seq Scan on contentlet_version_info  (cost=0.00..163402.49 rows=1857649 width=37)
                     ->  Parallel Hash  (cost=10909253.80..10909253.80 rows=2212134 width=37)
                           ->  Parallel Bitmap Heap Scan on contentlet  (cost=178538.26..10909253.80 rows=2212134 width=37)
                                 Recheck Cond: (mod_date > (now() - '1 mon'::interval))
                                 ->  Bitmap Index Scan on idx_contentlet_mod_date  (cost=0.00..177210.98 rows=5309121 width=0)
                                       Index Cond: (mod_date > (now() - '1 mon'::interval))
```


**AFTER:**

```
prod_1_db=> explain SELECT COUNT(working_inode) AS value 
FROM contentlet_version_info 
WHERE version_ts > now() - interval '1 month';
                                                 QUERY PLAN
-------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=179089.09..179089.10 rows=1 width=8)
   ->  Gather  (cost=179088.87..179089.08 rows=2 width=8)
         Workers Planned: 2
         ->  Partial Aggregate  (cost=178088.87..178088.88 rows=1 width=8)
               ->  Parallel Seq Scan on contentlet_version_info  (cost=0.00..177334.85 rows=301607 width=37)
                     Filter: (version_ts > (now() - '1 mon'::interval))
```              


**BEFORE:**
```
_prod_1_db=> explain select cvi.working_inode as inode
from contentlet_version_info cvi, tree t, contentlet c
where t.parent= 'f1d378c9-b784-45d0-a43c-9790af678f13' and
t.relation_type = 'Blog.blogComment' and
t.child = cvi.identifier  and
cvi.working_inode = c.inode
order by c.sort_order;
                                                                QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=24.88..24.89 rows=1 width=41)
   Sort Key: c.sort_order
   ->  Nested Loop  (cost=1.68..24.87 rows=1 width=41)
         ->  Nested Loop  (cost=1.11..17.19 rows=1 width=37)
               ->  Index Only Scan using idx_tree_4 on tree t  (cost=0.56..8.60 rows=1 width=35)
                     Index Cond: ((parent = 'f1d378c9-b784-45d0-a43c-9790af678f13'::text) AND (relation_type = 'Blog.blogComment'::text))
               ->  Index Scan using contentlet_version_info_pkey on contentlet_version_info cvi  (cost=0.56..8.57 rows=1 width=71)
                     Index Cond: ((identifier)::text = (t.child)::text)
         ->  Index Scan using idx_contentlet_3 on contentlet c  (cost=0.56..7.68 rows=1 width=41)
               Index Cond: ((inode)::text = (cvi.working_inode)::text)                                       
```         
          
          
**AFTER:**  
    
```
prod_1_db-> explain select cvi.working_inode as inode 
from contentlet_version_info cvi, tree t
where t.parent= 'f1d378c9-b784-45d0-a43c-9790af678f13' and 
t.relation_type = 'Blog.blogComment' and 
t.child = cvi.identifier 
order by t.tree_order;
                                                                     QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=17.20..17.21 rows=1 width=41)
   Sort Key: t.tree_order
   ->  Nested Loop  (cost=1.11..17.19 rows=1 width=41)
         ->  Index Scan using idx_tree_4 on tree t  (cost=0.56..8.60 rows=1 width=39)
               Index Cond: (((parent)::text = 'f1d378c9-b784-45d0-a43c-9790af678f13'::text) AND ((relation_type)::text = 'Blog.blogComment'::text))
         ->  Index Scan using contentlet_version_info_pkey on contentlet_version_info cvi  (cost=0.56..8.57 rows=1 width=71)
               Index Cond: ((identifier)::text = (t.child)::text)
(7 rows)
```


                                       
                              
                                       



This PR fixes: #34454