### PR TITLE
fix(velocity): use correct default field var in DotParse#resolveDotAsset based on content type

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotParse.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/directive/DotParse.java
@@ -14,6 +14,7 @@ import org.apache.velocity.context.Context;
 import org.apache.velocity.context.InternalContextAdapter;
 import org.apache.velocity.exception.ResourceNotFoundException;
 import com.dotcms.contenttype.model.type.DotAssetContentType;
+import com.dotcms.contenttype.model.type.FileAssetContentType;
 import com.dotcms.util.ConversionUtils;
 import com.dotcms.uuid.shorty.ShortType;
 import com.dotcms.uuid.shorty.ShortyId;
@@ -243,7 +244,7 @@ public class DotParse extends DotDirective {
 
         tokens.nextToken();
         final String inodeOrIdentifier = tokens.nextToken();
-        final String fieldVar = tokens.hasMoreTokens() ? tokens.nextToken() : DotAssetContentType.ASSET_FIELD_VAR;
+        final String explicitFieldVar = tokens.hasMoreTokens() ? tokens.nextToken() : null;
         final Optional<ShortyId> shortOpt = APILocator.getShortyAPI().getShorty(inodeOrIdentifier);
 
         if (shortOpt.isEmpty()) {
@@ -260,6 +261,11 @@ public class DotParse extends DotDirective {
         if (conOpt.isEmpty()) {
             return Optional.empty();
         }
+
+        final String defaultFieldVar = conOpt.get().getContentType() instanceof FileAssetContentType
+                        ? FileAssetContentType.FILEASSET_FILEASSET_FIELD_VAR
+                        : DotAssetContentType.ASSET_FIELD_VAR;
+        final String fieldVar = (explicitFieldVar != null) ? explicitFieldVar : defaultFieldVar;
 
         final Identifier identifier = APILocator.getIdentifierAPI().find(conOpt.get().getIdentifier());
         return Optional.of(Tuple.of(identifier, fieldVar));

--- a/dotcms-integration/src/test/java/com/dotcms/datagen/ContentTypeDataGen.java
+++ b/dotcms-integration/src/test/java/com/dotcms/datagen/ContentTypeDataGen.java
@@ -285,7 +285,7 @@ public class ContentTypeDataGen extends AbstractDataGen<ContentType> {
 
         if (null != contentType) {
             try {
-                APILocator.getContentTypeAPI(APILocator.systemUser()).delete(contentType);
+                APILocator.getContentTypeAPI(APILocator.systemUser()).deleteSync(contentType);
             } catch (Exception e) {
                 if (failSilently) {
                     Logger.error(ContentTypeDataGen.class, "Unable to remove ContentType.", e);

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/directive/DotParseTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/directive/DotParseTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.mock;
 
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.DotAssetDataGen;
 import com.dotcms.datagen.FileAssetDataGen;
 import com.dotcms.datagen.FolderDataGen;
 import com.dotcms.datagen.SiteDataGen;
@@ -11,6 +12,7 @@ import com.dotcms.datagen.TestUserUtils;
 import com.dotcms.rendering.velocity.util.VelocityUtil;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.util.Logger;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.folders.model.Folder;
@@ -20,6 +22,7 @@ import com.liferay.portal.model.User;
 import com.liferay.util.FileUtil;
 import java.io.File;
 import java.io.Writer;
+import java.nio.file.Files;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.velocity.context.Context;
@@ -69,6 +72,109 @@ public class DotParseTest extends IntegrationTestBase {
         Assert.assertNotNull(parsedCode);
         Assert.assertEquals(vtlData,parsedCode);
 
+    }
+
+    /**
+     * Method to test: {@link DotParse#resolveTemplatePath(Context, Writer, RenderParams, String[])}
+     * Given Scenario: A FileAsset contentlet is referenced via /dA/{identifier} with no explicit
+     *                  fieldVar in the path. The method should default to "fileAsset" for
+     *                  FileAssetContentType and still resolve the file correctly.
+     * ExpectedResult: Data written in the vtl file should be resolved and parsed.
+     */
+    @Test
+    public void Test_DotParse_FileAsset_DefaultFieldVar_success() throws Exception {
+        Host host = null;
+        File file = null;
+        try {
+            host = new SiteDataGen().nextPersisted();
+            final Folder folder = new FolderDataGen().site(host).nextPersisted();
+            final User user = TestUserUtils.getAdminUser();
+            final String vtlData = "<h1>fileAsset default</h1>";
+            file = File.createTempFile("testing-file-asset-default", ".vtl");
+            FileUtil.write(file, vtlData);
+            final Contentlet fileAsset = new FileAssetDataGen(folder, file).host(host).nextPersisted();
+            ContentletDataGen.publish(fileAsset);
+            final String shortyId = APILocator.getShortyAPI().shortify(fileAsset.getIdentifier());
+
+            // No fieldVar in the path — should default to "fileAsset" for FileAssetContentType
+            final String velocityCode = "#dotParse(\"/dA/" + shortyId + "\")";
+            final HttpServletRequest request = mock(HttpServletRequest.class);
+            final HttpServletResponse response = mock(HttpServletResponse.class);
+            final Language language = APILocator.getLanguageAPI().getDefaultLanguage();
+            final RenderParams renderParams = new RenderParams(user, language, host, PageMode.PREVIEW_MODE);
+            Mockito.when(request.getAttribute(RenderParams.RENDER_PARAMS_ATTRIBUTE)).thenReturn(renderParams);
+            final Context velocityContext = VelocityUtil.getInstance().getContext(request, response);
+            final String parsedCode = VelocityUtil.eval(velocityCode, velocityContext);
+            Assert.assertNotNull(parsedCode);
+            Assert.assertEquals(vtlData, parsedCode);
+        } finally {
+            if (file != null) {
+                try {
+                    Files.deleteIfExists(file.toPath());
+                } catch (Exception e) {
+                    Logger.error(DotParseTest.class, "Error cleaning up temp test file: " + file.getAbsolutePath(), e);
+                }
+            }
+            if (host != null) {
+                try {
+                    APILocator.getHostAPI().archive(host, APILocator.systemUser(), false);
+                    APILocator.getHostAPI().delete(host, APILocator.systemUser(), false);
+                } catch (Exception e) {
+                    Logger.error(DotParseTest.class, "Error cleaning up test host: " + host.getName(), e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Method to test: {@link DotParse#resolveTemplatePath(Context, Writer, RenderParams, String[])}
+     * Given Scenario: A DotAsset contentlet is referenced via /dA/{identifier} with no explicit
+     *                  fieldVar in the path. The method should default to "asset" for
+     *                  DotAssetContentType and still resolve the file correctly.
+     * ExpectedResult: Data written in the vtl file should be resolved and parsed.
+     */
+    @Test
+    public void Test_DotParse_DotAsset_DefaultFieldVar_success() throws Exception {
+        Host host = null;
+        File file = null;
+        try {
+            host = new SiteDataGen().nextPersisted();
+            final User user = TestUserUtils.getAdminUser();
+            final String vtlData = "<h1>dotAsset default</h1>";
+            file = File.createTempFile("testing-dot-asset-default", ".vtl");
+            FileUtil.write(file, vtlData);
+            final Contentlet dotAsset = new DotAssetDataGen(host, file).nextPersisted();
+            ContentletDataGen.publish(dotAsset);
+            final String shortyId = APILocator.getShortyAPI().shortify(dotAsset.getIdentifier());
+
+            // No fieldVar in the path — should default to "asset" for DotAssetContentType
+            final String velocityCode = "#dotParse(\"/dA/" + shortyId + "\")";
+            final HttpServletRequest request = mock(HttpServletRequest.class);
+            final HttpServletResponse response = mock(HttpServletResponse.class);
+            final Language language = APILocator.getLanguageAPI().getDefaultLanguage();
+            final RenderParams renderParams = new RenderParams(user, language, host, PageMode.PREVIEW_MODE);
+            Mockito.when(request.getAttribute(RenderParams.RENDER_PARAMS_ATTRIBUTE)).thenReturn(renderParams);
+            final Context velocityContext = VelocityUtil.getInstance().getContext(request, response);
+            final String parsedCode = VelocityUtil.eval(velocityCode, velocityContext);
+            Assert.assertNotNull(parsedCode);
+            Assert.assertEquals(vtlData, parsedCode);
+        } finally {
+            if (file != null) {
+                try {
+                    Files.deleteIfExists(file.toPath());
+                } catch (Exception e) {
+                    Logger.error(DotParseTest.class, "Error cleaning up temp test file: " + file.getAbsolutePath(), e);
+                }
+            }
+            if (host != null) {
+                try {
+                    APILocator.getHostAPI().archive(host, APILocator.systemUser(), false);
+                    APILocator.getHostAPI().delete(host, APILocator.systemUser(), false);
+                } catch (Exception e) {
+                    Logger.error(DotParseTest.class, "Error cleaning up test host: " + host.getName(), e);
+                }
+            }
+        }
     }
 
 

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/directive/DotParseTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/directive/DotParseTest.java
@@ -3,8 +3,11 @@ package com.dotcms.rendering.velocity.directive;
 import static org.mockito.Mockito.mock;
 
 import com.dotcms.IntegrationTestBase;
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.DotAssetContentType;
+import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.ContentletDataGen;
-import com.dotcms.datagen.DotAssetDataGen;
 import com.dotcms.datagen.FileAssetDataGen;
 import com.dotcms.datagen.FolderDataGen;
 import com.dotcms.datagen.SiteDataGen;
@@ -137,13 +140,25 @@ public class DotParseTest extends IntegrationTestBase {
     public void Test_DotParse_DotAsset_DefaultFieldVar_success() throws Exception {
         Host host = null;
         File file = null;
+        ContentType testDotAssetType = null;
         try {
             host = new SiteDataGen().nextPersisted();
             final User user = TestUserUtils.getAdminUser();
             final String vtlData = "<h1>dotAsset default</h1>";
-            file = File.createTempFile("testing-dot-asset-default", ".html");
+            file = File.createTempFile("testing-dot-asset-default", ".vtl");
             FileUtil.write(file, vtlData);
-            final Contentlet dotAsset = new DotAssetDataGen(host, file).nextPersisted();
+
+            // Create a test-specific DotAsset content type with no accept restriction
+            // so the test is not affected by the file type configuration of the seeded "DotAsset" type
+            testDotAssetType = new ContentTypeDataGen()
+                    .baseContentType(BaseContentType.DOTASSET)
+                    .host(host)
+                    .nextPersisted();
+
+            final Contentlet dotAsset = new ContentletDataGen(testDotAssetType.id())
+                    .setProperty(DotAssetContentType.ASSET_FIELD_VAR, file)
+                    .host(host)
+                    .nextPersisted();
             ContentletDataGen.publish(dotAsset);
             final String shortyId = APILocator.getShortyAPI().shortify(dotAsset.getIdentifier());
 
@@ -164,6 +179,13 @@ public class DotParseTest extends IntegrationTestBase {
                     Files.deleteIfExists(file.toPath());
                 } catch (Exception e) {
                     Logger.error(DotParseTest.class, "Error cleaning up temp test file: " + file.getAbsolutePath(), e);
+                }
+            }
+            if (testDotAssetType != null) {
+                try {
+                    ContentTypeDataGen.remove(testDotAssetType);
+                } catch (Exception e) {
+                    Logger.error(DotParseTest.class, "Error cleaning up test content type: " + testDotAssetType.name(), e);
                 }
             }
             if (host != null) {

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/directive/DotParseTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/directive/DotParseTest.java
@@ -141,7 +141,7 @@ public class DotParseTest extends IntegrationTestBase {
             host = new SiteDataGen().nextPersisted();
             final User user = TestUserUtils.getAdminUser();
             final String vtlData = "<h1>dotAsset default</h1>";
-            file = File.createTempFile("testing-dot-asset-default", ".vtl");
+            file = File.createTempFile("testing-dot-asset-default", ".html");
             FileUtil.write(file, vtlData);
             final Contentlet dotAsset = new DotAssetDataGen(host, file).nextPersisted();
             ContentletDataGen.publish(dotAsset);


### PR DESCRIPTION
Closes #33658

###  Problem                                                                                                                                           
When `#dotParse("/dA/{identifier}")` is called without an explicit field variable, `resolveDotAsset` always defaulted to "asset" (`DotAssetContentType.ASSET_FIELD_VAR`). This caused silent resolution failures for `FileAssetContentType` content, which uses "fileAsset" as its field variable.

### Proposed Changes
* `DotParse.java` — After fetching the contentlet, the default field variable is now resolved based on the actual content type:
    - FileAssetContentType → defaults to "fileAsset"
    - All other types (including DotAssetContentType) → defaults to "asset"
    - An explicitly provided field variable in the path is always respected as-is (no behavior change for existing callers).
* `DotParseTest.java` — Two new integration tests covering the new behavior:
    - Test_DotParse_FileAsset_DefaultFieldVar_success — verifies FileAssetContentType resolves correctly with no field var in the path
    - Test_DotParse_DotAsset_DefaultFieldVar_success — verifies DotAssetContentType still resolves correctly with no field var in the path
    - Both tests include proper cleanup (archive/delete for the test host, Files.deleteIfExists for temp files) with logged errors on cleanup failure.

### Checklist
- [x] Tests

This PR fixes: #33658