### PR TITLE
#34980 include exception in addBinaries

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/strategy/DefaultTransformStrategy.java
@@ -271,7 +271,7 @@ public class DefaultTransformStrategy extends AbstractTransformStrategy<Contentl
                 Logger.warn(this,
                                 String.format("An error occurred when retrieving the Binary file from field"
                                                 + " '%s' in Contentlet with ID '%s': %s", field.variable(),
-                                                contentlet.getIdentifier(), e.getMessage()));
+                                                contentlet.getIdentifier(), e.getMessage()), e);
             }
 
 


### PR DESCRIPTION
## Summary

- Pass the caught exception to `Logger.warn()` in `DefaultTransformStrategy#addBinaries` so the full stack trace is included in the warning log, not just the message string.

## Problem

When a binary field fails to be retrieved during contentlet transformation, the warning log only captured `e.getMessage()` as a string argument. This meant the stack trace was silently dropped, making it very difficult to diagnose the root cause of binary retrieval failures.

## Solution

Pass `e` as the third argument to `Logger.warn()`, which triggers the overload that logs both the message and the full exception stack trace.

```java
// Before
Logger.warn(this,
    String.format("An error occurred when retrieving the Binary file from field"
        + " '%s' in Contentlet with ID '%s': %s", field.variable(),
        contentlet.getIdentifier(), e.getMessage()));

// After
Logger.warn(this,
    String.format("An error occurred when retrieving the Binary file from field"
        + " '%s' in Contentlet with ID '%s': %s", field.variable(),
        contentlet.getIdentifier(), e.getMessage()), e);
```

## Test plan

- [ ] Trigger a binary field retrieval failure and confirm the full stack trace appears in the logs

This PR fixes: #34980