### PR TITLE
fix(block-editor): prevent forward delete from crossing grid column boundary

### DIFF
--- a/core-web/libs/block-editor/src/lib/nodes/grid-block/grid-block.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/grid-block/grid-block.node.ts
@@ -163,6 +163,35 @@ export const GridBlock = Node.create({
 
                 return false;
             },
+            Delete: ({ editor }) => {
+                const { state } = editor;
+                const { $from, empty } = state.selection;
+
+                if (!empty) {
+                    return false;
+                }
+
+                // Find the gridColumn ancestor
+                for (let depth = $from.depth; depth > 0; depth--) {
+                    if ($from.node(depth).type.name === 'gridColumn') {
+                        // Check if cursor is at the very end of the column content.
+                        // $from.pos is inside the deepest node (e.g. paragraph),
+                        // $from.end(depth) is at the end of the column content.
+                        // The difference accounts for closing tokens of nested nodes.
+                        const cursorAtEnd = $from.pos === $from.end($from.depth);
+                        const lastChildInColumn =
+                            $from.index(depth) === $from.node(depth).childCount - 1;
+
+                        if (cursorAtEnd && lastChildInColumn) {
+                            return true;
+                        }
+
+                        return false;
+                    }
+                }
+
+                return false;
+            },
             Tab: ({ editor }) => {
                 const { state } = editor;
                 const { $from } = state.selection;


### PR DESCRIPTION
## Summary
- Forward delete (fn+Delete on Mac) at the end of a grid column crosses into the adjacent column and deletes its content
- Block forward delete when cursor is at the end of the last child node in a `gridColumn`

## Test plan
- [ ] Insert a grid block with content in both columns
- [ ] Place cursor at end of left column, press fn+Delete — should do nothing
- [ ] Normal delete within a column still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)