### PR TITLE
fix: Migration hot-fixes for PrimeNG v17→v21 upgrade (#34805)

### DIFF
--- a/core-web/apps/dotcms-ui/project.json
+++ b/core-web/apps/dotcms-ui/project.json
@@ -69,7 +69,8 @@
                     "node_modules/prismjs/themes/prism-okaidia.css",
                     "node_modules/primeicons/primeicons.css",
                     "libs/dotcms-scss/angular/styles.scss",
-                    "apps/dotcms-ui/src/style.css"
+                    "apps/dotcms-ui/src/style.css",
+                    "node_modules/gridstack/dist/gridstack.min.css"
                 ],
                 "scripts": [],
                 "stylePreprocessorOptions": {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.component.html
@@ -31,7 +31,7 @@
     https://github.com/primefaces/primeng/issues/19191
 -->
 <p-tieredmenu
-    (onHide)="closeMenu()"
+    (onHide)="menuItems.set([])"
     [appendTo]="'body'"
     [popup]="true"
     #menu

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/dot-pages.component.spec.ts
@@ -223,15 +223,11 @@ describe('DotPagesComponent', () => {
     });
 
     describe('menu behavior', () => {
-        it('should close menu and clear menuItems when p-tieredmenu emits onHide', () => {
-            const menu = spectator.component.menu() as unknown as MenuStubComponent;
-            menu.visible = true;
-
+        it('should clear menuItems when p-tieredmenu emits onHide', () => {
             spectator.component.menuItems.set([{ label: 'x' }]);
             spectator.triggerEventHandler('p-tieredmenu', 'onHide', null);
 
             expect(spectator.component.menuItems()).toEqual([]);
-            expect(menu.visible).toBe(false);
         });
 
         it('toggleMenu should close when already visible (triggered by dot-pages-table openMenu)', () => {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.spec.ts
@@ -75,6 +75,8 @@ describe('DotTemplateNewComponent', () => {
             {
                 header: 'Create a template',
                 width: '37rem',
+                closable: true,
+                draggable: false,
                 contentStyle: { padding: '0px' },
                 data: {
                     options: {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-new/dot-template-new.component.ts
@@ -38,6 +38,8 @@ export class DotTemplateNewComponent implements OnInit {
         const ref = this.dialogService.open(DotBinaryOptionSelectorComponent, {
             header: this.dotMessageService.get('templates.select.template.title'),
             width: '37rem',
+            closable: true,
+            draggable: false,
             data: { options: this.options },
             contentStyle: { padding: '0px' }
         });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.html
@@ -1,5 +1,5 @@
 <p-dialog
-    [(visible)]="visible"
+    [visible]="visible()"
     [header]="'login-as' | dm"
     [modal]="true"
     [draggable]="false"
@@ -8,7 +8,7 @@
     appendTo="body"
     data-testid="dot-login-as-dialog"
     (onHide)="close()">
-    <div class="login-as" data-testid="dot-login-as-container">
+    <div class="login-as mt-[5px]" data-testid="dot-login-as-container">
         @if (errorMessage()) {
             <p class="login-as__error-message" data-testid="dot-login-as-error-message">
                 {{ errorMessage() }}

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.spec.ts
@@ -334,16 +334,75 @@ describe('DotLoginAsComponent', () => {
 
     describe('Dialog interaction', () => {
         it('should close dialog when cancel button is clicked', () => {
-            // Arrange
             jest.spyOn(component, 'close');
             spectator.setInput('visible', true);
             spectator.detectChanges();
 
-            // Act
             spectator.click(byTestId('dot-login-as-cancel-button'));
 
-            // Assert
             expect(component.close).toHaveBeenCalled();
+        });
+    });
+
+    describe('close()', () => {
+        it('should emit cancel, reset form state when visible is true', () => {
+            const cancelSpy = jest.fn();
+            spectator.output('cancel').subscribe(cancelSpy);
+
+            spectator.setInput('visible', true);
+            spectator.detectChanges();
+
+            component.form.get('loginAsUser').setValue(mockUser());
+            component.errorMessage.set('some error');
+            component.needPassword.set(true);
+
+            component.close();
+
+            expect(cancelSpy).toHaveBeenCalledWith(true);
+            expect(component.form.get('loginAsUser').value).toBeNull();
+            expect(component.errorMessage()).toBe('');
+            expect(component.needPassword()).toBe(false);
+        });
+
+        it('should not emit cancel or reset state when visible is false (guard)', () => {
+            const cancelSpy = jest.fn();
+            spectator.output('cancel').subscribe(cancelSpy);
+
+            spectator.setInput('visible', false);
+            spectator.detectChanges();
+
+            component.errorMessage.set('some error');
+            component.needPassword.set(true);
+
+            component.close();
+
+            expect(cancelSpy).not.toHaveBeenCalled();
+            expect(component.errorMessage()).toBe('some error');
+            expect(component.needPassword()).toBe(true);
+        });
+
+        it('should emit cancel when p-dialog emits onHide and visible is true', () => {
+            const cancelSpy = jest.fn();
+            spectator.output('cancel').subscribe(cancelSpy);
+
+            spectator.setInput('visible', true);
+            spectator.detectChanges();
+
+            spectator.triggerEventHandler('p-dialog', 'onHide', null);
+
+            expect(cancelSpy).toHaveBeenCalledWith(true);
+        });
+
+        it('should not emit cancel when p-dialog emits onHide and visible is false', () => {
+            const cancelSpy = jest.fn();
+            spectator.output('cancel').subscribe(cancelSpy);
+
+            spectator.setInput('visible', false);
+            spectator.detectChanges();
+
+            spectator.triggerEventHandler('p-dialog', 'onHide', null);
+
+            expect(cancelSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-login-as/dot-login-as.component.ts
@@ -50,7 +50,6 @@ import { DotNavigationService } from '../../../dot-navigation/services/dot-navig
 })
 export class DotLoginAsComponent implements OnInit, OnDestroy {
     visible = input<boolean>(false);
-    visibleChange = output<boolean>();
     cancel = output<boolean>();
 
     passwordElem = viewChild<ElementRef>('password');
@@ -87,9 +86,16 @@ export class DotLoginAsComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Emit cancel
+     * Resets dialog state and notifies parent to close.
+     * Guard prevents double-emit: (onHide) fires after [visible]=false is
+     * already propagated from the parent, so visible() is false by then.
      */
     close(): void {
+        if (!this.visible()) return;
+
+        this.form?.reset();
+        this.errorMessage.set('');
+        this.needPassword.set(false);
         this.cancel.emit(true);
     }
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/dot-toolbar-user.component.html
@@ -22,9 +22,7 @@
         <dot-my-account (shutdown)="store.showMyAccount(false)" [visible]="vm.showMyAccount" />
     }
 
-    @if (vm.showLoginAs) {
-        @defer (when vm.showLoginAs) {
-            <dot-login-as (cancel)="store.showLoginAs(false)" [visible]="vm.showLoginAs" />
-        }
+    @defer (when vm.showLoginAs) {
+        <dot-login-as (cancel)="store.showLoginAs(false)" [visible]="vm.showLoginAs" />
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/store/dot-toolbar-user.store.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/dot-toolbar/components/dot-toolbar-user/store/dot-toolbar-user.store.ts
@@ -1,7 +1,7 @@
 import { ComponentStore } from '@ngrx/component-store';
 import { Observable } from 'rxjs';
 
-import { Injectable, inject } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 
 import { MenuItem } from 'primeng/api';
 

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/main/dot-login-page.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/main/dot-login-page.component.spec.ts
@@ -47,10 +47,11 @@ describe('DotLoginPageComponent', () => {
         fixture.detectChanges();
     });
 
-    it('should set the background Image and background color', () => {
-        expect(document.body.style.backgroundColor).toEqual('rgb(58, 56, 71)');
-        expect(document.body.style.backgroundImage).toEqual(
-            'url(/html/images/backgrounds/bg-11.jpg)'
-        );
+    it('should set the background image, color, and layout styles on body', () => {
+        expect(['#3a3847', 'rgb(58, 56, 71)']).toContain(document.body.style.backgroundColor);
+        expect(document.body.style.backgroundImage).toContain('/html/images/backgrounds/bg-11.jpg');
+        expect(document.body.style.backgroundPosition).toEqual('top center');
+        expect(document.body.style.backgroundRepeat).toEqual('no-repeat');
+        expect(document.body.style.backgroundSize).toEqual('cover');
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/main/dot-login-page.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/main/dot-login-page.component.ts
@@ -32,6 +32,9 @@ export class DotLoginPageComponent implements OnInit {
                     dotLoginUserSystemInformation.backgroundPicture
                         ? `url('${dotLoginUserSystemInformation.backgroundPicture}')`
                         : '';
+                document.body.style.backgroundPosition = 'top center';
+                document.body.style.backgroundRepeat = 'no-repeat';
+                document.body.style.backgroundSize = 'cover';
             });
     }
 }

--- a/core-web/apps/dotcms-ui/src/app/view/components/main-legacy/main-legacy.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/main-legacy/main-legacy.component.ts
@@ -41,6 +41,9 @@ export class MainComponentLegacyComponent implements OnInit {
     ngOnInit(): void {
         document.body.style.backgroundColor = '';
         document.body.style.backgroundImage = '';
+        document.body.style.backgroundPosition = '';
+        document.body.style.backgroundRepeat = '';
+        document.body.style.backgroundSize = '';
     }
 
     /**

--- a/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.ts
@@ -307,6 +307,7 @@ export class AngularFormBridge implements FormBridge {
             this.#dialogRef = this.dialogService.open(DotBrowserSelectorComponent, {
                 header,
                 appendTo: 'body',
+                closable: true,
                 closeOnEscape: false,
                 draggable: false,
                 keepInViewport: false,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.html
@@ -121,6 +121,7 @@
         <p-dialog
             [(visible)]="dialogOpen"
             [appendTo]="'body'"
+            [closable]="true"
             [closeOnEscape]="false"
             [draggable]="false"
             [header]="dialogHeaderMap[vm.mode] | dm"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.spec.ts
@@ -9,6 +9,18 @@ import {
 } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
+// Monaco Editor is a global object loaded by the editor library at runtime.
+// In jsdom, it is never defined, so any timer callbacks that reach getLanguage()
+// (e.g. the debounced name.valueChanges subscription in DotBinaryFieldEditorComponent)
+// would throw a ReferenceError that leaks across tests. Define a minimal mock here.
+globalThis.monaco = {
+    languages: {
+        getLanguages: () => [],
+        register: jest.fn(),
+        setMonarchTokensProvider: jest.fn()
+    }
+} as unknown as typeof monaco;
+
 import { provideHttpClient } from '@angular/common/http';
 import { Component, NgZone } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
@@ -273,6 +273,7 @@ export class DotFileFieldComponent
         this.#dialogRef = this.#dialogService.open(DotFormImportUrlComponent, {
             header,
             appendTo: 'body',
+            closable: true,
             closeOnEscape: false,
             draggable: false,
             keepInViewport: false,
@@ -318,6 +319,7 @@ export class DotFileFieldComponent
         this.#dialogRef = this.#dialogService.open(DotAIImagePromptComponent, {
             header,
             appendTo: 'body',
+            closable: true,
             closeOnEscape: false,
             draggable: false,
             keepInViewport: false,
@@ -367,6 +369,7 @@ export class DotFileFieldComponent
         this.#dialogRef = this.#dialogService.open(DotFormFileEditorComponent, {
             header,
             appendTo: 'body',
+            closable: true,
             closeOnEscape: false,
             draggable: false,
             keepInViewport: false,

--- a/core-web/libs/ui/src/lib/services/dot-copy-content-modal/dot-copy-content-modal.service.spec.ts
+++ b/core-web/libs/ui/src/lib/services/dot-copy-content-modal/dot-copy-content-modal.service.spec.ts
@@ -33,6 +33,8 @@ const CONTENT_EDIT_OPTIONS_MOCK = {
 const DYNAMIC_DIALOG_CONFIG = {
     header: 'Edit Content',
     width: '37rem',
+    closable: true,
+    draggable: false,
     data: { options: CONTENT_EDIT_OPTIONS_MOCK },
     contentStyle: { padding: '0px' }
 };

--- a/core-web/libs/ui/src/lib/services/dot-copy-content-modal/dot-copy-content-modal.service.ts
+++ b/core-web/libs/ui/src/lib/services/dot-copy-content-modal/dot-copy-content-modal.service.ts
@@ -50,6 +50,8 @@ export class DotCopyContentModalService {
         const ref = this.dialogService.open(DotBinaryOptionSelectorComponent, {
             header: this.dotMessageService.get('Edit-Content'),
             width: '37rem',
+            closable: true,
+            draggable: false,
             data: { options: this.CONTENT_EDIT_OPTIONS },
             contentStyle: { padding: '0px' }
         });

--- a/core-web/libs/ui/src/lib/theme/theme.config.ts
+++ b/core-web/libs/ui/src/lib/theme/theme.config.ts
@@ -43,6 +43,15 @@ export const CustomLaraPreset = definePreset(Lara, {
                 borderRadius: '0',
                 padding: '0.5rem 1rem'
             }
+        },
+        confirmpopup: {
+            // Hide the arrow (pseudo-elements) on p-confirmpopup; no token for visibility in the preset.
+            css: `
+                .p-confirmpopup:before,
+                .p-confirmpopup:after {
+                    display: none !important;
+                }
+            `
         }
     }
 });


### PR DESCRIPTION
## Summary
This PR addresses critical regressions introduced during the PrimeNG v17→v21 migration.

## Fixes
- **DialogService**: Restored `closable: true` and `draggable: false` on DialogService.open() calls that were broken by PrimeNG's booleanAttribute migration
- **dot-login-as**: Resolved double-open issue, p-select freeze, and focus ring clipping regressions
- **dot-pages**: Fixed circular onHide→hide() loop in TieredMenu and corrected arrow hiding class name for PrimeNG v21 compatibility
- **Layout**: Fixed layout styles and popup dialogs

## Related Issue
Fixes #34805


This PR fixes: #34805