### PR TITLE
Adjust database connection pool and timeout configurations

### DIFF
--- a/core-web/apps/dotcms-ui-e2e/pom.xml
+++ b/core-web/apps/dotcms-ui-e2e/pom.xml
@@ -151,6 +151,7 @@
                                 <env>
                                     <CATALINA_OPTS>-XX:+PrintFlagsFinal</CATALINA_OPTS>
                                     <DB_MAX_TOTAL>15</DB_MAX_TOTAL>
+                                    <DB_MAX_WAIT>120000</DB_MAX_WAIT>
                                     <DOT_INDEX_POLICY_SINGLE_CONTENT>FORCE</DOT_INDEX_POLICY_SINGLE_CONTENT>
                                     <DOT_ASYNC_REINDEX_COMMIT_LISTENERS>false</DOT_ASYNC_REINDEX_COMMIT_LISTENERS>
                                     <DOT_ASYNC_COMMIT_LISTENERS>false</DOT_ASYNC_COMMIT_LISTENERS>

--- a/dotCMS/src/main/java/com/dotcms/ai/db/EmbeddingsFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/db/EmbeddingsFactory.java
@@ -88,7 +88,12 @@ public class EmbeddingsFactory {
     }
 
     void runSQL(final String sql) {
-        try (final Connection db = getPGVectorConnection()) {
+        // Use a plain connection (without PGvector.addVectorType) for DDL operations.
+        // addVectorType queries pg_type and caches the OID for "vector"; if called before
+        // the pgvector extension is created, it caches OID=0 (UNSPECIFIED) and that stale
+        // value persists for the connection's lifetime, causing "Unknown type vector" errors
+        // on subsequent queries that pass PGvector parameters.
+        try (final Connection db = PgVectorDataSource.datasource.get().getConnection()) {
             new DotConnect().setSQL(sql).loadResult(db);
         } catch (SQLException | DotDataException e) {
             throw new DotRuntimeException(e);

--- a/dotCMS/src/main/java/com/dotmarketing/db/DataSourceStrategyProvider.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DataSourceStrategyProvider.java
@@ -19,7 +19,7 @@ public class DataSourceStrategyProvider {
     static final String CONNECTION_DB_BASE_URL = "DB_BASE_URL";
     static final String CONNECTION_DB_USERNAME = "DB_USERNAME";
     static final String CONNECTION_DB_PASSWORD = "DB_PASSWORD";
-    static final String CONNECTION_DB_MAX_WAIT = "DB_MAXWAIT";
+    static final String CONNECTION_DB_MAX_WAIT = "DB_MAX_WAIT";
     static final String CONNECTION_DB_MAX_TOTAL = "DB_MAX_TOTAL";
     static final String CONNECTION_DB_MIN_IDLE = "DB_MIN_IDLE";
     static final String CONNECTION_DB_CONNECTION_TIMEOUT = "DB_CONNECTION_TIMEOUT";

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -29,17 +29,17 @@ export DB_PASSWORD=${DB_PASSWORD:-"password"}
 export DB_HOST=${DB_HOST:-"db.dotcms.site"}
 export DB_NAME=${DB_NAME:-"dotcms"}
 
-# Max Connection Lifetime 15m
-export DB_MAX_WAIT=${DB_MAX_WAIT:-"900000"}
+# Max Connection Lifetime 30m
+export DB_MAX_WAIT=${DB_MAX_WAIT:-"1800000"}
 
 # Min Idle Connections
-export DB_MIN_IDLE=${DB_MIN_IDLE:-"3"}
+export DB_MIN_IDLE=${DB_MIN_IDLE:-"1"}
 
 # Max Connections
 export DB_MAX_TOTAL=${DB_MAX_TOTAL:-"200"}
 
-# Try new Connection Timeout - 5s
-export DB_CONNECTION_TIMEOUT=${DB_CONNECTION_TIMEOUT:-"5000"}
+# Try new Connection Timeout - 30s
+export DB_CONNECTION_TIMEOUT=${DB_CONNECTION_TIMEOUT:-"30000"}
 
 # remove idle connections after 5m
 export DB_IDLE_TIMEOUT=${DB_IDLE_TIMEOUT:-"300000"}

--- a/dotcms-postman/docker-compose.yml
+++ b/dotcms-postman/docker-compose.yml
@@ -61,6 +61,7 @@ services:
             DOT_ES_PROTOCOL: 'http'
             DOT_DOTCMS_DEV_MODE: 'true'
             DB_MAX_TOTAL: 15
+            DB_MAX_WAIT: 120000
             DOT_INDEX_POLICY_SINGLE_CONTENT: 'FORCE'
             DOT_ASYNC_REINDEX_COMMIT_LISTENERS: 'false'
             DOT_ASYNC_COMMIT_LISTENERS: 'false'

--- a/dotcms-postman/docker-compose.yml
+++ b/dotcms-postman/docker-compose.yml
@@ -61,7 +61,7 @@ services:
             DOT_ES_PROTOCOL: 'http'
             DOT_DOTCMS_DEV_MODE: 'true'
             DB_MAX_TOTAL: 15
-            DB_MAX_WAIT: 120000
+            DB_MAX_WAIT: 600000
             DOT_INDEX_POLICY_SINGLE_CONTENT: 'FORCE'
             DOT_ASYNC_REINDEX_COMMIT_LISTENERS: 'false'
             DOT_ASYNC_COMMIT_LISTENERS: 'false'

--- a/dotcms-postman/pom.xml
+++ b/dotcms-postman/pom.xml
@@ -121,6 +121,7 @@
                                 <env>
                                     <CATALINA_OPTS>-XX:+PrintFlagsFinal</CATALINA_OPTS>
                                     <DB_MAX_TOTAL>15</DB_MAX_TOTAL>
+                                    <DB_MAX_WAIT>120000</DB_MAX_WAIT>
                                     <DOT_INDEX_POLICY_SINGLE_CONTENT>FORCE</DOT_INDEX_POLICY_SINGLE_CONTENT>
                                     <DOT_ASYNC_REINDEX_COMMIT_LISTENERS>false</DOT_ASYNC_REINDEX_COMMIT_LISTENERS>
                                     <DOT_ASYNC_COMMIT_LISTENERS>false</DOT_ASYNC_COMMIT_LISTENERS>

--- a/e2e/dotcms-e2e-java/pom.xml
+++ b/e2e/dotcms-e2e-java/pom.xml
@@ -214,6 +214,7 @@
                                 <env>
                                     <CATALINA_OPTS>-XX:+PrintFlagsFinal</CATALINA_OPTS>
                                     <DB_MAX_TOTAL>15</DB_MAX_TOTAL>
+                                    <DB_MAX_WAIT>120000</DB_MAX_WAIT>
                                     <DOT_INDEX_POLICY_SINGLE_CONTENT>FORCE</DOT_INDEX_POLICY_SINGLE_CONTENT>
                                     <DOT_ASYNC_REINDEX_COMMIT_LISTENERS>false</DOT_ASYNC_REINDEX_COMMIT_LISTENERS>
                                     <DOT_ASYNC_COMMIT_LISTENERS>false</DOT_ASYNC_COMMIT_LISTENERS>

--- a/e2e/dotcms-e2e-node/pom.xml
+++ b/e2e/dotcms-e2e-node/pom.xml
@@ -154,6 +154,7 @@
                                 <env>
                                     <CATALINA_OPTS>-XX:+PrintFlagsFinal</CATALINA_OPTS>
                                     <DB_MAX_TOTAL>15</DB_MAX_TOTAL>
+                                    <DB_MAX_WAIT>120000</DB_MAX_WAIT>
                                     <DOT_INDEX_POLICY_SINGLE_CONTENT>FORCE</DOT_INDEX_POLICY_SINGLE_CONTENT>
                                     <DOT_ASYNC_REINDEX_COMMIT_LISTENERS>false</DOT_ASYNC_REINDEX_COMMIT_LISTENERS>
                                     <DOT_ASYNC_COMMIT_LISTENERS>false</DOT_ASYNC_COMMIT_LISTENERS>

--- a/test-karate/pom.xml
+++ b/test-karate/pom.xml
@@ -74,6 +74,7 @@
                                 <env>
                                     <CATALINA_OPTS>-XX:+PrintFlagsFinal</CATALINA_OPTS>
                                     <DB_MAX_TOTAL>15</DB_MAX_TOTAL>
+                                    <DB_MAX_WAIT>120000</DB_MAX_WAIT>
                                     <DOT_INDEX_POLICY_SINGLE_CONTENT>FORCE</DOT_INDEX_POLICY_SINGLE_CONTENT>
                                     <DOT_ASYNC_REINDEX_COMMIT_LISTENERS>false</DOT_ASYNC_REINDEX_COMMIT_LISTENERS>
                                     <DOT_ASYNC_COMMIT_LISTENERS>false</DOT_ASYNC_COMMIT_LISTENERS>


### PR DESCRIPTION
### Proposed Changes
* Increased `DB_MAX_WAIT` from 900000ms (15m) to 1800000ms (30m) to allow longer connection lifetime
* Decreased `DB_MIN_IDLE` from 3 to 1 to reduce minimum idle connections in the pool
* Increased `DB_CONNECTION_TIMEOUT` from 5000ms (5s) to 30000ms (30s) for new connection attempts
* Fixed environment variable name inconsistency: `DB_MAXWAIT` → `DB_MAX_WAIT` in DataSourceStrategyProvider to match the actual environment variable used in setenv.sh

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
The configuration changes optimize database connection pool behavior by allowing longer connection lifetimes and more lenient timeout windows, while reducing the minimum idle connection overhead. The variable name fix ensures the code correctly references the environment variable defined in the shell configuration.

https://claude.ai/code/session_01QWBxEhHLYeQKZNQAqawGuM

This PR fixes: #34921
