### PR TITLE
fix(edit-content): scope RelationshipFieldStore to component level #34795

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -49,8 +49,7 @@ import { BaseControlValueAccessor } from '../../../shared/base-control-value-acc
         ChipModule,
         ContentletStatusPipe,
         LanguagePipe,
-        PaginationComponent,
-        DotMessagePipe
+        PaginationComponent
     ],
     templateUrl: './dot-relationship-field.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -56,6 +56,7 @@ import { BaseControlValueAccessor } from '../../../shared/base-control-value-acc
     changeDetection: ChangeDetectionStrategy.OnPush,
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
     providers: [
+        RelationshipFieldStore,
         {
             multi: true,
             provide: NG_VALUE_ACCESSOR,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -215,8 +215,8 @@ export class DotRelationshipFieldComponent
 
         const contentType = this.store.contentType();
 
-        // Don't open dialog if contentTypeId is null (invalid field data)
-        if (!contentType.id) {
+        // Don't open dialog if contentType or its ID is null (invalid field data)
+        if (!contentType?.id) {
             return;
         }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.spec.ts
@@ -105,7 +105,6 @@ xdescribe('DotEditContentRelationshipFieldComponent', () => {
         detectChanges: false,
         componentMocks: [DotCardFieldComponent, DotCardFieldContentComponent, PaginationComponent],
         providers: [
-            RelationshipFieldStore,
             provideHttpClient(),
             provideHttpClientTesting(),
             mockProvider(DotMessageService, {
@@ -517,8 +516,8 @@ xdescribe('DotEditContentRelationshipFieldComponent', () => {
             emptySpectator.detectChanges();
             emptySpectator.flushEffects();
 
-            const emptyStore = emptySpectator.inject(RelationshipFieldStore, true);
-            expect(emptyStore.data()).toEqual([]);
+            const fieldComponent = emptySpectator.query(DotRelationshipFieldComponent);
+            expect(fieldComponent.store.data()).toEqual([]);
         });
 
         it('should handle invalid field data gracefully', () => {
@@ -549,8 +548,8 @@ xdescribe('DotEditContentRelationshipFieldComponent', () => {
             invalidSpectator.detectChanges();
             invalidSpectator.flushEffects();
 
-            const invalidStore = invalidSpectator.inject(RelationshipFieldStore, true);
-            expect(invalidStore.data()).toBeDefined();
+            const fieldComponent = invalidSpectator.query(DotRelationshipFieldComponent);
+            expect(fieldComponent.store.data()).toBeDefined();
         });
 
         it('should handle null contentlet gracefully', () => {
@@ -572,8 +571,8 @@ xdescribe('DotEditContentRelationshipFieldComponent', () => {
             nullContentletSpectator.detectChanges();
             nullContentletSpectator.flushEffects();
 
-            const nullStore = nullContentletSpectator.inject(RelationshipFieldStore, true);
-            expect(nullStore.data()).toBeDefined();
+            const fieldComponent = nullContentletSpectator.query(DotRelationshipFieldComponent);
+            expect(fieldComponent.store.data()).toBeDefined();
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -2,6 +2,8 @@ import { expect, describe } from '@jest/globals';
 import { SpectatorService, createServiceFactory, mockProvider } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
+import { TestBed } from '@angular/core/testing';
+
 import {
     DotContentTypeService,
     DotFieldService,
@@ -379,5 +381,107 @@ describe('RelationshipFieldStore', () => {
                 expect(store.status()).toBe(ComponentStatus.ERROR);
             });
         });
+    });
+});
+
+describe('RelationshipFieldStore - Instance Isolation', () => {
+    const mockContentType = {
+        id: 'test-content-type',
+        name: 'Test Content Type',
+        metadata: {
+            [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: true
+        }
+    };
+
+    const storeProviders = [
+        RelationshipFieldStore,
+        RelationshipFieldService,
+        mockProvider(DotContentTypeService, {
+            getContentType: jest.fn().mockReturnValue(of(mockContentType))
+        }),
+        mockProvider(DotFieldService),
+        mockProvider(DotHttpErrorManagerService, {
+            handle: jest.fn()
+        })
+    ];
+
+    /**
+     * These tests use TestBed directly because Spectator's createServiceFactory
+     * shares the same TestBed context — calling it twice returns the same singleton.
+     * TestBed.resetTestingModule() is needed to create truly independent injectors.
+     */
+
+    it('should create independent instances that do not share state', () => {
+        const injector1 = TestBed.configureTestingModule({ providers: [...storeProviders] });
+        const store1 = injector1.inject(RelationshipFieldStore);
+
+        TestBed.resetTestingModule();
+
+        const injector2 = TestBed.configureTestingModule({ providers: [...storeProviders] });
+        const store2 = injector2.inject(RelationshipFieldStore);
+
+        expect(store1).not.toBe(store2);
+
+        const dataA = [
+            createFakeContentlet({ inode: 'a1', identifier: 'id-a1', id: 'a1' }),
+            createFakeContentlet({ inode: 'a2', identifier: 'id-a2', id: 'a2' })
+        ];
+        const dataB = [createFakeContentlet({ inode: 'b1', identifier: 'id-b1', id: 'b1' })];
+
+        store1.setData(dataA);
+        store2.setData(dataB);
+
+        expect(store1.data().length).toBe(2);
+        expect(store2.data().length).toBe(1);
+        expect(store1.formattedRelationship()).toBe('id-a1,id-a2');
+        expect(store2.formattedRelationship()).toBe('id-b1');
+    });
+
+    it('should not reset one instance when another initializes', () => {
+        const injector1 = TestBed.configureTestingModule({ providers: [...storeProviders] });
+        const store1 = injector1.inject(RelationshipFieldStore);
+
+        TestBed.resetTestingModule();
+
+        const injector2 = TestBed.configureTestingModule({ providers: [...storeProviders] });
+        const store2 = injector2.inject(RelationshipFieldStore);
+
+        const data = [createFakeContentlet({ inode: 'x1', identifier: 'id-x1', id: 'x1' })];
+        store1.setData(data);
+
+        const mockField = createFakeRelationshipField({
+            variable: 'other_field',
+            relationships: { cardinality: 0, isParentField: true, velocityVar: 'test-content-type' }
+        });
+        const mockContentlet = createFakeContentlet({ id: '999', inode: '999' });
+
+        store2.initialize({ field: mockField, contentlet: mockContentlet });
+
+        expect(store1.data().length).toBe(1);
+        expect(store1.formattedRelationship()).toBe('id-x1');
+    });
+
+    it('should not affect other instance when deleting items', () => {
+        const injector1 = TestBed.configureTestingModule({ providers: [...storeProviders] });
+        const store1 = injector1.inject(RelationshipFieldStore);
+
+        TestBed.resetTestingModule();
+
+        const injector2 = TestBed.configureTestingModule({ providers: [...storeProviders] });
+        const store2 = injector2.inject(RelationshipFieldStore);
+
+        const sharedItem = createFakeContentlet({
+            inode: 'shared-inode',
+            identifier: 'shared-id',
+            id: 'shared'
+        });
+
+        store1.setData([sharedItem]);
+        store2.setData([sharedItem]);
+
+        store1.deleteItem('shared-inode');
+
+        expect(store1.data().length).toBe(0);
+        expect(store2.data().length).toBe(1);
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -385,6 +385,8 @@ describe('RelationshipFieldStore', () => {
 });
 
 describe('RelationshipFieldStore - Instance Isolation', () => {
+    afterEach(() => TestBed.resetTestingModule());
+
     const mockContentType = {
         id: 'test-content-type',
         name: 'Test Content Type',

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -58,7 +58,6 @@ const initialState: RelationshipFieldState = {
  * This store manages the state and actions related to the relationship field.
  */
 export const RelationshipFieldStore = signalStore(
-    { providedIn: 'root' },
     withState(initialState),
     withComputed((state) => ({
         /**


### PR DESCRIPTION
## Summary

- **Root cause:** `RelationshipFieldStore` was declared with `providedIn: 'root'`, creating a singleton shared across all relationship field instances on a form
- **Fix:** Removed root-level provision and added the store to `DotRelationshipFieldComponent`'s `providers` array so each field instance gets its own isolated store
- **Pattern:** Follows the same approach used by `FileFieldStore` and `CategoryFieldStore` in the codebase

Closes #34795

## Changes

| File | Change |
|------|--------|
| `core-web/.../store/relationship-field.store.ts` | Removed `{ providedIn: 'root' }` from `signalStore()` config |
| `core-web/.../dot-relationship-field.component.ts` | Added `RelationshipFieldStore` to component `providers` array |
| `core-web/.../dot-edit-content-relationship-field.component.spec.ts` | Removed store from host providers, updated edge case tests to access store from component instance |

## Acceptance Criteria

- [ ] Each relationship field in the new Edit Content maintains its own value independently
- [ ] Filling one relationship field does not change the value of other relationship fields
- [ ] When a content type has two relationship fields referencing different content types (e.g., Blog's "author" and "comments"), both display correct data
- [ ] Existing content with multiple relationship fields displays and edits correctly in the new editor
- [ ] Content types with a single relationship field continue to work correctly (no regression)
- [ ] The legacy Edit Content editor behavior remains unchanged
- [ ] When a content type has three or more relationship fields, all fields maintain independent state

## Test Plan

- [ ] Create a content type with two relationship fields referencing the same content type. Fill one field — verify the other stays empty
- [ ] Create a content type with two relationship fields referencing different content types. Verify both display correct related content
- [ ] Edit an existing contentlet (e.g., Blog with author + comments) using the new editor — verify both fields show correct data
- [ ] Verify single-relationship-field content types still work correctly
- [ ] Delete a related item from one field — verify the other field is unaffected

## Visual Changes

https://github.com/user-attachments/assets/46c1a820-c17b-45ec-bd50-d57cb3e67a94

## Notes

- The component spec (`dot-edit-content-relationship-field.component.spec.ts`) remains `xdescribe` (skipped) due to a pre-existing test setup issue (`ɵcmp` resolution error) unrelated to this fix
- Store unit tests (`relationship-field.store.spec.ts`) pass — 100 suites, 1639 tests
- The edge case tests in the spec were updated to access the store via `spectator.query(DotRelationshipFieldComponent).store` instead of `spectator.inject(RelationshipFieldStore, true)` since the store is now component-scoped

This PR fixes: #34795