### PR TITLE
fix(test): upgrade testcontainers to 1.21.4 for Docker API compatibility #34628

### DIFF
--- a/tools/dotcms-cli/api-data-model/pom.xml
+++ b/tools/dotcms-cli/api-data-model/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <testcontainers.version>1.17.6</testcontainers.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <test.failure.ignore>false</test.failure.ignore>
         <maven.plugin.jar.version>3.3.0</maven.plugin.jar.version>
         <jackson.module.model.version>1.2.2</jackson.module.model.version>

--- a/tools/dotcms-cli/cli/pom.xml
+++ b/tools/dotcms-cli/cli/pom.xml
@@ -16,7 +16,7 @@
         <executable-suffix/>
         <distribution.directory>${project.build.directory}/distributions</distribution.directory>
         <picocli.codegen.version>4.6.3</picocli.codegen.version>
-        <testcontainers.version>1.17.6</testcontainers.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <test.failure.ignore>false</test.failure.ignore>
         <docker.output.image.name>dotcms/dotcms-test</docker.output.image.name>
         <docker.version.tag>${project.version}</docker.version.tag>


### PR DESCRIPTION
## Summary
- Upgrades testcontainers from 1.17.6 to 1.21.4 in CLI modules to resolve Docker API version incompatibility
- Fixes intermittent CLI test failures in GitHub Actions caused by outdated docker-compose image using API version 1.32 (newer Docker requires 1.44+)

## Test plan
- [ ] Verify CLI tests pass in GitHub Actions on runners with Docker 29.1.5+
- [ ] Confirm no regression in local development testing
- [ ] Verify testcontainers functionality works with the updated version

## Files changed
- `tools/dotcms-cli/api-data-model/pom.xml` - testcontainers version bump
- `tools/dotcms-cli/cli/pom.xml` - testcontainers version bump

Closes #34628

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34628