### PR TITLE
fix(ci): [DEFECT] Autolabeling incorrectly applies Area  CI (#34669)

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -79,8 +79,15 @@ area_documentation:
 # matching the negation (e.g., '!.github/**/*.md' matches all files in core-web/, dotCMS/).
 # This is a known bug: https://github.com/dorny/paths-filter/issues/97
 #
-# Solution: Use explicit positive patterns only (no negations). Use wildcards for directories
-# with many files (workflows/, actions/) and explicit paths for individual config files.
+# Solution Options:
+# 1. Use explicit positive patterns (simple, clear) - PREFERRED for most cases
+#    Example: list each file/directory explicitly
+# 2. Use picomatch inline negation !(pattern) - ONLY when explicit listing is impractical
+#    Example (already used in backend filter): dotCMS/src/main/webapp/html/**/!(*.{css,js})
+#    This matches all files in the path EXCEPT .css and .js files
+#
+# For area_cicd, we use option 1: wildcards for directories with many files (workflows/,
+# actions/) and explicit paths for individual config files.
 #
 # This filter matches CI/CD code and configuration that affects build/test/deploy:
 # - GitHub Actions workflows (all files in workflows/)

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -73,10 +73,32 @@ area_documentation:
   - 'dotCMS/*.md'
   - 'tools/**/*.md'
 
+# IMPORTANT: Negation patterns (like '!pattern') do NOT work correctly with dorny/paths-filter
+#
+# Due to OR logic in dorny/paths-filter, separate negation patterns match ANY file not
+# matching the negation (e.g., '!.github/**/*.md' matches all files in core-web/, dotCMS/).
+# This is a known bug: https://github.com/dorny/paths-filter/issues/97
+#
+# Solution: Use explicit positive patterns only (no negations). Use wildcards for directories
+# with many files (workflows/, actions/) and explicit paths for individual config files.
+#
+# This filter matches CI/CD code and configuration that affects build/test/deploy:
+# - GitHub Actions workflows (all files in workflows/)
+# - Custom GitHub Actions (all files in actions/)
+# - CI/CD configuration files (filters, labels, test matrix)
+#
+# Does NOT match (intentionally excluded by not listing):
+# - ISSUE_TEMPLATE/ and PULL_REQUEST_TEMPLATE/ (non-code metadata)
+# - data/ directory (reference data like slack-mappings.json)
+# - instructions/ directory (documentation)
+# - *.md files (documentation)
+# - copilot-instructions.md (AI tool configuration)
 area_cicd:
-  - '.github/**'
-  - '!.github/ISSUE_TEMPLATE/**'
-  - '!.github/**/*.md'
+  - '.github/workflows/**'
+  - '.github/actions/**'
+  - '.github/filters.yaml'
+  - '.github/area-labels.yml'
+  - '.github/test-matrix.yml'
 
 jvm_unit_test:
   - *backend


### PR DESCRIPTION
## Description

Fixes the auto-labeling bug where the `area_cicd` filter incorrectly applied "Area : CI/CD" label to PRs with **no `.github/` changes**. This was caused by a known bug in `dorny/paths-filter` where negation patterns use OR logic instead of AND logic.

### Root Cause

The original filter used separate negation patterns:
```yaml
area_cicd:
  - '.github/**'
  - '!.github/ISSUE_TEMPLATE/**'
  - '!.github/**/*.md'
```

Due to OR logic in dorny/paths-filter, the negation `'!.github/**/*.md'` matched **any file NOT a markdown file in .github/**, which includes ALL files in `core-web/`, `dotCMS/`, etc.

Example from workflow run 22088029961:
- Changed files: `core-web/apps/dotcms-ui/src/.../onboarding-author.component.html`
- Filter result: `area_cicd = true` ❌ (WRONG - no .github/ changes!)

### Solution

Replace negation patterns with explicit positive patterns only:
```yaml
area_cicd:
  - '.github/workflows/**'        # All workflow files
  - '.github/actions/**'           # All custom actions
  - '.github/filters.yaml'         # CI/CD config
  - '.github/area-labels.yml'      # PR labeling config
  - '.github/test-matrix.yml'      # Test matrix config
```

**Hybrid Approach:**
- ✅ Wildcards for directories with many files (workflows/, actions/)
- ✅ Explicit paths for individual config files
- ✅ No negation patterns (avoids dorny/paths-filter bug)
- ✅ Self-documenting (what's NOT listed is intentionally excluded)

## Changes

- [x] Updated `area_cicd` filter to use explicit positive patterns only
- [x] Added comprehensive documentation explaining the negation bug
- [x] Documented what files are intentionally excluded (ISSUE_TEMPLATE/, data/, *.md, etc.)
- [x] Referenced upstream bug reports (dorny/paths-filter #97, #184)

## Testing

- [x] Verified filter syntax is valid YAML
- [x] Confirmed patterns match intended files (workflows, actions, config)
- [x] Verified excluded patterns (templates, docs, data files)
- [ ] **Requires validation**: Create test PR with frontend-only changes to verify label is NOT applied
- [ ] **Requires validation**: Create test PR with workflow changes to verify label IS applied

## Additional Context

**Upstream Bug Reports:**
- https://github.com/dorny/paths-filter/issues/97
- https://github.com/dorny/paths-filter/issues/184

**Follow-up Work:**
- Issue #34673 created for larger filter refactoring with consistent naming convention

Closes #34669

This PR fixes: #34669