### PR TITLE
fix: upgrade Claude AI workflow to ai-workflows@v2.0.0

### DIFF
--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -80,12 +80,10 @@ jobs:
           )
         )
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: interactive
-      allowed_tools: |
-        Bash(git status)
-        Bash(git diff)
+      claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: true  # Uses built-in @claude mention detection
@@ -110,14 +108,12 @@ jobs:
       !contains(github.event.pull_request.body, '@claude') &&
       !contains(github.event.pull_request.body, '@Claude') &&
       !contains(github.event.pull_request.body, '@CLAUDE')
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v1.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
     with:
       trigger_mode: automatic
-      direct_prompt: |
+      prompt: |
         Review this PR. Flag anything that looks wrong, risky, or worth a second look: bad assumptions, missing edge cases, design problems, security issues. Skip praise. If it is clean, say so in one line.
-      allowed_tools: |
-        Bash(git status)
-        Bash(git diff)
+      claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: false


### PR DESCRIPTION
## Summary

- Upgrades `ai_claude-orchestrator.yml` from `ai-workflows@v1.0.0` to `@v2.0.0`
- Migrates breaking input changes from the `claude-code-action@v1` GA release
- Validated and working in `dotCMS/core-workflow-test`

## Changes

| Before | After |
|--------|-------|
| `direct_prompt:` | `prompt:` |
| `allowed_tools:` (multiline list) | `claude_args:` (CLI flag string) |
| `@v1.0.0` | `@v2.0.0` |

## Test plan

- [x] Validated in `dotCMS/core-workflow-test` — automatic PR review and rollback safety check both passing
- [x] Verify interactive (`@claude`) mention works on a PR in this repo (Fails cuz it has to be in main before it works)
- [ ] Verify automatic review fires on a normal PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fixes #34988 