### PR TITLE
feat(dx): Phase 2 — worktree-aware development with worktrunk

### DIFF
--- a/.claude/skills/dotcms-dev-services/SKILL.md
+++ b/.claude/skills/dotcms-dev-services/SKILL.md
@@ -1,21 +1,23 @@
 ---
-description: Dev infrastructure for running the dotCMS stack — dev-run modes, shared services for parallel development, frontend dev server, and command chaining rules for AI agents. Use this skill when the user asks about starting/stopping dotCMS, dev-run options, shared services setup or cleanup, port discovery, build-then-restart workflows, or AI agent cleanup after finishing work. Trigger on "start the stack", "shared services", "dev-run", "dev environment", "frontend dev server", "dev-restart", "dev-stop", "clean up indexes", or any question about the development lifecycle beyond the basic commands shown in AGENTS.md. Also use proactively when an AI agent needs to run dev commands in sequence or manage shared infrastructure.
+description: Dev infrastructure for running the dotCMS stack — dev-run modes, shared services for parallel worktrees, frontend dev server, and command chaining rules for AI agents. Use this skill when the user asks about starting/stopping dotCMS, dev-run options, shared services setup or cleanup, port discovery, build-then-restart workflows, or AI agent cleanup after finishing work. Trigger on "start the stack", "shared services", "dev-run", "dev environment", "frontend dev server", "dev-restart", "dev-stop", "clean up indexes", or any question about the development lifecycle beyond the basic commands shown in AGENTS.md. Also use proactively when an AI agent needs to run dev commands in sequence or manage shared infrastructure.
 allowed-tools: Bash(just *), Bash(docker *), Bash(./mvnw *), Bash(curl *)
 ---
 
 # Dev Services for dotCMS
 
-Running, managing, and tearing down the dotCMS development stack. Covers starting services, shared infrastructure for parallel development, frontend dev server, and rules AI agents should follow when chaining dev commands.
+Running, managing, and tearing down the dotCMS development stack. Covers starting services, shared infrastructure for parallel worktrees, frontend dev server, and rules AI agents should follow when chaining dev commands.
+
+For creating and managing worktrees themselves (branching, merging, agent spawning), see the `dotcms-worktree` skill.
 
 ## Starting the Stack
 
 `just dev-run` is the primary entry point. It resolves the port, Docker image, detects shared vs local mode, and starts the app.
 
 ```bash
-just dev-run                         # start on project's port (.dev-port → else 8082)
+just dev-run                         # start on worktree's port (.dev-port → else 8082)
 just dev-run 8080                    # start on explicit port
 just dev-run 8080 image=default      # use stock 1.0.0-SNAPSHOT image (skip build)
-just dev-run 8080 mode=local         # force local sidecars (ignore shared services)
+just dev-run 8080 mode=local         # force per-worktree sidecars (ignore shared services)
 just dev-run 8080 mode=shared        # force shared services mode
 ```
 
@@ -23,9 +25,9 @@ just dev-run 8080 mode=shared        # force shared services mode
 
 Port is resolved in order: explicit argument > `.dev-port` file > default `8082`.
 
-The `.dev-port` file can be created manually or by tooling to assign a fixed port to a project folder. This means `just dev-run` (no args) works immediately, and parallel projects never collide on ports.
+The `.dev-port` file is **automatically created** when a worktree is set up via `wt switch --create`. The `hash_port` filter in `.config/wt.toml` generates a deterministic port in the 10000-19999 range from the branch name — the same branch always gets the same port on any machine. This means `just dev-run` (no args) works immediately in any worktree, and parallel worktrees never collide on ports.
 
-To assign a port, create the file:
+To assign a port to an existing worktree that predates this feature, create the file manually:
 ```bash
 echo 14500 > .dev-port      # pick any unused port
 ```
@@ -39,16 +41,16 @@ When `mode` is omitted (the default), `dev-run` auto-detects:
 3. If no → **local mode** (starts app + DB + OpenSearch sidecars via fabric8)
 
 In shared mode, `dev-run`:
-- Creates a per-project database in the shared PostgreSQL instance
+- Creates a per-worktree database in the shared PostgreSQL instance
 - Sets `DOT_DOTCMS_CLUSTER_ID` for OpenSearch index isolation
 - Activates the `shared-services` Maven profile (app joins `dotcms-shared` network, no sidecar links)
 
-In local mode, `dev-run` uses the standard fabric8 docker-maven-plugin path with per-project container namespacing.
+In local mode, `dev-run` uses the standard fabric8 docker-maven-plugin path with per-worktree container namespacing.
 
 ### Image resolution
 
 When `image` is omitted:
-1. Looks for `dotcms/dotcms-test:<project-slug>` (built by `just build`)
+1. Looks for `dotcms/dotcms-test:<worktree-slug>` (built by `just build`)
 2. Falls back to `dotcms/dotcms-test:1.0.0-SNAPSHOT`
 3. Fails with guidance if neither exists
 
@@ -57,18 +59,18 @@ When `image` is omitted:
 ### Stopping and restarting
 
 ```bash
-just dev-stop                        # stop current project's containers (both modes)
-just dev-stop-all                    # stop ALL dotCMS containers across all projects
-just dev-restart                     # stop + restart on project's port (same resolution as dev-run)
+just dev-stop                        # stop current worktree's containers (both modes)
+just dev-stop-all                    # stop ALL dotCMS containers across all worktrees
+just dev-restart                     # stop + restart on worktree's port (same resolution as dev-run)
 just dev-restart 8080 mode=local     # restart forcing explicit port + local mode
-just dev-clean-volumes               # remove Docker volumes for current project
+just dev-clean-volumes               # remove Docker volumes for current worktree
 ```
 
 `dev-stop` handles both modes: directly removes the app container (shared mode), then runs Maven docker-stop for sidecars (local mode). Either path is a safe no-op if not applicable.
 
 ## Shared Services
 
-For running multiple projects simultaneously without duplicating DB + OpenSearch per project (~4GB+ RAM saved).
+For running multiple worktrees simultaneously without duplicating DB + OpenSearch per worktree (~4GB+ RAM saved).
 
 ### Setup
 
@@ -81,32 +83,32 @@ Fixed host ports (well outside dynamic allocation range):
 - OpenSearch 1.3 → `localhost:19200`
 - OpenSearch 3.4 → `localhost:19201`
 
-After starting, `just dev-run` in any project auto-detects and uses them.
+After starting, `just dev-run` in any worktree auto-detects and uses them.
 
-### Per-project isolation
+### Per-worktree isolation
 
-**Database:** Each project gets its own PostgreSQL database (e.g., `dotcms_core_cursor_development_envir_0e809b4d`). Created automatically on first `dev-run`. Format: `<module>_<project-id>` where project-id is `<prefix_24>_<sha256_8>` — unique within PostgreSQL's 63-char identifier limit.
+**Database:** Each worktree gets its own PostgreSQL database (e.g., `dotcms_core_cursor_development_envir_0e809b4d`). Created automatically on first `dev-run`. Format: `<module>_<worktree-id>` where worktree-id is `<prefix_24>_<sha256_8>` — unique within PostgreSQL's 63-char identifier limit.
 
-**OpenSearch indexes:** Prefixed with `cluster_<project-id>.` (see `ESIndexAPI.java:152`). Setting `DOT_DOTCMS_CLUSTER_ID` per project gives full index namespace isolation — the same mechanism used in production multi-cluster deployments.
+**OpenSearch indexes:** Prefixed with `cluster_<worktree-id>.` (see `ESIndexAPI.java:152`). Setting `DOT_DOTCMS_CLUSTER_ID` per worktree gives full index namespace isolation — the same mechanism used in production multi-cluster deployments.
 
 ### Management
 
 ```bash
 just dev-shared-status               # compose ps for shared services
-just dev-shared-list-dbs             # list all project databases with sizes
+just dev-shared-list-dbs             # list all worktree databases with sizes
 just dev-shared-stop                 # stop shared services (preserves volumes)
 just dev-shared-clean                # stop + remove all data volumes
 ```
 
-### Per-project cleanup
+### Per-worktree cleanup
 
 ```bash
-just dev-shared-drop-db              # drop current project's database
-just dev-shared-drop-indexes         # delete OpenSearch indexes matching project prefix
-just dev-shared-drop-project        # both: drop DB + indexes for current project
+just dev-shared-drop-db              # drop current worktree's database
+just dev-shared-drop-indexes         # delete OpenSearch indexes matching worktree prefix
+just dev-shared-drop-worktree        # both: drop DB + indexes for current worktree
 ```
 
-`dev-shared-drop-indexes` calls `DELETE /cluster_<project-id>.*` on both shared OpenSearch instances. Safe to run while shared services are still serving other projects.
+`dev-shared-drop-indexes` calls `DELETE /cluster_<worktree-id>.*` on both shared OpenSearch instances. Safe to run while shared services are still serving other worktrees.
 
 ### Lifecycle management
 
