### PR TITLE
34141 feedback content drive

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-sidebar/dot-content-drive-sidebar.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-sidebar/dot-content-drive-sidebar.component.html
@@ -1,4 +1,4 @@
-<div class="flex items-center px-3 pt-7 pb-4 gap-2 h-17.5">
+<div class="flex items-center px-3 pt-7 pb-8 gap-2 h-17.5">
     <dot-content-drive-tree-toggler data-testid="tree-toggler" />
     <h3 class="text-base m-0 font-semibold" data-testid="current-site-hostname">
         {{ $currentSite()?.hostname }}

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-sidebar/dot-content-drive-sidebar.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-sidebar/dot-content-drive-sidebar.component.html
@@ -1,4 +1,4 @@
-<div class="flex items-center px-3 pt-7 pb-8 gap-2 h-17.5">
+<div class="flex items-center px-3 pt-7 pb-4 gap-2 h-17.5">
     <dot-content-drive-tree-toggler data-testid="tree-toggler" />
     <h3 class="text-base m-0 font-semibold" data-testid="current-site-hostname">
         {{ $currentSite()?.hostname }}

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-content-type-field/dot-content-drive-content-type-field.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-content-type-field/dot-content-drive-content-type-field.component.html
@@ -25,7 +25,7 @@
     </ng-template>
     <ng-template pTemplate="footer">
         @if (fechingItems()) {
-            <div class="flex items-center justify-start py-2 px-3 text-[var(--gray-500)] gap-4">
+            <div class="flex items-center justify-start py-2 px-3 text-(--gray-500) gap-4">
                 <i class="pi pi-spin pi-spinner"></i>
                 <span>{{ 'content.drive.contenttype.search.state.label' | dm }}</span>
             </div>

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-tree-toggler/dot-content-drive-tree-toggler.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-tree-toggler/dot-content-drive-tree-toggler.component.html
@@ -1,3 +1,3 @@
 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" data-testid="tree-toggle-icon">
-    <use href="/assets/dot-content-drive/tree-folder.svg#tree-folder"></use>
+    <use href="./assets/dot-content-drive/tree-folder.svg#tree-folder"></use>
 </svg>

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
@@ -1,13 +1,11 @@
-<p-toolbar class="gap-1 h-full px-3  justify-start border-none! ">
+<p-toolbar class="gap-1 h-full px-3 justify-start border-none!">
     <div
         class="grid w-full items-center transition-all duration-300 ease-in-out gap-y-1 py-3"
         [class.gap-x-1]="!$treeExpanded()"
         [class.gap-x-0]="$treeExpanded()"
         [class]="'grid-cols-[min-content_1fr] grid-rows-2'">
         @if (!$treeExpanded()) {
-            <dot-content-drive-tree-toggler
-                data-testid="tree-toggler"
-              />
+            <dot-content-drive-tree-toggler data-testid="tree-toggler" />
         }
 
         <div

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
@@ -1,4 +1,4 @@
-<p-toolbar class="gap-1 h-full px-3 justify-start">
+<p-toolbar class="gap-1 h-full px-3 justify-start border-none!">
     <div
         class="grid w-full items-center transition-all duration-300 ease-in-out gap-y-1"
         [class.gap-x-1]="!$treeExpanded()"

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
@@ -1,16 +1,14 @@
-<p-toolbar
-    class="bg-[--color-palette-gray-100] border-none border-b border-[--color-palette-gray-300] gap-1 h-full px-3 py-1 justify-start">
+<p-toolbar class="gap-1 h-full px-3 justify-start">
     <div
         class="grid w-full items-center transition-all duration-300 ease-in-out gap-y-1"
         [class.gap-x-1]="!$treeExpanded()"
         [class.gap-x-0]="$treeExpanded()"
         [class]="'grid-cols-[min-content_1fr] grid-rows-2'">
-        <dot-content-drive-tree-toggler
-            data-testid="tree-toggler"
-            class="flex transition-all duration-300 ease-in-out row-start-1 col-start-1"
-            [class.invisible]="$treeExpanded()"
-            [class.w-0]="$treeExpanded()"
-            [class.min-w-0]="$treeExpanded()" />
+        @if (!$treeExpanded()) {
+            <dot-content-drive-tree-toggler
+                data-testid="tree-toggler"
+                class="flex transition-all duration-300 ease-in-out row-start-1 col-start-1" />
+        }
 
         <div
             class="grid items-center w-full gap-1 row-start-1 col-start-2"

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
@@ -1,13 +1,13 @@
-<p-toolbar class="gap-1 h-full px-3 justify-start border-none!">
+<p-toolbar class="gap-1 h-full px-3  justify-start border-none! ">
     <div
-        class="grid w-full items-center transition-all duration-300 ease-in-out gap-y-1"
+        class="grid w-full items-center transition-all duration-300 ease-in-out gap-y-1 py-3"
         [class.gap-x-1]="!$treeExpanded()"
         [class.gap-x-0]="$treeExpanded()"
         [class]="'grid-cols-[min-content_1fr] grid-rows-2'">
         @if (!$treeExpanded()) {
             <dot-content-drive-tree-toggler
                 data-testid="tree-toggler"
-                class="flex transition-all duration-300 ease-in-out row-start-1 col-start-1" />
+              />
         }
 
         <div

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
@@ -114,12 +114,11 @@ describe('DotContentDriveToolbarComponent', () => {
             expect(toggler).toBeDefined();
         });
 
-        it('should add the invisible class to the tree toggler when tree is expanded', () => {
+        it('should not render the tree toggler when tree is expanded', () => {
             store.isTreeExpanded.mockReturnValue(true);
             spectator.detectChanges();
-            const toggler = spectator.debugElement.query(By.css('[data-testid="tree-toggler"]'));
-            expect(toggler).toBeDefined();
-            expect(toggler?.classes['invisible']).toBe(true);
+            const toggler = spectator.query('[data-testid="tree-toggler"]');
+            expect(toggler).toBeNull();
         });
     });
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
@@ -1,9 +1,8 @@
-import { it, describe, expect, beforeEach, afterEach } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import { Spectator, SpyObject, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
 import { provideHttpClient } from '@angular/common/http';
-import { By } from '@angular/platform-browser';
 
 import { DotContentTypeService, DotLanguagesService } from '@dotcms/data-access';
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.html
@@ -33,11 +33,11 @@
 <dot-content-drive-toolbar
     (addNewDotAsset)="onAddNewDotAsset()"
     data-testid="toolbar"
-    class="col-start-2 row-start-2" />
+    />
 
 <div
     class="flex flex-col justify-center items-center text-xl font-semibold overflow-hidden transition-all duration-300 ease-in-out border-r border-gray-300 col-start-1 row-start-2 row-span-2"
-    [class]="$treeExpanded() ? 'w-[16.5rem]' : 'w-0'"
+    [class]="$treeExpanded() ? 'w-66' : 'w-0'"
     data-testid="tree-selector">
     <dot-content-drive-sidebar
         data-testid="sidebar"

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.html
@@ -30,10 +30,7 @@
     }
 </div>
 
-<dot-content-drive-toolbar
-    (addNewDotAsset)="onAddNewDotAsset()"
-    data-testid="toolbar"
-    />
+<dot-content-drive-toolbar (addNewDotAsset)="onAddNewDotAsset()" data-testid="toolbar" />
 
 <div
     class="flex flex-col justify-center items-center text-xl font-semibold overflow-hidden transition-all duration-300 ease-in-out border-r border-gray-300 col-start-1 row-start-2 row-span-2"

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/sidebar/withSidebar.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/store/features/sidebar/withSidebar.spec.ts
@@ -274,10 +274,14 @@ describe('withSidebar', () => {
             });
 
             expect(loadedResult).not.toBeNull();
-            expect(loadedResult!.folders.length).toBeGreaterThan(0);
+            if (!loadedResult) {
+                throw new Error('Expected child folders to be loaded.');
+            }
+
+            expect(loadedResult.folders.length).toBeGreaterThan(0);
 
             // Update folders with new children
-            const updatedFolders = [...store.folders(), ...loadedResult!.folders];
+            const updatedFolders = [...store.folders(), ...loadedResult.folders];
             store.updateFolders(updatedFolders);
 
             // Verify the folders were updated

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/test-setup.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/test-setup.ts
@@ -26,3 +26,13 @@ console.error = function (...data) {
 // We need to setup the ResizeObserver mock globally for testing
 // PrimeNG Tabs use this and fails if not setup
 setupResizeObserverMock();
+
+// Mock MutationObserver for PrimeNG components
+global.MutationObserver = class MutationObserver {
+    constructor(callback: MutationCallback) {}
+    disconnect() {}
+    observe(target: Node, options?: MutationObserverInit) {}
+    takeRecords(): MutationRecord[] {
+        return [];
+    }
+};

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/test-setup.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/test-setup.ts
@@ -29,9 +29,15 @@ setupResizeObserverMock();
 
 // Mock MutationObserver for PrimeNG components
 global.MutationObserver = class MutationObserver {
-    constructor(callback: MutationCallback) {}
-    disconnect() {}
-    observe(target: Node, options?: MutationObserverInit) {}
+    constructor() {
+        //mock constructor
+    }
+    disconnect() {
+        //mock disconnect
+    }
+    observe() {
+        //mock observe
+    }
     takeRecords(): MutationRecord[] {
         return [];
     }

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -156,7 +156,7 @@
     <ng-template pTemplate="emptymessage">
         <tr class="hover:bg-transparent! h-max">
             <td colspan="7" class="p-6 text-center h-full border-none">
-                <div class="flex flex-col items-center gap-4 max-w-[400px] mx-auto">
+                <div class="flex flex-col items-center gap-4 max-w-100 mx-auto">
                     <div class="flex items-center justify-center w-20 h-20 rounded-full">
                         <i class="pi pi-folder-open text-(--surface-500) text-6xl!"></i>
                     </div>

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-tree-folder/dot-tree-folder.component.scss
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-tree-folder/dot-tree-folder.component.scss
@@ -11,8 +11,7 @@
                 display: none;
             }
 
-            /* PrimeNG v21 changed element from p-treenode to p-tree-node */
-            .p-tree-root-children > p-tree-node:first-of-type {
+            .p-tree-root-children > p-treenode:first-of-type {
                 .toggler-first {
                     display: block;
                 }


### PR DESCRIPTION
## Description
This PR addresses several UI inconsistencies and layout issues within the Content Drive portlet to ensure it aligns with the design specifications. The changes focus on the tree panel navigation, command bar alignment, and general visual polish.
## Changes
### 1. Tree Panel Improvements
- **Site Icon**: Fixed an issue where the site icon was missing in the left side tree panel.
- **"All" Folder Icon**: Updated the icon for the "All" folder from a generic folder to `folder-open` to provide better visual feedback for the root container.
### 2. Command Bar Adjustments
- **Alignment**: Corrected the command bar's horizontal alignment to ensure it is perfectly flushed with the item list checkboxes.
- **Vertical Padding**: Adjusted the vertical padding of the command bar to meet standard spacing guidelines, improving the overall balance of the header area.
### 3. Visual Polish
- **Double Line Removal**: Fixed a CSS/layout issue that caused a redundant double line separator to appear in the interface.
---

## Verification Plan
- [x] Manually verified icon visibility and correctness in the tree panel.
- [x] Verified alignment and padding of the command bar.
- [x] Confirmed the removal of the redundant line.
- [x] Ran existing unit tests to ensure no regressions in functionality.

DEMO:

https://github.com/user-attachments/assets/f56606fe-1ae4-4e6a-8c5a-5914945c2b9b


This PR fixes: #34141