### PR TITLE
Return conv rate is a better format supported by Cube

### DIFF
--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/ContentAttribution.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/ContentAttribution.js
@@ -44,7 +44,9 @@ cube('ContentAttribution', {
                   event_type <> 'conversion'    
             GROUP BY customer_id, cluster_id, context_user_id, context_site_id, event_type, identifier, title
         )
-       SELECT customer_id, cluster_id, context_user_id, context_site_id, event_type, identifier, title, day, conversions, totalEvents, (conversions * 100)/totalEvents as convRate
+       SELECT customer_id, cluster_id, context_user_id, context_site_id, event_type, identifier, title, day, conversions, totalEvents, if(totalEvents = 0, 0.0,
+                                                                                                                                            round(toFloat64(conversions) * 100 / totalEvents, 2)
+                                                                                                                                       ) as convRate
        FROM conversions_total
                 INNER JOIN events_total ON
            conversions_total.customer_id = events_total.customer_id AND

--- a/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Conversion.js
+++ b/docker/docker-compose-examples/analytics/setup/config/dev/cube/schema/Conversion.js
@@ -75,11 +75,18 @@ cube('Conversion', {
             conversion.conversion_name,
             conversion.context_site_id,
             conversion.total as total_conversion,
-            ((conversion.total * 100)/ total_conversion.total ) as conv_rate,
+            if(total_conversion.total = 0, 0.0,
+               round(toFloat64(conversion.total) * 100/ total_conversion.total , 2)
+            ) as conv_rate,
             day,
             arrayMap(
-                x -> mapUpdate(x, map('conv_rate', toString((toInt64(x['conversions'])* 100) / conversion.total))),
-            top_attributed_content.top_attributed_content
+                x -> mapUpdate(x, map('conv_rate', toString(if(conversion.total = 0, 0.0,
+                                                               round((toInt64(x['conversions']) * 100) / conversion.total, 2)
+                                                            )
+                                                   )
+                                    )
+                    ),
+                    top_attributed_content.top_attributed_content
             ) as top_attributed_content
         FROM conversion 
             LEFT JOIN total_conversion ON 1 = 1


### PR DESCRIPTION
### Proposed Changes
* Avoid high precision decimal when calculate conversion rate in Conversion and ConversionAttribute cube, using the follow statement 

if(totalEvents = 0, 0.0, round(toFloat64(conversions) * 100 / totalEvents, 4)) as convRate

This guarantees:

- No division by zero
- No Decimal
- Always Float64
- No NaN / Inf

This PR fixes: #34631

This PR fixes: #34631