### PR TITLE
fix(analytics): update storage handling during keepalive flush to prevent duplicate event sends

### DIFF
--- a/core-web/libs/sdk/analytics/src/lib/core/shared/queue/dot-analytics.queue.utils.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/queue/dot-analytics.queue.utils.spec.ts
@@ -800,11 +800,14 @@ describe('createAnalyticsQueue', () => {
 
             queue.enqueue(mockEvent, mockContext);
 
+            // Clear previous calls from initialize/enqueue
+            sessionStorageRemoveItem.mockClear();
+
             // Simulate normal flush (keepalive=false)
             sendBatchCallback([mockEvent], []);
 
-            // Should clear storage after successful send
-            expect(sessionStorageRemoveItem).toHaveBeenCalled();
+            // Should clear storage after dispatching send
+            expect(sessionStorageRemoveItem).toHaveBeenCalledTimes(1);
         });
 
         it('should clear storage on keepalive flush to prevent duplicate sends', () => {
@@ -832,7 +835,7 @@ describe('createAnalyticsQueue', () => {
             // Storage should be cleared even for keepalive flushes.
             // sessionStorage writes are synchronous and complete before unload,
             // so leaving stale events causes the next page to re-send them.
-            expect(sessionStorageRemoveItem).toHaveBeenCalled();
+            expect(sessionStorageRemoveItem).toHaveBeenCalledTimes(1);
         });
 
         it('should handle corrupted storage gracefully', () => {

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/queue/dot-analytics.queue.utils.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/queue/dot-analytics.queue.utils.spec.ts
@@ -807,7 +807,7 @@ describe('createAnalyticsQueue', () => {
             expect(sessionStorageRemoveItem).toHaveBeenCalled();
         });
 
-        it('should NOT clear storage on keepalive flush', () => {
+        it('should clear storage on keepalive flush to prevent duplicate sends', () => {
             const queue = createAnalyticsQueue(mockConfig);
             queue.initialize();
 
@@ -829,8 +829,10 @@ describe('createAnalyticsQueue', () => {
             // Simulate flush with keepalive
             sendBatchCallback([mockEvent], []);
 
-            // Should NOT clear storage (keepalive flush leaves backup)
-            expect(sessionStorageRemoveItem).not.toHaveBeenCalled();
+            // Storage should be cleared even for keepalive flushes.
+            // sessionStorage writes are synchronous and complete before unload,
+            // so leaving stale events causes the next page to re-send them.
+            expect(sessionStorageRemoveItem).toHaveBeenCalled();
         });
 
         it('should handle corrupted storage gracefully', () => {

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/queue/dot-analytics.queue.utils.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/queue/dot-analytics.queue.utils.ts
@@ -237,11 +237,13 @@ export const createAnalyticsQueue = (config: DotCMSAnalyticsConfig) => {
             (e) => !events.some((sent) => sent === e)
         );
 
-        // Always update storage after sending — even for keepalive flushes.
+        // Always update storage after dispatching the send — even for keepalive flushes.
+        // Note: sendAnalyticsEvent is fire-and-forget (the returned promise is not awaited),
+        // so this runs regardless of whether the HTTP request succeeds.
         // sessionStorage writes are synchronous and complete before page unload,
         // so the persistence state stays consistent. Previously, keepalive flushes
-        // skipped the storage update as a "safety net", but that caused the next
-        // page load to re-send the same events from persistence, producing duplicates.
+        // skipped the storage update, which caused the next page load to re-send
+        // the same events from persistence, producing duplicates.
         if (eventsForPersistence.length === 0) {
             clearStorage();
         } else {

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/queue/dot-analytics.queue.utils.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/queue/dot-analytics.queue.utils.ts
@@ -237,15 +237,15 @@ export const createAnalyticsQueue = (config: DotCMSAnalyticsConfig) => {
             (e) => !events.some((sent) => sent === e)
         );
 
-        // Clear storage after normal flush (not keepalive)
-        // For keepalive flushes (page unload), keep events in storage as backup
-        if (!keepalive) {
-            if (eventsForPersistence.length === 0) {
-                clearStorage();
-            } else {
-                // Update storage with remaining events
-                persistToStorage();
-            }
+        // Always update storage after sending — even for keepalive flushes.
+        // sessionStorage writes are synchronous and complete before page unload,
+        // so the persistence state stays consistent. Previously, keepalive flushes
+        // skipped the storage update as a "safety net", but that caused the next
+        // page load to re-send the same events from persistence, producing duplicates.
+        if (eventsForPersistence.length === 0) {
+            clearStorage();
+        } else {
+            persistToStorage();
         }
     };
 


### PR DESCRIPTION
PR Description:                                                                                                                                                                

  ## Summary

  Fixes duplicate analytics event sends caused by keepalive flushes (page unload) skipping the storage update. The stale events left in `sessionStorage` were re-sent on the next
  page load.

  ## Changes Made

  ### Frontend (SDK)

  - **`dot-analytics.queue.utils.ts`**: Removed the `if (!keepalive)` guard around storage cleanup after batch sends. Storage is now always updated after flushing — both for
  normal and keepalive flushes — since `sessionStorage` writes are synchronous and complete before page unload.
  - **`dot-analytics.queue.utils.spec.ts`**: Updated the keepalive flush test to assert that storage **is** cleared (previously asserted it was not), with comments explaining why.

  ## Technical Details

  The previous implementation treated keepalive flushes (triggered during `visibilitychange`/`beforeunload`) as a special case: it intentionally left sent events in
  `sessionStorage` as a "backup" in case the beacon request failed. However, because `sessionStorage.removeItem()` is synchronous and guaranteed to complete before the page
  unloads, this backup was unnecessary. Worse, it caused the next page load to pick up the stale persisted events and re-send them, resulting in duplicate analytics data.

  The fix removes the keepalive branch so that `clearStorage()` / `persistToStorage()` always runs after a successful batch send, regardless of the flush trigger.

  ## Breaking Changes

  None

  ## Testing

  - [x] Unit tests updated
  - [ ] Integration tests added/updated
  - [ ] Manual testing performed
  - [ ] E2E tests added/updated

  ## Related Issues

  Closes #34357

  ## Additional Notes

  None

This PR fixes: #34357