### PR TITLE
fix(ci): use zsh for SDKMAN install on macOS #35004

### DIFF
--- a/.github/actions/core-cicd/setup-java/action.yml
+++ b/.github/actions/core-cicd/setup-java/action.yml
@@ -68,7 +68,11 @@ runs:
       run: |
         if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
         echo "Downloading SDKMAN install"
-        curl -s "https://get.sdkman.io" | bash
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          curl -s "https://get.sdkman.io" | zsh
+        else
+          curl -s "https://get.sdkman.io" | bash
+        fi
         fi
     - name: Save Cache SDKMan install
       id: save-cache-sdkman


### PR DESCRIPTION
## Summary

- SDKMAN 5.21.0 (released 2026-03-14) added a Bash 4+ requirement that breaks the macOS native CLI build
- macOS runners ship with Apple's system Bash 3.2.57 (Apple won't upgrade past 3.x due to GPL v3)
- Conditionally use `zsh` for the SDKMAN installer on macOS; Linux continues using `bash` (5.x, unaffected)

Closes #35004

## Test plan

- [ ] Nightly build passes on macOS-Silicon with cold SDKMAN cache
- [ ] Linux builds continue to work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)