@@ -114,15 +116,15 @@ just dev-shared-drop-project        # both: drop DB + indexes for current projec
 just dev-shared-stop-if-idle         # stop only if no app containers are connected
 ```
 
-Inspects the `dotcms-shared` Docker network for `dotbuild_*` containers. If any are attached (from other projects), prints them and does nothing. Safe to call unconditionally from automation.
+Inspects the `dotcms-shared` Docker network for `dotbuild_*` containers. If any are attached (from other worktrees), prints them and does nothing. Safe to call unconditionally from automation.
 
 ## AI Agent Cleanup Lifecycle
 
-When an AI agent finishes work in a project, clean up in this order:
+When an AI agent finishes work in a worktree, clean up in this order:
 
 1. `just dev-stop` — stop the app container
-2. `just dev-shared-drop-project` — remove DB + OpenSearch indexes for this project
-3. `just dev-shared-stop-if-idle` — stop shared services if no other projects need them
+2. `just dev-shared-drop-worktree` — remove DB + OpenSearch indexes for this worktree
+3. `just dev-shared-stop-if-idle` — stop shared services if no other worktrees need them
 
 Step 3 is safe to call unconditionally — it checks before acting. Always run step 2 to prevent OpenSearch index bloat (indexes accumulate indefinitely if not cleaned).
 
@@ -130,7 +132,7 @@ Step 3 is safe to call unconditionally — it checks before acting. Always run s
 
 ```bash
 just dev-start-frontend              # start nx serve at :4200 (background, PID-managed)
-just dev-start-frontend 4201         # custom port — for parallel projects
+just dev-start-frontend 4201         # custom port — for parallel worktrees
 just dev-frontend-wait               # block until ready (fails fast on build errors)
 just dev-stop-frontend               # stop it (uses PID file, port-agnostic)
 just dev-frontend-logs               # tail the log (blocking — Ctrl-C to exit)
@@ -139,7 +141,7 @@ just dev-frontend-status             # last 40 lines (non-blocking snapshot)
 
 Auto-discovers the backend port from Docker and injects it into the proxy config. Falls back to `:8080` if no container is running. The proxy target is fixed at startup — restart the frontend dev server if the backend moves to a different port.
 
-For parallel projects, use different frontend ports (e.g., 4200, 4201, 4202) — each proxies to its own project's backend container (auto-discovered from Docker). `NX_DAEMON=false` is set automatically to prevent the Nx daemon from serializing parallel project builds.
+For parallel worktrees, use different frontend ports (e.g., 4200, 4201, 4202) — each proxies to its own worktree's backend container (auto-discovered from Docker). `NX_DAEMON=false` is set automatically to prevent the Nx daemon from serializing parallel worktree builds.
 
 **Important:** The frontend dev server URL serves live `core-web/` edits via hot-reload. The backend's `/dotAdmin` serves the Angular WAR compiled into the Docker image at build time and does NOT reflect `core-web/` changes.
 
@@ -147,8 +149,8 @@ For parallel projects, use different frontend ports (e.g., 4200, 4201, 4202) —
 
 If `dev-start-frontend` starts but the Angular build fails with TypeScript errors (check `just dev-frontend-status`), common causes:
 
-1. **Missing Stencil build** — `dotcms-webcomponents` is a Stencil library that must be pre-built (generates `loader/` directory). `just project-init` handles this automatically for new projects. For existing projects: `cd core-web && NX_DAEMON=false yarn nx build dotcms-webcomponents`.
-2. **Branch mismatch** — If the project branched from a stale base, the frontend code may reference APIs that don't exist yet in library types. Rebase onto `main` or the correct base branch.
+1. **Missing Stencil build** — `dotcms-webcomponents` is a Stencil library that must be pre-built (generates `loader/` directory). `just worktree-init` handles this automatically for new worktrees. For existing worktrees: `cd core-web && NX_DAEMON=false yarn nx build dotcms-webcomponents`.
+2. **Branch mismatch** — If the worktree branched from a stale base, the frontend code may reference APIs that don't exist yet in library types. Rebase onto `main` or the correct base branch.
 3. **Stale `node_modules`** — After rebases that pull in new dependencies: `cd core-web && yarn install`. If yarn says "already up-to-date" but packages are missing, delete `node_modules` and reinstall.
 
 The dev server enters watch mode even with errors — fixing the source files will trigger a hot-reload rebuild without restarting.
@@ -157,7 +159,7 @@ The dev server enters watch mode even with errors — fixing the source files wi
 
 `just build` runs a full Maven build — all modules including `core-web` (yarn install + nx build all + WAR packaging). The resulting Docker image is fully self-consistent.
 
-`just build-quicker` builds ONLY `dotcms-core` (`-pl :dotcms-core`). Dependencies like the `dotcms-core-web` WAR (Angular frontend) are pulled from `~/.m2/repository/` — **whatever was last installed by any project's `just build`**. The staleness check at the top of `build-quicker` warns when the embedded frontend is from a different branch.
+`just build-quicker` builds ONLY `dotcms-core` (`-pl :dotcms-core`). Dependencies like the `dotcms-core-web` WAR (Angular frontend) are pulled from `~/.m2/repository/` — **whatever was last installed by any worktree's `just build`**. The staleness check at the top of `build-quicker` warns when the embedded frontend is from a different branch.
 
 **When to use which:**
 
@@ -167,9 +169,9 @@ The dev server enters watch mode even with errors — fixing the source files wi
 | Backend-only change + testing at `:PORT/dotAdmin` | `build-quicker` | Frontend in WAR may be stale but backend API is fresh |
 | Frontend + backend change | `build` | Need consistent WAR with both changes |
 | E2E tests | `build` | Tests need a self-consistent image |
-| First build in a new project | `build` | No cached WAR in `.m2` for this branch |
+| First build in a new worktree | `build` | No cached WAR in `.m2` for this branch |
 
-**The `.m2` sharing problem:** All projects share `~/.m2/repository/`. A `just build` in project A writes `dotcms-core-web-1.0.0-SNAPSHOT.war` to `.m2`, then `just build-quicker` in project B picks up A's frontend. The `build-quicker` recipe detects this and warns.
+**The `.m2` sharing problem:** All worktrees share `~/.m2/repository/`. A `just build` in worktree A writes `dotcms-core-web-1.0.0-SNAPSHOT.war` to `.m2`, then `just build-quicker` in worktree B picks up A's frontend. The `build-quicker` recipe detects this and warns.
 
 ## Command Chaining Rules
 
