### PR TITLE
fix(ci): pass required change-detection input to initialize phase in Release CLI workflow (#34726)

### DIFF
--- a/.github/workflows/cicd_release-cli.yml
+++ b/.github/workflows/cicd_release-cli.yml
@@ -54,6 +54,8 @@ jobs:
   initialize:
     name: Initialize
     uses: ./.github/workflows/cicd_comp_initialize-phase.yml
+    with:
+      change-detection: 'disabled'
 
   # Perform pre-release checks and setup
   precheck:


### PR DESCRIPTION
## Description

`cicd_release-cli.yml` is the dedicated workflow responsible for building the CLI tool and publishing `@dotcms/dotcli` to NPM. It is triggered by GitHub Release creation events and is **separate from** `cicd_6-release.yml` (the main dotCMS product release), which explicitly skips NPM CLI publishing (`publish-npm-cli: false`).

A recent change made the `change-detection` input **required** in `cicd_comp_initialize-phase.yml`, but `cicd_release-cli.yml` was not updated to pass it. This caused every GitHub Release event to immediately fail with `startup_failure` before any jobs could execute.

> **Note:** Future work may consider integrating the CLI release directly into the main release pipeline (`cicd_6-release.yml`), but this PR is a targeted fix to restore current functionality.

## Changes

- Added `with: change-detection: 'disabled'` to the `initialize` job in `cicd_release-cli.yml`
  - `disabled` is the correct value here — the CLI release should always run all build/test components unconditionally, with no selective change detection
  - This is consistent with how the same parameter was applied in the related fix for `cicd_7` and `cicd_8` (#34689)

## Testing

To manually trigger the workflow against this branch via the `gh` CLI:

```bash
gh workflow run cicd_release-cli.yml \
  --repo dotCMS/core \
  --ref issue-34726-defect-release-cli-workflow-fails-with \
  --field version=v26.02.23-01 \
  --field dry-run=false
```

**QA run:** https://github.com/dotCMS/core/actions/runs/22315061235
- This `workflow_dispatch` run against this branch serves as the end-to-end validation for this fix
- Merge once this run completes successfully

Closes #34726

**Issue:** [DEFECT] Release CLI workflow fails with startup_failure due to missing change-detection parameter

This PR fixes: #34726