### PR TITLE
fix(pre-commit): enforce BunnyCDN registry URLs in yarn.lock

### DIFF
--- a/core-web/.husky/pre-commit
+++ b/core-web/.husky/pre-commit
@@ -132,6 +132,42 @@ check_sdk_client_affected() {
     fi
 }
 
+check_yarn_lock_registry() {
+    local yarn_lock="${root_dir}/core-web/yarn.lock"
+    local expected_registry="dotcms-npm.b-cdn.net"
+    local bad_registries=("registry.yarnpkg.com" "registry.npmjs.org")
+
+    # Only run if yarn.lock is staged
+    if ! git diff --cached --name-only | grep -q "core-web/yarn.lock"; then
+        print_color "$BLUE" "ℹ️  yarn.lock not staged — skipping registry check"
+        return 0
+    fi
+
+    local found_bad=false
+    for registry in "${bad_registries[@]}"; do
+        if grep -q "$registry" "$yarn_lock"; then
+            print_color "$RED" "❌ yarn.lock contains '$registry' instead of BunnyCDN ($expected_registry)"
+            found_bad=true
+        fi
+    done
+
+    if [ "$found_bad" = true ]; then
+        print_color "$RED" "❌ yarn.lock was regenerated with the wrong registry"
+        print_color "$YELLOW" "   This usually means you have a global registry override set."
+        print_color "$YELLOW" "   Check with:  yarn config list | grep registry"
+        print_color "$YELLOW" "   Or:          npm config get registry"
+        print_color "$YELLOW" "   Fix with:"
+        print_color "$BLUE"   "     yarn config delete registry"
+        print_color "$BLUE"   "     npm config delete registry   # if set via npm"
+        print_color "$BLUE"   "     cd core-web && yarn install"
+        has_errors=true
+        return 1
+    fi
+
+    print_color "$GREEN" "✅ yarn.lock registry URLs are correct (BunnyCDN)"
+    return 0
+}
+
 check_sdkman() {
     SDKMAN_INIT="$HOME/.sdkman/bin/sdkman-init.sh"
 
@@ -174,6 +210,7 @@ perform_frontend_fixes() {
         cd "$root_dir" || exit 1
         git add "core-web/yarn.lock"
         cd "${root_dir}/core-web" || exit 1
+        check_yarn_lock_registry
     fi
 
     # ENOBUFS auto-fix will handle cache issues when they occur


### PR DESCRIPTION
## Summary

Adds a `check_yarn_lock_registry()` function to the pre-commit hook (`core-web/.husky/pre-commit`) that **blocks commits where `yarn.lock` contains wrong registry URLs** (`registry.yarnpkg.com` or `registry.npmjs.org`) instead of the project's BunnyCDN cache (`dotcms-npm.b-cdn.net`).

### Background

This is a recurrence of the issue fixed in #34676. When the Lara Theme / Angular 21 upgrade (#34531) was merged, the developer who regenerated `yarn.lock` had a global registry override set locally. Yarn 1.x does **not** reliably honour the project-level `.yarnrc` when a global config is present — `npm config set registry` silently takes higher priority, causing the lockfile to be regenerated with the wrong registry URLs and breaking CI/CD reliability.

### Root cause

- `core-web/.yarnrc` correctly points to `https://dotcms-npm.b-cdn.net`
- A developer's local `yarn config set registry` or `npm config set registry` silently overrides this
- `yarn install` regenerates `yarn.lock` with upstream registry URLs (3,455+ affected entries)
- CI/CD follows the lockfile exactly, bypassing the BunnyCDN cache and hitting the upstream registry, which is prone to rate limiting and availability issues

### What this PR does

- Adds `check_yarn_lock_registry()` to `.husky/pre-commit`
- Called immediately after `yarn install` stages `yarn.lock`
- Scans the lockfile for `registry.yarnpkg.com` or `registry.npmjs.org` entries
- **Blocks the commit** if wrong URLs are found, with clear instructions to fix:
  ```
  yarn config delete registry
  npm config delete registry
  cd core-web && yarn install
  ```
- **Zero cost** on normal commits — only activates when `yarn.lock` is actually staged

### What this PR does NOT do

- This does not fix the currently broken `yarn.lock` on `main` — that requires a separate PR where someone with no global registry override regenerates it correctly
- This does not replace the CI-level check Steve mentioned — that should be added as a second line of defence

## Test plan

- [ ] Temporarily set a wrong registry: `yarn config set registry https://registry.npmjs.org`
- [ ] Modify a package and run `yarn install` in `core-web/`
- [ ] Stage `core-web/yarn.lock` and attempt to commit — hook should block with a clear error message
- [ ] Remove the override: `yarn config delete registry`
- [ ] Re-run `yarn install`, re-stage, re-commit — hook should pass

## Related

- Fixes #34619
- Re-introduced by #34531
- Originally fixed in #34676

🤖 Generated with [Claude Code](https://claude.com/claude-code)