@@ -184,10 +186,10 @@ Rules for AI agents running dev commands:
    just dev-wait              # blocks until healthy (max 3 min)
    just dev-urls              # print actual ports
    ```
-   Always use `just dev-run` rather than raw `./mvnw` — it handles shared vs local mode detection, image resolution, and project namespacing.
+   Always use `just dev-run` rather than raw `./mvnw` — it handles shared vs local mode detection, image resolution, and worktree namespacing.
 
 3. **`dev-urls` is the source of truth for ports** — The management port is always dynamic. Never hardcode it; always call `just dev-urls` or `just dev-health` to discover live port mappings.
 
 4. **`dev-health` before `dev-urls`** — If unsure whether the app is up, check `just dev-health` first (single line, fast). Only call `dev-urls` after confirming liveness.
 
-5. **Build scope matches what changed** — `just build-quicker` (core only, ~2-3 min) when only Java changed; `just build` (full, ~8-15 min) when multi-module or frontend WAR changed. After any build, `just dev-restart` picks up the new image (uses the project's `.dev-port` automatically).
+5. **Build scope matches what changed** — `just build-quicker` (core only, ~2-3 min) when only Java changed; `just build` (full, ~8-15 min) when multi-module or frontend WAR changed. After any build, `just dev-restart` picks up the new image (uses the worktree's `.dev-port` automatically).

--- a/.claude/skills/dotcms-worktree/SKILL.md
+++ b/.claude/skills/dotcms-worktree/SKILL.md
@@ -1,0 +1,369 @@
+---
+description: Create and manage isolated worktrees for parallel development in the dotCMS monorepo using worktrunk (wt). Use this skill whenever the user wants to set up a new branch for a task, work on multiple things in parallel, split work into sub-tasks, spawn a Claude agent in a separate environment, merge sub-task branches back together, list or clean up worktrees, or mentions "worktree", "branch off", "parallel tasks", "spin up an agent", or "isolated environment". Also use this skill proactively when EnterWorktree is about to be used — it must be intercepted in this repo.
+allowed-tools: Bash(wt *), Bash(mise exec -- wt *), Bash(git branch*), Bash(git worktree*), Bash(git log*), Bash(git rev-parse*), Bash(git fetch*), Bash(tmux *), Bash(zellij *), Bash(command -v *), Bash(cursor *), Bash(code *), Bash(idea *)
+---
+
+# Worktree Management for dotCMS
+
+Create and manage isolated worktrees for parallel development. Each worktree gets a warm start — build artifacts, node_modules, and caches are copied from the source branch via copy-on-write (reflink), so new worktrees are ready to `just dev-run` immediately.
+
+This skill is the **authoritative source** for worktree operations in this repository. It supersedes the generic `worktrunk:worktrunk` vendor plugin for all dotCMS-specific workflows.
+
+## CRITICAL: Do not use EnterWorktree
+
+**Never use Claude Code's built-in `EnterWorktree` tool** in this repository. It creates worktrees in `.claude/worktrees/` without running worktrunk's post-create hooks, resulting in:
+- No build artifacts copied (requires full ~15 min rebuild)
+- No `yarn install` (frontend broken)
+- No git hooks (`yarn` prepare / `core-web/prepare.js` never ran)
+- No `mise trust` (tool versions not resolved)
+
+**Always use `wt switch --create` via Bash instead.** This runs the project's `.config/wt.toml` hooks and produces a ready-to-use worktree.
+
+## Usage
+
+```
+/dotcms-worktree <action> [args]     # slash command entry point
+```
+
+## Workflow Detection
+
+Before creating a worktree, determine which pattern the user needs. If the signals are ambiguous — for example the user says "set up a branch" without indicating whether it's independent work or a sub-task — ask a brief clarifying question rather than guessing:
+
+- "Should this be its own PR (branching from main), or a sub-task of your current branch that merges back?"
+- "Do you want to work on this yourself, or should I spawn a Claude agent for it?"
+
+When the user is already on a feature branch (not `main`), default to Pattern 2 (sub-task) unless they explicitly say otherwise — developers on feature branches usually want sub-tasks that merge back.
+
+### Pattern 1: Independent work (own PR)
+
+For standalone features, bug fixes, or tasks that will be pushed as their own branch and PR. Branches from `main`.
+
+```
+main ──→ feature-branch ──→ own PR
+```
+
+**Signals:** "new feature", "fix bug #123", "independent task", "its own PR", or no indication of merging back to a parent feature branch.
+
+**Ensure a fresh base** — the `copy-ignored` post-create hook needs a local worktree to copy build artifacts from, so `--base` must point to a local branch (not `origin/main`). The approach is: create from a local branch, then rebase to catch up with remote.
+
+```bash
+git fetch origin                          # update remote tracking refs
+wt switch --create <branch-name>          # branches from local main (default)
+# After creation, in the new worktree:
+git rebase origin/main                    # align with latest remote main
+```
+
+If the current worktree is not on `main`, explicitly specify the base so `copy-ignored` can find build artifacts to copy:
+
+```bash
+wt switch --create <branch-name> --base main
+git rebase origin/main
+```
+
+### Pattern 2: Sub-tasks of current work (merge back)
+
+For parallel sub-tasks that will merge back into the current branch before submitting as a single PR. Branches from the current branch.
+
+```
+current-branch ──→ sub-task-1 ──┐
+                ├→ sub-task-2 ──┤──→ merge back ──→ single PR
+                └→ sub-task-3 ──┘
+```
+
+**Signals:** "split this into parallel tasks", "work on X and Y simultaneously", "merge back", "single PR", or the user is already on a feature branch.
+
+```bash
+# Record the parent branch name for merge-back
+PARENT=$(git rev-parse --abbrev-ref HEAD)
+
+# Use <short-parent>--<sub-task> naming (see Naming Conventions for why)
+wt switch --create <short-parent>--<sub-task-name> --base "$PARENT"
+```
+
+### Pattern 3: Spawn with an AI agent
+
+Launch a worktree with Claude Code running a specific task. `-x claude` tells worktrunk to start an interactive Claude session in the new worktree; arguments after `--` become its initial prompt.
+
+Pick the simplest approach that fits the developer's setup:
+
+#### Option A: Simplest — new terminal tab (no extra tools needed)
+
+Create the worktree first, then open a new tab/window and start Claude there. This works everywhere — iTerm2, Terminal.app, VS Code terminal, any setup.
+
+```bash
+# Step 1: Create the worktree (from Claude Code or any terminal)
+git fetch origin                                  # ensure tracking refs are current
+wt switch --create fix-auth-bug --yes             # --yes for non-interactive (Claude Code, scripts)
+
+# Step 2: Tell the developer to open a new terminal tab and run:
+#   cd <worktree-path>    (shown in wt output)
+#   git rebase origin/main                        # catch up with remote (Pattern 1 only)
+#   claude 'Fix the session timeout bug in AuthResource.java'
+```
+
+For sub-tasks (Pattern 2), replace the create command with `wt switch --create <name> --base "$PARENT" --yes` — no rebase needed since you're branching from the current work.
+
+When running from within Claude Code, prefer this approach — print the commands for the developer to copy-paste into a new tab. The `--yes` flag auto-approves post-create hooks since Claude Code can't answer interactive prompts.
+
+#### Option B: One-liner — from the developer's own terminal
+
+If the developer is typing directly in their terminal (not inside Claude Code), `-x claude` works in a single command:
+
+```bash
+wt switch --create fix-auth-bug -x claude -- 'Fix the session timeout bug in AuthResource.java'
+
+# Sub-task from current branch
+wt switch --create add-tests --base "$(git rev-parse --abbrev-ref HEAD)" -x claude -- 'Add integration tests for the new endpoint'
+```
+
+#### Option C: Background agents — tmux (for parallel work)
+
+For spawning multiple agents that run simultaneously, tmux creates detached sessions each with their own terminal. Developers unfamiliar with tmux just need these commands:
+
+```bash
+# Spawn a background agent
+tmux new-session -d -s fix-auth "wt switch --create fix-auth --yes -x claude -- 'Fix the session timeout'"
+
+# Check on it later
+tmux attach -t fix-auth         # connect to the session (Ctrl-B D to detach)
+tmux ls                          # list all running sessions
+```
+
+Multiple agents in parallel:
+
+```bash
+PARENT=$(git rev-parse --abbrev-ref HEAD)
+# Use a short recognizable prefix — see Naming Conventions re: git ref collisions
+SHORT="my-feature"   # extract from $PARENT or ask the developer
+tmux new-session -d -s task-a "wt switch --create ${SHORT}--api-tests    --base $PARENT --yes -x claude -- 'Add API integration tests'"
+tmux new-session -d -s task-b "wt switch --create ${SHORT}--fix-styling  --base $PARENT --yes -x claude -- 'Fix the dashboard CSS regressions'"
+tmux new-session -d -s task-c "wt switch --create ${SHORT}--update-docs  --base $PARENT --yes -x claude -- 'Update API documentation for new endpoints'"
+```
+
+Detect what's available before suggesting: check `$TMUX` (already in tmux), `command -v tmux` (tmux installed), `$ZELLIJ` (in zellij). If nothing is available and the developer only needs one agent, use Option A.
+
+## Opening in an editor
+
+After creating a worktree, open it in the developer's preferred editor. The `-x` flag runs any command after switching, and `{{ worktree_path }}` expands to the worktree directory.
+
+| Editor | Command | Setup needed? |
+|--------|---------|---------------|
+| VS Code | `code <path>` | No — CLI installed automatically |
+| Cursor | `cursor <path>` | No — CLI installed automatically |
+| IntelliJ IDEA | `idea <path>` | Yes — see below |
+| Terminal only | `cd <path>` | No |
+
+**IntelliJ setup:** The `idea` command-line launcher is not available by default. To enable it: open IntelliJ → Tools → Create Command-line Launcher. This creates the `idea` shell script (typically at `/usr/local/bin/idea`). If `command -v idea` returns nothing, guide the developer through this step before using `-x idea`.
+
+**Inline** — open the editor as part of creation:
+
+```bash
+wt switch --create fix-auth-bug -x 'cursor {{ worktree_path }}'
+```
+
+**After creation** — if the worktree already exists, just open it:
+
+```bash
+cursor "$(wt switch fix-auth-bug 2>&1 | grep -o '/.*')"
+# or simply: open the path shown by wt switch
+```
+
+**Ask the developer** which editor they use if unknown — don't assume. To detect what's available:
+
+```bash
+# Check for common editors (use the first one found, or ask)
+command -v cursor && echo "Cursor"
+command -v code && echo "VS Code"
+command -v idea && echo "IntelliJ"
+```
+
+**Shell aliases** — for developers who always want the same editor, suggest adding a shell alias:
+
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+alias wtc='wt switch --create -x "cursor {{ worktree_path }}"'
+alias wtv='wt switch --create -x "code {{ worktree_path }}"'
+alias wti='wt switch --create -x "idea {{ worktree_path }}"'
+
+# Then: wtc fix-auth-bug   → creates worktree + opens in Cursor
+```
+
+## Actions
+
+### create — Create a new worktree
+
+Ask the user (or infer from context):
+1. **Branch name** — suggest a descriptive name based on the task
+2. **Base branch** — main (Pattern 1) or current branch (Pattern 2)
+3. **Agent or editor** — launch Claude Code, open in an editor, or just create
+
+```bash
+# Pattern 1: Independent work (create from local main, then rebase to latest)
+git fetch origin
+wt switch --create <name>
+git rebase origin/main
+
+# Pattern 2: Sub-task
+wt switch --create <name> --base <parent-branch>
+
+# Open in editor after creation
+cursor <worktree-path>              # or code, idea
+
+# With agent — see Pattern 3 for the right option (A/B/C) based on context.
+# Do NOT run `-x claude` directly from the Bash tool — it needs a TTY.
+```
+
+After creation, confirm what happened:
+- Which post-create hooks ran (mise trust, copy-ignored, yarn install → prepare.js / git hooks)
+- The worktree path
+- How to open it: editor command or `wt switch <name>`
+
+### list — Show all worktrees
+
+```bash
+wt list
+```
+
+### switch — Switch to an existing worktree
+
+```bash
+wt switch <branch-name>
+# Interactive picker if no branch specified:
+wt switch
+```
+
+### merge — Merge a sub-task back to its parent
+
+From within the sub-task worktree:
+
+```bash
+wt merge <parent-branch>
+```
+
+This squashes commits, rebases onto the parent, merges, and removes the worktree.
+
+For merging multiple sub-tasks back:
+
+```bash
+# In sub-task-1 worktree:
+wt merge <parent-branch>
+
+# In sub-task-2 worktree:
+wt merge <parent-branch>
+
+# In sub-task-3 worktree:
+wt merge <parent-branch>
+
+# Now parent-branch has all sub-task work, ready for a single PR
+```
+
+### cleanup — Remove completed worktrees
+
+**Never remove worktrees without explicit developer confirmation.** Worktrees may contain uncommitted work, stashed changes, or in-progress experiments that aren't visible from a branch listing.
+
+```bash
+# List all worktrees — look for stale ones (old age, no recent commits, merged branches)
+wt list
+
+# Show details before removing — let the developer review
+wt list   # developer confirms which to remove
+
+# Remove a specific worktree (prompts if unmerged changes exist)
+wt remove <branch-name>
+
+# Bulk cleanup of merged worktrees (interactive — developer confirms each one)
+wt cleanup
+```
+
+When suggesting cleanup, show `wt list` output and highlight candidates (e.g. worktrees older than 2 weeks with no uncommitted changes), but always ask before removing.
+
+## Naming Conventions
+
+Suggest branch names that follow the project's convention:
+- Features: `feature/<short-description>` or `<issue-id>-<short-description>`
+- Bug fixes: `fix/<short-description>`
+- Sub-tasks: `<parent-short-name>--<sub-task-name>` (use `--` as separator)
+
+**Git ref collision:** Git cannot create `A/B` if `A` already exists as a branch (refs are filesystem paths). This means the pattern `<parent-branch>/<sub-task>` **fails** when the parent branch contains slashes (e.g. `cursor/my-feature` blocks `cursor/my-feature/sub-task`). Always use `--` to join the parent's short name to the sub-task:
+
+```
+# Parent: cursor/development-environment-setup-e028
+# Good:  dev-env-setup--api-tests
+# Bad:   cursor/development-environment-setup-e028/api-tests  ← git ref collision
+```
+
+Extract a short, recognizable portion of the parent branch name rather than using the full name.
+
+## What Happens on Creation
+
+The project config `.config/wt.toml` runs `post-create` hooks (blocking — all complete before you can work):
+
+1. **`wt step copy-ignored --from <base>`** — copies Nx/Angular caches via reflink (near-zero disk cost on APFS/btrfs). Scoped by `.worktreeinclude` — copies caches only, NOT `node_modules`.
+2. **`just worktree-init`** — declares **`setup`** as a [prior dependency](https://just.systems/man/en/dependencies.html) (mise, shell integration, `prepare.js` git hooks — idempotent), then `mise trust` for this path, `yarn install` (fresh lockfile; `prepare` runs again via package.json), builds Stencil webcomponents.
+3. **Docker image re-tag** — tags the source worktree's image for the new branch so `just dev-run` works immediately.
+4. **Port assignment** — writes a deterministic port (10000-19999 range, derived from branch name via `hash_port`) to `.dev-port`.
+
+See `.config/wt.toml` for the hook definitions and `just worktree-init` for the init recipe. These are the source of truth — this section is a summary.
+
+Files copied (scoped by `.worktreeinclude`):
+
+| Pattern | Size | Purpose |
+|---------|------|---------|
+| `core-web/.nx/` | ~150MB | Nx build cache |
+| `core-web/.angular/cache` | ~400MB | Angular compilation cache |
+| `core-web/.sass-cache` | small | Sass compilation cache |
+| `.venv/` | small | Python virtual environment |
+
+`node_modules/` is NOT copied — `just worktree-init` runs `yarn install` fresh to ensure deps match the branch's lockfile. `target/` and `.cache/` are also excluded.
+
+## Post-Creation Dev Commands
+
+After switching to a worktree, the developer can immediately:
+
+```bash
+just dev-run 8080                  # start the stack (uses worktree's image, falls back to 1.0.0-SNAPSHOT)
+just dev-run 8080 image=default    # start with stock 1.0.0-SNAPSHOT (no build needed — frontend devs)
+just dev-start-frontend            # start Angular dev server at :4200 proxying to backend
+just build-quicker                 # rebuild if Java code differs from base
+just dev-images                    # see all locally available images
+just dev-containers                # see all running dotCMS stacks across worktrees
+```
+
+**Frontend-only workflow (no build):** New worktrees inherit the parent's Docker image tag via the `image` post-create hook. Frontend devs can skip building entirely:
+
+```bash
+wt switch --create ui-redesign
+just dev-run 8084 image=default    # start stock image on a free port
+just dev-start-frontend            # nx serve at :4200, auto-discovers backend port
+```
+
+**Parallel worktrees:** Each worktree gets its own container namespace, so multiple stacks can run simultaneously on different ports without collision. Use `just dev-stop` to stop only the current worktree's containers, or `just dev-stop-all` to stop everything.
+
+**Shared services (resource-efficient parallel):** Running 3+ worktrees wastes ~4GB+ RAM on duplicate DB + OpenSearch sidecars. Use `just dev-shared-start` once, then `just dev-run` auto-detects and shares them. Each worktree gets its own database and index namespace — fully isolated.
+
+For shared services setup, dev-run mode options, command chaining rules, frontend dev server details, and AI agent cleanup lifecycle, see the `dotcms-dev-services` skill.
+
+## Configuration Reference
+
+### Project config: `.config/wt.toml`
+
+Committed, shared with the team. Defines lifecycle hooks for worktree creation/cleanup. Edit this to change what runs on `wt switch --create`.
+
+### Copied files: `.worktreeinclude`
+
+Committed. Controls which gitignored files are copied between worktrees. Also read by Claude Code desktop's native worktree support.
+
+### User config: `~/.config/worktrunk/config.toml`
+
+Personal preferences — worktree path template, LLM commit message generation, command defaults. Not committed. Run `wt config create` to initialize.
+
+### LLM commit messages
+
+Worktrunk can generate commit messages during `wt merge` using an LLM. This is configured in the user config:
+
+```toml
+[commit.generation]
+command = "claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
+```
+
+Run `wt config show` to check current configuration.

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,37 @@
+# Worktrunk project config for dotCMS
+# Lifecycle hooks that run when creating/removing worktrees.
+# See: wt hook --help
+
+[post-create]
+# Copy build caches from the source worktree (not the stale primary).
+# Scoped by .worktreeinclude — Nx/Angular caches only, NOT node_modules.
+# Uses copy-on-write (reflink) on APFS/btrfs: near-zero disk cost.
+copy = "wt step copy-ignored --from {{ base }}"
+
+# Install tools, deps, build Stencil webcomponents, wire git hooks.
+# Delegates to justfile to keep logic in one place.
+init = "just worktree-init"
+
+# Re-tag source worktree's Docker image for the new branch so dev-run works immediately.
+image = """
+docker tag "dotcms/dotcms-test:{{ base | sanitize }}" "dotcms/dotcms-test:{{ branch | sanitize }}" 2>/dev/null || \
+docker tag "dotcms/dotcms-test:1.0.0-SNAPSHOT" "dotcms/dotcms-test:{{ branch | sanitize }}" 2>/dev/null || true
+"""
+
+# Persist a deterministic port for this worktree (10000-19999 range, stable per branch name).
+# `just dev-run` reads this file so you never need to specify a port manually.
+port = "echo {{ branch | hash_port }} > {{ worktree_path }}/.dev-port"
+
+[pre-remove]
+# Stop this worktree's dev containers before removal (safe no-op if not running).
+stop = """
+cd {{ worktree_path }} && just dev-stop 2>/dev/null || true
+"""
+
+[post-remove]
+# Clean up leftover container for the removed worktree.
+cleanup = """
+SLUG=$(echo "{{ branch }}" | sed 's/[^a-zA-Z0-9._-]/-/g; s/^[.-]*//' | cut -c1-64)
+CONTAINER="dotbuild_dotcms-core_${SLUG}_dotcms"
+docker stop "$CONTAINER" 2>/dev/null; docker rm "$CONTAINER" 2>/dev/null || true
+"""

--- a/.mise.toml
+++ b/.mise.toml
@@ -11,6 +11,9 @@ lefthook = "latest"
 # Command runner for build/dev tasks
 just = "latest"
 
+# Git worktree manager for parallel AI agent sessions
+"github:max-sixty/worktrunk" = "latest"
+
 # GitHub CLI for issue/PR management
 gh = "latest"
 

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,18 @@
+# Files to copy between worktrees (must also be gitignored).
+# Used by: wt step copy-ignored (worktrunk) and Claude Code desktop worktrees.
+#
+# Intentionally excludes target/ and .cache/ — developers typically rebuild
+# after creating a worktree (code changed), so copying stale build artifacts
+# delays startup without helping the build.
+#
+# node_modules is NOT copied — yarn install must run fresh to match the
+# target branch's yarn.lock. Copying from a different branch causes silent
+# stale-dependency bugs that yarn install doesn't detect.
+
+# Frontend build caches
+core-web/.nx/
+core-web/.angular/cache
+core-web/.sass-cache
+
+# Python virtual environment (mise-managed)
+.venv/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ Tool versions (Java, Node) are read from `.sdkmanrc` and `.nvmrc` via [mise](htt
 just build                                         # full build (~8-15 min)
 just build-quicker                                 # core only (~2-3 min, uses cached frontend WAR)
 just dev                                           # start backend + frontend + wait for both
-just dev-run                                       # start backend on project's port (.dev-port, else 8082)
-just dev-stop                                      # stop current project's containers
+just dev-run                                       # start backend on worktree's port (.dev-port, else 8082)
+just dev-stop                                      # stop current worktree's containers
 just dev-restart                                   # stop + restart — use after a rebuild
 just dev-urls                                      # print live URLs (dotAdmin, REST API, health)
 just dev-health                                    # check server health
@@ -30,7 +30,7 @@ just dev-health                                    # check server health
 
 Run `just --list` for all available commands. For dev lifecycle details (shared services, modes, port resolution, frontend dev server, command chaining), see the `/dotcms-dev-services` skill.
 
-> **Dev loop:** `just build` → `just dev` → edit code → `just build-quicker` → `just dev-restart`. Port resolution: explicit arg > `.dev-port` file > 8082. The management port is always dynamic — use `just dev-urls`.
+> **Dev loop:** `just build` → `just dev` → edit code → `just build-quicker` → `just dev-restart`. Port resolution: explicit arg > `.dev-port` file (set by `wt switch --create`) > 8082. The management port is always dynamic — use `just dev-urls`.
 
 ### Testing
 
@@ -56,12 +56,23 @@ Tests are **silently skipped** without explicit `skip=false` flags: `-Dcoreit.te
 - `docs/infrastructure/DEV_ENVIRONMENT_SETUP.md` — mise/just setup, shell configuration, CI/CD
 - `docs/claude/CONTEXT_ARCHITECTURE.md` — where to place new instructions for AI agents
 
+## Worktrees
+
+Use [worktrunk](https://worktrunk.dev) (`wt`) to create isolated worktrees — **do not use Claude Code's built-in `EnterWorktree`**, which bypasses the project's post-create hooks and produces cold-start worktrees (no deps, no hooks, no port assignment).
+
+```bash
+wt switch --create feature-x                       # branch from main → own PR
+wt switch --create sub-task --base current-branch   # branch from current → merge back
+```
+
+New worktrees start warm — `.config/wt.toml` hooks run `just worktree-init`, re-tag the Docker image, and assign a deterministic port. Ready to `just dev` immediately. See the `/dotcms-worktree` skill for full workflow patterns.
+
 ## Gotchas
 
 - **Git hooks require mise** — run `mise install` to set up lefthook, or `LEFTHOOK=0 git commit` to skip
 - **Frontend memory** — standalone Nx builds may OOM; set `NODE_OPTIONS="--max_old_space_size=4096"`
 - **Frontend changes only show via `nx serve`** — `core-web/` edits are served live by `just dev-start-frontend`. They do NOT appear at the backend's `/dotAdmin`, which serves the Angular WAR from the Docker image. If changes are invisible, check which URL you're using.
-- **`build-quicker` shares `.m2` across projects** — `just build-quicker` uses the frontend WAR last installed by any project's `just build`. The recipe detects and warns when the WAR is from a different branch. Use `nx serve` for frontend dev, or `just build` for a consistent image.
+- **`build-quicker` shares `.m2` across worktrees** — `just build-quicker` uses the frontend WAR last installed by any worktree's `just build`. The recipe detects and warns when the WAR is from a different branch. Use `nx serve` for frontend dev, or `just build` for a consistent image.
 - **Docker image build fails with stale SHA** — run `docker builder prune -f` then retry
 - **Tests are silently skipped** — integration, postman, karate, and E2E tests all require explicit `-Dskip=false` flags or nothing runs
 - **Pre-push hook may auto-commit and exit 2** — if REST API Java files changed, the `openapi-freshness` hook regenerates the OpenAPI spec, auto-commits it, and exits 2 (not 1) to signal "retry needed". Agents must re-push after this; the second push will succeed.

--- a/docker/docker-compose-shared-services.yml
+++ b/docker/docker-compose-shared-services.yml
@@ -1,4 +1,4 @@
-# Shared services for parallel development.
+# Shared services for parallel worktree development.
 # Start once: just dev-shared-start
 # Then each worktree: just dev-run 8080 (auto-detects shared services)
 services:

--- a/docs/claude/CONTEXT_ARCHITECTURE.md
+++ b/docs/claude/CONTEXT_ARCHITECTURE.md
@@ -237,7 +237,7 @@ Build commands, architecture decisions, and conventions belong in instruction fi
 
 ### Documenting raw commands instead of aliases
 
-Writing `./mvnw install -pl :dotcms-core -DskipTests -Ddocker.version.tag=$(just _project-slug)` instead of `just build-quicker`. The raw command consumes more tokens, breaks when flags change, and forces you to update documentation alongside implementation.
+Writing `./mvnw install -pl :dotcms-core -DskipTests -Ddocker.version.tag=$(just _worktree-slug)` instead of `just build-quicker`. The raw command consumes more tokens, breaks when flags change, and forces you to update documentation alongside implementation.
 
 ### Hard-coding values that the alias resolves
 
@@ -382,6 +382,7 @@ How these concepts are applied in this monorepo.
     rules/                      # Claude Code path-scoped rules (8 files)
     skills/                     # Claude Code skills
       dotcms-dev-services/      #   Dev lifecycle (start, stop, shared services)
+      dotcms-worktree/          #   Worktree management
       ...
   .cursor/
     rules/                      # Cursor path-scoped rules (6 files)
@@ -400,6 +401,7 @@ How these concepts are applied in this monorepo.
 | Setup commands | Root AGENTS.md | Always |
 | Core dev loop | Root AGENTS.md | Always |
 | Critical gotchas | Root AGENTS.md | Always |
+| "Don't use EnterWorktree" | Root AGENTS.md | Always |
 | Test skip flags warning | Root AGENTS.md | Always |
 | Cross-platform shell rules | Path-scoped rule (`justfile`, `*.sh`) | When editing scripts |
 | Java patterns (Config, Logger) | Path-scoped rule (`**/*.java`) | When editing Java |
@@ -408,6 +410,7 @@ How these concepts are applied in this monorepo.
 | Frontend Angular conventions | `core-web/AGENTS.md` | When reading core-web/ files |
 | Test patterns (Spectator, Jest) | Path-scoped rule (`**/*.spec.ts`) | When editing tests |
 | Dev lifecycle (dev-run, shared services) | Skill (`dotcms-dev-services`) | On demand |
+| Worktree management | Skill (`dotcms-worktree`) | On demand |
 | Detailed Java standards | `docs/backend/JAVA_STANDARDS.md` | Referenced from rules |
 | Detailed Angular standards | `docs/frontend/ANGULAR_STANDARDS.md` | Referenced from rules |
 

--- a/docs/infrastructure/DEV_ENVIRONMENT_SETUP.md
+++ b/docs/infrastructure/DEV_ENVIRONMENT_SETUP.md
@@ -51,6 +51,7 @@ The primary configuration file, committed to the repository. Declares all tool v
 Key tools managed:
 - `lefthook` — git hooks manager (replaces husky + lint-staged)
 - `just` — command runner for build/dev tasks
+- `github:max-sixty/worktrunk` — git worktree manager for parallel AI agent sessions
 - `gh` — GitHub CLI
 - `python` — for automation scripts and CI diagnostics
 - `actionlint` + `shellcheck` — GitHub Actions and shell linting
@@ -59,7 +60,7 @@ Java and Node versions are **not** declared in `.mise.toml` — they are read fr
 
 ### `justfile`
 
-Defines the `setup` task and all build/dev/test commands. The setup recipe installs mise if not present, configures the developer's shell for both interactive and non-interactive sessions, and installs all tools.
+Defines the `setup` task and all build/dev/test commands. The setup recipe installs mise if not present, configures the developer's shell for both interactive and non-interactive sessions, installs all tools, and sets up worktrunk shell integration.
 
 ### `.gitignore`
 
@@ -87,14 +88,14 @@ The setup script writes two lines per developer based on their detected shell. T
 
 | File | Line added | Purpose |
 |---|---|---|
-| `~/.zprofile` / `~/.bash_profile` | `export PATH="$HOME/.local/share/mise/shims:$PATH"` | Non-interactive sessions (Claude Code, git hooks, cron) |
+| `~/.zprofile` / `~/.bash_profile` | `eval "$(mise activate zsh --shims)"` | Non-interactive sessions |
 | `~/.zshrc` / `~/.bashrc` | `eval "$(mise activate zsh)"` | Interactive terminal sessions |
 
 When an interactive shell starts, `mise activate` automatically removes the shims directory from PATH and replaces it with direct tool paths, so there is no duplication or conflict between the two lines.
 
 ### Why two files matter for Claude Code
 
-Tools like Claude Code spawn non-interactive shells that never source `.zshrc`, so `mise activate` never runs in those processes. By adding the mise shims directory directly to PATH in the profile file — which is sourced by all login shells — tools resolve for every child process, including those spawned by Claude Code, without requiring the mise binary itself to be on PATH or any eval activation.
+Tools like Claude Code spawn non-interactive shells that never source `.zshrc`, so `mise activate` never runs in those processes. By placing `mise activate --shims` in the profile file — which is sourced by all login shells — the shims directory is on PATH for every child process, including those spawned by Claude Code, without requiring any further activation.
 
 ```
 Login shell starts
@@ -123,6 +124,77 @@ java=21.0.8-ms
 Mise reads these automatically and uses them as the version source when no version is specified in `[tools]`. Developers already using nvm or sdkman do not need to change or remove their existing setup — both tools read the same version files and resolve to the same version. If both are active in the same shell, mise wins because `mise activate` re-runs on every prompt. The only practical side effect is that both tools maintain their own separate installation of the same version, resulting in duplicate disk usage but no functional conflict.
 
 Note that not all sdkman Java vendors are supported by mise. The following are **not** supported: `bsg` (Bisheng), `graal` (GraalVM), `nik` (Liberica NIK). If your project requires one of these, manual installation is needed for those developers.
+
+---
+
+## Worktrunk (`wt`)
+
+[Worktrunk](https://worktrunk.dev) is a CLI for Git worktree management designed for running AI agents in parallel. It makes it trivial to give each Claude Code session its own isolated branch and working directory.
+
+It is installed automatically via mise using the GitHub backend:
+
+```toml
+[tools]
+"github:max-sixty/worktrunk" = "latest"
+```
+
+The `just setup` script runs `wt config shell install` after tool installation to enable the shell integration required for `wt switch` to `cd` automatically.
+
+### Warm starts — no rebuild needed
+
+When `wt switch --create` creates a new worktree, the project config (`.config/wt.toml`) runs `post-create` hooks that:
+
+1. **Trust mise** — so tool versions resolve immediately
+2. **Copy build artifacts** from the source worktree via `wt step copy-ignored` — uses copy-on-write (reflink) on APFS/btrfs, copying ~6GB in ~20s with near-zero disk cost
+3. **Run `yarn install`** — fast no-op if `node_modules/` was copied and the lockfile matches
+4. **Install lefthook** — wires up git hooks in the new worktree
+
+What gets copied is scoped by `.worktreeinclude`:
+
+| Pattern | Size | Why |
+|---------|------|-----|
+| `target/` | ~3GB | Maven build output — avoids full rebuild |
+| `core-web/node_modules/` | ~2.8GB | Frontend dependencies |
+| `core-web/.nx/` | varies | Nx build cache |
+| `core-web/.angular/cache` | varies | Angular compilation cache |
+| `.cache/` | varies | Maven build cache |
+| `.venv/` | small | Python virtual environment |
+
+The net effect: a new worktree is ready to `just dev-run` immediately after creation — no build step required unless the branch changes Java or frontend code that invalidates the copied artifacts.
+
+### Core workflow
+
+```sh
+# Create a new branch and worktree, launch Claude Code in it
+wt switch --create feature-auth -x claude
+
+# Run multiple agents in parallel
+wt switch -x claude -c feature-a -- 'Add user authentication'
+wt switch -x claude -c feature-b -- 'Fix the pagination bug'
+wt switch -x claude -c feature-c -- 'Write tests for the API'
+
+# Check status across all worktrees
+wt list
+
+# Merge completed work
+wt merge main
+```
+
+### Project config (`.config/wt.toml`)
+
+The project config is committed and shared with the team. It defines lifecycle hooks:
+
+```toml
+[post-create]
+mise = "command -v mise >/dev/null 2>&1 && mise trust || true"
+copy = "wt step copy-ignored --from {{ base }}"
+deps = "cd core-web && yarn install --frozen-lockfile"
+hooks = "lefthook install 2>/dev/null || true"
+```
+
+All `post-create` hooks are **blocking** — they complete before any `--execute` command runs, ensuring the worktree is fully ready for use.
+
+> **Windows note:** `wt` conflicts with Windows Terminal's command. Windows developers should use `git-wt` instead, or disable the Windows Terminal alias via Settings → Privacy & security → For developers → App Execution Aliases.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ home_dir := env_var('HOME')
 #
 # Getting started:
 #   brew install just          # or: mise install (if you have mise)
-#   just setup                 # installs mise, configures shell, installs all tools
+#   just setup                 # installs mise, configures shell, installs all tools, wires git hooks
 #   just build                 # full build (~8-15 min)
 #   just dev-run 8080          # start the stack
 #
@@ -58,30 +58,22 @@ setup:
 
     echo "Detected shell: $SHELL_NAME"
 
-    # Profile files (.zprofile, .bash_profile) are sourced by all login shells, including
-    # non-interactive ones (Claude Code, git hooks, cron). We add the shims directory to
-    # PATH directly — no eval, no mise binary lookup — so tools resolve regardless of how
-    # mise was installed (curl, Homebrew, apt, etc.).
-    # Interactive rc files (.zshrc, .bashrc) then replace shims with direct tool paths via
-    # full `mise activate`.
-    SHIMS_LINE='export PATH="$HOME/.local/share/mise/shims:$PATH"'
-
     case "$SHELL_NAME" in
         zsh)
-            if add_line_if_missing ~/.zprofile "$SHIMS_LINE"; then SHELL_CONFIG_CHANGED=1; fi
+            if add_line_if_missing ~/.zprofile 'eval "$(mise activate zsh --shims)"'; then SHELL_CONFIG_CHANGED=1; fi
             if add_line_if_missing ~/.zshrc 'eval "$(mise activate zsh)"'; then SHELL_CONFIG_CHANGED=1; fi
             ;;
         bash)
-            if add_line_if_missing ~/.bash_profile "$SHIMS_LINE"; then SHELL_CONFIG_CHANGED=1; fi
+            if add_line_if_missing ~/.bash_profile 'eval "$(mise activate bash --shims)"'; then SHELL_CONFIG_CHANGED=1; fi
             if add_line_if_missing ~/.bashrc 'eval "$(mise activate bash)"'; then SHELL_CONFIG_CHANGED=1; fi
             ;;
         fish)
