### PR TITLE
Remove confirmation dialog for archiving content on Content Drive

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-workflow-actions/dot-content-drive-workflow-actions.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-workflow-actions/dot-content-drive-workflow-actions.component.spec.ts
@@ -736,11 +736,11 @@ describe('DotContentDriveWorkflowActionsComponent', () => {
     });
 
     describe('Integration Tests', () => {
-        it('should handle full workflow for archive action with confirmation', () => {
+        it('should handle full workflow for delete action with confirmation', () => {
             const mockItems = [
                 {
-                    archived: false,
-                    live: true,
+                    archived: true,
+                    live: false,
                     working: false,
                     baseType: 'CONTENT',
                     inode: 'test-inode-1'
@@ -756,11 +756,11 @@ describe('DotContentDriveWorkflowActionsComponent', () => {
                 return confirmationService;
             });
 
-            const archiveButton = spectator.query(
-                `[data-testid="workflow-action-${WORKFLOW_ACTION_ID.ARCHIVE}"]`
+            const deleteButton = spectator.query(
+                `[data-testid="workflow-action-${WORKFLOW_ACTION_ID.DELETE}"]`
             );
 
-            spectator.click(archiveButton);
+            spectator.click(deleteButton);
 
             expect(confirmationService.confirm).toHaveBeenCalled();
             expect(dotWorkflowActionsFireService.fireDefaultAction).toHaveBeenCalled();

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/workflow-actions.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/utils/workflow-actions.ts
@@ -123,8 +123,7 @@ const ARCHIVE_ACTION: ContentDriveWorkflowAction = {
     showWhen: {
         noneArchived: true,
         noneFolder: true
-    },
-    confirmationMessage: 'content.drive.worflow.action.archive.confirm'
+    }
 };
 
 const UNARCHIVE_ACTION: ContentDriveWorkflowAction = {
@@ -133,8 +132,7 @@ const UNARCHIVE_ACTION: ContentDriveWorkflowAction = {
     showWhen: {
         allArchived: true,
         noneFolder: true
-    },
-    confirmationMessage: 'content.drive.worflow.action.unarchive.confirm'
+    }
 };
 
 const DELETE_ACTION: ContentDriveWorkflowAction = {


### PR DESCRIPTION
## Summary
- Remove the confirmation dialog that appeared before archiving content on the Content Drive
- The archive action now executes immediately without requiring user confirmation

https://github.com/user-attachments/assets/817c8716-fdfc-4443-98d2-ebb10efc5dd6




## Test plan
- [ ] Verify archiving content on the Content Drive no longer shows a confirmation dialog
- [ ] Verify the archive action executes correctly without the dialog
- [ ] Verify no regression in other archive-related actions

Closes #34772

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34772