### PR TITLE
fix(test): [DEFECT] Flaky DotAssetAPITest.test_try_match  Tes (#34605)

### DIFF
--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/test/DotAssetAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/test/DotAssetAPITest.java
@@ -9,6 +9,8 @@ import com.dotcms.contenttype.model.field.ImmutableFieldVariable;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.ContentTypeBuilder;
 import com.dotcms.contenttype.model.type.DotAssetContentType;
+import com.dotcms.datagen.ContentTypeDataGen;
+import com.dotcms.datagen.SiteDataGen;
 import org.apache.commons.io.FileUtils;
 import com.dotcms.util.TestMediaCreator;
 import com.dotmarketing.beans.Host;
@@ -16,13 +18,17 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
+import com.dotmarketing.util.Logger;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
+import org.junit.After;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -31,17 +37,46 @@ import static org.junit.Assert.assertTrue;
 
 public class DotAssetAPITest extends ContentTypeBaseTest  {
 
+    private final List<ContentType> contentTypesToCleanUp = new ArrayList<>();
+    private Host testSite;
+
+    @After
+    public void tearDown() {
+        for (final ContentType contentType : contentTypesToCleanUp) {
+            try {
+                ContentTypeDataGen.remove(contentType);
+            } catch (Exception e) {
+                Logger.warn(this, "Failed to clean up content type: " + contentType.variable(), e);
+            }
+        }
+        contentTypesToCleanUp.clear();
+
+        if (testSite != null) {
+            try {
+                APILocator.getHostAPI().archive(testSite, APILocator.systemUser(), false);
+                APILocator.getHostAPI().delete(testSite, APILocator.systemUser(), false);
+            } catch (Exception e) {
+                Logger.warn(this, "Failed to clean up test site: " + testSite.getHostname(), e);
+            }
+            testSite = null;
+        }
+    }
+
     @Test
     public void test_try_match () throws Exception {
 
-        final Host host = APILocator.systemHost();
-        final Tuple2<Field, ContentType> fieldDotVideoAssetContentType = this.createDotAssetContentType(host,
+        // Use a dedicated test site instead of system host to ensure test content types
+        // have priority over any pre-existing system host content types in tryMatch()
+        // (site-specific types are matched before system host types)
+        testSite = new SiteDataGen().nextPersisted();
+
+        final Tuple2<Field, ContentType> fieldDotVideoAssetContentType = this.createDotAssetContentType(testSite,
                 "video/*", "videoDotAsset" + System.currentTimeMillis());
 
-        final Tuple2<Field, ContentType> fieldDotTextAssetContentType = this.createDotAssetContentType(host,
+        final Tuple2<Field, ContentType> fieldDotTextAssetContentType = this.createDotAssetContentType(testSite,
                 "text/*", "textDotAsset" + System.currentTimeMillis());
 
-        final Tuple2<Field, ContentType> fieldDotimageAssetContentType = this.createDotAssetContentType(host,
+        final Tuple2<Field, ContentType> fieldDotimageAssetContentType = this.createDotAssetContentType(testSite,
                 "image/*", "imageDotAsset" + System.currentTimeMillis());
 
         final File tempTestFile = File
@@ -52,27 +87,27 @@ public class DotAssetAPITest extends ContentTypeBaseTest  {
 
         final File tempMovieTestFile = TestMediaCreator.lookupMOV();
         contentTypeOpt = APILocator.getDotAssetAPI().tryMatch(
-                tempMovieTestFile, host, APILocator.systemUser());
+                tempMovieTestFile, testSite, APILocator.systemUser());
 
         assertTrue(contentTypeOpt.isPresent());
         assertEquals(fieldDotVideoAssetContentType._2().variable(), contentTypeOpt.get().variable());
 
         contentTypeOpt = APILocator.getDotAssetAPI().tryMatch(
-                tempTestFile, host, APILocator.systemUser());
+                tempTestFile, testSite, APILocator.systemUser());
 
         assertTrue(contentTypeOpt.isPresent());
         assertEquals(fieldDotTextAssetContentType._2().variable(), contentTypeOpt.get().variable());
 
         final File tempImageTestFile = TestMediaCreator.lookupPNG();
         contentTypeOpt = APILocator.getDotAssetAPI().tryMatch(
-                tempImageTestFile, host, APILocator.systemUser());
+                tempImageTestFile, testSite, APILocator.systemUser());
 
         assertTrue(contentTypeOpt.isPresent());
         assertEquals(fieldDotimageAssetContentType._2().variable(), contentTypeOpt.get().variable());
 
         final File tempImageTestFile2 = TestMediaCreator.lookupJPG();
         contentTypeOpt = APILocator.getDotAssetAPI().tryMatch(
-                tempImageTestFile2, host, APILocator.systemUser());
+                tempImageTestFile2, testSite, APILocator.systemUser());
 
         assertTrue(contentTypeOpt.isPresent());
         assertEquals(fieldDotimageAssetContentType._2().variable(), contentTypeOpt.get().variable());
@@ -96,6 +131,9 @@ public class DotAssetAPITest extends ContentTypeBaseTest  {
         dotAssetContentType = contentTypeAPI.save(dotAssetContentType);
         binaryField = fieldAPI.save(binaryField, user);
         fieldAPI.save(allowFileTypes, user);
+
+        // Register for cleanup to prevent test pollution
+        contentTypesToCleanUp.add(dotAssetContentType);
 
         return Tuple.of(binaryField, dotAssetContentType);
     }


### PR DESCRIPTION
## Description

Add @After cleanup method to DotAssetAPITest to remove created content types after test execution. This prevents test pollution from stale content types causing non-deterministic tryMatch() results when multiple content types match the same mime type pattern.

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #34605

**Issue:** [DEFECT] Flaky DotAssetAPITest.test_try_match  Tes

This PR fixes: #34605