-            if add_line_if_missing ~/.config/fish/config.fish 'set -gx PATH $HOME/.local/share/mise/shims $PATH'; then SHELL_CONFIG_CHANGED=1; fi
+            if add_line_if_missing ~/.config/fish/config.fish 'mise activate fish --shims | source'; then SHELL_CONFIG_CHANGED=1; fi
             if add_line_if_missing ~/.config/fish/config.fish 'mise activate fish | source'; then SHELL_CONFIG_CHANGED=1; fi
             ;;
         *)
             echo "Unknown shell: $SHELL_NAME, falling back to ~/.profile"
-            if add_line_if_missing ~/.profile "$SHIMS_LINE"; then SHELL_CONFIG_CHANGED=1; fi
+            if add_line_if_missing ~/.profile 'export PATH="$HOME/.local/share/mise/shims:$PATH"'; then SHELL_CONFIG_CHANGED=1; fi
             ;;
     esac
 
@@ -96,6 +88,12 @@ setup:
     echo ""
     echo "Installing tools..."
     "$MISE" install
+
+    # Install worktrunk shell integration if available
+    if command -v wt &>/dev/null || [ -f "$HOME/.local/share/mise/shims/wt" ]; then
+        "$MISE" exec -- wt config shell install 2>/dev/null && \
+            echo "  ✓ worktrunk shell integration installed" || true
+    fi
 
     # Git hooks — core-web/prepare.js writes branch-aware wrappers (no yarn install required).
     if [ -f "$REPO_ROOT/core-web/prepare.js" ]; then
