### PR TITLE
fix: resolve GridColumn schema error when block types are restricted via Settings

### DIFF
--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
@@ -645,7 +645,7 @@ export class DotBlockEditorComponent implements OnInit, OnChanges, OnDestroy, Co
             }),
             ...DotCMSTableExtensions,
             DotTableCellContextMenu(this.viewContainerRef),
-            createGridColumn(this.allowedBlocks?.length > 1 ? this.allowedBlocks : [])
+            createGridColumn(this.allowedBlocks.length > 1 ? this.allowedBlocks : [])
         ];
 
         if (isAIPluginInstalled) {

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.ts
@@ -69,8 +69,8 @@ import {
 import {
     AIContentNode,
     ContentletBlock,
+    createGridColumn,
     GridBlock,
-    GridColumn,
     ImageNode,
     LoaderNode,
     VideoNode
@@ -645,7 +645,7 @@ export class DotBlockEditorComponent implements OnInit, OnChanges, OnDestroy, Co
             }),
             ...DotCMSTableExtensions,
             DotTableCellContextMenu(this.viewContainerRef),
-            GridColumn
+            createGridColumn(this.allowedBlocks?.length > 1 ? this.allowedBlocks : [])
         ];
 
         if (isAIPluginInstalled) {

--- a/core-web/libs/block-editor/src/lib/nodes/grid-block/grid-column.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/grid-block/grid-column.node.ts
@@ -1,5 +1,9 @@
 import { Node } from '@tiptap/core';
 
+// Maps allowedBlocks keys to their TipTap node names for grid column content.
+// Custom nodes such as `aiContent` and `loader` are intentionally absent — they are
+// editor-level utilities that do not make sense inside a grid column and are not
+// registered as StarterKit node types.
 const GRID_COLUMN_CONTENT_MAP: Record<string, string> = {
     heading: 'heading',
     bulletList: 'bulletList',
@@ -29,6 +33,8 @@ function buildGridColumnContent(allowedBlocks: string[]): string {
     }
 
     const headingAllowed = allowedBlocks.some((b) => b.startsWith('heading'));
+    // `paragraph` is always included — StarterKit always registers it and
+    // DotBlockEditorComponent seeds allowedBlocks with ['paragraph'] at initialization.
     const nodeTypes = ['paragraph'];
 
     for (const [key, nodeType] of Object.entries(GRID_COLUMN_CONTENT_MAP)) {

--- a/core-web/libs/block-editor/src/lib/nodes/grid-block/grid-column.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/grid-block/grid-column.node.ts
@@ -1,23 +1,68 @@
 import { Node } from '@tiptap/core';
 
-export const GridColumn = Node.create({
-    name: 'gridColumn',
-    group: 'gridColumn',
-    // gridBlock is intentionally excluded to prevent nested grids.
-    // Nested grid support requires a more robust resize implementation.
-    content:
-        '(paragraph | heading | bulletList | orderedList | codeBlock | blockquote | table | horizontalRule | dotImage | dotVideo | dotContent)+',
-    isolating: true,
+const GRID_COLUMN_CONTENT_MAP: Record<string, string> = {
+    heading: 'heading',
+    bulletList: 'bulletList',
+    orderedList: 'orderedList',
+    codeBlock: 'codeBlock',
+    blockquote: 'blockquote',
+    table: 'table',
+    horizontalRule: 'horizontalRule',
+    image: 'dotImage',
+    video: 'dotVideo',
+    dotContent: 'dotContent'
+};
 
-    parseHTML() {
-        return [{ tag: 'div[data-type="gridColumn"]' }];
-    },
+const ALL_NODE_TYPES = Object.values(GRID_COLUMN_CONTENT_MAP);
+const DEFAULT_CONTENT = `(paragraph | ${ALL_NODE_TYPES.join(' | ')})+`;
 
-    renderHTML({ HTMLAttributes }) {
-        return [
-            'div',
-            { ...HTMLAttributes, 'data-type': 'gridColumn', class: 'grid-block__column' },
-            0
-        ];
+/**
+ * Builds the TipTap content expression for GridColumn based on the allowed blocks.
+ * This is necessary because StarterKit removes disabled node types from the schema at init time,
+ * so a static content expression that references a removed node (e.g. `blockquote`) causes
+ * a schema validation error. By deriving the expression from `allowedBlocks`, we ensure
+ * GridColumn only references nodes that are actually registered in the schema.
+ */
+function buildGridColumnContent(allowedBlocks: string[]): string {
+    if (!allowedBlocks.length) {
+        return DEFAULT_CONTENT;
     }
-});
+
+    const headingAllowed = allowedBlocks.some((b) => b.startsWith('heading'));
+    const nodeTypes = ['paragraph'];
+
+    for (const [key, nodeType] of Object.entries(GRID_COLUMN_CONTENT_MAP)) {
+        if (key === 'heading') {
+            if (headingAllowed) nodeTypes.push(nodeType);
+        } else if (allowedBlocks.includes(key)) {
+            nodeTypes.push(nodeType);
+        }
+    }
+
+    return `(${nodeTypes.join(' | ')})+`;
+}
+
+export function createGridColumn(allowedBlocks: string[] = []) {
+    return Node.create({
+        name: 'gridColumn',
+        group: 'gridColumn',
+        // gridBlock is intentionally excluded to prevent nested grids.
+        // Nested grid support requires a more robust resize implementation.
+        content: buildGridColumnContent(allowedBlocks),
+        isolating: true,
+
+        parseHTML() {
+            return [{ tag: 'div[data-type="gridColumn"]' }];
+        },
+
+        renderHTML({ HTMLAttributes }) {
+            return [
+                'div',
+                { ...HTMLAttributes, 'data-type': 'gridColumn', class: 'grid-block__column' },
+                0
+            ];
+        }
+    });
+}
+
+export const GridColumn = createGridColumn();

--- a/core-web/libs/block-editor/src/lib/nodes/grid-block/index.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/grid-block/index.ts
@@ -1,3 +1,3 @@
 export { GridBlock } from './grid-block.node';
-export { GridColumn } from './grid-column.node';
+export { GridColumn, createGridColumn } from './grid-column.node';
 export { GridResizePlugin, GRID_RESIZE_PLUGIN_KEY } from './grid-resize.plugin';


### PR DESCRIPTION
This PR fixes: #35032

## Root Cause

When the Block Editor's **Settings tab** is used to restrict which block types are allowed, TipTap's `StarterKit` removes the disabled node types from the schema entirely at initialization time.

The original `GridColumn` node had a **static content expression** that referenced all possible node types:

```
(paragraph | heading | bulletList | orderedList | codeBlock | blockquote | table | horizontalRule | dotImage | dotVideo | dotContent)+
```

If any of those types were disabled (e.g. `blockquote`), StarterKit would remove them from the schema, but `GridColumn.content` would still reference them. TipTap throws a schema validation error on init, causing the editor to render as a blank blue button instead of the full editing surface.

## Fix

`GridColumn` is converted from a static export to a factory function `createGridColumn(allowedBlocks)` that **dynamically builds the content expression** based on the blocks actually registered in the schema. This ensures `GridColumn` never references a node type that StarterKit has removed.

`DotBlockEditorComponent` now calls `createGridColumn(this.allowedBlocks)` at extension initialization time, passing the active allowed list. The original `GridColumn` constant is preserved as a default export (`createGridColumn()` with no args) to avoid breaking other consumers.

## Changes

- `grid-column.node.ts` — converts static node to `createGridColumn(allowedBlocks)` factory; adds `buildGridColumnContent()` to derive the TipTap content expression from the allowed list
- `dot-block-editor.component.ts` — replaces static `GridColumn` with `createGridColumn(this.allowedBlocks)`
- `index.ts` — exports both `GridColumn` (backwards compat) and `createGridColumn`

### Video


https://github.com/user-attachments/assets/61727785-0dcf-4824-bb89-64debfa9468b


This PR fixes: #35032