### PR TITLE
docs: refine issue refinement guidelines for clarity and structure

### DIFF
--- a/.claude/skills/dotcms-github-issues/references/issue-refinement.md
+++ b/.claude/skills/dotcms-github-issues/references/issue-refinement.md
@@ -38,8 +38,7 @@ Scan every sentence. Flag each ambiguity:
 - Type: <see taxonomy>
 - Severity: CRITICAL | MAJOR | MINOR
 - Exact quote: "<copy vague text>"
-- Problem: why this cannot be implemented / tested as-is
-- Impact: what breaks if left unresolved
+- Why it matters: what breaks or cannot be implemented / tested if left unresolved
 ```
 
 ### Ambiguity Taxonomy
@@ -75,24 +74,18 @@ For each CRITICAL and MAJOR ambiguity, craft one precise question and present al
 - Use `multiSelect: false` (each ambiguity needs one clear resolution)
 - Set a short `header` derived from the ambiguity type (e.g., "Scope", "Error handling", "Actor")
 
----
-
-## Phase 4 — Wait for Answers
-
-`AskUserQuestion` blocks until the user responds — no extra action needed.
-
-Do NOT proceed until answers are received. Do NOT guess.
+> **Wait for answers.** Do NOT proceed until the user responds. Do NOT guess.
 
 ---
 
-## Phase 5 — Re-Analyze
+## Phase 4 — Re-Analyze
 
 After receiving answers:
 
 1. Confirm each answer resolves its ambiguity
 2. Check if any answer introduced NEW ambiguities
 3. If new CRITICAL / MAJOR ambiguities found → return to Phase 3
-4. If all CRITICAL + MAJOR resolved → proceed to Phase 6
+4. If all CRITICAL + MAJOR resolved → proceed to Phase 5
 
 Print resolution summary:
 
@@ -104,19 +97,27 @@ Print resolution summary:
 
 ---
 
-## Phase 6 — Write Acceptance Criteria
+## Phase 5 — Write Acceptance Criteria
 
 Only when all CRITICAL + MAJOR ambiguities are resolved (or loop 3 is reached).
 
 Write acceptance criteria as **checkbox items** — one per testable requirement. This matches the format expected by the issue templates.
 
-### Coverage requirements
+### Writing Process
 
-| Path | Required |
-|---|---|
-| Happy path (core functionality) | ✅ |
-| Sad path (error / rejection) | ✅ when applicable |
-| Edge case (boundary / empty / concurrent) | ✅ when applicable |
+1. **Anchor to the user story** — Every criterion traces back to the user story it validates.
+2. **Write outcome-focused criteria** — Describe what the user experiences, not implementation steps.
+3. **Validate against Required Characteristics** — Review each criterion against the five characteristics table below. Rewrite any that fail.
+
+### Coverage by Issue Type
+
+| Issue type | Happy path | Sad path | Edge cases | Notes |
+|---|---|---|---|---|
+| **Feature** | ✅ | ✅ | ✅ when applicable | Full coverage — user-facing behavior |
+| **Bug fix** | ✅ (fixed behavior) | ✅ (original bug no longer reproduces) | ✅ related regressions | Include: steps to reproduce, expected vs actual, fix confirmation |
+| **Refactor / Tech debt** | ✅ (behavior unchanged) | — | — | Focus on: no regressions, same observable behavior, measurable improvement |
+| **Spike / Research** | — | — | — | Deliverables: decision document, PoC, benchmark results, recommendation |
+| **UX / Design** | ✅ | ✅ when applicable | ✅ responsive / a11y | Focus on: visual states, interactions, breakpoints, accessibility |
 
 ### Format
 
@@ -127,30 +128,51 @@ Write acceptance criteria as **checkbox items** — one per testable requirement
 
 **Rules:**
 - Each checkbox = one verifiable outcome (pass/fail)
-- Use concrete values, not vague adjectives ("response under 3s" not "fast response")
-- Group related items logically (e.g., backend changes, frontend changes, validation)
+- Use concrete values, not vague adjectives ("response under 3 s" not "fast response")
 - Include the "what" and "where" when useful (e.g., "Engagement tab visible in Analytics Dashboard without flag check")
-- Omit sad path / edge case checkboxes when the issue type doesn't warrant them (e.g., a simple refactoring task has no error scenarios)
+- Omit sad path / edge case checkboxes when the issue type doesn't warrant them
+
+**Grouping order** (follow when applicable):
+
+1. Preconditions / setup
+2. Happy path (core functionality)
+3. Input validation
+4. Error handling / sad path
+5. Edge cases
+6. Non-functional (performance, accessibility)
+
+### Required Characteristics
+
+Every acceptance criterion **must** satisfy all five characteristics. If any criterion fails, rewrite it before scoring.
+
+| Characteristic | Requirement | Fail signal |
+|---|---|---|
+| **Clarity & Conciseness** | Plain, unambiguous language all stakeholders interpret the same way. No jargon. | Stakeholders disagree on meaning |
+| **Testability** | Maps to one or more executable tests with objective pass/fail. | Cannot write a concrete test |
+| **Outcome-focused** | Describes user-visible result, not implementation steps. | Reads like a how-to recipe |
+| **Measurability** | Quantified threshold where possible ("300×300 px", "≤ 3 s"). | Vague adjectives with no numbers |
+| **Independence** | Stands on its own — no reliance on other criteria. | Only makes sense with another criterion |
+
+### Anti-patterns
+
+| Bad AC | Problem | Rewrite |
+|---|---|---|
+| "The page should load fast" | VAGUE_QUANTIFIER — no threshold | "Page renders interactive content within 2 s on a 4G connection" |
+| "Errors are handled properly" | UNTESTABLE — no scenarios defined | "Submitting an empty form displays inline errors for each required field" |
+| "The feature works correctly" | UNTESTABLE — tautology | "Clicking Save persists the updated email and displays confirmation toast" |
+| "User can manage their settings" | TOO BROAD — multiple behaviors in one | Split into: "User can update display name" + "User can change notification preferences" |
+| "After step 2 above, the data is saved" | NOT INDEPENDENT — depends on another criterion | "When the user clicks Save with valid input, the record is persisted in the database" |
+| "Implement caching layer for API responses" | IMPLEMENTATION, NOT OUTCOME | "Subsequent identical API requests return within 50 ms after the first request" |
 
 ### Clarity Score
 
-After writing AC, score:
-
-| Dimension | Max | Criteria |
-|---|---|---|
-| Specificity | 25 | All values are concrete / measurable |
-| Testability | 25 | Each checkbox can unambiguously pass or fail |
-| Completeness | 25 | All relevant paths covered for the issue type |
-| Atomicity | 25 | Each checkbox tests exactly one thing |
-
-**Total: / 100**
-
-If score < 80 and loops remain → identify gaps and loop again.
-If score < 80 and on loop 3 → flag unresolved items with `⚠ UNRESOLVED` and proceed.
+Score each criterion 0–20 per Required Characteristic (5 × 20 = 100). **Total must be ≥ 80.** If < 80 and loops remain → identify gaps and loop again. If < 80 on loop 3 → flag unresolved items with `⚠ UNRESOLVED` and proceed.
 
 ---
 
-## Example (condensed)
+## Examples
+
+### Example 1 — Refinement loop (vague → concrete)
 
 **Input (vague):** "The user should be able to upload files quickly and the system should handle errors properly."
 
@@ -173,4 +195,38 @@ If score < 80 and on loop 3 → flag unresolved items with `⚠ UNRESOLVED` and 
 - [ ] No file is stored on the server when upload is rejected
 - [ ] Network timeout during upload shows "Upload failed — please try again" and no partial file is stored
 - [ ] Admin users can also upload files with the same constraints
+```
+
+### Example 2 — Feature (product search)
+
+**User story:** As a customer, I want to search for products by name so I can quickly find the items I'm looking for.
+
+```markdown
+- [ ] System returns all products that exactly match the entered search term
+- [ ] System returns partial matches when the user enters at least three characters
+- [ ] Search results display product name, image, and price in a clear, organized layout
+- [ ] Search results page supports pagination with a maximum of 20 results per page
+- [ ] When no results are found, the system displays a "No results found" message with suggested next steps
+```
+
+### Example 3 — Bug fix
+
+**Bug:** Users report that editing their email address does not persist after clicking Save.
+
+```markdown
+- [ ] User updates email address and clicks Save — new email is persisted in the database
+- [ ] After saving, the Edit Profile page displays the updated email (no stale cache)
+- [ ] Original bug scenario (edit email → save → reload → old email shown) no longer reproduces
+- [ ] Updating other fields (first name, phone) still works correctly after the fix
+```
+
+### Example 4 — Spike / Research
+
+**Spike:** Evaluate caching strategies for the content API to reduce response times.
+
+```markdown
+- [ ] Decision document comparing at least 3 caching strategies (in-memory, Redis, CDN) with trade-offs
+- [ ] PoC branch demonstrating the recommended strategy with benchmark results
+- [ ] Benchmark measures p50 and p99 latency for 100 concurrent requests before and after caching
+- [ ] Recommendation includes estimated implementation effort and infrastructure cost impact
 ```


### PR DESCRIPTION
- Updated ambiguity flagging section to clarify the importance of each ambiguity.
- Reorganized phases for better flow, renaming Phase 4 to 'Re-Analyze' and Phase 5 to 'Write Acceptance Criteria.'
- Enhanced writing process guidelines to emphasize outcome-focused criteria and clarity in acceptance criteria.
- Added examples to illustrate the refinement process and improve understanding.

These changes aim to improve the documentation's usability and ensure clearer communication of the refinement process.

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **
