### PR TITLE
fix(ci): [DEFECT] Manual deploy workflow cicd_8manualdeploy (#34689)

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -22,8 +22,9 @@ inputs:
     description: 'The commit id that triggered the build'
     required: true
   ref:
-    description: 'The branch or type of build to tag the image with'
-    required: true
+    description: 'The branch or type of build to tag the image with. Only used when docker-use-ref is true; when docker-use-ref is false the version input drives all tags and this is ignored.'
+    required: false
+    default: ''
   docker-use-ref:
     description: 'The branch or type of build to tag the image with'
     required: false
@@ -65,6 +66,18 @@ inputs:
     description: 'Pull image before building'
     required: false
     default: 'false'
+  identifier-tag:
+    description: 'Optional mutable alias tag managed by the deployment phase (e.g., nightly_20250218_java25, manual_issue-123_java25). Applied when non-empty.'
+    required: false
+    default: ''
+  custom-tag:
+    description: 'Optional custom alias tag chosen by the developer (e.g., modernization, java25-testing). Applied when non-empty.'
+    required: false
+    default: ''
+  extra-tags:
+    description: 'Escape hatch: additional tags in docker/metadata-action format (type=raw,value=...), one per line. Use for cases not covered by identifier-tag or custom-tag.'
+    required: false
+    default: ''
 outputs:
   tags:
     description: "The tags that were used to build the image"
@@ -104,6 +117,9 @@ runs:
         REF: ${{ inputs.ref }}
         USE_REF: ${{ inputs.docker-use-ref }}
         VERSION: ${{ inputs.version }}
+        IDENTIFIER_TAG: ${{ inputs.identifier-tag }}
+        CUSTOM_TAG: ${{ inputs.custom-tag }}
+        EXTRA_TAGS: ${{ inputs.extra-tags }}
       run: |
         
         # Set defaults for flags
@@ -137,6 +153,13 @@ runs:
           echo "type=raw,value=${RESULT}_{{sha}},enable=true" >> $GITHUB_ENV
           echo "type=raw,value=${RESULT},enable=true" >> $GITHUB_ENV
           echo "type=raw,value=latest,enable=${enable_latest}" >> $GITHUB_ENV
+          [[ -n "${IDENTIFIER_TAG}" ]] && echo "type=raw,value=${IDENTIFIER_TAG},enable=true" >> $GITHUB_ENV
+          [[ -n "${CUSTOM_TAG}" ]] && echo "type=raw,value=${CUSTOM_TAG},enable=true" >> $GITHUB_ENV
+          if [[ -n "${EXTRA_TAGS}" ]]; then
+            while IFS= read -r tag_line; do
+              [[ -n "${tag_line}" ]] && echo "${tag_line}" >> $GITHUB_ENV
+            done <<< "${EXTRA_TAGS}"
+          fi
         echo "EOF" >> $GITHUB_ENV
     - name: Docker.io login
       uses: docker/login-action@v3.0.0

--- a/.github/workflows/cicd_1-pr.yml
+++ b/.github/workflows/cicd_1-pr.yml
@@ -20,6 +20,7 @@
 
 
 name: '-1 PR Check'
+run-name: 'PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }} (@${{ github.event.pull_request.user.login }})'
 
 on:
   pull_request:

--- a/.github/workflows/cicd_2-merge-queue.yml
+++ b/.github/workflows/cicd_2-merge-queue.yml
@@ -1,4 +1,5 @@
 name: '-2 Merge Group Check'
+run-name: 'MQ: ${{ github.event.merge_group.head_commit.message }}'
 on:
   merge_group:
     types: [ checks_requested ]

--- a/.github/workflows/cicd_3-trunk.yml
+++ b/.github/workflows/cicd_3-trunk.yml
@@ -130,6 +130,7 @@ jobs:
     uses: ./.github/workflows/cicd_comp_deployment-phase.yml
     with:
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
+      deploy-cli: true
       publish-npm-sdk-libs: ${{ fromJSON(needs.initialize.outputs.filters).sdk_libs == 'true' && github.event_name != 'workflow_dispatch' }}
       environment: trunk
       # tag-identifier intentionally omitted: trunk uses only the environment name as its tag

--- a/.github/workflows/cicd_3-trunk.yml
+++ b/.github/workflows/cicd_3-trunk.yml
@@ -11,7 +11,7 @@
 # - Final reporting of the workflow status
 
 name: '-3 Trunk Workflow'
-run-name: 'Trunk${{ inputs.java-version && format(" [{0}]", inputs.java-version) || "" }}'
+run-name: "Trunk${{ inputs.java-version && format(' [{0}]', inputs.java-version) || '' }}"
 
 on:
   push:

--- a/.github/workflows/cicd_3-trunk.yml
+++ b/.github/workflows/cicd_3-trunk.yml
@@ -11,6 +11,7 @@
 # - Final reporting of the workflow status
 
 name: '-3 Trunk Workflow'
+run-name: 'Trunk${{ inputs.java-version && format(" [{0}]", inputs.java-version) || "" }}'
 
 on:
   push:
@@ -131,6 +132,7 @@ jobs:
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
       publish-npm-sdk-libs: ${{ fromJSON(needs.initialize.outputs.filters).sdk_libs == 'true' && github.event_name != 'workflow_dispatch' }}
       environment: trunk
+      # tag-identifier intentionally omitted: trunk uses only the environment name as its tag
       java-version: ${{ github.event.inputs.java-version || '' }}
       artifact-suffix: ${{ github.event.inputs.artifact-suffix || '' }}
     secrets:

--- a/.github/workflows/cicd_4-nightly.yml
+++ b/.github/workflows/cicd_4-nightly.yml
@@ -10,8 +10,17 @@
 # - Optional NPM package publishing
 # - Deployment to the nightly environment
 # - Final reporting of the workflow status
+#
+# Commit pinning:
+# - Default (both scheduled and manual dispatch): builds from the last commit on main
+#   at or before midnight UTC. This ensures repeatability — manually re-running the
+#   nightly later in the day to investigate a failure produces the same build.
+#   The date tag (nightly_YYYYMMDD) correctly labels the day covered, not the run day.
+# - Manual dispatch with use-latest-commit=true: builds from current HEAD of main,
+#   useful when you want to pick up commits made after midnight.
 
 name: '-4 Nightly Workflow'
+run-name: 'Nightly${{ inputs.use-latest-commit && " (HEAD)" || "" }}${{ inputs.java-version && format(" [{0}]", inputs.java-version) || "" }}'
 
 on:
   schedule:
@@ -49,8 +58,57 @@ on:
         type: string
         required: false
         default: ''
+      use-latest-commit:
+        description: 'Use current HEAD of main instead of the midnight UTC commit. Set to true when you want to pick up commits made after midnight rather than reproduce the scheduled run.'
+        type: boolean
+        default: false
 
 jobs:
+  # Setup job - determines the commit to build from.
+  # Default (scheduled and manual): last commit on main at or before midnight UTC for repeatability.
+  # Manual with use-latest-commit=true: current HEAD of main.
+  setup:
+    name: Setup
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    outputs:
+      build-ref: ${{ steps.find-commit.outputs.build-ref }}
+      tag-date: ${{ steps.find-commit.outputs.tag-date }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Find Build Commit
+        id: find-commit
+        run: |
+          if [[ "${{ inputs.use-latest-commit }}" == "true" ]]; then
+            # Explicit override: use current HEAD of main.
+            # Useful when you want to pick up commits made after midnight.
+            BUILD_REF=$(git rev-parse HEAD)
+            TAG_DATE=$(date -u +%Y%m%d)
+            echo "use-latest-commit=true: building from current HEAD of main: ${BUILD_REF}"
+          else
+            # Default for both scheduled and manual dispatch: use the last commit
+            # at or before midnight UTC. This ensures repeatability — manually
+            # re-running later in the day to investigate a failure gives the same build.
+            MIDNIGHT=$(date -u +"%Y-%m-%dT00:00:00")
+            BUILD_REF=$(git log --before="${MIDNIGHT}" --format="%H" -1)
+            if [[ -z "${BUILD_REF}" ]]; then
+              # No commits before today's midnight — use the absolute last commit.
+              # This handles edge cases (e.g., very new repos) without falling back to
+              # current HEAD which might include post-midnight commits.
+              BUILD_REF=$(git log --format="%H" -1)
+              echo "⚠️ No commit found before ${MIDNIGHT}, using last available commit: ${BUILD_REF}"
+            else
+              echo "Building from commit at midnight UTC (${MIDNIGHT}): ${BUILD_REF}"
+            fi
+            # Tag with yesterday's date: the nightly covers the previous calendar day
+            TAG_DATE=$(date -u -d "yesterday" +%Y%m%d)
+          fi
+          echo "build-ref=${BUILD_REF}" >> "$GITHUB_OUTPUT"
+          echo "tag-date=${TAG_DATE}" >> "$GITHUB_OUTPUT"
+
   # Initialize the nightly build process
   initialize:
     name: Initialize
@@ -64,10 +122,11 @@ jobs:
   # Build job - only runs if no artifacts were found during initialization
   build:
     name: Nightly Build
-    needs: [ initialize ]
+    needs: [ setup, initialize ]
     if: needs.initialize.outputs.found_artifacts == 'false'
     uses: ./.github/workflows/cicd_comp_build-phase.yml
     with:
+      ref: ${{ needs.setup.outputs.build-ref }}
       java-version: ${{ github.event.inputs.java-version || '' }}
       maven-compiler-release: ${{ github.event.inputs.maven-compiler-release || '' }}
       artifact-suffix: ${{ github.event.inputs.artifact-suffix || '' }}
@@ -108,15 +167,15 @@ jobs:
 
   # Deployment job - deploys to the nightly environment
   deployment:
-    needs: [ initialize,build-cli,test ]
+    needs: [ setup, initialize,build-cli,test ]
     if: always() && !failure() && !cancelled()
     uses: ./.github/workflows/cicd_comp_deployment-phase.yml
     with:
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
       environment: nightly
+      tag-identifier: ${{ needs.setup.outputs.tag-date }}
       deploy-dev-image: true
       publish-npm-cli: ${{ ( github.event_name == 'workflow_dispatch' && inputs.publish-npm-cli == true ) || github.event_name == 'schedule' }}
-      reuse-previous-build: ${{ inputs.reuse-previous-build || false }}
       java-version: ${{ github.event.inputs.java-version || '' }}
       artifact-suffix: ${{ github.event.inputs.artifact-suffix || '' }}
     secrets:
@@ -132,7 +191,7 @@ jobs:
   finalize:
     name: Finalize
     if: always()
-    needs: [ initialize, build, build-cli, test, deployment ]
+    needs: [ setup, initialize, build, build-cli, test, deployment ]
     uses: ./.github/workflows/cicd_comp_finalize-phase.yml
     with:
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}

--- a/.github/workflows/cicd_4-nightly.yml
+++ b/.github/workflows/cicd_4-nightly.yml
@@ -174,6 +174,7 @@ jobs:
       artifact-run-id: ${{ needs.initialize.outputs.artifact-run-id }}
       environment: nightly
       tag-identifier: ${{ needs.setup.outputs.tag-date }}
+      deploy-cli: true
       deploy-dev-image: true
       publish-npm-cli: ${{ ( github.event_name == 'workflow_dispatch' && inputs.publish-npm-cli == true ) || github.event_name == 'schedule' }}
       java-version: ${{ github.event.inputs.java-version || '' }}

--- a/.github/workflows/cicd_4-nightly.yml
+++ b/.github/workflows/cicd_4-nightly.yml
@@ -20,7 +20,7 @@
 #   useful when you want to pick up commits made after midnight.
 
 name: '-4 Nightly Workflow'
-run-name: 'Nightly${{ inputs.use-latest-commit && " (HEAD)" || "" }}${{ inputs.java-version && format(" [{0}]", inputs.java-version) || "" }}'
+run-name: "Nightly${{ inputs.use-latest-commit && ' (HEAD)' || '' }}${{ inputs.java-version && format(' [{0}]', inputs.java-version) || '' }}"
 
 on:
   schedule:

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -122,6 +122,7 @@ jobs:
       omit-environment-prefix: true
       artifact-run-id: ${{ github.run_id }}
       latest: ${{ needs.release-prepare.outputs.is_latest == 'true' }}
+      deploy-cli: true
       deploy-dev-image: true
       publish-npm-cli: false
       publish-npm-sdk-libs: false

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -18,7 +18,7 @@
 #
 
 name: '-6 Release Process'
-run-name: 'Release ${{ inputs.release_version }}${{ inputs.java-version && format(" [{0}]", inputs.java-version) || "" }}'
+run-name: "Release ${{ inputs.release_version }}${{ inputs.java-version && format(' [{0}]', inputs.java-version) || '' }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -18,6 +18,7 @@
 #
 
 name: '-6 Release Process'
+run-name: 'Release ${{ inputs.release_version }}${{ inputs.java-version && format(" [{0}]", inputs.java-version) || "" }}'
 
 on:
   workflow_dispatch:
@@ -116,11 +117,12 @@ jobs:
     if: always() && !failure() && !cancelled()
     uses: ./.github/workflows/cicd_comp_deployment-phase.yml
     with:
-      environment: ${{ needs.release-prepare.outputs.release_version }}
+      environment: 'release'
+      tag-identifier: ${{ needs.release-prepare.outputs.release_version }}
+      omit-environment-prefix: true
       artifact-run-id: ${{ github.run_id }}
       latest: ${{ needs.release-prepare.outputs.is_latest == 'true' }}
       deploy-dev-image: true
-      reuse-previous-build: false
       publish-npm-cli: false
       publish-npm-sdk-libs: false
       java-version: ${{ github.event.inputs.java-version }}

--- a/.github/workflows/cicd_7-release-java-variant.yml
+++ b/.github/workflows/cicd_7-release-java-variant.yml
@@ -28,6 +28,7 @@
 #
 
 name: '-7 Release Java Variant'
+run-name: 'Release Java Variant - ${{ github.event_name == ''workflow_dispatch'' && inputs.release_branch || github.ref_name }}${{ inputs.java_version && format(" [{0}]", inputs.java_version) || "" }}'
 
 on:
   push:
@@ -100,7 +101,7 @@ jobs:
     needs: [ extract-version ]
     uses: ./.github/workflows/cicd_comp_initialize-phase.yml
     with:
-      validation-level: 'none'
+      change-detection: 'disabled'  # Release builds everything - no change detection needed
 
   # Build - standard build phase with Java version override
   build:
@@ -127,7 +128,9 @@ jobs:
     if: always() && !failure() && !cancelled()
     uses: ./.github/workflows/cicd_comp_deployment-phase.yml
     with:
-      environment: ${{ needs.extract-version.outputs.version }}
+      environment: 'release'
+      tag-identifier: ${{ needs.extract-version.outputs.version }}
+      omit-environment-prefix: true
       artifact-run-id: ${{ github.run_id }}
       deploy-dev-image: true
       java-version: ${{ github.event_name == 'workflow_dispatch' && inputs.java_version || vars.RELEASE_JAVA_VARIANT_VERSION }}

--- a/.github/workflows/cicd_7-release-java-variant.yml
+++ b/.github/workflows/cicd_7-release-java-variant.yml
@@ -41,9 +41,10 @@ on:
         required: true
         type: string
       java_version:
-        description: 'Java version to build (SDKMAN format, e.g., 25.0.2-ms). For push-triggered builds this comes from the RELEASE_JAVA_VARIANT_VERSION repository variable.'
-        required: true
+        description: 'Java version to build (SDKMAN format, e.g., 25.0.2-ms). Leave empty to use the RELEASE_JAVA_VARIANT_VERSION repository variable (same as push-triggered builds).'
+        required: false
         type: string
+        default: ''
       artifact_suffix:
         description: 'Artifact suffix without leading separator (e.g., java25, java25-ms). Separators added automatically: dash (-) for Maven artifacts, underscore (_) for Docker tags. If not set, derived from java-version major (e.g., java25).'
         required: false

--- a/.github/workflows/cicd_7-release-java-variant.yml
+++ b/.github/workflows/cicd_7-release-java-variant.yml
@@ -41,10 +41,9 @@ on:
         required: true
         type: string
       java_version:
-        description: 'Java version to build (SDKMAN format, e.g., 25.0.1-open)'
+        description: 'Java version to build (SDKMAN format, e.g., 25.0.2-ms). For push-triggered builds this comes from the RELEASE_JAVA_VARIANT_VERSION repository variable.'
         required: true
         type: string
-        default: '25.0.1-open'
       artifact_suffix:
         description: 'Artifact suffix without leading separator (e.g., java25, java25-ms). Separators added automatically: dash (-) for Maven artifacts, underscore (_) for Docker tags. If not set, derived from java-version major (e.g., java25).'
         required: false

--- a/.github/workflows/cicd_7-release-java-variant.yml
+++ b/.github/workflows/cicd_7-release-java-variant.yml
@@ -28,7 +28,7 @@
 #
 
 name: '-7 Release Java Variant'
-run-name: 'Release Java Variant - ${{ github.event_name == ''workflow_dispatch'' && inputs.release_branch || github.ref_name }}${{ inputs.java_version && format(" [{0}]", inputs.java_version) || "" }}'
+run-name: "Release Java Variant - ${{ github.event_name == 'workflow_dispatch' && inputs.release_branch || github.ref_name }}${{ inputs.java_version && format(' [{0}]', inputs.java_version) || '' }}"
 
 on:
   push:

--- a/.github/workflows/cicd_8-manual-deploy.yml
+++ b/.github/workflows/cicd_8-manual-deploy.yml
@@ -62,7 +62,7 @@
 # ─────────────────────────────────────────────────────────────
 
 name: '-8 Manual Deploy'
-run-name: 'Manual${{ inputs.ref && format(" [{0}]", inputs.ref) || "" }}${{ inputs.java_version && format(" ({0})", inputs.java_version) || "" }}${{ inputs.custom_tag && format(" → {0}", inputs.custom_tag) || "" }}'
+run-name: "Manual${{ inputs.ref && format(' [{0}]', inputs.ref) || '' }}${{ inputs.java_version && format(' ({0})', inputs.java_version) || '' }}${{ inputs.custom_tag && format(' → {0}', inputs.custom_tag) || '' }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/cicd_8-manual-deploy.yml
+++ b/.github/workflows/cicd_8-manual-deploy.yml
@@ -73,12 +73,12 @@ on:
     inputs:
       # ── Common inputs (needed by most developers) ──────────────────────────
       ref:
-        description: 'Branch, tag, or commit SHA to build. Leave empty to build from the "Use workflow from" branch — same behavior as the legacy workflow. Set explicitly when you want to run the latest workflow code from main while building a different branch (e.g., workflow from main, code from issue-33882-feature).'
+        description: 'Branch, tag, or commit SHA to build. Leave empty to build from the "Use workflow from" branch. Set explicitly when you want to run the latest workflow code from main while building a different branch (e.g., workflow from main, code from issue-33882-feature).'
         required: false
         type: string
         default: ''
       custom_tag:
-        description: 'Extra Docker tag applied after the build — replaces "Custom Docker Image Tag" from the legacy workflow. Creates dotcms/dotcms:{your-tag} as an alias pointing to the same image. Leave empty to rely only on the automatic tags (e.g., manual, manual_issue-33882-primeng-update).'
+        description: 'Optional human-readable alias tag applied after the build (e.g., modernization, java25-testing). Creates dotcms/dotcms:{your-tag} pointing to the same image as the automatic tags. Leave empty to rely only on the automatic tags (e.g., manual, manual_issue-33882-primeng-update).'
         required: false
         type: string
       java_version:

--- a/.github/workflows/cicd_8-manual-deploy.yml
+++ b/.github/workflows/cicd_8-manual-deploy.yml
@@ -1,36 +1,96 @@
 #
 # Manual Deploy Workflow
 #
-# This workflow provides on-demand deployment of Docker images from any branch, tag, or commit.
-# It's designed for testing feature branches, deploying hotfixes, or creating ad-hoc builds.
+# On-demand deployment of Docker images from any branch, tag, or commit.
+# Designed for testing feature branches, deploying hotfixes, or creating ad-hoc builds.
 #
+# ─────────────────────────────────────────────────────────────
+# How Docker tags are produced
+# ─────────────────────────────────────────────────────────────
+# All deployments use environment='manual' (fixed). Tags follow the standard pattern:
 #
-# Important: GitHub "environment" vs "version"
-# - environment: Used for GitHub deployment UI grouping (categorical: manual, feature-test, hotfix, release-java25)
-# - version: Used for Docker tags and artifact naming (unique: feature-test-123, manual-20240216)
+#   manual[_{suffix}]          ← mutable base tag  (e.g., manual, manual_java25)
+#   manual[_{suffix}]_{sha}    ← immutable, always created
+#   manual[_{suffix}]_{ref}    ← mutable alias, ref-derived (when ref is not protected)
+#   {custom_tag}               ← optional exact alias chosen by the developer
 #
+# effective_artifact_suffix priority: explicit artifact_suffix → java_version major → empty
+#
+# ref-derived alias format: manual[_{suffix}]_{sanitized-ref}
+#   ref=issue-33882-primeng, no java  → manual_issue-33882-primeng
+#   ref=issue-33882-primeng, java25   → manual_issue-33882-primeng_java25
+#   ref=main, release-*, v[0-9]*      → no alias (protected refs)
+#
+# version input is for Maven artifact isolation ONLY – does NOT affect Docker tags.
+# Auto-derives from 'ref' when empty.
+#
+# ─────────────────────────────────────────────────────────────
+# Migration from legacy-release_publish-dotcms-docker-image.yml
+# ─────────────────────────────────────────────────────────────
+#
+# MOST COMMON PATTERN – replaces "modernization" builds (legacy-compatible):
+#   Old:  Actions → "Build/Push dotCMS docker image" → select branch → custom_tag=modernization
+#   New:  Actions → "-8 Manual Deploy" → "Use workflow from" → select branch → custom_tag=modernization
+#           ref: (leave empty — build ref defaults to the "Use workflow from" branch)
+#   Result: dotcms/dotcms:manual  +  dotcms/dotcms:manual_issue-33882-primeng-update
+#           + dotcms/dotcms:modernization
+#
+# BRANCH-ONLY PATTERN – no custom_tag, leave ref empty:
+#   "Use workflow from": issue-33882-primeng-update   (ref left empty)
+#   Result: dotcms/dotcms:manual  +  dotcms/dotcms:manual_issue-33882-primeng-update
+#
+# DECOUPLED PATTERN – run latest workflow against a feature branch:
+#   "Use workflow from": main   (latest workflow code)
+#   ref: issue-33882-primeng-update   (branch to build)
+#   Result: same tags, but workflow logic is always from main
+#
+# JAVA VARIANT PATTERN:
+#   ref:          issue-33865-java-25-part2
+#   java_version: 25.0.2-ms
+#   custom_tag:   java25-testing
+#   Result: dotcms/dotcms:manual_java25  +  dotcms/dotcms:manual_issue-33865-java-25-part2_java25
+#           + dotcms/dotcms:java25-testing
+#   -OR- without custom_tag:
+#   Result: dotcms/dotcms:manual_java25  +  dotcms/dotcms:manual_issue-33865-java-25-part2_java25
+#
+# LTS/HOTFIX PATTERN – release refs are protected (no auto-alias):
+#   ref: release-24.12.27_lts
+#   Result: dotcms/dotcms:manual  +  dotcms/dotcms:manual_{sha}  (no ref alias)
+#
+# ─────────────────────────────────────────────────────────────
 # This workflow replaces legacy-release_publish-dotcms-docker-image.yml
-# with a modern, modular approach that's consistent with the CI/CD pipeline.
-#
+# ─────────────────────────────────────────────────────────────
 
 name: '-8 Manual Deploy'
+run-name: 'Manual${{ inputs.ref && format(" [{0}]", inputs.ref) || "" }}${{ inputs.java_version && format(" ({0})", inputs.java_version) || "" }}${{ inputs.custom_tag && format(" → {0}", inputs.custom_tag) || "" }}'
 
 on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Branch, tag, or commit SHA to build (e.g., main, issue-123-feature, release-25.01.01)'
-        required: true
+        description: 'Branch, tag, or commit SHA to build (e.g., main, issue-123-feature, release-25.01.01). Leave empty to build from the same branch as "Use workflow from" — matching legacy behavior. Set explicitly to separate workflow source from build source (e.g., run latest workflow from main while building from a feature branch).'
+        required: false
         type: string
-      environment:
-        description: 'GitHub deployment environment (categorical: manual, feature-test, hotfix, release, release-java25). Used for GitHub UI grouping, NOT artifact naming.'
-        required: true
+        default: ''
+      custom_tag:
+        description: 'Human-readable Docker tag to apply after build (e.g., modernization, java25-testing, qa-env-1). This is the tag most developers use to identify their build.'
+        required: false
         type: string
-        default: 'manual'
+      java_version:
+        description: 'Override Java version (SDKMAN format, e.g., 25.0.2-ms). Leave empty to use default Java 21 from .sdkmanrc.'
+        required: false
+        type: string
+        default: ''
       version:
-        description: 'Version for Docker tag and artifacts (e.g., feature-test-123, manual-20240216). Prevent collision: never use actual release versions!'
-        required: true
+        description: 'Maven artifact version identifier. Optional – auto-derived from ref when empty. Does NOT affect Docker tags. Only set if you need a specific artifact version (e.g., hotfix-25.01.01).'
+        required: false
         type: string
+        default: ''
+      artifact_suffix:
+        description: 'Advanced: explicit artifact suffix override (e.g., java25-ms). When empty, auto-derives from java_version (e.g., java25). Only needed for fine-grained control independent of java_version (e.g., java25-ms vs java25).'
+        required: false
+        type: string
+        default: ''
       deploy_dev_image:
         description: 'Also deploy dev image (dotcms/dotcms-dev)'
         type: boolean
@@ -39,54 +99,70 @@ on:
         description: 'Tag as latest (use cautiously - typically only for main branch deployments)'
         type: boolean
         default: false
-      custom_tag:
-        description: 'Additional custom Docker tag (optional, e.g., customer-demo, qa-env-1)'
-        required: false
-        type: string
-      java_version:
-        description: 'Override Java version (SDKMAN format, e.g., 25.0.2-ms). Leave empty for default Java 21.'
-        required: false
-        type: string
-        default: ''
-      artifact_suffix:
-        description: 'Artifact suffix without leading separator (e.g., java25-ms, manual). If not set, derived from java-version major. REQUIRED to prevent artifact collision!'
-        required: false
-        type: string
-        default: 'manual'
       allow_release_override:
         description: '⚠️ DANGER: Allow overriding actual release artifacts in Maven/Artifactory. Only enable if you know what you are doing!'
         type: boolean
         default: false
 
-# Allow concurrent manual deploys but prevent duplicate runs for same ref+version+java
+# Allow concurrent manual deploys but prevent duplicate runs for same ref+java+custom_tag
 concurrency:
-  group: manual-deploy-${{ github.event.inputs.ref }}-${{ github.event.inputs.version }}-${{ github.event.inputs.java_version }}
+  group: manual-deploy-${{ github.event.inputs.ref || github.ref_name }}-${{ github.event.inputs.java_version }}-${{ github.event.inputs.custom_tag }}
   cancel-in-progress: true
 
 jobs:
   # Safety checks - prevent accidental artifact collision
+  # Also computes effective_version (auto-derived from ref when version input is empty)
   safety-check:
     name: Safety Check
     runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
     outputs:
       safe_to_proceed: ${{ steps.validate.outputs.safe_to_proceed }}
       warning_message: ${{ steps.validate.outputs.warning_message }}
+      effective_version: ${{ steps.validate.outputs.effective_version }}
+      effective_artifact_suffix: ${{ steps.validate.outputs.effective_artifact_suffix }}
+      effective_ref_tag: ${{ steps.validate.outputs.effective_ref_tag }}
+      effective_ref: ${{ steps.validate.outputs.effective_ref }}
     steps:
       - name: Validate Inputs
         id: validate
         run: |
           VERSION="${{ inputs.version }}"
+
+          # Resolve build ref: explicit input takes priority, otherwise fall back to the
+          # dispatch branch ("Use workflow from"). This preserves legacy behavior when ref
+          # is left empty, while allowing workflow source and build source to differ.
+          if [[ -n "${{ inputs.ref }}" ]]; then
+            REF="${{ inputs.ref }}"
+            echo "ℹ️  Using explicit ref: '${REF}'"
+          else
+            REF="${{ github.ref_name }}"
+            echo "ℹ️  No ref provided — using dispatch branch: '${REF}'"
+          fi
+
           ARTIFACT_SUFFIX="${{ inputs.artifact_suffix }}"
+          JAVA_VERSION="${{ inputs.java_version }}"
+          CUSTOM_TAG="${{ inputs.custom_tag }}"
           ALLOW_OVERRIDE="${{ inputs.allow_release_override }}"
 
-          # Check if version looks like a release version (yy.mm.dd-## or yy.mm.dd_lts_v##)
-          if [[ "${VERSION}" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]{2}(-[0-9]{1,2}|_lts_v[0-9]{1,2})$ ]]; then
+          # Auto-derive version from ref when not provided
+          # Version is used only for Maven artifact naming, not Docker tags
+          if [[ -z "${VERSION}" ]]; then
+            # Sanitize ref for use as Maven version: replace / with -
+            EFFECTIVE_VERSION=$(echo "${REF}" | tr '/' '-')
+            echo "ℹ️  Version not set - auto-derived from ref: '${EFFECTIVE_VERSION}'"
+          else
+            EFFECTIVE_VERSION="${VERSION}"
+          fi
+          echo "effective_version=${EFFECTIVE_VERSION}" >> "$GITHUB_OUTPUT"
+
+          # Check if effective_version looks like a release version (yy.mm.dd-## or yy.mm.dd_lts_v##)
+          if [[ "${EFFECTIVE_VERSION}" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]{2}(-[0-9]{1,2}|_lts_v[0-9]{1,2})$ ]]; then
             if [[ "${ALLOW_OVERRIDE}" != "true" ]]; then
