### PR TITLE
fix: make DbConnectionFactory.getConnection() safe for try-with-resources

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/business/interceptor/CoreTransactionOps.java
+++ b/dotCMS/src/main/java/com/dotcms/business/interceptor/CoreTransactionOps.java
@@ -71,7 +71,7 @@ public final class CoreTransactionOps implements TransactionOps {
             LocalTransaction.handleTransactionInteruption(connection, threadStack);
         } else {
             // When called from WrapInTransaction (no stack captured), check inline
-            if (DbConnectionFactory.getConnection() != connection) {
+            if (!DbConnectionFactory.getConnection().equals(connection)) {
                 final String action = Config.getStringProperty(
                         "LOCAL_TRANSACTION_INTERUPTED_ACTION", "LOG");
                 if ("LOG".equalsIgnoreCase(action)) {

--- a/dotCMS/src/main/java/com/dotmarketing/db/DbConnectionFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DbConnectionFactory.java
@@ -199,7 +199,13 @@ public class DbConnectionFactory {
                     connectionsHolder.set(connectionsList);
                 }
 
-                connectionsList.put(DATABASE_DEFAULT_DATASOURCE, connection);
+                // Always store the raw connection, never a ManagedConnection wrapper.
+                // getConnection() creates a fresh ManagedConnection on each call with the
+                // correct ownership flag, so the ThreadLocal must hold the unwrapped connection.
+                final Connection raw = (connection instanceof ManagedConnection)
+                        ? ((ManagedConnection) connection).internalConnection
+                        : connection;
+                connectionsList.put(DATABASE_DEFAULT_DATASOURCE, raw);
             }
         } catch (Exception e) {
             Logger.error(DbConnectionFactory.class, "---------- DBConnectionFactory: error : " + e);
@@ -209,13 +215,31 @@ public class DbConnectionFactory {
     }
     
     /**
-     * This method retrieves the default connection to the dotCMS DB
+     * Retrieves the default connection to the dotCMS DB, wrapped in a {@link ManagedConnection}
+     * that is safe for use in try-with-resources blocks.
+     *
+     * <p>If a connection already exists on the current thread (ThreadLocal), the same connection
+     * is returned but wrapped so that {@code close()} is a no-op — the owning scope manages
+     * its lifecycle. If no connection exists, a new one is created from the pool, and
+     * {@code close()} will properly close it and clean up the ThreadLocal.</p>
+     *
+     * <p><b>Safe usage:</b></p>
+     * <pre>
+     * try (Connection conn = DbConnectionFactory.getConnection()) {
+     *     // Use conn — close() at end is safe whether or not a connection
+     *     // already existed on this thread
+     * }
+     * </pre>
+     *
+     * @return a {@link ManagedConnection} wrapping the ThreadLocal-managed connection
+     * @see ManagedConnection
      */
     public static Connection getConnection() {
 
         try {
             HashMap<String, Connection> connectionsList = (HashMap<String, Connection>) connectionsHolder.get();
             Connection connection = null;
+            boolean isNewConnection = false;
             connectionsCalledFor++;
             if (connectionsList == null) {
                 connectionsList = new HashMap<>();
@@ -228,14 +252,13 @@ public class DbConnectionFactory {
                 DataSource db = getDataSource();
                 connection = db.getConnection();
                 connectionsList.put(DATABASE_DEFAULT_DATASOURCE, connection);
+                isNewConnection = true;
                 Logger.debug(DbConnectionFactory.class,
                     "Connection opened for thread " + Thread.currentThread().getId() + "-" +
                         DATABASE_DEFAULT_DATASOURCE);
             }
 
- 
-
-            return connection;
+            return new ManagedConnection(connection, isNewConnection);
         } catch (com.dotcms.shutdown.ShutdownException e) {
             // Handle shutdown exceptions quietly
             Logger.debug(DbConnectionFactory.class, "Database access during shutdown: " + e.getMessage());

--- a/dotCMS/src/main/java/com/dotmarketing/db/DotConnectionWrapper.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DotConnectionWrapper.java
@@ -357,11 +357,11 @@ public class DotConnectionWrapper implements Connection {
 
   @Override
   public boolean equals(Object obj) {
-    Object conn = obj;
     if (obj instanceof DotConnectionWrapper) {
-      return internalConnection.equals(((DotConnectionWrapper) conn).internalConnection);
+      return internalConnection.equals(((DotConnectionWrapper) obj).internalConnection);
     }
-    return super.equals(obj);
+    // Handle comparison with raw (unwrapped) connections — e.g., from setConnection()
+    return internalConnection.equals(obj);
   }
 
   @Override

--- a/dotCMS/src/main/java/com/dotmarketing/db/LocalTransaction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/LocalTransaction.java
@@ -142,7 +142,7 @@ public class LocalTransaction {
 
     public static void handleTransactionInteruption(final Connection conn,
             final StackTraceElement[] threadStack) throws DotDataException {
-        if (DbConnectionFactory.getConnection() != conn) {
+        if (!DbConnectionFactory.getConnection().equals(conn)) {
             final String action = Config.getStringProperty("LOCAL_TRANSACTION_INTERUPTED_ACTION",
                     TransactionErrorEnum.LOG.name());
             if (TransactionErrorEnum.LOG.name().equalsIgnoreCase(action)) {

--- a/dotCMS/src/main/java/com/dotmarketing/db/ManagedConnection.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/ManagedConnection.java
@@ -1,0 +1,101 @@
+package com.dotmarketing.db;
+
+import com.dotmarketing.util.Logger;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * A {@link Connection} wrapper that is safe for use in try-with-resources blocks
+ * with {@link DbConnectionFactory#getConnection()}.
+ *
+ * <p>The problem: {@code DbConnectionFactory.getConnection()} returns a ThreadLocal-managed
+ * connection. If a connection already exists on the current thread, the same connection is
+ * returned. Using it in try-with-resources causes {@code close()} to be called on exit,
+ * which closes and removes the ThreadLocal connection — breaking any outer scope that
+ * was still using it.</p>
+ *
+ * <p>This wrapper tracks whether the connection was <b>newly created</b> by the
+ * {@code getConnection()} call or <b>borrowed</b> from an existing ThreadLocal entry.
+ * On {@code close()}:</p>
+ * <ul>
+ *   <li>If the connection was newly created (this call opened it): close via
+ *       {@code DbConnectionFactory.closeSilently()} to properly clean up the ThreadLocal.</li>
+ *   <li>If the connection was borrowed (already existed): no-op. The owning scope
+ *       (typically {@code @CloseDBIfOpened} or {@code @WrapInTransaction}) manages lifecycle.</li>
+ * </ul>
+ *
+ * @see DbConnectionFactory#getConnection()
+ */
+public class ManagedConnection extends DotConnectionWrapper {
+
+    private final boolean ownsConnection;
+    private boolean closed;
+
+    /**
+     * Creates a managed connection wrapper.
+     *
+     * @param delegate       the real JDBC connection
+     * @param ownsConnection true if this wrapper owns the connection lifecycle
+     *                       (i.e., no connection existed on the thread before this call)
+     */
+    ManagedConnection(final Connection delegate, final boolean ownsConnection) {
+        super(delegate);
+        this.ownsConnection = ownsConnection;
+        this.closed = false;
+    }
+
+    /**
+     * Returns whether this wrapper owns the underlying connection.
+     * When true, {@link #close()} will actually close and clean up the ThreadLocal.
+     *
+     * @return true if this wrapper created the connection
+     */
+    public boolean isOwner() {
+        return ownsConnection;
+    }
+
+    /**
+     * Closes the connection only if this wrapper owns it.
+     *
+     * <p>If the connection was borrowed from an existing ThreadLocal entry,
+     * this method is a no-op — the connection remains open for the owning scope.</p>
+     */
+    @Override
+    public void close() throws SQLException {
+        if (closed) {
+            return;
+        }
+
+        if (ownsConnection) {
+            closed = true;
+            Logger.debug(ManagedConnection.class,
+                    () -> "ManagedConnection closing owned connection for thread "
+                            + Thread.currentThread().getId());
+            DbConnectionFactory.closeSilently();
+        } else {
+            Logger.debug(ManagedConnection.class,
+                    () -> "ManagedConnection skipping close() — connection borrowed from outer scope on thread "
+                            + Thread.currentThread().getId());
+        }
+    }
+
+    /**
+     * Returns whether this managed connection has been logically closed.
+     * For borrowed connections, this always returns false (the underlying connection
+     * is still open and managed by its owner).
+     */
+    @Override
+    public boolean isClosed() throws SQLException {
+        if (closed) {
+            return true;
+        }
+        return internalConnection.isClosed();
+    }
+
+    @Override
+    public String toString() {
+        return "ManagedConnection{owns=" + ownsConnection
+                + ", closed=" + closed
+                + ", delegate=" + internalConnection + "}";
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00001LoadSchema.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runalways/Task00001LoadSchema.java
@@ -94,23 +94,14 @@ public class Task00001LoadSchema implements StartupTask {
 
 	@Override
 	public boolean forceRun() {
-		
-		Connection conn = null;
-		
-		try{
-			conn =DbConnectionFactory.getConnection();
-		}
-		catch(DotRuntimeException dre){
-			Logger.fatal(this.getClass(),"Unable to get the dotCMS database connection. Please " +
-					"change your connection properties and restart");
-			Logger.fatal(this.getClass(),"Unable to get the dotCMS database connection. Please " +
-					"change your connection properties and restart");
-			Logger.fatal(this.getClass(),"Unable to get the dotCMS database connection. Please " +
-					"change your connection properties and restart");
-		}
-		try {
-			Statement stmt = conn.createStatement();
-			ResultSet rs = stmt.executeQuery("select count(*) as test from inode");
+		// Use a direct pool connection (not the ThreadLocal-managed one) because
+		// StartupTasksExecutor may already have a transaction open on the ThreadLocal
+		// connection. If the probe query fails (expected on an empty DB), the PostgreSQL
+		// transaction is aborted and cannot be reused. A direct pool connection is
+		// independently closed and returned to the pool without affecting the outer scope.
+		try (Connection conn = DbConnectionFactory.getDataSource().getConnection();
+			 Statement stmt = conn.createStatement();
+			 ResultSet rs = stmt.executeQuery("select count(*) as test from inode")) {
 			rs.next();
 			return false;
 		} catch (SQLException e1) {
@@ -120,15 +111,6 @@ public class Task00001LoadSchema implements StartupTask {
 			Logger.info(this.getClass(),"");
 			Logger.info(this.getClass(),"-------------------------------------------------------------------------------------");
 			return true;
-		}finally{
-			try{
-				if(conn != null){
-					conn.close();
-				}
-			}
-			catch(Exception e){
-				Logger.error(this.getClass(),"Unable to close connection... Should not be here.");
-			}
 		}
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04205MigrateVanityURLToContent.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task04205MigrateVanityURLToContent.java
@@ -88,14 +88,16 @@ public class Task04205MigrateVanityURLToContent extends AbstractJDBCStartupTask 
     @WrapInTransaction
     public void executeUpgrade() throws DotDataException {
 
-        Connection conn =null;
         Logger.info(this, "============= Running Task04205MigrateVanityURLToContent =============");
-        try {
+        // Use a direct pool connection (not the ThreadLocal-managed one) because this task
+        // sets autoCommit=true and manages its own lifecycle.  On a fresh database the
+        // virtual_link table does not exist, so queries will fail — a direct connection
+        // isolates that failure from the outer transaction opened by StartupTasksExecutor.
+        try (Connection conn = DbConnectionFactory.getDataSource().getConnection()) {
 
 			/* drop virtual link constraints*/
             dropConstraints();
 
-            conn = DbConnectionFactory.getConnection();
             conn.setAutoCommit(true);
             DotConnect dc = new DotConnect();
 
@@ -143,15 +145,6 @@ public class Task04205MigrateVanityURLToContent extends AbstractJDBCStartupTask 
             Logger.error(this,
                     String.format(ERROR_MESSAGE,
                             e.getMessage()), e);
-        } finally {
-            try {
-                conn.close();
-            }catch (SQLException e){
-                Logger.error(this,
-                        String.format(ERROR_MESSAGE,
-                                e.getMessage()), e);
-            }
-
         }
         Logger.info(this,
                 "============= Finished Task04205MigrateVanityURLToContent =============");

--- a/dotcms-integration/src/test/java/com/dotcms/business/interceptor/InterceptorHandlerTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/business/interceptor/InterceptorHandlerTest.java
@@ -92,19 +92,22 @@ public class InterceptorHandlerTest extends IntegrationTestBase {
     public void externalizeTransaction_uses_separate_connection() throws Exception {
         DbConnectionFactory.closeSilently();
 
-        // Start a parent connection
-        final String parentConn = DbConnectionFactory.getConnection().toString();
+        // Start a parent connection — getConnection() returns a ManagedConnection wrapper
+        // each time, so capture the Connection object for identity/equals comparison.
+        final java.sql.Connection parentConn = DbConnectionFactory.getConnection();
 
-        final String innerConn = ExternalTransactionHandler.externalizeTransaction(() ->
-                DbConnectionFactory.getConnection().toString()
+        final java.sql.Connection innerConn = ExternalTransactionHandler.externalizeTransaction(() ->
+                DbConnectionFactory.getConnection()
         );
 
         assertNotEquals("External transaction should use a different connection",
                 parentConn, innerConn);
 
-        // Parent connection should be restored
+        // Parent connection should be restored — equals() compares the underlying
+        // delegate connections, so a different ManagedConnection wrapper with the
+        // same delegate (but owns=false after restore) will still match.
         assertEquals("Parent connection should be restored",
-                parentConn, DbConnectionFactory.getConnection().toString());
+                parentConn, DbConnectionFactory.getConnection());
 
         DbConnectionFactory.closeSilently();
     }


### PR DESCRIPTION
## Summary

Makes `DbConnectionFactory.getConnection()` safe for try-with-resources by wrapping the returned connection in a `ManagedConnection` that only closes when it owns the connection lifecycle.

Additionally fixes **all identity comparisons** (`!=`) on connections that break when `getConnection()` returns a new wrapper object each call:

- **`DotConnectionWrapper.equals()`** — fallback now compares `internalConnection.equals(obj)` instead of `super.equals(obj)`, correctly handling raw-vs-wrapped connection comparisons
- **`LocalTransaction.handleTransactionInteruption()`** — `!=` → `.equals()`
- **`CoreTransactionOps.handleTransactionInterruption()`** — `!=` → `.equals()` (bug latent in #34946, only exposed by ManagedConnection wrapper)

## Dependency

> **⚠️ This branch is rebased on top of #34946. That PR must merge to `main` first.**
>
> Once #34946 is merged, the commits from that PR will already be on `main` and this branch will merge cleanly with only its own changes. Until then, the PR diff will show #34946's commits as well.

## Changes (this PR only)

### `ManagedConnection.java` (new)
- Extends `DotConnectionWrapper`, tracks `ownsConnection` flag
- `close()` is a no-op for borrowed connections; calls `closeSilently()` for owned ones

### `DbConnectionFactory.getConnection()`
- Returns `new ManagedConnection(connection, isNewConnection)` instead of raw connection
- Try-with-resources is now safe whether or not a ThreadLocal connection already exists

### `DotConnectionWrapper.equals()`
- Fixed fallback: `internalConnection.equals(obj)` instead of `super.equals(obj)`
- Enables correct equality when comparing wrapped connections to raw connections (e.g., from `setConnection()`)

### `LocalTransaction.handleTransactionInteruption()`
- Changed `DbConnectionFactory.getConnection() != conn` to `!DbConnectionFactory.getConnection().equals(conn)`
- Without this, every transaction would trigger a spurious "Transaction broken" warning

### `CoreTransactionOps.handleTransactionInterruption()`
- Same `!=` → `.equals()` fix for the inline check path (when `threadStack == null`)

## Test plan

- [ ] `./mvnw install -pl :dotcms-core -DskipTests` — builds clean ✅
- [ ] Run `DbConnectionFactoryTest` integration test
- [ ] Verify no spurious "Transaction broken" warnings in logs during any integration test
- [ ] Grep for remaining `getConnection() !=` patterns: `grep -rn "getConnection() !=" dotCMS/src/main/java/`

Closes #34489

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34489