### PR TITLE
Add /api/v1/content/_refresh endpoint for cache and index refresh

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -5799,6 +5799,45 @@ paths:
       summary: Lock a given contentlet by the current user
       tags:
       - Content
+  /v1/content/_refresh/{identifierOrInode}:
+    put:
+      description: Reindexes and clears cache for the contentlet specified by its
+        identifier or inode. This operation forces the content to be refreshed in
+        both the search index and application cache.
+      operationId: refreshContent
+      parameters:
+      - description: Contentlet identifier or inode
+        in: path
+        name: identifierOrInode
+        required: true
+        schema:
+          type: string
+      - description: Language ID for content localization
+        in: query
+        name: language
+        schema:
+          type: string
+          default: "-1"
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityBooleanView"
+          description: Successfully refreshed contentlet
+        "400":
+          description: Bad request - Invalid identifier format
+        "401":
+          description: Unauthorized - User not authenticated
+        "403":
+          description: Forbidden - User lacks write permissions
+        "404":
+          description: Content not found
+        "500":
+          description: Internal Server Error
+      summary: Refresh a contentlet
+      tags:
+      - Content
   /v1/content/_unlock/{inodeOrIdentifier}:
     put:
       description: "If the user is allowed to unlock the contentlet specified by its\

--- a/dotcms-postman/src/main/resources/postman/ContentResourceV1.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/ContentResourceV1.postman_collection.json
@@ -3047,6 +3047,64 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "RefreshContent",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "let id = pm.collectionVariables.get('contentletIdentifier');",
+                  "const responseJson = pm.response.json();",
+                  "",
+                  "pm.test(\"Valid response - Content refreshed successfully\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "    pm.expect(responseJson.entity).to.eql(true);",
+                  "});",
+                  "",
+                  "pm.test(\"Response structure is correct\", function () {",
+                  "    pm.expect(responseJson).to.have.property('entity');",
+                  "    pm.expect(responseJson).to.have.property('errors');",
+                  "    pm.expect(responseJson).to.have.property('messages');",
+                  "});",
+                  "",
+                  ""
+                ],
+                "type": "text/javascript",
+                "packages": {}
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{jwt}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "method": "PUT",
+            "header": [],
+            "url": {
+              "raw": "{{serverURL}}/api/v1/content/_refresh/{{contentletIdentifier}}",
+              "host": [
+                "{{serverURL}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "content",
+                "_refresh",
+                "{{contentletIdentifier}}"
+              ]
+            },
+            "description": "Refreshes a contentlet by reindexing it and clearing it from cache. This operation forces the content to be refreshed in both the search index and application cache. Returns a boolean value indicating success."
+          },
+          "response": []
         }
       ],
       "event": [


### PR DESCRIPTION
Closes #33587 

### Proposed Changes
* This PR introduces a new REST endpoint (/api/v1/content/_refresh) that allows manual refresh of a contentlet in the cache and the search index. This is particularly useful for troubleshooting cache-related issues and forcing content reindexing.
* A postman test has been included to verify the new endpoint.

### Checklist
- [x] Tests

This PR fixes: #33587