### PR TITLE
task(content analytics) #34395 : Adding missing column. Adding cluster + client ID exclusion in SQL query.

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/EngagementDaily.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/EngagementDaily.js
@@ -1,6 +1,6 @@
 /**
  * =====================================================================================
- * 1) EngagementDaily Cube
+ * EngagementDaily Cube
  * =====================================================================================
  *
  * Source table:
@@ -33,6 +33,7 @@
 cube(`EngagementDaily`, {
     sql: `
     SELECT
+      cluster_id,
       customer_id,
       context_site_id,
       day,
@@ -45,6 +46,10 @@ cube(`EngagementDaily`, {
       total_duration_engaged,
       updated_at
     FROM clickhouse_test_db.engagement_daily
+    WHERE ${FILTER_PARAMS.EngagementDaily.customerId.filter('customer_id')} AND (
+        ${FILTER_PARAMS.EngagementDaily.clusterId ? FILTER_PARAMS.EngagementDaily.clusterId.filter('cluster_id') : '1=1'}
+            OR (${FILTER_PARAMS.EngagementDaily.clusterId ? 'FALSE' : '(cluster_id IS NULL OR cluster_id = \'\')'})) AND
+        ${FILTER_PARAMS.EngagementDaily.day.filter('day')}
   `,
 
     measures: {

--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/SessionsByBrowserDaily.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/SessionsByBrowserDaily.js
@@ -1,6 +1,6 @@
 /**
  * =====================================================================================
- * 3) SessionsByBrowserDaily Cube
+ * SessionsByBrowserDaily Cube
  * =====================================================================================
  *
  * Source table:
@@ -17,6 +17,7 @@
 cube(`SessionsByBrowserDaily`, {
     sql: `
         SELECT
+            cluster_id,
             customer_id,
             context_site_id,
             day,
@@ -26,6 +27,10 @@ cube(`SessionsByBrowserDaily`, {
             total_duration_engaged_seconds,
             updated_at
         FROM clickhouse_test_db.sessions_by_browser_daily
+        WHERE ${FILTER_PARAMS.EngagementDaily.customerId.filter('customer_id')} AND (
+            ${FILTER_PARAMS.EngagementDaily.clusterId ? FILTER_PARAMS.EngagementDaily.clusterId.filter('cluster_id') : '1=1'}
+                OR (${FILTER_PARAMS.EngagementDaily.clusterId ? 'FALSE' : '(cluster_id IS NULL OR cluster_id = \'\')'})) AND
+            ${FILTER_PARAMS.EngagementDaily.day.filter('day')}
     `,
 
     measures: {

--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/SessionsByDeviceDaily.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/SessionsByDeviceDaily.js
@@ -1,6 +1,6 @@
 /**
  * =====================================================================================
- * 2) SessionsByDeviceDaily Cube
+ * SessionsByDeviceDaily Cube
  * =====================================================================================
  *
  * Source table:
@@ -19,6 +19,7 @@
 cube(`SessionsByDeviceDaily`, {
     sql: `
         SELECT
+            cluster_id,
             customer_id,
             context_site_id,
             day,
@@ -28,6 +29,10 @@ cube(`SessionsByDeviceDaily`, {
             total_duration_engaged_seconds,
             updated_at
         FROM clickhouse_test_db.sessions_by_device_daily
+        WHERE ${FILTER_PARAMS.EngagementDaily.customerId.filter('customer_id')} AND (
+            ${FILTER_PARAMS.EngagementDaily.clusterId ? FILTER_PARAMS.EngagementDaily.clusterId.filter('cluster_id') : '1=1'}
+                OR (${FILTER_PARAMS.EngagementDaily.clusterId ? 'FALSE' : '(cluster_id IS NULL OR cluster_id = \'\')'})) AND
+            ${FILTER_PARAMS.EngagementDaily.day.filter('day')}
     `,
 
     measures: {

--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/SessionsByLanguageDaily.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/SessionsByLanguageDaily.js
@@ -1,6 +1,6 @@
 /**
  * =====================================================================================
- * 4) SessionsByLanguageDaily Cube
+ * SessionsByLanguageDaily Cube
  * =====================================================================================
  *
  * Source table:
@@ -21,6 +21,7 @@
  cube(`SessionsByLanguageDaily`, {
     sql: `
         SELECT
+            cluster_id,
             customer_id,
             context_site_id,
             day,
@@ -30,6 +31,10 @@
             total_duration_engaged_seconds,
             updated_at
         FROM clickhouse_test_db.sessions_by_language_daily
+        WHERE ${FILTER_PARAMS.EngagementDaily.customerId.filter('customer_id')} AND (
+            ${FILTER_PARAMS.EngagementDaily.clusterId ? FILTER_PARAMS.EngagementDaily.clusterId.filter('cluster_id') : '1=1'}
+                OR (${FILTER_PARAMS.EngagementDaily.clusterId ? 'FALSE' : '(cluster_id IS NULL OR cluster_id = \'\')'})) AND
+            ${FILTER_PARAMS.EngagementDaily.day.filter('day')}
     `,
 
     measures: {


### PR DESCRIPTION
### Proposed Changes
* Add missing `cluster_id` column, which was causing an error in CubeJS queries when referencing that dimension.
* Add missing customer and cluster ID filtering in order to narrow down required ClickHouse data even more in all Engagement-related Cubes.

This PR fixes: #34395

This PR fixes: #34395