### PR TITLE
#34980 fix DotDataException(Throwable) not setting message field

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/exception/DotDataException.java
+++ b/dotCMS/src/main/java/com/dotmarketing/exception/DotDataException.java
@@ -17,6 +17,7 @@ public class DotDataException extends BaseInternationalizationException {
 	private String message;
 	public DotDataException(Throwable t) {
 	    super(t.getMessage(), t);
+	    this.message = t.getMessage();
 	}
 	public DotDataException(String message) {
 		this.message = message;

--- a/dotCMS/src/test/java/com/dotmarketing/exception/DotDataExceptionTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/exception/DotDataExceptionTest.java
@@ -1,0 +1,46 @@
+package com.dotmarketing.exception;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class DotDataExceptionTest {
+
+    @Test
+    public void testThrowableConstructor_preservesMessage() {
+        final RuntimeException cause = new RuntimeException("original cause message");
+        final DotDataException exception = new DotDataException(cause);
+        assertEquals("DotDataException(Throwable) must preserve the cause's message",
+                "original cause message", exception.getMessage());
+    }
+
+    @Test
+    public void testThrowableConstructor_preservesCause() {
+        final RuntimeException cause = new RuntimeException("cause");
+        final DotDataException exception = new DotDataException(cause);
+        assertEquals(cause, exception.getCause());
+    }
+
+    @Test
+    public void testThrowableConstructor_nullCauseMessage() {
+        final RuntimeException cause = new RuntimeException();
+        final DotDataException exception = new DotDataException(cause);
+        assertNull("When cause has no message, DotDataException message should also be null",
+                exception.getMessage());
+    }
+
+    @Test
+    public void testStringConstructor_preservesMessage() {
+        final DotDataException exception = new DotDataException("direct message");
+        assertEquals("direct message", exception.getMessage());
+    }
+
+    @Test
+    public void testStringThrowableConstructor_preservesMessage() {
+        final RuntimeException cause = new RuntimeException("cause");
+        final DotDataException exception = new DotDataException("explicit message", cause);
+        assertEquals("explicit message", exception.getMessage());
+        assertEquals(cause, exception.getCause());
+    }
+}


### PR DESCRIPTION
## Summary

- `DotDataException(Throwable t)` constructor called `super(t.getMessage(), t)` but never set the instance field `this.message`
- Since `getMessage()` is overridden to return `this.message`, all exceptions wrapped via this constructor always returned `null` from `getMessage()`
- Fix: add `this.message = t.getMessage()` to the constructor

## Test plan

- [x] `DotDataExceptionTest.testThrowableConstructor_preservesMessage` — verifies the wrapped cause's message is now returned
- [x] `DotDataExceptionTest.testThrowableConstructor_preservesCause` — verifies the cause is still set correctly
- [x] `DotDataExceptionTest.testThrowableConstructor_nullCauseMessage` — verifies null cause message handled gracefully
- [x] `DotDataExceptionTest.testStringConstructor_preservesMessage` — existing behaviour unchanged
- [x] `DotDataExceptionTest.testStringThrowableConstructor_preservesMessage` — existing behaviour unchanged

## Related

Closes #34980


This PR fixes: #34980