### PR TITLE
fix(publishing): fix OpenAPI spec inconsistencies in PublishingResource (#34860)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractEndpointDetailView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractEndpointDetailView.java
@@ -63,7 +63,7 @@ public interface AbstractEndpointDetailView {
      * @return Port number
      */
     @Schema(
-            description = "Server port number",
+            description = "Server port number as a string (valid range: 1–65535). May be empty if not configured.",
             example = "443",
             requiredMode = Schema.RequiredMode.REQUIRED
     )

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractPublishingJobDetailView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractPublishingJobDetailView.java
@@ -30,7 +30,7 @@ public interface AbstractPublishingJobDetailView {
      */
     @Schema(
             description = "Unique bundle identifier",
-            example = "f3d9a4b7-staging-bundle-2026-01-15",
+            example = "01KJWNJM2C67DM56GHBJ4S7B89",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     String bundleId();
@@ -70,6 +70,20 @@ public interface AbstractPublishingJobDetailView {
     )
     @Nullable
     String filterName();
+
+    /**
+     * Publishing filter key used for this bundle.
+     * Pass this value as the {@code filterKey} field in {@code POST /api/v1/publishing/push/{bundleId}}
+     * to reproduce the same push configuration.
+     *
+     * @return Filter key or null if not set
+     */
+    @Schema(
+            description = "Publishing filter key (pass to POST /push/{bundleId} filterKey to reproduce this push)",
+            example = "ForcePush.yml"
+    )
+    @Nullable
+    String filterKey();
 
     /**
      * Total number of assets in the bundle.

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractPublishingJobView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractPublishingJobView.java
@@ -32,7 +32,7 @@ public interface AbstractPublishingJobView {
      */
     @Schema(
             description = "Unique bundle identifier",
-            example = "f3d9a4b7-staging-bundle-2026-01-15",
+            example = "01KJWNJM2C67DM56GHBJ4S7B89",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     String bundleId();

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractPushBundleResultView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractPushBundleResultView.java
@@ -29,7 +29,7 @@ public interface AbstractPushBundleResultView {
      */
     @Schema(
             description = "Bundle identifier",
-            example = "550e8400-e29b-41d4-a716-446655440000",
+            example = "01KJWNJM2C67DM56GHBJ4S7B89",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     String bundleId();

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractRetryBundlesForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractRetryBundlesForm.java
@@ -58,8 +58,11 @@ public interface AbstractRetryBundlesForm {
      */
     @Schema(
             description = "Which endpoints to retry: ALL_ENDPOINTS sends to all, " +
-                    "FAILED_ENDPOINTS sends only to previously failed endpoints",
-            example = "FAILED_ENDPOINTS"
+                    "FAILED_ENDPOINTS sends only to previously failed endpoints. " +
+                    "Case-sensitive: must be uppercase.",
+            example = "FAILED_ENDPOINTS",
+            allowableValues = {"ALL_ENDPOINTS", "FAILED_ENDPOINTS"},
+            defaultValue = "ALL_ENDPOINTS"
     )
     @Value.Default
     default DeliveryStrategy deliveryStrategy() {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractRetryBundlesForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/AbstractRetryBundlesForm.java
@@ -29,7 +29,7 @@ public interface AbstractRetryBundlesForm {
      */
     @Schema(
             description = "List of bundle identifiers to retry",
-            example = "[\"bundle-123\", \"bundle-456\"]",
+            example = "[\"01KJWNJM2C67DM56GHBJ4S7B89\", \"01KJWNJM2C67DM56GHBJ4S7B90\"]",
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     List<String> bundleIds();

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/PublishingJobsHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/PublishingJobsHelper.java
@@ -362,6 +362,7 @@ public class PublishingJobsHelper {
                 .bundleName(bundle != null ? bundle.getName() : null)
                 .status(auditStatus.getStatus())
                 .filterName(resolveFilterName(bundle))
+                .filterKey(bundle != null ? bundle.getFilterKey() : null)
                 .assetCount(auditStatus.getTotalNumberOfAssets())
                 .environments(buildEnvironmentDetails(history))
                 .timestamps(buildTimestamps(auditStatus, history))

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/PublishingResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/PublishingResource.java
@@ -201,13 +201,20 @@ public class PublishingResource {
             )
             @QueryParam("filter") final String filter,
             @Parameter(
-                    description = "Comma-separated status values to filter (e.g., SUCCESS,FAILED_TO_PUBLISH). " +
-                            "Valid values: BUNDLE_REQUESTED, WAITING_FOR_PUBLISHING, BUNDLING, SENDING_TO_ENDPOINTS, " +
-                            "PUBLISHING_BUNDLE, BUNDLE_SENT_SUCCESSFULLY, RECEIVED_BUNDLE, BUNDLE_SAVED_SUCCESSFULLY, " +
-                            "SUCCESS, SUCCESS_WITH_WARNINGS, FAILED_TO_BUNDLE, FAILED_TO_SENT, " +
-                            "FAILED_TO_SEND_TO_ALL_GROUPS, FAILED_TO_SEND_TO_SOME_GROUPS, FAILED_TO_PUBLISH, " +
-                            "FAILED_INTEGRITY_CHECK, INVALID_TOKEN, LICENSE_REQUIRED",
-                    example = "SUCCESS,FAILED_TO_PUBLISH"
+                    description = "Comma-separated status values to filter (e.g., SUCCESS,FAILED_TO_PUBLISH).",
+                    example = "SUCCESS,FAILED_TO_PUBLISH",
+                    schema = @Schema(
+                            type = "string",
+                            allowableValues = {
+                                    "BUNDLE_REQUESTED", "WAITING_FOR_PUBLISHING", "BUNDLING",
+                                    "SENDING_TO_ENDPOINTS", "PUBLISHING_BUNDLE", "BUNDLE_SENT_SUCCESSFULLY",
+                                    "RECEIVED_BUNDLE", "BUNDLE_SAVED_SUCCESSFULLY", "SUCCESS",
+                                    "SUCCESS_WITH_WARNINGS", "FAILED_TO_BUNDLE", "FAILED_TO_SENT",
+                                    "FAILED_TO_SEND_TO_ALL_GROUPS", "FAILED_TO_SEND_TO_SOME_GROUPS",
+                                    "FAILED_TO_PUBLISH", "FAILED_INTEGRITY_CHECK", "INVALID_TOKEN",
+                                    "LICENSE_REQUIRED"
+                            }
+                    )
             )
             @QueryParam("status") final String status) throws DotPublisherException {
 
@@ -324,7 +331,7 @@ public class PublishingResource {
             @Parameter(
                     description = "Bundle identifier",
                     required = true,
-                    example = "f3d9a4b7-staging-bundle-2026-01-15"
+                    example = "01KJWNJM2C67DM56GHBJ4S7B89"
             )
             @PathParam("bundleId") final String bundleId) throws DotPublisherException {
 
@@ -412,7 +419,7 @@ public class PublishingResource {
             ),
             @ApiResponse(
                     responseCode = "404",
-                    description = "Bundle not found",
+                    description = "Bundle not found in either the publishing audit history or the bundle table",
                     content = @Content(mediaType = MediaType.APPLICATION_JSON)
             ),
             @ApiResponse(
@@ -432,7 +439,7 @@ public class PublishingResource {
             @Parameter(
                     description = "Bundle identifier",
                     required = true,
-                    example = "550e8400-e29b-41d4-a716-446655440000"
+                    example = "01KJWNJM2C67DM56GHBJ4S7B89"
             )
             @PathParam("bundleId") final String bundleId) throws DotDataException, DotPublisherException {
 
@@ -700,7 +707,7 @@ public class PublishingResource {
             @Parameter(
                     description = "Bundle identifier",
                     required = true,
-                    example = "550e8400-e29b-41d4-a716-446655440000"
+                    example = "01KJWNJM2C67DM56GHBJ4S7B89"
             )
             @PathParam("bundleId") final String bundleId,
             @io.swagger.v3.oas.annotations.parameters.RequestBody(
@@ -845,7 +852,9 @@ public class PublishingResource {
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
-                    description = "Purge operation initiated (processes in background)",
+                    description = "Purge operation initiated (processes in background). " +
+                            "The result is delivered as a system notification to the triggering user's " +
+                            "browser session. Non-browser API clients will not receive the completion event.",
                     content = @Content(
                             mediaType = MediaType.APPLICATION_JSON,
                             schema = @Schema(implementation = ResponseEntityPurgeView.class)
@@ -878,8 +887,19 @@ public class PublishingResource {
             @Parameter(
                     description = "Comma-separated status values to purge. If omitted, uses safe defaults " +
                             "(all terminal + queued, excludes in-progress). " +
-                            "Cannot include: BUNDLING, SENDING_TO_ENDPOINTS, PUBLISHING_BUNDLE",
-                    example = "SUCCESS,FAILED_TO_PUBLISH"
+                            "Cannot include: BUNDLING, SENDING_TO_ENDPOINTS, PUBLISHING_BUNDLE.",
+                    example = "SUCCESS,FAILED_TO_PUBLISH",
+                    schema = @Schema(
+                            type = "string",
+                            allowableValues = {
+                                    "BUNDLE_REQUESTED", "WAITING_FOR_PUBLISHING",
+                                    "BUNDLE_SENT_SUCCESSFULLY", "RECEIVED_BUNDLE", "BUNDLE_SAVED_SUCCESSFULLY",
+                                    "SUCCESS", "SUCCESS_WITH_WARNINGS", "FAILED_TO_BUNDLE", "FAILED_TO_SENT",
+                                    "FAILED_TO_SEND_TO_ALL_GROUPS", "FAILED_TO_SEND_TO_SOME_GROUPS",
+                                    "FAILED_TO_PUBLISH", "FAILED_INTEGRITY_CHECK", "INVALID_TOKEN",
+                                    "LICENSE_REQUIRED"
+                            }
+                    )
             )
             @QueryParam("status") final String status) throws DotDataException {
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/PushBundleForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/publishing/PushBundleForm.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Set;
 
@@ -26,21 +29,28 @@ public class PushBundleForm extends Validated {
     private static final Set<String> VALID_OPERATIONS = Set.of("publish", "expire", "publishexpire");
 
     @Schema(
-            description = "Operation type: publish, expire, or publishexpire",
+            description = "Operation type (case-insensitive): publish, expire, or publishexpire",
             example = "publish",
+            allowableValues = {"publish", "expire", "publishexpire"},
             requiredMode = Schema.RequiredMode.REQUIRED
     )
     private String operation;
 
     @Schema(
-            description = "Scheduled publish date in ISO 8601 format with timezone offset",
-            example = "2025-03-15T14:30:00-05:00"
+            description = "Scheduled publish date in ISO 8601 format. " +
+                    "Timezone offset is required (e.g., -05:00 or Z). " +
+                    "Dates without timezone offset are rejected.",
+            example = "2025-03-15T14:30:00-05:00",
+            format = "date-time"
     )
     private String publishDate;
 
     @Schema(
-            description = "Scheduled expire date in ISO 8601 format with timezone offset",
-            example = "2025-04-15T14:30:00-05:00"
+            description = "Scheduled expire date in ISO 8601 format. " +
+                    "Timezone offset is required (e.g., -05:00 or Z). " +
+                    "Dates without timezone offset are rejected.",
+            example = "2025-04-15T14:30:00-05:00",
+            format = "date-time"
     )
     private String expireDate;
 
@@ -114,6 +124,14 @@ public class PushBundleForm extends Validated {
             throw new BadRequestException("expireDate is required for " + normalizedOperation + " operation");
         }
 
+        // Validate date format (ISO 8601 with timezone offset) before any downstream lookup
+        if (UtilMethods.isSet(publishDate)) {
+            validateDateFormat(publishDate, "publishDate");
+        }
+        if (UtilMethods.isSet(expireDate)) {
+            validateDateFormat(expireDate, "expireDate");
+        }
+
         // Validate environments
         if (!UtilMethods.isSet(environments) || environments.isEmpty()) {
             throw new BadRequestException("At least one environment ID is required");
@@ -163,6 +181,25 @@ public class PushBundleForm extends Validated {
 
     public void setFilterKey(final String filterKey) {
         this.filterKey = filterKey;
+    }
+
+    /**
+     * Validates that a date string is ISO 8601 format with a timezone offset.
+     * Mirrors the parsing logic in {@code PublishingJobsHelper#parseISO8601Date} so that
+     * format errors are caught during form validation (400) before any bundle lookup (404).
+     *
+     * @param dateStr   the date string to validate
+     * @param fieldName the field name used in the error message
+     * @throws BadRequestException if the format is invalid or the timezone offset is missing
+     */
+    private static void validateDateFormat(final String dateStr, final String fieldName) {
+        try {
+            OffsetDateTime.parse(dateStr, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+        } catch (DateTimeParseException e) {
+            throw new BadRequestException(String.format(
+                    "Invalid %s format: '%s'. Expected ISO 8601 with timezone offset (e.g., 2025-03-15T14:30:00-05:00)",
+                    fieldName, dateStr));
+        }
     }
 
 }


### PR DESCRIPTION
## Summary

Fixes 10 OpenAPI spec issues in `PublishingResource` (`/api/v1/publishing`) and related form/view classes.

- Add `allowableValues` to `status` query params on `GET /` and `DELETE /purge` — enables Swagger UI dropdowns and codegen enums
- Add `allowableValues`, `defaultValue`, and case-sensitivity note to `deliveryStrategy` in `RetryBundlesForm`
- Document `operation` as case-insensitive with `allowableValues` in `PushBundleForm`
- Add `format = "date-time"` and timezone-required note to `publishDate`/`expireDate`
- Move date format validation into `PushBundleForm.checkValid()` so invalid dates return `400` before bundle lookup (not `404`)
- Expose `filterKey` in `PublishingJobDetailView` so callers can reproduce a push configuration
- Document purge async result delivery for non-browser API clients
- Clarify `DELETE /{bundleId}` 404 condition (checks both audit and bundle tables)
- Update all `bundleId` examples to ULID format across views and parameters
- Add valid range note to `EndpointDetailView.port`

## Test plan

- [ ] Existing `PublishingResourceIntegrationTest` passes unchanged — no behavior change for valid requests
- [ ] `test_pushBundle_invalidDateFormat_returns400` still passes — `BadRequestException` now thrown in `checkValid()` instead of the switch block, same result
- [ ] Swagger UI shows dropdowns for `status` and `deliveryStrategy` fields
- [ ] `GET /api/v1/publishing/{bundleId}` response includes `filterKey` field