@@ -132,16 +130,17 @@ setup:
         esac
     fi
 
-# Initializes a project after cloning or creating a worktree. Depends on `setup` (prior dependency —
-# see https://just.systems/man/en/dependencies.html); avoids recursive `just` (same manual warns that
+# Initializes a worktree after creation. Depends on `setup` (prior dependency — see
+# https://just.systems/man/en/dependencies.html); avoids recursive `just` (same manual warns that
 # child invocations recalculate state and can duplicate work). Recipe cwd is the justfile directory.
-# Safe to run manually to fix a broken environment.
-init: setup
+# Called by wt.toml post-create hook — keeps logic in one place instead of duplicating in wt.toml.
+# Also safe to run manually to fix a broken worktree.
+worktree-init: setup
     #!/usr/bin/env bash
     set -euo pipefail
-    echo "Initializing project..."
+    echo "Initializing worktree..."
 
-    # Fresh checkouts may need this path trusted for mise config (harmless if already trusted).
+    # New worktrees may need this path trusted for mise config (harmless if already trusted).
     command -v mise >/dev/null 2>&1 && mise trust 2>/dev/null || true
 
     # Frontend deps — yarn install reconciles node_modules against lockfile
@@ -150,7 +149,7 @@ init: setup
     echo "Installing frontend dependencies..."
     cd core-web && yarn install && cd ..
 
