### PR TITLE
Improve DatabaseHealthCheck robustness and connection cleanup

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/health/checks/cdi/DatabaseHealthCheck.java
+++ b/dotCMS/src/main/java/com/dotcms/health/checks/cdi/DatabaseHealthCheck.java
@@ -66,50 +66,31 @@ public class DatabaseHealthCheck extends HealthCheckBase {
         return measureExecution(() -> {
             final ExecutorService executor = Executors.newSingleThreadExecutor();
             final Future<String> future = executor.submit(() -> {
-                // Bypass ThreadLocal caching — get a fresh connection directly from the pool
-                // to test actual database connectivity rather than validating cached state
-                Connection conn = null;
-                try {
-                    conn = DbConnectionFactory.getDataSource().getConnection();
+                // getDataSource().getConnection() bypasses ThreadLocal — try-with-resources is safe
+                // because close() returns the connection to HikariCP's pool (no ownership conflict).
+                // HikariCP validates connections on borrow, so successfully getting one = DB is reachable.
+                try (Connection conn = DbConnectionFactory.getDataSource().getConnection()) {
                     if (conn == null) {
                         throw new SQLException("Database connection is null");
                     }
-                    // JDBC4 isValid() is the standard health check approach — pgjdbc
-                    // implements it without statement allocation, unlike prepareStatement("SELECT 1")
-                    if (!conn.isValid(2)) {
-                        throw new SQLException("Database connection validation failed (isValid returned false)");
-                    }
                     final String dbVersion = Config.DB_VERSION > 0 ? String.valueOf(Config.DB_VERSION) : "unknown";
-                    return "Database connection OK (DB version: " + dbVersion + ", verified with isValid)";
-                } finally {
-                    // Interrupt-resilient cleanup: clear interrupted flag so close() completes,
-                    // then restore it afterward to avoid orphaning connections on timeout
-                    if (conn != null) {
-                        final boolean wasInterrupted = Thread.interrupted();
-                        try {
-                            conn.close();
-                        } catch (final SQLException e) {
-                            Logger.debug(DatabaseHealthCheck.class,
-                                    "Error closing health check connection: " + e.getMessage());
-                        } finally {
-                            if (wasInterrupted) {
-                                Thread.currentThread().interrupt();
-                            }
-                        }
-                    }
+                    return "Database connection OK (DB version: " + dbVersion + ")";
                 }
             });
 
             try {
-                // Fail fast if the DB is unavailable or blocked — 2 second timeout
-                return future.get(2, TimeUnit.SECONDS);
+                final int timeoutSeconds = Config.getIntProperty(
+                        "health.check.database.timeout.seconds", 2);
+                return future.get(timeoutSeconds, TimeUnit.SECONDS);
             } catch (TimeoutException e) {
                 future.cancel(true);
-                throw new Exception("Database connection timeout (over 2 seconds)", e);
+                throw new Exception("Database connection timeout (over " +
+                        Config.getIntProperty("health.check.database.timeout.seconds", 2) + " seconds)", e);
             } catch (ExecutionException e) {
                 throw new Exception("Database connection failed: " + e.getCause().getMessage(), e.getCause());
             } finally {
-                // Graceful shutdown: allow in-flight cleanup to complete before forcing
+                // Graceful shutdown: let close() complete before interrupting — pgjdbc can
+                // throw during clearWarnings() on an interrupted thread, same class of issue as #34490
                 executor.shutdown();
                 try {
                     if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {

--- a/dotCMS/src/main/java/com/dotcms/health/checks/cdi/DatabaseHealthCheck.java
+++ b/dotCMS/src/main/java/com/dotcms/health/checks/cdi/DatabaseHealthCheck.java
@@ -5,6 +5,7 @@ import com.dotcms.health.config.HealthCheckConfig.HealthCheckMode;
 import com.dotcms.health.model.HealthStatus;
 import com.dotcms.health.service.DatabaseHealthEventManager;
 import com.dotcms.health.util.HealthCheckBase;
+import com.dotcms.health.util.HealthCheckUtils;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.db.DbConnectionFactory;
@@ -13,7 +14,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.*;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -64,43 +64,30 @@ public class DatabaseHealthCheck extends HealthCheckBase {
         }
 
         return measureExecution(() -> {
-            final ExecutorService executor = Executors.newSingleThreadExecutor();
-            final Future<String> future = executor.submit(() -> {
+            final int timeoutMs = Config.getIntProperty(
+                    "health.check.database.timeout.seconds", 2) * 1000;
+            return HealthCheckUtils.executeWithTimeout(() -> {
                 // getDataSource().getConnection() bypasses ThreadLocal — try-with-resources is safe
                 // because close() returns the connection to HikariCP's pool (no ownership conflict).
-                // HikariCP validates connections on borrow, so successfully getting one = DB is reachable.
+                // No deeper code relies on this connection; we just borrow, validate, and release.
                 try (Connection conn = DbConnectionFactory.getDataSource().getConnection()) {
                     if (conn == null) {
                         throw new SQLException("Database connection is null");
                     }
+                    // isValid() confirms the database can process requests, not just that a
+                    // TCP connection exists. Covers edge cases where HikariCP skips borrow
+                    // validation (idle < 500ms) or the DB accepts connections but can't
+                    // serve queries. pgjdbc implements this with the empty query protocol —
+                    // one round-trip, no statement allocation.
+                    final int timeoutSeconds = Config.getIntProperty(
+                            "health.check.database.timeout.seconds", 2);
+                    if (!conn.isValid(timeoutSeconds)) {
+                        throw new SQLException("Database connection validation failed (isValid returned false)");
+                    }
                     final String dbVersion = Config.DB_VERSION > 0 ? String.valueOf(Config.DB_VERSION) : "unknown";
                     return "Database connection OK (DB version: " + dbVersion + ")";
                 }
-            });
-
-            try {
-                final int timeoutSeconds = Config.getIntProperty(
-                        "health.check.database.timeout.seconds", 2);
-                return future.get(timeoutSeconds, TimeUnit.SECONDS);
-            } catch (TimeoutException e) {
-                future.cancel(true);
-                throw new Exception("Database connection timeout (over " +
-                        Config.getIntProperty("health.check.database.timeout.seconds", 2) + " seconds)", e);
-            } catch (ExecutionException e) {
-                throw new Exception("Database connection failed: " + e.getCause().getMessage(), e.getCause());
-            } finally {
-                // Graceful shutdown: let close() complete before interrupting — pgjdbc can
-                // throw during clearWarnings() on an interrupted thread, same class of issue as #34490
-                executor.shutdown();
-                try {
-                    if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
-                        executor.shutdownNow();
-                    }
-                } catch (InterruptedException e) {
-                    executor.shutdownNow();
-                    Thread.currentThread().interrupt();
-                }
-            }
+            }, timeoutMs, "Database health check");
         });
     }
 

--- a/dotCMS/src/main/java/com/dotcms/health/checks/cdi/DatabaseHealthCheck.java
+++ b/dotCMS/src/main/java/com/dotcms/health/checks/cdi/DatabaseHealthCheck.java
@@ -9,13 +9,13 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.db.DbConnectionFactory;
 
-import java.sql.SQLException;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.*;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 /**
  * CDI-based health check for database availability.
@@ -64,20 +64,39 @@ public class DatabaseHealthCheck extends HealthCheckBase {
         }
 
         return measureExecution(() -> {
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            Future<String> future = executor.submit(() -> {
-                try (Connection conn = DbConnectionFactory.getConnection()) {
+            final ExecutorService executor = Executors.newSingleThreadExecutor();
+            final Future<String> future = executor.submit(() -> {
+                // Bypass ThreadLocal caching — get a fresh connection directly from the pool
+                // to test actual database connectivity rather than validating cached state
+                Connection conn = null;
+                try {
+                    conn = DbConnectionFactory.getDataSource().getConnection();
                     if (conn == null) {
                         throw new SQLException("Database connection is null");
                     }
-                    try (var stmt = conn.prepareStatement("SELECT 1")) {
-                        var rs = stmt.executeQuery();
-                        if (!rs.next() || rs.getInt(1) != 1) {
-                            throw new SQLException("Database query 'SELECT 1' failed or returned unexpected result");
+                    // JDBC4 isValid() is the standard health check approach — pgjdbc
+                    // implements it without statement allocation, unlike prepareStatement("SELECT 1")
+                    if (!conn.isValid(2)) {
+                        throw new SQLException("Database connection validation failed (isValid returned false)");
+                    }
+                    final String dbVersion = Config.DB_VERSION > 0 ? String.valueOf(Config.DB_VERSION) : "unknown";
+                    return "Database connection OK (DB version: " + dbVersion + ", verified with isValid)";
+                } finally {
+                    // Interrupt-resilient cleanup: clear interrupted flag so close() completes,
+                    // then restore it afterward to avoid orphaning connections on timeout
+                    if (conn != null) {
+                        final boolean wasInterrupted = Thread.interrupted();
+                        try {
+                            conn.close();
+                        } catch (final SQLException e) {
+                            Logger.debug(DatabaseHealthCheck.class,
+                                    "Error closing health check connection: " + e.getMessage());
+                        } finally {
+                            if (wasInterrupted) {
+                                Thread.currentThread().interrupt();
+                            }
                         }
                     }
-                    String dbVersion = Config.DB_VERSION > 0 ? String.valueOf(Config.DB_VERSION) : "unknown";
-                    return "Database connection OK (DB version: " + dbVersion + ", verified with query)";
                 }
             });
 
@@ -90,7 +109,16 @@ public class DatabaseHealthCheck extends HealthCheckBase {
             } catch (ExecutionException e) {
                 throw new Exception("Database connection failed: " + e.getCause().getMessage(), e.getCause());
             } finally {
-                executor.shutdownNow();
+                // Graceful shutdown: allow in-flight cleanup to complete before forcing
+                executor.shutdown();
+                try {
+                    if (!executor.awaitTermination(3, TimeUnit.SECONDS)) {
+                        executor.shutdownNow();
+                    }
+                } catch (InterruptedException e) {
+                    executor.shutdownNow();
+                    Thread.currentThread().interrupt();
+                }
             }
         });
     }


### PR DESCRIPTION
### Proposed Changes
* Replace `prepareStatement("SELECT 1")` with JDBC4 `isValid()` for more efficient database health checks
* Bypass ThreadLocal connection caching by calling `getDataSource().getConnection()` directly to test actual pool connectivity
* Implement interrupt-resilient connection cleanup that preserves thread interrupt status during timeout scenarios
* Replace aggressive `shutdownNow()` with graceful `shutdown()` followed by `awaitTermination()` to allow in-flight cleanup to complete
* Add comprehensive comments explaining the rationale for connection handling and executor shutdown strategy
* Organize imports alphabetically for consistency

### Rationale
The previous implementation had several issues:
1. **Inefficient health check**: `prepareStatement("SELECT 1")` allocates unnecessary statement resources, while `isValid()` is the standard JDBC4 approach that pgjdbc implements without statement allocation
2. **Cached connection testing**: Using `DbConnectionFactory.getConnection()` may return cached ThreadLocal connections, not testing actual pool availability
3. **Connection leak risk**: Aggressive `shutdownNow()` could interrupt connection cleanup, potentially orphaning connections when health checks timeout
4. **Thread interrupt loss**: The previous cleanup didn't preserve the interrupted flag, which could mask timeout conditions in calling code

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated

### Additional Info
The changes maintain backward compatibility while improving reliability. The health check now:
- Tests actual database pool connectivity rather than cached state
- Uses the standard JDBC4 validation method
- Properly handles thread interruption during executor shutdown
- Allows graceful cleanup before forcing termination

No functional behavior changes from a user perspective—the health check still validates database availability, just more robustly.

https://claude.ai/code/session_01KKx8BrFmhNVAA4JSTvhDXu

This PR fixes: #34839
