### PR TITLE
chore: rename review skill to dotcms-frontend-review

### DIFF
--- a/.claude/skills/dotcms-frontend-review/SKILL.md
+++ b/.claude/skills/dotcms-frontend-review/SKILL.md
@@ -9,8 +9,8 @@ Intelligent, self-validating pull request reviewer that automatically selects th
 ## Usage
 
 ```bash
-/review <PR_NUMBER>
-/review <PR_URL>
+/dotcms-frontend-review <PR_NUMBER>
+/dotcms-frontend-review <PR_URL>
 ```
 
 ## How It Works

--- a/.claude/skills/skill-doctor/reference.md
+++ b/.claude/skills/skill-doctor/reference.md
@@ -584,9 +584,9 @@ Used after a fix PR is merged to clean up the Discussion thread.
 ## Example: Diagnose Flow
 
 ```
-Developer: /skill-doctor review
+Developer: /skill-doctor dotcms-frontend-review
 
-1. Validate: .claude/skills/review/ exists (repo version, no local override)
+1. Validate: .claude/skills/dotcms-frontend-review/ exists (repo version, no local override)
 2. Classify: invalid_command (gh pr diff --name-only doesn't exist)
 3. Investigate:
    - Reproduce: gh pr diff --name-only -> "unknown flag: --name-only"


### PR DESCRIPTION
## Summary
- Renames the `review` skill to `dotcms-frontend-review` to follow the naming convention used by all other dotCMS skills
- Updates usage references in `SKILL.md` and `skill-doctor/reference.md`

## Test plan
- [ ] Verify `/dotcms-frontend-review <PR_NUMBER>` works correctly
- [ ] Verify old `/review` command is no longer available