-    # Warn if yarn.lock drifted (copied cache from another branch can cause this)
+    # Warn if yarn.lock drifted (cross-branch cache can cause this)
     if ! git diff --quiet -- core-web/yarn.lock 2>/dev/null; then
         echo ""
         echo "WARNING: yarn.lock changed after install (cross-branch cache drift)."
@@ -166,24 +165,24 @@ init: setup
     # Git hooks: yarn install (step 2) already ran core-web/prepare.js — do not run
     # lefthook install here; it would replace branch-aware wrappers with machine-specific scripts.
 
-    echo "✓ Project ready"
+    echo "✓ Worktree ready"
 
-# Derives a Docker-safe slug from the project folder name (used for image tags and container namespaces)
-_project-slug:
-    @basename "$(pwd)" \
+# Derives a Docker-safe slug from the current branch name (used for image tags and container namespaces)
+_worktree-slug:
+    @git rev-parse --abbrev-ref HEAD 2>/dev/null \
         | sed 's/[^a-zA-Z0-9._-]/-/g; s/^[.-]*//' | cut -c1-64 \
         || echo "default"
 
-# Image tag: slug + short commit hash (e.g., "my-project-a1b2c3d4")
-_project-image-tag:
-    @echo "$(just _project-slug)-$(git rev-parse --short=8 HEAD 2>/dev/null || echo unknown)"
+# Image tag: slug + short commit hash (e.g., "my-feature-a1b2c3d4")
+_worktree-image-tag:
+    @echo "$(just _worktree-slug)-$(git rev-parse --short=8 HEAD 2>/dev/null || echo unknown)"
 
