### PR TITLE
fix: Change webp processing lib (#34082)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -15,7 +15,7 @@
         <maven.deploy.skip>false</maven.deploy.skip>
         <flatten.mode>bom</flatten.mode>
         <aws-java-sdk.version>1.12.488</aws-java-sdk.version>
-        <twelvemonkeys.version>3.13.1-fixed</twelvemonkeys.version>
+        <twelvemonkeys.version>3.13.2-SNAPSHOT</twelvemonkeys.version>
         <swagger.version>2.2.34</swagger.version>
         <bytebuddy.version>1.18.1</bytebuddy.version>
         <batik.version>1.17</batik.version>
@@ -455,6 +455,11 @@
                 <groupId>com.dotcms.lib</groupId>
                 <artifactId>dot.webp-imageio-core</artifactId>
                 <version>0.1.6</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.gotson</groupId>
+                <artifactId>webp-imageio</artifactId>
+                <version>0.2.2</version>
             </dependency>
             <dependency>
                 <groupId>com.dotcms.lib</groupId>
@@ -1123,11 +1128,6 @@
             <dependency>
                 <groupId>com.twelvemonkeys.imageio</groupId>
                 <artifactId>imageio-tiff</artifactId>
-                <version>${twelvemonkeys.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.twelvemonkeys.imageio</groupId>
-                <artifactId>imageio-webp</artifactId>
                 <version>${twelvemonkeys.version}</version>
             </dependency>
             <dependency>

--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -15,7 +15,7 @@
         <maven.deploy.skip>false</maven.deploy.skip>
         <flatten.mode>bom</flatten.mode>
         <aws-java-sdk.version>1.12.488</aws-java-sdk.version>
-        <twelvemonkeys.version>3.13.2-SNAPSHOT</twelvemonkeys.version>
+        <twelvemonkeys.version>3.13.1-fixed</twelvemonkeys.version>
         <swagger.version>2.2.34</swagger.version>
         <bytebuddy.version>1.18.1</bytebuddy.version>
         <batik.version>1.17</batik.version>
@@ -455,11 +455,6 @@
                 <groupId>com.dotcms.lib</groupId>
                 <artifactId>dot.webp-imageio-core</artifactId>
                 <version>0.1.6</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.gotson</groupId>
-                <artifactId>webp-imageio</artifactId>
-                <version>0.2.2</version>
             </dependency>
             <dependency>
                 <groupId>com.dotcms.lib</groupId>
@@ -1040,6 +1035,11 @@
 
 
             <!-- Image Processing -->
+            <dependency>
+                <groupId>com.github.gotson</groupId>
+                <artifactId>webp-imageio</artifactId>
+                <version>0.2.2</version>
+            </dependency>
             <dependency>
                 <groupId>com.twelvemonkeys.imageio</groupId>
                 <artifactId>imageio-batik</artifactId>

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -408,6 +408,10 @@
             <artifactId>dot.webp-imageio-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.github.gotson</groupId>
+            <artifactId>webp-imageio</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.dotcms.lib</groupId>
             <artifactId>dot.woodstox-core-lgpl</artifactId>
         </dependency>
@@ -973,10 +977,6 @@
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-tiff</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.twelvemonkeys.imageio</groupId>
-            <artifactId>imageio-webp</artifactId>
         </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.servlet</groupId>

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -408,10 +408,6 @@
             <artifactId>dot.webp-imageio-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.gotson</groupId>
-            <artifactId>webp-imageio</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.dotcms.lib</groupId>
             <artifactId>dot.woodstox-core-lgpl</artifactId>
         </dependency>
@@ -906,6 +902,10 @@
 
 
         <!-- Image Processing -->
+        <dependency>
+            <groupId>com.github.gotson</groupId>
+            <artifactId>webp-imageio</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.twelvemonkeys.imageio</groupId>
             <artifactId>imageio-batik</artifactId>


### PR DESCRIPTION
This change of lib fixes the quality loss problem for webps on the preview and on S3.

This PR fixes: #34082

This PR fixes: #34082