### PR TITLE
fix (Site Browser): fix folder context retention problem (#33825)

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
@@ -684,13 +684,16 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
         //Showing the loading message
         Element.show('loadingContentListing');
 
-        //Calling ajax
-        BrowserAjax.openFolderContent (inode, '', showArchived, lang, selectFolderContentCallBack);
 
-        //Opening folder at the left side
-        if(!openFolders.contains(inode)) {
-            treeFolderSignSelected(inode);
-        }
+        var needsTreeExpansion = !openFolders.contains(inode);
+
+        BrowserAjax.openFolderContent(inode, '', showArchived, lang, function(content) {
+            selectFolderContentCallBack(content);
+            // Opening folder at the left side - sequential to avoid race condition
+            if(needsTreeExpansion) {
+                treeFolderSignSelected(inode);
+            }
+        });
 
     }
 


### PR DESCRIPTION
 Fixes folder context loss in Site Browser when navigating back via the "Browser" breadcrumb in clustered environments with shared Redis sessions.

  Problem: When users navigate through folders, then open a page, and click the "Browser" breadcrumb to return, they are redirected to the root folder instead of their last selected subfolder. 

⚠️ **This only occurs in the client's clustered environment and could not be reproduced locally or in demo.dotcms.com.**

 Possible Root Cause: The treeFolderSelected() function fired two parallel AJAX calls without waiting for the first to complete:
  1. BrowserAjax.openFolderContent() - sets ACTIVE_FOLDER_ID in session
  2. BrowserAjax.openFolderTree() - updates OPEN_FOLDER_IDS in session

  In a Redis-clustered environment, these concurrent session updates create a race condition where the second call can read a stale session and overwrite the first call's changes when writing back.

  Fix: Made the AJAX calls sequential by moving the tree expansion call inside the openFolderContent callback, ensuring session updates happen atomically one after another.
  
---
 Findings

 ### Workaround

  Clicking the **plus button** first to expand the folder tree, then clicking the folder name, avoids the race condition, this could be because:
  - Plus button only triggers one AJAX call (openFolderTree)
  - User interaction delay allows session replication to complete
  - Subsequent folder name click triggers a single openFolderContent call (tree already expanded)


This PR fixes: #33825

This PR fixes: #33825