### PR TITLE
feat(ci): [TASK] Add Java override parameters to core CICD a (#34586)

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-cli-npm/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-cli-npm/action.yml
@@ -27,10 +27,6 @@ inputs:
     default: ${{ github.run_id }}
     description: 'The run id of the cli artifacts'
     required: false
-  java-suffix:
-    description: 'Suffix for Java version isolation (e.g., -java25). Appended to NPM version after rc.'
-    required: false
-    default: ''
 outputs:
   npm-package-version:
     description: 'NPM package version'
@@ -144,12 +140,6 @@ runs:
           NPM_PACKAGE_VERSION_TAG="latest"
           NPM_PACKAGE_VERSION=${MVN_PACKAGE_VERSION}
         fi;
-
-        # Append java-suffix if provided (e.g., 1.0.0-rc1 becomes 1.0.0-rc1-java25)
-        if [ -n "${{ inputs.java-suffix }}" ]; then
-          NPM_PACKAGE_VERSION="${NPM_PACKAGE_VERSION}${{ inputs.java-suffix }}"
-          echo "::debug::NPM_PACKAGE_VERSION with java suffix: $NPM_PACKAGE_VERSION"
-        fi
 
         echo "::debug::NPM_PACKAGE_VERSION: $NPM_PACKAGE_VERSION"
         echo "::debug::NPM_PACKAGE_VERSION_TAG: $NPM_PACKAGE_VERSION_TAG"

--- a/.github/actions/core-cicd/deployment/deploy-cli-npm/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-cli-npm/action.yml
@@ -27,6 +27,10 @@ inputs:
     default: ${{ github.run_id }}
     description: 'The run id of the cli artifacts'
     required: false
+  java-suffix:
+    description: 'Suffix for Java version isolation (e.g., -java25). Appended to NPM version after rc.'
+    required: false
+    default: ''
 outputs:
   npm-package-version:
     description: 'NPM package version'
@@ -140,6 +144,13 @@ runs:
           NPM_PACKAGE_VERSION_TAG="latest"
           NPM_PACKAGE_VERSION=${MVN_PACKAGE_VERSION}
         fi;
+
+        # Append java-suffix if provided (e.g., 1.0.0-rc1 becomes 1.0.0-rc1-java25)
+        if [ -n "${{ inputs.java-suffix }}" ]; then
+          NPM_PACKAGE_VERSION="${NPM_PACKAGE_VERSION}${{ inputs.java-suffix }}"
+          echo "::debug::NPM_PACKAGE_VERSION with java suffix: $NPM_PACKAGE_VERSION"
+        fi
+
         echo "::debug::NPM_PACKAGE_VERSION: $NPM_PACKAGE_VERSION"
         echo "::debug::NPM_PACKAGE_VERSION_TAG: $NPM_PACKAGE_VERSION_TAG"
 

--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -57,6 +57,14 @@ inputs:
     description: 'Build arguments to pass to the Docker build'
     required: false
     default: ''
+  artifact_suffix:
+    description: 'Suffix for artifact names (e.g., -java25). Used to download the correct docker-build-context artifact.'
+    required: false
+    default: ''
+  pull:
+    description: 'Pull image before building'
+    required: false
+    default: 'false'
 outputs:
   tags:
     description: "The tags that were used to build the image"
@@ -68,7 +76,7 @@ runs:
       uses: actions/download-artifact@v4
       if: inputs.build_run_id # Only download the artifact if a build run id is provided
       with:
-        name: docker-build-context
+        name: docker-build-context${{ inputs.artifact_suffix }}
         path: ${{ github.workspace }}
         run-id: ${{ inputs.build_run_id }}
         github-token: ${{ inputs.github_token }}

--- a/.github/actions/core-cicd/deployment/deploy-jfrog/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-jfrog/action.yml
@@ -34,6 +34,10 @@ inputs:
   artifact-run-id:
     default: ${{ github.run_id }}
     description: 'The run id of the core artifacts'
+  java-suffix:
+    description: 'Suffix for Java version isolation (e.g., -java25). Appended to artifact version.'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -51,6 +55,7 @@ runs:
         stage-name: "Deploy Artifacts Validate"
         maven-args: "validate" # We don't need to build just get the repo and use validate to check everything exists
         artifacts-from: ${{ inputs.artifact-run-id }}
+        artifact-suffix: ${{ inputs.java-suffix }}
 
     - uses: jfrog/setup-jfrog-cli@v4
 
@@ -122,7 +127,13 @@ runs:
       run: |
         echo "::group::Extract project version"
         version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-        echo "::notice::version: $version"
+        # Append java-suffix if provided (e.g., 1.0.0-SNAPSHOT becomes 1.0.0-SNAPSHOT-java25)
+        if [ -n "${{ inputs.java-suffix }}" ]; then
+          version="${version}${{ inputs.java-suffix }}"
+          echo "::notice::version with java suffix: $version"
+        else
+          echo "::notice::version: $version"
+        fi
         echo "version=$version" >> $GITHUB_OUTPUT
         echo "::endgroup::"
       shell: bash

--- a/.github/actions/core-cicd/deployment/deploy-jfrog/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-jfrog/action.yml
@@ -34,10 +34,6 @@ inputs:
   artifact-run-id:
     default: ${{ github.run_id }}
     description: 'The run id of the core artifacts'
-  java-suffix:
-    description: 'Suffix for Java version isolation (e.g., -java25). Appended to artifact version.'
-    required: false
-    default: ''
 
 runs:
   using: "composite"
@@ -55,7 +51,6 @@ runs:
         stage-name: "Deploy Artifacts Validate"
         maven-args: "validate" # We don't need to build just get the repo and use validate to check everything exists
         artifacts-from: ${{ inputs.artifact-run-id }}
-        artifact-suffix: ${{ inputs.java-suffix }}
 
     - uses: jfrog/setup-jfrog-cli@v4
 
@@ -127,13 +122,7 @@ runs:
       run: |
         echo "::group::Extract project version"
         version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-        # Append java-suffix if provided (e.g., 1.0.0-SNAPSHOT becomes 1.0.0-SNAPSHOT-java25)
-        if [ -n "${{ inputs.java-suffix }}" ]; then
-          version="${version}${{ inputs.java-suffix }}"
-          echo "::notice::version with java suffix: $version"
-        else
-          echo "::notice::version: $version"
-        fi
+        echo "::notice::version: $version"
         echo "version=$version" >> $GITHUB_OUTPUT
         echo "::endgroup::"
       shell: bash

--- a/.github/actions/core-cicd/maven-job/action.yml
+++ b/.github/actions/core-cicd/maven-job/action.yml
@@ -93,6 +93,12 @@ inputs:
     description: 'Require GraalVM to be installed'
     required: true
     default: 'false'
+  maven-compiler-release:
+    description: 'Override Maven compiler release version (e.g., 21). Preferred over source/target.'
+    required: false
+  artifact-suffix:
+    description: 'Suffix for artifact names (e.g., -java25). Computed from java-version if not provided.'
+    required: false
 runs:
   using: 'composite'
   steps:
@@ -104,6 +110,23 @@ runs:
         java-version: ${{ inputs.java-version }}
         require-graalvm: ${{ inputs.native || inputs.require-graalvm }}
         graalvm-version: ${{ inputs.graalvm-version }}
+
+    - name: Compute Artifact Suffix
+      id: artifact-suffix
+      shell: bash
+      run: |
+        # Use provided artifact-suffix if set, otherwise compute from java-version
+        if [ -n "${{ inputs.artifact-suffix }}" ]; then
+          ARTIFACT_SUFFIX="${{ inputs.artifact-suffix }}"
+        elif [ -n "${{ inputs.java-version }}" ]; then
+          JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
+          ARTIFACT_SUFFIX="-java${JAVA_MAJOR}"
+        else
+          ARTIFACT_SUFFIX=""
+        fi
+        echo "suffix=${ARTIFACT_SUFFIX}" >> $GITHUB_OUTPUT
+        echo "Artifact suffix: '${ARTIFACT_SUFFIX}'"
+
     - id: setup-license
       if: ${{ inputs.dotcms-license != '' }}
       name: Setup License
@@ -171,7 +194,7 @@ runs:
       with:
         run-id: ${{ inputs.artifacts-from }}
         github-token: ${{ inputs.github-token }}
-        name: maven-repo
+        name: maven-repo${{ steps.artifact-suffix.outputs.suffix }}
         path: ~/.m2/repository
 
     - id: restore-artifact-docker-image
@@ -179,7 +202,7 @@ runs:
       if: ${{ inputs.needs-docker-image == 'true' }}
       uses: actions/download-artifact@v4
       with:
-        name: docker-image
+        name: docker-image${{ steps.artifact-suffix.outputs.suffix }}
         path: /tmp/docker-image
 
     - name: Load Docker image from tar file
@@ -194,7 +217,7 @@ runs:
       with:
         run-id: ${{ inputs.artifacts-from }}
         github-token: ${{ inputs.github-token }}
-        name: "build-classes"
+        name: build-classes${{ steps.artifact-suffix.outputs.suffix }}
 
     - id: run-maven-build
       name: Run Maven Build
@@ -209,7 +232,22 @@ runs:
         if [[ "${{ inputs.native }}" == "true" ]]; then
           DEFAULT_ARGS="$DEFAULT_ARGS -Pnative"
         fi
-        FINAL_ARGS=$(echo "$DEFAULT_ARGS $MAVEN_ARGS" | tr ' ' '\n' | awk '!seen[$0]++' | tr '\n' ' ')
+
+        # Add Maven compiler release override flag
+        # Priority: explicit maven-compiler-release > default from java-version major > project defaults
+        COMPILER_ARGS=""
+        if [[ -n "${{ inputs.maven-compiler-release }}" ]]; then
+          # Explicit release override takes precedence
+          COMPILER_ARGS="-Dmaven.compiler.release=${{ inputs.maven-compiler-release }}"
+          echo "Using explicit maven.compiler.release=${{ inputs.maven-compiler-release }}"
+        elif [[ -n "${{ inputs.java-version }}" ]]; then
+          # Default compiler release to match the overridden Java version
+          JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
+          COMPILER_ARGS="-Dmaven.compiler.release=${JAVA_MAJOR}"
+          echo "Defaulting maven.compiler.release=${JAVA_MAJOR} to match java-version"
+        fi
+
+        FINAL_ARGS=$(echo "$DEFAULT_ARGS $COMPILER_ARGS $MAVEN_ARGS" | tr ' ' '\n' | awk '!seen[$0]++' | tr '\n' ' ')
 
         if [[ "${{ runner.os }}" == "Windows" && "${{ inputs.native }}" == "true" ]]; then
           echo "Building Maven with args $FINAL_ARGS"
@@ -227,7 +265,7 @@ runs:
       if: ${{ inputs.generate-artifacts == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        name: maven-repo
+        name: maven-repo${{ steps.artifact-suffix.outputs.suffix }}
         path: ~/.m2/repository
 
     - id: persist-docker-build-context
@@ -235,7 +273,7 @@ runs:
       if: ${{ inputs.generate-docker == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        name: docker-build-context
+        name: docker-build-context${{ steps.artifact-suffix.outputs.suffix }}
         path: dotCMS/target/docker-build.tar
 
     - id: get-sdkman-version
@@ -243,14 +281,18 @@ runs:
       if: ${{ inputs.generate-docker == 'true' }}
       shell: bash
       run: |
-        if [ -f ".sdkmanrc" ]; then
+        # Use provided java-version if set, otherwise read from .sdkmanrc
+        if [ -n "${{ inputs.java-version }}" ]; then
+          SDKMAN_JAVA_VERSION="${{ inputs.java-version }}"
+          echo "Using override Java version: ${SDKMAN_JAVA_VERSION}"
+        elif [ -f ".sdkmanrc" ]; then
           SDKMAN_JAVA_VERSION=$(awk -F= '/^java=/ {print $2}' .sdkmanrc)
-          echo "SDKMAN_JAVA_VERSION=${SDKMAN_JAVA_VERSION}" >> $GITHUB_ENV
-          echo "Extracted SDKMAN_JAVA_VERSION: ${SDKMAN_JAVA_VERSION}"
+          echo "Using default Java version from .sdkmanrc: ${SDKMAN_JAVA_VERSION}"
         else
-          echo "Error: .sdkmanrc file not found"
+          echo "Error: .sdkmanrc file not found and no java-version override provided"
           exit 1
         fi
+        echo "SDKMAN_JAVA_VERSION=${SDKMAN_JAVA_VERSION}" >> $GITHUB_ENV
 
     - id: build-docker-image-from-archive
       name: Build Docker Image from Archive
@@ -278,7 +320,7 @@ runs:
       uses: actions/upload-artifact@v4
       if: ${{ inputs.generate-docker == 'true' }}
       with:
-        name: docker-image
+        name: docker-image${{ steps.artifact-suffix.outputs.suffix }}
         path: /tmp/image.tar
 
     - id: persist-build-classes
@@ -286,7 +328,7 @@ runs:
       if: ${{ inputs.generate-artifacts == 'true' }}
       uses: actions/upload-artifact@v4
       with:
-        name: "build-classes"
+        name: build-classes${{ steps.artifact-suffix.outputs.suffix }}
         path: |
           **/target/classes/**/*.class
           **/target/generated-sources/**/*.java

--- a/.github/actions/core-cicd/maven-job/action.yml
+++ b/.github/actions/core-cicd/maven-job/action.yml
@@ -233,18 +233,19 @@ runs:
           DEFAULT_ARGS="$DEFAULT_ARGS -Pnative"
         fi
 
-        # Add Maven compiler release override flag
+        # Add Maven compiler release override flag for core modules
         # Priority: explicit maven-compiler-release > default from java-version major > project defaults
+        # Note: Core modules use dotcms.core.compiler.release (default 11), CLI uses dotcms.cli.compiler.release (default 11) for Quarkus/GraalVM compatibility
         COMPILER_ARGS=""
         if [[ -n "${{ inputs.maven-compiler-release }}" ]]; then
           # Explicit release override takes precedence
-          COMPILER_ARGS="-Dmaven.compiler.release=${{ inputs.maven-compiler-release }}"
-          echo "Using explicit maven.compiler.release=${{ inputs.maven-compiler-release }}"
+          COMPILER_ARGS="-Ddotcms.core.compiler.release=${{ inputs.maven-compiler-release }}"
+          echo "Using explicit dotcms.core.compiler.release=${{ inputs.maven-compiler-release }}"
         elif [[ -n "${{ inputs.java-version }}" ]]; then
           # Default compiler release to match the overridden Java version
           JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
-          COMPILER_ARGS="-Dmaven.compiler.release=${JAVA_MAJOR}"
-          echo "Defaulting maven.compiler.release=${JAVA_MAJOR} to match java-version"
+          COMPILER_ARGS="-Ddotcms.core.compiler.release=${JAVA_MAJOR}"
+          echo "Defaulting dotcms.core.compiler.release=${JAVA_MAJOR} to match java-version"
         fi
 
         FINAL_ARGS=$(echo "$DEFAULT_ARGS $COMPILER_ARGS $MAVEN_ARGS" | tr ' ' '\n' | awk '!seen[$0]++' | tr '\n' ' ')

--- a/.github/workflows/cicd_3-trunk.yml
+++ b/.github/workflows/cicd_3-trunk.yml
@@ -39,6 +39,21 @@ on:
         description: 'Disable Semgrep job'
         type: boolean
         default: false
+      java-version:
+        description: 'Override Java version (SDKMAN format, e.g., 25.0.1-open)'
+        type: string
+        required: false
+        default: ''
+      maven-compiler-release:
+        description: 'Override Maven compiler release version (e.g., 21). Preferred over source/target.'
+        type: string
+        required: false
+        default: ''
+      artifact-suffix:
+        description: 'Override artifact suffix (e.g., -java25, -java25.0.1, -java25-ms). If not set, derived from java-version major.'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   # Initialize the trunk check process
@@ -57,6 +72,10 @@ jobs:
     needs: [ initialize ]
     if: needs.initialize.outputs.found_artifacts == 'false'
     uses: ./.github/workflows/cicd_comp_build-phase.yml
+    with:
+      java-version: ${{ github.event.inputs.java-version || '' }}
+      maven-compiler-release: ${{ github.event.inputs.maven-compiler-release || '' }}
+      artifact-suffix: ${{ github.event.inputs.artifact-suffix || '' }}
     permissions:
       contents: read
       packages: write
@@ -71,6 +90,9 @@ jobs:
       run-all-tests: ${{ inputs.run-all-tests || false }}
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
       e2e: false
+      java-version: ${{ github.event.inputs.java-version || '' }}
+      maven-compiler-release: ${{ github.event.inputs.maven-compiler-release || '' }}
+      artifact-suffix: ${{ github.event.inputs.artifact-suffix || '' }}
     secrets:
       DOTCMS_LICENSE: ${{ secrets.DOTCMS_LICENSE }}
     permissions:
@@ -88,10 +110,11 @@ jobs:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 
   # CLI Build job - builds CLI artifacts
+  # Skipped when java-version is overridden due to GraalVM/Quarkus compatibility requirements
   build-cli:
     name: CLI Build
     needs: [ initialize,test ]
-    if: always() && !failure() && !cancelled()
+    if: always() && !failure() && !cancelled() && !inputs.java-version
     uses: ./.github/workflows/cicd_comp_cli-native-build-phase.yml
     with:
       buildNativeImage: true
@@ -107,6 +130,8 @@ jobs:
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
       publish-npm-sdk-libs: ${{ needs.initialize.outputs.sdk_libs != 'false' && github.event_name != 'workflow_dispatch' }}
       environment: trunk
+      java-version: ${{ github.event.inputs.java-version || '' }}
+      artifact-suffix: ${{ github.event.inputs.artifact-suffix || '' }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/cicd_4-nightly.yml
+++ b/.github/workflows/cicd_4-nightly.yml
@@ -34,6 +34,21 @@ on:
         description: 'Run all tests'
         type: boolean
         default: true
+      java-version:
+        description: 'Override Java version (SDKMAN format, e.g., 25.0.1-open)'
+        type: string
+        required: false
+        default: ''
+      maven-compiler-release:
+        description: 'Override Maven compiler release version (e.g., 21). Preferred over source/target.'
+        type: string
+        required: false
+        default: ''
+      artifact-suffix:
+        description: 'Override artifact suffix (e.g., -java25, -java25.0.1, -java25-ms). If not set, derived from java-version major.'
+        type: string
+        required: false
+        default: ''
 
 jobs:
   # Initialize the nightly build process
@@ -50,6 +65,10 @@ jobs:
     needs: [ initialize ]
     if: needs.initialize.outputs.found_artifacts == 'false'
     uses: ./.github/workflows/cicd_comp_build-phase.yml
+    with:
+      java-version: ${{ github.event.inputs.java-version || '' }}
+      maven-compiler-release: ${{ github.event.inputs.maven-compiler-release || '' }}
+      artifact-suffix: ${{ github.event.inputs.artifact-suffix || '' }}
     permissions:
       contents: read
       packages: write
@@ -64,6 +83,9 @@ jobs:
       run-all-tests: ${{ inputs.run-all-tests || true }}
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
       e2e: false
+      java-version: ${{ github.event.inputs.java-version || '' }}
+      maven-compiler-release: ${{ github.event.inputs.maven-compiler-release || '' }}
+      artifact-suffix: ${{ github.event.inputs.artifact-suffix || '' }}
     secrets:
       DOTCMS_LICENSE: ${{ secrets.DOTCMS_LICENSE }}
     permissions:
@@ -71,10 +93,11 @@ jobs:
       packages: write
 
   # CLI Build job - builds CLI artifacts
+  # Skipped when java-version is overridden due to GraalVM/Quarkus compatibility requirements
   build-cli:
     name: Nightly CLI Build
     needs: [ initialize, test ]
-    if: always() && !failure() && !cancelled()
+    if: always() && !failure() && !cancelled() && !inputs.java-version
     uses: ./.github/workflows/cicd_comp_cli-native-build-phase.yml
     with:
       buildNativeImage: true
@@ -92,6 +115,8 @@ jobs:
       deploy-dev-image: true
       publish-npm-cli: ${{ ( github.event_name == 'workflow_dispatch' && inputs.publish-npm-cli == true ) || github.event_name == 'schedule' }}
       reuse-previous-build: ${{ inputs.reuse-previous-build || false }}
+      java-version: ${{ github.event.inputs.java-version || '' }}
+      artifact-suffix: ${{ github.event.inputs.artifact-suffix || '' }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -53,6 +53,16 @@ on:
         type: boolean
         default: true
         required: false
+      java-version:
+        description: 'Override Java version (SDKMAN format, e.g., 25.0.1-open). Compiler release auto-defaults to Java major version.'
+        type: string
+        required: false
+        default: ''
+      artifact-suffix:
+        description: 'Override artifact suffix (e.g., -java25, -java25.0.1, -java25-ms). If not set, derived from java-version major.'
+        type: string
+        required: false
+        default: ''
 
 # No concurrency control - releases should complete without interruption
 concurrency:
@@ -92,6 +102,8 @@ jobs:
       validate: false
       version: ${{ needs.release-prepare.outputs.release_version }}
       generate-docker: true
+      java-version: ${{ github.event.inputs.java-version }}
+      artifact-suffix: ${{ github.event.inputs.artifact-suffix }}
     permissions:
       contents: read
       packages: write
@@ -110,6 +122,8 @@ jobs:
       reuse-previous-build: false
       publish-npm-cli: false
       publish-npm-sdk-libs: false
+      java-version: ${{ github.event.inputs.java-version }}
+      artifact-suffix: ${{ github.event.inputs.artifact-suffix }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
@@ -133,6 +147,8 @@ jobs:
       upload_javadocs: ${{ github.event.inputs.upload_javadocs == 'true' }}
       update_plugins: ${{ github.event.inputs.update_plugins == 'true' }}
       update_github_labels: ${{ github.event.inputs.update_github_labels == 'true' }}
+      java-version: ${{ github.event.inputs.java-version }}
+      artifact-suffix: ${{ github.event.inputs.artifact-suffix }}
     secrets:
       EE_REPO_USERNAME: ${{ secrets.EE_REPO_USERNAME }}
       EE_REPO_PASSWORD: ${{ secrets.EE_REPO_PASSWORD }}

--- a/.github/workflows/cicd_comp_build-phase.yml
+++ b/.github/workflows/cicd_comp_build-phase.yml
@@ -43,6 +43,21 @@ on:
         required: false
         type: boolean
         default: true
+      java-version:
+        description: 'Override Java version (SDKMAN format, e.g., 25.0.1-open)'
+        required: false
+        type: string
+        default: ''
+      maven-compiler-release:
+        description: 'Override Maven compiler release version (e.g., 21). Preferred over source/target.'
+        required: false
+        type: string
+        default: ''
+      artifact-suffix:
+        description: 'Override artifact suffix (e.g., -java25, -java25.0.1-ms). If not set, derived from java-version major.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   # Initial JDK Build
@@ -101,6 +116,9 @@ jobs:
           cleanup-runner: true
           version: ${{ inputs.version }}
           generate-docker: ${{ inputs.generate-docker }}
+          java-version: ${{ inputs.java-version }}
+          maven-compiler-release: ${{ inputs.maven-compiler-release }}
+          artifact-suffix: ${{ inputs.artifact-suffix }}
 
       # Check for unauthorized changes to the working directory (only for PR checks)
       - name: Check for changes to source during build

--- a/.github/workflows/cicd_comp_cli-native-build-phase.yml
+++ b/.github/workflows/cicd_comp_cli-native-build-phase.yml
@@ -35,6 +35,9 @@ on:
         required: false
         type: string
         default: '1.0.0-SNAPSHOT'
+      # Note: Java override inputs are intentionally not supported for CLI native builds
+      # due to GraalVM/Quarkus compatibility requirements. The calling workflows skip
+      # CLI builds when java-version is overridden.
     outputs:
       artifact-id:
         description: 'The ID of the uploaded artifact'
@@ -89,6 +92,7 @@ jobs:
           ref: ${{ env.BRANCH }}
 
       # Use custom Maven job action to build the native image
+      # Note: Java override not supported for CLI - uses default from .sdkmanrc
       - uses: ./.github/actions/core-cicd/maven-job
         with:
           cleanup-runner: true

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -38,6 +38,16 @@ on:
       publish-npm-sdk-libs:
         default: false
         type: boolean
+      java-version:
+        description: 'Override Java version (SDKMAN format, e.g., 25.0.1-open)'
+        required: false
+        type: string
+        default: ''
+      artifact-suffix:
+        description: 'Override artifact suffix (e.g., -java25, -java25.0.1-ms). If not set, derived from java-version major.'
+        required: false
+        type: string
+        default: ''
     outputs:
       docker_tags:
         description: 'Docker image tags that were built'
@@ -87,14 +97,30 @@ jobs:
         id: get-sdkman-version
         shell: bash
         run: |
-          if [ -f .sdkmanrc ]; then
+          # Use provided java-version if set, otherwise read from .sdkmanrc
+          if [ -n "${{ inputs.java-version }}" ]; then
+            SDKMAN_JAVA_VERSION="${{ inputs.java-version }}"
+            echo "Using override Java version: ${SDKMAN_JAVA_VERSION}"
+            # Compute Java suffix for artifact isolation
+            # Priority: explicit artifact-suffix > derived from java-version major
+            if [ -n "${{ inputs.artifact-suffix }}" ]; then
+              JAVA_SUFFIX="${{ inputs.artifact-suffix }}"
+              echo "Using explicit artifact suffix: ${JAVA_SUFFIX}"
+            else
+              JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
+              JAVA_SUFFIX="-java${JAVA_MAJOR}"
+              echo "Using derived artifact suffix: ${JAVA_SUFFIX}"
+            fi
+          elif [ -f .sdkmanrc ]; then
             SDKMAN_JAVA_VERSION=$(awk -F "=" '/^java=/ {print $2}' .sdkmanrc)
-            echo "using default Java version from .sdkmanrc: ${SDKMAN_JAVA_VERSION}"
-            echo "SDKMAN_JAVA_VERSION=${SDKMAN_JAVA_VERSION}" >> $GITHUB_OUTPUT
+            echo "Using default Java version from .sdkmanrc: ${SDKMAN_JAVA_VERSION}"
+            JAVA_SUFFIX=""
           else
             echo "No .sdkmanrc file found"
             exit 1
           fi
+          echo "SDKMAN_JAVA_VERSION=${SDKMAN_JAVA_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "java_suffix=${JAVA_SUFFIX}" >> "$GITHUB_OUTPUT"
 
       # Clean up the runner to ensure a fresh environment
       - uses: ./.github/actions/core-cicd/cleanup-runner
@@ -110,15 +136,16 @@ jobs:
           commit_id: ${{ github.sha }}
           ref: ${{ inputs.environment }}
           docker-use-ref: false
-          version: ${{ inputs.environment }}
-          latest: ${{ inputs.latest }}
+          version: ${{ inputs.environment }}${{ steps.get-sdkman-version.outputs.java_suffix }}
+          latest: ${{ inputs.latest && steps.get-sdkman-version.outputs.java_suffix == '' }}
           do_deploy: ${{ vars.DOCKER_DEPLOY || 'true' }}
           docker_io_username: ${{ secrets.DOCKER_USERNAME }}
           docker_io_token: ${{ secrets.DOCKER_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pull: true
+          artifact_suffix: ${{ steps.get-sdkman-version.outputs.java_suffix }}
           build_args: |
-            DOTCMS_DOCKER_TAG=${{ inputs.environment }}
+            DOTCMS_DOCKER_TAG=${{ inputs.environment }}${{ steps.get-sdkman-version.outputs.java_suffix }}
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
 
       # Format tags for Slack notifications
@@ -148,21 +175,23 @@ jobs:
           commit_id: ${{ github.sha }}
           ref: ${{ inputs.environment }}
           docker-use-ref: false
-          version: ${{ inputs.environment }}
-          latest: true
+          version: ${{ inputs.environment }}${{ steps.get-sdkman-version.outputs.java_suffix }}
+          latest: ${{ steps.get-sdkman-version.outputs.java_suffix == '' }}
           do_deploy: ${{ vars.DOCKER_DEPLOY || 'true' }}
           docker_io_username: ${{ secrets.DOCKER_USERNAME }}
           docker_io_token: ${{ secrets.DOCKER_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_args: |
-            DOTCMS_DOCKER_TAG=${{ inputs.environment }}
+            DOTCMS_DOCKER_TAG=${{ inputs.environment }}${{ steps.get-sdkman-version.outputs.java_suffix }}
             DEV_REQUEST_TOKEN=${{ secrets.DEV_REQUEST_TOKEN }}
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
 
       # Deploy CLI artifacts to JFrog Artifactory
+      # Skipped when java-version is overridden (CLI not built due to GraalVM/Quarkus compatibility)
       - name: CLI Deploy
         continue-on-error: true
         id: cli_deploy
+        if: steps.get-sdkman-version.outputs.java_suffix == ''
         uses: ./.github/actions/core-cicd/deployment/deploy-jfrog
         with:
           artifactory-username: ${{ secrets.EE_REPO_USERNAME }}
@@ -170,9 +199,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # Publish CLI to NPM (if required)
+      # Skipped when java-version is overridden (CLI not built due to GraalVM/Quarkus compatibility)
       - name: CLI Publish
         id: cli_publish
-        if: inputs.publish-npm-cli
+        if: inputs.publish-npm-cli && steps.get-sdkman-version.outputs.java_suffix == ''
         uses: ./.github/actions/core-cicd/deployment/deploy-cli-npm
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cicd_comp_release-phase.yml
+++ b/.github/workflows/cicd_comp_release-phase.yml
@@ -50,6 +50,16 @@ on:
         description: 'Update GitHub labels'
         type: boolean
         default: true
+      java-version:
+        description: 'Override Java version (SDKMAN format, e.g., 25.0.1-open)'
+        required: false
+        type: string
+        default: ''
+      artifact-suffix:
+        description: 'Override artifact suffix (e.g., -java25, -java25.0.1-ms). If not set, derived from java-version major.'
+        required: false
+        type: string
+        default: ''
     secrets:
       EE_REPO_USERNAME:
         required: false
@@ -83,14 +93,36 @@ jobs:
 
       - uses: ./.github/actions/core-cicd/cleanup-runner
 
+      - name: Compute Java Suffix
+        id: java-suffix
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.java-version }}" ]; then
+            # Priority: explicit artifact-suffix > derived from java-version major
+            if [ -n "${{ inputs.artifact-suffix }}" ]; then
+              JAVA_SUFFIX="${{ inputs.artifact-suffix }}"
+              echo "Using explicit artifact suffix: ${JAVA_SUFFIX}"
+            else
+              JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
+              JAVA_SUFFIX="-java${JAVA_MAJOR}"
+              echo "Using derived artifact suffix: ${JAVA_SUFFIX}"
+            fi
+          else
+            JAVA_SUFFIX=""
+          fi
+          echo "suffix=${JAVA_SUFFIX}" >> "$GITHUB_OUTPUT"
+          echo "Java suffix: '${JAVA_SUFFIX}'"
+
       - name: Setup Java
         id: setup-java
         uses: ./.github/actions/core-cicd/setup-java
+        with:
+          java-version: ${{ inputs.java-version }}
 
       - name: Restore Maven Repository
         uses: actions/download-artifact@v4
         with:
-          name: maven-repo
+          name: maven-repo${{ steps.java-suffix.outputs.suffix }}
           path: ~/.m2/repository
 
       - name: Configure Maven Settings
@@ -129,7 +161,7 @@ jobs:
 
           site_dir=./dotCMS/target/site
           javadoc_dir=${site_dir}/javadocs
-          s3_uri=s3://static.dotcms.com/docs/${{ inputs.release_version }}/javadocs
+          s3_uri=s3://static.dotcms.com/docs/${{ inputs.release_version }}${{ steps.java-suffix.outputs.suffix }}/javadocs
 
           mv ${site_dir}/apidocs ${javadoc_dir}
           echo "Running: aws s3 cp ${javadoc_dir} ${s3_uri} --recursive"

--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -50,6 +50,21 @@ on:
         required: false
         type: boolean
         default: false
+      java-version:
+        description: 'Override Java version (SDKMAN format, e.g., 25.0.1-open)'
+        required: false
+        type: string
+        default: ''
+      maven-compiler-release:
+        description: 'Override Maven compiler release version (e.g., 21). Preferred over source/target.'
+        required: false
+        type: string
+        default: ''
+      artifact-suffix:
+        description: 'Override artifact suffix (e.g., -java25, -java25.0.1-ms). If not set, derived from java-version major.'
+        required: false
+        type: string
+        default: ''
     secrets:
       DOTCMS_LICENSE:
         required: true
@@ -187,5 +202,6 @@ jobs:
           needs-docker-image: ${{ matrix.needs_docker == true }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           artifacts-from: ${{ env.ARTIFACT_RUN_ID }}
-
-
+          java-version: ${{ inputs.java-version }}
+          maven-compiler-release: ${{ inputs.maven-compiler-release }}
+          artifact-suffix: ${{ inputs.artifact-suffix }}

--- a/.mise.toml
+++ b/.mise.toml
@@ -19,6 +19,12 @@ gh = "latest"
 # Python for cicd-diagnostics skill and automation scripts
 python = "3.11"
 
+# GitHub Actions workflow linter
+actionlint = "latest"
+
+# Shell script linter (used by actionlint for run: blocks)
+shellcheck = "latest"
+
 [env]
 # Python virtual environment location
 _.python.venv = { path = ".venv", create = true }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -26,7 +26,10 @@
          support new version default in environments/environment.properties and can be changed for local developer in
         environments/dev/user-dev.properties -->
         <!--suppress UnresolvedMavenProperty -->
-        <maven.compiler.release>11</maven.compiler.release>
+        <!-- Core modules compiler release - can be overridden via -Ddotcms.core.compiler.release
+             Defaults to 11 to maintain current bytecode compatibility -->
+        <dotcms.core.compiler.release>11</dotcms.core.compiler.release>
+        <maven.compiler.release>${dotcms.core.compiler.release}</maven.compiler.release>
         <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
         <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
         <maven.compiler.testSource>${maven.compiler.source}</maven.compiler.testSource>


### PR DESCRIPTION
## Description

Add optional Java version and Maven compiler override parameters to reusable CI/CD workflows, enabling builds with different Java versions and bytecode targets without modifying .sdkmanrc. Includes artifact naming isolation, Docker tag suffixes, and backward compatibility.

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #34586

**Issue:** [TASK] Add Java override parameters to core CICD a

This PR fixes: #34586