-# Derives a short, unique, human-readable identifier from the project slug.
-# Format: <prefix_24>_<sha256_8> — e.g., "core_baseline_cursor_dev_0e809b4d"
+# Derives a short, unique, human-readable identifier from the worktree slug.
+# Format: <prefix_24>_<sha256_8> — e.g., "cursor_development_envir_0e809b4d"
 # Guarantees uniqueness (hash) while remaining identifiable (prefix).
-_project-id:
+_worktree-id:
     #!/usr/bin/env bash
-    SLUG=$(just _project-slug)
+    SLUG=$(just _worktree-slug)
     PREFIX=$(echo "$SLUG" | sed 's/[^a-zA-Z0-9_]/_/g' | cut -c1-24)
     HASH=$(printf '%s' "$SLUG" | shasum -a 256 2>/dev/null || printf '%s' "$SLUG" | sha256sum)
     HASH=${HASH%% *}
@@ -194,14 +193,14 @@ _shared-services-running:
     @docker inspect dotcms-shared-db --format '{{ "{{.State.Running}}" }}' 2>/dev/null | grep -q true
 
 # Derives a PostgreSQL-safe database name for the given module and context.
-# Format: <module>_<project-id> — unique and within PostgreSQL's 63-char limit.
+# Format: <module>_<worktree-id> — unique and within PostgreSQL's 63-char limit.
 _shared-dbname module="dotcms-core":
     #!/usr/bin/env bash
     MODULE=$(echo '{{ module }}' | sed 's/[^a-zA-Z0-9_]/_/g')
-    WTID=$(just _project-id)
+    WTID=$(just _worktree-id)
     echo "${MODULE}_${WTID}"
 
-# Creates per-project database in shared PostgreSQL if it doesn't exist
+# Creates per-worktree database in shared PostgreSQL if it doesn't exist
 _ensure-shared-db module="dotcms-core":
     #!/usr/bin/env bash
     DB_NAME=$(just _shared-dbname {{ module }})
@@ -213,12 +212,12 @@ _ensure-shared-db module="dotcms-core":
     fi
 
 # Full build without tests — filters output to phase transitions and errors. Full log saved to /tmp.
-# Tags the image with project slug + commit SHA, plus mutable aliases.
+# Tags the image with worktree slug + commit SHA, plus mutable aliases.
 build:
     #!/usr/bin/env bash
     set -o pipefail
-    WTAG=$(just _project-image-tag)
-    WSLUG=$(just _project-slug)
+    WTAG=$(just _worktree-image-tag)
+    WSLUG=$(just _worktree-slug)
     LOG=$(mktemp /tmp/dotcms-build.XXXXXX)
     echo "Building dotCMS (full) — image: dotcms/dotcms-test:${WTAG} — log: $LOG"
     ./mvnw -DskipTests clean install \
@@ -255,10 +254,10 @@ build-quick:
     ./mvnw -DskipTests install
 
 # Builds dotcms-core incrementally, showing phase/error progress. Full log saved to /tmp.
-# Tags the image with project slug + commit SHA, plus mutable aliases.
+# Tags the image with worktree slug + commit SHA, plus mutable aliases.
 #
 # WARNING: Only builds dotcms-core (-pl :dotcms-core). Dependencies like core-web are pulled
-# from ~/.m2/repository/ — whatever was last installed by ANY project's `just build`.
+# from ~/.m2/repository/ — whatever was last installed by ANY worktree's `just build`.
 # The embedded frontend WAR may be from a different branch. This is fine when:
 #   - Testing backend-only changes with `nx serve` at :4200 (frontend comes from source)
 #   - The .m2 WAR is recent and from the same branch
@@ -266,8 +265,8 @@ build-quick:
 build-quicker:
     #!/usr/bin/env bash
     set -o pipefail
-    WTAG=$(just _project-image-tag)
-    WSLUG=$(just _project-slug)
+    WTAG=$(just _worktree-image-tag)
+    WSLUG=$(just _worktree-slug)
     LOG=$(mktemp /tmp/dotcms-build.XXXXXX)
 
     # Check if the .m2 core-web WAR is from this branch (warn if not)
@@ -335,19 +334,19 @@ build-select-module module="dotcms-core":
 build-select-module-deps module=":dotcms-core":
     ./mvnw install -pl {{ module }} --am -DskipTests=true
 
-# Starts dotCMS on the given port. Defaults to current project's image.
-# port=""         → read from .dev-port file, else 8082
-# image=""        → auto-detect from project (dotcms/dotcms-test:{slug})
+# Starts dotCMS on the given port. Defaults to current worktree's image.
+# port=""         → read from .dev-port (set by `wt switch --create` via hash_port), else 8082
+# image=""        → auto-detect from worktree (dotcms/dotcms-test:{slug})
 # image="default" → use stock 1.0.0-SNAPSHOT (no build needed — for frontend devs)
-# image="<full>"  → use as-is (e.g., another project's tag)
+# image="<full>"  → use as-is (e.g., another worktree's tag)
 # mode=""         → auto-detect (shared if running, else local)
 # mode="shared"   → force shared services (error if not running)
-# mode="local"    → force local sidecars via fabric8
+# mode="local"    → force per-worktree sidecars via fabric8
 dev-run port="" image="" mode="":
     #!/usr/bin/env bash
     set -euo pipefail
     just dev-stop 2>/dev/null || true
-    WSLUG=$(just _project-slug)
+    WSLUG=$(just _worktree-slug)
     # --- Resolve port: explicit > .dev-port > default 8082 ---
     PORT="{{ port }}"
     if [ -z "$PORT" ] && [ -f .dev-port ]; then
@@ -359,7 +358,7 @@ dev-run port="" image="" mode="":
     if [ -z "{{ image }}" ]; then
         IMG="dotcms/dotcms-test:${WSLUG}"
         if ! docker image inspect "$IMG" >/dev/null 2>&1; then
-            echo "No image for this project (${WSLUG}). Trying 1.0.0-SNAPSHOT..."
+            echo "No image for this worktree (${WSLUG}). Trying 1.0.0-SNAPSHOT..."
             IMG="dotcms/dotcms-test:1.0.0-SNAPSHOT"
         fi
     elif [ "{{ image }}" = "default" ]; then
@@ -382,7 +381,7 @@ dev-run port="" image="" mode="":
 
     if [ "$USE_SHARED" = "true" ]; then
         DB_NAME=$(just _shared-dbname dotcms-core)
-        CLUSTER_ID=$(just _project-id)
+        CLUSTER_ID=$(just _worktree-id)
         just _ensure-shared-db dotcms-core
         echo "Starting $IMG on :${PORT} (shared services, db: ${DB_NAME}, namespace: ${WSLUG})"
         ./mvnw -pl :dotcms-core -Pdocker-start,shared-services \
@@ -424,11 +423,11 @@ dev-urls:
     echo "  Health    → http://localhost:${MGMT}/dotmgt/livez"
     echo ""
 
-# Stops current project's dev containers. In shared mode, stops only the app container.
+# Stops current worktree's dev containers. In shared mode, stops only the app container.
 # In local mode, stops app + sidecars. Safe no-op if not running.
 dev-stop:
     #!/usr/bin/env bash
-    WSLUG=$(just _project-slug)
+    WSLUG=$(just _worktree-slug)
     CONTAINER="dotbuild_dotcms-core_${WSLUG}_dotcms"
     # Direct stop handles shared-mode containers (not fabric8-managed)
     if docker inspect "$CONTAINER" >/dev/null 2>&1; then
@@ -445,7 +444,7 @@ dev-restart port="" image="" mode="":
     just dev-run {{ port }} {{ image }} {{ mode }}
 
 # Starts the Angular frontend dev server on :4200. Discovers backend port from Docker; falls back to :8080.
-# port=""  → 4200 (default). Use a different port for parallel projects (e.g., 4201, 4202).
+# port=""  → 4200 (default). Use a different port for parallel worktrees (e.g., 4201, 4202).
 dev-start-frontend port="4200":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -454,8 +453,8 @@ dev-start-frontend port="4200":
         exit 0
     fi
     # Discover the backend app port from Docker. Falls back to 8080 if no container is running.
