### PR TITLE
fix(PP) : fix language for story block dependencies

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPI.java
@@ -58,24 +58,26 @@ public interface StoryBlockAPI {
 
     /**
      * Traverses every {@link com.dotcms.contenttype.model.field.StoryBlockField} in the specified Contentlet, and
-     * returns the list with the Identifiers that are being referenced in such a field.
+     * returns the list with the dependency information (identifier and languageId) for contentlets being referenced
+     * in such fields.
      *
      * @param contentlet The {@link Contentlet} whose Story Block references must be retrieved.
      *
-     * @return The {@link List} with the Identifiers of the Contentlets that are being referenced in every Story
-     * Block fields.
+     * @return The {@link List} of {@link StoryBlockDependency} objects containing the identifier and languageId
+     * of the Contentlets that are being referenced in every Story Block field.
      */
-    List<String> getDependencies (final Contentlet contentlet);
+    List<StoryBlockDependency> getDependencies (final Contentlet contentlet);
 
     /**
-     * Returns the list with the Identifiers that are being referenced in the specified Story Block value.
+     * Returns the list with the dependency information (identifier and languageId) for contentlets being referenced
+     * in the specified Story Block value.
      *
      * @param storyBlockValue The value of the Story Block -- usually in the form of a JSON String.
      *
-     * @return The {@link List} with the Identifiers of the Contentlets that are being referenced in the Story Block
-     * field.
+     * @return The {@link List} of {@link StoryBlockDependency} objects containing the identifier and languageId
+     * of the Contentlets that are being referenced in the Story Block field.
      */
-    List<String> getDependencies (final Object storyBlockValue);
+    List<StoryBlockDependency> getDependencies (final Object storyBlockValue);
 
     /**
      * Adds a Contentlet to the specified Story Block field.

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockDependency.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockDependency.java
@@ -1,0 +1,57 @@
+package com.dotcms.contenttype.business;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+/**
+ * Represents a dependency reference found within a Story Block field.
+ * Contains the identifier and language ID of the referenced contentlet.
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableStoryBlockDependency.class)
+@JsonDeserialize(as = ImmutableStoryBlockDependency.class)
+public interface StoryBlockDependency {
+
+    /**
+     * The identifier of the referenced contentlet (image, video, or content).
+     *
+     * @return The contentlet identifier.
+     */
+    @JsonProperty("identifier")
+    String identifier();
+
+    /**
+     * The language ID of the referenced contentlet.
+     * This is the actual language of the dependency as stored in the Story Block field,
+     * which may differ from the parent contentlet's language.
+     *
+     * @return The language ID of the dependency.
+     */
+    @JsonProperty("languageId")
+    long languageId();
+
+    /**
+     * Creates a new builder for StoryBlockDependency.
+     *
+     * @return A new builder instance.
+     */
+    static ImmutableStoryBlockDependency.Builder builder() {
+        return ImmutableStoryBlockDependency.builder();
+    }
+
+    /**
+     * Creates a StoryBlockDependency from identifier and languageId.
+     *
+     * @param identifier The contentlet identifier.
+     * @param languageId The language ID.
+     * @return A new StoryBlockDependency instance.
+     */
+    static StoryBlockDependency of(final String identifier, final long languageId) {
+        return ImmutableStoryBlockDependency.builder()
+                .identifier(identifier)
+                .languageId(languageId)
+                .build();
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushPublishigDependencyProcesor.java
@@ -603,17 +603,23 @@ public class PushPublishigDependencyProcesor implements DependencyProcessor {
      */
     private void processStoryBockDependencies(final Contentlet contentlet) {
         if (contentlet.getContentType().hasStoryBlockFields()) {
-            this.storyBlockAPI.get().getDependencies(contentlet).forEach(contentletId -> {
+            this.storyBlockAPI.get().getDependencies(contentlet).forEach(dependency -> {
                 Contentlet contentInStoryBlock = new Contentlet();
                 try {
-                    contentInStoryBlock = this.contentletAPI.get().findContentletByIdentifier(contentletId,
-                            contentlet.isLive(), contentlet.getLanguageId(), APILocator.systemUser(), false);
+                    // Use the languageId stored in the Story Block field data, not the parent contentlet's language
+                    // This fixes the issue where dependencies in non-default languages were not being found
+                    contentInStoryBlock = this.contentletAPI.get().findContentletByIdentifier(
+                            dependency.identifier(),
+                            contentlet.isLive(),
+                            dependency.languageId(),
+                            APILocator.systemUser(),
+                            false);
                     tryToAddAndProcessDependencies(PusheableAsset.CONTENTLET, contentInStoryBlock,
                             ManifestReason.INCLUDE_DEPENDENCY_FROM.getMessage(contentlet));
                 } catch (final DotDataException | DotSecurityException e) {
-                    Logger.warn(this, String.format("Could not analyze dependent Contentlet '%s' referenced in Story "
-                                                            + "Block field from Contentlet Inode " + "'%s': %s",
-                            contentInStoryBlock, contentlet.getInode(), e.getMessage()));
+                    Logger.warn(this, String.format("Could not analyze dependent Contentlet '%s' (language: %d) "
+                                                            + "referenced in Story Block field from Contentlet Inode '%s': %s",
+                            dependency.identifier(), dependency.languageId(), contentlet.getInode(), e.getMessage()));
                 }
             });
         }

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/StoryBlockAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/StoryBlockAPITest.java
@@ -18,6 +18,7 @@ import com.dotcms.IntegrationTestBase;
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.api.web.HttpServletResponseThreadLocal;
 import com.dotcms.content.business.json.ContentletJsonHelper;
+import com.dotcms.contenttype.business.StoryBlockDependency;
 import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.FieldBuilder;
@@ -403,12 +404,12 @@ public class StoryBlockAPITest extends IntegrationTestBase {
 
 
         assertNotNull(newStoryBlockMap);
-        final List<String> contentletIdList = APILocator.getStoryBlockAPI().getDependencies(newStoryBlockJson3);
-        assertNotNull(contentletIdList);
-        assertEquals(3, contentletIdList.size());
-        assertTrue(contentletIdList.contains(richTextContentlet1.getIdentifier()));
-        assertTrue(contentletIdList.contains(richTextContentlet2.getIdentifier()));
-        assertTrue(contentletIdList.contains(richTextContentlet3.getIdentifier()));
+        final List<StoryBlockDependency> dependencyList = APILocator.getStoryBlockAPI().getDependencies(newStoryBlockJson3);
+        assertNotNull(dependencyList);
+        assertEquals(3, dependencyList.size());
+        assertTrue(dependencyList.stream().anyMatch(dep -> dep.identifier().equals(richTextContentlet1.getIdentifier())));
+        assertTrue(dependencyList.stream().anyMatch(dep -> dep.identifier().equals(richTextContentlet2.getIdentifier())));
+        assertTrue(dependencyList.stream().anyMatch(dep -> dep.identifier().equals(richTextContentlet3.getIdentifier())));
     }
 
     /**
@@ -421,11 +422,11 @@ public class StoryBlockAPITest extends IntegrationTestBase {
 
         final Object newStoryBlockJson1        = "<html>pufff</html>";
 
-        final List<String> contentletIdList = APILocator.getStoryBlockAPI().getDependencies(newStoryBlockJson1);
-        assertNotNull(contentletIdList);
-        assertTrue(contentletIdList.isEmpty());
+        final List<StoryBlockDependency> dependencyList = APILocator.getStoryBlockAPI().getDependencies(newStoryBlockJson1);
+        assertNotNull(dependencyList);
+        assertTrue(dependencyList.isEmpty());
     }
-    
+
     /**
      * Method to test: {@link StoryBlockAPI#getDependencies(Object)}
      * Given Scenario: Test a story block value that is a json (html in this case) see (https://github.com/dotCMS/core/issues/24299)
@@ -436,11 +437,11 @@ public class StoryBlockAPITest extends IntegrationTestBase {
 
         final Object newStoryBlockJson1        = "{\"test\":\"test\"}";
 
-        final List<String> contentletIdList = APILocator.getStoryBlockAPI().getDependencies(newStoryBlockJson1);
-        assertNotNull(contentletIdList);
-        assertTrue(contentletIdList.isEmpty());
+        final List<StoryBlockDependency> dependencyList = APILocator.getStoryBlockAPI().getDependencies(newStoryBlockJson1);
+        assertNotNull(dependencyList);
+        assertTrue(dependencyList.isEmpty());
     }
-    
+
     /**
      * Method to test: {@link StoryBlockAPI#getDependencies(Object)}
      * Given Scenario: Test a story block value that is a json (html in this case) see (https://github.com/dotCMS/core/issues/24299)
@@ -451,9 +452,9 @@ public class StoryBlockAPITest extends IntegrationTestBase {
 
         final Object newStoryBlockJson1        = "{\"content\":\"test\"}";
 
-        final List<String> contentletIdList = APILocator.getStoryBlockAPI().getDependencies(newStoryBlockJson1);
-        assertNotNull(contentletIdList);
-        assertTrue(contentletIdList.isEmpty());
+        final List<StoryBlockDependency> dependencyList = APILocator.getStoryBlockAPI().getDependencies(newStoryBlockJson1);
+        assertNotNull(dependencyList);
+        assertTrue(dependencyList.isEmpty());
     }
 
     /**
@@ -539,16 +540,16 @@ public class StoryBlockAPITest extends IntegrationTestBase {
             );
 
 
-            final List<String> contentletIdList = APILocator.getStoryBlockAPI()
+            final List<StoryBlockDependency> dependencyList = APILocator.getStoryBlockAPI()
                     .getDependencies(storyBlockJsonWithNestedImages);
 
             // Verify both images are detected
-            assertNotNull("Dependency list should not be null", contentletIdList);
-            assertEquals("Should find 2 image dependencies", 2, contentletIdList.size());
+            assertNotNull("Dependency list should not be null", dependencyList);
+            assertEquals("Should find 2 image dependencies", 2, dependencyList.size());
             assertTrue("Should contain top-level image",
-                    contentletIdList.contains(imageFileAsset1.getIdentifier()));
+                    dependencyList.stream().anyMatch(dep -> dep.identifier().equals(imageFileAsset1.getIdentifier())));
             assertTrue("Should contain nested image inside list",
-                    contentletIdList.contains(imageFileAsset2.getIdentifier()));
+                    dependencyList.stream().anyMatch(dep -> dep.identifier().equals(imageFileAsset2.getIdentifier())));
 
         } finally {
             


### PR DESCRIPTION
Closes #34464

### Proposed Changes
* Modified the Story Block dependency processing to preserve and use the language ID stored within the Story Block field data, rather than assuming dependencies are in the same language as the parent content.

### Checklist
- [x] Tests

This PR fixes: #34464