### PR TITLE
fix: update `starter.deploy.version` to latest version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -84,7 +84,7 @@
         <docker.jacoco.skip>true</docker.jacoco.skip>
         <!-- starter -->
         <starter.download.folder>${project.build.directory}/starter</starter.download.folder>
-        <starter.deploy.version>empty_20260211</starter.deploy.version>
+        <starter.deploy.version>empty_20260225</starter.deploy.version>
         <starter.deploy.filename>starter.zip</starter.deploy.filename>
         <starter.run.version>${starter.deploy.version}</starter.run.version>
         <starter.run.filename>starter-${starter.run.version}.zip</starter.run.filename>


### PR DESCRIPTION
Ref: #33780

New empty starter with new edit mode enabled for all content types

This PR fixes: #33780