-              echo "❌ ERROR: Version '${VERSION}' matches release version pattern!"
+              echo "❌ ERROR: Version '${EFFECTIVE_VERSION}' matches release version pattern!"
               echo "This could overwrite actual release artifacts in Maven/Artifactory."
               echo ""
               echo "To proceed, you must:"
-              echo "1. Use a different version name (e.g., ${VERSION}-test, manual-${VERSION})"
+              echo "1. Use a different version name (e.g., ${EFFECTIVE_VERSION}-test, manual-${EFFECTIVE_VERSION})"
               echo "2. OR set allow_release_override: true (dangerous!)"
               echo ""
               echo "safe_to_proceed=false" >> "$GITHUB_OUTPUT"
@@ -98,19 +174,66 @@ jobs:
             fi
           fi
 
-          # Warn if artifact_suffix is empty or default
-          if [[ -z "${ARTIFACT_SUFFIX}" || "${ARTIFACT_SUFFIX}" == "manual" ]]; then
-            echo "✅ Using artifact suffix: '${ARTIFACT_SUFFIX:-manual}' (safe - prevents collision)"
-          else
-            echo "✅ Using custom artifact suffix: '${ARTIFACT_SUFFIX}'"
-          fi
-
           # Warn if version is too generic
-          if [[ "${VERSION}" == "main" || "${VERSION}" == "master" || "${VERSION}" == "latest" ]]; then
-            echo "⚠️  WARNING: Generic version name '${VERSION}' may cause confusion"
-            echo "Consider using a more specific version like 'manual-$(date +%Y%m%d)' or 'feature-test-123'"
+          if [[ "${EFFECTIVE_VERSION}" == "main" || "${EFFECTIVE_VERSION}" == "master" || "${EFFECTIVE_VERSION}" == "latest" ]]; then
+            echo "⚠️  WARNING: Generic version name '${EFFECTIVE_VERSION}' may cause confusion"
+            echo "Consider setting an explicit version like 'manual-$(date +%Y%m%d)' or 'feature-test-123'"
           fi
 
