### PR TITLE
feat(ci): enable path-based test filtering in merge queue (#34679)

### DIFF
--- a/.github/workflows/cicd_2-merge-queue.yml
+++ b/.github/workflows/cicd_2-merge-queue.yml
@@ -7,10 +7,10 @@ jobs:
   initialize:
     name: Initialize
     uses: ./.github/workflows/cicd_comp_initialize-phase.yml
-    # Runs ALL tests to catch flaky tests and filter gaps that PR checks might miss
-    # To enable selective testing, change to: change-detection: 'enabled'
+    # Uses path-based filtering to skip integration/postman/karate tests for frontend-only changes
+    # See ADR-0013: https://github.com/dotCMS/platform-adrs/pull/53
     with:
-      change-detection: 'disabled'
+      change-detection: 'enabled'
   build:
     name: Merge Group Build
     needs: [ initialize ]


### PR DESCRIPTION
## Summary
- Enable `change-detection: 'enabled'` in merge queue workflow to match PR workflow behavior
- Frontend-only changes will now skip integration, postman, and karate tests in merge queue
- Reduces merge queue time for frontend PRs from ~45 minutes to ~10-15 minutes

## Test plan
- [ ] Verify merge queue workflow runs path-based filtering for frontend-only PRs
- [ ] Verify backend/mixed changes still run full test suite
- [ ] Confirm workflow summary shows correct "Build & Test Matrix" filtering

## References
- ADR-0013: https://github.com/dotCMS/platform-adrs/pull/53
- Related discussion: PR #34622

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34679