### PR TITLE
fix: remove refresh button from Usage Dashboard (#34485)

### DIFF
--- a/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.html
+++ b/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.html
@@ -21,18 +21,6 @@
             </span>
         }
     </div>
-    <div class="p-toolbar-group-end">
-        <p-button
-            icon="pi pi-refresh"
-            [label]="'analytics.dashboard.refresh.button' | dm"
-            [loading]="loading()"
-            [disabled]="loading()"
-            (onClick)="onRefresh()"
-            [rounded]="false"
-            severity="primary"
-            size="small"
-            data-testid="refresh-button"></p-button>
-    </div>
 </p-toolbar>
 
 <div class="mx-auto" style="max-width: 50rem">

--- a/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.spec.ts
@@ -108,15 +108,6 @@ describe('DotUsageShellComponent', () => {
         expect(spectator.query('[data-testid="system-COUNT_LANGUAGES-card"]')).toBeTruthy();
     });
 
-    it('should handle refresh button click', () => {
-        jest.clearAllMocks();
-        const refreshButton = spectator.query('[data-testid="refresh-button"]');
-        expect(refreshButton).toBeTruthy();
-
-        spectator.click(refreshButton);
-        expect(usageService.getSummary).toHaveBeenCalled();
-    });
-
     it('should handle retry button click', () => {
         spectator.component.loading.set(false);
         spectator.component.error.set('Some error');

--- a/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.ts
+++ b/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.ts
@@ -85,10 +85,6 @@ export class DotUsageShellComponent implements OnInit, OnDestroy {
         });
     }
 
-    onRefresh(): void {
-        this.loadData();
-    }
-
     onRetry(): void {
         this.summary.set(null);
         this.error.set(null);


### PR DESCRIPTION
## Summary
Removes the refresh button from the Usage Dashboard to prevent user confusion about real-time data updates.

## Changes
- ✅ Removed refresh button from toolbar (`dot-usage-shell.component.html`)
- ✅ Removed `onRefresh()` method (`dot-usage-shell.component.ts`)
- ✅ Removed refresh button test (`dot-usage-shell.component.spec.ts`)
- ✅ Preserved "Last updated" timestamp for data freshness visibility
- ✅ Preserved error state retry button (different functionality)

## Why this change?
Usage statistics are not updated in real-time. The refresh button implied that clicking it would immediately update the data, which is misleading. Removing the button prevents this confusion while maintaining the "Last updated" timestamp to inform users about data age.

## Test Plan
- [x] Built frontend (core-web) successfully
- [x] Built backend with Maven successfully
- [x] Built Docker image with changes
- [x] Started dotCMS in Docker
- [x] Manually verified in browser:
  - Refresh button is NOT visible in toolbar
  - "Last updated" timestamp is still displayed
  - Dashboard loads and displays metrics correctly
  - No console errors

## Related Issues
Closes #34485

This PR fixes: #34485