+          # Compute effective artifact suffix (drives Docker base tag and Maven namespace)
+          # Priority: explicit artifact_suffix → java_version major → empty
+          # Note: custom_tag does NOT affect the base tag - it is a separate alias only
+          if [[ -n "${ARTIFACT_SUFFIX}" ]]; then
+            EFFECTIVE_ARTIFACT_SUFFIX="${ARTIFACT_SUFFIX}"
+            echo "✅ Using explicit artifact suffix: '${EFFECTIVE_ARTIFACT_SUFFIX}'"
+          elif [[ -n "${JAVA_VERSION}" ]]; then
+            JAVA_MAJOR=$(echo "${JAVA_VERSION}" | grep -oE '^[0-9]+')
+            EFFECTIVE_ARTIFACT_SUFFIX="java${JAVA_MAJOR}"
+            echo "ℹ️  Artifact suffix derived from java_version: '${EFFECTIVE_ARTIFACT_SUFFIX}'"
+          else
+            EFFECTIVE_ARTIFACT_SUFFIX=""
+            echo "ℹ️  No artifact suffix - standard build (base tag: manual)"
+          fi
+          echo "effective_artifact_suffix=${EFFECTIVE_ARTIFACT_SUFFIX}" >> "$GITHUB_OUTPUT"
+
+          # Compute ref-derived tag identifier for build discoverability.
+          # This is passed to the deployment phase as tag-identifier, which creates
+          # manual[_{suffix}]_{identifier} (e.g., manual_issue-33882 or manual_java25_issue-33882).
+          # Protected refs (main, master, release-*, v[0-9]*) are skipped to avoid overwriting official images.
+          # Sanitize: replace / with -, strip invalid Docker tag chars, cap at 100 chars
+          if [[ "${REF}" == "main" || "${REF}" == "master" ]]; then
+            EFFECTIVE_REF_TAG=""
+            echo "ℹ️  Skipping ref-derived tag for main/master (protected ref)"
+          elif [[ "${REF}" =~ ^release- || "${REF}" =~ ^v[0-9] ]]; then
+            EFFECTIVE_REF_TAG=""
+            echo "ℹ️  Skipping ref-derived tag for release ref (protected ref)"
+          else
+            EFFECTIVE_REF_TAG=$(echo "${REF}" | tr '/' '-' | tr -cd 'a-zA-Z0-9_.-' | cut -c1-100)
+            echo "ℹ️  Ref-derived tag identifier: '${EFFECTIVE_REF_TAG}'"
+          fi
+          echo "effective_ref_tag=${EFFECTIVE_REF_TAG}" >> "$GITHUB_OUTPUT"
+
+          # Safety check: prevent custom_tag from overwriting official images
+          if [[ -n "${CUSTOM_TAG}" ]]; then
+            # Block protected workflow tags
+            if [[ "${CUSTOM_TAG}" == "latest" || "${CUSTOM_TAG}" == "trunk" || "${CUSTOM_TAG}" == "nightly" ]]; then
+              echo "❌ ERROR: custom_tag '${CUSTOM_TAG}' is a protected workflow tag that cannot be overwritten"
+              echo "safe_to_proceed=false" >> "$GITHUB_OUTPUT"
+              echo "warning_message=custom_tag '${CUSTOM_TAG}' is protected" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+            # Block release version patterns (yy.mm.dd-## or yy.mm.dd_lts_v##)
+            if [[ "${CUSTOM_TAG}" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]{2}(-[0-9]{1,2}|_lts(_v[0-9]{1,2})?)$ ]]; then
+              echo "❌ ERROR: custom_tag '${CUSTOM_TAG}' matches a release version pattern"
+              echo "This would overwrite an official release Docker image!"
+              echo "safe_to_proceed=false" >> "$GITHUB_OUTPUT"
+              echo "warning_message=custom_tag '${CUSTOM_TAG}' matches release version pattern" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
+            echo "✅ Custom tag '${CUSTOM_TAG}' validated"
+          fi
+
+          echo "effective_ref=${REF}" >> "$GITHUB_OUTPUT"
           echo "safe_to_proceed=true" >> "$GITHUB_OUTPUT"
           echo "warning_message=" >> "$GITHUB_OUTPUT"
 
