### PR TITLE
fix: update Publish Starter workflow to use supported macOS runner

### DIFF
--- a/.github/workflows/cicd_manual_publish-starter.yml
+++ b/.github/workflows/cicd_manual_publish-starter.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   get-starter:
-    runs-on: macos-latest
+    runs-on: macos-${{ vars.MACOS_RUNNER_VERSION || 'latest' }}
     if: github.repository == 'dotcms/core'
     environment: starter
     steps:

--- a/.github/workflows/cicd_manual_publish-starter.yml
+++ b/.github/workflows/cicd_manual_publish-starter.yml
@@ -40,7 +40,7 @@ env:
 
 jobs:
   get-starter:
-    runs-on: macos-13
+    runs-on: macos-latest
     if: github.repository == 'dotcms/core'
     environment: starter
     steps:


### PR DESCRIPTION
## Summary
Updates the **Publish Starter** GitHub Actions workflow to use a supported macOS runner, fixing immediate workflow cancellation on manual trigger.

## Changes
- **Updated runner**: `macos-13` → `macos-latest`
- **File**: `.github/workflows/cicd_manual_publish-starter.yml`

## Why `macos-latest`
- Always uses the most recent supported macOS version
- GitHub maintains compatibility automatically  
- No manual updates needed for future macOS versions
- Currently maps to `macos-14` (Apple Silicon)

## Testing
- [x] Workflow file syntax validated
- [ ] Manual workflow trigger test pending
- [ ] Artifact generation verification pending

## Fixes
Closes #34577

---

### Validation Steps
1. Navigate to Actions → [Publish Starter workflow](https://github.com/dotCMS/core/actions/workflows/cicd_manual_publish-starter.yml)
2. Trigger workflow manually using `workflow_dispatch`
3. Verify `get-starter` job executes successfully
4. Confirm artifacts are generated and uploaded
5. Verify downstream jobs (`deploy-artifacts`, `send-notification`) run normally

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

This PR fixes: #34577