### PR TITLE
debt(dwr): replacing PermissionAjax with rest endpoint

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/permission/AbstractRolePermissionView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/permission/AbstractRolePermissionView.java
@@ -96,4 +96,46 @@ public interface AbstractRolePermissionView {
     )
     @Nullable
     Map<PermissionAPI.Scope, Set<PermissionAPI.Type>> inheritable();
+
+    /**
+     * Gets the type of the asset from which permissions are inherited.
+     * Only populated when {@link #inherited()} is true.
+     *
+     * @return Inherited source type (host, folder, category, structure), or empty string if not inherited
+     */
+    @JsonProperty("inheritedFromType")
+    @Schema(
+        description = "Type of the parent asset from which permissions are inherited (host, folder, category, structure)",
+        example = "folder"
+    )
+    @Value.Default
+    default String inheritedFromType() { return ""; }
+
+    /**
+     * Gets the display path/name of the asset from which permissions are inherited.
+     * Only populated when {@link #inherited()} is true.
+     *
+     * @return Inherited source path or name, or empty string if not inherited
+     */
+    @JsonProperty("inheritedFromPath")
+    @Schema(
+        description = "Display path or name of the parent asset from which permissions are inherited",
+        example = "/about-us/"
+    )
+    @Value.Default
+    default String inheritedFromPath() { return ""; }
+
+    /**
+     * Gets the ID of the asset from which permissions are inherited.
+     * Only populated when {@link #inherited()} is true.
+     *
+     * @return Inherited source asset ID, or empty string if not inherited
+     */
+    @JsonProperty("inheritedFromId")
+    @Schema(
+        description = "Identifier of the parent asset from which permissions are inherited",
+        example = "abc-123-def-456"
+    )
+    @Value.Default
+    default String inheritedFromId() { return ""; }
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/permission/PermissionableObjectView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/permission/PermissionableObjectView.java
@@ -1,0 +1,70 @@
+package com.dotcms.rest.api.v1.system.permission;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * View object representing metadata about a permissionable asset.
+ * Used by the permissions tab to determine UI rendering (e.g., which
+ * permission checkboxes to show, whether to show folder/host-specific options).
+ *
+ * <p>Replaces the legacy {@code PermissionableObjectDWR} used by DWR.
+ */
+public class PermissionableObjectView {
+
+    private final String id;
+    private final String type;
+    private final boolean isFolder;
+    private final boolean isHost;
+    private final boolean isContentType;
+    private final boolean isParentPermissionable;
+    private final boolean doesUserHavePermissionsToEdit;
+
+    public PermissionableObjectView(final String id,
+                                     final String type,
+                                     final boolean isFolder,
+                                     final boolean isHost,
+                                     final boolean isContentType,
+                                     final boolean isParentPermissionable,
+                                     final boolean doesUserHavePermissionsToEdit) {
+        this.id = id;
+        this.type = type;
+        this.isFolder = isFolder;
+        this.isHost = isHost;
+        this.isContentType = isContentType;
+        this.isParentPermissionable = isParentPermissionable;
+        this.doesUserHavePermissionsToEdit = doesUserHavePermissionsToEdit;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty("isFolder")
+    public boolean isFolder() {
+        return isFolder;
+    }
+
+    @JsonProperty("isHost")
+    public boolean isHost() {
+        return isHost;
+    }
+
+    @JsonProperty("isContentType")
+    public boolean isContentType() {
+        return isContentType;
+    }
+
+    @JsonProperty("isParentPermissionable")
+    public boolean isParentPermissionable() {
+        return isParentPermissionable;
+    }
+
+    @JsonProperty("doesUserHavePermissionsToEdit")
+    public boolean isDoesUserHavePermissionsToEdit() {
+        return doesUserHavePermissionsToEdit;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/permission/ResponseEntityPermissionableObjectView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/permission/ResponseEntityPermissionableObjectView.java
@@ -1,0 +1,14 @@
+package com.dotcms.rest.api.v1.system.permission;
+
+import com.dotcms.rest.ResponseEntityView;
+
+/**
+ * Typed ResponseEntityView for PermissionableObjectView.
+ * Used for accurate Swagger schema documentation.
+ */
+public class ResponseEntityPermissionableObjectView extends ResponseEntityView<PermissionableObjectView> {
+
+    public ResponseEntityPermissionableObjectView(final PermissionableObjectView entity) {
+        super(entity);
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionableObjectDWR.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionableObjectDWR.java
@@ -1,5 +1,10 @@
 package com.dotmarketing.business;
 
+/**
+ * @deprecated This DWR bean is deprecated and will be removed in a future release.
+ *             Use {@link com.dotcms.rest.api.v1.system.permission.PermissionableObjectView} instead.
+ */
+@Deprecated(forRemoval = true)
 public class PermissionableObjectDWR {
 	
 	private String id;

--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/HostAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/HostAjax.java
@@ -47,6 +47,11 @@ import java.util.stream.Collectors;
  * @version 1.0
  * @since Mar 22, 2012
  */
+/**
+ * @deprecated This DWR class is deprecated and will be removed in a future release.
+ *             Use the JAX-RS REST API at {@code /api/v1/site/} instead.
+ */
+@Deprecated(forRemoval = true)
 public class HostAjax {
 
 	private final HostAPI hostAPI = APILocator.getHostAPI();

--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/InodeAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/InodeAjax.java
@@ -7,6 +7,11 @@ import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.util.InodeUtils;
 import com.dotmarketing.util.Logger;
 
+/**
+ * @deprecated This DWR class is deprecated and will be removed in a future release.
+ *             No JSP callers remain. DWR entry removed from dwr.xml.
+ */
+@Deprecated(forRemoval = true)
 public class InodeAjax {
 	
 	public int compareInodes(String inodeStr1,String inodeStr2){

--- a/dotCMS/src/main/java/com/dotmarketing/business/ajax/PermissionAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/ajax/PermissionAjax.java
@@ -64,6 +64,11 @@ import com.liferay.portal.model.User;
  * @author davidtorresv
  *
  */
+/**
+ * @deprecated This DWR class is deprecated and will be removed in a future release.
+ *             Use the JAX-RS REST API at {@code /api/v1/permissions/} instead.
+ */
+@Deprecated(forRemoval = true)
 public class PermissionAjax {
 
     private final ContentletAPI contentletAPI = APILocator.getContentletAPI();

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/ajax/CategoryAjax.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/ajax/CategoryAjax.java
@@ -37,6 +37,11 @@ import com.liferay.portal.util.PortalUtil;
 /**
  * @author David
  */
+/**
+ * @deprecated This DWR class is deprecated and will be removed in a future release.
+ *             Use the JAX-RS REST API at {@code /api/v1/categories/} instead.
+ */
+@Deprecated(forRemoval = true)
 public class CategoryAjax {
 
 	private CategoryAPI categoryAPI = APILocator.getCategoryAPI();

--- a/dotCMS/src/main/java/com/liferay/portal/util/PortalUtil.java
+++ b/dotCMS/src/main/java/com/liferay/portal/util/PortalUtil.java
@@ -427,7 +427,10 @@ public class PortalUtil {
       return null;
     }
 
-    String tok = req.getHeader("Authorization").replace("Bearer ", "").trim();
+    String tok = req.getHeader("Authorization")
+            .replace("Bearer ", "")
+            .replace("bearer ", "")
+            .trim();
 
     return Try.of(() -> JsonWebTokenFactory.getInstance().getJsonWebTokenService().parseToken(tok).getActiveUser()
             .orElse(null)).getOrNull();

--- a/dotCMS/src/main/webapp/WEB-INF/dwr.xml
+++ b/dotCMS/src/main/webapp/WEB-INF/dwr.xml
@@ -10,9 +10,7 @@
     <create creator="new" javascript="ContentletAjax" scope="application">
       <param name="class" value="com.dotmarketing.portlets.contentlet.ajax.ContentletAjax"/>
     </create>
-    <create creator="new" javascript="CategoryAjax" scope="application">
-      <param name="class" value="com.dotmarketing.portlets.categories.ajax.CategoryAjax"/>
-    </create>
+    <!-- CategoryAjax removed - migrated to JAX-RS /api/v1/categories -->
     <create creator="new" javascript="BrowserAjax" scope="application">
       <param name="class" value="com.dotmarketing.portlets.browser.ajax.BrowserAjax"/>
     </create>
@@ -34,15 +32,9 @@
     <create creator="new" javascript="LanguageAjax" scope="application">
       <param name="class" value="com.dotmarketing.portlets.languagesmanager.ajax.LanguageAjax"/>
     </create>
-    <create creator="new" javascript="InodeAjax" scope="application">
-      <param name="class" value="com.dotmarketing.business.ajax.InodeAjax"/>
-    </create>
-    <create creator="new" javascript="PermissionAjax" scope="application">
-      <param name="class" value="com.dotmarketing.business.ajax.PermissionAjax"/>
-    </create>
-    <create creator="new" javascript="HostAjax" scope="application">
-      <param name="class" value="com.dotmarketing.business.ajax.HostAjax"/>
-    </create>
+    <!-- InodeAjax removed - no callers, deprecated -->
+    <!-- PermissionAjax removed - migrated to JAX-RS REST compatibility layer in JSP -->
+    <!-- HostAjax removed - migrated to JAX-RS /api/v1/site -->
     <create creator="new" javascript="HostVariableAjax" scope="application">
       <param name="class" value="com.dotmarketing.portlets.hostvariable.ajax.HostVariableAjax"/>
     </create>
@@ -102,10 +94,6 @@
 	</convert>
 	<convert match="java.lang.StackTraceElement" converter="bean"/>
 	<convert converter="null" match="java.io.File"/>
-	<convert converter="bean"
-      match="com.dotmarketing.business.PermissionableObjectDWR">
-      <param name="include"
-        value="id,type,isParentPermissionable,doesUserHavePermissionsToEdit,isFolder,isHost"/>
-    </convert>
+	<!-- PermissionableObjectDWR removed - replaced by PermissionableObjectView in REST API -->
   </allow>
 </dwr>

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -28057,6 +28057,20 @@ components:
           type: boolean
           description: Whether permissions are inherited from a parent asset
           example: false
+        inheritedFromId:
+          type: string
+          description: Identifier of the parent asset from which permissions are inherited
+          example: abc-123-def-456
+        inheritedFromPath:
+          type: string
+          description: Display path or name of the parent asset from which permissions
+            are inherited
+          example: /about-us/
+        inheritedFromType:
+          type: string
+          description: "Type of the parent asset from which permissions are inherited\
+            \ (host, folder, category, structure)"
+          example: folder
         roleId:
           type: string
           description: Role identifier

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -11125,6 +11125,72 @@ paths:
       summary: Update asset permissions
       tags:
       - Permissions
+  /v1/permissions/{assetId}/_individualpermission:
+    put:
+      description: "Breaks permission inheritance for a specific asset, giving it\
+        \ individual permissions copied from its parent. After this operation, the\
+        \ asset's permissions can be modified independently of the parent."
+      operationId: permissionIndividually
+      parameters:
+      - description: Asset identifier (inode or identifier)
+        in: path
+        name: assetId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Inheritance broken successfully
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: Forbidden - user lacks EDIT_PERMISSIONS on asset
+        "404":
+          content:
+            application/json: {}
+          description: Asset not found
+      summary: Break permission inheritance
+      tags:
+      - Permissions
+  /v1/permissions/{assetId}/_permissionable:
+    get:
+      description: "Retrieves metadata about a permissionable asset including its\
+        \ type, whether it is a folder/host/content type, and whether the current\
+        \ user has permission to edit its permissions."
+      operationId: getPermissionableObject
+      parameters:
+      - description: Asset identifier (inode or identifier)
+        in: path
+        name: assetId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityPermissionableObjectView"
+          description: Asset metadata retrieved successfully
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "404":
+          content:
+            application/json: {}
+          description: Asset not found
+      summary: Get permissionable asset metadata
+      tags:
+      - Permissions
   /v1/permissions/{assetId}/_reset:
     put:
       description: "Removes all individual permissions from an asset, making it inherit\
@@ -24490,6 +24556,23 @@ components:
           type: string
         permissionType:
           type: string
+    PermissionableObjectView:
+      type: object
+      properties:
+        doesUserHavePermissionsToEdit:
+          type: boolean
+        id:
+          type: string
+        isContentType:
+          type: boolean
+        isFolder:
+          type: boolean
+        isHost:
+          type: boolean
+        isParentPermissionable:
+          type: boolean
+        type:
+          type: string
     Persona:
       type: object
       properties:
@@ -26141,6 +26224,29 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/PermissionView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityPermissionableObjectView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/PermissionableObjectView"
         errors:
           type: array
           items:

--- a/dotCMS/src/main/webapp/html/common/top_inc.jsp
+++ b/dotCMS/src/main/webapp/html/common/top_inc.jsp
@@ -106,12 +106,10 @@ THIS FILE AND ITS INCLUDES
 	<script type="text/javascript" src="/html/js/dwr-cookie-security.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/dwr/engine.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/dwr/util.js?b=<%= ReleaseInfo.getVersion() %>"></script>
-	<script type="text/javascript" src="/dwr/interface/HostAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/dwr/interface/ContainerAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/dwr/interface/RoleAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/dwr/interface/BrowserAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 	<script type="text/javascript" src="/dwr/interface/UserAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
-	<script type="text/javascript" src="/dwr/interface/InodeAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 
 
 	<script type="text/javascript">

--- a/dotCMS/src/main/webapp/html/legacy_custom_field/legacy-custom-field.jsp
+++ b/dotCMS/src/main/webapp/html/legacy_custom_field/legacy-custom-field.jsp
@@ -108,12 +108,10 @@
 <script type="text/javascript" src="/html/js/dwr-cookie-security.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/dwr/engine.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/dwr/util.js?b=<%= ReleaseInfo.getVersion() %>"></script>
-<script type="text/javascript" src="/dwr/interface/HostAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/dwr/interface/ContainerAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/dwr/interface/RoleAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/dwr/interface/BrowserAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <script type="text/javascript" src="/dwr/interface/UserAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
-<script type="text/javascript" src="/dwr/interface/InodeAjax.js?b=<%= ReleaseInfo.getVersion() %>"></script>
 <%
     // Cache busting for development - use timestamp
     String cacheBuster = String.valueOf(System.currentTimeMillis());

--- a/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
+++ b/dotCMS/src/main/webapp/html/ng-contentlet-selector.jsp
@@ -248,8 +248,6 @@
     <script type="text/javascript" src="/dwr/interface/StructureAjax.js"></script>
     <script type="text/javascript" src="/dwr/interface/ContentletAjax.js"></script>
     <script type="text/javascript" src="/dwr/interface/BrowserAjax.js"></script>
-    <script type="text/javascript" src="/dwr/interface/CategoryAjax.js"></script>
-
 
     <script type="text/javascript">
         dojo.require("dotcms.dijit.form.ContentSelector");

--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
@@ -36,8 +36,6 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
     }
 </style>
 
-<script type="text/javascript" src="/dwr/interface/HostAjax.js"></script>
-
 <script src="/html/js/scriptaculous/prototype.js" type="text/javascript"></script>
 <script src="/html/js/scriptaculous/scriptaculous.js" type="text/javascript"></script>
 
@@ -1149,7 +1147,10 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
 
     function setAsDefaultHost(objId,referer) {
         if (confirm('<%= UtilMethods.escapeSingleQuotes(LanguageUtil.get(pageContext, "Are-you-sure-you-want-to-set-this-host-as-the-default-host")) %>')) {
-            HostAjax.makeDefault(objId, setAsDefaultHostCallback);
+            fetch('/api/v1/site/' + objId + '/_makedefault', {method: 'PUT', cache: 'no-cache'})
+                .then(function(r) { return r.json(); })
+                .then(function() { setAsDefaultHostCallback(); })
+                .catch(function(error) { console.error('Error setting default host:', error); });
         }
     }
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/calendar/view_calendar_main_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/calendar/view_calendar_main_inc.jsp
@@ -38,7 +38,6 @@
 <%@page import="com.dotmarketing.business.PermissionAPI"%>
 
 <script type='text/javascript' src='/dwr/interface/CalendarAjax.js'></script>
-<script type='text/javascript' src='/dwr/interface/CategoryAjax.js'></script>
 <script type='text/javascript' src='/dwr/interface/StructureAjax.js'></script>
 <script type='text/javascript' src='/dwr/interface/TagAjax.js'></script>
 <script type='text/javascript' src='/dwr/engine.js'></script>

--- a/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories.jsp
@@ -58,7 +58,6 @@
     }
 
 </style>
-<script type="text/javascript" src="/dwr/interface/CategoryAjax.js"></script>
 <script type="text/javascript">
     dojo.require("dojox.grid.enhanced.plugins.Pagination");
     dojo.require("dojox.grid.enhanced.plugins.Search");
@@ -125,7 +124,18 @@
     };
 
     var sortCat = function() {
-        CategoryAjax.sortCategory(this.name, this.value);
+        var inode = this.name;
+        var sortOrder = parseInt(this.value, 10);
+        var categoryData = {};
+        categoryData[inode] = sortOrder;
+        fetch('/api/v1/categories/_sort', {
+            method: 'PUT',
+            cache: 'no-cache',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({categoryData: categoryData, parentInode: currentInodeOrIdentifier || null})
+        })
+        .then(function(r) { return r.json(); })
+        .catch(function(error) { console.error('Error updating sort order:', error); });
     };
 
     var sortSelectable = function() {
@@ -585,14 +595,19 @@
 			}
         }
 
-        CategoryAjax.getCategoryMap(inode,getCategoryMapCallback);
+        if (inode && inode !== '0') {
+            fetch('/api/v1/categories/' + encodeURIComponent(inode), {cache: 'no-cache'})
+                .then(function(r) { return r.json(); })
+                .then(function(data) { getCategoryMapCallback(data.entity); })
+                .catch(function(error) { console.error('Error fetching category:', error); });
+        }
     }
 
     function getCategoryMapCallback(categoryMap){
         var inode = categoryMap['inode'];
-        var name = categoryMap['category_name'];
-        var velVar = categoryMap['category_velocity_var_name'];
-        var key = categoryMap['category_key'];
+        var name = categoryMap['categoryName'];
+        var velVar = categoryMap['categoryVelocityVarName'];
+        var key = categoryMap['key'];
         var keywords = categoryMap['keywords'];
 
         key = key=="null"?"":key;
@@ -616,25 +631,35 @@
                 var dia = dijit.byId('dotDeleteCategoriesDialog');
                 dia.show();
 
-                CategoryAjax.deleteCategories(currentInodeOrIdentifier, {
-                    callback:function(result) {
-                        if(result==0) {
+                var deleteBody = currentInodeOrIdentifier ? [currentInodeOrIdentifier] : [];
+                fetch('/api/v1/categories', {
+                    method: 'DELETE',
+                    cache: 'no-cache',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify(deleteBody)
+                })
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    var result = data.entity;
+                    if (result && result.fails && result.fails.length > 0) {
+                        dojo.byId("warningDiv").innerHTML = '<%= LanguageUtil.get(pageContext, "message.category.delete.failed.has.dependencies") %>';
+                        var t = new dojox.timing.Timer();
+                        t.setInterval(5000);
+                        t.onTick = function() {
+                            t.stop();
                             dojo.byId("warningDiv").innerHTML = '';
-                        } else if(result==1) {
-                            dojo.byId("warningDiv").innerHTML = '<%= LanguageUtil.get(pageContext, "message.category.delete.failed.has.dependencies") %>';
-                            var t = new dojox.timing.Timer();
-                            t.setInterval(5000);
-                            t.onTick = function() {
-                                t.stop();
-                                dojo.byId("warningDiv").innerHTML = '';
-                            };
-                            t.start();
-                        }
-
-                        dia.hide();
-                        doSearch(false, true);
-                        grid.selection.clear();
+                        };
+                        t.start();
+                    } else {
+                        dojo.byId("warningDiv").innerHTML = '';
                     }
+                    dia.hide();
+                    doSearch(false, true);
+                    grid.selection.clear();
+                })
+                .catch(function(error) {
+                    console.error('Error deleting categories:', error);
+                    dia.hide();
                 });
             }
 
@@ -648,27 +673,34 @@
                     inodes[index] = selectedItem.i.inode;
                 });
 
-                CategoryAjax.deleteSelectedCategories(inodes, {
-                    callback:function(result) {
-                        if(result==0) {
+                fetch('/api/v1/categories', {
+                    method: 'DELETE',
+                    cache: 'no-cache',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify(inodes)
+                })
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    var result = data.entity;
+                    if (result && result.fails && result.fails.length > 0) {
+                        dojo.byId("warningDiv").innerHTML = '<%= LanguageUtil.get(pageContext, "message.category.delete.failed.has.dependencies") %>';
+                        var t = new dojox.timing.Timer();
+                        t.setInterval(5000);
+                        t.onTick = function() {
                             dojo.byId("warningDiv").innerHTML = '';
-                        } else if(result==1) { // has dependencies
-                            dojo.byId("warningDiv").innerHTML = '<%= LanguageUtil.get(pageContext, "message.category.delete.failed.has.dependencies") %>';
-                            var t = new dojox.timing.Timer();
-                            t.setInterval(5000);
-                            t.onTick = function() {
-                                dojo.byId("warningDiv").innerHTML = '';
-                                t.stop();
-                            }
-                            t.start();
-                        } else if (result==2) {
-                            dojo.byId("warningDiv").innerHTML = '';
+                            t.stop();
                         }
-
-                        grid.selection.clear();
-                        doSearch(false, true);
-                        dia.hide();
+                        t.start();
+                    } else {
+                        dojo.byId("warningDiv").innerHTML = '';
                     }
+                    grid.selection.clear();
+                    doSearch(false, true);
+                    dia.hide();
+                })
+                .catch(function(error) {
+                    console.error('Error deleting categories:', error);
+                    dia.hide();
                 });
             };
         }
@@ -695,41 +727,74 @@
         var key = dojo.byId(prefix+"CatKey").value;
         var keywords = dojo.byId(prefix+"CatKeywords").value;
 
-        CategoryAjax.saveOrUpdateCategory(save, currentInodeOrIdentifier, name, velVar, key, keywords, {
-            callback:function(result) {
+        var requestBody;
+        var requestMethod;
+        var requestUrl = '/api/v1/categories';
+
+        if (save) {
+            requestMethod = 'POST';
+            requestBody = {
+                categoryName: name,
+                categoryVelocityVarName: velVar,
+                key: key,
+                keywords: keywords,
+                parent: currentInodeOrIdentifier || null
+            };
+        } else {
+            requestMethod = 'PUT';
+            requestBody = {
+                inode: currentInodeOrIdentifier,
+                categoryName: name,
+                categoryVelocityVarName: velVar,
+                key: key,
+                keywords: keywords
+            };
+        }
+
+        fetch(requestUrl, {
+            method: requestMethod,
+            cache: 'no-cache',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(requestBody)
+        })
+        .then(function(r) {
+            if (r.status === 403) {
+                return r.json().then(function() {
+                    var message = `<%= LanguageUtil.get(pageContext, "message.category.permission.error") %>`;
+                    dojo.byId("savedMessage").innerHTML = message;
+                    dojo.byId("savedMessage").style = "color:red; font-size:11px;";
+                    if (!save) { showDotCMSSystemMessage(message); }
+                });
+            }
+            if (!r.ok) {
+                return r.json().then(function(errData) {
+                    var errMsg = (errData && errData.message) ? errData.message : '';
+                    var message;
+                    if (errMsg.indexOf('taken') !== -1 || errMsg.indexOf('key') !== -1) {
+                        message = `<%= LanguageUtil.get(pageContext, "error.category.folder.taken") %>`;
+                    } else {
+                        message = errMsg || `<%= LanguageUtil.get(pageContext, "error.category.folder.taken") %>`;
+                    }
+                    dojo.byId("savedMessage").innerHTML = message;
+                    dojo.byId("savedMessage").style = "color:red; font-size:11px;";
+                });
+            }
+            return r.json().then(function() {
                 doSearch(false, true);
                 grid.selection.clear();
-
-                var message = "";
-                var messageStyle = "color:green; font-size:11px;";
-
-                switch (result) {
-                    case 0:
-                        message = `<%= LanguageUtil.get(pageContext, "message.category.add") %>`;
-                        clearAddDialog();
-                        if(!save) {
-                            message = `<%= LanguageUtil.get(pageContext, "message.category.update") %>`;
-                            showDotCMSSystemMessage(message);
-                        }
-                        break;
-                    case 1:
-                        message = `<%= LanguageUtil.get(pageContext, "message.category.permission.error") %>`;
-                        messageStyle = "color:red; font-size:11px;";
-                        error = true;
-						if(!save) {
-							showDotCMSSystemMessage(message);
-						}
-                        break;
-                    case 2:
-                        message = `<%= LanguageUtil.get(pageContext, "error.category.folder.taken") %>`;
-                        messageStyle = "color:red; font-size:11px;";
-                        break;
-                    default:
+                var message = `<%= LanguageUtil.get(pageContext, "message.category.add") %>`;
+                if (!save) {
+                    message = `<%= LanguageUtil.get(pageContext, "message.category.update") %>`;
+                    showDotCMSSystemMessage(message);
+                } else {
+                    clearAddDialog();
                 }
-
                 dojo.byId("savedMessage").innerHTML = message;
-                dojo.byId("savedMessage").style = messageStyle;
-            }
+                dojo.byId("savedMessage").style = "color:green; font-size:11px;";
+            });
+        })
+        .catch(function(error) {
+            console.error('Error saving category:', error);
         });
     }
 
@@ -741,21 +806,36 @@
     }
 
     function importCategories() {
-        var file = dwr.util.getValue('uploadFile');
+        var fileInput = document.getElementById('uploadFile');
         var filter = dojo.byId("catFilter").value;
         var merge = dojo.byId("radioTwo");
         var exportType = "replace";
 
-        if(merge.checked) {
+        if (merge.checked) {
             exportType = "merge";
         }
 
-        CategoryAjax.importCategories(currentInodeOrIdentifier, filter, file, exportType, function(result) {
-            var dia = dijit.byId('importCategoriesOptions');
+        if (!fileInput || !fileInput.files || fileInput.files.length === 0) {
+            console.error('No file selected for import');
+            return;
+        }
 
-            if(result==0) {
-                dojo.byId("warningDiv").innerHTML = '';
-            }  else if (result==1) {
+        var formData = new FormData();
+        formData.append('file', fileInput.files[0]);
+        formData.append('filter', filter || '');
+        formData.append('exportType', exportType);
+        formData.append('contextInode', currentInodeOrIdentifier || '');
+
+        fetch('/api/v1/categories/_import', {
+            method: 'POST',
+            cache: 'no-cache',
+            body: formData
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            var dia = dijit.byId('importCategoriesOptions');
+            var result = data.entity;
+            if (result && result.fails && result.fails.length > 0) {
                 dojo.byId("warningDiv").innerHTML = `<%= LanguageUtil.get(pageContext, "message.category.delete.failed.has.dependencies") %>`;
                 var t = new dojox.timing.Timer();
                 t.setInterval(5000);
@@ -764,11 +844,15 @@
                     t.stop();
                 }
                 t.start();
+            } else {
+                dojo.byId("warningDiv").innerHTML = '';
             }
-
             dia.hide();
             doSearch(false, true);
             grid.selection.clear();
+        })
+        .catch(function(error) {
+            console.error('Error importing categories:', error);
         });
     }
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories.jsp
@@ -858,6 +858,10 @@
 
 
     function initPermission() {
+        if (!currentInodeOrIdentifier) {
+            return;
+        }
+
         var nameField = dojo.byId("permCatName");
         nameField.innerHTML = currentCatName;
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories_dialog.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/categories/view_categories_dialog.jsp
@@ -41,8 +41,6 @@
 }
 
 </style>
-<script type="text/javascript" src="/dwr/interface/CategoryAjax.js"></script>
-
 <script type="text/javascript">
 	dojo.require("dojox.grid.enhanced.plugins.Pagination");
 	dojo.require('dijit.layout.ContentPane');

--- a/dotCMS/src/main/webapp/html/portlet/ext/common/edit_permissions_tab_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/common/edit_permissions_tab_js_inc.jsp
@@ -17,7 +17,220 @@
 <%@ page import="com.dotmarketing.portlets.rules.model.Rule" %>
 <%@ page import="com.dotmarketing.portlets.templates.design.bean.TemplateLayout" %>
 
-<script type="text/javascript" src="/dwr/interface/PermissionAjax.js"></script>
+<script type="text/javascript">
+// DWR-to-REST compatibility layer for PermissionAjax
+var PermissionAjax = (function () {
+
+    var PERM_BIT = {
+        READ: 1,
+        WRITE: 2,
+        PUBLISH: 4,
+        EDIT_PERMISSIONS: 8,
+        CAN_ADD_CHILDREN: 16
+    };
+
+    var SCOPE_TO_CLASS = {
+        HOST: 'com.dotmarketing.beans.Host',
+        FOLDER: 'com.dotmarketing.portlets.folders.model.Folder',
+        CONTAINER: 'com.dotmarketing.portlets.containers.model.Container',
+        TEMPLATE: 'com.dotmarketing.portlets.templates.model.Template',
+        TEMPLATE_LAYOUT: 'com.dotmarketing.portlets.templates.design.bean.TemplateLayout',
+        PAGE: 'com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage',
+        LINK: 'com.dotmarketing.portlets.links.model.Link',
+        CONTENT: 'com.dotmarketing.portlets.contentlet.model.Contentlet',
+        STRUCTURE: 'com.dotmarketing.portlets.structure.model.Structure',
+        CATEGORY: 'com.dotmarketing.portlets.categories.model.Category',
+        RULES: 'com.dotmarketing.portlets.rules.model.Rule'
+    };
+
+    // Maps the field names used by applyPermissionChanges() to REST scope names.
+    // Includes both singular and plural variants used across different callers.
+    var FIELD_TO_SCOPE = {
+        foldersPermission: 'FOLDER',
+        containersPermission: 'CONTAINER',
+        templatesPermission: 'TEMPLATE',
+        templateLayoutsPermission: 'TEMPLATE_LAYOUT',
+        pagesPermission: 'PAGE',
+        linksPermission: 'LINK',
+        contentPermission: 'CONTENT',
+        structurePermission: 'STRUCTURE',
+        categoriesPermissions: 'CATEGORY',
+        rulesPermissions: 'RULES',
+        rulesPermission: 'RULES'
+    };
+
+    function namesToBits(nameArray) {
+        var bits = 0;
+        if (!nameArray) return bits;
+        nameArray.forEach(function (p) {
+            if (PERM_BIT[p] !== undefined) bits |= PERM_BIT[p];
+        });
+        return bits;
+    }
+
+    function resolveCallback(callbackConfig) {
+        if (typeof callbackConfig === 'function') {
+            return { fn: callbackConfig, scope: window };
+        }
+        return { fn: callbackConfig.callback, scope: callbackConfig.scope || window };
+    }
+
+    return {
+
+        getAssetPermissions: function (assetId, languageId, callbackConfig) {
+            var cb = resolveCallback(callbackConfig);
+            var langParam = languageId ? '&languageId=' + encodeURIComponent(languageId) : '';
+            fetch('/api/v1/permissions/' + encodeURIComponent(assetId) + '?per_page=100' + langParam, { cache: 'no-cache' })
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    var entity = data.entity || {};
+                    var permissions = entity.permissions || [];
+                    var dwrRoles = permissions.map(function (rp) {
+                        var role = {
+                            id: rp.roleId,
+                            name: rp.roleName,
+                            inherited: !!rp.inherited,
+                            inheritedFromType: rp.inheritedFromType || '',
+                            inheritedFromPath: rp.inheritedFromPath || '',
+                            inheritedFromId: rp.inheritedFromId || '',
+                            editPermissions: true,
+                            locked: false,
+                            permissions: []
+                        };
+                        // Merge all permission types into "individual" to match DWR behavior.
+                        // DWR's getAssetPermissions() forced ALL permissions from getPermissions()
+                        // to type="individual", so roles with only inheritable-type permissions
+                        // (e.g., FOLDER READ) still had their bits in the "individual" bucket.
+                        var allBits = namesToBits(rp.individual);
+                        var inheritable = rp.inheritable || {};
+                        Object.keys(inheritable).forEach(function (scope) {
+                            allBits |= namesToBits(inheritable[scope]);
+                        });
+                        if (allBits > 0) {
+                            role.permissions.push({
+                                type: 'individual',
+                                permission: allBits,
+                                inode: entity.assetId
+                            });
+                        }
+                        // Also add scope-specific entries for inheritable permissions
+                        // (these come from the separate getInheritablePermissions() call in the DWR)
+                        Object.keys(inheritable).forEach(function (scope) {
+                            var className = SCOPE_TO_CLASS[scope] || scope;
+                            role.permissions.push({
+                                type: className,
+                                permission: namesToBits(inheritable[scope]),
+                                inode: entity.assetId
+                            });
+                        });
+                        return role;
+                    });
+                    cb.fn.call(cb.scope, dwrRoles);
+                })
+                .catch(function (error) {
+                    console.error('PermissionAjax.getAssetPermissions failed:', error);
+                });
+        },
+
+        saveAssetPermissions: function (assetId, languageId, permissions, cascade, callbackConfig) {
+            function bitsToNames(bits) {
+                var names = [];
+                if (bits & PERM_BIT.READ) names.push('READ');
+                if (bits & PERM_BIT.WRITE) names.push('WRITE');
+                if (bits & PERM_BIT.PUBLISH) names.push('PUBLISH');
+                if (bits & PERM_BIT.EDIT_PERMISSIONS) names.push('EDIT_PERMISSIONS');
+                if (bits & PERM_BIT.CAN_ADD_CHILDREN) names.push('CAN_ADD_CHILDREN');
+                return names;
+            }
+
+            // Track which REST scopes have been mapped to avoid duplicates
+            // when both rulesPermission and rulesPermissions are present.
+            var restPermissions = permissions.map(function (p) {
+                var roleForm = { roleId: p.roleId, individual: [] };
+                if (p.individualPermission != null) {
+                    roleForm.individual = bitsToNames(parseInt(p.individualPermission) || 0);
+                }
+                var inheritable = {};
+                Object.keys(FIELD_TO_SCOPE).forEach(function (field) {
+                    if (p[field] != null) {
+                        var scope = FIELD_TO_SCOPE[field];
+                        if (!inheritable[scope]) {
+                            var names = bitsToNames(parseInt(p[field]) || 0);
+                            if (names.length > 0) {
+                                inheritable[scope] = names;
+                            }
+                        }
+                    }
+                });
+                if (Object.keys(inheritable).length > 0) {
+                    roleForm.inheritable = inheritable;
+                }
+                return roleForm;
+            });
+
+            var url = '/api/v1/permissions/' + encodeURIComponent(assetId) + '?cascade=' + (cascade ? 'true' : 'false');
+            if (languageId) url += '&languageId=' + encodeURIComponent(languageId);
+
+            fetch(url, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ permissions: restPermissions }),
+                cache: 'no-cache'
+            })
+                .then(function (r) { return r.json(); })
+                .then(function () {
+                    if (typeof callbackConfig === 'function') {
+                        callbackConfig();
+                    } else if (callbackConfig && typeof callbackConfig.callback === 'function') {
+                        callbackConfig.callback.call(callbackConfig.scope || window);
+                    }
+                })
+                .catch(function (error) {
+                    console.error('PermissionAjax.saveAssetPermissions failed:', error);
+                });
+        },
+
+        permissionIndividually: function (assetId, languageId, callback) {
+            var url = '/api/v1/permissions/' + encodeURIComponent(assetId) + '/_individualpermission';
+            if (languageId) url += '?languageId=' + encodeURIComponent(languageId);
+            fetch(url, { method: 'PUT', cache: 'no-cache' })
+                .then(function (r) { return r.json(); })
+                .then(function () {
+                    if (typeof callback === 'function') callback();
+                })
+                .catch(function (error) {
+                    console.error('PermissionAjax.permissionIndividually failed:', error);
+                });
+        },
+
+        resetAssetPermissions: function (assetId, languageId, callback) {
+            var url = '/api/v1/permissions/' + encodeURIComponent(assetId) + '/_reset';
+            if (languageId) url += '?languageId=' + encodeURIComponent(languageId);
+            fetch(url, { method: 'PUT', cache: 'no-cache' })
+                .then(function (r) { return r.json(); })
+                .then(function () {
+                    if (typeof callback === 'function') callback();
+                })
+                .catch(function (error) {
+                    console.error('PermissionAjax.resetAssetPermissions failed:', error);
+                });
+        },
+
+        getAsset: function (inodeOrId, callbackConfig) {
+            var cb = resolveCallback(callbackConfig);
+            fetch('/api/v1/permissions/' + encodeURIComponent(inodeOrId) + '/_permissionable', { cache: 'no-cache' })
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    cb.fn.call(cb.scope, data.entity);
+                })
+                .catch(function (error) {
+                    console.error('PermissionAjax.getAsset failed:', error);
+                });
+        }
+
+    };
+}());
+</script>
 <script type="text/javascript" src="/html/js/dotcms/dijit/form/RolesFilteringSelect.js"></script>
 <script type="text/javascript"><!--
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field_js.jsp
@@ -18,7 +18,6 @@
 <%@ page import="org.apache.commons.lang.StringUtils" %>
 
 <script type='text/javascript' src='/dwr/interface/StructureAjax.js'></script>
-<script type='text/javascript' src='/dwr/interface/CategoryAjax.js'></script>
 <script type='text/javascript' src='/dwr/interface/ContentletAjax.js'></script>
 <script type='text/javascript' src='/dwr/interface/TagAjax.js'></script>
 <script type='text/javascript' src='/dwr/interface/FileAssetAjax.js'></script>

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets.jsp
@@ -216,7 +216,6 @@
 <jsp:include page="/html/portlet/ext/folders/context_menus_js.jsp" />
 <script type='text/javascript' src='/html/js/scriptaculous/prototype.js'></script>
 <script type='text/javascript' src='/dwr/interface/StructureAjax.js'></script>
-<script type='text/javascript' src='/dwr/interface/CategoryAjax.js'></script>
 <script type='text/javascript' src='/dwr/interface/ContentletAjax.js'></script>
 <script type='text/javascript' src='/dwr/interface/TagAjax.js'></script>
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_js_inc.jsp
@@ -1387,7 +1387,12 @@ final String calendarEventInode = null!=calendarEventSt ? calendarEventSt.inode(
                         var selectId = cat["categoryName"].replace(/[^A-Za-z0-9_]/g, "") + "Select";
                         var mycallbackfnc = function(data) { fillCategorySelect(selectId, data); }
 
-                        CategoryAjax.getSubCategories(cat["inode"], '', { callback: mycallbackfnc, async: false });
+                        (function(cb) {
+                            fetch('/api/v1/categories/children?inode=' + encodeURIComponent(cat["inode"]) + '&allLevels=true&per_page=1000', {cache: 'no-cache'})
+                                .then(function(r) { return r.json(); })
+                                .then(function(data) { cb(data.entity || []); })
+                                .catch(function(error) { console.error('Error loading subcategories:', error); cb([]); });
+                        })(mycallbackfnc);
                 }
         }
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_popup.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/view_contentlets_popup.jsp
@@ -22,7 +22,6 @@
 
 
 <script type='text/javascript' src='/dwr/interface/StructureAjax.js'></script>
-<script type='text/javascript' src='/dwr/interface/CategoryAjax.js'></script>
 <script type='text/javascript' src='/dwr/interface/ContentletAjax.js'></script>
 <script type='text/javascript' src='/dwr/engine.js'></script>
 <script type='text/javascript' src='/dwr/util.js'></script>
@@ -310,7 +309,12 @@ function renderSearchField (field) {
 			var cat = categories[i];
 			var selectId = cat["categoryName"].replace(/[^A-Za-z0-9_]/, "") + "Select";
 			var mycallbackfnc = function(data) { fillCategorySelect(selectId, data); }
-			CategoryAjax.getSubCategories(cat["inode"], '', { callback: mycallbackfnc, async: false });
+			(function(cb) {
+				fetch('/api/v1/categories/children?inode=' + encodeURIComponent(cat["inode"]) + '&allLevels=true&per_page=1000', {cache: 'no-cache'})
+					.then(function(r) { return r.json(); })
+					.then(function(data) { cb(data.entity || []); })
+					.catch(function(error) { console.error('Error loading subcategories:', error); cb([]); });
+			})(mycallbackfnc);
 		}
 	}
 	

