### PR TITLE
fix(content-drive): resolve UX regressions in toolbar and content type filter #34889

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-content-type-field/dot-content-drive-content-type-field.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/components/dot-content-drive-content-type-field/dot-content-drive-content-type-field.component.html
@@ -19,6 +19,7 @@
     [placeholder]="'content-drive.content-type.placeholder' | dm"
     [showClear]="false"
     data-testid="content-type-field"
+    autofocusFilter="true"
     class="w-full">
     <ng-template pTemplate="item" let-item>
         <div class="flex items-center gap-2 w-full">

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.ts
@@ -58,7 +58,7 @@ interface ToolbarAnimationState {
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         class: 'block transition-all duration-300 ease-in-out',
-        '[style.height]': '"7.125rem"'
+        '[style.min-height]': '"7.125rem"'
     },
     styles: [
         `


### PR DESCRIPTION
### Proposed Changes
* Fix toolbar height constraint: changed `[style.height]` to `[style.min-height]` on the host element so the Content Drive filter table is not cut off on smaller screens or when DevTools is open
* Add `autofocusFilter="true"` to the content type `p-select` component so the filter input correctly focuses and displays typed characters beyond the first letter

### Checklist
- [ ] Tests
- [ ] Translations
- [x] Security Implications Contemplated (no security impact — UI/styling fixes only)

### Additional Info
Fixes #34889 — Multiple UX regressions introduced after the Content Drive modernization upgrade.

The `height` binding was preventing the toolbar from expanding on smaller viewports, causing the filter table to be clipped. The missing `autofocusFilter` attribute on the PrimeNG Select component caused the filter input to lose focus after the first keystroke, making multi-character filtering impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34889