### PR TITLE
fix(content-types): dialog stays open and NG0100 error after saving a content type

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
@@ -17,13 +17,14 @@
 }
 
 <p-dialog
-    [(visible)]="show"
+    [visible]="show()"
     [header]="templateInfo.header"
     [modal]="true"
     [closable]="dialogCloseable"
     [style]="{ width: '50rem' }"
-    (visibleChange)="onDialogHide()">
-    @if (show) {
+    (visibleChange)="show.set($event)"
+    (onHide)="onDialogHide()">
+    @if (show()) {
         <dot-content-types-form
             ($valid)="setDialogOkButtonState($event)"
             ($send)="handleFormSubmit($event)"

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
@@ -219,7 +219,7 @@ describe('DotContentTypesEditComponent', () => {
 
         it('should have dialog opened by default & has css base-type class', () => {
             expect(dialog).not.toBeNull();
-            expect(comp.show).toBeTruthy();
+            expect(comp.show()).toBeTruthy();
         });
 
         it('should set dialog actions set correctly', () => {
@@ -238,7 +238,7 @@ describe('DotContentTypesEditComponent', () => {
 
         it('should close the dialog when cancel button is clicked', fakeAsync(() => {
             // Open the dialog first
-            comp.show = true;
+            comp.show.set(true);
             fixture.detectChanges();
             tick();
 
@@ -440,7 +440,7 @@ describe('DotContentTypesEditComponent', () => {
             it('should open form dialog by default in create mode', () => {
                 const dialog = de.query(By.css('p-dialog'));
                 expect(dialog).not.toBeNull();
-                expect(comp.show).toBeTruthy();
+                expect(comp.show()).toBeTruthy();
             });
         });
     });
@@ -590,7 +590,7 @@ describe('DotContentTypesEditComponent', () => {
             clickEditButton();
 
             expect(dialog).not.toBeNull();
-            expect(comp.show).toBeTruthy();
+            expect(comp.show()).toBeTruthy();
         });
 
         it('should send notifications to add rows & tab divider', () => {
@@ -965,6 +965,39 @@ describe('DotContentTypesEditComponent', () => {
                 contentTypeForm.triggerEventHandler('$send', fakeContentType);
                 expect(comp.savingContentType()).toBe(false);
             });
+
+            it('should close the dialog after a successful update', fakeAsync(() => {
+                const response$ = new Subject<DotCMSContentType>();
+                jest.spyOn(crudService, 'putData').mockReturnValue(response$.asObservable());
+
+                contentTypeForm.triggerEventHandler('$send', fakeContentType);
+                fixture.detectChanges();
+
+                expect(comp.show()).toBe(true);
+
+                response$.next(fakeContentType);
+                response$.complete();
+                tick();
+                fixture.detectChanges();
+
+                expect(comp.show()).toBe(false);
+            }));
+
+            it('should keep dialog closed after update (no reopen)', fakeAsync(() => {
+                const response$ = new Subject<DotCMSContentType>();
+                jest.spyOn(crudService, 'putData').mockReturnValue(response$.asObservable());
+                jest.spyOn(comp, 'startFormDialog');
+
+                contentTypeForm.triggerEventHandler('$send', fakeContentType);
+
+                response$.next(fakeContentType);
+                response$.complete();
+                tick();
+                fixture.detectChanges();
+
+                expect(comp.show()).toBe(false);
+                expect(comp.startFormDialog).not.toHaveBeenCalled();
+            }));
         });
 
         describe('checkAndOpenFormDialog', () => {
@@ -1017,6 +1050,26 @@ describe('DotContentTypesEditComponent', () => {
                 tick();
 
                 expect(comp.startFormDialog).toHaveBeenCalledTimes(1);
+            }));
+
+            it('should not reopen dialog when route.data emits again after update', fakeAsync(() => {
+                // Simulate successful update: dialog opens, update fires, dialog closes
+                queryParams.next({ 'open-config': 'true' });
+                tick();
+
+                expect(comp.startFormDialog).toHaveBeenCalledTimes(1);
+                expect(comp.show()).toBe(true);
+
+                comp.show.set(false); // simulates show.set(false) from updateContentType
+
+                // Simulate route.data re-emitting (e.g. triggered by onDialogHide navigation)
+                // Since isFirstLoad = false (data was already set on first emission),
+                // checkAndOpenFormDialog should NOT run again
+                queryParams.next({ 'open-config': 'true' });
+                tick();
+
+                expect(comp.startFormDialog).toHaveBeenCalledTimes(1);
+                expect(comp.show()).toBe(false);
             }));
         });
     });

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
@@ -62,7 +62,7 @@ export class DotContentTypesEditComponent implements OnInit, OnDestroy {
     data: DotCMSContentType;
     dialogActions: DotDialogActions;
     layout: DotCMSContentTypeLayoutRow[];
-    show: boolean;
+    show = signal(false);
     templateInfo = {
         icon: '',
         header: ''
@@ -80,10 +80,13 @@ export class DotContentTypesEditComponent implements OnInit, OnDestroy {
                 takeUntilDestroyed(this.destroyRef)
             )
             .subscribe((contentType: DotCMSContentType) => {
+                const isFirstLoad = !this.data;
                 this.data = contentType;
                 this.dotEditContentTypeCacheService.set(contentType);
                 this.layout = contentType.layout;
-                this.checkAndOpenFormDialog();
+                if (isFirstLoad) {
+                    this.checkAndOpenFormDialog();
+                }
             });
 
         this.contentTypeActions = [
@@ -129,7 +132,7 @@ export class DotContentTypesEditComponent implements OnInit, OnDestroy {
      * @memberof DotContentTypesEditComponent
      */
     startFormDialog(): void {
-        this.show = true;
+        this.show.set(true);
         this.setEditContentletDialogOptions();
     }
 
@@ -333,7 +336,7 @@ export class DotContentTypesEditComponent implements OnInit, OnDestroy {
                         this.data.id,
                         this.dotRouterService.currentPortlet.id
                     );
-                    this.show = false;
+                    this.show.set(false);
                 },
                 (err) => {
                     this.savingContentType.set(false);
@@ -360,7 +363,7 @@ export class DotContentTypesEditComponent implements OnInit, OnDestroy {
                 (contentType: DotCMSContentType) => {
                     this.savingContentType.set(false);
                     this.data = contentType;
-                    this.show = false;
+                    this.show.set(false);
                 },
                 (err) => {
                     this.savingContentType.set(false);


### PR DESCRIPTION
## Problem

When editing an existing content type and clicking **Update**, two bugs occurred after the loading indicator was added to the save button:

1. **Dialog doesn't close on first click** — the endpoint was called successfully but the dialog remained open. A second click on Update closed it without calling the endpoint.
2. **`NG0100: ExpressionChangedAfterItHasBeenCheckedError`** — thrown on the `[(visible)]="show"` binding due to mixing a `signal` update (`savingContentType.set(false)`) with a plain property assignment (`this.show = false`) inside the same HTTP callback.

## Root Cause

**Bug 1 — Race condition in `checkAndOpenFormDialog`:**

The `route.data` subscriber called `checkAndOpenFormDialog()` on every emission. When `onDialogHide()` triggered `router.navigate([], { 'open-config': null })` to clean up the URL, this navigation caused `route.data` to re-emit. At that moment, `route.queryParams.pipe(take(1))` inside `checkAndOpenFormDialog` still captured the stale `open-config=true` value (navigation not yet committed), causing `startFormDialog()` to be called again and the dialog to reopen immediately.

**Bug 2 — Signal + plain property mixed in same CD cycle:**

In Angular 17+, `signal.set()` can schedule a targeted view refresh via microtask. When `savingContentType.set(false)` and `this.show = false` ran synchronously in the same HTTP callback, Angular's signal-driven CD pass saw `show = true` in the first pass and `show = false` in the verification pass → `NG0100`.

## Solution

### Fix 1 — Guard `checkAndOpenFormDialog` to first load only

```typescript
.subscribe((contentType: DotCMSContentType) => {
    const isFirstLoad = !this.data;
    this.data = contentType;
    this.layout = contentType.layout;
    if (isFirstLoad) {
        this.checkAndOpenFormDialog(); // only on initial data load
    }
});
```

### Fix 2 — Convert `show` to a signal

```typescript
// Before
show: boolean;

// After
show = signal(false);
```

All assignments updated to `this.show.set(true/false)`. Both `savingContentType` and `show` are now signals and are processed atomically in the same Angular reactive CD cycle, eliminating the `NG0100`.

### Fix 3 — Use PrimeNG's `(onHide)` instead of `(visibleChange)` for dialog close handler

```html
<!-- Before -->
<p-dialog [(visible)]="show" (visibleChange)="onDialogHide()">

<!-- After -->
<p-dialog [visible]="show()" (visibleChange)="show.set($event)" (onHide)="onDialogHide()">
```

`(onHide)` fires only when the dialog hides (not when it opens), making the intent explicit and avoiding spurious `onDialogHide()` calls on open.



Fixes #33882

This PR fixes: #33882