### PR TITLE
feat(sdk-react): server component support, buildSlots, and RSC-safe entry point

### DIFF
--- a/core-web/libs/sdk/react/.babelrc
+++ b/core-web/libs/sdk/react/.babelrc
@@ -3,8 +3,7 @@
         [
             "@nx/react/babel",
             {
-                "runtime": "automatic",
-                "useBuiltIns": "usage"
+                "runtime": "automatic"
             }
         ]
     ],

--- a/core-web/libs/sdk/react/README.md
+++ b/core-web/libs/sdk/react/README.md
@@ -210,24 +210,39 @@ All components and hooks should be imported from `@dotcms/react`:
 | ------------ | ------------------------ | -------- | -------------- | ---------------------------------------------- |
 | `page`       | `DotCMSPageAsset`        | ✅       | -              | The page asset containing the layout to render |
 | `components` | `DotCMSPageComponent`    | ✅       | `{}`           | [Map of content type → React component](#component-mapping)          |
-| `mode`       | `DotCMSPageRendererMode` | ❌       | `'production'` | [Rendering mode ('production' or 'development')](#layout-body-modes) |
+| `mode`       | `DotCMSPageRendererMode` | ❌       | `’production’` | [Rendering mode (‘production’ or ‘development’)](#layout-body-modes) |
+| `slots`      | `Record<string, ReactNode>` | ❌    | `{}`           | Pre-rendered server component nodes keyed by contentlet identifier. See [`buildSlots`](#buildslots). |
 
-#### Client-Side Only Component
+#### Next.js App Router
 
-> ⚠️ **Important: This is a client-side React component.**
-> `DotCMSLayoutBody` uses React features like `useContext`, `useEffect`, and `useState`.
-> If you're using a framework that supports Server-Side Rendering (like **Next.js**, **Gatsby**, or **Astro**), you **must** mark the parent component with `"use client"` or follow your framework’s guidelines for using client-side components.
->
-> 👉 [Learn more: Next.js – Client Components](https://nextjs.org/docs/getting-started/react-essentials#client-components)
+`DotCMSLayoutBody` requires a `"use client"` parent because `components` is a map of React component functions, which React cannot serialize across the server→client boundary. The recommended pattern is to fetch data in the server page and pass the plain result to a client wrapper:
+
+```tsx
+// page.tsx — server component, fetches data only
+export default async function Page() {
+    const pageContent = await getDotCMSPage(path);
+    return <PageView pageContent={pageContent} />;
+}
+```
+
+```tsx
+// PageView.tsx — "use client", owns components and renders layout
+‘use client’;
+
+export function PageView({ pageContent }) {
+    const { pageAsset } = useEditableDotCMSPage(pageContent);
+    return <DotCMSLayoutBody page={pageAsset} components={pageComponents} />;
+}
+```
 
 #### Usage
 
 ```tsx
-import type { DotCMSPageAsset } from '@dotcms/types';
-import { DotCMSLayoutBody } from '@dotcms/react';
+import type { DotCMSPageAsset } from ‘@dotcms/types’;
+import { DotCMSLayoutBody } from ‘@dotcms/react’;
 
-import { MyBlogCard } from './MyBlogCard';
-import { DotCMSProductComponent } from './DotCMSProductComponent';
+import { MyBlogCard } from ‘./MyBlogCard’;
+import { DotCMSProductComponent } from ‘./DotCMSProductComponent’;
 
 const COMPONENTS_MAP = {
     Blog: MyBlogCard,
@@ -238,6 +253,23 @@ const MyPage = ({ pageAsset }: DotCMSPageResponse) => {
     return <DotCMSLayoutBody page={pageAsset} components={COMPONENTS_MAP} />;
 };
 ```
+
+#### buildSlots
+
+Use `buildSlots` when you have Next.js async server components that need to fetch their own data. Since async server components can’t be called from inside a client component tree, pre-render them on the server and pass the result into the layout via `slots`:
+
+```tsx
+import { buildSlots, DotCMSLayoutBody } from ‘@dotcms/react’;
+
+// BlogListContainer is an async server component that fetches its own data
+const slots = buildSlots(pageContent.pageAsset.containers, {
+    BlogList: BlogListContainer,
+});
+
+<DotCMSLayoutBody page={pageAsset} components={pageComponents} slots={slots} />
+```
+
+The layout renders the pre-rendered slot node for a contentlet if one exists, otherwise falls back to the matching entry in `components`.
 
 #### Layout Body Modes
 
@@ -313,12 +345,13 @@ export default MyBannerComponent;
 
 `DotCMSBlockEditorRenderer` is a component for rendering [Block Editor](https://dev.dotcms.com/docs/block-editor) content from dotCMS with support for custom block renderers.
 
-| Input             | Type                 | Required | Description                                                                                                |
-| ----------------- | -------------------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `blocks`          | `BlockEditorContent` | ✅       | The [Block Editor](https://dev.dotcms.com/docs/block-editor) content to render                             |
-| `customRenderers` | `CustomRenderers`    | ❌       | Custom rendering functions for specific [block types](https://dev.dotcms.com/docs/block-editor#BlockTypes) |
-| `className`       | `string`             | ❌       | CSS class to apply to the container                                                                        |
-| `style`           | `CSSProperties`      | ❌       | Inline styles for the container                                                                            |
+| Input             | Type                 | Required | Default | Description                                                                                                |
+| ----------------- | -------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------- |
+| `blocks`          | `BlockEditorContent` | ✅       | -       | The [Block Editor](https://dev.dotcms.com/docs/block-editor) content to render                             |
+| `customRenderers` | `CustomRenderers`    | ❌       | -       | Custom rendering functions for specific [block types](https://dev.dotcms.com/docs/block-editor#BlockTypes) |
+| `className`       | `string`             | ❌       | -       | CSS class to apply to the container                                                                        |
+| `style`           | `CSSProperties`      | ❌       | -       | Inline styles for the container                                                                            |
+| `isDevMode`       | `boolean`            | ❌       | `false` | When `true`, shows a visible error message if the `blocks` data is invalid. When `false` (default), invalid blocks render nothing silently. |
 
 #### Usage
 
@@ -342,6 +375,27 @@ const DetailPage = ({ contentlet }: { contentlet: DotCMSBasicContentlet }) => {
         />
     );
 };
+```
+
+#### Next.js Server Components
+
+`DotCMSBlockEditorRenderer` can be used directly in a Next.js server component — it has no hooks or browser dependencies:
+
+```tsx
+// app/article/page.tsx — server component
+import { DotCMSBlockEditorRenderer } from '@dotcms/react';
+
+export default async function ArticlePage() {
+    const { pageAsset } = await getDotCMSPage('/article');
+    const blocks = pageAsset.containers['...'].contentlets[0].blockEditorContent;
+
+    return (
+        <DotCMSBlockEditorRenderer
+            blocks={blocks}
+            isDevMode={process.env.NODE_ENV === 'development'}
+        />
+    );
+}
 ```
 
 #### Recommendations

--- a/core-web/libs/sdk/react/package.json
+++ b/core-web/libs/sdk/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dotcms/react",
-  "version": "1.1.1",
+  "version": "1.2.6",
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18"

--- a/core-web/libs/sdk/react/project.json
+++ b/core-web/libs/sdk/react/project.json
@@ -23,7 +23,7 @@
                 "project": "libs/sdk/react/package.json",
                 "entryFile": "libs/sdk/react/src/index.ts",
                 "external": ["react/jsx-runtime"],
-                "rollupConfig": "@nx/react/plugins/bundle-rollup",
+                "rollupConfig": "libs/sdk/react/rollup.config.js",
                 "compiler": "babel",
                 "format": ["esm"],
                 "extractCss": false,

--- a/core-web/libs/sdk/react/rollup.config.js
+++ b/core-web/libs/sdk/react/rollup.config.js
@@ -1,0 +1,69 @@
+const preserveDirectives = require('rollup-plugin-preserve-directives').default;
+const path = require('path');
+const fs = require('fs');
+
+/**
+ * Rollup plugin that patches the output package.json to add the react-server
+ * export condition, pointing to the server-safe entry that excludes TinyMCE
+ * and other client-only modules.
+ */
+function patchPackageJsonPlugin(outputDir) {
+    return {
+        name: 'patch-package-json',
+        writeBundle() {
+            const pkgPath = path.join(outputDir, 'package.json');
+            if (!fs.existsSync(pkgPath)) return;
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+            if (pkg.exports && pkg.exports['.']) {
+                pkg.exports['.'] = {
+                    'react-server': './index.server.esm.js',
+                    ...pkg.exports['.']
+                };
+                fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+            }
+        }
+    };
+}
+
+module.exports = (options) => {
+    if (!options) return {};
+
+    // Add server entry point alongside the default entry
+    if (options.input && typeof options.input === 'object' && options.input.index) {
+        const mainEntry = options.input.index;
+        const serverEntry = mainEntry.replace('/index.ts', '/index.server.ts');
+        options.input['index.server'] = serverEntry;
+    }
+
+    // Enable preserveModules on all outputs
+    if (Array.isArray(options.output)) {
+        options.output.forEach((output) => {
+            output.preserveModules = true;
+            output.preserveModulesRoot = 'src';
+        });
+    } else if (options.output) {
+        options.output.preserveModules = true;
+        options.output.preserveModulesRoot = 'src';
+    }
+
+    // Determine output directory for package.json patching
+    const outputDir = Array.isArray(options.output)
+        ? options.output[0]?.dir
+        : options.output?.dir;
+
+    // Append preserveDirectives and package.json patcher as the last plugins
+    options.plugins = [
+        ...(Array.isArray(options.plugins) ? options.plugins : []),
+        preserveDirectives(),
+        ...(outputDir ? [patchPackageJsonPlugin(outputDir)] : []),
+    ];
+
+    // Suppress MODULE_LEVEL_DIRECTIVE warnings from rollup
+    options.onwarn = (warning, warn) => {
+        if (warning.code !== 'MODULE_LEVEL_DIRECTIVE') {
+            warn(warning);
+        }
+    };
+
+    return options;
+};

--- a/core-web/libs/sdk/react/rollup.config.js
+++ b/core-web/libs/sdk/react/rollup.config.js
@@ -14,10 +14,18 @@ function patchPackageJsonPlugin(outputDir) {
             const pkgPath = path.join(outputDir, 'package.json');
             if (!fs.existsSync(pkgPath)) return;
             const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-            if (pkg.exports && pkg.exports['.']) {
+            const mainExport = pkg.exports && pkg.exports['.'];
+
+            if (mainExport && typeof mainExport === 'object' && !Array.isArray(mainExport)) {
                 pkg.exports['.'] = {
                     'react-server': './index.server.esm.js',
-                    ...pkg.exports['.']
+                    ...mainExport
+                };
+                fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+            } else if (typeof mainExport === 'string') {
+                pkg.exports['.'] = {
+                    'react-server': './index.server.esm.js',
+                    import: mainExport
                 };
                 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
             }
@@ -31,7 +39,9 @@ module.exports = (options) => {
     // Add server entry point alongside the default entry
     if (options.input && typeof options.input === 'object' && options.input.index) {
         const mainEntry = options.input.index;
-        const serverEntry = mainEntry.replace('/index.ts', '/index.server.ts');
+        const parsed = path.parse(mainEntry);
+        const serverFileName = `${parsed.name}.server${parsed.ext}`;
+        const serverEntry = parsed.dir ? path.join(parsed.dir, serverFileName) : serverFileName;
         options.input['index.server'] = serverEntry;
     }
 
@@ -47,22 +57,21 @@ module.exports = (options) => {
     }
 
     // Determine output directory for package.json patching
-    const outputDir = Array.isArray(options.output)
-        ? options.output[0]?.dir
-        : options.output?.dir;
+    const outputDir = Array.isArray(options.output) ? options.output[0]?.dir : options.output?.dir;
 
     // Append preserveDirectives and package.json patcher as the last plugins
     options.plugins = [
         ...(Array.isArray(options.plugins) ? options.plugins : []),
         preserveDirectives(),
-        ...(outputDir ? [patchPackageJsonPlugin(outputDir)] : []),
+        ...(outputDir ? [patchPackageJsonPlugin(outputDir)] : [])
     ];
 
-    // Suppress MODULE_LEVEL_DIRECTIVE warnings from rollup
+    // Suppress MODULE_LEVEL_DIRECTIVE warnings from rollup, composing with any existing handler
+    const originalOnWarn = options.onwarn;
     options.onwarn = (warning, warn) => {
-        if (warning.code !== 'MODULE_LEVEL_DIRECTIVE') {
-            warn(warning);
-        }
+        if (warning.code === 'MODULE_LEVEL_DIRECTIVE') return;
+        if (typeof originalOnWarn === 'function') return originalOnWarn(warning, warn);
+        warn(warning);
     };
 
     return options;

--- a/core-web/libs/sdk/react/rollup.config.js
+++ b/core-web/libs/sdk/react/rollup.config.js
@@ -28,6 +28,11 @@ function patchPackageJsonPlugin(outputDir) {
                     import: mainExport
                 };
                 fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+            } else {
+                console.warn(
+                    '[patchPackageJsonPlugin] Unrecognized exports["."] shape — react-server condition was NOT added. ' +
+                        'SSR builds may pull in TinyMCE. Check the generated package.json exports field.'
+                );
             }
         }
     };
@@ -43,6 +48,11 @@ module.exports = (options) => {
         const serverFileName = `${parsed.name}.server${parsed.ext}`;
         const serverEntry = parsed.dir ? path.join(parsed.dir, serverFileName) : serverFileName;
         options.input['index.server'] = serverEntry;
+    } else {
+        console.warn(
+            '[rollup.config.js] Could not find options.input.index — server entry (index.server.ts) was NOT registered. ' +
+                'The react-server export condition will point to a missing file.'
+        );
     }
 
     // Enable preserveModules on all outputs

--- a/core-web/libs/sdk/react/src/index.server.ts
+++ b/core-web/libs/sdk/react/src/index.server.ts
@@ -1,12 +1,14 @@
 // Server-safe entry point — excludes client-only modules that import
 // browser APIs or class components (e.g. TinyMCE) which break SSR.
+// Hooks (useEditableDotCMSPage, useDotCMSShowWhen, useAISearch, useStyleEditorSchemas)
+// are intentionally excluded: they use useState/useEffect and have no 'use client'
+// directive, so including them here would pull React client APIs into the RSC module
+// graph and cause a build error in Next.js App Router.
 export { DotCMSLayoutBody } from './lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody';
 
-export { DotCMSShow } from './lib/next/components/DotCMSShow/DotCMSShow';
+export type { DotCMSLayoutBodyProps } from './lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody';
 
-export { useDotCMSShowWhen } from './lib/next/hooks/useDotCMSShowWhen';
-
-export { useEditableDotCMSPage } from './lib/next/hooks/useEditableDotCMSPage';
+export { buildSlots } from './lib/next/utils/buildSlots';
 
 export {
     DotCMSBlockEditorRenderer,
@@ -18,13 +20,5 @@ export type {
     CustomRendererProps
 } from './lib/next/components/DotCMSBlockEditorRenderer/DotCMSBlockEditorRenderer';
 
-export type { DotCMSLayoutBodyProps } from './lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody';
-
-export { useAISearch } from './lib/next/hooks/useAISearch';
-
-export { useStyleEditorSchemas } from './lib/next/hooks/useStyleEditorSchemas';
-
 //Export AI types from shared types
 export type { DotCMSAISearchValue, DotCMSAISearchProps } from './lib/next/shared/types';
-
-export { buildSlots } from './lib/next/utils/buildSlots';

--- a/core-web/libs/sdk/react/src/index.server.ts
+++ b/core-web/libs/sdk/react/src/index.server.ts
@@ -10,12 +10,15 @@ export { useEditableDotCMSPage } from './lib/next/hooks/useEditableDotCMSPage';
 
 export {
     DotCMSBlockEditorRenderer,
+    CustomRenderer
+} from './lib/next/components/DotCMSBlockEditorRenderer/DotCMSBlockEditorRenderer';
+
+export type {
     BlockEditorRendererProps,
-    CustomRenderer,
     CustomRendererProps
 } from './lib/next/components/DotCMSBlockEditorRenderer/DotCMSBlockEditorRenderer';
 
-export { DotCMSLayoutBodyProps } from './lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody';
+export type { DotCMSLayoutBodyProps } from './lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody';
 
 export { useAISearch } from './lib/next/hooks/useAISearch';
 

--- a/core-web/libs/sdk/react/src/index.server.ts
+++ b/core-web/libs/sdk/react/src/index.server.ts
@@ -1,3 +1,5 @@
+// Server-safe entry point — excludes client-only modules that import
+// browser APIs or class components (e.g. TinyMCE) which break SSR.
 export { DotCMSLayoutBody } from './lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody';
 
 export { DotCMSShow } from './lib/next/components/DotCMSShow/DotCMSShow';
@@ -5,8 +7,6 @@ export { DotCMSShow } from './lib/next/components/DotCMSShow/DotCMSShow';
 export { useDotCMSShowWhen } from './lib/next/hooks/useDotCMSShowWhen';
 
 export { useEditableDotCMSPage } from './lib/next/hooks/useEditableDotCMSPage';
-
-export { DotCMSEditableText } from './lib/next/components/DotCMSEditableText/DotCMSEditableText';
 
 export {
     DotCMSBlockEditorRenderer,

--- a/core-web/libs/sdk/react/src/index.ts
+++ b/core-web/libs/sdk/react/src/index.ts
@@ -10,12 +10,15 @@ export { DotCMSEditableText } from './lib/next/components/DotCMSEditableText/Dot
 
 export {
     DotCMSBlockEditorRenderer,
+    CustomRenderer
+} from './lib/next/components/DotCMSBlockEditorRenderer/DotCMSBlockEditorRenderer';
+
+export type {
     BlockEditorRendererProps,
-    CustomRenderer,
     CustomRendererProps
 } from './lib/next/components/DotCMSBlockEditorRenderer/DotCMSBlockEditorRenderer';
 
-export { DotCMSLayoutBodyProps } from './lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody';
+export type { DotCMSLayoutBodyProps } from './lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody';
 
 export { useAISearch } from './lib/next/hooks/useAISearch';
 

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Container.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Container.test.tsx
@@ -32,8 +32,7 @@ jest.mock('@dotcms/uve/internal', () => ({
 const DEFAULT_CONTEXT_VALUE: DotCMSPageContextProps = {
     pageAsset: MOCK_PAGE_ASSET,
     mode: 'production',
-    userComponents: {},
-    slots: {}
+    userComponents: {}
 };
 
 describe('Container', () => {

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Container.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Container.test.tsx
@@ -32,7 +32,8 @@ jest.mock('@dotcms/uve/internal', () => ({
 const DEFAULT_CONTEXT_VALUE: DotCMSPageContextProps = {
     pageAsset: MOCK_PAGE_ASSET,
     mode: 'production',
-    userComponents: {}
+    userComponents: {},
+    slots: {}
 };
 
 describe('Container', () => {

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
@@ -47,8 +47,7 @@ describe('Contentlet', () => {
     test('should render fallback component when no custom component exists', () => {
         const contextValue = {
             mode: 'development',
-            userComponents: {},
-            slots: {}
+            userComponents: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
@@ -84,8 +83,7 @@ describe('Contentlet', () => {
     test('should apply empty style when isDevMode is false', () => {
         const contextValue = {
             mode: 'production',
-            userComponents: {},
-            slots: {}
+            userComponents: {}
         };
 
         const { container } = renderContentlet(contextValue, {
@@ -107,8 +105,7 @@ describe('Contentlet', () => {
 
         const contextValue = {
             mode: 'development',
-            userComponents: {},
-            slots: {}
+            userComponents: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
@@ -120,8 +117,7 @@ describe('Contentlet', () => {
     test('should always apply UVE attributes in production', () => {
         const contextValue = {
             mode: 'production',
-            userComponents: {},
-            slots: {}
+            userComponents: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
@@ -133,8 +129,7 @@ describe('Contentlet', () => {
     test('should always apply UVE attributes even when isDevMode is false', () => {
         const contextValue = {
             mode: 'production',
-            userComponents: {},
-            slots: {}
+            userComponents: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
@@ -146,8 +141,7 @@ describe('Contentlet', () => {
     test('should always apply UVE attributes in development mode (UVE)', () => {
         const contextValue = {
             mode: 'development',
-            userComponents: {},
-            slots: {}
+            userComponents: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
@@ -148,4 +148,53 @@ describe('Contentlet', () => {
         // UVE attributes should always be called
         expect(getDotContentletAttributesMock).toHaveBeenCalledWith(dummyContentlet, 'container-1');
     });
+
+    test('should render slot node when present for contentlet identifier', () => {
+        const slotNode = <div data-testid="slot-node">Server rendered slot</div>;
+        const contextValue = {
+            mode: 'production',
+            userComponents: {},
+            slots: { 'slot-id': slotNode }
+        };
+
+        renderContentlet(contextValue, {
+            contentlet: { ...dummyContentlet, identifier: 'slot-id' },
+            container: 'container-1'
+        });
+
+        expect(screen.getByTestId('slot-node')).toBeInTheDocument();
+        expect(screen.getByTestId('slot-node')).toHaveTextContent('Server rendered slot');
+    });
+
+    test('should fall back to userComponents when no slot exists for identifier', () => {
+        const CustomComponentMock = () => <div data-testid="custom">Custom</div>;
+        const contextValue = {
+            mode: 'production',
+            userComponents: { 'test-type': CustomComponentMock },
+            slots: { 'other-id': <div>Other slot</div> }
+        };
+
+        renderContentlet(contextValue, {
+            contentlet: { ...dummyContentlet, identifier: 'no-slot-id' },
+            container: 'container-1'
+        });
+
+        expect(screen.getByTestId('custom')).toBeInTheDocument();
+    });
+
+    test('should not crash when slots is omitted from context', () => {
+        const contextValue = {
+            mode: 'production',
+            userComponents: {}
+        };
+
+        expect(() =>
+            renderContentlet(contextValue, {
+                contentlet: { ...dummyContentlet, identifier: 'some-id' },
+                container: 'container-1'
+            })
+        ).not.toThrow();
+
+        expect(screen.getByTestId('fallback')).toBeInTheDocument();
+    });
 });

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
@@ -47,7 +47,8 @@ describe('Contentlet', () => {
     test('should render fallback component when no custom component exists', () => {
         const contextValue = {
             mode: 'development',
-            userComponents: {}
+            userComponents: {},
+            slots: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
@@ -70,7 +71,8 @@ describe('Contentlet', () => {
             mode: 'development',
             userComponents: {
                 'test-type': CustomComponentMock
-            }
+            },
+            slots: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
@@ -82,7 +84,8 @@ describe('Contentlet', () => {
     test('should apply empty style when isDevMode is false', () => {
         const contextValue = {
             mode: 'production',
-            userComponents: {}
+            userComponents: {},
+            slots: {}
         };
 
         const { container } = renderContentlet(contextValue, {
@@ -104,7 +107,8 @@ describe('Contentlet', () => {
 
         const contextValue = {
             mode: 'development',
-            userComponents: {}
+            userComponents: {},
+            slots: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
@@ -116,7 +120,8 @@ describe('Contentlet', () => {
     test('should always apply UVE attributes in production', () => {
         const contextValue = {
             mode: 'production',
-            userComponents: {}
+            userComponents: {},
+            slots: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
@@ -128,7 +133,8 @@ describe('Contentlet', () => {
     test('should always apply UVE attributes even when isDevMode is false', () => {
         const contextValue = {
             mode: 'production',
-            userComponents: {}
+            userComponents: {},
+            slots: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });
@@ -140,7 +146,8 @@ describe('Contentlet', () => {
     test('should always apply UVE attributes in development mode (UVE)', () => {
         const contextValue = {
             mode: 'development',
-            userComponents: {}
+            userComponents: {},
+            slots: {}
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Contentlet.test.tsx
@@ -70,8 +70,7 @@ describe('Contentlet', () => {
             mode: 'development',
             userComponents: {
                 'test-type': CustomComponentMock
-            },
-            slots: {}
+            }
         };
 
         renderContentlet(contextValue, { contentlet: dummyContentlet, container: 'container-1' });

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/DotCMSBlockEditorRenderer.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/DotCMSBlockEditorRenderer.test.tsx
@@ -8,7 +8,6 @@ import {
     CustomRendererProps,
     DotCMSBlockEditorRenderer
 } from '../../components/DotCMSBlockEditorRenderer/DotCMSBlockEditorRenderer';
-import * as isDevModeHook from '../../hooks/useIsDevMode';
 
 describe('DotCMSBlockEditorRenderer', () => {
     const blocks: BlockEditorNode = {
@@ -28,7 +27,6 @@ describe('DotCMSBlockEditorRenderer', () => {
     };
 
     beforeEach(() => {
-        jest.spyOn(isDevModeHook, 'useIsDevMode').mockReturnValue(true);
         jest.spyOn(console, 'error').mockImplementation(() => {
             /* empty */
         });
@@ -79,7 +77,10 @@ describe('DotCMSBlockEditorRenderer', () => {
             });
 
             const { getByTestId } = render(
-                <DotCMSBlockEditorRenderer blocks={null as unknown as BlockEditorNode} />
+                <DotCMSBlockEditorRenderer
+                    blocks={null as unknown as BlockEditorNode}
+                    isDevMode={true}
+                />
             );
 
             expect(getByTestId('invalid-blocks-message')).toHaveTextContent(
@@ -96,6 +97,7 @@ describe('DotCMSBlockEditorRenderer', () => {
             const { getByTestId } = render(
                 <DotCMSBlockEditorRenderer
                     blocks={'Invalid blocks' as unknown as BlockEditorNode}
+                    isDevMode={true}
                 />
             );
 
@@ -108,7 +110,6 @@ describe('DotCMSBlockEditorRenderer', () => {
         });
 
         it('should not render error message in production mode when blocks are invalid', () => {
-            jest.spyOn(isDevModeHook, 'useIsDevMode').mockReturnValue(false);
             jest.spyOn(blockValidator, 'isValidBlocks').mockReturnValue({
                 error: 'Error: Blocks content is empty'
             });
@@ -133,12 +134,10 @@ describe('DotCMSBlockEditorRenderer', () => {
             expect(isValidBlocksSpy).toHaveBeenCalledWith(blocks);
         });
 
-        it('should update block state when blocks change', () => {
+        it('should validate updated blocks on rerender', () => {
             const isValidBlocksSpy = jest
                 .spyOn(blockValidator, 'isValidBlocks')
                 .mockReturnValue({ error: null });
-
-            const { rerender } = render(<DotCMSBlockEditorRenderer blocks={blocks} />);
 
             const updatedBlocks: BlockEditorNode = {
                 type: 'doc',
@@ -156,6 +155,7 @@ describe('DotCMSBlockEditorRenderer', () => {
                 ]
             };
 
+            const { rerender } = render(<DotCMSBlockEditorRenderer blocks={blocks} />);
             rerender(<DotCMSBlockEditorRenderer blocks={updatedBlocks} />);
 
             expect(isValidBlocksSpy).toHaveBeenCalledWith(updatedBlocks);

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/DotContent.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/DotContent.test.tsx
@@ -4,15 +4,10 @@ import { render, screen } from '@testing-library/react';
 import { BlockEditorNode } from '@dotcms/types';
 
 import { DotContent } from '../../components/DotCMSBlockEditorRenderer/components/blocks/DotContent';
-import * as hook from '../../hooks/useIsDevMode';
 
 const mockCustomRenderers = {
     KnownContentType: () => <div data-testid="known-content-type">Known Content</div>
 };
-
-jest.mock('../../hooks/useIsDevMode', () => ({
-    useIsDevMode: jest.fn().mockReturnValue(true)
-}));
 
 const mockNode: BlockEditorNode = {
     attrs: {
@@ -24,12 +19,6 @@ const mockNode: BlockEditorNode = {
 };
 
 describe('DotContent Component', () => {
-    let useIsDevModeSpy: jest.SpyInstance<boolean>;
-
-    beforeEach(() => {
-        useIsDevModeSpy = jest.spyOn(hook, 'useIsDevMode');
-    });
-
     it('should show the no data message when there is no data', () => {
         const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {
             /* empty function */
@@ -42,7 +31,9 @@ describe('DotContent Component', () => {
     });
 
     it('should call the UnknownContentType component in dev mode when there is no component', () => {
-        const { container } = render(<DotContent customRenderers={{}} node={mockNode} />);
+        const { container } = render(
+            <DotContent customRenderers={{}} node={mockNode} isDevMode={true} />
+        );
         const unknownContentType = container.querySelector(
             "div[data-testid='no-component-provided']"
         );
@@ -50,11 +41,12 @@ describe('DotContent Component', () => {
     });
 
     it('should show a warning and render nothing when there is no component in production mode', () => {
-        useIsDevModeSpy.mockReturnValue(false);
         const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {
             /* empty function */
         });
-        const { container } = render(<DotContent customRenderers={{}} node={mockNode} />);
+        const { container } = render(
+            <DotContent customRenderers={{}} node={mockNode} isDevMode={false} />
+        );
         expect(consoleWarnSpy).toHaveBeenCalledWith(
             '[DotCMSBlockEditorRenderer]: No matching component found for content type: KnownContentType. Provide a custom renderer for this content type to fix this error.'
         );

--- a/core-web/libs/sdk/react/src/lib/next/__test__/hook/useIsDevMode.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/hook/useIsDevMode.test.tsx
@@ -9,7 +9,7 @@ import { useIsDevMode } from '../../hooks/useIsDevMode';
 
 const Wrapper = ({ children, mode = 'production' }: any) => {
     return (
-        <DotCMSPageContext.Provider value={{ mode, pageAsset: {} as any, userComponents: {} }}>
+        <DotCMSPageContext.Provider value={{ mode, pageAsset: {} as any, userComponents: {}, slots: {} }}>
             {children}
         </DotCMSPageContext.Provider>
     );

--- a/core-web/libs/sdk/react/src/lib/next/__test__/hook/useIsDevMode.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/hook/useIsDevMode.test.tsx
@@ -9,7 +9,7 @@ import { useIsDevMode } from '../../hooks/useIsDevMode';
 
 const Wrapper = ({ children, mode = 'production' }: any) => {
     return (
-        <DotCMSPageContext.Provider value={{ mode, pageAsset: {} as any, userComponents: {}, slots: {} }}>
+        <DotCMSPageContext.Provider value={{ mode, pageAsset: {} as any, userComponents: {} }}>
             {children}
         </DotCMSPageContext.Provider>
     );

--- a/core-web/libs/sdk/react/src/lib/next/__test__/utils/buildSlots.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/utils/buildSlots.test.tsx
@@ -1,0 +1,62 @@
+import '@testing-library/jest-dom';
+
+import { buildSlots } from '../../utils/buildSlots';
+
+const makeContainers = (contentlets: object[]) => ({
+    'container-1': {
+        contentlets: {
+            'uuid-1': contentlets
+        }
+    }
+});
+
+describe('buildSlots', () => {
+    test('returns empty record when no server components provided', () => {
+        const containers = makeContainers([{ identifier: 'abc', contentType: 'Blog' }]);
+        const result = buildSlots(containers, {});
+        expect(result).toEqual({});
+    });
+
+    test('builds a slot for each contentlet matching a server component', () => {
+        const BlogComponent = ({ title }: any) => <div>{title}</div>;
+        const containers = makeContainers([
+            { identifier: 'id-1', contentType: 'Blog', title: 'Hello' }
+        ]);
+
+        const result = buildSlots(containers, { Blog: BlogComponent });
+        expect(result).toHaveProperty('id-1');
+    });
+
+    test('skips contentlets with no matching component type', () => {
+        const BlogComponent = () => <div />;
+        const containers = makeContainers([
+            { identifier: 'id-1', contentType: 'Blog' },
+            { identifier: 'id-2', contentType: 'News' }
+        ]);
+
+        const result = buildSlots(containers, { Blog: BlogComponent });
+        expect(result).toHaveProperty('id-1');
+        expect(result).not.toHaveProperty('id-2');
+    });
+
+    test('builds slots across multiple containers', () => {
+        const BlogComponent = () => <div />;
+        const containers = {
+            'container-1': {
+                contentlets: { 'uuid-1': [{ identifier: 'id-1', contentType: 'Blog' }] }
+            },
+            'container-2': {
+                contentlets: { 'uuid-2': [{ identifier: 'id-2', contentType: 'Blog' }] }
+            }
+        };
+
+        const result = buildSlots(containers, { Blog: BlogComponent });
+        expect(result).toHaveProperty('id-1');
+        expect(result).toHaveProperty('id-2');
+    });
+
+    test('returns empty record when containers is empty', () => {
+        const result = buildSlots({}, { Blog: () => <div /> });
+        expect(result).toEqual({});
+    });
+});

--- a/core-web/libs/sdk/react/src/lib/next/__test__/utils/buildSlots.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/utils/buildSlots.test.tsx
@@ -11,35 +11,56 @@ const makeContainers = (contentlets: object[]) => ({
 });
 
 describe('buildSlots', () => {
-    test('returns empty record when no server components provided', () => {
+    test('returns empty record when no server components provided', async () => {
         const containers = makeContainers([{ identifier: 'abc', contentType: 'Blog' }]);
-        const result = buildSlots(containers, {});
+        const result = await buildSlots(containers, {});
         expect(result).toEqual({});
     });
 
-    test('builds a slot for each contentlet matching a server component', () => {
-        const BlogComponent = ({ title }: any) => <div>{title}</div>;
+    test('builds a slot for each contentlet matching a server component', async () => {
+        const BlogComponent = ({ title }: { title: string }) => <div>{title}</div>;
         const containers = makeContainers([
             { identifier: 'id-1', contentType: 'Blog', title: 'Hello' }
         ]);
 
-        const result = buildSlots(containers, { Blog: BlogComponent });
+        const result = await buildSlots(containers, { Blog: BlogComponent });
         expect(result).toHaveProperty('id-1');
+        expect(result['id-1']).not.toBeNull();
     });
 
-    test('skips contentlets with no matching component type', () => {
+    test('resolves async server components', async () => {
+        const AsyncComponent = async ({ title }: { title: string }) => <div>{title}</div>;
+        const containers = makeContainers([
+            { identifier: 'id-async', contentType: 'Blog', title: 'Async' }
+        ]);
+
+        const result = await buildSlots(containers, { Blog: AsyncComponent });
+        expect(result).toHaveProperty('id-async');
+        expect(result['id-async']).not.toBeNull();
+    });
+
+    test('skips contentlets with no matching component type', async () => {
         const BlogComponent = () => <div />;
         const containers = makeContainers([
             { identifier: 'id-1', contentType: 'Blog' },
             { identifier: 'id-2', contentType: 'News' }
         ]);
 
-        const result = buildSlots(containers, { Blog: BlogComponent });
+        const result = await buildSlots(containers, { Blog: BlogComponent });
         expect(result).toHaveProperty('id-1');
         expect(result).not.toHaveProperty('id-2');
     });
 
-    test('builds slots across multiple containers', () => {
+    test('skips contentlets with undefined identifier', async () => {
+        const BlogComponent = () => <div />;
+        const containers = makeContainers([{ contentType: 'Blog' }]); // no identifier
+
+        const result = await buildSlots(containers, { Blog: BlogComponent });
+        expect(result).not.toHaveProperty('undefined');
+        expect(Object.keys(result)).toHaveLength(0);
+    });
+
+    test('builds slots across multiple containers', async () => {
         const BlogComponent = () => <div />;
         const containers = {
             'container-1': {
@@ -50,13 +71,13 @@ describe('buildSlots', () => {
             }
         };
 
-        const result = buildSlots(containers, { Blog: BlogComponent });
+        const result = await buildSlots(containers, { Blog: BlogComponent });
         expect(result).toHaveProperty('id-1');
         expect(result).toHaveProperty('id-2');
     });
 
-    test('returns empty record when containers is empty', () => {
-        const result = buildSlots({}, { Blog: () => <div /> });
+    test('returns empty record when containers is empty', async () => {
+        const result = await buildSlots({}, { Blog: () => <div /> });
         expect(result).toEqual({});
     });
 });

--- a/core-web/libs/sdk/react/src/lib/next/components/Container/Container.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Container/Container.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useContext, useMemo } from 'react';
 
 import { DotCMSBasicContentlet, DotCMSColumnContainer } from '@dotcms/types';

--- a/core-web/libs/sdk/react/src/lib/next/components/Container/ContainerFallbacks.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Container/ContainerFallbacks.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect } from 'react';
 
 import { DotContainerAttributes } from '@dotcms/types/internal';

--- a/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useContext, useMemo, useRef } from 'react';
 
 import { DotCMSBasicContentlet } from '@dotcms/types';
@@ -91,14 +93,7 @@ export function Contentlet({ contentlet, container }: DotCMSContentletRendererPr
  * @internal
  */
 function CustomComponent({ contentlet }: CustomComponentProps) {
-    const { userComponents, slots } = useContext(DotCMSPageContext);
-
-    const slotNode = slots[contentlet?.identifier];
-
-    if (slotNode !== undefined) {
-        return <>{slotNode}</>;
-    }
-
+    const { userComponents } = useContext(DotCMSPageContext);
     const UserComponent = userComponents[contentlet?.contentType];
 
     if (UserComponent) {

--- a/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
@@ -95,7 +95,7 @@ export function Contentlet({ contentlet, container }: DotCMSContentletRendererPr
 function CustomComponent({ contentlet }: CustomComponentProps) {
     const { userComponents, slots } = useContext(DotCMSPageContext);
 
-    const slotNode = slots[contentlet?.identifier];
+    const slotNode = slots?.[contentlet?.identifier];
 
     if (slotNode !== undefined) {
         return <>{slotNode}</>;

--- a/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
@@ -93,7 +93,14 @@ export function Contentlet({ contentlet, container }: DotCMSContentletRendererPr
  * @internal
  */
 function CustomComponent({ contentlet }: CustomComponentProps) {
-    const { userComponents } = useContext(DotCMSPageContext);
+    const { userComponents, slots } = useContext(DotCMSPageContext);
+
+    const slotNode = slots[contentlet?.identifier];
+
+    if (slotNode !== undefined) {
+        return <>{slotNode}</>;
+    }
+
     const UserComponent = userComponents[contentlet?.contentType];
 
     if (UserComponent) {

--- a/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
@@ -95,7 +95,7 @@ export function Contentlet({ contentlet, container }: DotCMSContentletRendererPr
 function CustomComponent({ contentlet }: CustomComponentProps) {
     const { userComponents, slots } = useContext(DotCMSPageContext);
 
-    const slotNode = slots?.[contentlet?.identifier];
+    const slotNode = contentlet?.identifier ? slots?.[contentlet.identifier] : undefined;
 
     if (slotNode !== undefined) {
         return <>{slotNode}</>;

--- a/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/Contentlet/Contentlet.tsx
@@ -91,7 +91,14 @@ export function Contentlet({ contentlet, container }: DotCMSContentletRendererPr
  * @internal
  */
 function CustomComponent({ contentlet }: CustomComponentProps) {
-    const { userComponents } = useContext(DotCMSPageContext);
+    const { userComponents, slots } = useContext(DotCMSPageContext);
+
+    const slotNode = slots[contentlet?.identifier];
+
+    if (slotNode !== undefined) {
+        return <>{slotNode}</>;
+    }
+
     const UserComponent = userComponents[contentlet?.contentType];
 
     if (UserComponent) {

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/DotCMSBlockEditorRenderer.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/DotCMSBlockEditorRenderer.tsx
@@ -1,12 +1,7 @@
-import { useEffect, useState } from 'react';
-
 import { BlockEditorNode } from '@dotcms/types';
-import { BlockEditorState } from '@dotcms/types/internal';
 import { isValidBlocks } from '@dotcms/uve/internal';
 
 import { BlockEditorBlock } from './components/BlockEditorBlock';
-
-import { useIsDevMode } from '../../hooks/useIsDevMode';
 
 /**
  * Props that all custom renderers must accept.
@@ -54,6 +49,7 @@ export interface BlockEditorRendererProps {
     style?: React.CSSProperties;
     className?: string;
     customRenderers?: CustomRenderer;
+    isDevMode?: boolean;
 }
 
 /**
@@ -71,35 +67,16 @@ export const DotCMSBlockEditorRenderer = ({
     blocks,
     style,
     className,
-    customRenderers
+    customRenderers,
+    isDevMode = false
 }: BlockEditorRendererProps) => {
-    const [blockEditorState, setBlockEditorState] = useState<BlockEditorState>({ error: null });
-    const isDevMode = useIsDevMode();
+    const validationResult = isValidBlocks(blocks);
 
-    /**
-     * Validates the blocks structure and updates the block editor state.
-     *
-     * This effect:
-     * 1. Validates that blocks have the correct structure (doc type, content array, etc)
-     * 2. Updates the block editor state with validation result
-     * 3. Logs any validation errors to console
-     *
-     * @dependency {Block} blocks - The content blocks to validate
-     */
-    useEffect(() => {
-        const validationResult = isValidBlocks(blocks);
-        setBlockEditorState(validationResult);
-
-        if (validationResult.error) {
-            console.error(validationResult.error);
-        }
-    }, [blocks]);
-
-    if (blockEditorState.error) {
-        console.error(blockEditorState.error);
+    if (validationResult.error) {
+        console.error(validationResult.error);
 
         if (isDevMode) {
-            return <div data-testid="invalid-blocks-message">{blockEditorState.error}</div>;
+            return <div data-testid="invalid-blocks-message">{validationResult.error}</div>;
         }
 
         return null;
@@ -107,7 +84,11 @@ export const DotCMSBlockEditorRenderer = ({
 
     return (
         <div className={className} style={style} data-testid="dot-block-editor-container">
-            <BlockEditorBlock content={blocks?.content} customRenderers={customRenderers} />
+            <BlockEditorBlock
+                content={blocks?.content}
+                customRenderers={customRenderers}
+                isDevMode={isDevMode}
+            />
         </div>
     );
 };

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/BlockEditorBlock.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/BlockEditorBlock.tsx
@@ -16,6 +16,7 @@ import { CustomRenderer } from '../DotCMSBlockEditorRenderer';
 interface BlockEditorBlockProps {
     content: BlockEditorNode[] | undefined;
     customRenderers?: CustomRenderer;
+    isDevMode?: boolean;
 }
 
 /**
@@ -25,7 +26,11 @@ interface BlockEditorBlockProps {
  * @param customRenderers - Optional custom renderers for specific node types.
  * @returns The rendered block editor item.
  */
-export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockProps) => {
+export const BlockEditorBlock = ({
+    content,
+    customRenderers,
+    isDevMode
+}: BlockEditorBlockProps) => {
     if (!content) {
         return null;
     }
@@ -37,7 +42,11 @@ export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockP
         if (CustomRendererComponent) {
             return (
                 <CustomRendererComponent key={key} node={node}>
-                    <BlockEditorBlock content={node.content} customRenderers={customRenderers} />
+                    <BlockEditorBlock
+                        content={node.content}
+                        customRenderers={customRenderers}
+                        isDevMode={isDevMode}
+                    />
                 </CustomRendererComponent>
             );
         }
@@ -49,6 +58,7 @@ export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockP
                         <BlockEditorBlock
                             content={node.content}
                             customRenderers={customRenderers}
+                            isDevMode={isDevMode}
                         />
                     </Paragraph>
                 );
@@ -59,6 +69,7 @@ export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockP
                         <BlockEditorBlock
                             content={node.content}
                             customRenderers={customRenderers}
+                            isDevMode={isDevMode}
                         />
                     </Heading>
                 );
@@ -72,6 +83,7 @@ export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockP
                         <BlockEditorBlock
                             content={node.content}
                             customRenderers={customRenderers}
+                            isDevMode={isDevMode}
                         />
                     </BulletList>
                 );
@@ -82,6 +94,7 @@ export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockP
                         <BlockEditorBlock
                             content={node.content}
                             customRenderers={customRenderers}
+                            isDevMode={isDevMode}
                         />
                     </OrderedList>
                 );
@@ -92,6 +105,7 @@ export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockP
                         <BlockEditorBlock
                             content={node.content}
                             customRenderers={customRenderers}
+                            isDevMode={isDevMode}
                         />
                     </ListItem>
                 );
@@ -102,6 +116,7 @@ export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockP
                         <BlockEditorBlock
                             content={node.content}
                             customRenderers={customRenderers}
+                            isDevMode={isDevMode}
                         />
                     </BlockQuote>
                 );
@@ -112,6 +127,7 @@ export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockP
                         <BlockEditorBlock
                             content={node.content}
                             customRenderers={customRenderers}
+                            isDevMode={isDevMode}
                         />
                     </CodeBlock>
                 );
@@ -153,6 +169,7 @@ export const BlockEditorBlock = ({ content, customRenderers }: BlockEditorBlockP
                         key={key}
                         customRenderers={customRenderers as CustomRenderer}
                         node={node}
+                        isDevMode={isDevMode}
                     />
                 );
 

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/DotContent.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/DotContent.tsx
@@ -2,12 +2,12 @@ import { BlockEditorNode } from '@dotcms/types';
 
 import { NoComponentProvided } from './NoComponentProvided';
 
-import { useIsDevMode } from '../../../../hooks/useIsDevMode';
 import { CustomRenderer } from '../../DotCMSBlockEditorRenderer';
 
 interface DotContentProps {
     customRenderers?: CustomRenderer;
     node: BlockEditorNode;
+    isDevMode?: boolean;
 }
 
 const DOT_CONTENT_NO_DATA_MESSAGE =
@@ -22,8 +22,7 @@ const DOT_CONTENT_NO_MATCHING_COMPONENT_MESSAGE = (contentType: string) =>
  * @param {DotContentProps} props - The props for the DotContent component.
  * @returns {JSX.Element} The rendered DotContent component.
  */
-export const DotContent = ({ customRenderers, node }: DotContentProps) => {
-    const isDevMode = useIsDevMode();
+export const DotContent = ({ customRenderers, node, isDevMode = false }: DotContentProps) => {
     const { attrs = {} } = node;
     const { data } = attrs;
 

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
@@ -1,10 +1,8 @@
-import { ReactNode } from 'react';
-
 import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '@dotcms/types';
 
 import { ErrorMessage } from './components/ErrorMessage';
+import { DotCMSPageProvider } from './DotCMSPageProvider';
 
-import { DotCMSPageContext } from '../../contexts/DotCMSPageContext';
 import { Row } from '../Row/Row';
 
 export interface DotCMSLayoutBodyProps<
@@ -16,25 +14,6 @@ export interface DotCMSLayoutBodyProps<
         [key: string]: React.ComponentType<TContentlet> | React.ComponentType<any>;
     };
     mode?: DotCMSPageRendererMode;
-    /**
-     * Pre-rendered server component nodes keyed by contentlet identifier.
-     * Use this to render Next.js server components (async components) within the layout.
-     * When a contentlet's identifier matches a key in this map, the pre-rendered node
-     * is used instead of looking up a component in `components`.
-     *
-     * @example
-     * ```tsx
-     * // Server component (page.tsx)
-     * const slots = {
-     *   [blogListContentlet.identifier]: <BlogListContainer {...blogListContentlet} />
-     * };
-     * <Page pageContent={pageContent} slots={slots} />
-     *
-     * // Client component (Page.tsx)
-     * <DotCMSLayoutBody page={pageAsset} components={pageComponents} slots={slots} />
-     * ```
-     */
-    slots?: Record<string, ReactNode>;
 }
 
 /**
@@ -43,13 +22,15 @@ export interface DotCMSLayoutBodyProps<
  * It utilizes the dotCMS page asset's layout body to render the page body.
  * If the layout body does not exist, it renders an error message in the mode is `development`.
  *
+ * This is a server component. Client-side interactivity (UVE editing, hooks) is handled
+ * by child components that are individually marked with "use client".
+ *
  * @public
  * @component
  * @param {Object} props - Component properties.
  * @param {DotCMSPageAsset} props.page - The DotCMS page asset containing the layout information.
  * @param {Record<string, React.ComponentType<DotCMSContentlet>>} [props.components] - mapping of custom components for content rendering.
  * @param {DotCMSPageRendererMode} [props.mode='production'] - The renderer mode; defaults to 'production'. Alternate modes might trigger different behaviors.
- * @param {Record<string, ReactNode>} [props.slots] - Pre-rendered server component nodes keyed by contentlet identifier.
  *
  * @returns {JSX.Element} The rendered DotCMS page body or an error message if the layout body is missing.
  *
@@ -57,25 +38,17 @@ export interface DotCMSLayoutBodyProps<
 export const DotCMSLayoutBody = ({
     page,
     components = {},
-    mode = 'production',
-    slots = {}
+    mode = 'production'
 }: DotCMSLayoutBodyProps) => {
     const dotCMSPageBody = page?.layout?.body;
 
-    const contextValue = {
-        pageAsset: page,
-        userComponents: components,
-        mode,
-        slots
-    };
-
     return (
-        <DotCMSPageContext.Provider value={contextValue}>
+        <DotCMSPageProvider page={page} components={components} mode={mode}>
             {dotCMSPageBody ? (
                 dotCMSPageBody.rows.map((row, index) => <Row key={index} row={row} />)
             ) : (
                 <ErrorMessage />
             )}
-        </DotCMSPageContext.Provider>
+        </DotCMSPageProvider>
     );
 };

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '@dotcms/types';
 
 import { ErrorMessage } from './components/ErrorMessage';
@@ -14,6 +16,23 @@ export interface DotCMSLayoutBodyProps<
         [key: string]: React.ComponentType<TContentlet> | React.ComponentType<any>;
     };
     mode?: DotCMSPageRendererMode;
+    /**
+     * Pre-rendered server component nodes keyed by contentlet identifier.
+     * Use this to render Next.js async server components within the layout.
+     * Build this map using the `buildSlots` helper.
+     *
+     * @example
+     * ```tsx
+     * import { buildSlots } from '@dotcms/react';
+     *
+     * const slots = buildSlots(pageContent.pageAsset.containers, {
+     *   BlogList: BlogListContainer,
+     * });
+     *
+     * <DotCMSLayoutBody page={pageAsset} components={pageComponents} slots={slots} />
+     * ```
+     */
+    slots?: Record<string, ReactNode>;
 }
 
 /**
@@ -22,15 +41,13 @@ export interface DotCMSLayoutBodyProps<
  * It utilizes the dotCMS page asset's layout body to render the page body.
  * If the layout body does not exist, it renders an error message in the mode is `development`.
  *
- * This is a server component. Client-side interactivity (UVE editing, hooks) is handled
- * by child components that are individually marked with "use client".
- *
  * @public
  * @component
  * @param {Object} props - Component properties.
  * @param {DotCMSPageAsset} props.page - The DotCMS page asset containing the layout information.
  * @param {Record<string, React.ComponentType<DotCMSContentlet>>} [props.components] - mapping of custom components for content rendering.
  * @param {DotCMSPageRendererMode} [props.mode='production'] - The renderer mode; defaults to 'production'. Alternate modes might trigger different behaviors.
+ * @param {Record<string, ReactNode>} [props.slots] - Pre-rendered server component nodes keyed by contentlet identifier.
  *
  * @returns {JSX.Element} The rendered DotCMS page body or an error message if the layout body is missing.
  *
@@ -38,12 +55,13 @@ export interface DotCMSLayoutBodyProps<
 export const DotCMSLayoutBody = ({
     page,
     components = {},
-    mode = 'production'
+    mode = 'production',
+    slots = {}
 }: DotCMSLayoutBodyProps) => {
     const dotCMSPageBody = page?.layout?.body;
 
     return (
-        <DotCMSPageProvider page={page} components={components} mode={mode}>
+        <DotCMSPageProvider page={page} components={components} mode={mode} slots={slots}>
             {dotCMSPageBody ? (
                 dotCMSPageBody.rows.map((row, index) => <Row key={index} row={row} />)
             ) : (

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '@dotcms/types';
 
 import { ErrorMessage } from './components/ErrorMessage';
@@ -14,6 +16,25 @@ export interface DotCMSLayoutBodyProps<
         [key: string]: React.ComponentType<TContentlet> | React.ComponentType<any>;
     };
     mode?: DotCMSPageRendererMode;
+    /**
+     * Pre-rendered server component nodes keyed by contentlet identifier.
+     * Use this to render Next.js server components (async components) within the layout.
+     * When a contentlet's identifier matches a key in this map, the pre-rendered node
+     * is used instead of looking up a component in `components`.
+     *
+     * @example
+     * ```tsx
+     * // Server component (page.tsx)
+     * const slots = {
+     *   [blogListContentlet.identifier]: <BlogListContainer {...blogListContentlet} />
+     * };
+     * <Page pageContent={pageContent} slots={slots} />
+     *
+     * // Client component (Page.tsx)
+     * <DotCMSLayoutBody page={pageAsset} components={pageComponents} slots={slots} />
+     * ```
+     */
+    slots?: Record<string, ReactNode>;
 }
 
 /**
@@ -28,6 +49,7 @@ export interface DotCMSLayoutBodyProps<
  * @param {DotCMSPageAsset} props.page - The DotCMS page asset containing the layout information.
  * @param {Record<string, React.ComponentType<DotCMSContentlet>>} [props.components] - mapping of custom components for content rendering.
  * @param {DotCMSPageRendererMode} [props.mode='production'] - The renderer mode; defaults to 'production'. Alternate modes might trigger different behaviors.
+ * @param {Record<string, ReactNode>} [props.slots] - Pre-rendered server component nodes keyed by contentlet identifier.
  *
  * @returns {JSX.Element} The rendered DotCMS page body or an error message if the layout body is missing.
  *
@@ -35,14 +57,16 @@ export interface DotCMSLayoutBodyProps<
 export const DotCMSLayoutBody = ({
     page,
     components = {},
-    mode = 'production'
+    mode = 'production',
+    slots = {}
 }: DotCMSLayoutBodyProps) => {
     const dotCMSPageBody = page?.layout?.body;
 
     const contextValue = {
         pageAsset: page,
         userComponents: components,
-        mode
+        mode,
+        slots
     };
 
     return (

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
@@ -32,7 +32,7 @@ export interface DotCMSLayoutBodyProps<
      * <DotCMSLayoutBody page={pageAsset} components={pageComponents} slots={slots} />
      * ```
      */
-    slots?: Record<string, ReactNode>;
+    slots?: Record<string, ReactNode | Promise<ReactNode>>;
 }
 
 /**

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSLayoutBody.tsx
@@ -32,7 +32,7 @@ export interface DotCMSLayoutBodyProps<
      * <DotCMSLayoutBody page={pageAsset} components={pageComponents} slots={slots} />
      * ```
      */
-    slots?: Record<string, ReactNode | Promise<ReactNode>>;
+    slots?: Record<string, ReactNode>;
 }
 
 /**

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+import { DotCMSPageAsset, DotCMSPageRendererMode } from '@dotcms/types';
+
+import { DotCMSPageContext } from '../../contexts/DotCMSPageContext';
+
+interface DotCMSPageProviderProps {
+    page: DotCMSPageAsset;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    components: Record<string, React.ComponentType<any>>;
+    mode: DotCMSPageRendererMode;
+    children: ReactNode;
+}
+
+/**
+ * @internal
+ *
+ * Client boundary that provides the DotCMS page context to the layout tree.
+ * Keeping this separate from DotCMSLayoutBody allows the layout to remain
+ * a server component while only the context provider runs on the client.
+ */
+export function DotCMSPageProvider({ page, components, mode, children }: DotCMSPageProviderProps) {
+    return (
+        <DotCMSPageContext.Provider value={{ pageAsset: page, userComponents: components, mode }}>
+            {children}
+        </DotCMSPageContext.Provider>
+    );
+}

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
@@ -22,9 +22,16 @@ interface DotCMSPageProviderProps {
  * Keeping this separate from DotCMSLayoutBody allows the layout to remain
  * a server component while only the context provider runs on the client.
  */
-export function DotCMSPageProvider({ page, components, mode, slots, children }: DotCMSPageProviderProps) {
+export function DotCMSPageProvider({
+    page,
+    components,
+    mode,
+    slots,
+    children
+}: DotCMSPageProviderProps) {
     return (
-        <DotCMSPageContext.Provider value={{ pageAsset: page, userComponents: components, mode, slots }}>
+        <DotCMSPageContext.Provider
+            value={{ pageAsset: page, userComponents: components, mode, slots }}>
             {children}
         </DotCMSPageContext.Provider>
     );

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
@@ -11,7 +11,7 @@ interface DotCMSPageProviderProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     components: Record<string, React.ComponentType<any>>;
     mode: DotCMSPageRendererMode;
-    slots: Record<string, ReactNode>;
+    slots: Record<string, ReactNode | Promise<ReactNode>>;
     children: ReactNode;
 }
 

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
@@ -11,6 +11,7 @@ interface DotCMSPageProviderProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     components: Record<string, React.ComponentType<any>>;
     mode: DotCMSPageRendererMode;
+    slots: Record<string, ReactNode>;
     children: ReactNode;
 }
 
@@ -21,9 +22,9 @@ interface DotCMSPageProviderProps {
  * Keeping this separate from DotCMSLayoutBody allows the layout to remain
  * a server component while only the context provider runs on the client.
  */
-export function DotCMSPageProvider({ page, components, mode, children }: DotCMSPageProviderProps) {
+export function DotCMSPageProvider({ page, components, mode, slots, children }: DotCMSPageProviderProps) {
     return (
-        <DotCMSPageContext.Provider value={{ pageAsset: page, userComponents: components, mode }}>
+        <DotCMSPageContext.Provider value={{ pageAsset: page, userComponents: components, mode, slots }}>
             {children}
         </DotCMSPageContext.Provider>
     );

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
@@ -11,7 +11,7 @@ interface DotCMSPageProviderProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     components: Record<string, React.ComponentType<any>>;
     mode: DotCMSPageRendererMode;
-    slots: Record<string, ReactNode>;
+    slots?: Record<string, ReactNode>;
     children: ReactNode;
 }
 

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/DotCMSPageProvider.tsx
@@ -11,7 +11,7 @@ interface DotCMSPageProviderProps {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     components: Record<string, React.ComponentType<any>>;
     mode: DotCMSPageRendererMode;
-    slots: Record<string, ReactNode | Promise<ReactNode>>;
+    slots: Record<string, ReactNode>;
     children: ReactNode;
 }
 

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/components/ErrorMessage.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSLayoutBody/components/ErrorMessage.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useEffect } from 'react';
 
 import { useIsDevMode } from '../../../hooks/useIsDevMode';

--- a/core-web/libs/sdk/react/src/lib/next/components/FallbackComponent/FallbackComponent.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/FallbackComponent/FallbackComponent.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { DotCMSBasicContentlet } from '@dotcms/types';
 
 import { useIsDevMode } from '../../hooks/useIsDevMode';

--- a/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext } from 'react';
+import { createContext } from 'react';
 
 import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '@dotcms/types';
 
@@ -10,13 +10,11 @@ import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '
  * @property {DotCMSPageAsset} pageAsset - The DotCMS page asset
  * @property {RendererMode} mode - The renderer mode
  * @property {Record<string, React.ComponentType<DotCMSContentlet>>} userComponents - The user components
- * @property {Record<string, ReactNode>} slots - Pre-rendered server component nodes keyed by contentlet identifier
  */
 export interface DotCMSPageContextProps {
     pageAsset: DotCMSPageAsset;
     mode: DotCMSPageRendererMode;
     userComponents: Record<string, React.ComponentType<DotCMSBasicContentlet>>;
-    slots: Record<string, ReactNode>;
 }
 
 /**
@@ -27,6 +25,5 @@ export interface DotCMSPageContextProps {
 export const DotCMSPageContext = createContext<DotCMSPageContextProps>({
     pageAsset: {} as DotCMSPageAsset,
     mode: 'production',
-    userComponents: {},
-    slots: {}
+    userComponents: {}
 });

--- a/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
@@ -1,4 +1,6 @@
-import { createContext } from 'react';
+'use client';
+
+import { ReactNode, createContext } from 'react';
 
 import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '@dotcms/types';
 
@@ -10,11 +12,13 @@ import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '
  * @property {DotCMSPageAsset} pageAsset - The DotCMS page asset
  * @property {RendererMode} mode - The renderer mode
  * @property {Record<string, React.ComponentType<DotCMSContentlet>>} userComponents - The user components
+ * @property {Record<string, ReactNode>} slots - Pre-rendered server component nodes keyed by contentlet identifier
  */
 export interface DotCMSPageContextProps {
     pageAsset: DotCMSPageAsset;
     mode: DotCMSPageRendererMode;
     userComponents: Record<string, React.ComponentType<DotCMSBasicContentlet>>;
+    slots: Record<string, ReactNode>;
 }
 
 /**
@@ -25,5 +29,6 @@ export interface DotCMSPageContextProps {
 export const DotCMSPageContext = createContext<DotCMSPageContextProps>({
     pageAsset: {} as DotCMSPageAsset,
     mode: 'production',
-    userComponents: {}
+    userComponents: {},
+    slots: {}
 });

--- a/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
@@ -1,4 +1,4 @@
-import { createContext } from 'react';
+import { ReactNode, createContext } from 'react';
 
 import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '@dotcms/types';
 
@@ -10,11 +10,13 @@ import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '
  * @property {DotCMSPageAsset} pageAsset - The DotCMS page asset
  * @property {RendererMode} mode - The renderer mode
  * @property {Record<string, React.ComponentType<DotCMSContentlet>>} userComponents - The user components
+ * @property {Record<string, ReactNode>} slots - Pre-rendered server component nodes keyed by contentlet identifier
  */
 export interface DotCMSPageContextProps {
     pageAsset: DotCMSPageAsset;
     mode: DotCMSPageRendererMode;
     userComponents: Record<string, React.ComponentType<DotCMSBasicContentlet>>;
+    slots: Record<string, ReactNode>;
 }
 
 /**
@@ -25,5 +27,6 @@ export interface DotCMSPageContextProps {
 export const DotCMSPageContext = createContext<DotCMSPageContextProps>({
     pageAsset: {} as DotCMSPageAsset,
     mode: 'production',
-    userComponents: {}
+    userComponents: {},
+    slots: {}
 });

--- a/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
@@ -12,13 +12,13 @@ import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '
  * @property {DotCMSPageAsset} pageAsset - The DotCMS page asset
  * @property {RendererMode} mode - The renderer mode
  * @property {Record<string, React.ComponentType<DotCMSContentlet>>} userComponents - The user components
- * @property {Record<string, ReactNode>} slots - Pre-rendered server component nodes keyed by contentlet identifier
+ * @property {Record<string, ReactNode | Promise<ReactNode>>} [slots] - Pre-rendered server component nodes keyed by contentlet identifier
  */
 export interface DotCMSPageContextProps {
     pageAsset: DotCMSPageAsset;
     mode: DotCMSPageRendererMode;
     userComponents: Record<string, React.ComponentType<DotCMSBasicContentlet>>;
-    slots?: Record<string, ReactNode>;
+    slots?: Record<string, ReactNode | Promise<ReactNode>>;
 }
 
 /**

--- a/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
@@ -18,7 +18,7 @@ export interface DotCMSPageContextProps {
     pageAsset: DotCMSPageAsset;
     mode: DotCMSPageRendererMode;
     userComponents: Record<string, React.ComponentType<DotCMSBasicContentlet>>;
-    slots: Record<string, ReactNode>;
+    slots?: Record<string, ReactNode>;
 }
 
 /**

--- a/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/contexts/DotCMSPageContext.tsx
@@ -12,13 +12,13 @@ import { DotCMSBasicContentlet, DotCMSPageAsset, DotCMSPageRendererMode } from '
  * @property {DotCMSPageAsset} pageAsset - The DotCMS page asset
  * @property {RendererMode} mode - The renderer mode
  * @property {Record<string, React.ComponentType<DotCMSContentlet>>} userComponents - The user components
- * @property {Record<string, ReactNode | Promise<ReactNode>>} [slots] - Pre-rendered server component nodes keyed by contentlet identifier
+ * @property {Record<string, ReactNode>} [slots] - Pre-rendered server component nodes keyed by contentlet identifier
  */
 export interface DotCMSPageContextProps {
     pageAsset: DotCMSPageAsset;
     mode: DotCMSPageRendererMode;
     userComponents: Record<string, React.ComponentType<DotCMSBasicContentlet>>;
-    slots?: Record<string, ReactNode | Promise<ReactNode>>;
+    slots?: Record<string, ReactNode>;
 }
 
 /**

--- a/core-web/libs/sdk/react/src/lib/next/utils/buildSlots.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/utils/buildSlots.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from 'react';
+
+import { DotCMSBasicContentlet, DotCMSPageAssetContainers } from '@dotcms/types';
+
+/**
+ * Builds a slots map of pre-rendered server component nodes keyed by contentlet identifier.
+ *
+ * Use this in Next.js server components to render async server components
+ * (e.g., components that fetch data) within a DotCMS page layout. Pass the
+ * resulting map to `DotCMSLayoutBody` via the `slots` prop.
+ *
+ * @public
+ * @param containers - The containers map from `pageAsset.containers`
+ * @param serverComponents - A map of content type names to async server components
+ * @returns A record mapping contentlet identifiers to pre-rendered ReactNodes
+ *
+ * @example
+ * ```tsx
+ * const slots = buildSlots(pageContent.pageAsset.containers, {
+ *   BlogList: BlogListContainer,
+ * });
+ *
+ * <DotCMSLayoutBody page={pageAsset} components={pageComponents} slots={slots} />
+ * ```
+ */
+export function buildSlots(
+    containers: DotCMSPageAssetContainers,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    serverComponents: Record<string, React.ComponentType<any>>
+): Record<string, ReactNode> {
+    const slots: Record<string, ReactNode> = {};
+
+    for (const { contentlets } of Object.values(containers)) {
+        for (const contentletList of Object.values(contentlets)) {
+            for (const contentlet of contentletList) {
+                const Component = serverComponents[contentlet.contentType];
+
+                if (Component) {
+                    slots[contentlet.identifier] = (
+                        <Component {...(contentlet as DotCMSBasicContentlet)} />
+                    );
+                }
+            }
+        }
+    }
+
+    return slots;
+}

--- a/core-web/libs/sdk/react/src/lib/next/utils/buildSlots.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/utils/buildSlots.tsx
@@ -25,20 +25,20 @@ import { DotCMSBasicContentlet, DotCMSPageAssetContainers } from '@dotcms/types'
  */
 export function buildSlots(
     containers: DotCMSPageAssetContainers,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    serverComponents: Record<string, React.ComponentType<any>>
-): Record<string, ReactNode> {
-    const slots: Record<string, ReactNode> = {};
+    serverComponents: Record<
+        string,
+        (props: DotCMSBasicContentlet) => ReactNode | Promise<ReactNode>
+    >
+): Record<string, ReactNode | Promise<ReactNode>> {
+    const slots: Record<string, ReactNode | Promise<ReactNode>> = {};
 
     for (const { contentlets } of Object.values(containers)) {
         for (const contentletList of Object.values(contentlets)) {
             for (const contentlet of contentletList) {
                 const Component = serverComponents[contentlet.contentType];
 
-                if (Component) {
-                    slots[contentlet.identifier] = (
-                        <Component {...(contentlet as DotCMSBasicContentlet)} />
-                    );
+                if (Component && contentlet.identifier) {
+                    slots[contentlet.identifier] = Component(contentlet as DotCMSBasicContentlet);
                 }
             }
         }

--- a/core-web/libs/sdk/react/src/lib/next/utils/buildSlots.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/utils/buildSlots.tsx
@@ -9,28 +9,31 @@ import { DotCMSBasicContentlet, DotCMSPageAssetContainers } from '@dotcms/types'
  * (e.g., components that fetch data) within a DotCMS page layout. Pass the
  * resulting map to `DotCMSLayoutBody` via the `slots` prop.
  *
+ * Each component is awaited, so the returned record contains resolved `ReactNode`
+ * values — safe to pass as props to client components without `React.use()`.
+ *
  * @public
  * @param containers - The containers map from `pageAsset.containers`
  * @param serverComponents - A map of content type names to async server components
- * @returns A record mapping contentlet identifiers to pre-rendered ReactNodes
+ * @returns A promise resolving to a record mapping contentlet identifiers to pre-rendered ReactNodes
  *
  * @example
  * ```tsx
- * const slots = buildSlots(pageContent.pageAsset.containers, {
+ * const slots = await buildSlots(pageContent.pageAsset.containers, {
  *   BlogList: BlogListContainer,
  * });
  *
  * <DotCMSLayoutBody page={pageAsset} components={pageComponents} slots={slots} />
  * ```
  */
-export function buildSlots(
+export async function buildSlots(
     containers: DotCMSPageAssetContainers,
     serverComponents: Record<
         string,
         (props: DotCMSBasicContentlet) => ReactNode | Promise<ReactNode>
     >
-): Record<string, ReactNode | Promise<ReactNode>> {
-    const slots: Record<string, ReactNode | Promise<ReactNode>> = {};
+): Promise<Record<string, ReactNode>> {
+    const slots: Record<string, ReactNode> = {};
 
     for (const { contentlets } of Object.values(containers)) {
         for (const contentletList of Object.values(contentlets)) {
@@ -38,7 +41,9 @@ export function buildSlots(
                 const Component = serverComponents[contentlet.contentType];
 
                 if (Component && contentlet.identifier) {
-                    slots[contentlet.identifier] = Component(contentlet as DotCMSBasicContentlet);
+                    slots[contentlet.identifier] = await Component(
+                        contentlet as DotCMSBasicContentlet
+                    );
                 }
             }
         }

--- a/core-web/package.json
+++ b/core-web/package.json
@@ -255,6 +255,7 @@
         "react-test-renderer": "18.2.0",
         "rollup": "4.14.0",
         "rollup-plugin-postcss": "4.0.2",
+        "rollup-plugin-preserve-directives": "^0.4.0",
         "sass": "1.56.2",
         "storybook": "10.2.9",
         "ts-jest": "29.4.6",

--- a/core-web/package.json
+++ b/core-web/package.json
@@ -255,7 +255,7 @@
         "react-test-renderer": "18.2.0",
         "rollup": "4.14.0",
         "rollup-plugin-postcss": "4.0.2",
-        "rollup-plugin-preserve-directives": "^0.4.0",
+        "rollup-plugin-preserve-directives": "0.4.0",
         "sass": "1.56.2",
         "storybook": "10.2.9",
         "ts-jest": "29.4.6",

--- a/core-web/yarn.lock
+++ b/core-web/yarn.lock
@@ -19294,7 +19294,7 @@ rollup-plugin-postcss@4.0.2, rollup-plugin-postcss@^4.0.2:
     safe-identifier "^0.4.2"
     style-inject "^0.3.0"
 
-rollup-plugin-preserve-directives@^0.4.0:
+rollup-plugin-preserve-directives@0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/rollup-plugin-preserve-directives/-/rollup-plugin-preserve-directives-0.4.0.tgz#5e22f448a49b8aa28898d151e7a707b0eab15a6e"
   integrity sha512-gx4nBxYm5BysmEQS+e2tAMrtFxrGvk+Pe5ppafRibQi0zlW7VYAbEGk6IKDw9sJGPdFWgVTE0o4BU4cdG0Fylg==
@@ -20343,16 +20343,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -20469,14 +20460,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -22147,7 +22131,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -22160,15 +22144,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/core-web/yarn.lock
+++ b/core-web/yarn.lock
@@ -19294,6 +19294,14 @@ rollup-plugin-postcss@4.0.2, rollup-plugin-postcss@^4.0.2:
     safe-identifier "^0.4.2"
     style-inject "^0.3.0"
 
+rollup-plugin-preserve-directives@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/rollup-plugin-preserve-directives/-/rollup-plugin-preserve-directives-0.4.0.tgz#5e22f448a49b8aa28898d151e7a707b0eab15a6e"
+  integrity sha512-gx4nBxYm5BysmEQS+e2tAMrtFxrGvk+Pe5ppafRibQi0zlW7VYAbEGk6IKDw9sJGPdFWgVTE0o4BU4cdG0Fylg==
+  dependencies:
+    "@rollup/pluginutils" "^5.1.0"
+    magic-string "^0.30.5"
+
 rollup-plugin-typescript2@^0.36.0:
   version "0.36.0"
   resolved "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.36.0.tgz#309564eb70d710412f5901344ca92045e180ed53"

--- a/examples/nextjs/src/app/[[...slug]]/page.js
+++ b/examples/nextjs/src/app/[[...slug]]/page.js
@@ -2,6 +2,7 @@ import NotFound from "@/app/not-found";
 import { Page } from "@/views/Page";
 import { getDotCMSPage } from "@/utils/getDotCMSPage";
 
+
 export async function generateMetadata(props) {
     const params = await props.params;
     try {

--- a/examples/nextjs/src/components/content-types/Banner.js
+++ b/examples/nextjs/src/components/content-types/Banner.js
@@ -1,10 +1,12 @@
+"use client";
+
 import { DotCMSEditableText } from "@dotcms/react";
 import Image from "next/image";
 import Link from "next/link";
 
 function Banner(contentlet) {
     const { title, caption, inode, image, link, buttonText, dotStyleProperties } = contentlet;
-    
+
     // Extract style properties with defaults
     const titleSize = dotStyleProperties?.["title-size"] || "text-6xl"
     const captionSize = dotStyleProperties?.["caption-size"] || "text-xl"

--- a/examples/nextjs/src/components/content-types/index.js
+++ b/examples/nextjs/src/components/content-types/index.js
@@ -7,7 +7,6 @@ import CallToAction from "./CallToAction";
 import CategoryFilter from "./CategoryFilter";
 import SimpleWidget from "./SimpleWidget";
 import ImageComponent from "./Image";
-import PageForm from "./PageForm";
 import Product from "./Product";
 import StoreProductList from "./StoreProductList";
 import VtlInclude from "./VtlInclude";
@@ -23,7 +22,6 @@ export const pageComponents = {
     CategoryFilter: CategoryFilter,
     CustomNoComponent: CustomNoComponent,
     Image: ImageComponent,
-    PageForm: PageForm,
     Product: Product,
     SimpleWidget: SimpleWidget,
     StoreProductList: StoreProductList,


### PR DESCRIPTION


https://github.com/user-attachments/assets/92906cec-0b87-4550-9c11-a0d444e3abf7



**Problem**

Importing `@dotcms/react` in a Next.js server component crashed the build — TinyMCE pulls in browser-only APIs (`document`, `window`) that don't exist in the RSC runtime. There was also no way to render async server components inside the dotCMS page layout.

**Solution: `react-server` export condition**

What that hell is that?

> The react-server export condition is a feature used in React Server Components (RSC) environments that allows a package author to provide different entry points for their module depending on whether it is being imported in a server or client environment

Added `index.server.ts` — a server-safe entry that excludes TinyMCE and any hooks using `useState`/`useEffect`. Next.js (and any bundler that respects the Node.js exports conditions spec) automatically resolves this entry when bundling server components. **No import path change needed** — `import { X } from '@dotcms/react'` just works on both sides. This is the same pattern used by React itself, `react-query`, `zustand`, and others to ship server-safe builds.

**`slots` + `buildSlots`**

Lets you pre-render async server components on the server and inject them into the client-rendered page layout:

```tsx
// page.tsx (server component)
const slots = await buildSlots(pageAsset, { Banner: AsyncBannerComponent });
return <PageView pageContent={pageContent} slots={slots} />;

// PageView.tsx ("use client")
export function PageView({ pageContent, slots }) {
    const { pageAsset } = useEditableDotCMSPage(pageContent);
    return <DotCMSLayoutBody page={pageAsset} components={pageComponents} slots={slots} />;
}
```

When a slot exists for a contentlet, it renders the pre-built `ReactNode` instead of going through `userComponents`.

**`DotCMSBlockEditorRenderer` — now server-compatible**

Removed `useState`/`useEffect` for block validation. Validation is now synchronous, `isDevMode` is a prop:

```tsx
// Works directly in a server page — no client wrapper needed
<DotCMSBlockEditorRenderer
    blocks={blocks}
    isDevMode={process.env.NODE_ENV === 'development'}
/>
```

**Other fixes**

- Removed `useBuiltIns: "usage"` from Babel config — was injecting `core-js` imports into dist files, breaking Vercel builds (`Module not found: core-js/modules/...`)
- `rollup.config.js`: type-guard before spreading `pkg.exports['.']`, path-safe server entry resolution, compose with existing `onwarn`
- Pinned `rollup-plugin-preserve-directives` to exact version
- `slots` marked optional in `DotCMSPageContextProps`
