### PR TITLE
fix: dotcms-dev:latest incorrectly overwritten by nightly builds (#34765)

### DIFF
--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -23,7 +23,9 @@
 #
 #   release: {version}           ← mutable, e.g. 25.02.16-01  (omit-environment-prefix=true)
 #            {version}_{sha}     ← immutable
-#            latest              ← mutable, points to the latest release (when latest=true)
+#            latest              ← mutable, points to the latest release (when latest=true).
+#                                 ONLY when latest=true; never set by nightly/trunk/feature/manual.
+#                                 Applies to both main (dotcms) and dev (dotcms-dev) images.
 #
 #   manual:  manual              ← mutable, always latest manual build
 #            manual_{sha}        ← immutable
@@ -290,7 +292,7 @@ jobs:
           ref: ${{ inputs.environment }}
           docker-use-ref: false
           version: ${{ steps.docker-tags.outputs.base_tag }}
-          latest: ${{ steps.get-sdkman-version.outputs.docker_suffix == '' }}
+          latest: ${{ inputs.latest && steps.get-sdkman-version.outputs.docker_suffix == '' }}
           do_deploy: ${{ vars.DOCKER_DEPLOY || 'true' }}
           docker_io_username: ${{ secrets.DOCKER_USERNAME }}
           docker_io_token: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes #34765

Adds the missing `inputs.latest` guard to the dev image `latest` tag in `cicd_comp_deployment-phase.yml`, matching the main image pattern.

## Problem
The `dotcms/dotcms-dev:latest` Docker tag was overwritten on every nightly build because the dev image step (line 293) lacked the `inputs.latest` gate that the main image (line 250) correctly has.

## Changes
- **Line 300**: Add `inputs.latest &&` guard to dev image `latest` tag
- **Lines 25-27**: Update comment block to document the latest-only-on-release rule for both main and dev images

## Acceptance Criteria
- [x] Line 293 updated with `inputs.latest &&` guard
- [x] `dotcms/dotcms-dev:latest` no longer updated by nightly builds
- [x] Release workflow continues to update `latest` correctly (passes `latest: true`)
- [x] Variant release builds do not push `latest` (unchanged)
- [x] Comment block updated

Made with [Cursor](https://cursor.com)

This PR fixes: #34765