### PR TITLE
fix(password): align PasswordGenerator charset with RegExpToolkit validation pattern

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/db/DotCMSInitDb.java
+++ b/dotCMS/src/main/java/com/dotmarketing/db/DotCMSInitDb.java
@@ -188,7 +188,7 @@ public class DotCMSInitDb {
         if(UtilMethods.isSet(preSetPassword)){
             return Tuple.of(false, preSetPassword);
         }
-        final PasswordGenerator passwordGenerator = new PasswordGenerator.Builder().withDefaultValues().build();
+        final PasswordGenerator passwordGenerator = new PasswordGenerator.Builder().withRegExpToolkitValues().build();
         return Tuple.of(true, passwordGenerator.nextPassword());
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -191,10 +191,16 @@ public class PasswordGenerator {
                 final String rawPattern = PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN);
                 final String allowedChars = extractCharset(rawPattern);
                 if (allowedChars != null) {
-                    // Honour the minimum length from the pattern's {n,} quantifier.
+                    // Honour the minimum length from the pattern's {n,} or {n,m} quantifier.
                     this.length = Math.max(this.length, extractMinLength(rawPattern));
                     return withFilteredValues(allowedChars);
                 }
+                Logger.warn(Builder.class,
+                        "Could not extract a character class from passwords.regexptoolkit.pattern"
+                        + " (value: \"" + rawPattern + "\"). "
+                        + "Pattern must follow the /^[CharClass]{n,}$/ or /^[CharClass]{n,m}$/ shape. "
+                        + "Complex lookahead patterns are not supported. "
+                        + "Falling back to default password generator charsets.");
             }
             return withDefaultValues();
         }
@@ -315,8 +321,9 @@ public class PasswordGenerator {
             if (rawPattern == null || rawPattern.trim().isEmpty()) {
                 return null;
             }
+            // \\{\\d+,\\d*\\} matches both {n,} (open) and {n,m} (bounded) quantifiers
             final java.util.regex.Matcher m = Pattern.compile(
-                    "^/\\^(\\[(?:[^\\]\\\\]|\\\\.)*\\])\\{\\d+,\\}\\$/$"
+                    "^/\\^(\\[(?:[^\\]\\\\]|\\\\.)*\\])\\{\\d+,\\d*\\}\\$/$"
             ).matcher(rawPattern.trim());
             return m.matches() ? m.group(1) : null;
         }

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -146,11 +146,12 @@ public class PasswordGenerator {
         }
 
         /**
-         * Specify the password length
-         * @param length
-         * @return
+         * Sets the desired password length; must be at least 16.
+         *
+         * @param length desired password length (minimum 16)
+         * @return this builder
          */
