### PR TITLE
feat(dot-analytics): update date filter options and enforce 7-day minimum range

### DIFF
--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/dot-analytics-dashboard.store.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/dot-analytics-dashboard.store.ts
@@ -14,6 +14,7 @@ import { withPageview } from './features/with-pageview.feature';
 import { DASHBOARD_TABS, DashboardTab, TIME_RANGE_OPTIONS } from '../constants';
 import { TimeRangeInput } from '../types';
 import { isValidTab, paramsToTimeRange } from '../utils/filters.utils';
+import { silentNavigate } from '../utils/router.utils';
 
 /**
  * Analytics Dashboard Store
@@ -48,13 +49,7 @@ export const DotAnalyticsDashboardStore = signalStore(
              */
             setCurrentTabAndNavigate(tab: DashboardTab): void {
                 store.setCurrentTab(tab);
-
-                const urlTree = router.createUrlTree([], {
-                    relativeTo: route,
-                    queryParams: { tab },
-                    queryParamsHandling: 'merge'
-                });
-                location.replaceState(router.serializeUrl(urlTree));
+                silentNavigate(router, location, route, { tab });
             },
 
             /**
@@ -78,31 +73,37 @@ export const DotAnalyticsDashboardStore = signalStore(
 
             /**
              * Updates time range and syncs URL with query params.
+             *
+             * Uses `location.replaceState` (same as `setCurrentTabAndNavigate`) to avoid
+             * triggering router events that would reset component state.
+             *
+             * When `timeRange` is the bare `'custom'` string (dropdown selected but no
+             * dates chosen yet), only the URL is updated — store state is left unchanged
+             * so no data reload is triggered until a full date range is confirmed.
              */
             updateTimeRange(timeRange: TimeRangeInput): void {
-                store.setTimeRange(timeRange);
-
-                // Build query params from time range
                 const queryParams: Params = {};
 
                 if (Array.isArray(timeRange)) {
-                    // Custom date range
+                    // Complete custom date range — update state and URL
+                    store.setTimeRange(timeRange);
                     queryParams['time_range'] = TIME_RANGE_OPTIONS.custom;
                     queryParams['from'] = timeRange[0];
                     queryParams['to'] = timeRange[1];
                 } else {
-                    // Predefined range
+                    // Predefined range OR bare 'custom' (no dates yet)
+                    // Only update state for predefined ranges, not for bare 'custom'
+                    if (timeRange !== TIME_RANGE_OPTIONS.custom) {
+                        store.setTimeRange(timeRange);
+                    }
+
                     queryParams['time_range'] = timeRange;
+                    // Null out from/to to remove them from the URL when switching away from custom
+                    queryParams['from'] = null;
+                    queryParams['to'] = null;
                 }
 
-                // Update URL
-                // TODO: Find a better way to update the URL with the time range query params.
-                router.navigate([], {
-                    relativeTo: route,
-                    queryParams: queryParams,
-                    queryParamsHandling: 'merge',
-                    replaceUrl: true
-                });
+                silentNavigate(router, location, route, queryParams);
             }
         })
     ),

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/filters.utils.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/filters.utils.spec.ts
@@ -90,14 +90,6 @@ describe('Filters Utils', () => {
             expect(result).toBe(TIME_RANGE_OPTIONS.last7days);
         });
 
-        it('should handle empty params object', () => {
-            const params: Params = {};
-
-            const result = paramsToTimeRange(params);
-
-            expect(result).toBe(TIME_RANGE_OPTIONS.last7days);
-        });
-
         it('should handle null params', () => {
             const params: Params = null as unknown as Params;
 

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/filters.utils.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/filters.utils.spec.ts
@@ -105,5 +105,17 @@ describe('Filters Utils', () => {
 
             expect(result).toBe(TIME_RANGE_OPTIONS.last7days);
         });
+
+        it('should fall back to last7days when time_range is today', () => {
+            const params: Params = { time_range: TIME_RANGE_OPTIONS.today };
+
+            expect(paramsToTimeRange(params)).toBe(TIME_RANGE_OPTIONS.last7days);
+        });
+
+        it('should fall back to last7days when time_range is yesterday', () => {
+            const params: Params = { time_range: TIME_RANGE_OPTIONS.yesterday };
+
+            expect(paramsToTimeRange(params)).toBe(TIME_RANGE_OPTIONS.last7days);
+        });
     });
 });

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/filters.utils.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/filters.utils.ts
@@ -1,7 +1,9 @@
 import { Params } from '@angular/router';
 
 import { DASHBOARD_TABS, DashboardTab, TIME_RANGE_OPTIONS } from '../constants';
