### PR TITLE
fix(telemetry): prevent ThreadLocal connection poisoning in MetricStatsCollector #34926

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/MetricStatsCollector.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/MetricStatsCollector.java
@@ -10,6 +10,7 @@ import com.dotcms.telemetry.business.TimeoutConfig;
 import com.dotcms.telemetry.cache.MetricCacheConfig;
 import com.dotcms.telemetry.cache.MetricCacheManager;
 import com.dotcms.telemetry.util.MetricCaches;
+import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Logger;
 
@@ -140,23 +141,44 @@ public class MetricStatsCollector {
 
                 try {
                     // Submit metric collection as a task with timeout
-                    final Callable<Optional<MetricValue>> task = () -> cacheManager.get(
-                        metricType.getName(),
-                        () -> {
-                            // Supplier called = cache miss
-                            flags[2] = true;
-                            final long computationStart = System.currentTimeMillis();
-                            try {
-                                final Optional<MetricValue> result = getMetricValue(metricType);
-                                timingData[0] = System.currentTimeMillis() - computationStart;
-                                return result;
-                            } catch (final DotDataException e) {
-                                timingData[0] = System.currentTimeMillis() - computationStart;
-                                Logger.error(this, "Error getting metric value for " + metricType.getName(), e);
-                                return Optional.empty();
+                    final Callable<Optional<MetricValue>> task = () -> {
+                        try {
+                            return cacheManager.get(
+                                metricType.getName(),
+                                () -> {
+                                    // Supplier called = cache miss
+                                    flags[2] = true;
+                                    final long computationStart = System.currentTimeMillis();
+                                    try {
+                                        final Optional<MetricValue> result = getMetricValue(metricType);
+                                        timingData[0] = System.currentTimeMillis() - computationStart;
+                                        return result;
+                                    } catch (final DotDataException e) {
+                                        timingData[0] = System.currentTimeMillis() - computationStart;
+                                        Logger.error(this, "Error getting metric value for " + metricType.getName(), e);
+                                        return Optional.empty();
+                                    }
+                                }
+                            );
+                        } finally {
+                            // Defensive cleanup: close any DB connection left on this thread's
+                            // ThreadLocal by metrics that don't manage their own connection lifecycle.
+                            // Without this, a non-DBMetricType that opens a connection via DotConnect
+                            // without cleanup will "poison" the ThreadLocal — causing wrapConnection()
+                            // in subsequent DBMetricType metrics to skip its closeSilently(), leaking
+                            // the connection when the executor thread terminates. See #34926.
+                            if (DbConnectionFactory.connectionExists()) {
+                                if (!(metricType instanceof DBMetricType)) {
+                                    Logger.warn(MetricStatsCollector.class,
+                                            String.format("MetricType '%s' (%s) left a DB connection open on the "
+                                                + "telemetry thread. This connection will be closed defensively. "
+                                                + "The metric should manage its own connection lifecycle.",
+                                                metricType.getName(), metricType.getClass().getSimpleName()));
+                                }
+                                DbConnectionFactory.closeSilently();
                             }
                         }
-                    );
+                    };
                     final Future<Optional<MetricValue>> future = executor.submit(task);
 
                     try {

--- a/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfSitesWithThumbnailsMetricType.java
+++ b/dotCMS/src/main/java/com/dotcms/telemetry/collectors/site/CountOfSitesWithThumbnailsMetricType.java
@@ -6,7 +6,9 @@ import com.dotcms.telemetry.MetricType;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Logger;
 import io.vavr.control.Try;
 
@@ -56,7 +58,12 @@ public class CountOfSitesWithThumbnailsMetricType implements MetricType {
 
     @Override
     public Optional<Object> getValue() {
-        return Optional.of(getCountOfSitesWithThumbnails());
+        try {
+            return DbConnectionFactory.wrapConnection(
+                    () -> Optional.<Object>of(getCountOfSitesWithThumbnails()));
+        } catch (final Exception e) {
+            throw new DotRuntimeException(e);
+        }
     }
 
     private int getCountOfSitesWithThumbnails() {
@@ -65,7 +72,7 @@ public class CountOfSitesWithThumbnailsMetricType implements MetricType {
         try {
             final List<String> allSitesInodes = getAllSitesInodes();
 
-            for (String siteInode : allSitesInodes) {
+            for (final String siteInode : allSitesInodes) {
                 final File hostThumbnail = Try.of(() -> APILocator.getContentletAPI().getBinaryFile(siteInode,
                         Host.HOST_THUMB_KEY, APILocator.systemUser())).getOrNull();
                 if (hostThumbnail != null) {
@@ -73,7 +80,7 @@ public class CountOfSitesWithThumbnailsMetricType implements MetricType {
                 }
             }
 
-        } catch(Exception e) {
+        } catch (final Exception e) {
             Logger.debug(this, "Error counting Sites with thumbnails");
         }
 


### PR DESCRIPTION
## Summary

Fixes #34926 — `CountOfSitesWithThumbnailsMetricType` opens a DB connection via `DotConnect.loadObjectResults()` without cleanup, poisoning the executor thread's `ThreadLocal`. This causes `wrapConnection()` in subsequent `DBMetricType` metrics to skip its `closeSilently()`, leaking one connection per telemetry run per pod (~93 leaked connections/day on the Frankfurt cluster).

**Two-part fix:**

- **Defensive cleanup in `MetricStatsCollector`**: After each metric task completes on the executor thread, checks for and closes any orphaned ThreadLocal connection. Logs a warning for non-`DBMetricType` metrics that leave connections open — this surfaces future poison pills at dev time rather than waiting for production leaks.

- **Fix the known poison pill**: Wraps `CountOfSitesWithThumbnailsMetricType.getValue()` in `DbConnectionFactory.wrapConnection()` so the `DotConnect` query's connection is properly managed.

## Test plan

- [ ] Verify build compiles cleanly
- [ ] Deploy to staging and confirm no new idle connections accumulate in `pg_stat_activity` showing the experiments `ARCHIVED` query fingerprint
- [ ] Check logs for the new defensive warning message — should NOT appear once the poison pill fix is in place
- [ ] Verify telemetry metrics still collect successfully (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34926