-        public Builder charset(final int length) {
+        public Builder withLength(final int length) {
             Preconditions.checkArgument(length >= 16, "Password length must be at least 16");
             this.length = length;
             return this;
@@ -161,6 +162,7 @@ public class PasswordGenerator {
          * @return
          */
         public Builder withDefaultValues() {
+            charsets.clear();
             return charset(SPECIAL_CHARS, 2).charset(UPPER_CASE_LETTERS_CHARS, 2)
                     .charset(LOWER_CASE_LETTERS_CHARS, 2).charset(NUMBER_CHARS, 2);
         }
@@ -204,9 +206,18 @@ public class PasswordGenerator {
             if ("com.liferay.portal.pwd.RegExpToolkit".equals(configuredToolkit)) {
                 final String allowedChars = extractCharset(rawPattern);
                 if (allowedChars != null) {
-                    // Honour the minimum length from the pattern's {n}, {n,} or {n,m} quantifier,
-                    // routing through charset(int) so the length is properly validated.
-                    charset(Math.max(this.length, extractMinLength(rawPattern)));
+                    // Honour the length constraints from the pattern's quantifier.
+                    // For {n,} or {n,m} where max >= 16, route through withLength() for validation.
+                    // For exact {n} or bounded {n,m} where max < 16, set length directly —
+                    // the usual 16-char floor does not apply when the pattern mandates less.
+                    final int minLen = extractMinLength(rawPattern);
+                    final int maxLen = extractMaxLength(rawPattern);
+                    final int targetLen = Math.min(maxLen, Math.max(this.length, minLen));
+                    if (targetLen < 16) {
+                        this.length = targetLen;
+                    } else {
+                        withLength(targetLen);
+                    }
                     return withFilteredValues(allowedChars);
                 }
                 Logger.warn(Builder.class,
@@ -234,6 +245,7 @@ public class PasswordGenerator {
          * @return this builder
          */
         Builder withFilteredValues(final String allowedChars) {
+            charsets.clear();
             addFiltered(SPECIAL_CHARS, allowedChars, 2);
             addFiltered(UPPER_CASE_LETTERS_CHARS, allowedChars, 2);
             addFiltered(LOWER_CASE_LETTERS_CHARS, allowedChars, 2);
@@ -259,10 +271,7 @@ public class PasswordGenerator {
          * per-group minimum guarantee rather than silently falling to zero.
          */
         private Builder addFiltered(final String defaults, final String allowed, final int desiredMin) {
-            final String filtered = defaults.chars()
-                    .filter(c -> allowed.indexOf(c) >= 0)
-                    .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-                    .toString();
+            final String filtered = filterString(defaults, allowed);
             if (!filtered.isEmpty()) {
                 charset(filtered, Math.min(desiredMin, filtered.length()));
             }
@@ -408,7 +417,131 @@ public class PasswordGenerator {
             return m.find() ? Integer.parseInt(m.group(1)) : 0;
         }
 
+        /**
+         * Extracts the maximum password length from a pattern's quantifier:
+         * <ul>
+         *   <li>{@code {n}} (exact) → {@code n}</li>
+         *   <li>{@code {n,m}} (bounded) → {@code m}</li>
+         *   <li>{@code {n,}} (open) → {@link Integer#MAX_VALUE}</li>
+         * </ul>
+         *
+         * <p>Returns {@link Integer#MAX_VALUE} when the pattern is {@code null}, empty, or
+         * contains no recognisable quantifier.</p>
+         *
+         * @param rawPattern the raw Perl5 pattern string as stored in {@code portal.properties}
+         * @return the maximum length declared by the quantifier, or {@link Integer#MAX_VALUE}
+         */
+        static int extractMaxLength(final String rawPattern) {
+            if (rawPattern == null || rawPattern.trim().isEmpty()) {
+                return Integer.MAX_VALUE;
+            }
+            // Match bounded {n,m} — group 1 is the maximum
+            final java.util.regex.Matcher bounded = Pattern.compile("\\{\\d+,(\\d+)}")
+                    .matcher(rawPattern.trim());
+            if (bounded.find()) {
+                return Integer.parseInt(bounded.group(1));
+            }
+            // Match exact {n} (no comma) — group 1 is both min and max
+            final java.util.regex.Matcher exact = Pattern.compile("\\{(\\d+)}")
+                    .matcher(rawPattern.trim());
+            if (exact.find()) {
+                return Integer.parseInt(exact.group(1));
+            }
+            // {n,} or no quantifier — unbounded
+            return Integer.MAX_VALUE;
+        }
+
+        /**
+         * Returns a JSON array of per-group character strings for the JS password generator,
+         * enabling it to enforce the same per-group diversity guarantee as the Java generator.
+         *
+         * <p>When {@code RegExpToolkit} is active and the pattern is extractable, each default
+         * group is filtered to only characters accepted by the pattern.  Otherwise the full
+         * default groups are returned.  Empty groups are omitted from the array.</p>
+         *
+         * <p>Returns the string {@code "null"} when the toolkit is {@code RegExpToolkit} but
+         * the pattern is not extractable, so the JS side can fall back to its own logic.</p>
+         *
+         * @return a JS-safe JSON array literal like {@code ["!#...","ABCD...","abcd...","0123..."]}
+         *         or {@code "null"}
+         */
+        public static String buildJsGroupsJson() {
+            return buildJsGroupsJson(
+                    PropsUtil.get(PropsUtil.PASSWORDS_TOOLKIT),
+                    PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN));
+        }
+
+        /**
+         * Package-private overload that accepts the toolkit name and raw pattern directly,
+         * bypassing {@link PropsUtil}.  Enables unit-testing without a live Liferay context.
+         *
+         * @param configuredToolkit the value of {@code passwords.toolkit} (may be {@code null})
+         * @param rawPattern        the value of {@code passwords.regexptoolkit.pattern}
+         * @return a JS-safe JSON array literal or {@code "null"}
+         */
+        static String buildJsGroupsJson(final String configuredToolkit, final String rawPattern) {
+            final String[] groups;
+            if ("com.liferay.portal.pwd.RegExpToolkit".equals(configuredToolkit)) {
+                final String allowedChars = extractCharset(rawPattern);
+                if (allowedChars == null) {
+                    return "null";
+                }
+                groups = new String[] {
+                        filterString(SPECIAL_CHARS, allowedChars),
+                        filterString(UPPER_CASE_LETTERS_CHARS, allowedChars),
+                        filterString(LOWER_CASE_LETTERS_CHARS, allowedChars),
+                        filterString(NUMBER_CHARS, allowedChars)
+                };
+            } else {
+                groups = new String[] {
+                        SPECIAL_CHARS, UPPER_CASE_LETTERS_CHARS,
+                        LOWER_CASE_LETTERS_CHARS, NUMBER_CHARS
+                };
+            }
+            final StringBuilder sb = new StringBuilder("[");
+            boolean first = true;
+            for (final String group : groups) {
+                if (!group.isEmpty()) {
+                    if (!first) {
+                        sb.append(",");
+                    }
+                    sb.append("\"").append(escapeForJsonString(group)).append("\"");
+                    first = false;
+                }
+            }
+            sb.append("]");
+            return sb.toString();
+        }
+
+        /** Filters {@code defaults} to only the characters present in {@code allowed}. */
+        private static String filterString(final String defaults, final String allowed) {
+            return defaults.chars()
+                    .filter(c -> allowed.indexOf(c) >= 0)
+                    .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                    .toString();
+        }
+
+        /**
+         * Escapes a string for safe embedding as a JSON string value inside an HTML
+         * {@code <script>} block.
+         */
+        private static String escapeForJsonString(final String s) {
+            return s.replace("\\", "\\\\")
+                    .replace("\"", "\\\"")
+                    .replace("<", "\\u003c")
+                    .replace(">", "\\u003e")
+                    .replace("\r", "\\r")
+                    .replace("\n", "\\n");
+        }
+
+        /** Special characters included by the default password generator. */
         static final String SPECIAL_CHARS = "!#$%&'()*+,.:;<=>?@^_`~-[]";
+        /**
+         * Uppercase letters, deliberately excluding I, O and Q (visually ambiguous glyphs).
+         * When {@link #withRegExpToolkitValues()} is active, these three letters may appear in
+         * generated passwords if the portal pattern allows A–Z, because they land in the
+         * optional supplementary charset rather than this group.
+         */
         static final String UPPER_CASE_LETTERS_CHARS = "ABCDEFGHJKLMNPRSTUVWXYZ";
         static final String LOWER_CASE_LETTERS_CHARS = "abcdefghijklmnopqrstuvwxyz";
         static final String NUMBER_CHARS = "0123456789";

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -456,14 +456,14 @@ public class PasswordGenerator {
          * enabling it to enforce the same per-group diversity guarantee as the Java generator.
          *
          * <p>When {@code RegExpToolkit} is active and the pattern is extractable, each default
-         * group is filtered to only characters accepted by the pattern.  Otherwise the full
-         * default groups are returned.  Empty groups are omitted from the array.</p>
+         * group is filtered to only characters accepted by the pattern.  When the pattern is
+         * not extractable, or when a different toolkit is active, the full default groups are
+         * returned.  Empty groups are omitted from the array.</p>
          *
-         * <p>Returns the string {@code "null"} when the toolkit is {@code RegExpToolkit} but
-         * the pattern is not extractable, so the JS side can fall back to its own logic.</p>
+         * <p>This method always returns a valid JSON array — never the string {@code "null"} —
+         * so the JS side always has a per-group character set to work with.</p>
          *
          * @return a JS-safe JSON array literal like {@code ["!#...","ABCD...","abcd...","0123..."]}
-         *         or {@code "null"}
          */
         public static String buildJsGroupsJson() {
             return buildJsGroupsJson(
@@ -483,15 +483,21 @@ public class PasswordGenerator {
             final String[] groups;
             if ("com.liferay.portal.pwd.RegExpToolkit".equals(configuredToolkit)) {
                 final String allowedChars = extractCharset(rawPattern);
-                if (allowedChars == null) {
-                    return "null";
+                if (allowedChars != null) {
+                    groups = new String[] {
+                            filterString(SPECIAL_CHARS, allowedChars),
+                            filterString(UPPER_CASE_LETTERS_CHARS, allowedChars),
+                            filterString(LOWER_CASE_LETTERS_CHARS, allowedChars),
+                            filterString(NUMBER_CHARS, allowedChars)
+                    };
+                } else {
+                    // Pattern not extractable — fall back to full default groups so the
+                    // JS side always receives a valid per-group character set.
+                    groups = new String[] {
+                            SPECIAL_CHARS, UPPER_CASE_LETTERS_CHARS,
+                            LOWER_CASE_LETTERS_CHARS, NUMBER_CHARS
+                    };
                 }
-                groups = new String[] {
-                        filterString(SPECIAL_CHARS, allowedChars),
-                        filterString(UPPER_CASE_LETTERS_CHARS, allowedChars),
-                        filterString(LOWER_CASE_LETTERS_CHARS, allowedChars),
-                        filterString(NUMBER_CHARS, allowedChars)
-                };
             } else {
                 groups = new String[] {
                         SPECIAL_CHARS, UPPER_CASE_LETTERS_CHARS,
@@ -536,6 +542,7 @@ public class PasswordGenerator {
 
         /** Special characters included by the default password generator. */
         static final String SPECIAL_CHARS = "!#$%&'()*+,.:;<=>?@^_`~-[]";
+
         /**
          * Uppercase letters, deliberately excluding I, O and Q (visually ambiguous glyphs).
          * When {@link #withRegExpToolkitValues()} is active, these three letters may appear in

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -139,8 +139,8 @@ public class PasswordGenerator {
          */
         public Builder charset(final String charset, final int min) {
             Preconditions.checkNotNull(charset, "Charset param must not be null");
-            Preconditions.checkArgument(min < charset.length(),
-                    "min is expected to be less than " + charset.length());
+            Preconditions.checkArgument(min <= charset.length(),
+                    "min is expected to be at most " + charset.length());
             charsets.add(Charset.of(charset, min));
             return this;
         }
@@ -151,7 +151,7 @@ public class PasswordGenerator {
          * @return
          */
         public Builder charset(final int length) {
-            Preconditions.checkArgument(length <= 16, "The minimum length allowed is 16");
+            Preconditions.checkArgument(length >= 16, "Password length must be at least 16");
             this.length = length;
             return this;
         }
@@ -191,8 +191,9 @@ public class PasswordGenerator {
                 final String rawPattern = PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN);
                 final String allowedChars = extractCharset(rawPattern);
                 if (allowedChars != null) {
-                    // Honour the minimum length from the pattern's {n,} or {n,m} quantifier.
-                    this.length = Math.max(this.length, extractMinLength(rawPattern));
+                    // Honour the minimum length from the pattern's {n,} or {n,m} quantifier,
+                    // routing through charset(int) so the length is properly validated.
+                    charset(Math.max(this.length, extractMinLength(rawPattern)));
                     return withFilteredValues(allowedChars);
                 }
                 Logger.warn(Builder.class,
@@ -238,7 +239,8 @@ public class PasswordGenerator {
         /**
          * Filters {@code defaults} to the characters present in {@code allowed} and, if the
          * result is non-empty, registers it as a charset.  The minimum is capped at
-         * {@code filtered.length() - 1} to satisfy the builder precondition.
+         * {@code filtered.length()} so that even a single-character filtered group retains its
+         * per-group minimum guarantee rather than silently falling to zero.
          */
         private Builder addFiltered(final String defaults, final String allowed, final int desiredMin) {
             final String filtered = defaults.chars()
@@ -246,7 +248,7 @@ public class PasswordGenerator {
                     .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
                     .toString();
             if (!filtered.isEmpty()) {
-                charset(filtered, Math.min(desiredMin, filtered.length() - 1));
+                charset(filtered, Math.min(desiredMin, filtered.length()));
             }
             return this;
         }

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -186,12 +186,25 @@ public class PasswordGenerator {
          * @return this builder
          */
         public Builder withRegExpToolkitValues() {
-            final String configuredToolkit = PropsUtil.get(PropsUtil.PASSWORDS_TOOLKIT);
+            return withRegExpToolkitValues(
+                    PropsUtil.get(PropsUtil.PASSWORDS_TOOLKIT),
+                    PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN));
+        }
+
+        /**
+         * Package-private overload that accepts the toolkit name and raw pattern directly,
+         * bypassing {@link PropsUtil}.  Enables unit-testing the RegExpToolkit path without
+         * a live Liferay configuration context.
+         *
+         * @param configuredToolkit the value of {@code passwords.toolkit} (may be {@code null})
+         * @param rawPattern        the value of {@code passwords.regexptoolkit.pattern}
+         * @return this builder
+         */
+        Builder withRegExpToolkitValues(final String configuredToolkit, final String rawPattern) {
             if ("com.liferay.portal.pwd.RegExpToolkit".equals(configuredToolkit)) {
-                final String rawPattern = PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN);
                 final String allowedChars = extractCharset(rawPattern);
                 if (allowedChars != null) {
-                    // Honour the minimum length from the pattern's {n,} or {n,m} quantifier,
+                    // Honour the minimum length from the pattern's {n}, {n,} or {n,m} quantifier,
                     // routing through charset(int) so the length is properly validated.
                     charset(Math.max(this.length, extractMinLength(rawPattern)));
                     return withFilteredValues(allowedChars);
@@ -199,7 +212,8 @@ public class PasswordGenerator {
                 Logger.warn(Builder.class,
                         "Could not extract a character class from passwords.regexptoolkit.pattern"
                         + " (value: \"" + rawPattern + "\"). "
-                        + "Pattern must follow the /^[CharClass]{n,}$/ or /^[CharClass]{n,m}$/ shape. "
+                        + "Pattern must follow the /^[CharClass]{n}$/, /^[CharClass]{n,}$/ or "
+                        + "/^[CharClass]{n,m}$/ shape. "
                         + "Complex lookahead patterns are not supported. "
                         + "Falling back to default password generator charsets.");
             }
@@ -267,9 +281,21 @@ public class PasswordGenerator {
          * @return a JS regex literal like {@code "/[A-Za-z0-9!@...]/"}, or {@code "null"}
          */
         public static String buildJsCharPattern() {
-            final String configuredToolkit = PropsUtil.get(PropsUtil.PASSWORDS_TOOLKIT);
+            return buildJsCharPattern(
+                    PropsUtil.get(PropsUtil.PASSWORDS_TOOLKIT),
+                    PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN));
+        }
+
+        /**
+         * Package-private overload that accepts the toolkit name and raw pattern directly,
+         * bypassing {@link PropsUtil}.  Enables unit-testing without a live Liferay context.
+         *
+         * @param configuredToolkit the value of {@code passwords.toolkit} (may be {@code null})
+         * @param rawPattern        the value of {@code passwords.regexptoolkit.pattern}
+         * @return a JS regex literal like {@code "/[A-Za-z0-9!@...]/"}, or {@code "null"}
+         */
+        static String buildJsCharPattern(final String configuredToolkit, final String rawPattern) {
             if ("com.liferay.portal.pwd.RegExpToolkit".equals(configuredToolkit)) {
-                final String rawPattern = PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN);
                 final String charClass = extractCharClass(rawPattern);
                 if (charClass != null) {
                     return buildJsRegexLiteral(charClass);
@@ -287,6 +313,8 @@ public class PasswordGenerator {
          *       brackets from appearing raw in HTML output (defense-in-depth against injection);
          *       JS regex engines interpret these Unicode escapes identically to the literal
          *       characters.</li>
+         *   <li>{@code \r}, {@code \n} → {@code \r}, {@code \n} (escape sequences) — prevents
+         *       line-terminators from breaking the single-line JS regex literal.</li>
          * </ul>
          *
          * <p>For example, a char class {@code [A-Za-z0-9/]} becomes {@code /[A-Za-z0-9\/]/}.</p>
@@ -299,7 +327,9 @@ public class PasswordGenerator {
         static String buildJsRegexLiteral(final String charClass) {
             return "/" + charClass.replace("/", "\\/")
                                   .replace("<", "\\u003c")
-                                  .replace(">", "\\u003e") + "/";
+                                  .replace(">", "\\u003e")
+                                  .replace("\r", "\\r")
+                                  .replace("\n", "\\n") + "/";
         }
 
         /**
@@ -335,9 +365,10 @@ public class PasswordGenerator {
         }
 
         /**
-         * Extracts just the {@code [CharClass]} token from a {@code /^[CharClass]{n,}$/}
-         * pattern.  Returns {@code null} when the pattern is {@code null}, empty, or does not
-         * follow that simple shape.
+         * Extracts just the {@code [CharClass]} token from a pattern of the shape
+         * {@code /^[CharClass]{n}$/}, {@code /^[CharClass]{n,}$/}, or
+         * {@code /^[CharClass]{n,m}$/}.  Returns {@code null} when the pattern is
+         * {@code null}, empty, or does not follow one of those three shapes.
          *
          * <p>The inner {@code (?:[^\]\\]|\\.)*} handles escaped characters such as {@code \[}
          * and {@code \]} inside the class.</p>
@@ -349,16 +380,17 @@ public class PasswordGenerator {
             if (rawPattern == null || rawPattern.trim().isEmpty()) {
                 return null;
             }
-            // \\{\\d+,\\d*\\} matches both {n,} (open) and {n,m} (bounded) quantifiers
+            // \\{\\d+(?:,\\d*)?\\} matches {n} (exact), {n,} (open) and {n,m} (bounded) quantifiers
             final java.util.regex.Matcher m = Pattern.compile(
-                    "^/\\^(\\[(?:[^\\]\\\\]|\\\\.)*\\])\\{\\d+,\\d*\\}\\$/$"
+                    "^/\\^(\\[(?:[^\\]\\\\]|\\\\.)*\\])\\{\\d+(?:,\\d*)?\\}\\$/$"
             ).matcher(rawPattern.trim());
             return m.matches() ? m.group(1) : null;
         }
 
         /**
-         * Extracts the minimum password length from a pattern's {@code {n,}} or {@code {n,m}}
-         * quantifier (e.g. returns {@code 8} for {@code /^[...]{8,}$/}).
+         * Extracts the minimum password length from a pattern's {@code {n}}, {@code {n,}},
+         * or {@code {n,m}} quantifier (e.g. returns {@code 8} for {@code /^[...]{8,}$/} or
+         * {@code /^[...]{8}$/}).
          *
          * <p>Returns {@code 0} when the pattern is {@code null}, empty, or contains no
          * recognisable quantifier, leaving the caller's current length unchanged.</p>
@@ -370,13 +402,13 @@ public class PasswordGenerator {
             if (rawPattern == null || rawPattern.trim().isEmpty()) {
                 return 0;
             }
-            // Matches {n,} or {n,m} — group 1 is the minimum
-            final java.util.regex.Matcher m = Pattern.compile("\\{(\\d+),\\d*}")
+            // Matches {n}, {n,} or {n,m} — group 1 is the minimum (or exact) length
+            final java.util.regex.Matcher m = Pattern.compile("\\{(\\d+)(?:,\\d*)?}")
                     .matcher(rawPattern.trim());
             return m.find() ? Integer.parseInt(m.group(1)) : 0;
         }
 
-        static final String SPECIAL_CHARS = "!#$%&'()*+,.:;<=>?@^_`~";
+        static final String SPECIAL_CHARS = "!#$%&'()*+,.:;<=>?@^_`~-[]";
         static final String UPPER_CASE_LETTERS_CHARS = "ABCDEFGHJKLMNPRSTUVWXYZ";
         static final String LOWER_CASE_LETTERS_CHARS = "abcdefghijklmnopqrstuvwxyz";
         static final String NUMBER_CHARS = "0123456789";

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -91,7 +91,7 @@ public class PasswordGenerator {
      */
     String combineCharsets(final List<Charset> charsets) {
         return String.join("",
-                charsets.stream().map(charset -> charset.chars).collect(Collectors.toSet()));
+                charsets.stream().map(charset -> charset.chars).collect(Collectors.toList()));
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -1,12 +1,15 @@
 package com.dotmarketing.util;
 
 import com.google.common.base.Preconditions;
+import com.liferay.portal.util.PropsUtil;
 import java.nio.Buffer;
 import java.nio.CharBuffer;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 /**
@@ -160,6 +163,101 @@ public class PasswordGenerator {
         public Builder withDefaultValues() {
             return charset(SPECIAL_CHARS, 1).charset(UPPER_CASE_LETTERS_CHARS, 1)
                     .charset(LOWER_CASE_LETTERS_CHARS, 1).charset(NUMBER_CHARS, 1);
+        }
+
+        /**
+         * Builds the generator using the allowed character set derived from the
+         * {@code passwords.regexptoolkit.pattern} property, but only when
+         * {@code RegExpToolkit} is the active password toolkit.
+         *
+         * <p>The character class {@code [...]} is extracted from the pattern (which must
+         * follow the simple {@code /^[CharClass]{n,}$/} shape) and every printable ASCII
+         * character (32–126) is probed against it to produce the final charset string.
+         * The generated password will therefore contain only characters that the backend
+         * validator accepts, keeping generation and validation permanently in sync.</p>
+         *
+         * <p>Falls back to {@link #withDefaultValues()} when:</p>
+         * <ul>
+         *   <li>The active toolkit is not {@code RegExpToolkit}.</li>
+         *   <li>The pattern uses complex lookaheads with no extractable character class.</li>
+         * </ul>
+         *
+         * @return this builder
+         */
+        public Builder withRegExpToolkitValues() {
+            final String configuredToolkit = PropsUtil.get(PropsUtil.PASSWORDS_TOOLKIT);
+            if ("com.liferay.portal.pwd.RegExpToolkit".equals(configuredToolkit)) {
+                final String rawPattern = PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN);
+                final String allowedChars = extractCharset(rawPattern);
+                if (allowedChars != null) {
+                    // Honour the minimum length from the pattern's {n,} quantifier.
+                    // We keep the current length if it already exceeds the pattern minimum,
+                    // ensuring we never generate passwords shorter than the validator requires.
+                    this.length = Math.max(this.length, extractMinLength(rawPattern));
+                    return charset(allowedChars, 0);
+                }
+            }
+            return withDefaultValues();
+        }
+
+        /**
+         * Extracts the set of allowed characters from a simple {@code /^[CharClass]{n,}$/}
+         * pattern by testing every printable ASCII character (32–126) against the extracted
+         * character class.
+         *
+         * <p>Returns {@code null} when the pattern is {@code null}, empty, or does not match
+         * the expected simple character-class shape (e.g. lookahead-based patterns).</p>
+         *
+         * @param rawPattern the raw Perl5 pattern string as stored in {@code portal.properties}
+         * @return a string of all allowed characters, or {@code null} if extraction fails
+         */
+        static String extractCharset(final String rawPattern) {
+            if (rawPattern == null || rawPattern.trim().isEmpty()) {
+                return null;
+            }
+            // Captures the [CharClass] from patterns shaped like /^[CharClass]{n,}$/
+            // The inner (?:[^\]\\]|\\.)* handles escaped chars such as \[ and \] inside the class.
+            final java.util.regex.Matcher m = Pattern.compile(
+                    "^/\\^(\\[(?:[^\\]\\\\]|\\\\.)*\\])\\{\\d+,\\}\\$/$"
+            ).matcher(rawPattern.trim());
+            if (!m.matches()) {
+                return null;
+            }
+            final String charClass = m.group(1);
+            final Pattern charFilter;
+            try {
+                charFilter = Pattern.compile(charClass);
+            } catch (PatternSyntaxException e) {
+                return null;
+            }
+            // Collect every printable ASCII character accepted by the character class
+            final StringBuilder allowed = new StringBuilder();
+            for (char c = 32; c < 127; c++) {
+                if (charFilter.matcher(String.valueOf(c)).matches()) {
+                    allowed.append(c);
+                }
+            }
+            return allowed.length() > 0 ? allowed.toString() : null;
+        }
+
+        /**
+         * Extracts the minimum password length from a pattern's {@code {n,}} or {@code {n,m}}
+         * quantifier (e.g. returns {@code 8} for {@code /^[...]{8,}$/}).
+         *
+         * <p>Returns {@code 0} when the pattern is {@code null}, empty, or contains no
+         * recognisable quantifier, leaving the caller's current length unchanged.</p>
+         *
+         * @param rawPattern the raw Perl5 pattern string as stored in {@code portal.properties}
+         * @return the minimum length declared by the quantifier, or {@code 0} if not found
+         */
+        static int extractMinLength(final String rawPattern) {
+            if (rawPattern == null || rawPattern.trim().isEmpty()) {
+                return 0;
+            }
+            // Matches {n,} or {n,m} — group 1 is the minimum
+            final java.util.regex.Matcher m = Pattern.compile("\\{(\\d+),\\d*}")
+                    .matcher(rawPattern.trim());
+            return m.find() ? Integer.parseInt(m.group(1)) : 0;
         }
 
         static final String SPECIAL_CHARS = "!#%+:=?@";

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -170,12 +170,12 @@ public class PasswordGenerator {
          * filtered to only contain characters accepted by {@code passwords.regexptoolkit.pattern},
          * but only when {@code RegExpToolkit} is the active password toolkit.
          *
-         * <p>Each default charset group retains its "at least one" minimum requirement — only
-         * individual characters that the backend validator rejects are removed.  Any
-         * pattern-allowed characters not covered by the four default groups are added as an
-         * optional (min=0) supplementary charset, ensuring the generator never produces a
-         * character the validator rejects while still generating the strongest possible
-         * passwords.</p>
+         * <p>Each default charset group retains its "at least two" per-group minimum — matching
+         * the guarantee of {@link #withDefaultValues()} — only individual characters that the
+         * backend validator rejects are removed.  Any pattern-allowed characters not covered by
+         * the four default groups are added as an optional (min=0) supplementary charset,
+         * ensuring the generator never produces a character the validator rejects while still
+         * generating the strongest possible passwords.</p>
          *
          * <p>Falls back to {@link #withDefaultValues()} when:</p>
          * <ul>
@@ -208,9 +208,11 @@ public class PasswordGenerator {
 
         /**
          * Like {@link #withDefaultValues()} but each default charset is filtered so that only
-         * characters present in {@code allowedChars} are kept.  Any characters in
-         * {@code allowedChars} that fall outside the four default groups are appended as an
-         * optional supplementary charset (min=0).
+         * characters present in {@code allowedChars} are kept.  Each group retains the same
+         * "at least two" per-group minimum as {@link #withDefaultValues()}, capped at the
+         * number of characters that survive filtering.  Any characters in {@code allowedChars}
+         * that fall outside the four default groups are appended as an optional supplementary
+         * charset (min=0).
          *
          * <p>Package-private to allow direct unit-testing without a live PropsUtil context.</p>
          *
@@ -218,10 +220,10 @@ public class PasswordGenerator {
          * @return this builder
          */
         Builder withFilteredValues(final String allowedChars) {
-            addFiltered(SPECIAL_CHARS, allowedChars, 1);
-            addFiltered(UPPER_CASE_LETTERS_CHARS, allowedChars, 1);
-            addFiltered(LOWER_CASE_LETTERS_CHARS, allowedChars, 1);
-            addFiltered(NUMBER_CHARS, allowedChars, 1);
+            addFiltered(SPECIAL_CHARS, allowedChars, 2);
+            addFiltered(UPPER_CASE_LETTERS_CHARS, allowedChars, 2);
+            addFiltered(LOWER_CASE_LETTERS_CHARS, allowedChars, 2);
+            addFiltered(NUMBER_CHARS, allowedChars, 2);
 
             // Include any pattern-allowed chars not covered by the four default groups.
             final String allDefaults =
@@ -277,19 +279,27 @@ public class PasswordGenerator {
         }
 
         /**
-         * Wraps a character-class token in JS regex-literal delimiters, escaping any
-         * forward-slash ({@code /}) inside the class as {@code \/} so the literal is not
-         * prematurely terminated.
+         * Wraps a character-class token in JS regex-literal delimiters, escaping characters
+         * that could cause problems when embedded in an HTML {@code <script>} block:
+         * <ul>
+         *   <li>{@code /} → {@code \/} — prevents premature termination of the JS literal.</li>
+         *   <li>{@code <} → {@code \u003c}, {@code >} → {@code \u003e} — prevents angle
+         *       brackets from appearing raw in HTML output (defense-in-depth against injection);
+         *       JS regex engines interpret these Unicode escapes identically to the literal
+         *       characters.</li>
+         * </ul>
          *
          * <p>For example, a char class {@code [A-Za-z0-9/]} becomes {@code /[A-Za-z0-9\/]/}.</p>
          *
          * <p>Package-private to allow direct unit-testing without a live PropsUtil context.</p>
          *
          * @param charClass the raw {@code [...]} token extracted from the portal pattern
-         * @return a valid JS regex literal string
+         * @return a valid JS regex literal string safe for embedding in an HTML script block
          */
         static String buildJsRegexLiteral(final String charClass) {
-            return "/" + charClass.replace("/", "\\/") + "/";
+            return "/" + charClass.replace("/", "\\/")
+                                  .replace("<", "\\u003c")
+                                  .replace(">", "\\u003e") + "/";
         }
 
         /**
@@ -366,7 +376,7 @@ public class PasswordGenerator {
             return m.find() ? Integer.parseInt(m.group(1)) : 0;
         }
 
-        static final String SPECIAL_CHARS = "!#%+:=?@";
+        static final String SPECIAL_CHARS = "!#$%&'()*+,.:;<=>?@^_`~";
         static final String UPPER_CASE_LETTERS_CHARS = "ABCDEFGHJKLMNPRSTUVWXYZ";
         static final String LOWER_CASE_LETTERS_CHARS = "abcdefghijklmnopqrstuvwxyz";
         static final String NUMBER_CHARS = "0123456789";

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -166,15 +166,16 @@ public class PasswordGenerator {
         }
 
         /**
-         * Builds the generator using the allowed character set derived from the
-         * {@code passwords.regexptoolkit.pattern} property, but only when
-         * {@code RegExpToolkit} is the active password toolkit.
+         * Builds the generator using the default charsets (special, upper, lower, digits) each
+         * filtered to only contain characters accepted by {@code passwords.regexptoolkit.pattern},
+         * but only when {@code RegExpToolkit} is the active password toolkit.
          *
-         * <p>The character class {@code [...]} is extracted from the pattern (which must
-         * follow the simple {@code /^[CharClass]{n,}$/} shape) and every printable ASCII
-         * character (32–126) is probed against it to produce the final charset string.
-         * The generated password will therefore contain only characters that the backend
-         * validator accepts, keeping generation and validation permanently in sync.</p>
+         * <p>Each default charset group retains its "at least one" minimum requirement — only
+         * individual characters that the backend validator rejects are removed.  Any
+         * pattern-allowed characters not covered by the four default groups are added as an
+         * optional (min=0) supplementary charset, ensuring the generator never produces a
+         * character the validator rejects while still generating the strongest possible
+         * passwords.</p>
          *
          * <p>Falls back to {@link #withDefaultValues()} when:</p>
          * <ul>
@@ -191,13 +192,80 @@ public class PasswordGenerator {
                 final String allowedChars = extractCharset(rawPattern);
                 if (allowedChars != null) {
                     // Honour the minimum length from the pattern's {n,} quantifier.
-                    // We keep the current length if it already exceeds the pattern minimum,
-                    // ensuring we never generate passwords shorter than the validator requires.
                     this.length = Math.max(this.length, extractMinLength(rawPattern));
-                    return charset(allowedChars, 0);
+                    return withFilteredValues(allowedChars);
                 }
             }
             return withDefaultValues();
+        }
+
+        /**
+         * Like {@link #withDefaultValues()} but each default charset is filtered so that only
+         * characters present in {@code allowedChars} are kept.  Any characters in
+         * {@code allowedChars} that fall outside the four default groups are appended as an
+         * optional supplementary charset (min=0).
+         *
+         * <p>Package-private to allow direct unit-testing without a live PropsUtil context.</p>
+         *
+         * @param allowedChars the complete set of characters accepted by the backend validator
+         * @return this builder
+         */
+        Builder withFilteredValues(final String allowedChars) {
+            addFiltered(SPECIAL_CHARS, allowedChars, 1);
+            addFiltered(UPPER_CASE_LETTERS_CHARS, allowedChars, 1);
+            addFiltered(LOWER_CASE_LETTERS_CHARS, allowedChars, 1);
+            addFiltered(NUMBER_CHARS, allowedChars, 1);
+
+            // Include any pattern-allowed chars not covered by the four default groups.
+            final String allDefaults =
+                    SPECIAL_CHARS + UPPER_CASE_LETTERS_CHARS + LOWER_CASE_LETTERS_CHARS + NUMBER_CHARS;
+            final String remainder = allowedChars.chars()
+                    .filter(c -> allDefaults.indexOf(c) < 0)
+                    .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                    .toString();
+            if (!remainder.isEmpty()) {
+                charset(remainder, 0);
+            }
+            return this;
+        }
+
+        /**
+         * Filters {@code defaults} to the characters present in {@code allowed} and, if the
+         * result is non-empty, registers it as a charset.  The minimum is capped at
+         * {@code filtered.length() - 1} to satisfy the builder precondition.
+         */
+        private Builder addFiltered(final String defaults, final String allowed, final int desiredMin) {
+            final String filtered = defaults.chars()
+                    .filter(c -> allowed.indexOf(c) >= 0)
+                    .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+                    .toString();
+            if (!filtered.isEmpty()) {
+                charset(filtered, Math.min(desiredMin, filtered.length() - 1));
+            }
+            return this;
+        }
+
+        /**
+         * Returns the JS regex literal for per-character filtering, suitable for direct
+         * embedding in a JSP/JavaScript context.
+         *
+         * <p>When {@code RegExpToolkit} is the active toolkit and the configured pattern follows
+         * the simple {@code /^[CharClass]{n,}$/} shape, returns {@code "/[CharClass]/"}.
+         * Otherwise returns the string {@code "null"} so that the caller's JavaScript can fall
+         * back to its own default {@code _pattern}.</p>
+         *
+         * @return a JS regex literal like {@code "/[A-Za-z0-9!@...]/"}, or {@code "null"}
+         */
+        public static String buildJsCharPattern() {
+            final String configuredToolkit = PropsUtil.get(PropsUtil.PASSWORDS_TOOLKIT);
+            if ("com.liferay.portal.pwd.RegExpToolkit".equals(configuredToolkit)) {
+                final String rawPattern = PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN);
+                final String charClass = extractCharClass(rawPattern);
+                if (charClass != null) {
+                    return "/" + charClass + "/";
+                }
+            }
+            return "null";
         }
 
         /**
@@ -212,18 +280,10 @@ public class PasswordGenerator {
          * @return a string of all allowed characters, or {@code null} if extraction fails
          */
         static String extractCharset(final String rawPattern) {
-            if (rawPattern == null || rawPattern.trim().isEmpty()) {
+            final String charClass = extractCharClass(rawPattern);
+            if (charClass == null) {
                 return null;
             }
-            // Captures the [CharClass] from patterns shaped like /^[CharClass]{n,}$/
-            // The inner (?:[^\]\\]|\\.)* handles escaped chars such as \[ and \] inside the class.
-            final java.util.regex.Matcher m = Pattern.compile(
-                    "^/\\^(\\[(?:[^\\]\\\\]|\\\\.)*\\])\\{\\d+,\\}\\$/$"
-            ).matcher(rawPattern.trim());
-            if (!m.matches()) {
-                return null;
-            }
-            final String charClass = m.group(1);
             final Pattern charFilter;
             try {
                 charFilter = Pattern.compile(charClass);
@@ -238,6 +298,27 @@ public class PasswordGenerator {
                 }
             }
             return allowed.length() > 0 ? allowed.toString() : null;
+        }
+
+        /**
+         * Extracts just the {@code [CharClass]} token from a {@code /^[CharClass]{n,}$/}
+         * pattern.  Returns {@code null} when the pattern is {@code null}, empty, or does not
+         * follow that simple shape.
+         *
+         * <p>The inner {@code (?:[^\]\\]|\\.)*} handles escaped characters such as {@code \[}
+         * and {@code \]} inside the class.</p>
+         *
+         * @param rawPattern the raw Perl5 pattern string as stored in {@code portal.properties}
+         * @return the {@code [...]} character-class string, or {@code null} if not extractable
+         */
+        static String extractCharClass(final String rawPattern) {
+            if (rawPattern == null || rawPattern.trim().isEmpty()) {
+                return null;
+            }
+            final java.util.regex.Matcher m = Pattern.compile(
+                    "^/\\^(\\[(?:[^\\]\\\\]|\\\\.)*\\])\\{\\d+,\\}\\$/$"
+            ).matcher(rawPattern.trim());
+            return m.matches() ? m.group(1) : null;
         }
 
         /**

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -77,7 +77,7 @@ public class PasswordGenerator {
      */
     CharBuffer collectRequiredMinimums(final CharBuffer buffer, final List<Charset> charsets) {
         for (Charset charset : charsets) {
-            for (int i = 0; i <= charset.min; i++) {
+            for (int i = 0; i < charset.min; i++) {
                 buffer.append(nextChar(charset.chars));
             }
         }
@@ -161,8 +161,8 @@ public class PasswordGenerator {
          * @return
          */
         public Builder withDefaultValues() {
-            return charset(SPECIAL_CHARS, 1).charset(UPPER_CASE_LETTERS_CHARS, 1)
-                    .charset(LOWER_CASE_LETTERS_CHARS, 1).charset(NUMBER_CHARS, 1);
+            return charset(SPECIAL_CHARS, 2).charset(UPPER_CASE_LETTERS_CHARS, 2)
+                    .charset(LOWER_CASE_LETTERS_CHARS, 2).charset(NUMBER_CHARS, 2);
         }
 
         /**

--- a/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/PasswordGenerator.java
@@ -268,10 +268,26 @@ public class PasswordGenerator {
                 final String rawPattern = PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN);
                 final String charClass = extractCharClass(rawPattern);
                 if (charClass != null) {
-                    return "/" + charClass + "/";
+                    return buildJsRegexLiteral(charClass);
                 }
             }
             return "null";
+        }
+
+        /**
+         * Wraps a character-class token in JS regex-literal delimiters, escaping any
+         * forward-slash ({@code /}) inside the class as {@code \/} so the literal is not
+         * prematurely terminated.
+         *
+         * <p>For example, a char class {@code [A-Za-z0-9/]} becomes {@code /[A-Za-z0-9\/]/}.</p>
+         *
+         * <p>Package-private to allow direct unit-testing without a live PropsUtil context.</p>
+         *
+         * @param charClass the raw {@code [...]} token extracted from the portal pattern
+         * @return a valid JS regex literal string
+         */
+        static String buildJsRegexLiteral(final String charClass) {
+            return "/" + charClass.replace("/", "\\/") + "/";
         }
 
         /**

--- a/dotCMS/src/main/resources/portal.properties
+++ b/dotCMS/src/main/resources/portal.properties
@@ -310,10 +310,10 @@
     #   	1. Uppercase letters: A-Z
     #		2. Lowercase letters: a-z
     #		3. Digits: 0-9
-#           4. Special characters: !@#$%^&*()_\-=+.,';:`~<>\[\]
+#           4. Special characters: !@#$%^&*()_\-=+.,';:`~<>\[\]?
     # 		5. No white spaces or other characters not included in the specified set.
     # The entire password must consist exclusively of the allowed characters from the start (^) to the end ($) of the string.
-passwords.regexptoolkit.pattern=/^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]]{8,}$/
+passwords.regexptoolkit.pattern=/^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]?]{8,}$/
 
     # This pattern ensures that passwords must have between 6 and 20 valid
     # characters:

--- a/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
@@ -4,6 +4,7 @@
 <%@page import="com.dotmarketing.util.Config"%>
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.dotmarketing.util.UtilMethods"%>
+<%@page import="com.liferay.portal.util.PropsUtil"%>
 
 <script type="text/javascript" src="/dwr/interface/UserAjax.js"></script>
 <script type="text/javascript" src="/dwr/interface/RoleAjax.js"></script>
@@ -90,11 +91,36 @@
 		dwr.util.useLoadingMessage("<%=LanguageUtil.get(pageContext, "Loading")%>....");
 	});
 
+<%
+    // Extract the character class [...]  from the RegExpToolkit pattern so it can
+    // be used in JS as a per-character filter — the same role as PasswordGenerator._pattern.
+    // Falls back to null when a non-RegExpToolkit is configured or
+    // when the pattern uses complex lookaheads with no extractable class.
+    String _pwdToolkit = PropsUtil.get(PropsUtil.PASSWORDS_TOOLKIT);
+    String _rawPwdPattern = PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN);
+    boolean _isRegExpToolkit = "com.liferay.portal.pwd.RegExpToolkit".equals(_pwdToolkit);
+    String _jsPwdCharPattern = "null";
+    if (_isRegExpToolkit && _rawPwdPattern != null && !_rawPwdPattern.trim().isEmpty()) {
+        // Match simple /^[CharClass]{n,}$/ patterns and capture the [CharClass] part.
+        // The inner (?:[^\]\\]|\\.)* handles escaped chars like \[ and \] inside the class.
+        java.util.regex.Matcher _m = java.util.regex.Pattern.compile(
+            "^/\\^(\\[(?:[^\\]\\\\]|\\\\.)*\\])\\{\\d+,\\}\\$/$"
+        ).matcher(_rawPwdPattern.trim());
+        if (_m.matches()) {
+            _jsPwdCharPattern = "/" + _m.group(1) + "/";
+        }
+    }
+%>
     // Random Password Generator Fn
     var PasswordGenerator = {
 
-        // Based on https://www.grc.com/ppp.htm
+        // Based on https://www.grc.com/ppp.htm — fallback when no server pattern is available.
         _pattern: /[!#%+23456789:=?@ABCDEFGHJKLMNPRSTUVWXYZabcdefghijkmnopqrstuvwxyz]/,
+
+        // Character class extracted server-side from RegExpToolkit's pattern.
+        // When present it replaces _pattern as the per-character filter, keeping
+        // generation in sync with the backend policy.
+        _serverValidation: <%= _jsPwdCharPattern %>,
 
         _getRandomByte: function() {
         if(window.crypto && window.crypto.getRandomValues)
@@ -116,6 +142,7 @@
         },
 
         get: function(length) {
+        var charFilter = this._serverValidation || this._pattern;
         return Array.apply(null, {'length': length})
             .map(function()
             {
@@ -123,7 +150,7 @@
             while(true)
             {
                 result = String.fromCharCode(this._getRandomByte());
-                if(this._pattern.test(result))
+                if(charFilter.test(result))
                 {
                 return result;
                 }

--- a/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
@@ -4,7 +4,7 @@
 <%@page import="com.dotmarketing.util.Config"%>
 <%@page import="com.liferay.portal.language.LanguageUtil"%>
 <%@page import="com.dotmarketing.util.UtilMethods"%>
-<%@page import="com.liferay.portal.util.PropsUtil"%>
+<%@page import="com.dotmarketing.util.PasswordGenerator"%>
 
 <script type="text/javascript" src="/dwr/interface/UserAjax.js"></script>
 <script type="text/javascript" src="/dwr/interface/RoleAjax.js"></script>
@@ -92,24 +92,7 @@
 	});
 
 <%
-    // Extract the character class [...]  from the RegExpToolkit pattern so it can
-    // be used in JS as a per-character filter — the same role as PasswordGenerator._pattern.
-    // Falls back to null when a non-RegExpToolkit is configured or
-    // when the pattern uses complex lookaheads with no extractable class.
-    String _pwdToolkit = PropsUtil.get(PropsUtil.PASSWORDS_TOOLKIT);
-    String _rawPwdPattern = PropsUtil.get(PropsUtil.PASSWORDS_REGEXPTOOLKIT_PATTERN);
-    boolean _isRegExpToolkit = "com.liferay.portal.pwd.RegExpToolkit".equals(_pwdToolkit);
-    String _jsPwdCharPattern = "null";
-    if (_isRegExpToolkit && _rawPwdPattern != null && !_rawPwdPattern.trim().isEmpty()) {
-        // Match simple /^[CharClass]{n,}$/ patterns and capture the [CharClass] part.
-        // The inner (?:[^\]\\]|\\.)* handles escaped chars like \[ and \] inside the class.
-        java.util.regex.Matcher _m = java.util.regex.Pattern.compile(
-            "^/\\^(\\[(?:[^\\]\\\\]|\\\\.)*\\])\\{\\d+,\\}\\$/$"
-        ).matcher(_rawPwdPattern.trim());
-        if (_m.matches()) {
-            _jsPwdCharPattern = "/" + _m.group(1) + "/";
-        }
-    }
+    String _jsPwdCharPattern = PasswordGenerator.Builder.buildJsCharPattern();
 %>
     // Random Password Generator Fn
     var PasswordGenerator = {

--- a/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
@@ -92,23 +92,14 @@
 	});
 
 <%
-    String _jsPwdCharPattern = PasswordGenerator.Builder.buildJsCharPattern();
-    String _jsPwdGroups      = PasswordGenerator.Builder.buildJsGroupsJson();
+    String _jsPwdGroups = PasswordGenerator.Builder.buildJsGroupsJson();
 %>
     // Random Password Generator Fn
     var PasswordGenerator = {
 
-        // Based on https://www.grc.com/ppp.htm — fallback when no server pattern is available.
-        _pattern: /[!#%+23456789:=?@ABCDEFGHJKLMNPRSTUVWXYZabcdefghijkmnopqrstuvwxyz]/,
-
-        // Character class extracted server-side from RegExpToolkit's pattern.
-        // When present it replaces _pattern as the per-character filter, keeping
-        // generation in sync with the backend policy.
-        _serverValidation: <%= _jsPwdCharPattern %>,
-
         // Per-group character strings injected server-side.  Each element is one character
-        // group (special, upper, lower, digits).  When present, get() guarantees at least
-        // one character from each non-empty group — mirroring the Java PasswordGenerator.
+        // group (special, upper, lower, digits).  get() guarantees at least two characters
+        // from each non-empty group — mirroring the Java PasswordGenerator desiredMin=2.
         _groups: <%= _jsPwdGroups %>,
 
         _getRandomByte: function() {
@@ -130,51 +121,41 @@
         }
         },
 
+        // Uniform random index in [0, n) using rejection sampling to eliminate modulo bias.
+        // Bytes in the partial-bucket tail (>= floor(256/n)*n) are discarded and re-drawn.
+        _randomIndex: function(n) {
+        var threshold = Math.floor(256 / n) * n;
+        var b;
+        do { b = this._getRandomByte(); } while (b >= threshold);
+        return b % n;
+        },
+
         get: function(length) {
         var self = this;
         var groups = this._groups;
+        var password = [];
+        var combined = '';
 
-        if (groups && groups.length > 0) {
-            // Group-based generation: guarantees at least one char from every non-empty group,
-            // then fills the remaining slots from the combined pool and shuffles the result.
-            // This mirrors the Java PasswordGenerator.nextPassword() algorithm.
-            var password = [];
-            var combined = '';
-            for (var g = 0; g < groups.length; g++) {
-                if (groups[g].length > 0) {
-                    combined += groups[g];
-                    var idx = Math.floor(self._getRandomByte() * groups[g].length / 256);
-                    password.push(groups[g].charAt(idx));
+        // Guarantee at least 2 chars from every non-empty group (mirrors Java desiredMin=2).
+        for (var g = 0; g < groups.length; g++) {
+            if (groups[g].length > 0) {
+                combined += groups[g];
+                var toTake = Math.min(2, groups[g].length);
+                for (var k = 0; k < toTake; k++) {
+                    password.push(groups[g].charAt(self._randomIndex(groups[g].length)));
                 }
             }
-            while (password.length < length) {
-                var idx = Math.floor(self._getRandomByte() * combined.length / 256);
-                password.push(combined.charAt(idx));
-            }
-            // Fisher-Yates shuffle using cryptographic randomness
-            for (var i = password.length - 1; i > 0; i--) {
-                var j = Math.floor(self._getRandomByte() * (i + 1) / 256);
-                var tmp = password[i]; password[i] = password[j]; password[j] = tmp;
-            }
-            return password.join('');
         }
-
-        // Fallback: original filter-based generation (no per-group guarantee)
-        var charFilter = this._serverValidation || this._pattern;
-        return Array.apply(null, {'length': length})
-            .map(function()
-            {
-            var result;
-            while(true)
-            {
-                result = String.fromCharCode(self._getRandomByte());
-                if(charFilter.test(result))
-                {
-                return result;
-                }
-            }
-            })
-            .join('');
+        // Fill remaining slots from the combined pool.
+        while (password.length < length) {
+            password.push(combined.charAt(self._randomIndex(combined.length)));
+        }
+        // Fisher-Yates shuffle using rejection-sampled randomness.
+        for (var i = password.length - 1; i > 0; i--) {
+            var j = self._randomIndex(i + 1);
+            var tmp = password[i]; password[i] = password[j]; password[j] = tmp;
+        }
+        return password.join('');
         }
 
     };

--- a/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/useradmin/view_users_js_inc.jsp
@@ -93,6 +93,7 @@
 
 <%
     String _jsPwdCharPattern = PasswordGenerator.Builder.buildJsCharPattern();
+    String _jsPwdGroups      = PasswordGenerator.Builder.buildJsGroupsJson();
 %>
     // Random Password Generator Fn
     var PasswordGenerator = {
@@ -104,6 +105,11 @@
         // When present it replaces _pattern as the per-character filter, keeping
         // generation in sync with the backend policy.
         _serverValidation: <%= _jsPwdCharPattern %>,
+
+        // Per-group character strings injected server-side.  Each element is one character
+        // group (special, upper, lower, digits).  When present, get() guarantees at least
+        // one character from each non-empty group — mirroring the Java PasswordGenerator.
+        _groups: <%= _jsPwdGroups %>,
 
         _getRandomByte: function() {
         if(window.crypto && window.crypto.getRandomValues)
@@ -125,6 +131,35 @@
         },
 
         get: function(length) {
+        var self = this;
+        var groups = this._groups;
+
+        if (groups && groups.length > 0) {
+            // Group-based generation: guarantees at least one char from every non-empty group,
+            // then fills the remaining slots from the combined pool and shuffles the result.
+            // This mirrors the Java PasswordGenerator.nextPassword() algorithm.
+            var password = [];
+            var combined = '';
+            for (var g = 0; g < groups.length; g++) {
+                if (groups[g].length > 0) {
+                    combined += groups[g];
+                    var idx = Math.floor(self._getRandomByte() * groups[g].length / 256);
+                    password.push(groups[g].charAt(idx));
+                }
+            }
+            while (password.length < length) {
+                var idx = Math.floor(self._getRandomByte() * combined.length / 256);
+                password.push(combined.charAt(idx));
+            }
+            // Fisher-Yates shuffle using cryptographic randomness
+            for (var i = password.length - 1; i > 0; i--) {
+                var j = Math.floor(self._getRandomByte() * (i + 1) / 256);
+                var tmp = password[i]; password[i] = password[j]; password[j] = tmp;
+            }
+            return password.join('');
+        }
+
+        // Fallback: original filter-based generation (no per-group guarantee)
         var charFilter = this._serverValidation || this._pattern;
         return Array.apply(null, {'length': length})
             .map(function()
@@ -132,13 +167,13 @@
             var result;
             while(true)
             {
-                result = String.fromCharCode(this._getRandomByte());
+                result = String.fromCharCode(self._getRandomByte());
                 if(charFilter.test(result))
                 {
                 return result;
                 }
             }
-            }, this)
+            })
             .join('');
         }
 

--- a/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
@@ -510,4 +510,20 @@ public class PasswordGeneratorTest {
         assertNotEquals("Must not be null sentinel", "null", result);
     }
 
+    /**
+     * buildJsGroupsJson must fall back to default groups — not return "null" — when the
+     * toolkit is RegExpToolkit but the pattern is a complex lookahead that cannot be extracted.
+     * This ensures the JS side always has a valid per-group character set.
+     */
+    @Test
+    public void Test_BuildJsGroupsJson_Falls_Back_To_Default_Groups_When_Pattern_Not_Extractable() {
+        // Complex lookahead — extractCharset returns null for this pattern
+        final String complexPattern = "/((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%]).{6,})/";
+        final String result = PasswordGenerator.Builder.buildJsGroupsJson(
+                "com.liferay.portal.pwd.RegExpToolkit", complexPattern);
+        assertTrue("Must start with [",  result.startsWith("["));
+        assertTrue("Must end with ]",    result.endsWith("]"));
+        assertNotEquals("Must not return null sentinel for unextractable pattern", "null", result);
+    }
+
 }

--- a/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
@@ -5,6 +5,8 @@ import static com.dotmarketing.util.PasswordGenerator.Builder.NUMBER_CHARS;
 import static com.dotmarketing.util.PasswordGenerator.Builder.SPECIAL_CHARS;
 import static com.dotmarketing.util.PasswordGenerator.Builder.UPPER_CASE_LETTERS_CHARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -20,6 +22,10 @@ public class PasswordGeneratorTest {
             ImmutableList.of(
                     SPECIAL_CHARS, UPPER_CASE_LETTERS_CHARS, LOWER_CASE_LETTERS_CHARS, NUMBER_CHARS
             );
+
+    // Default portal.properties pattern (passwords.regexptoolkit.pattern) after the ? fix
+    static final String DEFAULT_REGEXP_PATTERN =
+            "/^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]?]{8,}$/";
 
     /**
      * Simply test we're getting back chars that match our charsets with the required minimum number of chars
@@ -42,6 +48,80 @@ public class PasswordGeneratorTest {
                 assertEquals(password.length(), 16);
                 assertTrue(generatedPasswords.add(password));
             }
+        }
+    }
+
+    /**
+     * extractMinLength should return the {n,} minimum from the pattern, or 0 when absent.
+     */
+    @Test
+    public void Test_ExtractMinLength_Returns_Correct_Value() {
+        assertEquals(8,  PasswordGenerator.Builder.extractMinLength(DEFAULT_REGEXP_PATTERN));
+        assertEquals(6,  PasswordGenerator.Builder.extractMinLength("/((?=.*\\d).{6,})/"));
+        assertEquals(10, PasswordGenerator.Builder.extractMinLength("/^[A-Z]{10,20}$/"));
+        assertEquals(0,  PasswordGenerator.Builder.extractMinLength(null));
+        assertEquals(0,  PasswordGenerator.Builder.extractMinLength(""));
+        assertEquals(0,  PasswordGenerator.Builder.extractMinLength("/^[A-Z]+$/"));
+    }
+
+    /**
+     * extractCharset should return null for null, empty, or complex lookahead patterns.
+     */
+    @Test
+    public void Test_ExtractCharset_Returns_Null_For_Invalid_Or_Complex_Patterns() {
+        assertNull(PasswordGenerator.Builder.extractCharset(null));
+        assertNull(PasswordGenerator.Builder.extractCharset(""));
+        // Complex lookahead pattern — no extractable character class
+        assertNull(PasswordGenerator.Builder.extractCharset(
+                "/((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%]).{6,})/"));
+    }
+
+    /**
+     * extractCharset should return a non-empty string of allowed characters for the default pattern.
+     * Every character in the result must match the extracted character class.
+     */
+    @Test
+    public void Test_ExtractCharset_Returns_Allowed_Chars_For_Default_Pattern() {
+        final String allowedChars = PasswordGenerator.Builder.extractCharset(DEFAULT_REGEXP_PATTERN);
+        assertNotNull(allowedChars);
+        assertTrue("Charset should not be empty", allowedChars.length() > 0);
+
+        // Every char returned must match the backend validation pattern
+        final Pattern validator = Pattern.compile(
+                "^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]?]+$");
+        assertTrue("All extracted chars must be accepted by the backend pattern",
+                validator.matcher(allowedChars).matches());
+
+        // '?' must be present — it was the root cause of issue #34616
+        assertTrue("'?' must be in the extracted charset", allowedChars.contains("?"));
+    }
+
+    /**
+     * A generator built with extractCharset + extractMinLength from the default pattern must
+     * produce passwords whose length is at least the pattern minimum and that contain only
+     * characters accepted by the backend validation pattern.
+     */
+    @Test
+    public void Test_Generate_Password_With_RegExp_Pattern_Only_Contains_Allowed_Chars() {
+        final String allowedChars = PasswordGenerator.Builder.extractCharset(DEFAULT_REGEXP_PATTERN);
+        assertNotNull(allowedChars);
+
+        final int minLength = PasswordGenerator.Builder.extractMinLength(DEFAULT_REGEXP_PATTERN);
+        assertEquals("Default pattern minimum length should be 8", 8, minLength);
+
+        // Simulate withRegExpToolkitValues(): honour the minimum length from the pattern
+        final int effectiveLength = Math.max(16, minLength);
+        final PasswordGenerator generator = new PasswordGenerator.Builder()
+                .charset(allowedChars, 0).build();
+
+        final Pattern validator = Pattern.compile(
+                "^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]?]{8,}$");
+
+        for (int i = 0; i < 100; i++) {
+            final String password = generator.nextPassword();
+            assertEquals(effectiveLength, password.length());
+            assertTrue("Password must match the backend pattern: " + password,
+                    validator.matcher(password).matches());
         }
     }
 

--- a/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
@@ -97,31 +97,83 @@ public class PasswordGeneratorTest {
     }
 
     /**
-     * A generator built with extractCharset + extractMinLength from the default pattern must
-     * produce passwords whose length is at least the pattern minimum and that contain only
-     * characters accepted by the backend validation pattern.
+     * extractCharClass should return the raw [CharClass] token from the default pattern.
      */
     @Test
-    public void Test_Generate_Password_With_RegExp_Pattern_Only_Contains_Allowed_Chars() {
+    public void Test_ExtractCharClass_Returns_Char_Class_For_Default_Pattern() {
+        final String charClass = PasswordGenerator.Builder.extractCharClass(DEFAULT_REGEXP_PATTERN);
+        assertNotNull(charClass);
+        assertTrue("Char class must start with '['", charClass.startsWith("["));
+        assertTrue("Char class must end with ']'", charClass.endsWith("]"));
+        // '?' must survive extraction — it was the root cause of issue #34616
+        assertTrue("'?' must be in the char class", charClass.contains("?"));
+    }
+
+    /**
+     * extractCharClass should return null for null, empty, or complex lookahead patterns.
+     */
+    @Test
+    public void Test_ExtractCharClass_Returns_Null_For_Invalid_Or_Complex_Patterns() {
+        assertNull(PasswordGenerator.Builder.extractCharClass(null));
+        assertNull(PasswordGenerator.Builder.extractCharClass(""));
+        assertNull(PasswordGenerator.Builder.extractCharClass(
+                "/((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%]).{6,})/"));
+    }
+
+    /**
+     * withFilteredValues() must produce passwords that:
+     * - contain at least one character from each default group (special, upper, lower, digit)
+     * - contain ONLY characters from the allowed set
+     * - are 16 characters long (default length)
+     */
+    @Test
+    public void Test_WithFilteredValues_Produces_Strong_Passwords_Within_Allowed_Set() {
         final String allowedChars = PasswordGenerator.Builder.extractCharset(DEFAULT_REGEXP_PATTERN);
         assertNotNull(allowedChars);
 
-        final int minLength = PasswordGenerator.Builder.extractMinLength(DEFAULT_REGEXP_PATTERN);
-        assertEquals("Default pattern minimum length should be 8", 8, minLength);
-
-        // Simulate withRegExpToolkitValues(): honour the minimum length from the pattern
-        final int effectiveLength = Math.max(16, minLength);
         final PasswordGenerator generator = new PasswordGenerator.Builder()
-                .charset(allowedChars, 0).build();
+                .withFilteredValues(allowedChars).build();
 
+        // Backend validator: only chars from the default pattern are allowed
         final Pattern validator = Pattern.compile(
                 "^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]?]{8,}$");
 
+        // Per-group patterns — filtered defaults must still land at least one char per group
+        final Pattern hasSpecial   = Pattern.compile("[" + SPECIAL_CHARS + "]");
+        final Pattern hasUpper     = Pattern.compile("[" + UPPER_CASE_LETTERS_CHARS + "]");
+        final Pattern hasLower     = Pattern.compile("[" + LOWER_CASE_LETTERS_CHARS + "]");
+        final Pattern hasDigit     = Pattern.compile("[" + NUMBER_CHARS + "]");
+
         for (int i = 0; i < 100; i++) {
             final String password = generator.nextPassword();
-            assertEquals(effectiveLength, password.length());
-            assertTrue("Password must match the backend pattern: " + password,
+            assertEquals("Password must be 16 chars", 16, password.length());
+            assertTrue("Password must match backend pattern: " + password,
                     validator.matcher(password).matches());
+            assertTrue("Password must contain at least one special char", hasSpecial.matcher(password).find());
+            assertTrue("Password must contain at least one uppercase letter", hasUpper.matcher(password).find());
+            assertTrue("Password must contain at least one lowercase letter", hasLower.matcher(password).find());
+            assertTrue("Password must contain at least one digit", hasDigit.matcher(password).find());
+        }
+    }
+
+    /**
+     * withFilteredValues() must remove characters not permitted by the allowed set.
+     * When the allowed set excludes all of a group's chars the group is simply omitted
+     * rather than causing an error.
+     */
+    @Test
+    public void Test_WithFilteredValues_Removes_Disallowed_Chars() {
+        // Allow only lowercase letters — special chars, uppercase and digits are excluded
+        final String onlyLower = LOWER_CASE_LETTERS_CHARS;
+
+        final PasswordGenerator generator = new PasswordGenerator.Builder()
+                .withFilteredValues(onlyLower).build();
+
+        final Pattern onlyLowerPattern = Pattern.compile("^[a-z]+$");
+        for (int i = 0; i < 50; i++) {
+            final String password = generator.nextPassword();
+            assertTrue("Password must contain only lowercase letters: " + password,
+                    onlyLowerPattern.matcher(password).matches());
         }
     }
 

--- a/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
@@ -77,6 +77,29 @@ public class PasswordGeneratorTest {
     }
 
     /**
+     * extractCharClass must handle both open {n,} and bounded {n,m} quantifiers.
+     * A bounded quantifier like {8,20} was previously unrecognised, causing a silent
+     * fallback to withDefaultValues() — issue #2 from PR #34989.
+     */
+    @Test
+    public void Test_ExtractCharClass_Handles_Both_Open_And_Bounded_Quantifiers() {
+        // Open quantifier {n,} — baseline
+        assertNotNull("Open quantifier {n,} must be recognised",
+                PasswordGenerator.Builder.extractCharClass(DEFAULT_REGEXP_PATTERN));
+
+        // Bounded quantifier {n,m}
+        final String bounded = "/^[A-Za-z0-9!@#$%]{8,20}$/";
+        final String charClass = PasswordGenerator.Builder.extractCharClass(bounded);
+        assertNotNull("Bounded quantifier {n,m} must be recognised", charClass);
+        assertTrue(charClass.startsWith("["));
+        assertTrue(charClass.endsWith("]"));
+
+        // extractCharset must also work for {n,m} patterns
+        assertNotNull("extractCharset must succeed for {n,m} pattern",
+                PasswordGenerator.Builder.extractCharset(bounded));
+    }
+
+    /**
      * extractCharset should return a non-empty string of allowed characters for the default pattern.
      * Every character in the result must match the extracted character class.
      */

--- a/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
@@ -5,6 +5,8 @@ import static com.dotmarketing.util.PasswordGenerator.Builder.NUMBER_CHARS;
 import static com.dotmarketing.util.PasswordGenerator.Builder.SPECIAL_CHARS;
 import static com.dotmarketing.util.PasswordGenerator.Builder.UPPER_CASE_LETTERS_CHARS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -23,6 +25,17 @@ public class PasswordGeneratorTest {
                     SPECIAL_CHARS, UPPER_CASE_LETTERS_CHARS, LOWER_CASE_LETTERS_CHARS, NUMBER_CHARS
             );
 
+    /**
+     * Escapes characters that have special meaning inside a Java regex character class
+     * ({@code [...]}).  Required when SPECIAL_CHARS contains {@code -}, {@code [}, or {@code ]}.
+     */
+    private static String escapeForCharClass(final String chars) {
+        return chars.replace("\\", "\\\\")   // must be first
+                    .replace("[",  "\\[")
+                    .replace("]",  "\\]")
+                    .replace("-",  "\\-");
+    }
+
     // Default portal.properties pattern (passwords.regexptoolkit.pattern) after the ? fix
     static final String DEFAULT_REGEXP_PATTERN =
             "/^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]?]{8,}$/";
@@ -39,7 +52,7 @@ public class PasswordGeneratorTest {
         final Set<String> generatedPasswords = new HashSet<>(100);
 
         for (final String acceptablePasswordChar : ACCEPTABLE_PASSWORD_CHARS) {
-            final String acceptableCharsPattern = "[" + String.join("", acceptablePasswordChar) + "]";
+            final String acceptableCharsPattern = "[" + escapeForCharClass(acceptablePasswordChar) + "]";
             final Pattern pattern = Pattern.compile(acceptableCharsPattern);
             //Lets do this a few times just to be sure
             for (int i = 0; i <= 100; i++) {
@@ -100,6 +113,86 @@ public class PasswordGeneratorTest {
     }
 
     /**
+     * extractCharClass and extractMinLength must also handle exact-length quantifiers {n}
+     * (no comma) — issue #2 from the second review of PR #34989.
+     */
+    @Test
+    public void Test_ExtractCharClass_And_MinLength_Handle_Exact_Quantifier() {
+        final String exactPattern = "/^[A-Za-z0-9]{8}$/";
+
+        // extractCharClass must recognise {n}
+        final String charClass = PasswordGenerator.Builder.extractCharClass(exactPattern);
+        assertNotNull("extractCharClass must succeed for {n} pattern", charClass);
+        assertTrue(charClass.startsWith("["));
+        assertTrue(charClass.endsWith("]"));
+
+        // extractCharset must also succeed
+        assertNotNull("extractCharset must succeed for {n} pattern",
+                PasswordGenerator.Builder.extractCharset(exactPattern));
+
+        // extractMinLength must return the exact value
+        assertEquals(8, PasswordGenerator.Builder.extractMinLength(exactPattern));
+
+        // Verify that {n,} and {n,m} still work alongside {n}
+        assertEquals(10, PasswordGenerator.Builder.extractMinLength("/^[A-Z]{10}$/"));
+        assertEquals(8,  PasswordGenerator.Builder.extractMinLength("/^[A-Z]{8,}$/"));
+        assertEquals(8,  PasswordGenerator.Builder.extractMinLength("/^[A-Z]{8,20}$/"));
+    }
+
+    /**
+     * withRegExpToolkitValues() happy path: when the toolkit is RegExpToolkit and the
+     * pattern is extractable, passwords must comply with the pattern and carry per-group
+     * guarantees identical to withDefaultValues().
+     * Uses the package-private overload to bypass PropsUtil.
+     */
+    @Test
+    public void Test_WithRegExpToolkitValues_HappyPath_Produces_Pattern_Compliant_Passwords() {
+        final PasswordGenerator generator = new PasswordGenerator.Builder()
+                .withRegExpToolkitValues("com.liferay.portal.pwd.RegExpToolkit", DEFAULT_REGEXP_PATTERN)
+                .build();
+
+        final Pattern validator = Pattern.compile(
+                "^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]?]{8,}$");
+        final Pattern hasSpecial = Pattern.compile("[" + escapeForCharClass(SPECIAL_CHARS) + "]");
+        final Pattern hasUpper   = Pattern.compile("[" + UPPER_CASE_LETTERS_CHARS + "]");
+        final Pattern hasLower   = Pattern.compile("[" + LOWER_CASE_LETTERS_CHARS + "]");
+        final Pattern hasDigit   = Pattern.compile("[" + NUMBER_CHARS + "]");
+
+        for (int i = 0; i < 100; i++) {
+            final String password = generator.nextPassword();
+            assertEquals("Password must be 16 chars", 16, password.length());
+            assertTrue("Password must match backend pattern: " + password,
+                    validator.matcher(password).matches());
+            assertTrue("Must have special char", hasSpecial.matcher(password).find());
+            assertTrue("Must have uppercase",    hasUpper.matcher(password).find());
+            assertTrue("Must have lowercase",    hasLower.matcher(password).find());
+            assertTrue("Must have digit",        hasDigit.matcher(password).find());
+        }
+    }
+
+    /**
+     * buildJsCharPattern() happy path: when the toolkit is RegExpToolkit and the pattern is
+     * extractable, returns a safe JS regex literal; falls back to "null" otherwise.
+     * Uses the package-private overload to bypass PropsUtil.
+     */
+    @Test
+    public void Test_BuildJsCharPattern_HappyPath_Returns_Js_Literal_For_RegExpToolkit() {
+        final String result = PasswordGenerator.Builder.buildJsCharPattern(
+                "com.liferay.portal.pwd.RegExpToolkit", DEFAULT_REGEXP_PATTERN);
+        assertTrue("Must start with /",   result.startsWith("/"));
+        assertTrue("Must end with /",     result.endsWith("/"));
+        assertNotEquals("Must not be the null sentinel", "null", result);
+        // Angle brackets must be escaped — not raw in the HTML output
+        assertFalse("Must not contain raw '<'", result.contains("<"));
+        assertFalse("Must not contain raw '>'", result.contains(">"));
+
+        // Non-RegExp toolkit → sentinel "null"
+        assertEquals("null", PasswordGenerator.Builder.buildJsCharPattern(
+                "com.liferay.portal.pwd.DefaultPasswordToolkit", DEFAULT_REGEXP_PATTERN));
+        assertEquals("null", PasswordGenerator.Builder.buildJsCharPattern(null, null));
+    }
+
+    /**
      * buildJsRegexLiteral must escape characters that are unsafe inside an HTML {@code <script>}
      * block: '/' is escaped as '\/' to prevent premature JS literal termination; '<' and '>' are
      * escaped as '\u003c' / '\u003e' (JS-valid Unicode escapes) to prevent angle brackets from
@@ -126,6 +219,10 @@ public class PasswordGeneratorTest {
         // Combined: slash + angle brackets all escaped together
         assertEquals("/[A-Za-z0-9\\/\\u003c\\u003e]/",
                 PasswordGenerator.Builder.buildJsRegexLiteral("[A-Za-z0-9/<>]"));
+
+        // Line terminators (\r, \n) must be escaped to prevent breaking the JS literal
+        assertEquals("/[A-Za-z\\r\\n]/",
+                PasswordGenerator.Builder.buildJsRegexLiteral("[A-Za-z\r\n]"));
     }
 
     /**
@@ -208,7 +305,7 @@ public class PasswordGeneratorTest {
                 "^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]?]{8,}$");
 
         // Per-group patterns — filtered defaults must still land at least one char per group
-        final Pattern hasSpecial   = Pattern.compile("[" + SPECIAL_CHARS + "]");
+        final Pattern hasSpecial   = Pattern.compile("[" + escapeForCharClass(SPECIAL_CHARS) + "]");
         final Pattern hasUpper     = Pattern.compile("[" + UPPER_CASE_LETTERS_CHARS + "]");
         final Pattern hasLower     = Pattern.compile("[" + LOWER_CASE_LETTERS_CHARS + "]");
         final Pattern hasDigit     = Pattern.compile("[" + NUMBER_CHARS + "]");
@@ -282,7 +379,7 @@ public class PasswordGeneratorTest {
         final PasswordGenerator generator = new PasswordGenerator.Builder()
                 .withRegExpToolkitValues().build();
 
-        final Pattern hasSpecial = Pattern.compile("[" + SPECIAL_CHARS + "]");
+        final Pattern hasSpecial = Pattern.compile("[" + escapeForCharClass(SPECIAL_CHARS) + "]");
         final Pattern hasUpper   = Pattern.compile("[" + UPPER_CASE_LETTERS_CHARS + "]");
         final Pattern hasLower   = Pattern.compile("[" + LOWER_CASE_LETTERS_CHARS + "]");
         final Pattern hasDigit   = Pattern.compile("[" + NUMBER_CHARS + "]");
@@ -312,7 +409,7 @@ public class PasswordGeneratorTest {
         final PasswordGenerator generator = new PasswordGenerator.Builder()
                 .withFilteredValues(allDefaults).build();
 
-        final Pattern hasSpecial = Pattern.compile("[" + SPECIAL_CHARS + "]");
+        final Pattern hasSpecial = Pattern.compile("[" + escapeForCharClass(SPECIAL_CHARS) + "]");
         final Pattern hasUpper   = Pattern.compile("[" + UPPER_CASE_LETTERS_CHARS + "]");
         final Pattern hasLower   = Pattern.compile("[" + LOWER_CASE_LETTERS_CHARS + "]");
         final Pattern hasDigit   = Pattern.compile("[" + NUMBER_CHARS + "]");

--- a/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
@@ -100,13 +100,14 @@ public class PasswordGeneratorTest {
     }
 
     /**
-     * buildJsRegexLiteral must escape any '/' inside the character class so that the
-     * resulting JS regex literal is syntactically valid — issue #3 from PR #34989.
-     * Without escaping, /[A-Za-z0-9/]/ would prematurely terminate the literal.
+     * buildJsRegexLiteral must escape characters that are unsafe inside an HTML {@code <script>}
+     * block: '/' is escaped as '\/' to prevent premature JS literal termination; '<' and '>' are
+     * escaped as '\u003c' / '\u003e' (JS-valid Unicode escapes) to prevent angle brackets from
+     * appearing raw in HTML output — issue #3 and issue #5 from PR #34989.
      */
     @Test
-    public void Test_BuildJsRegexLiteral_Escapes_ForwardSlash() {
-        // No slash — should pass through unchanged (most common case)
+    public void Test_BuildJsRegexLiteral_Escapes_Special_Html_Chars() {
+        // No special chars — should pass through unchanged (most common case)
         assertEquals("/[A-Za-z0-9!@#]/",
                 PasswordGenerator.Builder.buildJsRegexLiteral("[A-Za-z0-9!@#]"));
 
@@ -117,6 +118,14 @@ public class PasswordGeneratorTest {
         // Multiple slashes — all must be escaped
         assertEquals("/[A-Z\\/a-z\\/0-9]/",
                 PasswordGenerator.Builder.buildJsRegexLiteral("[A-Z/a-z/0-9]"));
+
+        // '<' and '>' must be escaped as \u003c / \u003e (defense-in-depth against HTML injection)
+        assertEquals("/[A-Za-z\\u003c\\u003e]/",
+                PasswordGenerator.Builder.buildJsRegexLiteral("[A-Za-z<>]"));
+
+        // Combined: slash + angle brackets all escaped together
+        assertEquals("/[A-Za-z0-9\\/\\u003c\\u003e]/",
+                PasswordGenerator.Builder.buildJsRegexLiteral("[A-Za-z0-9/<>]"));
     }
 
     /**
@@ -255,6 +264,36 @@ public class PasswordGeneratorTest {
             final String password = generator.nextPassword();
             assertTrue("Password must contain '!' even when it is the only allowed special char: " + password,
                     hasExclamation.matcher(password).find());
+        }
+    }
+
+    /**
+     * withRegExpToolkitValues() must fall back gracefully to withDefaultValues() when
+     * PropsUtil cannot provide a RegExpToolkit configuration (e.g. in unit-test environments
+     * where no Liferay context is active).  The resulting generator must meet the same
+     * per-group guarantees as withDefaultValues().
+     *
+     * <p>In a non-Liferay context PropsUtil.get() returns null, so the toolkit check
+     * fails and the method delegates to withDefaultValues().</p>
+     */
+    @Test
+    public void Test_WithRegExpToolkitValues_FallsBack_To_DefaultValues_When_Toolkit_Not_Configured() {
+        // PropsUtil returns null in unit-test scope → toolkit check fails → withDefaultValues()
+        final PasswordGenerator generator = new PasswordGenerator.Builder()
+                .withRegExpToolkitValues().build();
+
+        final Pattern hasSpecial = Pattern.compile("[" + SPECIAL_CHARS + "]");
+        final Pattern hasUpper   = Pattern.compile("[" + UPPER_CASE_LETTERS_CHARS + "]");
+        final Pattern hasLower   = Pattern.compile("[" + LOWER_CASE_LETTERS_CHARS + "]");
+        final Pattern hasDigit   = Pattern.compile("[" + NUMBER_CHARS + "]");
+
+        for (int i = 0; i < 100; i++) {
+            final String password = generator.nextPassword();
+            assertEquals("Password must be 16 chars", 16, password.length());
+            assertTrue("Must contain special char",  hasSpecial.matcher(password).find());
+            assertTrue("Must contain uppercase",     hasUpper.matcher(password).find());
+            assertTrue("Must contain lowercase",     hasLower.matcher(password).find());
+            assertTrue("Must contain digit",         hasDigit.matcher(password).find());
         }
     }
 

--- a/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
@@ -237,4 +237,55 @@ public class PasswordGeneratorTest {
         }
     }
 
+    /**
+     * Issue 1 regression: when filtering leaves exactly 1 char in a group the per-group
+     * minimum guarantee must still hold.  Previously Math.min(desiredMin, 1-1)=0 silently
+     * dropped the guarantee.
+     */
+    @Test
+    public void Test_WithFilteredValues_Preserves_Minimum_Guarantee_For_Single_Char_Group() {
+        // Allow only one special char ('!') plus all lowercase letters
+        final String restrictive = "!" + LOWER_CASE_LETTERS_CHARS;
+
+        final PasswordGenerator generator = new PasswordGenerator.Builder()
+                .withFilteredValues(restrictive).build();
+
+        final Pattern hasExclamation = Pattern.compile("!");
+        for (int i = 0; i < 100; i++) {
+            final String password = generator.nextPassword();
+            assertTrue("Password must contain '!' even when it is the only allowed special char: " + password,
+                    hasExclamation.matcher(password).find());
+        }
+    }
+
+    /**
+     * Issue 3 — fallback behaviour: when withFilteredValues receives the complete set of
+     * default characters (no filtering needed), the resulting generator must meet the same
+     * per-group guarantees as withDefaultValues().  This mirrors the production path where
+     * withRegExpToolkitValues() falls back to withDefaultValues() when the toolkit is not
+     * RegExpToolkit.
+     */
+    @Test
+    public void Test_WithFilteredValues_With_All_Default_Chars_Has_Same_Guarantees_As_WithDefaultValues() {
+        final String allDefaults = SPECIAL_CHARS + UPPER_CASE_LETTERS_CHARS
+                + LOWER_CASE_LETTERS_CHARS + NUMBER_CHARS;
+
+        final PasswordGenerator generator = new PasswordGenerator.Builder()
+                .withFilteredValues(allDefaults).build();
+
+        final Pattern hasSpecial = Pattern.compile("[" + SPECIAL_CHARS + "]");
+        final Pattern hasUpper   = Pattern.compile("[" + UPPER_CASE_LETTERS_CHARS + "]");
+        final Pattern hasLower   = Pattern.compile("[" + LOWER_CASE_LETTERS_CHARS + "]");
+        final Pattern hasDigit   = Pattern.compile("[" + NUMBER_CHARS + "]");
+
+        for (int i = 0; i < 100; i++) {
+            final String password = generator.nextPassword();
+            assertEquals("Password must be 16 chars", 16, password.length());
+            assertTrue("Must contain special char",  hasSpecial.matcher(password).find());
+            assertTrue("Must contain uppercase",     hasUpper.matcher(password).find());
+            assertTrue("Must contain lowercase",     hasLower.matcher(password).find());
+            assertTrue("Must contain digit",         hasDigit.matcher(password).find());
+        }
+    }
+
 }

--- a/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
@@ -100,6 +100,43 @@ public class PasswordGeneratorTest {
     }
 
     /**
+     * buildJsRegexLiteral must escape any '/' inside the character class so that the
+     * resulting JS regex literal is syntactically valid — issue #3 from PR #34989.
+     * Without escaping, /[A-Za-z0-9/]/ would prematurely terminate the literal.
+     */
+    @Test
+    public void Test_BuildJsRegexLiteral_Escapes_ForwardSlash() {
+        // No slash — should pass through unchanged (most common case)
+        assertEquals("/[A-Za-z0-9!@#]/",
+                PasswordGenerator.Builder.buildJsRegexLiteral("[A-Za-z0-9!@#]"));
+
+        // Single slash inside the class — must be escaped as \/
+        assertEquals("/[A-Za-z0-9\\/]/",
+                PasswordGenerator.Builder.buildJsRegexLiteral("[A-Za-z0-9/]"));
+
+        // Multiple slashes — all must be escaped
+        assertEquals("/[A-Z\\/a-z\\/0-9]/",
+                PasswordGenerator.Builder.buildJsRegexLiteral("[A-Z/a-z/0-9]"));
+    }
+
+    /**
+     * extractCharClass must capture '/' as a literal character inside a character class.
+     * Combined with buildJsRegexLiteral's escaping this prevents JS syntax errors.
+     */
+    @Test
+    public void Test_ExtractCharClass_Captures_ForwardSlash_In_Char_Class() {
+        final String patternWithSlash = "/^[A-Za-z0-9/]{8,}$/";
+        final String charClass = PasswordGenerator.Builder.extractCharClass(patternWithSlash);
+        assertNotNull("Pattern with '/' in char class must be extractable", charClass);
+        assertTrue("Extracted char class must contain '/'", charClass.contains("/"));
+
+        // buildJsRegexLiteral must then produce a safe JS literal
+        final String jsLiteral = PasswordGenerator.Builder.buildJsRegexLiteral(charClass);
+        assertTrue("JS literal must not contain unescaped '/' inside the class",
+                jsLiteral.matches("/\\[.*\\\\/.*\\]/"));
+    }
+
+    /**
      * extractCharset should return a non-empty string of allowed characters for the default pattern.
      * Every character in the result must match the extracted character class.
      */

--- a/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/PasswordGeneratorTest.java
@@ -424,4 +424,90 @@ public class PasswordGeneratorTest {
         }
     }
 
+    // ------------------------------------------------------------------ Issue 1 (exact quantifier)
+
+    /**
+     * extractMaxLength must return n for {n}, m for {n,m}, MAX_VALUE for {n,} and unrecognised.
+     */
+    @Test
+    public void Test_ExtractMaxLength_Returns_Correct_Value() {
+        assertEquals(8,                   PasswordGenerator.Builder.extractMaxLength("/^[A-Z]{8}$/"));
+        assertEquals(20,                  PasswordGenerator.Builder.extractMaxLength("/^[A-Z]{8,20}$/"));
+        assertEquals(Integer.MAX_VALUE,   PasswordGenerator.Builder.extractMaxLength("/^[A-Z]{8,}$/"));
+        assertEquals(Integer.MAX_VALUE,   PasswordGenerator.Builder.extractMaxLength(null));
+        assertEquals(Integer.MAX_VALUE,   PasswordGenerator.Builder.extractMaxLength(""));
+        assertEquals(Integer.MAX_VALUE,   PasswordGenerator.Builder.extractMaxLength("/^[A-Z]+$/"));
+    }
+
+    /**
+     * Issue 1: withRegExpToolkitValues with an exact {n} pattern where n < 16 must honour
+     * the exact length instead of bloating the password to 16 chars (which would fail the
+     * backend's strict ^[...]{n}$ validator).
+     */
+    @Test
+    public void Test_WithRegExpToolkitValues_Exact_Quantifier_Honours_Pattern_Length() {
+        // {10} — exact length of 10, still below our usual 16-char floor
+        final String exactPattern = "/^[A-Za-z0-9!@#$%]{10}$/";
+        final PasswordGenerator generator = new PasswordGenerator.Builder()
+                .withRegExpToolkitValues("com.liferay.portal.pwd.RegExpToolkit", exactPattern)
+                .build();
+
+        for (int i = 0; i < 50; i++) {
+            final String password = generator.nextPassword();
+            assertEquals("Password must be exactly 10 chars for {10} pattern", 10, password.length());
+        }
+    }
+
+    // ------------------------------------------------------------------ Issue 2 (charset accumulation)
+
+    /**
+     * Issue 2: calling withXxx methods in sequence must not accumulate charsets.
+     * withFilteredValues() after withDefaultValues() should replace, not append, the charsets —
+     * otherwise the minimum sum would exceed the default length and build() would throw.
+     */
+    @Test
+    public void Test_Chained_WithXxx_Calls_Do_Not_Accumulate_Charsets() {
+        // Previously: withDefaultValues() (min=8) + withFilteredValues() (min=8) = min=16+,
+        // causing build() to throw IllegalArgumentException for length=16.
+        final PasswordGenerator generator = new PasswordGenerator.Builder()
+                .withDefaultValues()
+                .withFilteredValues(SPECIAL_CHARS + UPPER_CASE_LETTERS_CHARS
+                        + LOWER_CASE_LETTERS_CHARS + NUMBER_CHARS)
+                .build(); // must NOT throw
+
+        // withFilteredValues replaced withDefaultValues — result should be 16 chars
+        assertEquals(16, generator.nextPassword().length());
+    }
+
+    // ------------------------------------------------------------------ Issue 4 (buildJsGroupsJson)
+
+    /**
+     * buildJsGroupsJson happy path: when RegExpToolkit is active with an extractable pattern,
+     * returns a JSON array of per-group char strings; angle brackets must be escaped.
+     * Uses the package-private overload to bypass PropsUtil.
+     */
+    @Test
+    public void Test_BuildJsGroupsJson_HappyPath_Returns_Json_Array_For_RegExpToolkit() {
+        final String result = PasswordGenerator.Builder.buildJsGroupsJson(
+                "com.liferay.portal.pwd.RegExpToolkit", DEFAULT_REGEXP_PATTERN);
+        assertTrue("Must start with [",  result.startsWith("["));
+        assertTrue("Must end with ]",    result.endsWith("]"));
+        assertNotEquals("Must not be null sentinel", "null", result);
+        // Angle brackets must be escaped — not raw in HTML output
+        assertFalse("Must not contain raw '<'", result.contains("<"));
+        assertFalse("Must not contain raw '>'", result.contains(">"));
+    }
+
+    /**
+     * buildJsGroupsJson fallback: when the toolkit is not RegExpToolkit, returns a JSON array
+     * based on the full default groups (still usable for per-group JS generation).
+     */
+    @Test
+    public void Test_BuildJsGroupsJson_Returns_Default_Groups_When_Toolkit_Not_RegExp() {
+        final String result = PasswordGenerator.Builder.buildJsGroupsJson(null, null);
+        assertTrue("Non-RegExp toolkit must still return a JSON array", result.startsWith("["));
+        assertTrue("Non-RegExp toolkit must still return a JSON array", result.endsWith("]"));
+        assertNotEquals("Must not be null sentinel", "null", result);
+    }
+
 }

--- a/dotCMS/src/test/java/com/liferay/portal/pwd/RegExpToolkitTest.java
+++ b/dotCMS/src/test/java/com/liferay/portal/pwd/RegExpToolkitTest.java
@@ -11,6 +11,9 @@ public class RegExpToolkitTest extends UnitTestBase {
 
     RegExpToolkit toolkit = new RegExpToolkit("/((?=.*\\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%]).{6,})/");
 
+    // Default pattern from portal.properties (passwords.regexptoolkit.pattern)
+    RegExpToolkit defaultToolkit = new RegExpToolkit("/^[A-Za-z0-9!@#$%^&*()_\\-=+.,';:`~<>\\[\\]?]{8,}$/");
+
     @Test
     public void testInvalidPasswordFormat() {
         assertFalse(toolkit.validate(null));
@@ -46,5 +49,28 @@ public class RegExpToolkitTest extends UnitTestBase {
         assertTrue(toolkit.validate("1T@e$s#t%"));
         assertTrue(toolkit
                 .validate("1T@e$s#t%1T@e$s#t%1T@e$s#t%1T@e$s#t%1T@e$s#t%1T@e$s#t%1T@e$s#t%1T@e$s#t%1T@e$s#t%1T@e$s#t%1T@e$s#t%1T@e$s#t%"));
+    }
+
+    @Test
+    public void testDefaultPatternRejectsInvalidPasswords() {
+        // Too short
+        assertFalse(defaultToolkit.validate("Abc1234"));
+        // Contains disallowed whitespace
+        assertFalse(defaultToolkit.validate("Abc 12345"));
+        // null
+        assertFalse(defaultToolkit.validate(null));
+    }
+
+    @Test
+    public void testDefaultPatternAcceptsValidPasswords() {
+        // Basic alphanumeric (8+ chars)
+        assertTrue(defaultToolkit.validate("Abcde123"));
+        // With special chars from the allowed set
+        assertTrue(defaultToolkit.validate("Abcde1!@"));
+        // With '?' — previously rejected, now allowed (issue #34616)
+        assertTrue(defaultToolkit.validate("Abcde12?"));
+        assertTrue(defaultToolkit.validate("Ab?de12#"));
+        // Mixed special chars including '?'
+        assertTrue(defaultToolkit.validate("P@ssw0rd?"));
     }
 }


### PR DESCRIPTION
## Proposed Changes
- Added `?` to the default `passwords.regexptoolkit.pattern` in `portal.properties` (root fix — `?` was already in `SPECIAL_CHARS` but the validator rejected it)
- Extended `PasswordGenerator` to read the configured `RegExpToolkit` pattern and filter each default charset group to only pattern-allowed characters, preserving the same per-group strength guarantees as `withDefaultValues()`
- Visually ambiguous uppercase letters (I, O, Q) are now consistently excluded from all generation paths, including the supplementary remainder charset
- Updated `DotCMSInitDb` to generate the initial admin password using the site's configured password policy instead of the hardcoded defaults
- Rewrote the JS `PasswordGenerator` in the user admin JSP: server-injected per-group character sets, at-least-2-chars-per-group guarantee, and rejection-sampled randomness to eliminate modulo bias
- Added unit tests covering charset extraction, pattern quantifier parsing, per-group guarantees, exact-length patterns, and JS group injection

## Checklist
- [x] Tests

Closes #34616

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34616