### PR TITLE
fix(ci): install Homebrew bash for SDKMAN on macOS runners #35004

### DIFF
--- a/.github/actions/core-cicd/setup-java/action.yml
+++ b/.github/actions/core-cicd/setup-java/action.yml
@@ -61,18 +61,29 @@ runs:
       with:
         path: ~/.sdkman
         key: ${{ runner.os }}-${{ env.ARCHITECTURE }}-sdkman-install
+    - name: Install Bash 4+ (macOS)
+      if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' && runner.os == 'macOS' }}
+      shell: bash
+      run: |
+        # macOS ships Bash 3.2 but SDKMAN 5.21+ requires Bash 4+.
+        # Homebrew is pre-installed on GitHub macOS runners.
+        brew install bash
+        echo "Installed Bash: $($(brew --prefix)/bin/bash --version | head -1)"
     - name: Install SDKMan
       id: install-sdkman
       if: ${{ steps.restore-cache-sdkman.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
         if [ ! -f "$HOME/.sdkman/bin/sdkman-init.sh" ]; then
-        echo "Downloading SDKMAN install"
-        if [[ "$RUNNER_OS" == "macOS" ]]; then
-          curl -s "https://get.sdkman.io" | zsh
-        else
-          curl -s "https://get.sdkman.io" | bash
-        fi
+          echo "Downloading SDKMAN install"
+          # Use Homebrew bash on macOS (Bash 4+), system bash on Linux (already 5.x)
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            BREW_BASH="$(brew --prefix)/bin/bash"
+            echo "Using Homebrew bash: $($BREW_BASH --version | head -1)"
+            curl -s "https://get.sdkman.io" | "$BREW_BASH"
+          else
+            curl -s "https://get.sdkman.io" | bash
+          fi
         fi
     - name: Save Cache SDKMan install
       id: save-cache-sdkman


### PR DESCRIPTION
## Summary

- Installs Homebrew bash (4+) on macOS runners before running SDKMAN installer
- macOS runners ship Bash 3.2 but SDKMAN 5.21+ requires Bash 4+
- The previous zsh workaround failed — SDKMAN's installer uses bashisms throughout ([confirmed by SDKMAN team](https://github.com/sdkman/sdkman-cli/issues/1520))
- Only runs on SDKMAN cache miss (~10-15s overhead, rare after first run)
- Stopgap until mise replaces SDKMAN in the pipeline

## Test plan

- [ ] Verify macOS CI jobs install SDKMAN successfully
- [ ] Verify Linux CI jobs are unaffected (continue using system bash 5.x)
- [ ] Verify cached runs skip both the brew install and SDKMAN install steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35004