### PR TITLE
fix: add mutable floating tag for Java variant release builds (#34745)

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -59,7 +59,7 @@ inputs:
     required: false
     default: ''
   artifact_suffix:
-    description: 'Suffix for artifact names (e.g., -java25). Used to download the correct docker-build-context artifact.'
+    description: 'Suffix for artifact names (e.g., -java-25). Used to download the correct docker-build-context artifact.'
     required: false
     default: ''
   pull:
@@ -67,11 +67,11 @@ inputs:
     required: false
     default: 'false'
   identifier-tag:
-    description: 'Optional mutable alias tag managed by the deployment phase (e.g., nightly_20250218_java25, manual_issue-123_java25). Applied when non-empty.'
+    description: 'Optional mutable alias tag managed by the deployment phase (e.g., nightly_20250218_java-25, manual_issue-123_java-25). Applied when non-empty.'
     required: false
     default: ''
   custom-tag:
-    description: 'Optional custom alias tag chosen by the developer (e.g., modernization, java25-testing). Applied when non-empty.'
+    description: 'Optional custom alias tag chosen by the developer (e.g., modernization, java-25-testing). Applied when non-empty.'
     required: false
     default: ''
   extra-tags:

--- a/.github/workflows/cicd_7-release-java-variant.yml
+++ b/.github/workflows/cicd_7-release-java-variant.yml
@@ -13,7 +13,7 @@
 # This variant workflow:
 # - Uses alternate Java version for compilation (e.g., Java 25 vs Java 21)
 # - Overrides -Dchangelist at runtime to create different Maven version
-#   (e.g., 25.02.16-01-java25 vs 25.02.16-01)
+#   (e.g., 25.02.16-01-java-25 vs 25.02.16-01)
 # - Adds artifact suffix to distinguish build artifacts and Docker tags
 # - Skips operations already performed by primary (javadocs, plugins, labels)
 #
@@ -24,7 +24,7 @@
 # Configuration:
 # Set repository variables for automatic parallel builds:
 #   RELEASE_JAVA_VARIANT_VERSION: Java version in SDKMAN format (e.g., 25.0.2-ms)
-#   RELEASE_JAVA_VARIANT_SUFFIX: Artifact suffix without separator (e.g., java25-ms)
+#   RELEASE_JAVA_VARIANT_SUFFIX: Artifact suffix without separator (e.g., java-25-ms)
 #
 
 name: '-7 Release Java Variant'
@@ -46,7 +46,7 @@ on:
         type: string
         default: ''
       artifact_suffix:
-        description: 'Artifact suffix without leading separator (e.g., java25, java25-ms). Separators added automatically: dash (-) for Maven artifacts, underscore (_) for Docker tags. If not set, derived from java-version major (e.g., java25).'
+        description: 'Artifact suffix without leading separator (e.g., java-25, java-25-ms). Separators added automatically: dash (-) for Maven artifacts, underscore (_) for Docker tags. If not set, derived from java-version major (e.g., java-25).'
         required: false
         type: string
         default: ''

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -25,15 +25,19 @@
 #            {version}_{sha}     ← immutable
 #            latest              ← mutable, points to the latest release (when latest=true)
 #
+#   release (Java variant):     Same as release, plus:
+#            {suffix}            ← mutable floating tag (e.g. java-25), variant equivalent of latest.
+#                                 Pushed unconditionally when raw_suffix is non-empty; not gated on latest.
+#
 #   manual:  manual              ← mutable, always latest manual build
 #            manual_{sha}        ← immutable
 #            manual_{ref}        ← mutable alias (tag-identifier = sanitized ref branch)
 #            {custom-tag}        ← optional exact alias chosen by the developer
 #
-#   Java variant suffix (_java25 etc.) is part of the base tag; in identifier aliases
-#   the identifier comes first (matching the release pattern 25.02.16-01_java25):
-#     nightly_java25, nightly_java25_{sha}, nightly_{date}_java25
-#     manual_java25,  manual_java25_{sha},  manual_{ref}_java25
+#   Java variant suffix (_java-25 etc.) is part of the base tag; in identifier aliases
+#   the identifier comes first (matching the release pattern 25.02.16-01_java-25):
+#     nightly_java-25, nightly_java-25_{sha}, nightly_{date}_java-25
+#     manual_java-25,  manual_java-25_{sha},  manual_{ref}_java-25
 #
 #   All tags (base, sha, identifier alias, custom) are applied in a single docker build.
 #   The deploy-docker action accepts semantic inputs (identifier-tag, custom-tag); the
@@ -67,7 +71,7 @@ on:
         type: boolean
         default: false
       custom-tag:
-        description: 'Optional exact alias tag, used by manual workflow for developer-chosen tag names (e.g., modernization, java25-testing). Pulled from the immutable SHA tag for reliability.'
+        description: 'Optional exact alias tag, used by manual workflow for developer-chosen tag names (e.g., modernization, java-25-testing). Pulled from the immutable SHA tag for reliability.'
         required: false
         type: string
         default: ''
@@ -95,7 +99,7 @@ on:
         type: string
         default: ''
       artifact-suffix:
-        description: 'Artifact suffix without leading separator (e.g., java25, java25-ms). Separators added automatically: dash (-) for Maven artifacts, underscore (_) for Docker tags. If not set, derived from java-version major (e.g., java25).'
+        description: 'Artifact suffix without leading separator (e.g., java-25, java-25-ms). Separators added automatically: dash (-) for Maven artifacts, underscore (_) for Docker tags. If not set, derived from java-version major (e.g., java-25).'
         required: false
         type: string
         default: ''
@@ -149,13 +153,13 @@ jobs:
         shell: bash
         run: |
           # Naming Convention for Java Variants:
-          # - User input: suffix without leading separator (e.g., "java25" or "java25-ms")
-          # - Maven artifacts: use dash separator (e.g., "-java25")
-          # - Docker tags: use underscore separator (e.g., "_java25")
+          # - User input: suffix without leading separator (e.g., "java-25" or "java-25-ms")
+          # - Maven artifacts: use dash separator (e.g., "-java-25")
+          # - Docker tags: use underscore separator (e.g., "_java-25")
           #
           # Note: Underscore in Docker tags is non-standard but follows existing dotCMS convention.
           # Docker typically uses dash or no separator, but we use underscore to distinguish from
-          # version dashes (e.g., "25.02.16-01_java25_abc123" vs "25.02.16-01-java25-abc123").
+          # version dashes (e.g., "25.02.16-01_java-25_abc123" vs "25.02.16-01-java-25-abc123").
           # This convention may be revisited in future.
 
           # Use provided java-version if set, otherwise read from .sdkmanrc
@@ -170,7 +174,7 @@ jobs:
               echo "Using explicit artifact suffix: ${RAW_SUFFIX}"
             else
               JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
-              RAW_SUFFIX="java${JAVA_MAJOR}"
+              RAW_SUFFIX="java-${JAVA_MAJOR}"
               echo "Using derived artifact suffix: ${RAW_SUFFIX}"
             fi
 
@@ -213,10 +217,10 @@ jobs:
       # Compute Docker tags for this build.
       #
       # base_tag:       primary mutable tag — {identifier|environment}{suffix}
-      #                 e.g. nightly_java25, 25.02.16-01_java25, manual_java25
+      #                 e.g. nightly_java-25, 25.02.16-01_java-25, manual_java-25
       #
       # identifier_tag: mutable alias — {environment}_{identifier}{suffix}
-      #                 e.g. nightly_20250218_java25, manual_issue-123_java25
+      #                 e.g. nightly_20250218_java-25, manual_issue-123_java-25
       #                 Empty (disabled) when:
       #                   - no tag-identifier (trunk has none)
       #                   - omit-environment-prefix=true (release: identifier IS the primary tag)
@@ -259,6 +263,7 @@ jobs:
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
           identifier-tag: ${{ steps.docker-tags.outputs.identifier_tag }}
           custom-tag: ${{ inputs.custom-tag }}
+          extra-tags: ${{ steps.get-sdkman-version.outputs.raw_suffix != '' && format('type=raw,value={0},enable=true', steps.get-sdkman-version.outputs.raw_suffix) || '' }}
 
       # Format tags for Slack notifications
       - name: Format Tags
@@ -299,7 +304,9 @@ jobs:
             DOTCMS_DOCKER_TAG=${{ steps.docker-tags.outputs.base_tag }}
             DEV_REQUEST_TOKEN=${{ secrets.DEV_REQUEST_TOKEN }}
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
+          artifact_suffix: ${{ steps.get-sdkman-version.outputs.maven_suffix }}
           identifier-tag: ${{ steps.docker-tags.outputs.identifier_tag }}
+          extra-tags: ${{ steps.get-sdkman-version.outputs.raw_suffix != '' && format('type=raw,value={0},enable=true', steps.get-sdkman-version.outputs.raw_suffix) || '' }}
 
       # Deploy CLI artifacts to JFrog Artifactory
       # Skipped when java-version is overridden (CLI not built due to GraalVM/Quarkus compatibility)


### PR DESCRIPTION
## Summary
Fixes #34745

When `raw_suffix` is non-empty (e.g., `java-25`), push a suffix-only mutable tag to Docker Hub for both `dotcms/dotcms` and `dotcms/dotcms-dev`. This provides the variant equivalent of `latest` for primary builds.

## Changes
- Add `extra-tags` to deploy-docker when `raw_suffix` is non-empty (unconditional, no `latest` gate)
- Add `artifact_suffix` to dev image deploy-docker call (was missing)
- Update tag model documentation with variant release floating tag
- Apply `java-25` naming convention (dash separator) per team decision

## Acceptance Criteria
- [x] When a Java variant release completes, a mutable tag matching the raw artifact suffix is pushed for both images
- [x] The suffix-based floating tag is pushed unconditionally whenever `raw_suffix` is non-empty
- [x] Existing tags (`{version}_{suffix}`, `{version}_{suffix}_{sha}`) continue to be created
- [x] The `latest` tag for primary releases is unaffected
- [x] `cicd_7-release-java-variant.yml` does not need `latest: true`
- [x] Tag model documentation updated

Made with [Cursor](https://cursor.com)

This PR fixes: #34745