### PR TITLE
fix: preserve mode parameter in createFullURL for proper view mode navigation (#34648)

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -610,7 +610,6 @@ export function createFullURL(params: DotPageApiParams, siteId?: string): string
     // Clean the params that are not needed for the page
     delete paramsCopy?.clientHost;
     delete paramsCopy?.url;
-    delete paramsCopy?.mode;
 
     const searchParams = new URLSearchParams(paramsCopy);
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -1180,7 +1180,7 @@ describe('utils functions', () => {
 
     describe('createFullURL', () => {
         const expectedURL =
-            'http://localhost:4200/page?language_id=1&com.dotmarketing.persona.id=persona&variantName=new&experimentId=1&depth=1';
+            'http://localhost:4200/page?language_id=1&com.dotmarketing.persona.id=persona&variantName=new&experimentId=1&mode=EDIT_MODE&depth=1';
         const params = {
             url: 'page',
             language_id: '1',


### PR DESCRIPTION
## Summary
Fixes the `createFullURL` function in UVE which was incorrectly removing the `mode` parameter, preventing users from maintaining their current viewing mode (LIVE/PREVIEW_MODE/EDIT_MODE) when navigating or using buttons that rely on this URL.

### Changes
- **Removed mode deletion**: The `createFullURL` function now preserves the `mode` parameter instead of deleting it
- **Updated test**: Modified test expectation to include the `mode` parameter in the generated URL

### Why this matters
The `createFullURL` function is intended to create a "CurrentViewURL" that preserves the user's current viewing context. By removing the mode parameter, users lost the ability to maintain their view mode when:
- Using navigation buttons in UVE
- Accessing page URLs generated by this function
- Switching between different view modes

## Test plan
- [x] Removed `delete paramsCopy?.mode;` line from `createFullURL` function
- [x] Updated unit test to verify mode parameter is preserved in URL
- [x] Unit test passes with mode parameter included
- [ ] Manual testing: Verify view mode is preserved when navigating in UVE
- [ ] Manual testing: Verify LIVE/PREVIEW_MODE/EDIT_MODE buttons work correctly

## Related Issue
Fixes #34648

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34648