### PR TITLE
fix(docker): replace libapr1 with libapr1t64 for Ubuntu 24.04 compatibility

### DIFF
--- a/docker/dev-env/Dockerfile
+++ b/docker/dev-env/Dockerfile
@@ -35,7 +35,7 @@ RUN chmod 777 /data
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends bash zip unzip wget libtcnative-1\
-    tzdata tini ca-certificates openssl libapr1 libpq-dev curl gnupg\
+    tzdata tini ca-certificates openssl libapr1t64 libpq-dev curl gnupg\
     vim libarchive-tools postgresql-common libmimalloc2.0 libarchive-tools 
 
 

--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH="$SDKMAN_DIR/bin:$PATH"
 # Installing basic packages and SDKMAN
 RUN apt update && \
     apt upgrade -y && \
-    apt install -y --no-install-recommends zip unzip wget libtcnative-1 tzdata tini ca-certificates openssl libapr1 libpq-dev curl gnupg && \
+    apt install -y --no-install-recommends zip unzip wget libtcnative-1 tzdata tini ca-certificates openssl libapr1t64 libpq-dev curl gnupg && \
     rm -rf /var/lib/apt/lists/* && \
     wget -O - https://get.sdkman.io | bash && \
     bash -c "source $SDKMAN_DIR/bin/sdkman-init.sh && sdk install java ${SDKMAN_JAVA_VERSION} && sdk flush archives" && \

--- a/dotCMS/src/main/docker/original/Dockerfile
+++ b/dotCMS/src/main/docker/original/Dockerfile
@@ -54,7 +54,7 @@ RUN apt update && \
         ca-certificates \
         libmimalloc2.0 \
         openssl \
-        libapr1 \
+        libapr1t64 \
         libarchive-tools \
         libpq-dev && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Replaces `libapr1` with `libapr1t64` in the Stage 2 `apt install` block of `dotCMS/src/main/docker/original/Dockerfile`
- `libapr1` was removed from Ubuntu 24.04 Noble as part of the 64-bit time_t transition
- Docker layer caching had been masking this failure; it surfaces on cold/clean builds

## Root Cause
The Ubuntu 24.04 base image migration (commit `cae4cebe68c`) introduced a latent bug: `libapr1` no longer exists in Noble's repos and must be referenced as `libapr1t64`. Cached Docker layers hid the failure until a clean build was attempted.

## Test plan
- [ ] Build the `dotcms-core` Docker image from a cold cache and confirm exit code 0
- [ ] Verify Tomcat Native (libtcnative-1) still loads correctly at runtime

Closes #34776

🤖 Generated with [Claude Code](https://claude.com/claude-code)