--- a/dotCMS/src/main/webapp/html/portlet/ext/files/upload_multiple_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/files/upload_multiple_js_inc.jsp
@@ -3,7 +3,6 @@
 
 <%@page import="com.dotmarketing.util.UtilMethods" %>
 
-<script src="/dwr/interface/HostAjax.js" type="text/javascript"></script>
 <script src="/html/js/scriptaculous/prototype.js" type="text/javascript"></script>
 <script src="/html/js/scriptaculous/scriptaculous.js" type="text/javascript"></script>
 

--- a/dotCMS/src/main/webapp/html/portlet/ext/fileupload/upload_multiple_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/fileupload/upload_multiple_js_inc.jsp
@@ -3,7 +3,6 @@
 
 <%@page import="com.dotmarketing.util.UtilMethods" %>
 
-<script src="/dwr/interface/HostAjax.js" type="text/javascript"></script>
 <script src="/html/js/scriptaculous/prototype.js" type="text/javascript"></script>
 <script src="/html/js/scriptaculous/scriptaculous.js" type="text/javascript"></script>
 


### PR DESCRIPTION
Prompt log: https://gist.github.com/wezell/c4b5f7f20e780e9ebe7f35a68c954ebc


## Summary
- Replaces `PermissionAjax` DWR calls with a new REST endpoint (`/api/v1/permissions`)
- Migrates all JSP frontend callers from DWR proxy to `fetch()` calls against the new JAX-RS resource
- Deprecates `PermissionAjax` and several other unused DWR classes (`HostAjax`, `InodeAjax`, `CategoryAjax`, `PermissionableObjectDWR`)
- Removes DWR script includes that are no longer needed

## Changes
- **New**: `PermissionResource.java` — REST endpoint for permission operations (get permissionable, get permissions, save permissions, reset permissions)
- **New**: `PermissionableObjectView.java`, `AssetPermissionHelper` enhancements
- **Updated**: 12 JSP files migrated from `PermissionAjax` DWR to REST fetch calls
- **Updated**: `dwr.xml` — removed unused DWR class mappings
- **Updated**: OpenAPI spec with new permission endpoints

## Test Plan
- [ ] Verify permission tab loads correctly on content types, containers, templates, folders, hosts
- [ ] Verify saving/resetting permissions works via the new REST endpoints
- [ ] Verify categories permissions dialog works
- [ ] Verify browser view permission checks still function

Ref: #34797

🤖 Generated with [Claude Code](https://claude.com/claude-code)