### PR TITLE
feat: replace dynamic timestamp with static cache message in usage dashboard

### DIFF
--- a/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.html
+++ b/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.html
@@ -14,12 +14,9 @@
 
 <p-toolbar>
     <div class="p-toolbar-group-start">
-        @if (lastUpdated()) {
-            <span class="text-color-secondary">
-                {{ 'usage.dashboard.lastUpdated' | dm }}:
-                {{ lastUpdated()! | date: 'short' }}
-            </span>
-        }
+        <span class="text-color-secondary">
+            {{ 'usage.dashboard.cacheInfo' | dm }}
+        </span>
     </div>
 </p-toolbar>
 

--- a/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.ts
+++ b/core-web/libs/portlets/dot-usage/src/lib/dot-usage-shell/dot-usage-shell.component.ts
@@ -47,7 +47,6 @@ export class DotUsageShellComponent implements OnInit, OnDestroy {
 
     // Computed values for display
     readonly hasData = computed(() => this.summary() !== null);
-    readonly lastUpdated = signal<Date | null>(null);
 
     ngOnInit(): void {
         this.loadData();
@@ -73,7 +72,6 @@ export class DotUsageShellComponent implements OnInit, OnDestroy {
             next: (summary) => {
                 this.summary.set(summary);
                 this.loading.set(false);
-                this.lastUpdated.set(new Date());
             },
             error: (error) => {
                 const errorMessage = this.usageService.getErrorMessage(error);

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6420,4 +6420,4 @@ usage.dashboard.error.serviceUnavailable=Service unavailable. Please try again l
 usage.dashboard.error.requestFailed=Request failed with status {0}.
 usage.dashboard.error.generic=Failed to load usage data. Please check your connection and try again.
 usage.dashboard.value.notAvailable=N/A
-usage.dashboard.lastUpdated=Last Updated
+usage.dashboard.cacheInfo=Data is cached and refreshed every 5 minutes


### PR DESCRIPTION
## Summary

Replaces the dynamic "Last Updated" timestamp in the Usage Dashboard with a static message that accurately reflects the data caching behavior.

### Changes Made
- Removed `lastUpdated` signal and dynamic date display from component
- Replaced timestamp with static message: "Data is cached and refreshed every 5 minutes"
- Updated i18n key from `usage.dashboard.lastUpdated` to `usage.dashboard.cacheInfo`

### Problem Solved
The previous implementation displayed `Instant.now()` on every page load, misleading users about data recency. The actual metrics data is cached for 5 minutes, so the displayed timestamp didn't reflect the true age of the data.

## Test Plan

- [x] Component builds successfully
- [x] Existing tests pass (7/9 passing - 2 pre-existing failures unrelated to this change)
- [ ] Manual verification: Load Usage Dashboard and verify static message displays correctly
- [ ] Manual verification: Message styling matches previous timestamp style
- [ ] Manual verification: Message is positioned in top left of toolbar

## Acceptance Criteria

- [x] New message shown at top left: "Data is cached and refreshed every 5 minutes"
- [x] Same type and font face as current date/time message (`text-color-secondary`)
- [x] Current date/time message removed

Resolves #34567

This PR fixes: #34567