### PR TITLE
Wrap DB connection in listActive method with DbConnectionFactory

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentsFactoryImpl.java
@@ -6,6 +6,7 @@ import com.dotcms.util.DotPreconditions;
 import com.dotcms.util.transform.TransformerLocator;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
@@ -185,13 +186,15 @@ public class ExperimentsFactoryImpl implements
      */
     @Override
     public final Collection<Experiment> listActive(final String pageIdentifier) throws DotDataException {
-        final List<Map<String, Object>> results = new DotConnect()
-                .setSQL(ACTIVE_EXPERIMENTS_BY_PAGE)
-                .addParam(AbstractExperiment.Status.ENDED.toString())
-                .addParam(AbstractExperiment.Status.ARCHIVED.toString())
-                .addParam(pageIdentifier)
-                .loadObjectResults();
+        return DbConnectionFactory.wrapConnection(() -> {
+            final List<Map<String, Object>> results = new DotConnect()
+                    .setSQL(ACTIVE_EXPERIMENTS_BY_PAGE)
+                    .addParam(AbstractExperiment.Status.ENDED.toString())
+                    .addParam(AbstractExperiment.Status.ARCHIVED.toString())
+                    .addParam(pageIdentifier)
+                    .loadObjectResults();
 
-        return TransformerLocator.createExperimentTransformer(results).list;
+            return TransformerLocator.createExperimentTransformer(results).list;
+        });
     }
 }


### PR DESCRIPTION
### Proposed Changes
* Wrapped the database query execution in `ExperimentsFactoryImpl.listActive()` with `DbConnectionFactory.wrapConnection()` to ensure proper connection management
* Added import for `DbConnectionFactory` class
* Refactored the method to use a lambda expression for connection handling

### Rationale
This change ensures that database connections are properly managed and released when querying active experiments by page identifier. Using `DbConnectionFactory.wrapConnection()` provides consistent connection lifecycle management across the codebase.

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
The functional behavior of the `listActive()` method remains unchanged - it still queries for active experiments (excluding ENDED and ARCHIVED statuses) and transforms the results into a collection of Experiment objects. This is a refactoring to improve resource management.

https://claude.ai/code/session_01QgxjLmXpypRcAYADtkEgg7

This PR fixes: #34831
