### PR TITLE
fix(static-PP) : remove URLMapContent for static PP regular pages

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/bundlers/HTMLPageAsContentBundler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/bundlers/HTMLPageAsContentBundler.java
@@ -340,7 +340,7 @@ public class HTMLPageAsContentBundler implements IBundler {
 				try (final OutputStream outputStream = bundleOutput.addFile(pageFilePath)) {
 					final String html = APILocator.getHTMLPageAssetAPI()
 							.getHTML(htmlPageWrapper.getAsset().getURI(),
-									site, live, htmlPageWrapper.getAsset().getInode(),
+									site, live, null,
 									uAPI.getSystemUser(), tryingLang,
 									getUserAgent(config));
 					if (UtilMethods.isSet(html)) {

--- a/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTest.java
@@ -68,6 +68,7 @@ import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherI
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getURLMapPageWithImage;
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getWorkingContentWithURlMap;
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getWorkingFileAsset;
+import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getLivePageWhenURLMapContentIsNotPopulated;
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getWorkingPage;
 import static com.dotcms.util.CollectionsUtils.list;
 import static junit.framework.TestCase.*;
@@ -123,6 +124,8 @@ public class StaticPublisherIntegrationTest {
      *  Should generate into the bundle two files when the Operation is equals to UN_PUBLISH: just the page's files
      * - Add into the bundle a LIVE Page with version in two different languages but Add into the bundle just one of the lang: should include just two files for the page's version in the lang included
      * - Add into the bundle a LIVE FileAsset with version in two different languages but Add into the bundle just one of the lang: should include just one file for File's version in the lang included
+     * - Add into the bundle a LIVE Page whose container renders a marker if {@code $URLMapContent} is set:
+     *   the generated HTML must be {@code <div></div>} (empty), confirming {@code $URLMapContent} is null for regular pages
      *
      * @return
      * @throws Exception
@@ -146,7 +149,8 @@ public class StaticPublisherIntegrationTest {
                 getLiveContentWithURlMap(),
                 getPageWithImage(),
                 getURLMapPageWithImage(),
-                getPageWithCSS()
+                getPageWithCSS(),
+                getLivePageWhenURLMapContentIsNotPopulated()
         };
 
        final TestCase[] testCasesWitLangFilter = {

--- a/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTestHelper.java
+++ b/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTestHelper.java
@@ -626,6 +626,78 @@ public class StaticPublisherIntegrationTestHelper {
         return new TestCase(livePageWithContent.page, filesExpected, livePageWithContent.language, assetsMap);
     }
 
+    /**
+     * Creates a TestCase for a live page that verifies {@code $URLMapContent} is NOT populated
+     * when bundling a regular (non-URL-mapped) HTML page. The container code renders a distinct
+     * marker string only if {@code $URLMapContent} is set, so the expected HTML output is
+     * {@code <div></div>} (empty container) when the variable is correctly absent.
+     */
+    public static TestCase getLivePageWhenURLMapContentIsNotPopulated()
+            throws WebAssetException, DotDataException, DotSecurityException {
+
+        final Host host = new SiteDataGen().nextPersisted();
+        final Language language = new LanguageDataGen().nextPersisted();
+        final Folder folder = new FolderDataGen().site(host).nextPersisted();
+
+        final Field textField = new FieldDataGen().type(TextField.class).next();
+        final ContentType contentType = new ContentTypeDataGen().field(textField).nextPersisted();
+
+        // Container code outputs a marker ONLY if $URLMapContent is populated.
+        // For regular (non-URL-mapped) pages $URLMapContent must always be null/empty.
+        final Container container = new ContainerDataGen()
+                .site(host)
+                .withContentType(contentType, "#if($URLMapContent)URLMapContentSet#end")
+                .nextPersisted();
+
+        final Template template = new TemplateDataGen()
+                .site(host)
+                .withContainer(container.getIdentifier())
+                .nextPersisted();
+
+        final Contentlet contentlet = new ContentletDataGen(contentType)
+                .host(host)
+                .languageId(language.getId())
+                .setProperty(textField.variable(), "pageContent")
+                .nextPersisted();
+
+        final HTMLPageAsset page = ((HTMLPageDataGen) new HTMLPageDataGen(folder, template)
+                .host(host)
+                .languageId(language.getId()))
+                .nextPersisted();
+
+        new MultiTreeDataGen()
+                .setContainer(container)
+                .setPage(page)
+                .setContentlet(contentlet)
+                .nextPersisted();
+
+        ContentletDataGen.publish(contentlet);
+        TemplateDataGen.publish(template);
+        ContainerDataGen.publish(container);
+        HTMLPageDataGen.publish(page);
+
+        final String xmlFilePath = File.separator + "live" + File.separator
+                + host.getHostname() + File.separator
+                + language.getId()
+                + page.getURI().replace("/", File.separator)
+                + HTMLPAGE_ASSET_EXTENSION;
+
+        final String pageFilePath = File.separator + "live" + File.separator
+                + host.getHostname() + File.separator
+                + language.getId()
+                + page.getURI().replace("/", File.separator);
+
+        // With the fix, $URLMapContent is null so #if block doesn't execute → empty container
+        final List<FileExpected> filesExpected = list(
+                new FileExpected(xmlFilePath, null, true),
+                new FileExpected(pageFilePath, "<div></div>", true)
+        );
+
+        final Map<String, String> assetsMap = getAssetsMap(page);
+
+        return new TestCase(page, filesExpected, list(language), assetsMap);
+    }
+
     public static TestCase getWorkingPage() {
         final PageWithDependencies workingPageWithContent = new PageWithDependenciesBuilder().build();
 


### PR DESCRIPTION
Closes #34381 

### Proposed Changes
* Removed `URLMapContent` from Velocity context for regular pages (non URL mapped content) generated for static PP.
* Added a test case `getLivePageWhenURLMapContentIsNotPopulated()` to `StaticPublisherIntegrationTest` test to verify that regular pages don't include `URLMapContent` in the Velocity context.

### Checklist
- [x] Tests

This PR fixes: #34381