-import { TimeRangeInput } from '../types';
+import { TimeRange, TimeRangeInput } from '../types';
+
+const VALID_TIME_RANGE_VALUES: readonly string[] = Object.values(TIME_RANGE_OPTIONS);
 
 /**
  * Validates if a string is a valid DashboardTab
@@ -13,8 +15,15 @@ export function isValidTab(tab: string): tab is DashboardTab {
     return Object.values(DASHBOARD_TABS).includes(tab as DashboardTab);
 }
 
+/** Time range values that are no longer supported as URL params */
+const EXCLUDED_TIME_RANGE_PARAMS: string[] = [
+    TIME_RANGE_OPTIONS.today,
+    TIME_RANGE_OPTIONS.yesterday
+];
+
 /**
- * Converts URL query params to TimeRangeInput
+ * Converts URL query params to TimeRangeInput.
+ * `today` and `yesterday` are excluded and fall back to `last7days`.
  *
  * @param params - The query params from the route
  * @returns A TimeRangeInput (either a predefined range string or a custom date array)
@@ -24,15 +33,26 @@ export function paramsToTimeRange(params: Params | null | undefined): TimeRangeI
         return TIME_RANGE_OPTIONS.last7days;
     }
 
+    const timeRange: string = params['time_range'];
+
+    // Excluded values fall back to the default
+    if (EXCLUDED_TIME_RANGE_PARAMS.includes(timeRange)) {
+        return TIME_RANGE_OPTIONS.last7days;
+    }
+
     // Only return custom date range if both from and to are provided
-    if (params['time_range'] === TIME_RANGE_OPTIONS.custom && params['from'] && params['to']) {
+    if (timeRange === TIME_RANGE_OPTIONS.custom && params['from'] && params['to']) {
         return [params['from'], params['to']];
     }
 
     // If time_range is custom but missing from/to, fall back to default
-    if (params['time_range'] === TIME_RANGE_OPTIONS.custom) {
+    if (timeRange === TIME_RANGE_OPTIONS.custom) {
         return TIME_RANGE_OPTIONS.last7days;
     }
 
-    return params['time_range'] || TIME_RANGE_OPTIONS.last7days;
+    if (timeRange && VALID_TIME_RANGE_VALUES.includes(timeRange)) {
+        return timeRange as TimeRange;
+    }
+
+    return TIME_RANGE_OPTIONS.last7days;
 }

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/router.utils.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/router.utils.ts
@@ -1,0 +1,20 @@
+import { Location } from '@angular/common';
+import { ActivatedRoute, Params, Router } from '@angular/router';
+
+/**
+ * Updates the URL via `location.replaceState` without triggering Angular router events.
+ * Merges the provided queryParams into the current URL.
+ */
+export function silentNavigate(
+    router: Router,
+    location: Location,
+    route: ActivatedRoute,
+    queryParams: Params
+): void {
+    const urlTree = router.createUrlTree([], {
+        relativeTo: route,
+        queryParams,
+        queryParamsHandling: 'merge'
+    });
+    location.replaceState(router.serializeUrl(urlTree));
+}

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/dot-analytics-dashboard.component.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/dot-analytics-dashboard.component.spec.ts
@@ -161,7 +161,7 @@ describe('DotAnalyticsDashboardComponent', () => {
             expect(store.timeRange()).toEqual(['2024-01-01', '2024-01-31']);
         });
 
