### PR TITLE
fix(CopyContent): Moved Multitree validation before copyContentlet call + added DEFAULT variantId logic in PageResourceHelper

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -492,28 +492,27 @@ public class PageResourceHelper implements Serializable {
                                       final PageMode pageMode, final Language language)
             throws DotDataException, DotSecurityException {
 
-        final Tuple2<Contentlet, Contentlet> tuple2 = this.copyContent(copyContentletForm, user, pageMode, language.getId());
-
-        final Contentlet copiedContentlet   = tuple2._1();
-        final Contentlet originalContentlet = tuple2._2();
         final String htmlPage   = copyContentletForm.getPageId();
         final String container  = castToOriginalContainerId(copyContentletForm.getContainerId(), user, pageMode.respectAnonPerms);
         final String contentId  = copyContentletForm.getContentId();
         final String instanceId = copyContentletForm.getRelationType();
-        final String variant    = copyContentletForm.getVariantId();
+        final String variant    = UtilMethods.isSet(copyContentletForm.getVariantId()) ? copyContentletForm.getVariantId() : VariantAPI.DEFAULT_VARIANT.name();
         final int treeOrder     = copyContentletForm.getTreeOrder();
         final String personalization = copyContentletForm.getPersonalization();
         final Map<String, Object> styleProperties = copyContentletForm.getStyleProperties();
 
-        Logger.debug(this, ()-> "Deleting current contentlet multi tree: " + copyContentletForm);
         final MultiTree currentMultitree = getMultiTree(htmlPage, container, contentId, instanceId, personalization, variant);
 
         if (null == currentMultitree) {
-
             throw new DoesNotExistException(
                     "Can not copied the contentlet in the page, because the record is not part of the page, multitree: " + copyContentletForm);
         }
 
+        final Tuple2<Contentlet, Contentlet> tuple2 = this.copyContent(copyContentletForm, user, pageMode, language.getId());
+        final Contentlet copiedContentlet   = tuple2._1();
+        final Contentlet originalContentlet = tuple2._2();
+
+        Logger.debug(this, ()-> "Deleting current contentlet multi tree: " + copyContentletForm);
         APILocator.getMultiTreeAPI().deleteMultiTree(currentMultitree);
 
         final MultiTree newMultitree = new MultiTree(htmlPage, container,


### PR DESCRIPTION
## Summary

Moved Multitree validation before copyContentlet call + added DEFAULT variantId logic in PageResourceHelper in case of null/empty values.

## Changes

- Changed the validation order in PageResourceHelper.copyContentlet() method. Now we validate the existence of the Multitree before actually copying the Contentlet.
- Added a default value for variantId in case the value from the request is null or empty.
- Added integration tests.

## Motivation

The issue related to this PR shows that we return a 404 when attempting to copy a contentlet and the variantId in the request is empty. To address this, we added logic to set a default value when the variantId is null or empty.

Additionally, while investigating this issue, we uncovered another problem. The contentlet was being copied before doing the required validations for the Multitree. So when the Multitree call returned null, the response was still a 404, but the contentlet had already been copied, and the rollback was not being done.

This means the bug was not limited to the empty variantId scenario. Any case where the Multitree was null could trigger the same unintended behavior.

## Related Issue
Fixes: [BUG: PUT /api/v1/page/copyContent returns 404 but successfully copies content when variantId is empty string #34473](https://github.com/dotCMS/core/issues/34473)