### PR TITLE
fix: Wrong redirect on pending bundles (#34749)

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_content_list.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_content_list.jsp
@@ -188,7 +188,7 @@
 					<input dojoType="dijit.form.CheckBox" type="checkbox" class="add_to_queue" name="add_to_queue" value="<%=c.getInode()%>" id="add_to_queue_<%=c.getInode()%>" />
 				</td>
 				<td width="100%" nowrap="nowrap">
-					<a href="/c/portal/layout?p_l_id=<%=layoutId %>&p_p_id="+PortletID.CONTENT+"&p_p_action=1&p_p_state=maximized&p_p_mode=view&_"+PortletID.CONTENT+"_struts_action=/ext/contentlet/edit_contentlet&_"+PortletID.CONTENT+"_cmd=edit&inode=<%=c.getInode() %>&referer=<%=referer %>">
+					<a href="/c/portal/layout?p_l_id=<%=layoutId %>&p_p_id=<%=PortletID.CONTENT%>&p_p_action=1&p_p_state=maximized&p_p_mode=view&_<%=PortletID.CONTENT%>_struts_action=/ext/contentlet/edit_contentlet&_<%=PortletID.CONTENT%>_cmd=edit&inode=<%=c.getInode() %>&referer=<%=referer %>">
 						<%=StringEscapeUtils.escapeHtml(c.getTitle())%>
 					</a>
 					<div style="float:right;color:silver">

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_queue_list.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_queue_list.jsp
@@ -323,7 +323,7 @@
 							final Object structureObject = asset.get(PublishQueueElementTransformer.CONTENT_TYPE_NAME_KEY);
 							structureName =  UtilMethods.isSet(structureObject) ? structureObject.toString() : StringPool.BLANK;
                         %>
-						    <a href="/c/portal/layout?p_l_id=<%=layoutId %>&p_p_id="+PortletID.CONTENT+"&p_p_action=1&p_p_state=maximized&p_p_mode=view&_"+PortletID.CONTENT+"_struts_action=/ext/contentlet/edit_contentlet&_"+PortletID.CONTENT+"_cmd=edit&inode=<%=inode %>&referer=<%=referer %>">
+						    <a href="/c/portal/layout?p_l_id=<%=layoutId %>&p_p_id=<%=PortletID.CONTENT%>&p_p_action=1&p_p_state=maximized&p_p_mode=view&_<%=PortletID.CONTENT%>_struts_action=/ext/contentlet/edit_contentlet&_<%=PortletID.CONTENT%>_cmd=edit&inode=<%=inode %>&referer=<%=referer %>">
 						        <%=StringEscapeUtils.escapeHtml(title)%>
                             </a>
 						<% } else {


### PR DESCRIPTION
The href url was malformed generating an unexpected redirect when clicking on the pending bundle

This PR fixes: #34749

This PR fixes: #34749