-    # 3-stage discovery: prefer current project's container, fall back to any.
-    WSLUG=$(just _project-slug)
+    # 3-stage discovery: prefer current worktree's container, fall back to any.
+    WSLUG=$(just _worktree-slug)
     CONTAINER=$(docker ps --filter "status=running" \
                           --format '{{ "{{.Names}}" }}' \
                           | grep -E "^dotbuild_dotcms-core_${WSLUG}_dotcms$" | head -1 || true)
@@ -478,7 +477,7 @@ dev-start-frontend port="4200":
     cd core-web
     # DOTCMS_HOST is read by proxy-dev.conf.mjs to set the proxy target.
     # export ensures it's visible to the nohup child process.
-    # NX_DAEMON=false prevents the Nx daemon from serializing parallel builds.
+    # NX_DAEMON=false prevents the Nx daemon from serializing parallel worktree builds.
     export DOTCMS_HOST
     export NX_DAEMON=false
     NODE_OPTIONS="--max_old_space_size=4096" nohup yarn nx serve dotcms-ui --port="$FE_PORT" > ../.frontend.log 2>&1 &
@@ -588,12 +587,12 @@ dev port="" fe-port="4200":
     echo ""
     echo "  Frontend → http://localhost:{{ fe-port }}/dotAdmin (live reload)"
 
-# Internal helper: finds the running dotCMS container. Prefers current project, falls back to any.
-# 3-stage discovery: 1) exact project match, 2) any dotcms-test image, 3) name pattern.
+# Internal helper: finds the running dotCMS container. Prefers current worktree, falls back to any.
+# 3-stage discovery: 1) exact worktree match, 2) any dotcms-test image, 3) name pattern.
 _dotcms-container:
     #!/usr/bin/env bash
-    WSLUG=$(just _project-slug)
-    # Stage 1: exact match for current project's container
+    WSLUG=$(just _worktree-slug)
+    # Stage 1: exact match for current worktree's container
     NAMES=$(docker ps --filter "status=running" \
                       --format '{{ "{{.Names}}" }}' \
                       | grep -E "^dotbuild_dotcms-core_${WSLUG}_dotcms$" || true)
@@ -649,21 +648,21 @@ dev-wait:
     echo ""
     just dev-health
 
-# Cleans up Docker volumes associated with the current project's development environment
+# Cleans up Docker volumes associated with the current worktree's development environment
 dev-clean-volumes:
     #!/usr/bin/env bash
-    WSLUG=$(just _project-slug)
+    WSLUG=$(just _worktree-slug)
     ./mvnw -pl :dotcms-core -Pdocker-clean-volumes -Dcontext.name="$WSLUG"
 
 # Lists locally built dotCMS images with tag, size, and age
 dev-images:
     @docker images dotcms/dotcms-test --format 'table {{ "{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}" }}'
 
-# Lists all running dotCMS containers across projects
+# Lists all running dotCMS containers across worktrees
 dev-containers:
     @docker ps --filter "name=dotbuild_" --format 'table {{ "{{.Names}}\t{{.Image}}\t{{.Ports}}\t{{.Status}}" }}'
 
-# Stops ALL dotCMS dev containers across all projects
+# Stops ALL dotCMS dev containers across all worktrees
 dev-stop-all:
     #!/usr/bin/env bash
     CONTAINERS=$(docker ps --filter "name=dotbuild_" -q)
@@ -695,10 +694,10 @@ dev-run-jmx-debug-glowroot:
     ./mvnw -pl :dotcms-core -Pdocker-start,jmx-debug,glowroot -Djmx.debug.enable=true -Ddocker.glowroot.enabled=true
 
 ###########################################################
-# Shared Services (parallel development)
+# Shared Services (multi-worktree)
 ###########################################################
 
-# Starts shared DB + OpenSearch for parallel development. Run once, use from all project folders.
+# Starts shared DB + OpenSearch for multi-worktree development. Run once, use from all worktrees.
 dev-shared-start:
     docker compose -f docker/docker-compose-shared-services.yml -p dotcms-shared up -d --wait
     @echo ""
@@ -707,7 +706,7 @@ dev-shared-start:
     @echo "  OpenSearch → localhost:19200"
     @echo "  OS Upgrade → localhost:19201"
     @echo ""
-    @echo "Now run 'just dev-run <port>' in any project folder."
+    @echo "Now run 'just dev-run <port>' in any worktree."
     @echo ""
     @echo "NOTE: These containers auto-restart on boot (~3GB RAM)."
     @echo "Run 'just dev-shared-stop' when you no longer need them."
@@ -724,24 +723,24 @@ dev-shared-status:
 dev-shared-clean:
     docker compose -f docker/docker-compose-shared-services.yml -p dotcms-shared down -v
 
-# Drops current project's database from shared PostgreSQL
+# Drops current worktree's database from shared PostgreSQL
 dev-shared-drop-db module="dotcms-core":
     #!/usr/bin/env bash
     DB_NAME=$(just _shared-dbname {{ module }})
     echo "Dropping database ${DB_NAME}..."
     docker exec dotcms-shared-db dropdb -U postgres --if-exists "${DB_NAME}"
 
-# Lists all project databases in shared PostgreSQL
+# Lists all worktree databases in shared PostgreSQL
 dev-shared-list-dbs:
     @docker exec dotcms-shared-db psql -U postgres -c \
         "SELECT datname, pg_size_pretty(pg_database_size(datname)) AS size FROM pg_database WHERE datname NOT IN ('postgres','template0','template1','dotcms') ORDER BY datname"
 
-# Deletes OpenSearch indexes for the current project from both shared instances.
-# Index prefix: cluster_<project-id>.* (see ESIndexAPI.java:152)
+# Deletes OpenSearch indexes for the current worktree from both shared instances.
+# Index prefix: cluster_<worktree-id>.* (see ESIndexAPI.java:152)
 dev-shared-drop-indexes:
     #!/usr/bin/env bash
     set -euo pipefail
-    WTID=$(just _project-id)
+    WTID=$(just _worktree-id)
     PREFIX="cluster_${WTID}."
     echo "Deleting indexes matching ${PREFIX}* from shared OpenSearch instances..."
     for container in dotcms-shared-es dotcms-shared-os-upgrade; do
@@ -759,20 +758,20 @@ dev-shared-drop-indexes:
         fi
     done
 
-# Removes all shared data for the current project: database + OpenSearch indexes.
-# Safe to run while shared services are still serving other projects.
-dev-shared-drop-project:
+# Removes all shared data for the current worktree: database + OpenSearch indexes.
+# Safe to run while shared services are still serving other worktrees.
+dev-shared-drop-worktree:
     just dev-shared-drop-db
     just dev-shared-drop-indexes
-    @echo "Project data cleaned from shared services."
+    @echo "Worktree data cleaned from shared services."
 
 # Returns 0 if any dotCMS app containers are using shared services
 _shared-services-in-use:
     @docker network inspect dotcms-shared --format '{{ "{{range .Containers}}{{.Name}} {{end}}" }}' 2>/dev/null \
         | grep -q 'dotbuild_'
 
-# Stops shared services only if no app containers are connected.
-# Use from automation/agents — safe no-op if other projects are still running.
+# Stops shared services only if no worktree app containers are connected.
+# Use from automation/agents — safe no-op if other worktrees are still running.
 dev-shared-stop-if-idle:
     #!/usr/bin/env bash
     if just _shared-services-in-use 2>/dev/null; then
@@ -781,7 +780,7 @@ dev-shared-stop-if-idle:
             | tr ' ' '\n' | grep 'dotbuild_' | sed 's/^/  /'
         echo "Not stopping. Use 'just dev-shared-stop' to force."
     else
-        echo "No projects using shared services. Stopping..."
+        echo "No worktrees using shared services. Stopping..."
         just dev-shared-stop
     fi
 


### PR DESCRIPTION
## Summary

Layers worktree-specific features on top of Phase 1's universal dev setup. Requires [worktrunk](https://worktrunk.dev) (`wt`) for full functionality.

> **Note:** This PR preserves the worktree-aware features from the original branch for completeness. We may choose not to merge Phase 2 in its current form — the worktree integration may be revisited, simplified, or deferred depending on how Phase 1 lands and what the team's actual parallel development needs look like in practice.

- **worktrunk** added to mise tools with shell integration in `just setup`
- **`.config/wt.toml`** — post-create hooks: copy caches via reflink, run `just init`, re-tag Docker image, assign deterministic port
- **`.worktreeinclude`** — scopes which gitignored files get copied between worktrees (Nx cache, Angular cache, .venv)
- **`dotcms-worktree` skill** — branching patterns, sub-task workflows, agent spawning (3 options), merge/cleanup
- **Branch-based slugs** (`_worktree-slug`) layered on folder-based (`_project-slug`) for richer container naming
- **`worktree-init`** recipe wrapping `init` with worktree-specific steps
- **`dev-shared-drop-worktree`** recipe for per-worktree shared data cleanup
- **AGENTS.md** Worktrees section with `EnterWorktree` warning
- **DEV_ENVIRONMENT_SETUP.md** Worktrunk section with warm-start docs

### Stacked on

Phase 1: #35100

## Test plan

- [ ] `just setup` installs worktrunk and shell integration
- [ ] `wt switch --create test-branch` creates warm-start worktree
- [ ] `.dev-port` file created with deterministic port
- [ ] `just dev-run` uses worktree-specific image tag
- [ ] `just dev-shared-drop-worktree` cleans DB + indexes for current worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: #34722 