### PR TITLE
fix: Use  signal instead of pageParams.variantName in EMA dialog

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 import {
-    Spectator,
-    SpyObject,
     byTestId,
     createComponentFactory,
-    mockProvider
+    mockProvider,
+    Spectator,
+    SpyObject
 } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
@@ -93,7 +93,8 @@ describe('DotEmaDialogComponent', () => {
                 useValue: {
                     pageParams: signal({
                         variantName: 'DEFAULT' // Is the only thing we need to test the component
-                    })
+                    }),
+                    $variantId: signal('DEFAULT')
                 }
             },
             {
@@ -589,7 +590,9 @@ describe('DotEmaDialogComponent', () => {
 
             renderCompareDialog();
 
-            spectator.triggerEventHandler(DotContentCompareComponent, 'letMeBringBack', {
+            const compareComponent = spectator.query(DotContentCompareComponent);
+            expect(compareComponent).toBeDefined();
+            compareComponent.letMeBringBack.emit({
                 name: 'getVersionBack',
                 args: ['123']
             });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/store/dot-ema-dialog.store.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/store/dot-ema-dialog.store.spec.ts
@@ -1,4 +1,4 @@
-import { expect, it, describe } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { SpectatorService, createServiceFactory } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
@@ -18,6 +18,12 @@ import { UVEStore } from '../../../store/dot-uve.store';
 
 const TEST_VARIANT = 'my-test-variant';
 
+/** Mock UVEStore signals used by DotEmaDialogStore (same shape as real store's $variantId) */
+const mockUveStore = {
+    pageParams: signal({ variantName: TEST_VARIANT }),
+    $variantId: signal(TEST_VARIANT)
+};
+
 describe('DotEmaDialogStoreService', () => {
     let spectator: SpectatorService<DotEmaDialogStore>;
 
@@ -27,11 +33,7 @@ describe('DotEmaDialogStoreService', () => {
         providers: [
             {
                 provide: UVEStore,
-                useValue: {
-                    pageParams: signal({
-                        variantName: TEST_VARIANT // Is the only thing we need to test the component
-                    })
-                }
+                useValue: mockUveStore
             },
 
             {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/store/dot-ema-dialog.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/store/dot-ema-dialog.store.ts
@@ -10,7 +10,7 @@ import { DotMessageService } from '@dotcms/data-access';
 import { DotCMSPage, DotCMSUVEAction } from '@dotcms/types';
 
 import { DotActionUrlService } from '../../../services/dot-action-url/dot-action-url.service';
-import { LAYOUT_URL, CONTENTLET_SELECTOR_URL } from '../../../shared/consts';
+import { CONTENTLET_SELECTOR_URL, LAYOUT_URL } from '../../../shared/consts';
 import { DialogStatus, FormStatus } from '../../../shared/enums';
 import {
     ActionPayload,
@@ -102,7 +102,7 @@ export class DotEmaDialogStore extends ComponentStore<EditEmaDialogState> {
         (state, { url, contentType, actionPayload }: CreateContentletAction) => {
             const completeURL = new URL(url, window.location.origin);
 
-            completeURL.searchParams.set('variantName', this.uveStore.pageParams().variantName);
+            completeURL.searchParams.set('variantName', this.uveStore.$variantId());
 
             return {
                 ...state,
@@ -320,7 +320,7 @@ export class DotEmaDialogStore extends ComponentStore<EditEmaDialogState> {
             _content_cmd: 'edit',
             inode: inode,
             angularCurrentPortlet: angularCurrentPortlet,
-            variantName: this.uveStore.pageParams().variantName
+            variantName: this.uveStore.$variantId()
         });
 
         return `${LAYOUT_URL}?${queryParams.toString()}`;
@@ -348,7 +348,7 @@ export class DotEmaDialogStore extends ComponentStore<EditEmaDialogState> {
             container_id: containerId,
             add: acceptTypes,
             language_id,
-            variantName: this.uveStore.pageParams().variantName
+            variantName: this.uveStore.$variantId()
         });
 
         return `${CONTENTLET_SELECTOR_URL}?${queryParams.toString()}`;
@@ -371,7 +371,7 @@ export class DotEmaDialogStore extends ComponentStore<EditEmaDialogState> {
             lang: newLanguage.toString(),
             populateaccept: 'true',
             reuseLastLang: 'true',
-            variantName: this.uveStore.pageParams().variantName
+            variantName: this.uveStore.$variantId()
         });
 
         return `${LAYOUT_URL}?${queryParams.toString()}`;


### PR DESCRIPTION
## Summary
- Fixed undefined variant parameter issue in UVE page properties by using the correct `$variantId` signal instead of accessing `variantName` from `pageParams`
- Updated all variant references in `DotEmaDialogStore` to use the dedicated `$variantId()` signal from UVEStore
- Updated test mocks to include the `$variantId` signal for consistency

## Changes
- **dot-ema-dialog.store.ts**: Replaced 4 instances of `this.uveStore.pageParams().variantName` with `this.uveStore.$variantId()`
- **dot-ema-dialog.component.spec.ts**: Added `$variantId` signal to test mock setup
- **dot-ema-dialog.store.spec.ts**: Created proper mock UVEStore with both `pageParams` and `$variantId` signals

## Test plan
- [x] Verify unit tests pass for dot-ema-dialog component and store
- [x] Verify force unlock workflow action properly uses variant ID
- [ ] Manual testing: Open UVE page properties and trigger force unlock action
- [ ] Manual testing: Verify variant parameter is correctly passed in all EMA dialog actions (create contentlet, edit layout, content selector, reorder menu)

## Related Issue
Fixes #34333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34333