### PR TITLE
feat(dot-edit-content-sidebar): Fix error related Custom Fiels and permissions

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.html
@@ -1,6 +1,7 @@
 @let contentlet = $store.contentlet();
 @let contentType = $store.contentType();
 @let activeIndex = $store.activeSidebarTab();
+@let isNew = $store.isNew();
 
 <!-- Information Component -->
 @let isLoadingInformation = $store.isLoadingInformation();
@@ -25,7 +26,7 @@
                 [title]="'edit.content.sidebar.general.title' | dm"
                 class="h-full">
                 <ng-template #sectionAction>
-                    @if (!$store.isNew() && !$store.isCopyingLocale()) {
+                    @if (!isNew && !$store.isCopyingLocale()) {
                         <dot-copy-button
                             [copy]="contentlet.identifier"
                             [label]="contentlet.shortyId"
@@ -103,17 +104,19 @@
             </ng-template>
         </p-tabPanel>
 
-        <p-tabPanel class="h-full flex-column tab-panel tab-panel--permissions">
-            <ng-template pTemplate="header">
-                <i class="pi pi-cog"></i>
-            </ng-template>
-            <ng-template pTemplate="content">
-                <dot-edit-content-sidebar-permissions
-                    [identifier]="$identifier() ?? ''"
-                    [languageId]="$contentlet()?.languageId ?? 0"
-                    data-testId="permissions" />
-            </ng-template>
-        </p-tabPanel>
+        @if (!isNew) {
+            <p-tabPanel class="h-full flex-column tab-panel tab-panel--permissions">
+                <ng-template pTemplate="header">
+                    <i class="pi pi-cog"></i>
+                </ng-template>
+                <ng-template pTemplate="content">
+                    <dot-edit-content-sidebar-permissions
+                        [identifier]="$identifier() ?? ''"
+                        [languageId]="$contentlet()?.languageId ?? 0"
+                        data-testId="permissions" />
+                </ng-template>
+            </p-tabPanel>
+        }
     </p-tabView>
 </aside>
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.html
@@ -2,6 +2,7 @@
 @let contentType = $store.contentType();
 @let activeIndex = $store.activeSidebarTab();
 @let isNew = $store.isNew();
+@let isCopyingLocale = $store.isCopyingLocale();
 
 <!-- Information Component -->
 @let isLoadingInformation = $store.isLoadingInformation();
@@ -26,7 +27,7 @@
                 [title]="'edit.content.sidebar.general.title' | dm"
                 class="h-full">
                 <ng-template #sectionAction>
-                    @if (!isNew && !$store.isCopyingLocale()) {
+                    @if (!isNew && !isCopyingLocale) {
                         <dot-copy-button
                             [copy]="contentlet.identifier"
                             [label]="contentlet.shortyId"

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.spec.ts
@@ -32,7 +32,7 @@ import {
     DotWorkflowService
 } from '@dotcms/data-access';
 import { DotContentletCanLock, DotContentletDepths } from '@dotcms/dotcms-models';
-import { MOCK_SINGLE_WORKFLOW_ACTIONS } from '@dotcms/utils-testing';
+import { createFakeContentlet, MOCK_SINGLE_WORKFLOW_ACTIONS } from '@dotcms/utils-testing';
 
 import { DotEditContentSidebarActivitiesComponent } from './components/dot-edit-content-sidebar-activities/dot-edit-content-sidebar-activities.component';
 import { DotEditContentSidebarHistoryComponent } from './components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component';
@@ -290,37 +290,12 @@ describe('DotEditContentSidebarComponent', () => {
                 const dotWorkflowService = spectator.inject(DotWorkflowService);
                 const dotEditContentService = spectator.inject(DotEditContentService);
 
-                const mockContentlet = {
+                const mockContentlet = createFakeContentlet({
                     inode: '123',
                     contentType: 'testContentType',
-                    archived: false,
-                    baseType: 'CONTENT',
-                    folder: 'SYSTEM_FOLDER',
-                    hasTitleImage: false,
-                    host: 'demo.dotcms.com',
-                    hostName: 'demo.dotcms.com',
                     identifier: '123-456',
-                    languageId: 1,
-                    live: true,
-                    locked: false,
-                    modDate: new Date().toISOString(),
-                    modUser: 'admin',
-                    modUserName: 'Admin User',
-                    owner: 'admin',
-                    permissionId: '123',
-                    permissionType: 'CONTENT',
-                    title: 'Test Content',
-                    working: true,
-                    URL_MAP_FOR_CONTENT: '/test',
-                    sortOrder: 0,
-                    stInode: '123-stInode',
-                    structure: {
-                        name: 'Test Structure',
-                        inode: '456'
-                    },
-                    titleImage: '',
-                    url: '/test-content'
-                };
+                    title: 'Test Content'
+                });
 
                 dotEditContentService.getContentById.mockReturnValue(of(mockContentlet));
                 dotContentTypeService.getContentTypeWithRender.mockReturnValue(
@@ -389,37 +364,12 @@ describe('DotEditContentSidebarComponent', () => {
                 const dotWorkflowService = spectator.inject(DotWorkflowService);
                 const dotEditContentService = spectator.inject(DotEditContentService);
 
-                const mockContentlet = {
+                const mockContentlet = createFakeContentlet({
                     inode: '456',
                     contentType: 'testContentType',
-                    archived: false,
-                    baseType: 'CONTENT',
-                    folder: 'SYSTEM_FOLDER',
-                    hasTitleImage: false,
-                    host: 'demo.dotcms.com',
-                    hostName: 'demo.dotcms.com',
                     identifier: '456-789',
-                    languageId: 1,
-                    live: true,
-                    locked: false,
-                    modDate: new Date().toISOString(),
-                    modUser: 'admin',
-                    modUserName: 'Admin User',
-                    owner: 'admin',
-                    permissionId: '456',
-                    permissionType: 'CONTENT',
-                    title: 'Existing Content',
-                    working: true,
-                    URL_MAP_FOR_CONTENT: '/existing',
-                    sortOrder: 0,
-                    stInode: '456-stInode',
-                    structure: {
-                        name: 'Test Structure',
-                        inode: '456'
-                    },
-                    titleImage: '',
-                    url: '/existing-content'
-                };
+                    title: 'Existing Content'
+                });
 
                 dotEditContentService.getContentById.mockReturnValue(of(mockContentlet));
                 dotContentTypeService.getContentTypeWithRender.mockReturnValue(
@@ -454,37 +404,12 @@ describe('DotEditContentSidebarComponent', () => {
                 const dotWorkflowService = spectator.inject(DotWorkflowService);
                 const dotEditContentService = spectator.inject(DotEditContentService);
 
-                const mockContentlet = {
+                const mockContentlet = createFakeContentlet({
                     inode: '789',
                     contentType: 'testContentType',
-                    archived: false,
-                    baseType: 'CONTENT',
-                    folder: 'SYSTEM_FOLDER',
-                    hasTitleImage: false,
-                    host: 'demo.dotcms.com',
-                    hostName: 'demo.dotcms.com',
                     identifier: '789-012',
-                    languageId: 1,
-                    live: true,
-                    locked: false,
-                    modDate: new Date().toISOString(),
-                    modUser: 'admin',
-                    modUserName: 'Admin User',
-                    owner: 'admin',
-                    permissionId: '789',
-                    permissionType: 'CONTENT',
-                    title: 'Reset Content',
-                    working: true,
-                    URL_MAP_FOR_CONTENT: '/reset',
-                    sortOrder: 0,
-                    stInode: '789-stInode',
-                    structure: {
-                        name: 'Test Structure',
-                        inode: '456'
-                    },
-                    titleImage: '',
-                    url: '/reset-content'
-                };
+                    title: 'Reset Content'
+                });
 
                 dotEditContentService.getContentById.mockReturnValue(of(mockContentlet));
                 dotContentTypeService.getContentTypeWithRender.mockReturnValue(
@@ -541,44 +466,17 @@ describe('DotEditContentSidebarComponent', () => {
 
     describe('Tabs Behavior', () => {
         beforeEach(fakeAsync(() => {
-            // Mock the services needed for initializeExistingContent
             const dotContentTypeService = spectator.inject(DotContentTypeService);
             const workflowActionsService = spectator.inject(DotWorkflowsActionsService);
             const dotWorkflowService = spectator.inject(DotWorkflowService);
             const dotEditContentService = spectator.inject(DotEditContentService);
 
-            // Mock contentlet response with all required DotCMSContentlet properties
-            const mockContentlet = {
+            const mockContentlet = createFakeContentlet({
                 inode: '123',
                 contentType: 'testContentType',
-                archived: false,
-                baseType: 'CONTENT',
-                folder: 'SYSTEM_FOLDER',
-                hasTitleImage: false,
-                host: 'demo.dotcms.com',
-                hostName: 'demo.dotcms.com',
                 identifier: '123-456',
-                languageId: 1,
-                live: true,
-                locked: false,
-                modDate: new Date().toISOString(),
-                modUser: 'admin',
-                modUserName: 'Admin User',
-                owner: 'admin',
-                permissionId: '123',
-                permissionType: 'CONTENT',
-                title: 'Test Content',
-                working: true,
-                URL_MAP_FOR_CONTENT: '/test',
-                sortOrder: 0,
-                stInode: '123-stInode',
-                structure: {
-                    name: 'Test Structure',
-                    inode: '456'
-                },
-                titleImage: '',
-                url: '/test-content'
-            };
+                title: 'Test Content'
+            });
 
             dotEditContentService.getContentById.mockReturnValue(of(mockContentlet));
             dotContentTypeService.getContentTypeWithRender.mockReturnValue(of(CONTENT_TYPE_MOCK));
@@ -591,8 +489,10 @@ describe('DotEditContentSidebarComponent', () => {
                 of({ locked: false, canLock: true } as DotContentletCanLock)
             );
 
-            // Initialize existing content
-            store.initializeExistingContent('123');
+            store.initializeExistingContent({
+                inode: '123',
+                depth: DotContentletDepths.TWO
+            });
             tick();
             spectator.detectChanges();
         }));

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/template_custom_field_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/template_custom_field_new.vtl
@@ -328,7 +328,10 @@
           return data.entity || null;
         }
       } catch (error) {
-        // Silently fail - template may have been deleted
+        console.warn("Failed to fetch template by ID, returning null. Template may have been deleted or an error occurred.", {
+          templateId,
+          error,
+        });
       }
       return null;
     }

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/template_custom_field_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/template_custom_field_new.vtl
@@ -318,6 +318,22 @@
     // UTILS END
   
     /**
+     * Fetches a single template by ID (used when selected template is not in first page)
+     */
+    async function fetchTemplateById(templateId) {
+      try {
+        const response = await fetch(`/api/v1/templates/${templateId}/working`);
+        if (response.ok) {
+          const data = await response.json();
+          return data.entity || null;
+        }
+      } catch (error) {
+        // Silently fail - template may have been deleted
+      }
+      return null;
+    }
+
+    /**
      * Fetches the template image from the server
      */
     async function fetchTemplateImage(templateId) {
@@ -409,22 +425,22 @@
     /**
      * Callback function to handle the template fetch
      */
-    const onTemplateFetchComplete = function (
+    const onTemplateFetchComplete = async function (
       templates,
       templateField,
       selectedTemplate,
     ) {
       const templateId = templateField.getValue() || "";
       const isTemplateValid = templateId && templateId !== ALL_SITES_IDENTIFIER;
-  
+
       if (!templates || templates.length === 0) {
         // If no templates, show "All Sites" as placeholder
         updateSelectButton(null);
         return;
       }
-  
+
       let template = selectedTemplate;
-  
+
       if (!template) {
         const { mapById, mapByName } = getTemplatesMaps(templates);
         const normalizedName = defaultTemplateName
@@ -434,13 +450,19 @@
           ? mapById[templateId]
           : mapByName[normalizedName]; // [cite: 18]
       }
-  
+
+      // When selected template is not in first page (e.g. user chose from page 2 and came back),
+      // fetch it by ID so the correct option is displayed
+      if (!template && isTemplateValid) {
+        template = await fetchTemplateById(templateId);
+      }
+
       if (!template) {
         // If no template found, show "All Sites" as placeholder
         updateSelectButton(null);
         return;
       }
-  
+
       const { identifier, fullTitle } = template;
       // We set the values directly into the components
       const currentTemplateIdElement = getElement("currentTemplateId");
@@ -940,7 +962,7 @@
             );
           }
   
-          onTemplateFetchComplete(
+          await onTemplateFetchComplete(
             result.templates,
             templateField,
             selectedTemplate,


### PR DESCRIPTION
This pull request introduces two main improvements: it enhances the logic and test coverage for the visibility of the Permissions tab in the content editing sidebar, and it improves template selection in the custom field UI by ensuring a selected template is always displayed, even if it's not in the first page of results. The changes include both UI logic updates and new/updated tests.

**Permissions Tab Visibility Improvements:**

* The Permissions tab in `dot-edit-content-sidebar.component.html` is now only rendered if the content is not new (`isNew` is false), preventing users from seeing permissions for unsaved content. This is handled using the `isNew` variable for cleaner template logic. [[1]](diffhunk://#diff-96315ade336a88f5f2f51d7a64dec588aa9fa44384539792c69e1a3346eaa5d0R4) [[2]](diffhunk://#diff-96315ade336a88f5f2f51d7a64dec588aa9fa44384539792c69e1a3346eaa5d0L28-R29) [[3]](diffhunk://#diff-96315ade336a88f5f2f51d7a64dec588aa9fa44384539792c69e1a3346eaa5d0R107) [[4]](diffhunk://#diff-96315ade336a88f5f2f51d7a64dec588aa9fa44384539792c69e1a3346eaa5d0R119)
* Comprehensive tests have been added to `dot-edit-content-sidebar.component.spec.ts` to verify that the Permissions tab and its contents are only visible for existing content, including edge cases for different initial contentlet states.

**Template Selection Improvements:**

* In `template_custom_field_new.vtl`, a new async function `fetchTemplateById` ensures that if a user selects a template not present in the initial fetch (e.g., from another page), the UI fetches and displays the correct template option. [[1]](diffhunk://#diff-0364d458c5c8250e0fc1046aa636f4fcb7e1b68901317844a0504626041a54d5R320-R335) [[2]](diffhunk://#diff-0364d458c5c8250e0fc1046aa636f4fcb7e1b68901317844a0504626041a54d5L412-R428) [[3]](diffhunk://#diff-0364d458c5c8250e0fc1046aa636f4fcb7e1b68901317844a0504626041a54d5R454-R459)
* The template fetch callback and its invocation are now asynchronous to support this logic, ensuring the UI remains consistent regardless of pagination. [[1]](diffhunk://#diff-0364d458c5c8250e0fc1046aa636f4fcb7e1b68901317844a0504626041a54d5L412-R428) [[2]](diffhunk://#diff-0364d458c5c8250e0fc1046aa636f4fcb7e1b68901317844a0504626041a54d5L943-R965)

This PR fixes: #34348

This PR fixes: #34348