### PR TITLE
refactor(index): add MappingOperationsES/OS and IndexMappingRestOperations

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/business/ContentIndexMappingAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/content/business/ContentIndexMappingAPI.java
@@ -1,0 +1,106 @@
+package com.dotcms.content.business;
+
+import com.dotcms.content.model.annotation.IndexLibraryIndependent;
+import com.dotmarketing.business.DotStateException;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Vendor-neutral API for mapping and serializing {@link Contentlet} objects for index storage.
+ *
+ * <p>Implementations must not expose any vendor-specific types (Elasticsearch, OpenSearch, etc.)
+ * in their public method signatures. Routing to the active index provider is handled by the
+ * router implementation.</p>
+ *
+ * @author root
+ * @since Mar 22nd, 2012
+ */
+@IndexLibraryIndependent
+public interface ContentIndexMappingAPI {
+
+	boolean RESPECT_FRONTEND_ROLES = Boolean.TRUE;
+    boolean DONT_RESPECT_FRONTEND_ROLES = Boolean.FALSE;
+
+    /**
+     * Applies the given mapping to all specified indexes.
+     *
+     * @param indexes list of index names to update
+     * @param mapping JSON mapping string
+     * @return {@code true} if the mapping was acknowledged by all nodes
+     */
+    boolean putMapping(List<String> indexes, String mapping) throws IOException;
+
+    /**
+     * Applies the given mapping to a single index.
+     *
+     * @param indexName target index
+     * @param mapping   JSON mapping string
+     * @return {@code true} if the mapping was acknowledged
+     */
+    boolean putMapping(String indexName, String mapping) throws IOException;
+
+    /**
+     * Returns the current mapping for the given index as a JSON string.
+     *
+     * @param index index name
+     * @return mapping JSON
+     */
+    String getMapping(String index) throws IOException;
+
+    /**
+     * Returns the mapping for a specific field in the given index.
+     *
+     * @param index     index name
+     * @param fieldName field name
+     * @return mapping source map, or an empty map if not found
+     */
+    Map<String, Object> getFieldMappingAsMap(String index, String fieldName) throws IOException;
+
+    /**
+     * Converts the given contentlet to its JSON index representation.
+     *
+     * @param contentlet contentlet to convert
+     * @return JSON string ready for indexing
+     */
+    String toJson(Contentlet contentlet) throws DotMappingException;
+
+    /**
+     * Builds the lowercased property map used for indexing the given contentlet.
+     *
+     * @param contentlet contentlet to map
+     * @return map of field names to values
+     */
+    Map<String, Object> toMap(Contentlet contentlet) throws DotMappingException;
+
+    /**
+     * Converts the given contentlet to a mapped object (currently equivalent to {@link #toJson}).
+     *
+     * @param con contentlet to convert
+     * @return mapped representation
+     */
+    Object toMappedObj(Contentlet con) throws DotMappingException;
+
+    /**
+     * Serializes the given map to a JSON string using the configured {@code ObjectMapper}.
+     *
+     * @param map map to serialize
+     * @return JSON string
+     */
+    String toJsonString(Map<String, Object> map) throws IOException;
+
+    /**
+     * Returns the identifiers of related contentlets that must be re-indexed when the given
+     * contentlet changes.
+     *
+     * @param con the contentlet whose dependencies should be collected
+     * @return list of dependent contentlet identifiers
+     */
+    List<String> dependenciesLeftToReindex(Contentlet con)
+            throws DotStateException, DotDataException, DotSecurityException;
+
+}

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/MappingOperationsES.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/MappingOperationsES.java
@@ -1,0 +1,100 @@
+package com.dotcms.content.elasticsearch.business;
+
+import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
+
+import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
+import com.dotcms.content.index.IndexAPI;
+import com.dotcms.content.index.IndexMappingRestOperations;
+import com.dotcms.util.CollectionsUtils;
+import com.dotmarketing.business.APILocator;
+import com.google.common.annotations.VisibleForTesting;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.indices.GetFieldMappingsRequest;
+import org.elasticsearch.client.indices.GetFieldMappingsResponse;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.PutMappingRequest;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Elasticsearch implementation of {@link IndexMappingRestOperations}.
+ *
+ * <p>Wraps the three mapping REST calls ({@code putMapping}, {@code getMapping},
+ * {@code getFieldMappingAsMap}) that use the ES {@code RestHighLevelClient}.
+ * All vendor-specific types are confined to this class and never exposed
+ * through the {@link IndexMappingRestOperations} contract.</p>
+ *
+ * @author Fabrizio Araya
+ * @see MappingOperationsOS
+ * @see com.dotcms.content.elasticsearch.business.ESMappingAPIImpl
+ */
+@ApplicationScoped
+public class MappingOperationsES implements IndexMappingRestOperations {
+
+    private final IndexAPI esIndexAPI;
+
+    /** CDI-managed default constructor. */
+    public MappingOperationsES() {
+        this(APILocator.getESIndexAPI());
+    }
+
+    /** Package-private constructor for unit testing. */
+    @VisibleForTesting
+    MappingOperationsES(final IndexAPI esIndexAPI) {
+        this.esIndexAPI = esIndexAPI;
+    }
+
+    @Override
+    public boolean putMapping(final List<String> indexes, final String mapping) throws IOException {
+        final PutMappingRequest request = new PutMappingRequest(
+                indexes.stream()
+                        .map(esIndexAPI::getNameWithClusterIDPrefix)
+                        .toArray(String[]::new));
+        request.setTimeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
+        request.source(mapping, XContentType.JSON);
+
+        return RestHighLevelClientProvider.getInstance()
+                .getClient()
+                .indices()
+                .putMapping(request, RequestOptions.DEFAULT)
+                .isAcknowledged();
+    }
+
+    @Override
+    public String getMapping(final String index) throws IOException {
+        final GetMappingsRequest request = new GetMappingsRequest();
+        request.indices(index);
+
+        return RestHighLevelClientProvider.getInstance()
+                .getClient()
+                .indices()
+                .getMapping(request, RequestOptions.DEFAULT)
+                .mappings()
+                .get(index)
+                .source()
+                .string();
+    }
+
+    @Override
+    public Map<String, Object> getFieldMappingAsMap(final String index,
+            final String fieldName) throws IOException {
+        final GetFieldMappingsRequest request = new GetFieldMappingsRequest();
+        request.indices(index).fields(fieldName);
+
+        final GetFieldMappingsResponse response = RestHighLevelClientProvider.getInstance()
+                .getClient()
+                .indices()
+                .getFieldMapping(request, RequestOptions.DEFAULT);
+
+        final GetFieldMappingsResponse.FieldMappingMetadata meta =
+                response.mappings().getOrDefault(index, Collections.emptyMap()).get(fieldName);
+
+        return meta != null ? meta.sourceAsMap() : Collections.emptyMap();
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/ContentletIndexOperations.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/ContentletIndexOperations.java
@@ -1,0 +1,147 @@
+package com.dotcms.content.index;
+
+import com.dotcms.content.index.domain.IndexBulkProcessor;
+import com.dotcms.content.index.domain.IndexBulkRequest;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.content.index.domain.IndexBulkListener;
+import com.dotmarketing.exception.DotDataException;
+import java.io.IOException;
+
+/**
+ * Vendor-neutral contract for the <em>write side</em> of the contentlet index pipeline.
+ *
+ * <p>This interface separates the two vendor-specific write implementations
+ * ({@code ContentletIndexOperationsES} and {@code ContentletIndexOperationsOS}) from
+ * the business logic that lives in the router ({@code ContentletIndexAPIImpl}).
+ * Vendor types ({@code BulkRequest}, {@code BulkProcessor}, OpenSearch equivalents)
+ * must not appear in any public method signature of either implementation.</p>
+ *
+ * <p>The design mirrors {@link ContentFactoryIndexOperations} for the read path:
+ * the router holds two typed fields, selects the active implementation via
+ * {@code getProvider()}, and delegates every call.</p>
+ *
+ * @author Fabrizio Araya
+ * @see com.dotcms.content.elasticsearch.business.ContentletIndexOperationsES
+ * @see com.dotcms.content.index.opensearch.ContentletIndexOperationsOS
+ */
+public interface ContentletIndexOperations {
+
+    // =========================================================================
+    // Batch (synchronous) write path
+    // =========================================================================
+
+    /**
+     * Creates a new empty batch ready to accumulate index and delete operations.
+     *
+     * @return a fresh, empty {@link IndexBulkRequest}
+     */
+    IndexBulkRequest createBulkRequest();
+
+    /**
+     * Appends an <em>index (upsert)</em> operation to {@code req}.
+     *
+     * @param req         the batch to append to
+     * @param indexName   the target index name
+     * @param docId       document id — {@code identifier_languageId_variantId}
+     * @param jsonMapping the JSON string produced by the content mapping API
+     */
+    void addIndexOp(IndexBulkRequest req, String indexName, String docId, String jsonMapping);
+
+    /**
+     * Appends a <em>delete</em> operation to {@code req}.
+     *
+     * @param req       the batch to append to
+     * @param indexName the target index name
+     * @param docId     document id to delete
+     */
+    void addDeleteOp(IndexBulkRequest req, String indexName, String docId);
+
+    /**
+     * Sets the refresh policy on the batch before submission.
+     *
+     * @param req    the batch to configure
+     * @param policy one of {@code "NONE"}, {@code "WAIT_FOR"}, or {@code "IMMEDIATE"}
+     */
+    void setRefreshPolicy(IndexBulkRequest req, IndexBulkRequest.RefreshPolicy policy);
+
+    /**
+     * Submits the accumulated batch synchronously and blocks until the cluster
+     * acknowledges all operations.
+     *
+     * @param req the batch to submit — no-op if the batch is empty
+     */
+    void putToIndex(IndexBulkRequest req);
+
+    // =========================================================================
+    // Async bulk-processor write path (used by ReindexThread)
+    // =========================================================================
+
+    /**
+     * Creates a self-flushing asynchronous bulk processor backed by the
+     * vendor-specific client.
+     *
+     * @param listener receives completion and failure callbacks for each flush
+     * @return a new {@link IndexBulkProcessor}
+     */
+    IndexBulkProcessor createBulkProcessor(IndexBulkListener listener);
+
+    /**
+     * Adds an <em>index (upsert)</em> operation directly to the async processor,
+     * which will flush it according to its internal thresholds.
+     *
+     * @param proc        the target processor
+     * @param indexName   the target index name
+     * @param docId       document id
+     * @param jsonMapping the JSON string produced by the content mapping API
+     */
+    void addIndexOpToProcessor(IndexBulkProcessor proc, String indexName, String docId,
+            String jsonMapping);
+
+    /**
+     * Adds a <em>delete</em> operation directly to the async processor.
+     *
+     * @param proc      the target processor
+     * @param indexName the target index name
+     * @param docId     document id to delete
+     */
+    void addDeleteOpToProcessor(IndexBulkProcessor proc, String indexName, String docId);
+
+    // =========================================================================
+    // Index lifecycle
+    // =========================================================================
+
+    /**
+     * Creates a search index with the provider-specific default settings and content mapping.
+     *
+     * <p>Each implementation loads its own settings file ({@code es-content-settings.json} or
+     * {@code os-content-settings.json}) and applies the corresponding content mapping, so the
+     * router does not need to know which backend is being targeted.</p>
+     *
+     * @param indexName the fully-qualified index name (with cluster prefix)
+     * @param shards    number of primary shards; {@code 0} means "use provider default"
+     * @return {@code true} if the index was created and the mapping applied successfully
+     * @throws IOException if index creation or mapping application fails
+     */
+    boolean createContentIndex(String indexName, int shards) throws IOException;
+
+    // =========================================================================
+    // Other write operations
+    // =========================================================================
+
+    /**
+     * Removes all documents belonging to the given content type from every
+     * active index in the cluster.
+     *
+     * @param contentType the content type whose documents should be removed
+     * @throws DotDataException if the operation fails
+     */
+    void removeContentFromIndexByContentType(ContentType contentType) throws DotDataException;
+
+    /**
+     * Returns the number of documents currently stored in the given index.
+     *
+     * @param indexName the fully-qualified index name (with cluster prefix)
+     * @return document count
+     */
+    long getIndexDocumentCount(String indexName);
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/IndexMappingRestOperations.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/IndexMappingRestOperations.java
@@ -1,0 +1,51 @@
+package com.dotcms.content.index;
+
+import com.dotcms.content.model.annotation.IndexLibraryIndependent;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Vendor-neutral contract for the three index-mapping REST operations that differ
+ * between Elasticsearch and OpenSearch.
+ *
+ * <p>Implementations of this interface ({@code MappingOperationsES},
+ * {@code MappingOperationsOS}) encapsulate vendor client calls so that
+ * {@code ESMappingAPIImpl} (the router) stays free of vendor imports.</p>
+ *
+ * <p>Follows the same pattern as {@link ContentFactoryIndexOperations}.</p>
+ *
+ * @author Fabrizio Araya
+ * @see com.dotcms.content.elasticsearch.business.MappingOperationsES
+ * @see com.dotcms.content.index.opensearch.MappingOperationsOS
+ */
+@IndexLibraryIndependent
+public interface IndexMappingRestOperations {
+
+    /**
+     * Applies the given JSON mapping to all specified indexes.
+     *
+     * @param indexes list of index names
+     * @param mapping JSON mapping string
+     * @return {@code true} if acknowledged by all nodes
+     */
+    boolean putMapping(List<String> indexes, String mapping) throws IOException;
+
+    /**
+     * Returns the current mapping for the given index as a JSON string.
+     *
+     * @param index index name
+     * @return mapping JSON
+     */
+    String getMapping(String index) throws IOException;
+
+    /**
+     * Returns the mapping for a specific field in the given index as a plain Java map.
+     *
+     * @param index     index name
+     * @param fieldName field name
+     * @return mapping source map, or an empty map if not found
+     */
+    Map<String, Object> getFieldMappingAsMap(String index, String fieldName) throws IOException;
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkItemResult.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkItemResult.java
@@ -1,0 +1,40 @@
+package com.dotcms.content.index.domain;
+
+import com.dotcms.annotations.Nullable;
+import org.immutables.value.Value;
+
+/**
+ * Vendor-neutral result for a single item in a completed bulk operation.
+ *
+ * <p>Replaces direct use of {@code org.elasticsearch.action.bulk.BulkItemResponse}
+ * (and its OpenSearch equivalent) in {@link IndexBulkListener} callbacks.
+ * Vendor implementations map their library-specific item types to this DTO
+ * inside the {@link com.dotcms.content.index.ContentletIndexOperations} adapter.</p>
+ *
+ * @author Fabrizzio Araya
+ */
+@Value.Immutable
+public interface IndexBulkItemResult {
+
+    /**
+     * Raw document ID as returned by the vendor client, before any
+     * caller-side trimming (e.g. stripping the {@code _languageId_variantId} suffix).
+     * ES: {@code BulkItemResponse.getFailure().getId()} / {@code DocWriteResponse.getId()}.
+     * OS: equivalent field on the OpenSearch bulk item.
+     */
+    String id();
+
+    /** Whether this item failed to be indexed or deleted. */
+    boolean failed();
+
+    /**
+     * Raw failure message when {@link #failed()} is {@code true}; {@code null} otherwise.
+     * ES: {@code BulkItemResponse.getFailure().getMessage()}.
+     */
+    @Nullable
+    String failureMessage();
+
+    static ImmutableIndexBulkItemResult.Builder builder() {
+        return ImmutableIndexBulkItemResult.builder();
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkListener.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkListener.java
@@ -1,0 +1,49 @@
+package com.dotcms.content.index.domain;
+
+import java.util.List;
+
+/**
+ * Vendor-neutral listener for async bulk-processor callbacks.
+ *
+ * <p>Replaces direct extension of
+ * {@code org.elasticsearch.action.bulk.BulkProcessor.Listener} so that the
+ * business logic in {@code BulkProcessorListener} is decoupled from any
+ * vendor library.  Each {@link com.dotcms.content.index.ContentletIndexOperations}
+ * implementation adapts its vendor-specific callback types to this interface
+ * before forwarding to the application listener.</p>
+ *
+ * <p>Lifecycle:</p>
+ * <ol>
+ *   <li>{@link #beforeBulk} — called once per flush, before the batch is sent.</li>
+ *   <li>{@link #afterBulk(long, List)} — called on success with per-item results.</li>
+ *   <li>{@link #afterBulk(long, Throwable)} — called when the entire batch fails.</li>
+ * </ol>
+ *
+ * @author Fabrizzio Araya
+ */
+public interface IndexBulkListener {
+
+    /**
+     * Called before a batch is submitted to the index.
+     *
+     * @param executionId unique ID assigned by the bulk processor
+     * @param actionCount number of operations in the batch
+     */
+    void beforeBulk(long executionId, int actionCount);
+
+    /**
+     * Called after a batch completes successfully (even if some individual items failed).
+     *
+     * @param executionId unique ID assigned by the bulk processor
+     * @param results     one {@link IndexBulkItemResult} per item in the batch
+     */
+    void afterBulk(long executionId, List<IndexBulkItemResult> results);
+
+    /**
+     * Called when the entire batch fails with an unrecoverable exception.
+     *
+     * @param executionId unique ID assigned by the bulk processor
+     * @param failure     the exception that caused the batch to fail
+     */
+    void afterBulk(long executionId, Throwable failure);
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkProcessor.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkProcessor.java
@@ -1,0 +1,24 @@
+package com.dotcms.content.index.domain;
+
+/**
+ * Vendor-neutral handle for an asynchronous, self-flushing bulk processor.
+ *
+ * <p>Used by high-throughput reindex pipelines (e.g. {@code ReindexThread}) that
+ * add operations one by one and let the processor decide when to flush based on
+ * configured thresholds (batch size, byte size, flush interval).</p>
+ *
+ * <p>Implementations hold the vendor-specific processor instance and expose it only
+ * through this interface. Callers must always close the processor when done —
+ * either explicitly or via try-with-resources.</p>
+ *
+ * @author Fabrizio Araya
+ */
+public interface IndexBulkProcessor extends AutoCloseable {
+
+    /**
+     * Flushes any remaining operations and releases underlying resources.
+     * Blocks until all pending operations are acknowledged by the cluster.
+     */
+    @Override
+    void close() throws Exception;
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkRequest.java
@@ -1,0 +1,39 @@
+package com.dotcms.content.index.domain;
+
+/**
+ * Vendor-neutral handle for a batch of document index and delete operations.
+ *
+ * <p>Callers receive an {@code IndexBulkRequest} from
+ * {@link com.dotcms.content.elasticsearch.business.ContentletIndexAPI#createBulkRequest()}
+ * and pass it back to
+ * {@link com.dotcms.content.elasticsearch.business.ContentletIndexAPI#appendBulkRequest} /
+ * {@link com.dotcms.content.elasticsearch.business.ContentletIndexAPI#putToIndex(IndexBulkRequest)}.
+ * No Elasticsearch or OpenSearch types leak through this interface.</p>
+ *
+ * @author Fabrizio Araya
+ */
+public interface IndexBulkRequest {
+
+    /**
+     * Vendor-neutral refresh policy applied to a bulk batch at submit time.
+     *
+     * <p>Maps to {@code WriteRequest.RefreshPolicy} on Elasticsearch and
+     * {@code org.opensearch.client.opensearch._types.Refresh} on OpenSearch.</p>
+     */
+    enum RefreshPolicy {
+        /** Do not refresh (server default). ES: {@code NONE}, OS: {@code false}. */
+        NONE,
+        /** Refresh affected shards immediately. ES: {@code IMMEDIATE}, OS: {@code true}. */
+        IMMEDIATE,
+        /** Wait for the next scheduled refresh. ES: {@code WAIT_UNTIL}, OS: {@code wait_for}. */
+        WAIT_FOR
+    }
+
+    /** Returns the number of pending operations accumulated in this batch. */
+    int size();
+
+    /** Returns {@code true} when no operations have been added yet. */
+    default boolean isEmpty() {
+        return size() == 0;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/MappingOperationsOS.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/MappingOperationsOS.java
@@ -1,0 +1,142 @@
+package com.dotcms.content.index.opensearch;
+
+import com.dotcms.cdi.CDIUtils;
+import com.dotcms.content.elasticsearch.business.MappingOperationsES;
+import com.dotcms.content.index.IndexAPI;
+import com.dotcms.content.index.IndexMappingRestOperations;
+import com.dotmarketing.util.Logger;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import org.opensearch.client.opensearch._types.mapping.FieldMapping;
+import org.opensearch.client.opensearch.generic.Bodies;
+import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.opensearch.generic.Response;
+import org.opensearch.client.opensearch.indices.GetFieldMappingResponse;
+import org.opensearch.client.opensearch.indices.GetMappingResponse;
+import org.opensearch.client.opensearch.indices.get_field_mapping.TypeFieldMappings;
+import org.opensearch.client.opensearch.indices.get_mapping.IndexMappingRecord;
+
+import javax.enterprise.context.ApplicationScoped;
+import jakarta.json.stream.JsonGenerator;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenSearch implementation of {@link IndexMappingRestOperations}.
+ *
+ * <p>Wraps the three mapping REST calls ({@code putMapping}, {@code getMapping},
+ * {@code getFieldMappingAsMap}) using the OpenSearch Java client v3.x.
+ * Vendor-specific types are confined to this class.</p>
+ *
+ * <p>{@code putMapping} uses the generic HTTP client because the typed
+ * {@code PutMappingRequest} builder does not accept a raw JSON string body;
+ * the raw JSON approach avoids re-serializing the ES-generated mapping.</p>
+ *
+ * @author Fabrizio Araya
+ * @see MappingOperationsES
+ * @see com.dotcms.content.elasticsearch.business.ESMappingAPIImpl
+ */
+@ApplicationScoped
+public class MappingOperationsOS implements IndexMappingRestOperations {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final OSClientProvider clientProvider;
+    private final IndexAPI osIndexAPI;
+
+    /** CDI-managed default constructor. */
+    public MappingOperationsOS() {
+        this(CDIUtils.getBeanThrows(OSClientProvider.class),
+                CDIUtils.getBeanThrows(OSIndexAPIImpl.class));
+    }
+
+    /** Package-private constructor for unit testing. */
+    @VisibleForTesting
+    MappingOperationsOS(final OSClientProvider clientProvider, final IndexAPI osIndexAPI) {
+        this.clientProvider = clientProvider;
+        this.osIndexAPI = osIndexAPI;
+    }
+
+    /**
+     * Puts the given JSON mapping on all specified indexes via raw HTTP PUT so the
+     * mapping string is forwarded verbatim (the typed OS client builder does not
+     * accept a raw JSON body for put-mapping).
+     */
+    @Override
+    public boolean putMapping(final List<String> indexes, final String mapping) throws IOException {
+        boolean allAcknowledged = true;
+        for (final String index : indexes) {
+            final String prefixed = osIndexAPI.getNameWithClusterIDPrefix(index);
+            final String endpoint = "/" + prefixed + "/_mapping";
+            try (Response response = clientProvider.getClient().generic()
+                    .execute(Requests.builder()
+                            .method("PUT")
+                            .endpoint(endpoint)
+                            .body(Bodies.json(mapping))
+                            .build())) {
+                final int status = response.getStatus();
+                if (status < 200 || status >= 300) {
+                    Logger.error(this, "putMapping failed for index " + prefixed
+                            + " — HTTP " + status);
+                    allAcknowledged = false;
+                }
+            }
+        }
+        return allAcknowledged;
+    }
+
+    @Override
+    public String getMapping(final String index) throws IOException {
+        final String prefixed = osIndexAPI.getNameWithClusterIDPrefix(index);
+        final GetMappingResponse response = clientProvider.getClient()
+                .indices()
+                .getMapping(r -> r.index(prefixed));
+
+        final IndexMappingRecord record = response.get(prefixed);
+        if (record == null) {
+            return "{}";
+        }
+
+        final StringWriter sw = new StringWriter();
+        try (final JsonGenerator gen = clientProvider.getClient()
+                ._transport().jsonpMapper()
+                .jsonProvider().createGenerator(sw)) {
+            record.mappings().serialize(gen,
+                    clientProvider.getClient()._transport().jsonpMapper());
+        }
+        return sw.toString();
+    }
+
+    @Override
+    public Map<String, Object> getFieldMappingAsMap(final String index,
+            final String fieldName) throws IOException {
+        final String prefixed = osIndexAPI.getNameWithClusterIDPrefix(index);
+        final GetFieldMappingResponse response = clientProvider.getClient()
+                .indices()
+                .getFieldMapping(r -> r.index(prefixed).fields(fieldName));
+
+        final TypeFieldMappings typeMappings = response.get(prefixed);
+        if (typeMappings == null) {
+            return Collections.emptyMap();
+        }
+
+        final FieldMapping fieldMapping = typeMappings.mappings().get(fieldName);
+        if (fieldMapping == null) {
+            return Collections.emptyMap();
+        }
+
+        // Serialize FieldMapping (PlainJsonSerializable) to JSON, then parse as plain Map
+        final StringWriter sw = new StringWriter();
+        try (final JsonGenerator gen = clientProvider.getClient()
+                ._transport().jsonpMapper()
+                .jsonProvider().createGenerator(sw)) {
+            fieldMapping.serialize(gen,
+                    clientProvider.getClient()._transport().jsonpMapper());
+        }
+        return MAPPER.readValue(sw.toString(), new TypeReference<Map<String, Object>>() {});
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `IndexMappingRestOperations` — vendor-neutral interface for the three index-mapping REST operations (`putMapping`, `getMapping`, `getFieldMappingAsMap`)
- Adds `MappingOperationsES` — Elasticsearch implementation of `IndexMappingRestOperations`
- Adds `MappingOperationsOS` — OpenSearch implementation of `IndexMappingRestOperations`

All changes are **purely additive** — no existing callers modified. These classes will be wired into `ESMappingAPIImpl` (which becomes a phase-aware router) in PR 3.

## Test plan
- [ ] `./mvnw compile -pl dotCMS` passes ✅ (verified locally)
- [ ] No existing tests broken

## PR chain
This is **PR 2 of 3** for issue #34933.
**Depends on PR 1:** https://github.com/dotCMS/core/pull/35091

Fixes: #34933
🤖 Generated with [Claude Code](https://claude.com/claude-code)