### PR TITLE
fix (Redis) : don't expire redis sessions from tomcat

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1531,7 +1531,7 @@
             <dependency>
                 <groupId>com.dotcms</groupId>
                 <artifactId>tomcat-redis-session-manager</artifactId>
-                <version>1.4</version>
+                <version>1.5</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
Closes #34491

### Proposed Changes
* Updating the Tomcat Redis Session Manager version in POM file to the latest

This PR fixes: #34491