@@ -120,7 +243,7 @@ jobs:
     needs: [ safety-check ]
     uses: ./.github/workflows/cicd_comp_initialize-phase.yml
     with:
-      validation-level: 'none'
+      change-detection: 'disabled'  # Manual deploy builds everything - no change detection needed
 
   # Build - standard build phase with custom ref and version
   build:
@@ -130,30 +253,36 @@ jobs:
     with:
       core-build: true
       run-pr-checks: false
-      ref: ${{ inputs.ref }}
+      ref: ${{ needs.safety-check.outputs.effective_ref }}
       validate: false
-      version: ${{ inputs.version }}
+      version: ${{ needs.safety-check.outputs.effective_version }}
       generate-docker: true
       java-version: ${{ inputs.java_version }}
-      artifact-suffix: ${{ inputs.artifact_suffix }}
+      artifact-suffix: ${{ needs.safety-check.outputs.effective_artifact_suffix }}
     permissions:
       contents: read
       packages: write
 
   # Deployment - standard deployment phase
-  # Note: Deploys Docker images to Docker Hub
-  # Note: Deploys CLI artifacts to Artifactory (namespace protected by artifact-suffix)
+  # Primary Docker tags (from deploy-docker action):
+  #   manual[_{suffix}]        ← mutable base tag  (e.g., manual, manual_java25)
+  #   manual[_{suffix}]_{sha}  ← immutable
+  # Alias tags (pushed after build):
+  #   manual[_{suffix}]_{ref}  ← mutable, ref-derived (when effective_ref_tag is set)
+  #   {custom_tag}             ← optional developer alias (pulled from immutable SHA tag)
   deployment:
     name: Deployment
     needs: [ safety-check, initialize, build ]
     uses: ./.github/workflows/cicd_comp_deployment-phase.yml
     with:
