### PR TITLE
fix(Secrets): Added logic to search for user in context if not present in request during automated workflow action

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/SecretTool.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/SecretTool.java
@@ -132,7 +132,15 @@ public class SecretTool implements ViewTool {
 			final Role scripting = APILocator.getRoleAPI().loadRoleByKey(Role.SCRIPTING_DEVELOPER);
 			boolean hasScriptingRole = checkRoleFromLastModUser(scripting);
 			if (!hasScriptingRole) {
-				final User user = WebAPILocator.getUserWebAPI().getUser(this.request);
+				User user = WebAPILocator.getUserWebAPI().getUser(this.request);
+
+				if (null == user || user.isAnonymousUser()) {
+					final User contextUser = (User) this.context.get("user");
+					if (null != contextUser) {
+						user = contextUser;
+					}
+				}
+
 				// try with the current user
 				if (null != user) {
 					hasScriptingRole = APILocator.getRoleAPI().doesUserHaveRole(user, scripting);

--- a/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/SecretToolTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rendering/velocity/viewtools/SecretToolTest.java
@@ -1,0 +1,128 @@
+package com.dotcms.rendering.velocity.viewtools;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.Role;
+import com.dotmarketing.business.RoleAPI;
+import com.dotmarketing.business.web.UserWebAPI;
+import com.dotmarketing.business.web.WebAPILocator;
+import com.dotmarketing.util.Config;
+import com.liferay.portal.model.User;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.velocity.context.Context;
+import org.apache.velocity.tools.view.context.ViewContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class SecretToolTest {
+
+    private SecretTool secretTool;
+    private Context velocityContext;
+    private HttpServletRequest request;
+    private ViewContext viewContext;
+
+    private MockedStatic<APILocator> mockedApiLocator;
+    private MockedStatic<WebAPILocator> mockedWebApiLocator;
+    private MockedStatic<Config> mockedConfig;
+
+    private RoleAPI roleAPI;
+    private UserWebAPI userWebAPI;
+
+    @BeforeEach
+    public void setUp() {
+        secretTool = new SecretTool();
+        velocityContext = mock(Context.class);
+        request = mock(HttpServletRequest.class);
+        viewContext = mock(ViewContext.class);
+
+        when(viewContext.getVelocityContext()).thenReturn(velocityContext);
+        when(viewContext.getRequest()).thenReturn(request);
+
+        mockedApiLocator = mockStatic(APILocator.class);
+        mockedWebApiLocator = mockStatic(WebAPILocator.class);
+        mockedConfig = mockStatic(Config.class);
+
+        roleAPI = mock(RoleAPI.class);
+        userWebAPI = mock(UserWebAPI.class);
+
+        mockedApiLocator.when(APILocator::getRoleAPI).thenReturn(roleAPI);
+        mockedWebApiLocator.when(WebAPILocator::getUserWebAPI).thenReturn(userWebAPI);
+
+        mockedConfig.when(() -> Config.getBooleanProperty(eq("secrets.scripting.enabled"), any(Boolean.class))).thenReturn(true); // Enabled by default
+
+        secretTool.init(viewContext);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        mockedApiLocator.close();
+        mockedWebApiLocator.close();
+        mockedConfig.close();
+    }
+
+    @Test
+    public void canUserEvaluate_ScriptingDisabled_ThrowsException() {
+        mockedConfig.when(() -> Config.getBooleanProperty(eq("secrets.scripting.enabled"), any(Boolean.class))).thenReturn(false);
+
+        assertThrows(SecurityException.class, () -> secretTool.canUserEvaluate());
+    }
+
+    @Test
+    public void canUserEvaluate_UserInRequestHasRole_Success() throws Exception {
+        User user = mock(User.class);
+        Role scriptingRole = mock(Role.class);
+
+        when(userWebAPI.getUser(request)).thenReturn(user);
+        when(user.isAnonymousUser()).thenReturn(false);
+        when(roleAPI.loadRoleByKey(Role.SCRIPTING_DEVELOPER)).thenReturn(scriptingRole);
+        when(roleAPI.doesUserHaveRole(user, scriptingRole)).thenReturn(true);
+
+        assertDoesNotThrow(() -> secretTool.canUserEvaluate());
+    }
+
+    @Test
+    public void canUserEvaluate_AnonymousInRequestButUserInContextHasRole_Success() throws Exception {
+        User anonymousUser = mock(User.class);
+        User contextUser = mock(User.class);
+        Role scriptingRole = mock(Role.class);
+
+        when(anonymousUser.isAnonymousUser()).thenReturn(true);
+        when(userWebAPI.getUser(request)).thenReturn(anonymousUser);
+        
+        when(velocityContext.get("user")).thenReturn(contextUser);
+        when(roleAPI.loadRoleByKey(Role.SCRIPTING_DEVELOPER)).thenReturn(scriptingRole);
+        when(roleAPI.doesUserHaveRole(contextUser, scriptingRole)).thenReturn(true);
+
+        assertDoesNotThrow(() -> secretTool.canUserEvaluate());
+    }
+
+    @Test
+    public void canUserEvaluate_NoUserAnywhere_ThrowsException() throws Exception {
+        when(userWebAPI.getUser(request)).thenReturn(null);
+        when(velocityContext.get("user")).thenReturn(null);
+        
+        assertThrows(SecurityException.class, () -> secretTool.canUserEvaluate());
+    }
+
+    @Test
+    public void canUserEvaluate_UserHasNoRole_ThrowsException() throws Exception {
+        User user = mock(User.class);
+        Role scriptingRole = mock(Role.class);
+
+        when(userWebAPI.getUser(request)).thenReturn(user);
+        when(user.isAnonymousUser()).thenReturn(false);
+        when(roleAPI.loadRoleByKey(Role.SCRIPTING_DEVELOPER)).thenReturn(scriptingRole);
+        when(roleAPI.doesUserHaveRole(user, scriptingRole)).thenReturn(false);
+
+        assertThrows(SecurityException.class, () -> secretTool.canUserEvaluate());
+    }
+}


### PR DESCRIPTION
### Summary
Modified the user resolution logic in `SecretTool.java` to ensure that secrets can be correctly accessed during background jobs (e.g., scheduled publishing) by falling back to the Velocity context user when no user is present in the HTTP request.

### Changes
*   **SecretTool.java**: Updated the `canUserEvaluate` method to attempt retrieving the user from the Velocity `context` (using the `"user"` key) if the user from `HttpServletRequest` is null or anonymous.
*   **SecretToolTest.java**: Created a new unit test suite to verify the hybrid user retrieval logic and ensure security constraints are maintained across different execution contexts.

### Motivation
The issue addressed by this PR was that `SecretTool` failed to resolve secrets when invoked from non-HTTP contexts, such as scheduled publication jobs or automated workflows. 

Previously, the tool only looked for the user in the current `HttpServletRequest`. In background jobs, this request is typically empty or contains an anonymous user, leading to a `SecurityException` because the anonymous user lacks the required `SCRIPTING_DEVELOPER` role. 

By allowing a fallback to the user object present in the Velocity execution context (often the "System User" or the user who triggered the job), we enable secrets to be correctly resolved during these automated tasks while maintaining existing security checks for standard web requests.

### Related Issue
[[DEFECT] Secrets not resolving during automated scheduled publishing #35344](https://github.com/dotCMS/core/issues/34901)
[Freshdesk ticket #35344](https://helpdesk.dotcms.com/a/tickets/35344)

This PR fixes: #34901
