### PR TITLE
security: upgrade Apache Tomcat from 9.0.108 to 9.0.113 (CVE-2025-66614)

### DIFF
--- a/dotCMS/src/test/java/com/dotcms/health/checks/TomcatVersionSecurityTest.java
+++ b/dotCMS/src/test/java/com/dotcms/health/checks/TomcatVersionSecurityTest.java
@@ -1,0 +1,52 @@
+package com.dotcms.health.checks;
+
+import org.apache.catalina.util.ServerInfo;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Security regression test for CVE-2025-66614.
+ *
+ * Verifies that the Apache Tomcat version in use meets the minimum required
+ * version (9.0.113+) that fixes the SNI/Host header mismatch vulnerability
+ * which allows bypassing client certificate authentication in multi-virtual-host
+ * configurations.
+ *
+ * @see <a href="https://app.opencve.io/cve/CVE-2025-66614">CVE-2025-66614</a>
+ */
+public class TomcatVersionSecurityTest {
+
+    private static final int[] MINIMUM_SAFE_VERSION = {9, 0, 113};
+
+    @Test
+    public void testTomcatVersion_MeetsMinimumForCVE_2025_66614() {
+        String serverNumber = ServerInfo.getServerNumber();
+        assertNotNull("Tomcat ServerInfo should be available on the classpath", serverNumber);
+
+        int[] actual = parseVersion(serverNumber);
+        assertTrue(
+            "Tomcat " + serverNumber + " is vulnerable to CVE-2025-66614. " +
+            "Minimum safe version is 9.0.113. Upgrade tomcat.version in parent/pom.xml.",
+            isVersionAtLeast(actual, MINIMUM_SAFE_VERSION)
+        );
+    }
+
+    private static int[] parseVersion(String version) {
+        String[] parts = version.trim().split("\\.");
+        int[] result = new int[parts.length];
+        for (int i = 0; i < parts.length; i++) {
+            result[i] = Integer.parseInt(parts[i].replaceAll("[^0-9].*", ""));
+        }
+        return result;
+    }
+
+    private static boolean isVersionAtLeast(int[] actual, int[] minimum) {
+        int len = Math.min(actual.length, minimum.length);
+        for (int i = 0; i < len; i++) {
+            if (actual[i] > minimum[i]) return true;
+            if (actual[i] < minimum[i]) return false;
+        }
+        return actual.length >= minimum.length;
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -67,7 +67,7 @@
         </java.module.args>
 
         <maven.deploy.skip>false</maven.deploy.skip>
-        <tomcat.version>9.0.108</tomcat.version>
+        <tomcat.version>9.0.113</tomcat.version>
         <!-- Add any properties here that are to have defaults and overrides set in the environment properties -->
         <!--suppress UnresolvedMavenProperty -->
         <mvn.environment.name>${ext.mvn.environment.name}</mvn.environment.name>


### PR DESCRIPTION
## Summary

Upgrades Apache Tomcat from `9.0.108` to `9.0.113` to remediate CVE-2025-66614.

Closes #34954

## What changed

- Updated `<tomcat.version>` in `parent/pom.xml` from `9.0.108` → `9.0.113`

## CVE Details

**CVE-2025-66614** (CVSS 7.6 - High) — Improper Input Validation in Apache Tomcat

Tomcat fails to validate that the TLS SNI hostname matches the HTTP `Host` header. In multi-virtual-host configurations, an attacker can exploit this to route requests to a virtual host with weaker authentication, bypassing client certificate auth enforced at the Connector level.

- **Affected:** 9.0.0-M1 through 9.0.112
- **Fixed:** 9.0.113+
- **Reference:** https://app.opencve.io/cve/CVE-2025-66614

## Test plan

- [ ] Verify existing Tomcat-related integration tests pass
- [ ] Confirm no breaking changes introduced by the minor Tomcat version bump
- [ ] Smoke test a local dotCMS instance with the upgraded Tomcat

🤖 Generated with [Claude Code](https://claude.com/claude-code)