### PR TITLE
fix(ci): [TASK] Remove unused listfiles option from pathsfi (#34683)

### DIFF
--- a/.github/workflows/cicd_comp_initialize-phase.yml
+++ b/.github/workflows/cicd_comp_initialize-phase.yml
@@ -138,7 +138,6 @@ jobs:
         id: filter
         with:
           filters: .github/filters.yaml
-          list-files: 'escape'
 
       - name: Rewrite Filter
         id: filter-rewrite


### PR DESCRIPTION
## Description

Remove unused list-files: 'escape' option from dorny/paths-filter in Initialize Phase workflow. This option generates file list outputs that are never used, but cause 'Argument list too long' failures on PRs with 1800+ changed files.

## Changes

- [ ] [List the main changes made]

## Testing

- [ ] [Describe testing approach]

Closes #34683

**Issue:** [TASK] Remove unused listfiles option from pathsfi

This PR fixes: #34683