-        it('should set timeRange to invalid value when query param is invalid', () => {
+        it('should fall back to last7days when query param is invalid', () => {
             spectator = createComponent({
                 queryParams: {
                     time_range: 'invalid-range'
@@ -169,8 +169,7 @@ describe('DotAnalyticsDashboardComponent', () => {
             });
             store = spectator.inject(DotAnalyticsDashboardStore);
 
-            // Without validation, invalid values are accepted as-is
-            expect(store.timeRange()).toBe('invalid-range');
+            expect(store.timeRange()).toBe(TIME_RANGE_OPTIONS.last7days);
         });
 
         it('should set timeRange to last7days when custom range has incomplete dates', () => {
@@ -186,7 +185,7 @@ describe('DotAnalyticsDashboardComponent', () => {
             expect(store.timeRange()).toBe('last7days');
         });
 
-        it('should set timeRange to custom range even when dates are inverted', () => {
+        it('should set timeRange to custom range when dates are inverted in query params', () => {
             spectator = createComponent({
                 queryParams: {
                     time_range: 'custom',
@@ -196,8 +195,31 @@ describe('DotAnalyticsDashboardComponent', () => {
             });
             store = spectator.inject(DotAnalyticsDashboardStore);
 
-            // Without validation, inverted date ranges are accepted
+            // paramsToTimeRange passes through raw date values without order validation;
+            // date validation is enforced in the UI layer via isValidCustomDateRange
             expect(store.timeRange()).toEqual(['2024-01-01', '1993-01-31']);
+        });
+
+        it('should set timeRange to last7days when today is in query params', () => {
+            spectator = createComponent({
+                queryParams: {
+                    time_range: 'today'
+                }
+            });
+            store = spectator.inject(DotAnalyticsDashboardStore);
+
+            expect(store.timeRange()).toBe(TIME_RANGE_OPTIONS.last7days);
+        });
+
+        it('should set timeRange to last7days when yesterday is in query params', () => {
+            spectator = createComponent({
+                queryParams: {
+                    time_range: 'yesterday'
+                }
+            });
+            store = spectator.inject(DotAnalyticsDashboardStore);
+
+            expect(store.timeRange()).toBe(TIME_RANGE_OPTIONS.last7days);
         });
     });
 

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.html
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.html
@@ -26,9 +26,21 @@
             [showIcon]="false"
             [placeholder]="customDatePlaceholder"
             dateFormat="mm/dd/yy"
+            [maxDate]="$today()"
+            [disabledDates]="$disabledDates()"
             [showButtonBar]="true"
             [style]="{ minWidth: '250px' }"
-            (onSelect)="onChangeCustomDateRange()"
-            data-testid="custom-date-range-calendar" />
+            (onSelect)="onDateSelect($event)"
+            (onClose)="onCalendarClosed()"
+            data-testid="custom-date-range-calendar">
+            <ng-template #buttonbar let-api>
+                <p-button
+                    [label]="'analytics.filters.custom-date-range.clear' | dm"
+                    [text]="true"
+                    size="small"
+                    (onClick)="clearDateRange(); api.onClearButtonClick($event)"
+                    data-testid="custom-date-range-clear-btn" />
+            </ng-template>
+        </p-datepicker>
     }
 </div>

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
@@ -243,24 +243,6 @@ describe('DotAnalyticsFiltersComponent', () => {
             expect(changeFiltersSpy).not.toHaveBeenCalled();
         });
 
-        it('should not emit when range is incomplete (only start date)', () => {
-            const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
-            spectator.component.$customDateRange.set([new Date('2024-01-01T00:00:00')]);
-            spectator.component.onChangeCustomDateRange();
-
-            expect(changeFiltersSpy).not.toHaveBeenCalled();
-        });
-
-        it('should not emit when date order is reversed', () => {
-            const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
-            spectator.component.$customDateRange.set([
-                new Date('2024-01-01T00:00:00'),
-                new Date('1993-01-01T00:00:00')
-            ]);
-            spectator.component.onChangeCustomDateRange();
-
-            expect(changeFiltersSpy).not.toHaveBeenCalled();
-        });
     });
 
     describe('clearDateRange', () => {

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
@@ -1,6 +1,6 @@
 import { createFakeEvent } from '@ngneat/spectator';
 import { byTestId, createComponentFactory, Spectator } from '@ngneat/spectator/jest';
-import { format } from 'date-fns';
+import { addDays, format } from 'date-fns';
 
 import { Select } from 'primeng/select';
 
@@ -73,6 +73,16 @@ describe('DotAnalyticsFiltersComponent', () => {
         it('should initialize custom date range as null', () => {
             expect(spectator.component.$customDateRange()).toBeNull();
         });
+
+        it('should not include today in TIME_PERIOD_OPTIONS', () => {
+            const values = TIME_PERIOD_OPTIONS.map((opt) => opt.value);
+            expect(values).not.toContain(TIME_RANGE_OPTIONS.today);
+        });
+
+        it('should not include yesterday in TIME_PERIOD_OPTIONS', () => {
+            const values = TIME_PERIOD_OPTIONS.map((opt) => opt.value);
+            expect(values).not.toContain(TIME_RANGE_OPTIONS.yesterday);
+        });
     });
 
     describe('Custom Time Range Visibility', () => {
@@ -140,38 +150,174 @@ describe('DotAnalyticsFiltersComponent', () => {
         });
     });
 
-    describe('Custom Date Range Change', () => {
-        it('should emit custom date range when custom date range is selected', () => {
-            const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
-            const customDateRange = [
-                new Date('2024-01-01T00:00:00'),
-                new Date('2024-01-31T00:00:00')
-            ];
-            spectator.component.$customDateRange.set(customDateRange);
-            spectator.component.onChangeCustomDateRange();
+    describe('$disabledDates', () => {
+        it('should return empty array when no range start is set', () => {
+            expect(spectator.component.$disabledDates()).toEqual([]);
+        });
 
+        it('should return 5 disabled dates (start+1 to start+5) after first date is selected', () => {
+            const startDate = new Date('2024-01-01T00:00:00');
+            spectator.component.onDateSelect(startDate);
+
+            const disabled = spectator.component.$disabledDates();
+            expect(disabled).toHaveLength(5);
+            expect(disabled[0]).toEqual(addDays(startDate, 1));
+            expect(disabled[4]).toEqual(addDays(startDate, 5));
+        });
+
+        it('should clear disabled dates after second date is selected', () => {
+            const startDate = new Date('2024-01-01T00:00:00');
+            const endDate = new Date('2024-01-15T00:00:00');
+            spectator.component.onDateSelect(startDate);
+            // Simulate model update PrimeNG would do before emitting (onSelect)
+            spectator.component.$customDateRange.set([startDate, endDate]);
+            spectator.component.onDateSelect(endDate);
+
+            expect(spectator.component.$disabledDates()).toEqual([]);
+        });
+
+        it('should clear disabled dates when clearDateRange is called', () => {
+            const startDate = new Date('2024-01-01T00:00:00');
+            spectator.component.onDateSelect(startDate);
+            spectator.component.clearDateRange();
+
+            expect(spectator.component.$disabledDates()).toEqual([]);
+        });
+    });
+
+    describe('$today', () => {
+        it('should be set to the start of today', () => {
+            const today = spectator.component.$today();
+            expect(today).toBeInstanceOf(Date);
+            expect(today.getHours()).toBe(0);
+            expect(today.getMinutes()).toBe(0);
+        });
+    });
+
+    describe('onDateSelect (range picking)', () => {
+        it('should set $rangeStart on first click and not emit', () => {
+            const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
+            const startDate = new Date('2024-01-01T00:00:00');
+
+            spectator.component.onDateSelect(startDate);
+
+            expect(spectator.component.$rangeStart()).toEqual(startDate);
+            expect(changeFiltersSpy).not.toHaveBeenCalled();
+        });
+
+        it('should emit a valid range and clear $rangeStart on second click', () => {
+            const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
+            const startDate = new Date('2024-01-01T00:00:00');
+            const endDate = new Date('2024-01-31T00:00:00');
+
+            spectator.component.onDateSelect(startDate);
+            spectator.component.$customDateRange.set([startDate, endDate]);
+            spectator.component.onDateSelect(endDate);
+
+            expect(spectator.component.$rangeStart()).toBeNull();
             expect(changeFiltersSpy).toHaveBeenCalledWith(['2024-01-01', '2024-01-31']);
         });
 
-        it('should not emit custom date range when custom date range is selected with incomplete date range', () => {
+        it('should emit when range is exactly 7 days', () => {
             const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
-            const customDateRange = [new Date('2024-01-01T00:00:00')];
-            spectator.component.$customDateRange.set(customDateRange);
+            const startDate = new Date('2024-01-01T00:00:00');
+            const endDate = new Date('2024-01-07T00:00:00');
+
+            spectator.component.onDateSelect(startDate);
+            spectator.component.$customDateRange.set([startDate, endDate]);
+            spectator.component.onDateSelect(endDate);
+
+            expect(changeFiltersSpy).toHaveBeenCalledWith(['2024-01-01', '2024-01-07']);
+        });
+
+        it('should not emit when range is shorter than 7 days', () => {
+            const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
+            const startDate = new Date('2024-01-01T00:00:00');
+            const endDate = new Date('2024-01-06T00:00:00');
+
+            spectator.component.onDateSelect(startDate);
+            spectator.component.$customDateRange.set([startDate, endDate]);
+            spectator.component.onDateSelect(endDate);
+
+            expect(changeFiltersSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not emit when range is incomplete (only start date)', () => {
+            const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
+            spectator.component.$customDateRange.set([new Date('2024-01-01T00:00:00')]);
             spectator.component.onChangeCustomDateRange();
 
             expect(changeFiltersSpy).not.toHaveBeenCalled();
         });
 
-        it('should not emit custom date range when custom date range is selected with invalid date range', () => {
+        it('should not emit when date order is reversed', () => {
             const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
-            const customDateRange = [
+            spectator.component.$customDateRange.set([
                 new Date('2024-01-01T00:00:00'),
                 new Date('1993-01-01T00:00:00')
-            ];
-            spectator.component.$customDateRange.set(customDateRange);
+            ]);
             spectator.component.onChangeCustomDateRange();
 
             expect(changeFiltersSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('clearDateRange', () => {
+        it('should clear $customDateRange and $rangeStart', () => {
+            spectator.component.onDateSelect(new Date('2024-01-01T00:00:00'));
+            spectator.component.$customDateRange.set([new Date('2024-01-01T00:00:00')]);
+
+            spectator.component.clearDateRange();
+
+            expect(spectator.component.$customDateRange()).toBeNull();
+            expect(spectator.component.$rangeStart()).toBeNull();
+        });
+    });
+
+    describe('onCalendarClosed', () => {
+        it('should reset $rangeStart when calendar closes with incomplete range', () => {
+            spectator.component.onDateSelect(new Date('2024-01-01T00:00:00'));
+            spectator.component.$customDateRange.set([new Date('2024-01-01T00:00:00')]);
+
+            spectator.component.onCalendarClosed();
+
+            expect(spectator.component.$rangeStart()).toBeNull();
+        });
+
+        it('should keep $rangeStart as null when calendar closes with complete range', () => {
+            const startDate = new Date('2024-01-01T00:00:00');
+            const endDate = new Date('2024-01-31T00:00:00');
+            spectator.component.$customDateRange.set([startDate, endDate]);
+
+            spectator.component.onCalendarClosed();
+
+            expect(spectator.component.$rangeStart()).toBeNull();
+        });
+    });
+
+    describe('Calendar buttonbar template', () => {
+        beforeEach(() => {
+            spectator.component.$selectedTimeRange.set(TIME_RANGE_OPTIONS.custom);
+            spectator.detectChanges();
+        });
+
+        it('should render the p-datepicker with showButtonBar enabled', () => {
+            // The #buttonbar ng-template overrides the default button bar content.
+            // Since PrimeNG renders the overlay only when opened (not in unit tests),
+            // we verify the datepicker host element is present with the correct attribute.
+            const calendar = spectator.query(byTestId('custom-date-range-calendar'));
+            expect(calendar).toBeTruthy();
+            // The host element exists — the buttonbar template is provided via ng-template
+            // and replaces the default buttonbar (removing the Today button).
+        });
+
+        it('should not render a Today button in the closed-state datepicker DOM', () => {
+            // The Today button is removed by replacing the #buttonbar template.
+            // When the overlay is not opened, neither Today nor Clear buttons are in the DOM.
+            const todayBtn = spectator.query(
+                '.p-datepicker-today-button, [data-testid="today-btn"]'
+            );
+            expect(todayBtn).toBeNull();
         });
     });
 

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
@@ -242,7 +242,6 @@ describe('DotAnalyticsFiltersComponent', () => {
 
             expect(changeFiltersSpy).not.toHaveBeenCalled();
         });
-
     });
 
     describe('clearDateRange', () => {

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
@@ -23,7 +23,6 @@ describe('DotAnalyticsFiltersComponent', () => {
 
     const createComponent = createComponentFactory({
         component: DotAnalyticsFiltersComponent,
-        mocks: [DotMessageService],
         providers: [
             {
                 provide: DotMessageService,

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.spec.ts
@@ -1,6 +1,6 @@
 import { createFakeEvent } from '@ngneat/spectator';
 import { byTestId, createComponentFactory, Spectator } from '@ngneat/spectator/jest';
-import { addDays, format } from 'date-fns';
+import { addDays, format, startOfDay } from 'date-fns';
 
 import { Select } from 'primeng/select';
 
@@ -154,22 +154,24 @@ describe('DotAnalyticsFiltersComponent', () => {
             expect(spectator.component.$disabledDates()).toEqual([]);
         });
 
-        it('should return 5 disabled dates (start+1 to start+5) after first date is selected', () => {
+        it('should return 10 disabled dates (5 forward + 5 backward) after first date is selected', () => {
             const startDate = new Date('2024-01-01T00:00:00');
             spectator.component.onDateSelect(startDate);
 
             const disabled = spectator.component.$disabledDates();
-            expect(disabled).toHaveLength(5);
-            expect(disabled[0]).toEqual(addDays(startDate, 1));
-            expect(disabled[4]).toEqual(addDays(startDate, 5));
+            expect(disabled).toHaveLength(10);
+            // Forward: start+1 to start+5
+            expect(disabled[0]).toEqual(startOfDay(addDays(startDate, 1)));
+            expect(disabled[4]).toEqual(startOfDay(addDays(startDate, 5)));
+            // Backward: start-1 to start-5
+            expect(disabled[5]).toEqual(startOfDay(addDays(startDate, -1)));
+            expect(disabled[9]).toEqual(startOfDay(addDays(startDate, -5)));
         });
 
         it('should clear disabled dates after second date is selected', () => {
             const startDate = new Date('2024-01-01T00:00:00');
             const endDate = new Date('2024-01-15T00:00:00');
             spectator.component.onDateSelect(startDate);
-            // Simulate model update PrimeNG would do before emitting (onSelect)
-            spectator.component.$customDateRange.set([startDate, endDate]);
             spectator.component.onDateSelect(endDate);
 
             expect(spectator.component.$disabledDates()).toEqual([]);
@@ -331,14 +333,14 @@ describe('DotAnalyticsFiltersComponent', () => {
             expect(changeFiltersSpy).toHaveBeenCalledWith(TIME_RANGE_OPTIONS.last7days);
         });
 
-        it('should not emit when time range is a custom date range', () => {
+        it('should emit the custom value when custom time range is selected from dropdown', () => {
             const changeFiltersSpy = jest.spyOn(spectator.component.changeFilters, 'emit');
             spectator.triggerEventHandler(Select, 'onChange', {
                 value: TIME_RANGE_OPTIONS.custom,
                 originalEvent: createFakeEvent('change')
             });
 
-            expect(changeFiltersSpy).not.toHaveBeenCalled();
+            expect(changeFiltersSpy).toHaveBeenCalledWith(TIME_RANGE_OPTIONS.custom);
         });
     });
 });

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.ts
@@ -59,20 +59,20 @@ export class DotAnalyticsFiltersComponent {
     $timeOptions = signal<FilterOption[]>(TIME_PERIOD_OPTIONS);
 
     /** Maximum selectable date — today (no future dates allowed) */
-    $today = signal<Date>(startOfDay(new Date()));
+    readonly $today = signal<Date>(startOfDay(new Date()));
 
     /**
      * Tracks the first date selected during range picking.
      * Used to compute which intermediate dates should be disabled.
      */
-    $rangeStart = signal<Date | null>(null);
+    readonly $rangeStart = signal<Date | null>(null);
 
     /**
      * Dates that cannot be selected as end date after a start date is chosen.
      * Disables dates that would create a range shorter than MIN_CUSTOM_DATE_RANGE_DAYS.
      * Resets to an empty array when no start date is active.
      */
-    $disabledDates = computed<Date[]>(() => {
+    readonly $disabledDates = computed<Date[]>(() => {
         const start = this.$rangeStart();
 
         if (!start) {
@@ -139,7 +139,13 @@ export class DotAnalyticsFiltersComponent {
             return;
         }
 
-        const [from, to] = customDateRange;
+        const from = customDateRange[0];
+        const to = customDateRange[1];
+
+        if (!(from instanceof Date) || !(to instanceof Date)) {
+            return;
+        }
+
         const fromDate = format(from, 'yyyy-MM-dd');
         const toDate = format(to, 'yyyy-MM-dd');
 

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.ts
@@ -142,31 +142,6 @@ export class DotAnalyticsFiltersComponent {
         }
     }
 
-    /** Handle change custom date range */
-    onChangeCustomDateRange(): void {
-        const customDateRange = this.$customDateRange();
-
-        if (!customDateRange?.length || customDateRange.length === 1) {
-            return;
-        }
-
-        const from = customDateRange[0];
-        const to = customDateRange[1];
-
-        if (!(from instanceof Date) || !(to instanceof Date)) {
-            return;
-        }
-
-        const fromDate = format(from, 'yyyy-MM-dd');
-        const toDate = format(to, 'yyyy-MM-dd');
-
-        if (!isValidCustomDateRange(fromDate, toDate)) {
-            return;
-        }
-
-        this.changeFilters.emit([fromDate, toDate]);
-    }
-
     /** Clears the custom date range selection and resets the range-start tracker */
     clearDateRange(): void {
         this.$rangeStart.set(null);

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.ts
@@ -1,5 +1,5 @@
 import { signalMethod } from '@ngrx/signals';
-import { addDays, format, parse, startOfDay } from 'date-fns';
+import { addDays, format, isBefore, parse, startOfDay } from 'date-fns';
 
 import {
     ChangeDetectionStrategy,
@@ -69,8 +69,8 @@ export class DotAnalyticsFiltersComponent {
 
     /**
      * Dates that cannot be selected as end date after a start date is chosen.
-     * Disables dates that would create a range shorter than MIN_CUSTOM_DATE_RANGE_DAYS.
-     * Resets to an empty array when no start date is active.
+     * Disables dates (both forward and backward) that would create a range shorter
+     * than MIN_CUSTOM_DATE_RANGE_DAYS. Resets to an empty array when no start date is active.
      */
     readonly $disabledDates = computed<Date[]>(() => {
         const start = this.$rangeStart();
@@ -79,11 +79,14 @@ export class DotAnalyticsFiltersComponent {
             return [];
         }
 
-        // Disable dates from start+1 to start+(MIN-2), inclusive
+        // Disable dates from start±1 to start±(MIN-2), inclusive
         // These would result in a range shorter than MIN_CUSTOM_DATE_RANGE_DAYS days
-        return Array.from({ length: MIN_CUSTOM_DATE_RANGE_DAYS - 2 }, (_, i) =>
-            addDays(start, i + 1)
-        );
+        const offsets = Array.from({ length: MIN_CUSTOM_DATE_RANGE_DAYS - 2 }, (_, i) => i + 1);
+
+        return [
+            ...offsets.map((i) => addDays(start, i)), // forward: too close after start
+            ...offsets.map((i) => addDays(start, -i)) // backward: too close before start
+        ];
     });
 
     /** Check if custom time range is selected */
@@ -106,28 +109,36 @@ export class DotAnalyticsFiltersComponent {
 
     /** Handle change time range */
     onChangeTimeRange(event: SelectChangeEvent): void {
-        if (event.value === TIME_RANGE_OPTIONS.custom) {
-            return;
-        }
-
         this.changeFilters.emit(event.value);
     }
 
     /**
      * Handles each date click in the calendar (range mode).
      * Tracks the first selected date to compute disabledDates for the minimum range.
-     * On the second click, validates and emits the complete range.
+     *
+     * On each click PrimeNG updates its internal model BEFORE firing (onSelect).
+     * However, since $customDateRange is a model() signal used via ControlValueAccessor,
+     * its value may not reflect the latest PrimeNG state synchronously. To avoid this
+     * timing issue, we compute the range directly from $rangeStart + the date argument.
+     *
+     * PrimeNG range-mode resets the selection when the second click is before the first.
+     * We detect this by comparing timestamps and treat it as a new first click.
      */
     onDateSelect(date: Date): void {
         const start = this.$rangeStart();
 
-        if (start === null) {
-            // First date click — record start for disabledDates computation
-            this.$rangeStart.set(date);
+        if (start === null || isBefore(date, start)) {
+            // First date click, or user clicked before start (PrimeNG reset) — start fresh
+            this.$rangeStart.set(startOfDay(date));
         } else {
-            // Second date click — range selection complete
+            // Second date click — compute range directly and emit
             this.$rangeStart.set(null);
-            this.onChangeCustomDateRange();
+            const fromDate = format(start, 'yyyy-MM-dd');
+            const toDate = format(date, 'yyyy-MM-dd');
+
+            if (isValidCustomDateRange(fromDate, toDate)) {
+                this.changeFilters.emit([fromDate, toDate]);
+            }
         }
     }
 

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/components/dot-analytics-filters/dot-analytics-filters.component.ts
@@ -1,5 +1,5 @@
 import { signalMethod } from '@ngrx/signals';
-import { format, parse } from 'date-fns';
+import { addDays, format, parse, startOfDay } from 'date-fns';
 
 import {
     ChangeDetectionStrategy,
@@ -13,6 +13,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
+import { ButtonModule } from 'primeng/button';
 import { DatePickerModule } from 'primeng/datepicker';
 import { SelectChangeEvent, SelectModule } from 'primeng/select';
 
@@ -25,7 +26,10 @@ import {
 import { DotMessagePipe } from '@dotcms/ui';
 
 import { FilterOption, TIME_PERIOD_OPTIONS } from '../../constants';
-import { isValidCustomDateRange } from '../../utils/dot-analytics.utils';
+import {
+    isValidCustomDateRange,
+    MIN_CUSTOM_DATE_RANGE_DAYS
+} from '../../utils/dot-analytics.utils';
 
 /**
  * Filter controls component for analytics dashboard.
@@ -34,7 +38,7 @@ import { isValidCustomDateRange } from '../../utils/dot-analytics.utils';
  */
 @Component({
     selector: 'dot-analytics-filters',
-    imports: [DatePickerModule, SelectModule, FormsModule, DotMessagePipe],
+    imports: [ButtonModule, DatePickerModule, SelectModule, FormsModule, DotMessagePipe],
     templateUrl: './dot-analytics-filters.component.html',
     styleUrls: ['./dot-analytics-filters.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush
@@ -53,6 +57,34 @@ export class DotAnalyticsFiltersComponent {
 
     /** Available time period options for dropdown */
     $timeOptions = signal<FilterOption[]>(TIME_PERIOD_OPTIONS);
+
+    /** Maximum selectable date — today (no future dates allowed) */
+    $today = signal<Date>(startOfDay(new Date()));
+
+    /**
+     * Tracks the first date selected during range picking.
+     * Used to compute which intermediate dates should be disabled.
+     */
+    $rangeStart = signal<Date | null>(null);
+
+    /**
+     * Dates that cannot be selected as end date after a start date is chosen.
+     * Disables dates that would create a range shorter than MIN_CUSTOM_DATE_RANGE_DAYS.
+     * Resets to an empty array when no start date is active.
+     */
+    $disabledDates = computed<Date[]>(() => {
+        const start = this.$rangeStart();
+
+        if (!start) {
+            return [];
+        }
+
+        // Disable dates from start+1 to start+(MIN-2), inclusive
+        // These would result in a range shorter than MIN_CUSTOM_DATE_RANGE_DAYS days
+        return Array.from({ length: MIN_CUSTOM_DATE_RANGE_DAYS - 2 }, (_, i) =>
+            addDays(start, i + 1)
+        );
+    });
 
     /** Check if custom time range is selected */
     $showCustomTimeRange = computed(() => this.$selectedTimeRange() === TIME_RANGE_OPTIONS.custom);
@@ -81,6 +113,24 @@ export class DotAnalyticsFiltersComponent {
         this.changeFilters.emit(event.value);
     }
 
+    /**
+     * Handles each date click in the calendar (range mode).
+     * Tracks the first selected date to compute disabledDates for the minimum range.
+     * On the second click, validates and emits the complete range.
+     */
+    onDateSelect(date: Date): void {
+        const start = this.$rangeStart();
+
+        if (start === null) {
+            // First date click — record start for disabledDates computation
+            this.$rangeStart.set(date);
+        } else {
+            // Second date click — range selection complete
+            this.$rangeStart.set(null);
+            this.onChangeCustomDateRange();
+        }
+    }
+
     /** Handle change custom date range */
     onChangeCustomDateRange(): void {
         const customDateRange = this.$customDateRange();
@@ -92,6 +142,7 @@ export class DotAnalyticsFiltersComponent {
         const [from, to] = customDateRange;
         const fromDate = format(from, 'yyyy-MM-dd');
         const toDate = format(to, 'yyyy-MM-dd');
+
         if (!isValidCustomDateRange(fromDate, toDate)) {
             return;
         }
@@ -99,8 +150,28 @@ export class DotAnalyticsFiltersComponent {
         this.changeFilters.emit([fromDate, toDate]);
     }
 
+    /** Clears the custom date range selection and resets the range-start tracker */
+    clearDateRange(): void {
+        this.$rangeStart.set(null);
+        this.$customDateRange.set(null);
+    }
+
+    /**
+     * Resets range-start tracker when the calendar closes without completing a range.
+     * Prevents stale state on the next calendar open.
+     */
+    onCalendarClosed(): void {
+        const range = this.$customDateRange();
+
+        if (!range || range.length !== 2) {
+            this.$rangeStart.set(null);
+        }
+    }
+
     /** Handle change input time range */
     readonly #handleChangeInputTimeRange = signalMethod<TimeRangeInput>((timeRange) => {
+        this.$rangeStart.set(null);
+
         if (Array.isArray(timeRange)) {
             this.$selectedTimeRange.set(TIME_RANGE_OPTIONS.custom);
             const [from, to] = timeRange.map((date) => parse(date, 'yyyy-MM-dd', new Date()));

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/constants/dot-analytics.constants.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/constants/dot-analytics.constants.ts
@@ -4,8 +4,6 @@ import { FilterOption } from '../types';
 
 /** Available time period options for analytics data filtering */
 export const TIME_PERIOD_OPTIONS: FilterOption[] = [
-    { label: 'analytics.filters.time-period.today', value: TIME_RANGE_OPTIONS.today },
-    { label: 'analytics.filters.time-period.yesterday', value: TIME_RANGE_OPTIONS.yesterday },
     { label: 'analytics.filters.time-period.last-7-days', value: TIME_RANGE_OPTIONS.last7days },
     { label: 'analytics.filters.time-period.last-30-days', value: TIME_RANGE_OPTIONS.last30days },
     { label: 'analytics.filters.time-period.custom', value: TIME_RANGE_OPTIONS.custom }

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/utils/dot-analytics.utils.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/utils/dot-analytics.utils.spec.ts
@@ -1,4 +1,6 @@
-import { hexToRgba, isValidCustomDateRange } from './dot-analytics.utils';
+import { TIME_RANGE_OPTIONS } from '@dotcms/portlets/dot-analytics/data-access';
+
+import { getValidTimeRangeUrl, hexToRgba, isValidCustomDateRange } from './dot-analytics.utils';
 
 describe('Analytics Utils', () => {
     // ============================================================================
@@ -6,9 +8,23 @@ describe('Analytics Utils', () => {
     // ============================================================================
 
     describe('isValidCustomDateRange', () => {
-        it('should return true for valid date range', () => {
+        it('should return true for valid date range spanning at least 7 days', () => {
             expect(isValidCustomDateRange('2024-01-01', '2024-01-31')).toBe(true);
             expect(isValidCustomDateRange('2023-12-01', '2024-01-01')).toBe(true);
+        });
+
+        it('should return true for exactly 7-day range', () => {
+            // day 1 (Jan 1) to day 7 (Jan 7) = 6 calendar days difference = exactly 7 days inclusive
+            expect(isValidCustomDateRange('2024-01-01', '2024-01-07')).toBe(true);
+        });
+
+        it('should return false for range shorter than 7 days', () => {
+            expect(isValidCustomDateRange('2024-01-01', '2024-01-06')).toBe(false);
+            expect(isValidCustomDateRange('2024-01-01', '2024-01-02')).toBe(false);
+        });
+
+        it('should return false for same-day range', () => {
+            expect(isValidCustomDateRange('2024-01-01', '2024-01-01')).toBe(false);
         });
 
         it('should return false for invalid dates', () => {
@@ -22,14 +38,31 @@ describe('Analytics Utils', () => {
             expect(isValidCustomDateRange('2024-12-31', '2024-01-01')).toBe(false);
         });
 
-        it('should return true for same dates', () => {
-            expect(isValidCustomDateRange('2024-01-01', '2024-01-01')).toBe(true);
-        });
-
         it('should return false for empty or null dates', () => {
             expect(isValidCustomDateRange('', '2024-01-31')).toBe(false);
             expect(isValidCustomDateRange('2024-01-01', '')).toBe(false);
             expect(isValidCustomDateRange('', '')).toBe(false);
+        });
+    });
+
+    describe('getValidTimeRangeUrl', () => {
+        it('should return a valid time range for accepted values', () => {
+            expect(getValidTimeRangeUrl(TIME_RANGE_OPTIONS.last7days)).toBe('last7days');
+            expect(getValidTimeRangeUrl(TIME_RANGE_OPTIONS.last30days)).toBe('last30days');
+            expect(getValidTimeRangeUrl(TIME_RANGE_OPTIONS.custom)).toBe('custom');
+        });
+
+        it('should return null for today', () => {
+            expect(getValidTimeRangeUrl(TIME_RANGE_OPTIONS.today)).toBeNull();
+        });
+
+        it('should return null for yesterday', () => {
+            expect(getValidTimeRangeUrl(TIME_RANGE_OPTIONS.yesterday)).toBeNull();
+        });
+
+        it('should return null for unknown or empty values', () => {
+            expect(getValidTimeRangeUrl('invalid-range')).toBeNull();
+            expect(getValidTimeRangeUrl('')).toBeNull();
         });
     });
 

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/utils/dot-analytics.utils.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/utils/dot-analytics.utils.ts
@@ -1,12 +1,16 @@
-import { isBefore, isDate, isSameDay, parse } from 'date-fns';
+import { differenceInCalendarDays, isBefore, isDate, isSameDay, parse } from 'date-fns';
 
 import { TIME_RANGE_OPTIONS, TimeRange } from '@dotcms/portlets/dot-analytics/data-access';
 
+/** Minimum number of days required for a custom date range (inclusive) */
+export const MIN_CUSTOM_DATE_RANGE_DAYS = 7;
+
 /**
- * Validates custom date range parameters
- * @param fromDate - Start date string (ISO format)
- * @param toDate - End date string (ISO format)
- * @returns true if the date range is valid
+ * Validates custom date range parameters.
+ * The range must span at least MIN_CUSTOM_DATE_RANGE_DAYS days (inclusive).
+ * @param fromDate - Start date string (yyyy-MM-dd)
+ * @param toDate - End date string (yyyy-MM-dd)
+ * @returns true if the date range is valid and meets the minimum span
  */
 export const isValidCustomDateRange = (fromDate: string, toDate: string): boolean => {
     const fromDateObj = parse(fromDate, 'yyyy-MM-dd', new Date());
@@ -17,17 +21,33 @@ export const isValidCustomDateRange = (fromDate: string, toDate: string): boolea
         return false;
     }
 
-    // Check if from date is before or equal to to date
-    return isBefore(fromDateObj, toDateObj) || isSameDay(fromDateObj, toDateObj);
+    // Check order: from must be before or equal to to
+    if (!isBefore(fromDateObj, toDateObj) && !isSameDay(fromDateObj, toDateObj)) {
+        return false;
+    }
+
+    // Enforce minimum 7-day span (inclusive: day 1 to day 7 = 6 calendar days difference)
+    return differenceInCalendarDays(toDateObj, fromDateObj) >= MIN_CUSTOM_DATE_RANGE_DAYS - 1;
 };
 
+/** Time range values that are no longer supported as URL params */
+const EXCLUDED_TIME_RANGE_URL_VALUES: string[] = [
+    TIME_RANGE_OPTIONS.today,
+    TIME_RANGE_OPTIONS.yesterday
+];
+
 /**
- * Validates and returns a valid time range from URL value
+ * Validates and returns a valid time range from a URL parameter value.
+ * `today` and `yesterday` are excluded as they are no longer supported options.
  * @param urlValue - URL parameter value for time range
- * @returns Valid TimeRange or null if invalid
+ * @returns Valid TimeRange or null if invalid or excluded
  */
 export const getValidTimeRangeUrl = (urlValue: string): TimeRange | null => {
     if (!urlValue || typeof urlValue !== 'string') {
+        return null;
+    }
+
+    if (EXCLUDED_TIME_RANGE_URL_VALUES.includes(urlValue)) {
         return null;
     }
 

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/utils/dot-analytics.utils.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/shared/utils/dot-analytics.utils.ts
@@ -1,4 +1,4 @@
-import { differenceInCalendarDays, isBefore, isDate, isSameDay, parse } from 'date-fns';
+import { differenceInCalendarDays, isBefore, isDate, parse } from 'date-fns';
 
 import { TIME_RANGE_OPTIONS, TimeRange } from '@dotcms/portlets/dot-analytics/data-access';
 
@@ -21,8 +21,8 @@ export const isValidCustomDateRange = (fromDate: string, toDate: string): boolea
         return false;
     }
 
-    // Check order: from must be before or equal to to
-    if (!isBefore(fromDateObj, toDateObj) && !isSameDay(fromDateObj, toDateObj)) {
+    // Check order: from must be strictly before to
+    if (!isBefore(fromDateObj, toDateObj)) {
         return false;
     }
 

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6225,6 +6225,7 @@ analytics.filters.time-period.last-7-days=Last 7 Days
 analytics.filters.time-period.last-30-days=Last 30 Days
 analytics.filters.time-period.custom=Custom Range
 analytics.filters.custom-date-range.placeholder=Select date range
+analytics.filters.custom-date-range.clear=Clear
 
 analytics.metrics.total-pageviews=Total Pageviews
 analytics.metrics.total-pageviews.subtitle=All pageview events


### PR DESCRIPTION
## Proposed Changes
- Remove `today` and `yesterday` from the time period dropdown (`TIME_PERIOD_OPTIONS`)
- URL params `time_range=today` and `time_range=yesterday` now silently fall back to `last7days`; unrecognized values also fall back
- Custom date ranges now require a minimum span of 7 days (enforced via `disabledDates` computed signal)
- After selecting a start date, the 5 intermediate dates (start+1 to start+5) are visually disabled in the calendar
- Future date selection is blocked with `[maxDate]="$today()"`
- The calendar button bar now shows only a **Clear** button (Today button removed via `#buttonbar` ng-template override)

## Acceptance Criteria
- [x] AC1: `today` and `yesterday` removed from the time period dropdown
- [x] AC2: Default period remains `last7days`
- [x] AC3: URLs with `today`/`yesterday` as `time_range` silently fall back to `last7days`
- [x] AC4: Custom date range must span a minimum of 7 days; calendar blocks invalid selections
- [x] AC5: After selecting a start date, dates within 6 days after are visually disabled (grayed out)
- [x] AC6: No future dates selectable (`[maxDate]` = today)
- [x] AC7: Today button removed from the calendar's button bar

## Test Coverage
23+ test cases covering all 7 ACs across portlet and data-access libraries.

**portlets-dot-analytics**: 249 tests passing (18 suites)
**portlets-dot-analytics-data-access**: 175 tests passing (5 suites)

## Checklist
- [x] Tests added/updated per test plan
- [ ] Translations required
- [ ] Security implications considered

## Technical Notes
The `[minDate]` approach was discarded because PrimeNG's DatePicker in range mode does **not** update the ngModel after the first date click — only after both dates are selected. The fix uses `(onSelect)` to track the first click via `$rangeStart` signal, then computes the array of disabled dates from it.

Closes #34397

This PR fixes: #34397