-      environment: ${{ inputs.environment }}
+      environment: 'manual'
+      tag-identifier: ${{ needs.safety-check.outputs.effective_ref_tag }}
+      custom-tag: ${{ inputs.custom_tag }}
       artifact-run-id: ${{ github.run_id }}
       deploy-dev-image: ${{ inputs.deploy_dev_image }}
       latest: ${{ inputs.latest }}
       java-version: ${{ inputs.java_version }}
-      artifact-suffix: ${{ inputs.artifact_suffix }}
+      artifact-suffix: ${{ needs.safety-check.outputs.effective_artifact_suffix }}
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
@@ -172,64 +301,24 @@ jobs:
       artifact-run-id: ${{ github.run_id }}
       needsData: ${{ toJson(needs) }}
 
-  # Custom tag application (if provided)
-  apply-custom-tag:
-    name: Apply Custom Tag
-    if: success() && inputs.custom_tag != ''
-    needs: [ deployment ]
-    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3.0.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Apply Custom Tag
-        run: |
-          # Compute the primary tag from version + artifact suffix
-          VERSION="${{ inputs.version }}"
-          ARTIFACT_SUFFIX="${{ inputs.artifact_suffix }}"
-
-          # Docker uses underscore separator for suffix
-          if [[ -n "${ARTIFACT_SUFFIX}" ]]; then
-            PRIMARY_TAG="${VERSION}_${ARTIFACT_SUFFIX}"
-          else
-            PRIMARY_TAG="${VERSION}"
-          fi
-
-          CUSTOM_TAG="${{ inputs.custom_tag }}"
-
-          echo "Pulling image: dotcms/dotcms:${PRIMARY_TAG}"
-          docker pull dotcms/dotcms:${PRIMARY_TAG}
-
-          echo "Tagging as: dotcms/dotcms:${CUSTOM_TAG}"
-          docker tag dotcms/dotcms:${PRIMARY_TAG} dotcms/dotcms:${CUSTOM_TAG}
-
-          echo "Pushing custom tag: dotcms/dotcms:${CUSTOM_TAG}"
-          docker push dotcms/dotcms:${CUSTOM_TAG}
-
-          echo "✅ Custom tag applied: dotcms/dotcms:${CUSTOM_TAG}"
-
   # Summary notification
   summary:
     name: Deployment Summary
     if: always()
