### PR TITLE
34450 fix custom fields fields bugs

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/content/file_browser_field_render_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/content/file_browser_field_render_new.vtl
@@ -1,6 +1,6 @@
 <script type="application/javascript">
   DotCustomFieldApi.ready(() => {
-    const field = DotCustomFieldApi.getField("${field.velocityVarName}");
+    const field = DotCustomFieldApi.getField("forwardTo");
     const vlUriInput = document.getElementById("vlUri");
     const browseButton = document.getElementById("browseButton");
     if (!vlUriInput || !browseButton) {

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/personas/keytag_custom_field_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/personas/keytag_custom_field_new.vtl
@@ -41,14 +41,17 @@
 			keyTagField.setValue(keyTagStr);
 		}
 
-		// When name field value changes: if keyTag is empty, derive from name (replaces old onblur on name input)
-		nameField.onChange(() => {
-			const currentKeyTag = keyTagField.getValue() || "";
-			if (currentKeyTag.trim().length > 0) {
-				return;
-			}
-			keyTagUpdate();
-		});
+		// When name field loses focus: if keyTag is empty, derive from name (same as title_custom_field_new / old onblur)
+		const nameInput = document.getElementById("name") || (window.parent && window.parent.document && window.parent.document.getElementById("name")) || null;
+		if (nameInput) {
+			nameInput.addEventListener("blur", () => {
+				const currentKeyTag = keyTagField.getValue() || "";
+				if (currentKeyTag.trim().length > 0) {
+					return;
+				}
+				keyTagUpdate();
+			});
+		}
 
 		// Initialize visible input with current field value
 		const initialValue = keyTagField.getValue() || "";

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/personas/keytag_custom_field_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/personas/keytag_custom_field_new.vtl
@@ -42,7 +42,15 @@
 		}
 
 		// When name field loses focus: if keyTag is empty, derive from name (same as title_custom_field_new / old onblur)
-		const nameInput = document.getElementById("name") || (window.parent && window.parent.document && window.parent.document.getElementById("name")) || null;
+		let parentNameInput = null;
+		try {
+			if (window.parent && window.parent !== window && window.parent.document) {
+				parentNameInput = window.parent.document.getElementById("name");
+			}
+		} catch (e) {
+			parentNameInput = null;
+		}
+		const nameInput = document.getElementById("name") || parentNameInput || null;
 		if (nameInput) {
 			nameInput.addEventListener("blur", () => {
 				const currentKeyTag = keyTagField.getValue() || "";

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/tag/tag_storage_field_creation_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/tag/tag_storage_field_creation_new.vtl
@@ -56,25 +56,25 @@
 <script type="application/javascript">
   (function() {
     function initTagStorageField() {
-      var field;
+      let field;
       try {
         field = DotCustomFieldApi.getField("tagStorage");
       } catch (e) {
         return;
       }
-      var holder = document.getElementById("tagStorageHolder");
-      var button = document.getElementById("tagStorageSelectButton");
-      var dropdown = document.getElementById("tagStorageDropdown");
+      const holder = document.getElementById("tagStorageHolder");
+      const button = document.getElementById("tagStorageSelectButton");
+      const dropdown = document.getElementById("tagStorageDropdown");
       if (!holder || !button || !dropdown) return;
 
-      var options = dropdown.querySelectorAll(".custom-option");
-      var selectedOption = dropdown.querySelector(".custom-option.selected");
-      var currentValue = field ? (field.getValue() || "") : "";
+      const options = Array.from(dropdown.querySelectorAll(".custom-option"));
+      let selectedOption = dropdown.querySelector(".custom-option.selected");
+      const currentValue = field ? (field.getValue() || "") : "";
       if (selectedOption && selectedOption.dataset.label) {
         button.textContent = selectedOption.dataset.label;
         button.classList.remove("placeholder");
       } else if (currentValue && options.length) {
-        var match = Array.prototype.find.call(options, function(o) { return o.dataset.identifier === currentValue; });
+        const match = options.find(function(o) { return o.dataset.identifier === currentValue; });
         if (match) {
           match.classList.add("selected");
           match.setAttribute("aria-selected", "true");
@@ -117,8 +117,8 @@
 
       options.forEach(function(opt) {
         opt.addEventListener("click", function () {
-          var identifier = this.dataset.identifier;
-          var label = this.dataset.label;
+          const identifier = this.dataset.identifier;
+          const label = this.dataset.label;
           if (field) field.setValue(identifier || "");
           button.textContent = label || "Select host";
           button.classList.remove("placeholder");

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/tag/tag_storage_field_creation_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/tag/tag_storage_field_creation_new.vtl
@@ -66,6 +66,7 @@
       const button = document.getElementById("tagStorageSelectButton");
       const dropdown = document.getElementById("tagStorageDropdown");
       if (!holder || !button || !dropdown) return;
+      const defaultLabel = (button.textContent || "").trim();
 
       const options = Array.from(dropdown.querySelectorAll(".custom-option"));
       let selectedOption = dropdown.querySelector(".custom-option.selected");
@@ -78,7 +79,7 @@
         if (match) {
           match.classList.add("selected");
           match.setAttribute("aria-selected", "true");
-          button.textContent = match.dataset.label || "Select host";
+          button.textContent = match.dataset.label || defaultLabel;
           button.classList.remove("placeholder");
           selectedOption = match;
         }
@@ -120,7 +121,7 @@
           const identifier = this.dataset.identifier;
           const label = this.dataset.label;
           if (field) field.setValue(identifier || "");
-          button.textContent = label || "Select host";
+          button.textContent = label || defaultLabel;
           button.classList.remove("placeholder");
           options.forEach(function(o) { o.classList.remove("selected"); });
           this.classList.add("selected");

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/tag/tag_storage_field_creation_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/tag/tag_storage_field_creation_new.vtl
@@ -69,12 +69,24 @@
 
       var options = dropdown.querySelectorAll(".custom-option");
       var selectedOption = dropdown.querySelector(".custom-option.selected");
+      var currentValue = field ? (field.getValue() || "") : "";
       if (selectedOption && selectedOption.dataset.label) {
         button.textContent = selectedOption.dataset.label;
         button.classList.remove("placeholder");
+      } else if (currentValue && options.length) {
+        var match = Array.prototype.find.call(options, function(o) { return o.dataset.identifier === currentValue; });
+        if (match) {
+          match.classList.add("selected");
+          match.setAttribute("aria-selected", "true");
+          button.textContent = match.dataset.label || "Select host";
+          button.classList.remove("placeholder");
+          selectedOption = match;
+        }
       }
       if (field && selectedOption && selectedOption.dataset.identifier) {
         field.setValue(selectedOption.dataset.identifier);
+      } else if (field && currentValue) {
+        field.setValue(currentValue);
       } else if (field) {
         field.setValue("");
       }


### PR DESCRIPTION
This pull request introduces several improvements to the behavior of custom fields 

**Custom field event handling improvements:**

* In `keytag_custom_field_new.vtl`, the logic for updating the key tag when the name field changes was replaced with an event listener for the `blur` (focus loss) event on the name input, ensuring the key tag is only derived when the user finishes editing the name. This also aligns with the behavior in related custom fields.

**Dropdown and field value initialization:**

* In `tag_storage_field_creation_new.vtl`, the dropdown initialization logic was enhanced to better handle cases where a value is already set: if the current value matches an option, that option is marked as selected and the button text is updated accordingly. This ensures that the dropdown correctly reflects the stored value even if the user hasn't interacted with it yet.

**Bug fix in field lookup:**

* In `file_browser_field_render_new.vtl`, the field lookup was changed from using a template variable to a hardcoded `"forwardTo"` field name, likely fixing a bug where the wrong field was being targeted in the file browser custom field.

DEMO

https://github.com/user-attachments/assets/1f04a921-704f-4183-a927-ab6c27a679b3



This PR fixes: #34450