### PR TITLE
Issue 34541 lock undefined

### DIFF
--- a/core-web/libs/dotcms-models/src/lib/dot-contentlet.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-contentlet.model.ts
@@ -24,7 +24,8 @@ export interface DotCMSContentlet {
     language?: string | DotLanguage;
     live: boolean;
     locked: boolean;
-    lockedBy?: DotContentletLockUser;
+    lockedBy?: string;
+    lockedByName?: string;
     mimeType?: string;
     modDate: string;
     modUser: string;

--- a/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.spec.ts
@@ -71,7 +71,8 @@ describe('LockFeature', () => {
         it('should determine if content is locked', () => {
             store.updateContent({
                 locked: true,
-                lockedBy: { userId: '123', firstName: 'John', lastName: 'Doe' }
+                lockedBy: '123',
+                lockedByName: 'John Doe'
             } as DotCMSContentlet);
 
             expect(store.isContentLocked()).toBe(true);
@@ -90,7 +91,8 @@ describe('LockFeature', () => {
             // Update with content locked by current user
             store.updateContent({
                 locked: true,
-                lockedBy: { userId: '123', firstName: 'John', lastName: 'Doe' }
+                lockedBy: '123',
+                lockedByName: 'John Doe'
             });
 
             store.updateCanLock(true);
@@ -105,7 +107,8 @@ describe('LockFeature', () => {
             // Update with content locked by another user
             store.updateContent({
                 locked: true,
-                lockedBy: { userId: '123', firstName: 'John', lastName: 'Doe' }
+                lockedBy: '123',
+                lockedByName: 'John Doe'
             });
 
             expect(store.lockWarningMessage()).toEqual(
@@ -122,7 +125,8 @@ describe('LockFeature', () => {
             // Update with content locked by another user
             store.updateContent({
                 locked: true,
-                lockedBy: { userId: '123', firstName: 'John', lastName: 'Doe' }
+                lockedBy: '123',
+                lockedByName: 'John Doe'
             });
 
             expect(store.lockWarningMessage()).toBe('Content is locked by John Doe');
@@ -146,7 +150,8 @@ describe('LockFeature', () => {
                 const lockedContentlet = {
                     ...mockContentlet,
                     locked: true,
-                    lockedBy: { userId: '123', firstName: 'John', lastName: 'Doe' }
+                    lockedBy: '123',
+                    lockedByName: 'John Doe'
                 };
 
                 dotContentletService.canLock.mockReturnValue(
@@ -195,13 +200,15 @@ describe('LockFeature', () => {
                 const mockContentlet = {
                     inode: '123',
                     locked: true,
-                    lockedBy: { userId: '123', firstName: 'John', lastName: 'Doe' }
+                    lockedBy: '123',
+                    lockedByName: 'John Doe'
                 } as DotCMSContentlet;
 
                 const unlockedContentlet = {
                     ...mockContentlet,
                     locked: false,
-                    lockedBy: null
+                    lockedBy: null,
+                    lockedByName: null
                 };
 
                 dotContentletService.canLock.mockReturnValue(

--- a/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
@@ -55,16 +55,16 @@ export function withLock() {
                     return null;
                 }
 
-                const { lockedBy } = contentlet;
+                const { lockedBy, lockedByName } = contentlet;
 
-                const isLockedByCurrentUser = currentUser?.userId === lockedBy?.userId;
+                const isLockedByCurrentUser = currentUser?.userId === lockedBy;
 
                 // content is not locked or locked by the current user
                 if (!lockedBy || isLockedByCurrentUser) {
                     return null;
                 }
 
-                const userDisplay = lockedBy.firstName + ' ' + lockedBy.lastName;
+                const userDisplay = lockedByName;
 
                 // If user doesn't have permission to lock, use the no permission message
                 if (!userCanLock) {

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -1367,11 +1367,8 @@ describe('Utils Functions', () => {
             // Arrange
             const contentlet = createFakeContentlet({
                 locked: true,
-                lockedBy: {
-                    firstName: 'John',
-                    lastName: 'Doe',
-                    userId: 'user123'
-                }
+                lockedBy: 'user123',
+                lockedByName: 'John Doe'
             });
 
             // Act

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentResource.java
@@ -644,7 +644,7 @@ public class ContentResource {
 
         final Contentlet contentletHydrated = new DotTransformerBuilder().contentResourceOptions(false)
                 .content(contentlet).build().hydrate().get(0);
-        return new ResponseEntityMapView(WorkflowHelper.getInstance().contentletToMap(contentlet));
+        return new ResponseEntityMapView(WorkflowHelper.getInstance().contentletToMap(contentletHydrated));
     }
 
     /**
@@ -702,7 +702,7 @@ public class ContentResource {
 
         final Contentlet contentletHydrated = new DotTransformerBuilder().contentResourceOptions(false)
                 .content(contentlet).build().hydrate().get(0);
-        return new ResponseEntityMapView(WorkflowHelper.getInstance().contentletToMap(contentlet));
+        return new ResponseEntityMapView(WorkflowHelper.getInstance().contentletToMap(contentletHydrated));
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR fixes issue #34541 by resolving inconsistencies in the content lock system where `lockedBy` data was undefined or incorrectly structured.

## Changes Made

### Frontend (TypeScript/Angular)
- **Updated `DotCMSContentlet` model** (`dot-contentlet.model.ts:27-28`): Changed `lockedBy` from complex `DotContentletLockUser` object to simple `string` and added separate `lockedByName` field
- **Improved lock display logic** (`lock.feature.ts:58-67`): Simplified user comparison logic and user display using the new `lockedByName` field directly
- **Updated all related tests** to use the new `lockedBy` structure with separate `lockedBy` (string) and `lockedByName` (string) fields

### Backend (Java)
- **Fixed ContentResource responses** (`ContentResource.java:647,705`): Ensured lock/unlock endpoints return hydrated contentlets instead of raw ones, preventing undefined `lockedBy` data in API responses

## Technical Details

The issue was caused by inconsistent data structures for the `lockedBy` field:
- Frontend expected `lockedBy` as a user object with `{userId, firstName, lastName}`
- Backend was sometimes returning raw contentlets without proper hydration
- This led to `undefined` values when accessing lock user information

**Root Cause**: Backend lock/unlock endpoints were returning non-hydrated contentlets, causing incomplete user data in the `lockedBy` field.

**Solution**: 
1. Simplified the data model to use separate string fields (`lockedBy` for user ID, `lockedByName` for display name)
2. Fixed backend to always return hydrated contentlets with complete user information
3. Updated all affected tests to match the new structure

## Testing

- Updated lock feature tests to verify correct lock status detection and user display
- Updated utility function tests to handle the new `lockedBy` structure
- All tests now properly mock the simplified lock data structure

This PR fixes: #34541
