### PR TITLE
fix(mvn): restore maven-build-cache-config.xml accidentally deleted in #34236

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,7 +163,6 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 release.properties
 .flattened-pom.xml
-.mvn/maven-build-cache-config.xml
 /dependencies.txt
 /updates.txt
 

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -1,0 +1,34 @@
+<!--
+Opted for a simple configuration to cache the build output of the project.
+
+For a full featured example, see:
+
+https://maven.apache.org/extensions/maven-build-cache-extension/maven-build-cache-config.xml
+
+
+-->
+
+<cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/BUILD-CACHE-CONFIG/1.0.0 https://maven.apache.org/xsd/build-cache-config-1.0.0.xsd">
+    <configuration>
+        <enabled>false</enabled>
+        <hashAlgorithm>SHA-256</hashAlgorithm>
+        <validateXml>true</validateXml>
+        <local>
+            <maxBuildsCached>3</maxBuildsCached>
+        </local>
+        <projectVersioning adjustMetaInf="true"/>
+    </configuration>
+    <input>
+        <global>
+            <glob> {*.java,*.yaml,*.properties,*.js,*.ts,*.json,*.xml,*.mjs,*.jsp} </glob>
+            <includes>
+                <include>src/</include>
+            </includes>
+            <excludes>
+                <exclude>temp.out</exclude>
+            </excludes>
+        </global>
+    </input>
+</cache>

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -1,11 +1,27 @@
 <!--
-Opted for a simple configuration to cache the build output of the project.
+Maven Build Cache Extension configuration.
 
-For a full featured example, see:
+DISABLED BY DEFAULT — caching is opt-in for good reason.
 
+Without careful configuration, the cache can serve stale artifacts when
+inputs change in ways the glob patterns don't capture (e.g. environment
+variables, generated sources, resource filtering). This leads to builds
+that appear to succeed but produce incorrect or inconsistent output,
+which is harder to debug than a clean build failure.
+
+Enable locally only if you understand the trade-offs:
+  ./mvnw install -Dmaven.build.cache.enabled=true
+
+Or persist it for your user in ~/.m2/maven.config:
+  -Dmaven.build.cache.enabled=true
+
+The input glob and include/exclude rules below define what the cache
+treats as a meaningful change. Review them before enabling. A follow-up
+issue exists to improve this configuration before we consider enabling
+it more broadly.
+
+For full configuration reference, see:
 https://maven.apache.org/extensions/maven-build-cache-extension/maven-build-cache-config.xml
-
-
 -->
 
 <cache xmlns="http://maven.apache.org/BUILD-CACHE-CONFIG/1.0.0"


### PR DESCRIPTION
## Summary

- Restores `.mvn/maven-build-cache-config.xml` with `<enabled>false</enabled>` — accidentally deleted in #34236 (Postgres 18 upgrade)
- Removes the file from `.gitignore` (also added in #34236)
- Adds a warning comment explaining why the cache is disabled by default and how to opt in

The `maven-build-cache-extension` in `.mvn/extensions.xml` was never removed, so the plugin was running with its defaults (caching **on**), causing over-caching and unpredictable build results for all developers.

## Why Caching Is Disabled by Default

Without correct input configuration, the cache can serve stale artifacts when inputs change in ways the glob patterns don't capture (e.g. environment variables, generated sources, resource filtering). This produces builds that appear to succeed but contain incorrect or inconsistent output — which is significantly harder to diagnose than a clean build failure.

The current input glob patterns have not been fully validated for this codebase and should be reviewed before enabling more broadly.

## Opt-in Options for Developers

**Per-build:**
```
./mvnw install -Dmaven.build.cache.enabled=true
```

**Persistently (user-level, not committed)** — add to `~/.m2/maven.config`:
```
-Dmaven.build.cache.enabled=true
```

**Custom config file** — to use your own tuned configuration:
```
-Dmaven.build.cache.configPath=/Users/you/.m2/maven-build-cache-config.xml
```

Closes #34885

## Test plan
- [ ] Verify `./mvnw install -pl :dotcms-core -DskipTests` completes normally with no unexpected cache hits
- [ ] Verify build cache is **not** active by default (no `.m2/build-cache` entries created)
- [ ] Verify `-Dmaven.build.cache.enabled=true` enables caching as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34885