### PR TITLE
fix(PushPublish): Removed split logic on endpoint list when saving to publishing_pushed_assets, during Push Publish when PushToAll is disabled

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushedAssetUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/util/dependencies/PushedAssetUtil.java
@@ -49,11 +49,6 @@ public class PushedAssetUtil {
                             .map(endPoint -> endPoint.getId())
                             .collect(Collectors.joining(","));
 
-                    if (!environment.getPushToAll() && endpointIds != null && endpointIds
-                            .contains(",")) {
-                        endpointIds = endpointIds.substring(0, endpointIds.indexOf(","));
-                    }
-
                     //Add environment endpoints and publisher to map
                     environmentsEndpointsAndPublisher.put(environment.getId() + ENDPOINTS_SUFFIX,
                             endpointIds);


### PR DESCRIPTION
### **Summary**
Modified the endpoint ID resolution in `PushedAssetUtil` to ensure that the full set of environment endpoints is recorded in the publishing history when "Push to One Endpoint" (rotation) is enabled.

### **Changes**
*   **PushedAssetUtil.java:** Removed the logic that truncated the `endpoint_ids` string to a single ID when `PushToAll` was disabled for an environment. 
*   **Database Persistence:** The system now persists the comma-separated list of all enabled endpoints for the environment in the `publishing_pushed_assets` table.

### **Motivation**
The issue addressed by this PR is caused by a mismatch between how push history is stored and how it is later queried for incremental publishing (mod-date filtering):
1.  Previously, `PushedAssetUtil` would only store the first endpoint ID in the database when rotation was active.
2.  However, the lookup logic in `DependencyModDateUtil` (and the underlying SQL query in `PushedAssetsFactoryImpl`) expects a concatenated string of all currently active endpoints for that environment.
3.  This mismatch resulted in the system failing to find previous push records, causing assets to be redundantly included in manifests even if they had not been modified.

By storing the full set of endpoints, we align the recording phase with the query phase, ensuring that incremental publishing works correctly in clustered environments with endpoint rotation.

### **Related Issue**
[[DEFECT] Push Publish Mode "Content and Relationships" include all in cluster #34868](https://github.com/dotCMS/core/issues/34868)