### PR TITLE
feat(ci): orchestrate automatic and interactive Claude reviews

### DIFF
--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -65,7 +65,22 @@ jobs:
   # Interactive Claude mentions (simplified using centralized logic)
   claude-interactive:
     needs: security-check
-    if: needs.security-check.outputs.authorized == 'true'
+    if: |
+      needs.security-check.outputs.authorized == 'true' &&
+      (
+        github.event_name == 'issue_comment' ||
+        github.event_name == 'pull_request_review_comment' ||
+        (
+          github.event_name == 'pull_request' && (
+            contains(github.event.pull_request.title, '@claude') ||
+            contains(github.event.pull_request.title, '@Claude') ||
+            contains(github.event.pull_request.title, '@CLAUDE') ||
+            contains(github.event.pull_request.body, '@claude') ||
+            contains(github.event.pull_request.body, '@Claude') ||
+            contains(github.event.pull_request.body, '@CLAUDE')
+          )
+        )
+      )
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
     with:
       trigger_mode: interactive

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -1,4 +1,4 @@
-name: Claude-Code When Mentioned
+name: Claude AI Orchestrator
 
 # Concurrency control to prevent multiple jobs running for the same PR/issue
 concurrency:
@@ -17,6 +17,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request:
+    types: [opened, synchronize]
 
 jobs:
   # Security gate: Check if user is dotCMS organization member
@@ -75,5 +77,31 @@ jobs:
       enable_mention_detection: true  # Uses built-in @claude mention detection
       # custom_trigger_condition: |    # Optional: Override default mention detection
       #   your custom condition here
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  # Automatic PR reviews (no @claude mention)
+  claude-automatic-review:
+    needs: security-check
+    if: |
+      needs.security-check.outputs.authorized == 'true' &&
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.title, '@claude') &&
+      !contains(github.event.pull_request.title, '@Claude') &&
+      !contains(github.event.pull_request.title, '@CLAUDE') &&
+      !contains(github.event.pull_request.body, '@claude') &&
+      !contains(github.event.pull_request.body, '@Claude') &&
+      !contains(github.event.pull_request.body, '@CLAUDE')
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    with:
+      trigger_mode: automatic
+      direct_prompt: |
+        Review this PR. Flag anything that looks wrong, risky, or worth a second look: bad assumptions, missing edge cases, design problems, security issues. Skip praise. If it is clean, say so in one line.
+      allowed_tools: |
+        Bash(git status)
+        Bash(git diff)
+      timeout_minutes: 15
+      runner: ubuntu-latest
+      enable_mention_detection: false
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -1,10 +1,5 @@
 name: Claude AI Orchestrator
 
-# Concurrency control to prevent multiple jobs running for the same PR/issue
-concurrency:
-  group: claude-${{ github.event.pull_request.number || github.event.issue.number || 'manual' }}
-  cancel-in-progress: false
-
 on:
   workflow_dispatch:
     inputs:
@@ -65,6 +60,10 @@ jobs:
   # Interactive Claude mentions (simplified using centralized logic)
   claude-interactive:
     needs: security-check
+    # Never cancel in-progress interactive sessions — a user may be mid-conversation
+    concurrency:
+      group: claude-interactive-${{ github.event.pull_request.number || github.event.issue.number || 'manual' }}
+      cancel-in-progress: false
     if: |
       needs.security-check.outputs.authorized == 'true' &&
       (
@@ -98,6 +97,10 @@ jobs:
   # Automatic PR reviews (no @claude mention)
   claude-automatic-review:
     needs: security-check
+    # Cancel in-progress automatic reviews when a new push arrives — always review latest state
+    concurrency:
+      group: claude-automatic-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     if: |
       needs.security-check.outputs.authorized == 'true' &&
       github.event_name == 'pull_request' &&


### PR DESCRIPTION
## Summary
- rename workflow to ai_claude-orchestrator.yml to reflect multi-trigger orchestration
- add pull_request triggers (opened, synchronize) for automatic Claude reviews
- add claude-automatic-review job using trigger_mode automatic
- skip automatic runs when PR title/body already contains @claude to avoid double-triggering (but we have concurrently control anyways)
- set direct prompt to a senior/staff review style (no praise, flag risk/issues, one-line clean verdict)

## Non-functional considerations
- to make sure that a bad actor can't FDoS us by opening a slew of PRs on junk to devour our tokens runs we are gated by public org membership (downside is that it must be set by our devs manually).  Should that fail or be removed...
  - limits set on the anthropic side
  - we have reporting and telemetry by key
  - the key isn't hard-coded to protect against forks and such


## Validation
- reviewed workflow YAML diff locally

Closes #34809