### PR TITLE
fix: restore issue templates visibility by removing empty title fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/defect.yaml
+++ b/.github/ISSUE_TEMPLATE/defect.yaml
@@ -1,6 +1,5 @@
 name: Defect
 description: Report a bug or issue with existing functionality
-title: ""
 labels: ["OKR : Customer Support"]
 type: bug
 assignees: []

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,6 +1,5 @@
 name: EPIC
 description: Wide area of functionality that delivers significant value within a theme
-title: ""
 labels: []
 type: epic
 assignees: []

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,6 +1,5 @@
 name: Feature
 description: Specific functionality within an EPIC that provides particular value
-title: ""
 labels: []
 type: feature
 assignees: []

--- a/.github/ISSUE_TEMPLATE/pillar.yml
+++ b/.github/ISSUE_TEMPLATE/pillar.yml
@@ -1,6 +1,5 @@
 name: Pillar
 description: High-level strategic initiative that groups related EPICs
-title: ""
 labels: []
 type: pillar
 assignees: []

--- a/.github/ISSUE_TEMPLATE/spike.yaml
+++ b/.github/ISSUE_TEMPLATE/spike.yaml
@@ -1,7 +1,6 @@
 name: Spike
 description: Timeboxed research to turn unknowns into knowns
-title: ""
-labels: [""]
+labels: []
 type: spike
 assignees: []
 projects: ["dotCMS/7"]

--- a/.github/ISSUE_TEMPLATE/task.yaml
+++ b/.github/ISSUE_TEMPLATE/task.yaml
@@ -1,6 +1,5 @@
 name: Task
 description: Technical task or improvement that needs to be completed
-title: ""
 labels: []
 type: task
 assignees: []


### PR DESCRIPTION
## Summary
- Remove `title: ""` from all 6 issue form templates — GitHub's form parser silently drops templates with an empty string `title`, causing none to appear in the issue chooser UI
- Fix `spike.yaml`'s `labels: [""]` (invalid empty-string label) to `labels: []`

## Root Cause
PR #34678 changed `title: "[LABEL] "` to `title: ""` across all templates. While the intent was to remove the bracket prefixes, setting the field to an empty string causes GitHub to silently reject those templates instead of just leaving the title blank. The fix is to omit the `title` key entirely.

## Test plan
- [ ] Go to https://github.com/dotCMS/core/issues/new/choose and verify all templates (Task, Defect, Feature, Spike, EPIC, Pillar) appear in the chooser
- [ ] Open each template and confirm the title field starts empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34678