-    needs: [ safety-check, deployment, apply-custom-tag ]
+    needs: [ safety-check, deployment ]
     runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
     steps:
       - name: Deployment Summary
         run: |
           echo "## 🚀 Manual Deployment Complete" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Ref:** \`${{ inputs.ref }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**GitHub Environment:** \`${{ inputs.environment }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** \`${{ inputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Artifact Suffix:** \`${{ inputs.artifact_suffix || '(none)' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Docker Tags:** \`${{ needs.deployment.outputs.docker_tags }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Build Ref:** \`${{ needs.safety-check.outputs.effective_ref }}\`${{ inputs.ref == '' && ' *(from dispatch branch)*' || '' }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Workflow Ref:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment (base Docker tag):** \`manual\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Maven Artifact Version:** \`${{ needs.safety-check.outputs.effective_version }}\`" >> $GITHUB_STEP_SUMMARY
 
-          if [[ -n "${{ inputs.custom_tag }}" ]]; then
-            echo "**Custom Tag:** \`dotcms/dotcms:${{ inputs.custom_tag }}\`" >> $GITHUB_STEP_SUMMARY
+          if [[ -n "${{ needs.safety-check.outputs.effective_artifact_suffix }}" ]]; then
+            echo "**Artifact Suffix:** \`${{ needs.safety-check.outputs.effective_artifact_suffix }}\`" >> $GITHUB_STEP_SUMMARY
           fi
 
           if [[ -n "${{ inputs.java_version }}" ]]; then
@@ -246,12 +335,49 @@ jobs:
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Usage" >> $GITHUB_STEP_SUMMARY
+          echo "### Docker Tags" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Base tags (from deployment phase):**" >> $GITHUB_STEP_SUMMARY
+          for tag in ${{ needs.deployment.outputs.docker_tags }}; do
+            echo "- \`${tag}\`" >> $GITHUB_STEP_SUMMARY
+          done
+
+          SUFFIX="${{ needs.safety-check.outputs.effective_artifact_suffix }}"
+          REF_ID="${{ needs.safety-check.outputs.effective_ref_tag }}"
+          if [[ -n "${REF_ID}" ]]; then
+            if [[ -n "${SUFFIX}" ]]; then
+              echo "- \`dotcms/dotcms:manual_${REF_ID}_${SUFFIX}\`  ← ref alias" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "- \`dotcms/dotcms:manual_${REF_ID}\`  ← ref alias" >> $GITHUB_STEP_SUMMARY
+            fi
+          fi
+
+          if [[ -n "${{ inputs.custom_tag }}" ]]; then
+            echo "- \`dotcms/dotcms:${{ inputs.custom_tag }}\`  ← custom tag alias" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Pull Commands" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "docker pull dotcms/dotcms:${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          if [[ -n "${{ inputs.custom_tag }}" ]]; then
+            echo "# Primary (custom tag):" >> $GITHUB_STEP_SUMMARY
+            echo "docker pull dotcms/dotcms:${{ inputs.custom_tag }}" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [[ -n "${REF_ID}" ]]; then
+            echo "# By branch:" >> $GITHUB_STEP_SUMMARY
+            if [[ -n "${SUFFIX}" ]]; then
+              echo "docker pull dotcms/dotcms:manual_${REF_ID}_${SUFFIX}" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "docker pull dotcms/dotcms:manual_${REF_ID}" >> $GITHUB_STEP_SUMMARY
+            fi
+          fi
+          if [[ -z "${{ inputs.custom_tag }}" && -z "${REF_ID}" ]]; then
+            for tag in ${{ needs.deployment.outputs.docker_tags }}; do
+              echo "docker pull ${tag}" >> $GITHUB_STEP_SUMMARY
+            done
+          fi
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Artifact Namespace" >> $GITHUB_STEP_SUMMARY
-          echo "Maven artifacts deployed with suffix: \`${{ inputs.artifact_suffix || '(default)' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "This prevents collision with actual release artifacts." >> $GITHUB_STEP_SUMMARY
+          echo "### Maven Artifact Namespace" >> $GITHUB_STEP_SUMMARY
+          echo "Version: \`${{ needs.safety-check.outputs.effective_version }}\`, Suffix: \`${{ needs.safety-check.outputs.effective_artifact_suffix || '(none)' }}\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cicd_8-manual-deploy.yml
+++ b/.github/workflows/cicd_8-manual-deploy.yml
@@ -14,6 +14,10 @@
 #   manual[_{suffix}]_{ref}    ← mutable alias, ref-derived (when ref is not protected)
 #   {custom_tag}               ← optional exact alias chosen by the developer
 #
+# Note: 'latest' tagging is intentionally not available in this workflow.
+# Manual builds are feature/hotfix builds and should never overwrite the official
+# 'latest' tag. Use the release workflow (cicd_6) for that.
+#
 # effective_artifact_suffix priority: explicit artifact_suffix → java_version major → empty
 #
 # ref-derived alias format: manual[_{suffix}]_{sanitized-ref}
@@ -67,13 +71,14 @@ run-name: "Manual [${{ inputs.ref || github.ref_name }}]${{ inputs.java_version 
 on:
   workflow_dispatch:
     inputs:
+      # ── Common inputs (needed by most developers) ──────────────────────────
       ref:
-        description: 'Branch, tag, or commit SHA to build (e.g., main, issue-123-feature, release-25.01.01). Leave empty to build from the same branch as "Use workflow from" — matching legacy behavior. Set explicitly to separate workflow source from build source (e.g., run latest workflow from main while building from a feature branch).'
+        description: 'Branch, tag, or commit SHA to build. Leave empty to build from the "Use workflow from" branch — same behavior as the legacy workflow. Set explicitly when you want to run the latest workflow code from main while building a different branch (e.g., workflow from main, code from issue-33882-feature).'
         required: false
         type: string
         default: ''
       custom_tag:
-        description: 'Human-readable Docker tag to apply after build (e.g., modernization, java25-testing, qa-env-1). This is the tag most developers use to identify their build.'
+        description: 'Extra Docker tag applied after the build — replaces "Custom Docker Image Tag" from the legacy workflow. Creates dotcms/dotcms:{your-tag} as an alias pointing to the same image. Leave empty to rely only on the automatic tags (e.g., manual, manual_issue-33882-primeng-update).'
         required: false
         type: string
       java_version:
@@ -81,24 +86,21 @@ on:
         required: false
         type: string
         default: ''
+      deploy_dev_image:
+        description: 'Also push a dev image (dotcms/dotcms-dev) alongside the standard image.'
+        type: boolean
+        default: false
+      # ── Advanced inputs (leave at defaults for normal feature-branch builds) ─
       version:
-        description: 'Maven artifact version identifier. Optional – auto-derived from ref when empty. Does NOT affect Docker tags. Only set if you need a specific artifact version (e.g., hotfix-25.01.01).'
+        description: 'Advanced: Maven artifact version. Auto-derived from ref when empty. Does NOT affect Docker tags — only controls how Maven names the built JARs. Set only when you need artifact isolation for a specific hotfix (e.g., hotfix-25.01.01).'
         required: false
         type: string
         default: ''
       artifact_suffix:
-        description: 'Advanced: explicit artifact suffix override (e.g., java25-ms). When empty, auto-derives from java_version (e.g., java25). Only needed for fine-grained control independent of java_version (e.g., java25-ms vs java25).'
+        description: 'Advanced: renames the Docker base-tag namespace AND Maven artifact namespace (e.g., java25-ms makes the base tag manual_java25-ms instead of manual_java25). Auto-derived from java_version when empty. This is unrelated to custom_tag — it does not add an extra alias tag, it changes the base tag itself. Leave empty unless you need a suffix distinct from what java_version derives.'
         required: false
         type: string
         default: ''
-      deploy_dev_image:
-        description: 'Also deploy dev image (dotcms/dotcms-dev)'
-        type: boolean
-        default: false
-      latest:
-        description: 'Tag as latest (use cautiously - typically only for main branch deployments)'
-        type: boolean
-        default: false
       allow_release_override:
         description: '⚠️ DANGER: Allow overriding actual release artifacts in Maven/Artifactory. Only enable if you know what you are doing!'
         type: boolean
@@ -280,7 +282,6 @@ jobs:
       custom-tag: ${{ inputs.custom_tag }}
       artifact-run-id: ${{ github.run_id }}
       deploy-dev-image: ${{ inputs.deploy_dev_image }}
-      latest: ${{ inputs.latest }}
       java-version: ${{ inputs.java_version }}
       artifact-suffix: ${{ needs.safety-check.outputs.effective_artifact_suffix }}
     secrets:

--- a/.github/workflows/cicd_8-manual-deploy.yml
+++ b/.github/workflows/cicd_8-manual-deploy.yml
@@ -62,7 +62,7 @@
 # ─────────────────────────────────────────────────────────────
 
 name: '-8 Manual Deploy'
-run-name: "Manual${{ inputs.ref && format(' [{0}]', inputs.ref) || '' }}${{ inputs.java_version && format(' ({0})', inputs.java_version) || '' }}${{ inputs.custom_tag && format(' → {0}', inputs.custom_tag) || '' }}"
+run-name: "Manual [${{ inputs.ref || github.ref_name }}]${{ inputs.java_version && format(' ({0})', inputs.java_version) || '' }}${{ inputs.custom_tag && format(' → {0}', inputs.custom_tag) || '' }}"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -300,10 +300,11 @@ jobs:
 
       # Deploy CLI artifacts to JFrog Artifactory
       # Skipped when java-version is overridden (CLI not built due to GraalVM/Quarkus compatibility)
+      # Skipped for manual environment (feature branch builds should not publish CLI artifacts)
       - name: CLI Deploy
         continue-on-error: true
         id: cli_deploy
-        if: steps.get-sdkman-version.outputs.java_suffix == ''
+        if: steps.get-sdkman-version.outputs.java_suffix == '' && inputs.environment != 'manual'
         uses: ./.github/actions/core-cicd/deployment/deploy-jfrog
         with:
           artifactory-username: ${{ secrets.EE_REPO_USERNAME }}

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -80,6 +80,9 @@ on:
       deploy-dev-image:
         default: false
         type: boolean
+      deploy-cli:
+        default: false
+        type: boolean
       publish-npm-cli:
         default: false
         type: boolean
@@ -300,11 +303,11 @@ jobs:
 
       # Deploy CLI artifacts to JFrog Artifactory
       # Skipped when java-version is overridden (CLI not built due to GraalVM/Quarkus compatibility)
-      # Skipped for manual environment (feature branch builds should not publish CLI artifacts)
+      # Skipped when deploy-cli is false (e.g., manual builds should not publish CLI artifacts)
       - name: CLI Deploy
         continue-on-error: true
         id: cli_deploy
-        if: steps.get-sdkman-version.outputs.java_suffix == '' && inputs.environment != 'manual'
+        if: inputs.deploy-cli && steps.get-sdkman-version.outputs.java_suffix == ''
         uses: ./.github/actions/core-cicd/deployment/deploy-jfrog
         with:
           artifactory-username: ${{ secrets.EE_REPO_USERNAME }}

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -10,6 +10,35 @@
 # - Artifact deployment to JFrog Artifactory
 # - CLI publishing to NPM
 # - Slack notifications for Docker image and CLI deployments
+#
+# Tag model:
+#   Each workflow type produces a consistent set of Docker tags:
+#
+#   trunk:   trunk               ← mutable, always latest trunk
+#            trunk_{sha}         ← immutable
+#
+#   nightly: nightly             ← mutable, always latest nightly
+#            nightly_{date}      ← mutable, date the nightly covers (tag-identifier=YYYYMMDD)
+#            nightly_{sha}       ← immutable
+#
+#   release: {version}           ← mutable, e.g. 25.02.16-01  (omit-environment-prefix=true)
+#            {version}_{sha}     ← immutable
+#            latest              ← mutable, points to the latest release (when latest=true)
+#
+#   manual:  manual              ← mutable, always latest manual build
+#            manual_{sha}        ← immutable
+#            manual_{ref}        ← mutable alias (tag-identifier = sanitized ref branch)
+#            {custom-tag}        ← optional exact alias chosen by the developer
+#
+#   Java variant suffix (_java25 etc.) is part of the base tag; in identifier aliases
+#   the identifier comes first (matching the release pattern 25.02.16-01_java25):
+#     nightly_java25, nightly_java25_{sha}, nightly_{date}_java25
+#     manual_java25,  manual_java25_{sha},  manual_{ref}_java25
+#
+#   All tags (base, sha, identifier alias, custom) are applied in a single docker build.
+#   The deploy-docker action accepts semantic inputs (identifier-tag, custom-tag); the
+#   identifier_tag value is computed by the Compute Docker Tags step in this workflow.
+#   extra-tags on deploy-docker is an escape hatch for any future advanced cases.
 
 name: Deployment Phase
 
@@ -17,9 +46,31 @@ on:
   workflow_call:
     inputs:
       environment:
-        description: 'The environment to deploy to'
+        description: 'GitHub environment for deployment grouping and secrets (e.g., trunk, nightly, release, manual)'
         required: true
         type: string
+      tag-identifier:
+        description: |
+          Optional specific identifier passed from the parent workflow. Creates a mutable alias tag
+          alongside the primary build tags. Each workflow passes its own identifying part:
+            nightly  → date string (YYYYMMDD) e.g. 20250218
+            release  → release version        e.g. 25.02.16-01
+            manual   → sanitized ref/branch   e.g. issue-33882-feature-x
+          The alias tag is formed as {base}_{identifier}, e.g. nightly_20250218.
+          When omit-environment-prefix is true (release), the identifier IS the primary tag.
+        required: false
+        type: string
+        default: ''
+      omit-environment-prefix:
+        description: 'For release: use tag-identifier as the primary tag instead of environment. Environment is still used for GitHub environment grouping and secrets.'
+        required: false
+        type: boolean
+        default: false
+      custom-tag:
+        description: 'Optional exact alias tag, used by manual workflow for developer-chosen tag names (e.g., modernization, java25-testing). Pulled from the immutable SHA tag for reliability.'
+        required: false
+        type: string
+        default: ''
       artifact-run-id:
         default: ${{ github.run_id }}
         type: string
@@ -27,9 +78,6 @@ on:
         default: false
         type: boolean
       deploy-dev-image:
-        default: false
-        type: boolean
-      reuse-previous-build:
         default: false
         type: boolean
       publish-npm-cli:
@@ -159,7 +207,32 @@ jobs:
       # Clean up the runner to ensure a fresh environment
       - uses: ./.github/actions/core-cicd/cleanup-runner
 
-      # Build and push the main Docker image
+      # Compute Docker tags for this build.
+      #
+      # base_tag:       primary mutable tag — {identifier|environment}{suffix}
+      #                 e.g. nightly_java25, 25.02.16-01_java25, manual_java25
+      #
+      # identifier_tag: mutable alias — {environment}_{identifier}{suffix}
+      #                 e.g. nightly_20250218_java25, manual_issue-123_java25
+      #                 Empty (disabled) when:
+      #                   - no tag-identifier (trunk has none)
+      #                   - omit-environment-prefix=true (release: identifier IS the primary tag)
+      - name: Compute Docker Tags
+        id: docker-tags
+        shell: bash
+        run: |
+          BASE_TAG="${{ (inputs.omit-environment-prefix && inputs.tag-identifier) || inputs.environment }}${{ steps.get-sdkman-version.outputs.docker_suffix }}"
+          echo "base_tag=${BASE_TAG}" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "${{ inputs.tag-identifier }}" && "${{ inputs.omit-environment-prefix }}" != "true" ]]; then
+            IDENTIFIER_TAG="${{ inputs.environment }}_${{ inputs.tag-identifier }}${{ steps.get-sdkman-version.outputs.docker_suffix }}"
+          else
+            IDENTIFIER_TAG=""
+          fi
+          echo "identifier_tag=${IDENTIFIER_TAG}" >> "$GITHUB_OUTPUT"
+
+      # Build and push the main Docker image.
+      # All tags (base, sha, identifier alias, custom) are applied in a single build.
       - name: Build/Push Docker Image
         id: docker_build
         uses: ./.github/actions/core-cicd/deployment/deploy-docker
@@ -170,7 +243,7 @@ jobs:
           commit_id: ${{ github.sha }}
           ref: ${{ inputs.environment }}
           docker-use-ref: false
-          version: ${{ inputs.environment }}${{ steps.get-sdkman-version.outputs.docker_suffix }}
+          version: ${{ steps.docker-tags.outputs.base_tag }}
           latest: ${{ inputs.latest && steps.get-sdkman-version.outputs.docker_suffix == '' }}
           do_deploy: ${{ vars.DOCKER_DEPLOY || 'true' }}
           docker_io_username: ${{ secrets.DOCKER_USERNAME }}
@@ -179,8 +252,10 @@ jobs:
           pull: true
           artifact_suffix: ${{ steps.get-sdkman-version.outputs.maven_suffix }}
           build_args: |
-            DOTCMS_DOCKER_TAG=${{ inputs.environment }}${{ steps.get-sdkman-version.outputs.docker_suffix }}
+            DOTCMS_DOCKER_TAG=${{ steps.docker-tags.outputs.base_tag }}
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
+          identifier-tag: ${{ steps.docker-tags.outputs.identifier_tag }}
+          custom-tag: ${{ inputs.custom-tag }}
 
       # Format tags for Slack notifications
       - name: Format Tags
@@ -211,16 +286,17 @@ jobs:
           commit_id: ${{ github.sha }}
           ref: ${{ inputs.environment }}
           docker-use-ref: false
-          version: ${{ inputs.environment }}${{ steps.get-sdkman-version.outputs.docker_suffix }}
+          version: ${{ steps.docker-tags.outputs.base_tag }}
           latest: ${{ steps.get-sdkman-version.outputs.docker_suffix == '' }}
           do_deploy: ${{ vars.DOCKER_DEPLOY || 'true' }}
           docker_io_username: ${{ secrets.DOCKER_USERNAME }}
           docker_io_token: ${{ secrets.DOCKER_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_args: |
-            DOTCMS_DOCKER_TAG=${{ inputs.environment }}${{ steps.get-sdkman-version.outputs.docker_suffix }}
+            DOTCMS_DOCKER_TAG=${{ steps.docker-tags.outputs.base_tag }}
             DEV_REQUEST_TOKEN=${{ secrets.DEV_REQUEST_TOKEN }}
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
+          identifier-tag: ${{ steps.docker-tags.outputs.identifier_tag }}
 
       # Deploy CLI artifacts to JFrog Artifactory
       # Skipped when java-version is overridden (CLI not built due to GraalVM/Quarkus compatibility)
@@ -276,9 +352,9 @@ jobs:
             >
             > This automated script is happy to announce that a new *_dotCLI_* version *tagged as:* [ `${{ steps.cli_publish.outputs.npm-package-version }}, ${{ steps.cli_publish.outputs.npm-package-version-tag }}` ] is now available on the `NPM` registry :package:!
             > `npm i -g @dotcms/dotcli@${{ steps.cli_publish.outputs.npm-package-version-tag }}`
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }} 
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
 
-      # Send Slack notification for SDK publication (if required)          
+      # Send Slack notification for SDK publication (if required)
       - name: Slack Notification (SDK announcement)
         if: success() && steps.sdks_publish.outputs.published == 'true'
         uses: ./.github/actions/core-cicd/notification/notify-slack
@@ -288,4 +364,4 @@ jobs:
             > :large_orange_circle: *Attention dotters:* SDK libs (Angular, Client, Experiments and React) published!
             >
             > This automated script is happy to announce that a new *_SDK libs_* version *tagged as:* [ `${{ steps.sdks_publish.outputs.npm-package-version }}` ] is now available on the `NPM` registry :package:!
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}         
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
## Description

Fix the `cicd_8-manual-deploy.yml` workflow that was failing with invalid input parameters, and improve CI/CD infrastructure consistency across all workflows: run-name visibility, Docker image tag architecture, nightly build repeatability and tag ordering, and CLI artifact deployment control.

## Changes

### Bug Fixes (cicd_8 manual deploy)
- **Fix invalid inputs**: use `change-detection='disabled'` instead of the invalid `validation-level='none'`
- **Make `ref` input optional**: defaults to the dispatch branch, preserving legacy behavior and fixing the concurrency group fallback when `ref` is empty

### Run-Name Improvements (all workflows)
- **Add `run-name` to all CI/CD workflows** (`cicd_1` through `cicd_8`) so every run is identifiable in the GitHub Actions UI without opening it
- **Fix expression syntax**: switch run-name YAML strings from single-quoted to double-quoted so that GitHub Actions expression parser receives properly single-quoted string literals inside `${{ }}` — fixes `Unexpected symbol: '"' in expression` validation error (cicd_3, cicd_4, cicd_6, cicd_7, cicd_8)
- **Always show ref in manual deploy run-name**: fall back to `github.ref_name` when the `ref` input is empty, so the run name is always `Manual [branch-name]` rather than just `Manual`

### Nightly Build Repeatability (cicd_4)
- **New `setup` job** that determines the commit to build from before any other jobs run
- **Default behavior (scheduled and manual dispatch)**: finds the last commit on `main` at or before midnight UTC. This ensures repeatability — re-running a nightly later in the day to investigate a failure produces the exact same build as the scheduled run. The date tag (`nightly_YYYYMMDD`) labels the day covered (yesterday), not the day the workflow runs.
- **New `use-latest-commit` dispatch input**: set to `true` to build from the current `HEAD` of `main` instead, useful when you need to pick up commits made after midnight
- **All downstream jobs** (`build`, `deployment`, `finalize`) now depend on `setup` and pass through its `build-ref` and `tag-date` outputs

### Docker Image Tag Architecture (nightly + all builds)
- **Redesign tag inputs on `deploy-docker` action**: replace raw `type=raw,value=...,enable=` format strings with semantic `identifier-tag` / `custom-tag` inputs — callers express intent, not bake-meta syntax
- **Centralize tag computation**: `Compute Docker Tags` step consolidates all tag logic in clear bash `if/else`, replacing the previous `Compute Docker Base Tag` + scattered `enable=` expressions
- **Fix tag ordering**: identifier appears before suffix (`nightly_20250218_java25`, not `nightly_java25_20250218`), consistent with the release pattern
- **Retain `extra-tags`** as an escape hatch for advanced cases

### CLI Artifact Deployment Control
- **Add `deploy-cli` boolean input** to the deployment phase composite workflow (default: `false`); replaces the previous hardcoded `environment != 'manual'` name check
- **Explicit opt-in pattern**: trunk, nightly, and release callers set `deploy-cli: true`; manual deploys omit it and default to `false`, preventing accidental JFrog publishes from feature-branch builds — mirrors the same pattern used by `publish-npm-cli` and `publish-npm-sdk-libs`
- **Restore `publish-npm-sdk-libs`** condition to input-only guard (environment hardcoding removed)

### Miscellaneous
- **Remove dead code**: `reuse-previous-build` removed from all deployment-phase calls (only meaningful in the initialize phase)
- **Remove stale `java_version` default** from `cicd_7-release-java-variant` dispatch input (`'25.0.1-open'` was outdated); update description to reference the `RELEASE_JAVA_VARIANT_VERSION` repository variable used by push-triggered builds

## Files Changed

| File | What changed |
|------|-------------|
| `.github/actions/core-cicd/deployment/deploy-docker/action.yml` | New `identifier-tag`/`custom-tag` inputs; centralized tag computation |
| `.github/workflows/cicd_1-pr.yml` | Add `run-name` |
| `.github/workflows/cicd_2-merge-queue.yml` | Add `run-name` |
| `.github/workflows/cicd_3-trunk.yml` | Add `run-name` (fixed quotes); add `deploy-cli: true` |
| `.github/workflows/cicd_4-nightly.yml` | Add `setup` job for commit pinning; add `use-latest-commit` input; add `run-name` (fixed quotes); fix tag ordering; add `deploy-cli: true` |
| `.github/workflows/cicd_6-release.yml` | Fix `run-name` quotes; add `deploy-cli: true` |
| `.github/workflows/cicd_7-release-java-variant.yml` | Fix `run-name` quotes; remove stale `java_version` default |
| `.github/workflows/cicd_8-manual-deploy.yml` | Fix invalid inputs; make `ref` optional; fix `run-name` always shows ref |
| `.github/workflows/cicd_comp_deployment-phase.yml` | Add `deploy-cli` input; replace env-name guard with input guard |
| `.github/workflows/cicd_comp_initialize-phase.yml` | Minor cleanup |

## Testing

- Workflow YAML validates on push (GitHub Actions schema validation)
- Manual deploy workflow (`cicd_8`) can be triggered successfully end-to-end
- Docker tags produced with correct naming pattern and ordering
- `run-name` displays correctly in GitHub Actions UI for all workflow types
- CLI artifacts are not published when running manual/feature-branch builds
- Nightly default behavior pins to the midnight UTC commit, not current HEAD

Closes #34689

**Issue:** [DEFECT] Manual deploy workflow cicd_8manualdeploy

This PR fixes: #34689