### PR TITLE
task(ContentletIndexAPIImpl Abstraction layers) Refs: #34938

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/business/ContentMappingAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/content/business/ContentMappingAPI.java
@@ -1,24 +1,105 @@
 package com.dotcms.content.business;
 
+import com.dotcms.content.model.annotation.IndexLibraryIndependent;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 /**
- * This API provides useful methods and mechanisms to map properties that are present in a {@link Contentlet} object,
- * specially for ES indexation purposes.
+ * Vendor-neutral API for mapping and serializing {@link Contentlet} objects for index storage.
+ *
+ * <p>Implementations must not expose any vendor-specific types (Elasticsearch, OpenSearch, etc.)
+ * in their public method signatures. Routing to the active index provider is handled by the
+ * router implementation.</p>
  *
  * @author root
  * @since Mar 22nd, 2012
  */
+@IndexLibraryIndependent
 public interface ContentMappingAPI {
 
-	boolean RESPECT_FRONTEND_ROLES = Boolean.TRUE;
+    boolean RESPECT_FRONTEND_ROLES = Boolean.TRUE;
     boolean DONT_RESPECT_FRONTEND_ROLES = Boolean.FALSE;
 
+    /**
+     * Applies the given mapping to all specified indexes.
+     *
+     * @param indexes list of index names to update
+     * @param mapping JSON mapping string
+     * @return {@code true} if the mapping was acknowledged by all nodes
+     */
+    boolean putMapping(List<String> indexes, String mapping) throws IOException;
+
+    /**
+     * Applies the given mapping to a single index.
+     *
+     * @param indexName target index
+     * @param mapping   JSON mapping string
+     * @return {@code true} if the mapping was acknowledged
+     */
+    boolean putMapping(String indexName, String mapping) throws IOException;
+
+    /**
+     * Returns the current mapping for the given index as a JSON string.
+     *
+     * @param index index name
+     * @return mapping JSON
+     */
+    String getMapping(String index) throws IOException;
+
+    /**
+     * Returns the mapping for a specific field in the given index.
+     *
+     * @param index     index name
+     * @param fieldName field name
+     * @return mapping source map, or an empty map if not found
+     */
+    Map<String, Object> getFieldMappingAsMap(String index, String fieldName) throws IOException;
+
+    /**
+     * Converts the given contentlet to its JSON index representation.
+     *
+     * @param contentlet contentlet to convert
+     * @return JSON string ready for indexing
+     */
+    String toJson(Contentlet contentlet) throws DotMappingException;
+
+    /**
+     * Builds the lowercased property map used for indexing the given contentlet.
+     *
+     * @param contentlet contentlet to map
+     * @return map of field names to values
+     */
+    Map<String, Object> toMap(Contentlet contentlet) throws DotMappingException;
+
+    /**
+     * Converts the given contentlet to a mapped object (currently equivalent to {@link #toJson}).
+     *
+     * @param con contentlet to convert
+     * @return mapped representation
+     */
+    Object toMappedObj(Contentlet con) throws DotMappingException;
+
+    /**
+     * Serializes the given map to a JSON string using the configured {@code ObjectMapper}.
+     *
+     * @param map map to serialize
+     * @return JSON string
+     */
+    String toJsonString(Map<String, Object> map) throws IOException;
+
+    /**
+     * Returns the identifiers of related contentlets that must be re-indexed when the given
+     * contentlet changes.
+     *
+     * @param con the contentlet whose dependencies should be collected
+     * @return list of dependent contentlet identifiers
+     */
     List<String> dependenciesLeftToReindex(Contentlet con)
             throws DotStateException, DotDataException, DotSecurityException;
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexOperationsES.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexOperationsES.java
@@ -1,0 +1,348 @@
+package com.dotcms.content.elasticsearch.business;
+
+import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
+import static com.dotmarketing.common.reindex.ReindexThread.BULK_PROCESSOR_AWAIT_TIMEOUT;
+import static com.dotmarketing.common.reindex.ReindexThread.ELASTICSEARCH_CONCURRENT_REQUESTS;
+
+import com.dotcms.content.index.ContentletIndexOperations;
+import com.dotcms.content.index.domain.CreateIndexStatus;
+import java.io.IOException;
+import com.dotcms.content.index.domain.IndexBulkProcessor;
+import com.dotcms.content.index.domain.IndexBulkRequest;
+import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.JsonUtil;
+import com.dotmarketing.util.DateUtil;
+import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
+import com.dotcms.exception.ExceptionUtil;
+import com.dotmarketing.business.APILocator;
+import com.dotcms.content.index.domain.ImmutableIndexBulkItemResult;
+import com.dotcms.content.index.domain.IndexBulkItemResult;
+import com.dotcms.content.index.domain.IndexBulkListener;
+import com.dotmarketing.common.reindex.ReindexThread;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.portlets.contentlet.business.ContentletFactory;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.dotmarketing.portlets.structure.model.Relationship;
+import com.dotmarketing.util.Logger;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.liferay.util.StringPool;
+import com.rainerhahnekamp.sneakythrow.Sneaky;
+import io.vavr.control.Try;
+import java.util.ArrayList;
+import java.util.List;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.bulk.BackoffPolicy;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.core.CountRequest;
+import org.elasticsearch.client.core.CountResponse;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.index.reindex.DeleteByQueryRequest;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+
+/**
+ * Elasticsearch implementation of {@link ContentletIndexOperations}.
+ *
+ * <p>All Elasticsearch-specific types ({@code BulkRequest}, {@code BulkProcessor},
+ * {@code IndexRequest}, {@code DeleteRequest}, etc.) are confined to this class.
+ * The public API exposes only {@link IndexBulkRequest} and {@link IndexBulkProcessor}
+ * handles to callers.</p>
+ *
+ * <p>Extracted from {@code ContentletIndexAPIImpl} as part of the vendor-neutral
+ * router pattern established in {@link ESContentFactoryImpl}.</p>
+ *
+ * @author Fabrizio Araya
+ * @see ContentletIndexOperationsOS
+ */
+public class ContentletIndexOperationsES implements ContentletIndexOperations {
+
+    private static final String ES_SETTINGS_FILE = "es-content-settings.json";
+    private static final String ES_MAPPING_FILE  = "es-content-mapping.json";
+
+    private final ESIndexAPI esIndexAPI;
+    private final MappingOperationsES mappingOps;
+
+    public ContentletIndexOperationsES() {
+        this(new ESIndexAPI(), new MappingOperationsES());
+    }
+
+    /** Package-private constructor for testing. */
+    ContentletIndexOperationsES(final ESIndexAPI esIndexAPI,
+            final MappingOperationsES mappingOps) {
+        this.esIndexAPI  = esIndexAPI;
+        this.mappingOps  = mappingOps;
+    }
+
+    // =========================================================================
+    // Inner wrappers — vendor types stay inside this class
+    // =========================================================================
+
+    /** Wraps an ES {@link BulkRequest} behind the neutral {@link IndexBulkRequest} handle. */
+    static final class ESIndexBulkRequest implements IndexBulkRequest {
+        final BulkRequest delegate;
+
+        ESIndexBulkRequest(final BulkRequest delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int size() {
+            return delegate.numberOfActions();
+        }
+    }
+
+    /** Wraps an ES {@link BulkProcessor} behind the neutral {@link IndexBulkProcessor} handle. */
+    static final class ESIndexBulkProcessor implements IndexBulkProcessor {
+        final BulkProcessor delegate;
+        private final int awaitTimeoutSeconds;
+
+        ESIndexBulkProcessor(final BulkProcessor delegate, final int awaitTimeoutSeconds) {
+            this.delegate = delegate;
+            this.awaitTimeoutSeconds = awaitTimeoutSeconds;
+        }
+
+        @Override
+        public void close() throws Exception {
+            delegate.awaitClose(awaitTimeoutSeconds, java.util.concurrent.TimeUnit.SECONDS);
+        }
+    }
+
+    // =========================================================================
+    // Index lifecycle
+    // =========================================================================
+
+    @Override
+    public boolean createContentIndex(final String indexName, final int shards)
+            throws IOException {
+        String settings = null;
+        try {
+            settings = JsonUtil.getJsonFileContentAsString(ES_SETTINGS_FILE);
+        } catch (Exception e) {
+            Logger.error(this, "cannot load " + ES_SETTINGS_FILE + ", skipping", e);
+        }
+
+        final String mapping = JsonUtil.getJsonFileContentAsString(ES_MAPPING_FILE);
+        final CreateIndexStatus status = esIndexAPI.createIndex(indexName, settings, shards);
+
+        int i = 0;
+        while (!status.acknowledged()) {
+            DateUtil.sleep(100);
+            if (i++ > 300) {
+                throw new IOException("ES index creation timed out for: " + indexName);
+            }
+        }
+
+        mappingOps.putMapping(CollectionsUtils.list(indexName), mapping);
+        return true;
+    }
+
+    // =========================================================================
+    // Batch write path
+    // =========================================================================
+
+    @Override
+    public IndexBulkRequest createBulkRequest() {
+        final BulkRequest bulkRequest = new BulkRequest();
+        bulkRequest.setRefreshPolicy(RefreshPolicy.NONE);
+        return new ESIndexBulkRequest(bulkRequest);
+    }
+
+    @Override
+    public void addIndexOp(final IndexBulkRequest req, final String indexName,
+            final String docId, final String jsonMapping) {
+        asBulkRequest(req).add(
+                new IndexRequest(indexName, "_doc", docId)
+                        .source(jsonMapping, XContentType.JSON));
+    }
+
+    @Override
+    public void addDeleteOp(final IndexBulkRequest req, final String indexName,
+            final String docId) {
+        asBulkRequest(req).add(new DeleteRequest(indexName, "_doc", docId));
+    }
+
+    @Override
+    public void setRefreshPolicy(final IndexBulkRequest req,
+            final IndexBulkRequest.RefreshPolicy policy) {
+        final WriteRequest.RefreshPolicy esPolicy;
+        switch (policy) {
+            case IMMEDIATE: esPolicy = WriteRequest.RefreshPolicy.IMMEDIATE;  break;
+            case WAIT_FOR:  esPolicy = WriteRequest.RefreshPolicy.WAIT_UNTIL; break;
+            default:        esPolicy = WriteRequest.RefreshPolicy.NONE;
+        }
+        asBulkRequest(req).setRefreshPolicy(esPolicy);
+    }
+
+    @Override
+    public void putToIndex(final IndexBulkRequest req) {
+        final BulkRequest bulkRequest = asBulkRequest(req);
+        if (bulkRequest.numberOfActions() == 0) {
+            return;
+        }
+        bulkRequest.timeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
+        try {
+            final BulkResponse response = RestHighLevelClientProvider.getInstance()
+                    .getClient().bulk(bulkRequest, RequestOptions.DEFAULT);
+            if (response != null && response.hasFailures()) {
+                Logger.error(this,
+                        "Error reindexing (" + response.getItems().length + ") content(s): "
+                                + response.buildFailureMessage());
+            }
+        } catch (final Exception e) {
+            if (ExceptionUtil.causedBy(e, IllegalStateException.class)) {
+                ContentletFactory.rebuildRestHighLevelClientIfNeeded(e);
+            }
+            Logger.warnAndDebug(ContentletIndexOperationsES.class, e);
+            throw new DotRuntimeException(e.getMessage(), e);
+        }
+    }
+
+    // =========================================================================
+    // Async bulk-processor write path
+    // =========================================================================
+
+    @Override
+    public IndexBulkProcessor createBulkProcessor(final IndexBulkListener listener) {
+        final int numberToReindexInRequest = Try.of(
+                () -> ReindexThread.ELASTICSEARCH_BULK_ACTIONS
+                        / APILocator.getServerAPI().getReindexingServers().size())
+                .getOrElse(10);
+
+        // Adapter: maps ES BulkProcessor.Listener callbacks → neutral IndexBulkListener
+        final BulkProcessor.Listener esAdapter = new BulkProcessor.Listener() {
+            @Override
+            public void beforeBulk(final long executionId, final BulkRequest request) {
+                listener.beforeBulk(executionId, request.numberOfActions());
+            }
+
+            @Override
+            public void afterBulk(final long executionId, final BulkRequest request,
+                    final BulkResponse response) {
+                final List<IndexBulkItemResult> results = new ArrayList<>();
+                for (final BulkItemResponse item : response) {
+                    final DocWriteResponse itemResponse = item.getResponse();
+                    if (item.isFailed() || itemResponse == null) {
+                        results.add(ImmutableIndexBulkItemResult.builder()
+                                .id(item.getFailure().getId())
+                                .failed(true)
+                                .failureMessage(item.getFailure().getMessage())
+                                .build());
+                    } else {
+                        results.add(ImmutableIndexBulkItemResult.builder()
+                                .id(itemResponse.getId())
+                                .failed(false)
+                                .build());
+                    }
+                }
+                listener.afterBulk(executionId, results);
+            }
+
+            @Override
+            public void afterBulk(final long executionId, final BulkRequest request,
+                    final Throwable failure) {
+                listener.afterBulk(executionId, failure);
+            }
+        };
+
+        final BulkProcessor processor = BulkProcessor.builder(
+                (request, bulkListener) ->
+                        RestHighLevelClientProvider.getInstance().getClient()
+                                .bulkAsync(request, RequestOptions.DEFAULT, bulkListener),
+                esAdapter)
+                .setBulkActions(numberToReindexInRequest)
+                .setBulkSize(new ByteSizeValue(ReindexThread.ELASTICSEARCH_BULK_SIZE, ByteSizeUnit.MB))
+                .setConcurrentRequests(ELASTICSEARCH_CONCURRENT_REQUESTS)
+                .setBackoffPolicy(BackoffPolicy.constantBackoff(
+                        TimeValue.timeValueSeconds(ReindexThread.BACKOFF_POLICY_TIME_IN_SECONDS),
+                        ReindexThread.BACKOFF_POLICY_MAX_RETRYS))
+                .build();
+
+        return new ESIndexBulkProcessor(processor, BULK_PROCESSOR_AWAIT_TIMEOUT);
+    }
+
+    @Override
+    public void addIndexOpToProcessor(final IndexBulkProcessor proc, final String indexName,
+            final String docId, final String jsonMapping) {
+        asBulkProcessor(proc).add(
+                new IndexRequest(indexName, "_doc", docId)
+                        .source(jsonMapping, XContentType.JSON));
+    }
+
+    @Override
+    public void addDeleteOpToProcessor(final IndexBulkProcessor proc, final String indexName,
+            final String docId) {
+        asBulkProcessor(proc).add(new DeleteRequest(indexName, "_doc", docId));
+    }
+
+    // =========================================================================
+    // Other write operations
+    // =========================================================================
+
+    @Override
+    public void removeContentFromIndexByContentType(final ContentType contentType)
+            throws DotDataException {
+        final String structureName = contentType.variable();
+        final IndiciesInfo info = APILocator.getIndiciesAPI().loadIndicies();
+
+        final List<String> idxs = new java.util.ArrayList<>();
+        idxs.add(info.getWorking());
+        idxs.add(info.getLive());
+        if (info.getReindexWorking() != null) {
+            idxs.add(info.getReindexWorking());
+        }
+        if (info.getReindexLive() != null) {
+            idxs.add(info.getReindexLive());
+        }
+
+        final DeleteByQueryRequest request = new DeleteByQueryRequest(
+                idxs.toArray(new String[0]));
+        request.setQuery(QueryBuilders.matchQuery("contenttype", structureName.toLowerCase()));
+        request.setTimeout(new TimeValue(INDEX_OPERATIONS_TIMEOUT_IN_MS));
+
+        final BulkByScrollResponse response = Sneaky.sneak(
+                () -> RestHighLevelClientProvider.getInstance().getClient()
+                        .deleteByQuery(request, RequestOptions.DEFAULT));
+
+        Logger.info(this, "Records deleted: " + response.getDeleted()
+                + " from contentType: " + structureName);
+    }
+
+    @Override
+    public long getIndexDocumentCount(final String indexName) {
+        final CountRequest countRequest = new CountRequest(indexName);
+        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+        countRequest.source(searchSourceBuilder);
+
+        final CountResponse countResponse = Sneaky.sneak(
+                () -> RestHighLevelClientProvider.getInstance().getClient()
+                        .count(countRequest, RequestOptions.DEFAULT));
+
+        return countResponse.getCount();
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private static BulkRequest asBulkRequest(final IndexBulkRequest req) {
+        return ((ESIndexBulkRequest) req).delegate;
+    }
+
+    private static BulkProcessor asBulkProcessor(final IndexBulkProcessor proc) {
+        return ((ESIndexBulkProcessor) proc).delegate;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentFactoryImpl.java
@@ -130,7 +130,7 @@ import org.apache.commons.lang.StringUtils;
 
 @IndexLibraryIndependent
 @IndexRouter(
-        access = IndexAccess.READ_ONLY
+        access = {IndexAccess.READ}
 )
 public class ESContentFactoryImpl implements ContentletFactory {
 

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/MappingOperationsES.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/MappingOperationsES.java
@@ -1,0 +1,100 @@
+package com.dotcms.content.elasticsearch.business;
+
+import static com.dotcms.content.elasticsearch.business.ESIndexAPI.INDEX_OPERATIONS_TIMEOUT_IN_MS;
+
+import com.dotcms.content.elasticsearch.util.RestHighLevelClientProvider;
+import com.dotcms.content.index.IndexAPI;
+import com.dotcms.content.index.IndexMappingRestOperations;
+import com.dotcms.util.CollectionsUtils;
+import com.dotmarketing.business.APILocator;
+import com.google.common.annotations.VisibleForTesting;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.indices.GetFieldMappingsRequest;
+import org.elasticsearch.client.indices.GetFieldMappingsResponse;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.PutMappingRequest;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Elasticsearch implementation of {@link IndexMappingRestOperations}.
+ *
+ * <p>Wraps the three mapping REST calls ({@code putMapping}, {@code getMapping},
+ * {@code getFieldMappingAsMap}) that use the ES {@code RestHighLevelClient}.
+ * All vendor-specific types are confined to this class and never exposed
+ * through the {@link IndexMappingRestOperations} contract.</p>
+ *
+ * @author Fabrizio Araya
+ * @see MappingOperationsOS
+ * @see com.dotcms.content.elasticsearch.business.ESMappingAPIImpl
+ */
+@ApplicationScoped
+public class MappingOperationsES implements IndexMappingRestOperations {
+
+    private final IndexAPI esIndexAPI;
+
+    /** CDI-managed default constructor. */
+    public MappingOperationsES() {
+        this(APILocator.getESIndexAPI());
+    }
+
+    /** Package-private constructor for unit testing. */
+    @VisibleForTesting
+    MappingOperationsES(final IndexAPI esIndexAPI) {
+        this.esIndexAPI = esIndexAPI;
+    }
+
+    @Override
+    public boolean putMapping(final List<String> indexes, final String mapping) throws IOException {
+        final PutMappingRequest request = new PutMappingRequest(
+                indexes.stream()
+                        .map(esIndexAPI::getNameWithClusterIDPrefix)
+                        .toArray(String[]::new));
+        request.setTimeout(TimeValue.timeValueMillis(INDEX_OPERATIONS_TIMEOUT_IN_MS));
+        request.source(mapping, XContentType.JSON);
+
+        return RestHighLevelClientProvider.getInstance()
+                .getClient()
+                .indices()
+                .putMapping(request, RequestOptions.DEFAULT)
+                .isAcknowledged();
+    }
+
+    @Override
+    public String getMapping(final String index) throws IOException {
+        final GetMappingsRequest request = new GetMappingsRequest();
+        request.indices(index);
+
+        return RestHighLevelClientProvider.getInstance()
+                .getClient()
+                .indices()
+                .getMapping(request, RequestOptions.DEFAULT)
+                .mappings()
+                .get(index)
+                .source()
+                .string();
+    }
+
+    @Override
+    public Map<String, Object> getFieldMappingAsMap(final String index,
+            final String fieldName) throws IOException {
+        final GetFieldMappingsRequest request = new GetFieldMappingsRequest();
+        request.indices(index).fields(fieldName);
+
+        final GetFieldMappingsResponse response = RestHighLevelClientProvider.getInstance()
+                .getClient()
+                .indices()
+                .getFieldMapping(request, RequestOptions.DEFAULT);
+
+        final GetFieldMappingsResponse.FieldMappingMetadata meta =
+                response.mappings().getOrDefault(index, Collections.emptyMap()).get(fieldName);
+
+        return meta != null ? meta.sourceAsMap() : Collections.emptyMap();
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/ContentletIndexOperations.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/ContentletIndexOperations.java
@@ -1,0 +1,147 @@
+package com.dotcms.content.index;
+
+import com.dotcms.content.index.domain.IndexBulkProcessor;
+import com.dotcms.content.index.domain.IndexBulkRequest;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.content.index.domain.IndexBulkListener;
+import com.dotmarketing.exception.DotDataException;
+import java.io.IOException;
+
+/**
+ * Vendor-neutral contract for the <em>write side</em> of the contentlet index pipeline.
+ *
+ * <p>This interface separates the two vendor-specific write implementations
+ * ({@code ContentletIndexOperationsES} and {@code ContentletIndexOperationsOS}) from
+ * the business logic that lives in the router ({@code ContentletIndexAPIImpl}).
+ * Vendor types ({@code BulkRequest}, {@code BulkProcessor}, OpenSearch equivalents)
+ * must not appear in any public method signature of either implementation.</p>
+ *
+ * <p>The design mirrors {@link ContentFactoryIndexOperations} for the read path:
+ * the router holds two typed fields, selects the active implementation via
+ * {@code getProvider()}, and delegates every call.</p>
+ *
+ * @author Fabrizio Araya
+ * @see com.dotcms.content.elasticsearch.business.ContentletIndexOperationsES
+ * @see com.dotcms.content.index.opensearch.ContentletIndexOperationsOS
+ */
+public interface ContentletIndexOperations {
+
+    // =========================================================================
+    // Batch (synchronous) write path
+    // =========================================================================
+
+    /**
+     * Creates a new empty batch ready to accumulate index and delete operations.
+     *
+     * @return a fresh, empty {@link IndexBulkRequest}
+     */
+    IndexBulkRequest createBulkRequest();
+
+    /**
+     * Appends an <em>index (upsert)</em> operation to {@code req}.
+     *
+     * @param req         the batch to append to
+     * @param indexName   the target index name
+     * @param docId       document id — {@code identifier_languageId_variantId}
+     * @param jsonMapping the JSON string produced by the content mapping API
+     */
+    void addIndexOp(IndexBulkRequest req, String indexName, String docId, String jsonMapping);
+
+    /**
+     * Appends a <em>delete</em> operation to {@code req}.
+     *
+     * @param req       the batch to append to
+     * @param indexName the target index name
+     * @param docId     document id to delete
+     */
+    void addDeleteOp(IndexBulkRequest req, String indexName, String docId);
+
+    /**
+     * Sets the refresh policy on the batch before submission.
+     *
+     * @param req    the batch to configure
+     * @param policy one of {@code "NONE"}, {@code "WAIT_FOR"}, or {@code "IMMEDIATE"}
+     */
+    void setRefreshPolicy(IndexBulkRequest req, IndexBulkRequest.RefreshPolicy policy);
+
+    /**
+     * Submits the accumulated batch synchronously and blocks until the cluster
+     * acknowledges all operations.
+     *
+     * @param req the batch to submit — no-op if the batch is empty
+     */
+    void putToIndex(IndexBulkRequest req);
+
+    // =========================================================================
+    // Async bulk-processor write path (used by ReindexThread)
+    // =========================================================================
+
+    /**
+     * Creates a self-flushing asynchronous bulk processor backed by the
+     * vendor-specific client.
+     *
+     * @param listener receives completion and failure callbacks for each flush
+     * @return a new {@link IndexBulkProcessor}
+     */
+    IndexBulkProcessor createBulkProcessor(IndexBulkListener listener);
+
+    /**
+     * Adds an <em>index (upsert)</em> operation directly to the async processor,
+     * which will flush it according to its internal thresholds.
+     *
+     * @param proc        the target processor
+     * @param indexName   the target index name
+     * @param docId       document id
+     * @param jsonMapping the JSON string produced by the content mapping API
+     */
+    void addIndexOpToProcessor(IndexBulkProcessor proc, String indexName, String docId,
+            String jsonMapping);
+
+    /**
+     * Adds a <em>delete</em> operation directly to the async processor.
+     *
+     * @param proc      the target processor
+     * @param indexName the target index name
+     * @param docId     document id to delete
+     */
+    void addDeleteOpToProcessor(IndexBulkProcessor proc, String indexName, String docId);
+
+    // =========================================================================
+    // Index lifecycle
+    // =========================================================================
+
+    /**
+     * Creates a search index with the provider-specific default settings and content mapping.
+     *
+     * <p>Each implementation loads its own settings file ({@code es-content-settings.json} or
+     * {@code os-content-settings.json}) and applies the corresponding content mapping, so the
+     * router does not need to know which backend is being targeted.</p>
+     *
+     * @param indexName the fully-qualified index name (with cluster prefix)
+     * @param shards    number of primary shards; {@code 0} means "use provider default"
+     * @return {@code true} if the index was created and the mapping applied successfully
+     * @throws IOException if index creation or mapping application fails
+     */
+    boolean createContentIndex(String indexName, int shards) throws IOException;
+
+    // =========================================================================
+    // Other write operations
+    // =========================================================================
+
+    /**
+     * Removes all documents belonging to the given content type from every
+     * active index in the cluster.
+     *
+     * @param contentType the content type whose documents should be removed
+     * @throws DotDataException if the operation fails
+     */
+    void removeContentFromIndexByContentType(ContentType contentType) throws DotDataException;
+
+    /**
+     * Returns the number of documents currently stored in the given index.
+     *
+     * @param indexName the fully-qualified index name (with cluster prefix)
+     * @return document count
+     */
+    long getIndexDocumentCount(String indexName);
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/IndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/IndexAPIImpl.java
@@ -46,7 +46,7 @@ import java.util.Set;
  */
 @IndexLibraryIndependent
 @IndexRouter(
-        access = IndexAccess.READ_WRITE
+        access = {IndexAccess.READ,IndexAccess.WRITE}
 )
 public class IndexAPIImpl implements IndexAPI {
 

--- a/dotCMS/src/main/java/com/dotcms/content/index/IndexConfigHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/IndexConfigHelper.java
@@ -123,6 +123,10 @@ public interface IndexConfigHelper {
         return MigrationPhase.current().isMigrationNotStarted();
     }
 
+    static boolean isMigrationStarted(){
+        return !isMigrationNotStarted();
+    }
+
     static boolean isDualWrite(){
         return MigrationPhase.current().isDualWrite();
     }

--- a/dotCMS/src/main/java/com/dotcms/content/index/IndexMappingRestOperations.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/IndexMappingRestOperations.java
@@ -1,0 +1,51 @@
+package com.dotcms.content.index;
+
+import com.dotcms.content.model.annotation.IndexLibraryIndependent;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Vendor-neutral contract for the three index-mapping REST operations that differ
+ * between Elasticsearch and OpenSearch.
+ *
+ * <p>Implementations of this interface ({@code MappingOperationsES},
+ * {@code MappingOperationsOS}) encapsulate vendor client calls so that
+ * {@code ESMappingAPIImpl} (the router) stays free of vendor imports.</p>
+ *
+ * <p>Follows the same pattern as {@link ContentFactoryIndexOperations}.</p>
+ *
+ * @author Fabrizio Araya
+ * @see com.dotcms.content.elasticsearch.business.MappingOperationsES
+ * @see com.dotcms.content.index.opensearch.MappingOperationsOS
+ */
+@IndexLibraryIndependent
+public interface IndexMappingRestOperations {
+
+    /**
+     * Applies the given JSON mapping to all specified indexes.
+     *
+     * @param indexes list of index names
+     * @param mapping JSON mapping string
+     * @return {@code true} if acknowledged by all nodes
+     */
+    boolean putMapping(List<String> indexes, String mapping) throws IOException;
+
+    /**
+     * Returns the current mapping for the given index as a JSON string.
+     *
+     * @param index index name
+     * @return mapping JSON
+     */
+    String getMapping(String index) throws IOException;
+
+    /**
+     * Returns the mapping for a specific field in the given index as a plain Java map.
+     *
+     * @param index     index name
+     * @param fieldName field name
+     * @return mapping source map, or an empty map if not found
+     */
+    Map<String, Object> getFieldMappingAsMap(String index, String fieldName) throws IOException;
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/PhaseRouter.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/PhaseRouter.java
@@ -1,0 +1,234 @@
+package com.dotcms.content.index;
+
+import static com.dotcms.content.index.IndexConfigHelper.isMigrationComplete;
+import static com.dotcms.content.index.IndexConfigHelper.isMigrationNotStarted;
+import static com.dotcms.content.index.IndexConfigHelper.isReadEnabled;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Phase-aware, generic two-provider router for the ES → OS migration.
+ *
+ * <h2>Routing table</h2>
+ * <pre>
+ * Phase                     | Read provider | Write providers
+ * --------------------------|---------------|-----------------
+ * 0 — not started           | ES            | [ES]
+ * 1 — dual-write, ES reads  | ES            | [ES, OS]
+ * 2 — dual-write, OS reads  | OS            | [ES, OS]
+ * 3 — OS only               | OS            | [OS]
+ * </pre>
+ *
+ * <h2>Typical usage in a router class</h2>
+ * <pre>{@code
+ * private final PhaseRouter<IndexAPI> router =
+ *         new PhaseRouter<>(esImpl, osImpl);
+ *
+ * // Read — single provider
+ * @Override public boolean indexExists(String name) {
+ *     return router.read(impl -> impl.indexExists(name));
+ * }
+ *
+ * // Write void — fan-out
+ * @Override public void closeIndex(String name) {
+ *     router.write(impl -> impl.closeIndex(name));
+ * }
+ *
+ * // Write boolean — AND of all providers
+ * @Override public boolean delete(String name) {
+ *     return router.writeBoolean(impl -> impl.delete(name));
+ * }
+ *
+ * // Write with return value — call all, return read-provider result
+ * @Override public CreateIndexStatus createIndex(String name, int shards) throws IOException {
+ *     return router.writeReturning(impl -> impl.createIndex(name, shards));
+ * }
+ *
+ * // Checked read
+ * @Override public Status getIndexStatus(String name) throws DotDataException {
+ *     return router.readChecked(impl -> impl.getIndexStatus(name));
+ * }
+ *
+ * // Checked write void
+ * @Override public void clearIndex(String name) throws IOException, DotDataException {
+ *     router.writeChecked(impl -> impl.clearIndex(name));
+ * }
+ * }</pre>
+ *
+ * <h2>Exceptions that do NOT fit the uniform pattern</h2>
+ * <p>Some methods require custom logic outside this router:</p>
+ * <ul>
+ *   <li><strong>Aggregating reads</strong> ({@code listIndices}, {@code getClosedIndexes},
+ *       {@code getClusterHealth}) — in dual-write phases results from both providers must be
+ *       <em>merged</em>, not just selected. Implement inline in the router class using
+ *       {@link #readProvider()} and {@link #writeProviders()} directly.</li>
+ *   <li><strong>Flush-and-return</strong> ({@code flushCaches}) — writes to all providers
+ *       but returns the read-provider's result. Use
+ *       {@link #writeReturning(ThrowingFunction)} after fan-out.</li>
+ * </ul>
+ *
+ * @param <T> the provider interface type (e.g. {@code IndexAPI})
+ * @author Fabrizio Araya
+ */
+public final class PhaseRouter<T> {
+
+    // -------------------------------------------------------------------------
+    // Checked functional interfaces (lambdas that can throw checked exceptions)
+    // -------------------------------------------------------------------------
+
+    /** Like {@link Function} but allows checked exceptions. */
+    @FunctionalInterface
+    public interface ThrowingFunction<T, R> {
+        R apply(T t) throws Exception;
+    }
+
+    /** Like {@link Consumer} but allows checked exceptions. */
+    @FunctionalInterface
+    public interface ThrowingConsumer<T> {
+        void accept(T t) throws Exception;
+    }
+
+    // -------------------------------------------------------------------------
+    // State
+    // -------------------------------------------------------------------------
+
+    private final T esImpl;
+    private final T osImpl;
+
+    public PhaseRouter(final T esImpl, final T osImpl) {
+        this.esImpl = esImpl;
+        this.osImpl = osImpl;
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase helpers — public so that callers can build aggregation logic
+    // -------------------------------------------------------------------------
+
+    /**
+     * The single provider that serves READ operations in the current phase.
+     * Phases 0/1 → ES; phases 2/3 → OS.
+     */
+    public T readProvider() {
+        return isReadEnabled() ? osImpl : esImpl;
+    }
+
+    /**
+     * All providers that should receive WRITE operations in the current phase.
+     * Phase 0 → [ES]; phases 1/2 → [ES, OS]; phase 3 → [OS].
+     */
+    public List<T> writeProviders() {
+        if (isMigrationNotStarted()) {
+            return List.of(esImpl);
+        }
+        if (isMigrationComplete()) {
+            return List.of(osImpl);
+        }
+        return List.of(esImpl, osImpl);
+    }
+
+    // -------------------------------------------------------------------------
+    // Standard (unchecked) delegators
+    // -------------------------------------------------------------------------
+
+    /**
+     * Delegates a read to the single current read provider.
+     *
+     * @param fn  must not throw checked exceptions; use {@link #readChecked} otherwise
+     * @return    result from the read provider
+     */
+    public <R> R read(final Function<T, R> fn) {
+        return fn.apply(readProvider());
+    }
+
+    /**
+     * Fans a void write out to all current write providers.
+     *
+     * @param action must not throw checked exceptions; use {@link #writeChecked} otherwise
+     */
+    public void write(final Consumer<T> action) {
+        for (final T impl : writeProviders()) {
+            action.accept(impl);
+        }
+    }
+
+    /**
+     * Fans a boolean write out to all current write providers and returns the AND of
+     * all results — {@code false} if any provider signals failure.
+     *
+     * @param fn must not throw checked exceptions
+     */
+    public boolean writeBoolean(final Function<T, Boolean> fn) {
+        boolean result = true;
+        for (final T impl : writeProviders()) {
+            result &= fn.apply(impl);
+        }
+        return result;
+    }
+
+    /**
+     * Fans a value-returning write to all current write providers and returns the result
+     * from the <em>read provider</em>, keeping the returned value consistent with what the
+     * caller would observe on a subsequent read.
+     *
+     * <p>In single-provider phases only one call is made (no overhead).</p>
+     *
+     * @param fn must not throw checked exceptions; use {@link #writeReturningChecked} otherwise
+     */
+    public <R> R writeReturning(final Function<T, R> fn) {
+        if (isMigrationNotStarted()) {
+            return fn.apply(esImpl);
+        }
+        if (isMigrationComplete()) {
+            return fn.apply(osImpl);
+        }
+        // Dual-write: call both, return read-provider's result
+        final R esResult = fn.apply(esImpl);
+        final R osResult = fn.apply(osImpl);
+        return isReadEnabled() ? osResult : esResult;
+    }
+
+    // -------------------------------------------------------------------------
+    // Checked delegators — same semantics, allow lambdas with checked exceptions
+    // -------------------------------------------------------------------------
+
+    /**
+     * Delegates a checked read to the single current read provider.
+     *
+     * @throws Exception any checked exception thrown by {@code fn}
+     */
+    public <R> R readChecked(final ThrowingFunction<T, R> fn) throws Exception {
+        return fn.apply(readProvider());
+    }
+
+    /**
+     * Fans a checked void write out to all current write providers.
+     *
+     * @throws Exception any checked exception thrown by {@code action}
+     */
+    public void writeChecked(final ThrowingConsumer<T> action) throws Exception {
+        for (final T impl : writeProviders()) {
+            action.accept(impl);
+        }
+    }
+
+    /**
+     * Fans a checked value-returning write to all current write providers and returns
+     * the result from the read provider.
+     *
+     * @throws Exception any checked exception thrown by {@code fn}
+     */
+    public <R> R writeReturningChecked(final ThrowingFunction<T, R> fn) throws Exception {
+        if (isMigrationNotStarted()) {
+            return fn.apply(esImpl);
+        }
+        if (isMigrationComplete()) {
+            return fn.apply(osImpl);
+        }
+        // Dual-write: call both, return read-provider's result
+        final R esResult = fn.apply(esImpl);
+        final R osResult = fn.apply(osImpl);
+        return isReadEnabled() ? osResult : esResult;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkItemResult.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkItemResult.java
@@ -1,0 +1,40 @@
+package com.dotcms.content.index.domain;
+
+import com.dotcms.annotations.Nullable;
+import org.immutables.value.Value;
+
+/**
+ * Vendor-neutral result for a single item in a completed bulk operation.
+ *
+ * <p>Replaces direct use of {@code org.elasticsearch.action.bulk.BulkItemResponse}
+ * (and its OpenSearch equivalent) in {@link IndexBulkListener} callbacks.
+ * Vendor implementations map their library-specific item types to this DTO
+ * inside the {@link com.dotcms.content.index.ContentletIndexOperations} adapter.</p>
+ *
+ * @author Fabrizzio Araya
+ */
+@Value.Immutable
+public interface IndexBulkItemResult {
+
+    /**
+     * Raw document ID as returned by the vendor client, before any
+     * caller-side trimming (e.g. stripping the {@code _languageId_variantId} suffix).
+     * ES: {@code BulkItemResponse.getFailure().getId()} / {@code DocWriteResponse.getId()}.
+     * OS: equivalent field on the OpenSearch bulk item.
+     */
+    String id();
+
+    /** Whether this item failed to be indexed or deleted. */
+    boolean failed();
+
+    /**
+     * Raw failure message when {@link #failed()} is {@code true}; {@code null} otherwise.
+     * ES: {@code BulkItemResponse.getFailure().getMessage()}.
+     */
+    @Nullable
+    String failureMessage();
+
+    static ImmutableIndexBulkItemResult.Builder builder() {
+        return ImmutableIndexBulkItemResult.builder();
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkListener.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkListener.java
@@ -1,0 +1,49 @@
+package com.dotcms.content.index.domain;
+
+import java.util.List;
+
+/**
+ * Vendor-neutral listener for async bulk-processor callbacks.
+ *
+ * <p>Replaces direct extension of
+ * {@code org.elasticsearch.action.bulk.BulkProcessor.Listener} so that the
+ * business logic in {@code BulkProcessorListener} is decoupled from any
+ * vendor library.  Each {@link com.dotcms.content.index.ContentletIndexOperations}
+ * implementation adapts its vendor-specific callback types to this interface
+ * before forwarding to the application listener.</p>
+ *
+ * <p>Lifecycle:</p>
+ * <ol>
+ *   <li>{@link #beforeBulk} — called once per flush, before the batch is sent.</li>
+ *   <li>{@link #afterBulk(long, List)} — called on success with per-item results.</li>
+ *   <li>{@link #afterBulk(long, Throwable)} — called when the entire batch fails.</li>
+ * </ol>
+ *
+ * @author Fabrizzio Araya
+ */
+public interface IndexBulkListener {
+
+    /**
+     * Called before a batch is submitted to the index.
+     *
+     * @param executionId unique ID assigned by the bulk processor
+     * @param actionCount number of operations in the batch
+     */
+    void beforeBulk(long executionId, int actionCount);
+
+    /**
+     * Called after a batch completes successfully (even if some individual items failed).
+     *
+     * @param executionId unique ID assigned by the bulk processor
+     * @param results     one {@link IndexBulkItemResult} per item in the batch
+     */
+    void afterBulk(long executionId, List<IndexBulkItemResult> results);
+
+    /**
+     * Called when the entire batch fails with an unrecoverable exception.
+     *
+     * @param executionId unique ID assigned by the bulk processor
+     * @param failure     the exception that caused the batch to fail
+     */
+    void afterBulk(long executionId, Throwable failure);
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkProcessor.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkProcessor.java
@@ -1,0 +1,24 @@
+package com.dotcms.content.index.domain;
+
+/**
+ * Vendor-neutral handle for an asynchronous, self-flushing bulk processor.
+ *
+ * <p>Used by high-throughput reindex pipelines (e.g. {@code ReindexThread}) that
+ * add operations one by one and let the processor decide when to flush based on
+ * configured thresholds (batch size, byte size, flush interval).</p>
+ *
+ * <p>Implementations hold the vendor-specific processor instance and expose it only
+ * through this interface. Callers must always close the processor when done —
+ * either explicitly or via try-with-resources.</p>
+ *
+ * @author Fabrizio Araya
+ */
+public interface IndexBulkProcessor extends AutoCloseable {
+
+    /**
+     * Flushes any remaining operations and releases underlying resources.
+     * Blocks until all pending operations are acknowledged by the cluster.
+     */
+    @Override
+    void close() throws Exception;
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkRequest.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/domain/IndexBulkRequest.java
@@ -1,0 +1,39 @@
+package com.dotcms.content.index.domain;
+
+/**
+ * Vendor-neutral handle for a batch of document index and delete operations.
+ *
+ * <p>Callers receive an {@code IndexBulkRequest} from
+ * {@link com.dotcms.content.elasticsearch.business.ContentletIndexAPI#createBulkRequest()}
+ * and pass it back to
+ * {@link com.dotcms.content.elasticsearch.business.ContentletIndexAPI#appendBulkRequest} /
+ * {@link com.dotcms.content.elasticsearch.business.ContentletIndexAPI#putToIndex(IndexBulkRequest)}.
+ * No Elasticsearch or OpenSearch types leak through this interface.</p>
+ *
+ * @author Fabrizio Araya
+ */
+public interface IndexBulkRequest {
+
+    /**
+     * Vendor-neutral refresh policy applied to a bulk batch at submit time.
+     *
+     * <p>Maps to {@code WriteRequest.RefreshPolicy} on Elasticsearch and
+     * {@code org.opensearch.client.opensearch._types.Refresh} on OpenSearch.</p>
+     */
+    enum RefreshPolicy {
+        /** Do not refresh (server default). ES: {@code NONE}, OS: {@code false}. */
+        NONE,
+        /** Refresh affected shards immediately. ES: {@code IMMEDIATE}, OS: {@code true}. */
+        IMMEDIATE,
+        /** Wait for the next scheduled refresh. ES: {@code WAIT_UNTIL}, OS: {@code wait_for}. */
+        WAIT_FOR
+    }
+
+    /** Returns the number of pending operations accumulated in this batch. */
+    int size();
+
+    /** Returns {@code true} when no operations have been added yet. */
+    default boolean isEmpty() {
+        return size() == 0;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOS.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOS.java
@@ -1,0 +1,415 @@
+package com.dotcms.content.index.opensearch;
+
+import com.dotcms.cdi.CDIUtils;
+import com.dotcms.content.elasticsearch.business.ContentletIndexOperationsES;
+import com.dotcms.content.elasticsearch.business.MappingOperationsES;
+import com.dotcms.content.index.ContentletIndexOperations;
+import com.dotcms.content.index.domain.CreateIndexStatus;
+import java.io.IOException;
+import com.dotcms.util.CollectionsUtils;
+import com.dotcms.util.JsonUtil;
+import com.dotmarketing.util.DateUtil;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import com.dotcms.content.index.VersionedIndices;
+import com.dotcms.content.index.domain.ImmutableIndexBulkItemResult;
+import com.dotcms.content.index.domain.IndexBulkItemResult;
+import com.dotcms.content.index.domain.IndexBulkListener;
+import com.dotcms.content.index.domain.IndexBulkProcessor;
+import com.dotcms.content.index.domain.IndexBulkRequest;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.common.reindex.ReindexThread;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.util.Logger;
+import com.dotcms.rest.api.v1.DotObjectMapperProvider;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rainerhahnekamp.sneakythrow.Sneaky;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.query_dsl.QueryStringQuery;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.CountRequest;
+import org.opensearch.client.opensearch.core.CountResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.client.opensearch.core.bulk.DeleteOperation;
+import org.opensearch.client.opensearch.core.bulk.IndexOperation;
+
+/**
+ * OpenSearch implementation of {@link ContentletIndexOperations}.
+ *
+ * <p>All OpenSearch-specific types ({@code org.opensearch.client.*}) are confined to this
+ * class. The public API exposes only {@link IndexBulkRequest} and {@link IndexBulkProcessor}
+ * handles to callers, keeping the router and callers fully library-agnostic.</p>
+ *
+ * <p>Methods that have no OpenSearch equivalent yet are stubbed with
+ * {@link UnsupportedOperationException} and flagged for follow-up implementation.</p>
+ *
+ * @author Fabrizio Araya
+ * @see ContentletIndexOperationsES
+ */
+@ApplicationScoped
+public class ContentletIndexOperationsOS implements ContentletIndexOperations {
+
+    private static final ObjectMapper OBJECT_MAPPER = DotObjectMapperProvider.createDefaultMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+    private static final String OS_SETTINGS_FILE = "os-content-settings.json";
+    /** OpenSearch accepts the same content mapping format as Elasticsearch. */
+    private static final String CONTENT_MAPPING_FILE = "es-content-mapping.json";
+
+    @Inject
+    private OSClientProvider clientProvider;
+
+    @Inject
+    private OSIndexAPIImpl osIndexAPI;
+
+    @Inject
+    private MappingOperationsOS mappingOps;
+
+    /**
+     * No-arg constructor required by CDI for proxy creation.
+     * All fields are injected via CDI field injection after construction.
+     */
+    public ContentletIndexOperationsOS() {
+        // CDI no-arg constructor
+    }
+
+    /** Package-private constructor for testing. */
+    ContentletIndexOperationsOS(final OSClientProvider clientProvider,
+            final OSIndexAPIImpl osIndexAPI,
+            final MappingOperationsOS mappingOps) {
+        this.clientProvider = clientProvider;
+        this.osIndexAPI     = osIndexAPI;
+        this.mappingOps     = mappingOps;
+    }
+
+    private OSClientProvider getClientProvider() {
+        return clientProvider;
+    }
+
+    // =========================================================================
+    // Inner wrappers — vendor types stay inside this class
+    // =========================================================================
+
+    /**
+     * Wraps an OpenSearch bulk request builder behind the neutral {@link IndexBulkRequest} handle.
+     * The builder is mutable: operations are accumulated before the final
+     * {@link BulkRequest} is built and submitted in {@link #putToIndex}.
+     */
+    static final class OSIndexBulkRequest implements IndexBulkRequest {
+        final List<BulkOperation> operations = new ArrayList<>();
+        Refresh refresh = null; // null means "use server default" (no refresh)
+
+        @Override
+        public int size() {
+            return operations.size();
+        }
+    }
+
+    /**
+     * {@link IndexBulkProcessor} for OpenSearch.
+     *
+     * <p>{@code opensearch-java} 3.x does not ship a built-in BulkProcessor equivalent, so
+     * this class implements the same behaviour manually: operations accumulate in a pending
+     * list and are flushed to OpenSearch whenever the list reaches {@code maxActions} or when
+     * {@link #close()} is called. The supplied {@link IndexBulkListener} receives
+     * {@code beforeBulk} / {@code afterBulk} callbacks around each flush, mirroring the
+     * contract provided by the Elasticsearch {@code BulkProcessor.Listener} adapter in
+     * {@link ContentletIndexOperationsES}.</p>
+     */
+    static final class OSIndexBulkProcessor implements IndexBulkProcessor {
+
+        private final List<BulkOperation> pending = new ArrayList<>();
+        private final OSClientProvider clientProvider;
+        private final IndexBulkListener listener;
+        private final int maxActions;
+        private final AtomicLong executionIdCounter = new AtomicLong(0);
+
+        OSIndexBulkProcessor(final OSClientProvider clientProvider,
+                final IndexBulkListener listener, final int maxActions) {
+            this.clientProvider = clientProvider;
+            this.listener = listener;
+            this.maxActions = maxActions;
+        }
+
+        synchronized void addAndMaybeFlush(final BulkOperation op) {
+            pending.add(op);
+            if (pending.size() >= maxActions) {
+                flush();
+            }
+        }
+
+        /**
+         * Submits the current pending batch to OpenSearch and fires listener callbacks.
+         * No-op when the pending list is empty. Synchronized on the same monitor as
+         * {@link #addAndMaybeFlush} to prevent {@link #close()} from racing with an
+         * auto-flush: without the lock, ops added after close() drains the list
+         * would silently never reach OpenSearch.
+         */
+        synchronized void flush() {
+            if (pending.isEmpty()) {
+                return;
+            }
+            final long executionId = executionIdCounter.incrementAndGet();
+            final List<BulkOperation> batch = new ArrayList<>(pending);
+            pending.clear();
+
+            listener.beforeBulk(executionId, batch.size());
+
+            try {
+                final OpenSearchClient client = clientProvider.getClient();
+                final BulkResponse response = client.bulk(
+                        BulkRequest.of(b -> b.operations(batch)));
+
+                final List<IndexBulkItemResult> results = new ArrayList<>(response.items().size());
+                for (final BulkResponseItem item : response.items()) {
+                    final boolean failed = item.error() != null;
+                    final String failureMessage = failed
+                            ? item.error().type() + ": " + item.error().reason()
+                            : null;
+                    results.add(ImmutableIndexBulkItemResult.builder()
+                            .id(item.id() != null ? item.id() : "")
+                            .failed(failed)
+                            .failureMessage(failureMessage)
+                            .build());
+                }
+                listener.afterBulk(executionId, results);
+
+            } catch (final Exception e) {
+                listener.afterBulk(executionId, e);
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            flush();
+        }
+    }
+
+    // =========================================================================
+    // Index lifecycle
+    // =========================================================================
+
+    @Override
+    public boolean createContentIndex(final String indexName, final int shards)
+            throws IOException {
+        String settings = null;
+        try {
+            settings = JsonUtil.getJsonFileContentAsString(OS_SETTINGS_FILE);
+        } catch (Exception e) {
+            Logger.error(this, "cannot load " + OS_SETTINGS_FILE + ", skipping", e);
+        }
+
+        final String mapping = JsonUtil.getJsonFileContentAsString(CONTENT_MAPPING_FILE);
+        final CreateIndexStatus status = osIndexAPI.createIndex(indexName, settings, shards);
+
+        int i = 0;
+        while (!status.acknowledged()) {
+            DateUtil.sleep(100);
+            if (i++ > 300) {
+                throw new IOException("OS index creation timed out for: " + indexName);
+            }
+        }
+
+        mappingOps.putMapping(CollectionsUtils.list(indexName), mapping);
+        return true;
+    }
+
+    // =========================================================================
+    // Batch write path
+    // =========================================================================
+
+    @Override
+    public IndexBulkRequest createBulkRequest() {
+        return new OSIndexBulkRequest();
+    }
+
+    @Override
+    public void addIndexOp(final IndexBulkRequest req, final String indexName,
+            final String docId, final String jsonMapping) {
+        asBulkRequest(req).operations.add(BulkOperation.of(op -> op
+                .index(IndexOperation.of(io -> io
+                        .index(indexName)
+                        .id(docId)
+                        .document(parseJsonToMap(jsonMapping))))));
+    }
+
+    @Override
+    public void addDeleteOp(final IndexBulkRequest req, final String indexName,
+            final String docId) {
+        asBulkRequest(req).operations.add(BulkOperation.of(op -> op
+                .delete(DeleteOperation.of(del -> del
+                        .index(indexName)
+                        .id(docId)))));
+    }
+
+    @Override
+    public void setRefreshPolicy(final IndexBulkRequest req,
+            final IndexBulkRequest.RefreshPolicy policy) {
+        final Refresh osRefresh;
+        switch (policy) {
+            case IMMEDIATE: osRefresh = Refresh.True;    break;
+            case WAIT_FOR:  osRefresh = Refresh.WaitFor; break;
+            default:        osRefresh = Refresh.False;   break;
+        }
+        asBulkRequest(req).refresh = osRefresh;
+    }
+
+    @Override
+    public void putToIndex(final IndexBulkRequest req) {
+        final OSIndexBulkRequest osReq = asBulkRequest(req);
+        if (osReq.operations.isEmpty()) {
+            return;
+        }
+        try {
+            final OpenSearchClient client = getClientProvider().getClient();
+            final Refresh refresh = osReq.refresh;
+            final BulkResponse response = client.bulk(
+                    BulkRequest.of(b -> {
+                        b.operations(osReq.operations);
+                        if (refresh != null) {
+                            b.refresh(refresh);
+                        }
+                        return b;
+                    }));
+            if (response.errors()) {
+                Logger.error(this,
+                        "OS bulk putToIndex: errors in response for "
+                                + osReq.operations.size() + " operations");
+            }
+        } catch (final Exception e) {
+            Logger.warnAndDebug(ContentletIndexOperationsOS.class, e);
+            throw new DotRuntimeException(e.getMessage(), e);
+        }
+    }
+
+    // =========================================================================
+    // Async bulk-processor write path
+    // =========================================================================
+
+    @Override
+    public IndexBulkProcessor createBulkProcessor(final IndexBulkListener listener) {
+        int maxActions = ReindexThread.ELASTICSEARCH_BULK_ACTIONS;
+        try {
+            final int servers = APILocator.getServerAPI().getReindexingServers().size();
+            if (servers > 0) {
+                maxActions = ReindexThread.ELASTICSEARCH_BULK_ACTIONS / servers;
+            }
+        } catch (final Exception e) {
+            Logger.warnAndDebug(ContentletIndexOperationsOS.class,
+                    "Could not determine reindexing server count; using default bulk actions: "
+                            + maxActions, e);
+        }
+        return new OSIndexBulkProcessor(clientProvider, listener, maxActions);
+    }
+
+    @Override
+    public void addIndexOpToProcessor(final IndexBulkProcessor proc, final String indexName,
+            final String docId, final String jsonMapping) {
+        asBulkProcessor(proc).addAndMaybeFlush(BulkOperation.of(op -> op
+                .index(IndexOperation.of(io -> io
+                        .index(indexName)
+                        .id(docId)
+                        .document(parseJsonToMap(jsonMapping))))));
+    }
+
+    @Override
+    public void addDeleteOpToProcessor(final IndexBulkProcessor proc, final String indexName,
+            final String docId) {
+        asBulkProcessor(proc).addAndMaybeFlush(BulkOperation.of(op -> op
+                .delete(DeleteOperation.of(del -> del
+                        .index(indexName)
+                        .id(docId)))));
+    }
+
+    // =========================================================================
+    // Other write operations
+    // =========================================================================
+
+    @Override
+    public void removeContentFromIndexByContentType(final ContentType contentType)
+            throws DotDataException {
+        final String structureName = contentType.variable();
+        final VersionedIndices info =
+                APILocator.getVersionedIndicesAPI().loadDefaultVersionedIndices()
+                        .orElseThrow(() -> new DotDataException(
+                                "No versioned indices found — cannot remove content type '"
+                                        + contentType.variable() + "' from OS index"));
+
+        final List<String> indices = new ArrayList<>();
+        info.working().ifPresent(indices::add);
+        info.live().ifPresent(indices::add);
+        info.reindexWorking().ifPresent(indices::add);
+        info.reindexLive().ifPresent(indices::add);
+
+        try {
+            final OpenSearchClient client = getClientProvider().getClient();
+            for (final String indexName : indices) {
+                final org.opensearch.client.opensearch.core.DeleteByQueryRequest deleteByQuery =
+                        org.opensearch.client.opensearch.core.DeleteByQueryRequest.of(r -> r
+                                .index(indexName)
+                                .query(q -> q.queryString(
+                                        QueryStringQuery.of(qs -> qs.query(
+                                                "contenttype:" + structureName.toLowerCase())))));
+                final org.opensearch.client.opensearch.core.DeleteByQueryResponse response =
+                        client.deleteByQuery(deleteByQuery);
+                Logger.info(this, "OS: Deleted " + response.deleted()
+                        + " records of contentType " + structureName
+                        + " from index " + indexName);
+            }
+        } catch (final Exception e) {
+            throw new DotDataException("Error removing content type from OS index: "
+                    + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public long getIndexDocumentCount(final String indexName) {
+        try {
+            final OpenSearchClient client = getClientProvider().getClient();
+            final CountResponse response = client.count(
+                    CountRequest.of(r -> r.index(indexName)));
+            return response.count();
+        } catch (final Exception e) {
+            Logger.warnAndDebug(ContentletIndexOperationsOS.class, e);
+            throw new DotRuntimeException(
+                    "Error getting document count from OS index: " + e.getMessage(), e);
+        }
+    }
+
+    // =========================================================================
+    // Private helpers
+    // =========================================================================
+
+    private static OSIndexBulkRequest asBulkRequest(final IndexBulkRequest req) {
+        if (!(req instanceof OSIndexBulkRequest)) {
+            throw new DotRuntimeException(
+                    "Expected OSIndexBulkRequest but got: " + req.getClass().getName());
+        }
+        return (OSIndexBulkRequest) req;
+    }
+
+    private static OSIndexBulkProcessor asBulkProcessor(final IndexBulkProcessor proc) {
+        if (!(proc instanceof OSIndexBulkProcessor)) {
+            throw new DotRuntimeException(
+                    "Expected OSIndexBulkProcessor but got: " + proc.getClass().getName());
+        }
+        return (OSIndexBulkProcessor) proc;
+    }
+
+    /**
+     * Parses a JSON string into a {@code Map<String,Object>} for use as the OpenSearch
+     * document source. Uses the same Jackson mapper already available in the codebase.
+     */
+    private static Map<String, Object> parseJsonToMap(final String jsonMapping) {
+        return Sneaky.sneak(() -> OBJECT_MAPPER.readValue(jsonMapping, MAP_TYPE));
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOS.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOS.java
@@ -63,7 +63,7 @@ public class ContentletIndexOperationsOS implements ContentletIndexOperations {
     private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
     private static final String OS_SETTINGS_FILE = "os-content-settings.json";
     /** OpenSearch accepts the same content mapping format as Elasticsearch. */
-    private static final String CONTENT_MAPPING_FILE = "es-content-mapping.json";
+    private static final String CONTENT_MAPPING_FILE = "os-content-mapping.json";
 
     @Inject
     private OSClientProvider clientProvider;

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/MappingOperationsOS.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/MappingOperationsOS.java
@@ -1,0 +1,142 @@
+package com.dotcms.content.index.opensearch;
+
+import com.dotcms.cdi.CDIUtils;
+import com.dotcms.content.elasticsearch.business.MappingOperationsES;
+import com.dotcms.content.index.IndexAPI;
+import com.dotcms.content.index.IndexMappingRestOperations;
+import com.dotmarketing.util.Logger;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import org.opensearch.client.opensearch._types.mapping.FieldMapping;
+import org.opensearch.client.opensearch.generic.Bodies;
+import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.opensearch.generic.Response;
+import org.opensearch.client.opensearch.indices.GetFieldMappingResponse;
+import org.opensearch.client.opensearch.indices.GetMappingResponse;
+import org.opensearch.client.opensearch.indices.get_field_mapping.TypeFieldMappings;
+import org.opensearch.client.opensearch.indices.get_mapping.IndexMappingRecord;
+
+import javax.enterprise.context.ApplicationScoped;
+import jakarta.json.stream.JsonGenerator;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenSearch implementation of {@link IndexMappingRestOperations}.
+ *
+ * <p>Wraps the three mapping REST calls ({@code putMapping}, {@code getMapping},
+ * {@code getFieldMappingAsMap}) using the OpenSearch Java client v3.x.
+ * Vendor-specific types are confined to this class.</p>
+ *
+ * <p>{@code putMapping} uses the generic HTTP client because the typed
+ * {@code PutMappingRequest} builder does not accept a raw JSON string body;
+ * the raw JSON approach avoids re-serializing the ES-generated mapping.</p>
+ *
+ * @author Fabrizio Araya
+ * @see MappingOperationsES
+ * @see com.dotcms.content.elasticsearch.business.ESMappingAPIImpl
+ */
+@ApplicationScoped
+public class MappingOperationsOS implements IndexMappingRestOperations {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final OSClientProvider clientProvider;
+    private final IndexAPI osIndexAPI;
+
+    /** CDI-managed default constructor. */
+    public MappingOperationsOS() {
+        this(CDIUtils.getBeanThrows(OSClientProvider.class),
+                CDIUtils.getBeanThrows(OSIndexAPIImpl.class));
+    }
+
+    /** Package-private constructor for unit testing. */
+    @VisibleForTesting
+    MappingOperationsOS(final OSClientProvider clientProvider, final IndexAPI osIndexAPI) {
+        this.clientProvider = clientProvider;
+        this.osIndexAPI = osIndexAPI;
+    }
+
+    /**
+     * Puts the given JSON mapping on all specified indexes via raw HTTP PUT so the
+     * mapping string is forwarded verbatim (the typed OS client builder does not
+     * accept a raw JSON body for put-mapping).
+     */
+    @Override
+    public boolean putMapping(final List<String> indexes, final String mapping) throws IOException {
+        boolean allAcknowledged = true;
+        for (final String index : indexes) {
+            final String prefixed = osIndexAPI.getNameWithClusterIDPrefix(index);
+            final String endpoint = "/" + prefixed + "/_mapping";
+            try (Response response = clientProvider.getClient().generic()
+                    .execute(Requests.builder()
+                            .method("PUT")
+                            .endpoint(endpoint)
+                            .body(Bodies.json(mapping))
+                            .build())) {
+                final int status = response.getStatus();
+                if (status < 200 || status >= 300) {
+                    Logger.error(this, "putMapping failed for index " + prefixed
+                            + " — HTTP " + status);
+                    allAcknowledged = false;
+                }
+            }
+        }
+        return allAcknowledged;
+    }
+
+    @Override
+    public String getMapping(final String index) throws IOException {
+        final String prefixed = osIndexAPI.getNameWithClusterIDPrefix(index);
+        final GetMappingResponse response = clientProvider.getClient()
+                .indices()
+                .getMapping(r -> r.index(prefixed));
+
+        final IndexMappingRecord record = response.get(prefixed);
+        if (record == null) {
+            return "{}";
+        }
+
+        final StringWriter sw = new StringWriter();
+        try (final JsonGenerator gen = clientProvider.getClient()
+                ._transport().jsonpMapper()
+                .jsonProvider().createGenerator(sw)) {
+            record.mappings().serialize(gen,
+                    clientProvider.getClient()._transport().jsonpMapper());
+        }
+        return sw.toString();
+    }
+
+    @Override
+    public Map<String, Object> getFieldMappingAsMap(final String index,
+            final String fieldName) throws IOException {
+        final String prefixed = osIndexAPI.getNameWithClusterIDPrefix(index);
+        final GetFieldMappingResponse response = clientProvider.getClient()
+                .indices()
+                .getFieldMapping(r -> r.index(prefixed).fields(fieldName));
+
+        final TypeFieldMappings typeMappings = response.get(prefixed);
+        if (typeMappings == null) {
+            return Collections.emptyMap();
+        }
+
+        final FieldMapping fieldMapping = typeMappings.mappings().get(fieldName);
+        if (fieldMapping == null) {
+            return Collections.emptyMap();
+        }
+
+        // Serialize FieldMapping (PlainJsonSerializable) to JSON, then parse as plain Map
+        final StringWriter sw = new StringWriter();
+        try (final JsonGenerator gen = clientProvider.getClient()
+                ._transport().jsonpMapper()
+                .jsonProvider().createGenerator(sw)) {
+            fieldMapping.serialize(gen,
+                    clientProvider.getClient()._transport().jsonpMapper());
+        }
+        return MAPPER.readValue(sw.toString(), new TypeReference<Map<String, Object>>() {});
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/content/model/annotation/IndexRouter.java
+++ b/dotCMS/src/main/java/com/dotcms/content/model/annotation/IndexRouter.java
@@ -6,46 +6,54 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to mark classes or methods for search index operations and OpenSearch migration.
- * This annotation provides detailed information about index interaction patterns, supported
- * search engines, and migration readiness.
+ * Marks a class or method as a participant in search-index operations during the ES → OS migration.
  *
- * Usage examples:
- * - @IndexRelation(access = IndexAccess.READ_ONLY, indexEngine = IndexEngine.ELASTICSEARCH)
- * - @IndexRelation(access = IndexAccess.READ_WRITE, indexEngine = IndexEngine.BOTH,
- *                  indexNames = {"content", "structure"})
- * - @IndexRelation(access = IndexAccess.READ_ONLY, indexEngine = IndexEngine.OPENSEARCH,
- *                  migrationReady = true, notes = "Migrated to use OpenSearch REST client")
+ * <p>The {@link #access()} array declares which kinds of operations the annotated element
+ * performs. Use a single value for read-only or write-only classes, and both values for
+ * router/facade classes that handle both paths:</p>
+ *
+ * <pre>
+ * // Read-only consumer (e.g. search query factory)
+ * {@literal @}IndexRouter(access = IndexAccess.READ)
+ *
+ * // Write-only producer (e.g. bulk-index pipeline)
+ * {@literal @}IndexRouter(access = IndexAccess.WRITE)
+ *
+ * // Router/facade — handles reads and writes (e.g. IndexAPIImpl, ContentletIndexAPIImpl)
+ * {@literal @}IndexRouter(access = {IndexAccess.READ, IndexAccess.WRITE})
+ * </pre>
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface IndexRouter {
 
     /**
-     * Defines the type of index access this class or method performs.
-     * @return the access type (default: READ_ONLY)
+     * The kinds of index operations performed by the annotated element.
+     *
+     * <p>Use {@code {IndexAccess.READ, IndexAccess.WRITE}} for router/facade classes
+     * that delegate to both ES and OS providers. Use a single value for classes that
+     * only read or only write.</p>
+     *
+     * @return one or more access kinds (default: {@code READ})
      */
-    IndexAccess access() default IndexAccess.READ_ONLY;
+    IndexAccess[] access() default IndexAccess.READ;
 
     /**
      * Optional notes about index usage, migration blockers, or special considerations.
-     * Useful for documenting ES-specific features or migration requirements.
+     *
      * @return descriptive notes (default: empty string)
      */
     String notes() default "";
 
     /**
-     * Enum defining the types of index access operations.
+     * The kind of index access an annotated element performs.
      */
     enum IndexAccess {
-        /** Only performs read operations on the search index */
-        READ_ONLY,
+        /** The element reads from the search index (queries, lookups, health checks). */
+        READ,
 
-        /** Performs both read and write operations on the search index */
-        READ_WRITE,
-
-        /** Only performs write operations on the search index */
-        WRITE_ONLY
+        /** The element writes to the search index (index, delete, bulk, mapping). */
+        WRITE
     }
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -104,7 +104,7 @@ public class ReindexThread {
             Config.getIntProperty("REINDEX_THREAD_ELASTICSEARCH_BULK_SIZE", 1);
 
     // Time (in seconds) to wait before closing bulk processor in a full reindex
-    private static final int BULK_PROCESSOR_AWAIT_TIMEOUT = Config.getIntProperty(
+    public static final int BULK_PROCESSOR_AWAIT_TIMEOUT = Config.getIntProperty(
             "BULK_PROCESSOR_AWAIT_TIMEOUT", 20);
 
     public static final int BACKOFF_POLICY_TIME_IN_SECONDS = Config.getIntProperty(

--- a/dotCMS/src/main/resources/os-content-mapping.json
+++ b/dotCMS/src/main/resources/os-content-mapping.json
@@ -1,0 +1,113 @@
+{
+  "date_detection": true,
+  "dynamic_date_formats": [
+    "yyyy-MM-dd't'HH:mm:ssZ||yyyy-MM-dd't'HH:mm:ss||MMM d, yyyy h:mm:ss a||yyyy-MM-dd HH:mm:ss||yyyy-MM-dd HH:mm:ss.SSS||yyyy-MM-dd||epoch_millis"
+  ],
+  "dynamic_templates": [
+    {
+      "template_1": {
+        "match": "*_dotraw",
+        "mapping": {
+          "type":  "keyword",
+          "ignore_above": 8191
+        }
+      }
+    },
+    {
+      "textmapping": {
+        "match": "*_text",
+        "mapping": {
+          "type": "text"
+        }
+      }
+    },
+    {
+      "strings_as_dates": {
+        "match_pattern": "regex",
+        "path_match": "calendarevent.originalstartdate|calendarevent.recurrencestart|calendarevent.recurrenceend",
+        "mapping": {
+          "type": "date"
+        }
+      }
+    },
+    {
+      "geomapping": {
+        "match": "*latlon",
+        "mapping": {
+          "type": "geo_point",
+          "ignore_malformed": true
+        }
+      }
+    },
+    {
+      "geomapping_2": {
+        "match": "*latlong",
+        "mapping": {
+          "type": "geo_point",
+          "ignore_malformed": true
+        }
+      }
+    },
+    {
+      "permissions": {
+        "match": "permissions",
+        "mapping": {
+          "analyzer": "whitespace",
+          "type": "text"
+        }
+      }
+    },
+    {
+      "keywordmapping" : {
+        "match_pattern": "regex",
+        "path_match": "categories|tags|conhost|conhostname|wfstep|structurename|contenttype|parentpath|path|urlmap|moduser|owner|metadata.contenttype|metadata.keywords|variant|categoryperms",
+        "mapping": {
+          "type": "keyword"
+        }
+      }
+    },
+    {
+      "hostaliases" : {
+        "path_match": "host.aliases",
+        "mapping": {
+          "analyzer": "whitespace",
+          "type": "text"
+        }
+      }
+    },
+    {
+      "longmapping" : {
+        "match_pattern": "regex",
+        "path_match": "metadata.length|metadata.height|metadata.width",
+        "mapping": {
+          "type": "long"
+        }
+      }
+    },
+    {
+      "hostname" : {
+        "path_match": "host.hostname",
+        "mapping": {
+          "type": "keyword"
+        }
+      }
+    },
+    {
+      "key_value": {
+        "match": "*key_value",
+        "mapping": {
+          "type": "keyword"
+        }
+      }
+    },
+    {
+      "textmapping": {
+        "match_mapping_type": "string",
+        "mapping": {
+          "analyzer": "my_analyzer",
+          "type": "text"
+        }
+      }
+    }
+  ]
+}

--- a/dotCMS/src/main/resources/os-content-settings.json
+++ b/dotCMS/src/main/resources/os-content-settings.json
@@ -1,0 +1,36 @@
+{
+	"analysis": {
+		"analyzer": {
+			"dot_comma_analyzer": {
+				"type": "pattern",
+				"pattern": ",,"
+			},
+			"default" : {
+				"type" : "whitespace"
+			},
+			"my_analyzer": {
+				"tokenizer": "standard",
+				"char_filter": [
+					"my_char_filter"
+				]
+			}
+		},
+
+		"char_filter": {
+			"my_char_filter": {
+				"type": "pattern_replace",
+				"pattern": "([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})",
+				"replacement": "$1_$2_$3_$4_$5"
+			}
+		}
+
+	},
+
+    "index.mapping.total_fields.limit" : "10000",
+
+    "index.mapping.nested_fields.limit" : "10000",
+
+	"index.max_result_window": "100000",
+
+	"index.query.default_field": "catchall"
+}

--- a/dotcms-integration/src/test/java/com/dotcms/OpenSearchUpgradeSuite.java
+++ b/dotcms-integration/src/test/java/com/dotcms/OpenSearchUpgradeSuite.java
@@ -1,5 +1,6 @@
 package com.dotcms;
 
+import com.dotcms.content.index.opensearch.ContentletIndexOperationsOSIntegrationTest;
 import com.dotcms.content.index.VersionedIndicesAPITest;
 import com.dotcms.content.index.opensearch.OSIndexAPIImplIntegrationTest;
 import com.dotcms.content.index.opensearch.OSClientConfigTest;
@@ -29,6 +30,7 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
         VersionedIndicesAPITest.class,
         OSIndexAPIImplIntegrationTest.class,
+        ContentletIndexOperationsOSIntegrationTest.class,
         OSClientProviderIntegrationTest.class,
         OSClientConfigTest.class
 })

--- a/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOSIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOSIntegrationTest.java
@@ -1,0 +1,480 @@
+package com.dotcms.content.index.opensearch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.DataProviderWeldRunner;
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.content.index.ContentletIndexOperations;
+import com.dotcms.content.index.domain.IndexBulkProcessor;
+import com.dotcms.content.index.domain.IndexBulkRequest;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotcms.content.index.domain.IndexBulkItemResult;
+import com.dotcms.content.index.domain.IndexBulkListener;
+import com.dotmarketing.util.Logger;
+import java.util.List;
+import java.util.UUID;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.indices.RefreshRequest;
+
+/**
+ * Integration tests for {@link ContentletIndexOperationsOS} that exercise all methods of the
+ * {@link ContentletIndexOperations} contract against a live OpenSearch 3.x container.
+ *
+ * <p>Requires the {@code opensearch-upgrade} Docker container running on
+ * {@code http://localhost:9201} with security disabled.
+ * Registered in {@link com.dotcms.OpenSearchUpgradeSuite}.</p>
+ *
+ * <p>Run with:
+ * <pre>
+ *   ./mvnw verify -pl :dotcms-integration \
+ *       -Dcoreit.test.skip=false \
+ *       -Dopensearch.upgrade.test=true
+ * </pre>
+ * </p>
+ *
+ * @author Fabrizzio Araya
+ */
+@ApplicationScoped
+@RunWith(DataProviderWeldRunner.class)
+public class ContentletIndexOperationsOSIntegrationTest extends IntegrationTestBase {
+
+    /**
+     * Unique suffix appended to every OS index name created by this suite.
+     * Prevents cross-run pollution in a shared OpenSearch node.
+     */
+    private static final String RUN_ID =
+            UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+    // ── bare index names — OSIndexAPIImpl adds the cluster prefix internally ─
+    private static final String IDX_LIVE    = "live_ops_"    + RUN_ID;
+    private static final String IDX_WORKING = "working_ops_" + RUN_ID;
+
+    /** Minimal JSON document used for indexing tests. */
+    private static final String TEST_DOC_JSON =
+            "{\"identifier\":\"test-id-" + RUN_ID + "\","
+            + "\"title\":\"ContentletIndexOperationsOS Integration Test\","
+            + "\"language_id\":1,"
+            + "\"contenttype\":\"testtype\"}";
+
+    private static final String TEST_DOC_ID = "test-id-" + RUN_ID + "_1_default";
+
+    // ── CDI-injected beans ────────────────────────────────────────────────────
+    // OSTestClientProvider (@Alternative @Priority(1)) is on the test classpath and will be
+    // used to configure ContentletIndexOperationsOS for testing.
+    @Inject
+    private ContentletIndexOperationsOS opsOS;
+
+    /** Helper for creating / deleting / checking test indices. */
+    @Inject
+    private OSIndexAPIImpl osIndexAPI;
+
+    /** Used directly for refresh-after-write operations in tests. */
+    @Inject
+    private OSClientProvider clientProvider;
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @Before
+    public void setUp() {
+        cleanupTestIndices();
+    }
+
+    @After
+    public void tearDown() {
+        cleanupTestIndices();
+    }
+
+    // =========================================================================
+    // Tests – synchronous batch write path
+    // =========================================================================
+
+    /**
+     * Given scenario: A fresh {@link IndexBulkRequest} is created via
+     *                 {@link ContentletIndexOperationsOS#createBulkRequest()}.
+     * Expected: The returned handle is non-null and reports size zero.
+     */
+    @Test
+    public void test_createBulkRequest_shouldReturnEmptyRequest() {
+        final IndexBulkRequest req = opsOS.createBulkRequest();
+
+        assertNotNull("createBulkRequest must never return null", req);
+        assertEquals("A fresh bulk request must have zero operations", 0, req.size());
+        assertTrue("isEmpty() must return true on a fresh request", req.isEmpty());
+        Logger.info(this, "✅ test_createBulkRequest_shouldReturnEmptyRequest passed");
+    }
+
+    /**
+     * Given scenario: An index operation is appended to an empty bulk request via
+     *                 {@link ContentletIndexOperationsOS#addIndexOp}.
+     * Expected: The request size increases to 1.
+     */
+    @Test
+    public void test_addIndexOp_shouldIncreaseBulkRequestSize() {
+        final IndexBulkRequest req = opsOS.createBulkRequest();
+        assertEquals("Pre-condition: request must be empty", 0, req.size());
+
+        opsOS.addIndexOp(req, IDX_LIVE, TEST_DOC_ID, TEST_DOC_JSON);
+
+        assertEquals("Bulk request must contain exactly one operation after addIndexOp", 1, req.size());
+        Logger.info(this, "✅ test_addIndexOp_shouldIncreaseBulkRequestSize passed");
+    }
+
+    /**
+     * Given scenario: A delete operation is appended to an empty bulk request via
+     *                 {@link ContentletIndexOperationsOS#addDeleteOp}.
+     * Expected: The request size increases to 1.
+     */
+    @Test
+    public void test_addDeleteOp_shouldIncreaseBulkRequestSize() {
+        final IndexBulkRequest req = opsOS.createBulkRequest();
+        assertEquals("Pre-condition: request must be empty", 0, req.size());
+
+        opsOS.addDeleteOp(req, IDX_LIVE, TEST_DOC_ID);
+
+        assertEquals("Bulk request must contain exactly one operation after addDeleteOp", 1, req.size());
+        Logger.info(this, "✅ test_addDeleteOp_shouldIncreaseBulkRequestSize passed");
+    }
+
+    /**
+     * Given scenario: A document is indexed via {@link ContentletIndexOperationsOS#putToIndex}
+     *                 into a freshly created OS index.
+     * Expected: {@link ContentletIndexOperationsOS#getIndexDocumentCount} returns 1 after indexing.
+     */
+    @Test
+    public void test_putToIndex_shouldIndexDocument() throws Exception {
+        osIndexAPI.createIndex(IDX_LIVE, 1);
+        final String fullName = osIndexAPI.getNameWithClusterIDPrefix(IDX_LIVE);
+        assertTrue("Pre-condition: index must exist", osIndexAPI.indexExists(IDX_LIVE));
+        assertEquals("Pre-condition: index must be empty", 0L, opsOS.getIndexDocumentCount(fullName));
+
+        final IndexBulkRequest req = opsOS.createBulkRequest();
+        opsOS.addIndexOp(req, fullName, TEST_DOC_ID, TEST_DOC_JSON);
+        opsOS.putToIndex(req);
+        refreshTestIndex(fullName);
+
+        assertEquals("Document count must be 1 after putToIndex", 1L,
+                opsOS.getIndexDocumentCount(fullName));
+        Logger.info(this, "✅ test_putToIndex_shouldIndexDocument passed");
+    }
+
+    /**
+     * Given scenario: A document is indexed and then deleted via a second
+     *                 {@link ContentletIndexOperationsOS#putToIndex} call containing a delete op.
+     * Expected: {@link ContentletIndexOperationsOS#getIndexDocumentCount} returns 0 after the delete.
+     */
+    @Test
+    public void test_putToIndex_withDeleteOp_shouldRemoveDocument() throws Exception {
+        osIndexAPI.createIndex(IDX_LIVE, 1);
+        final String fullName = osIndexAPI.getNameWithClusterIDPrefix(IDX_LIVE);
+
+        // Index the document first
+        final IndexBulkRequest indexReq = opsOS.createBulkRequest();
+        opsOS.addIndexOp(indexReq, fullName, TEST_DOC_ID, TEST_DOC_JSON);
+        opsOS.putToIndex(indexReq);
+        refreshTestIndex(fullName);
+        assertEquals("Pre-condition: document must be indexed", 1L,
+                opsOS.getIndexDocumentCount(fullName));
+
+        // Delete the document
+        final IndexBulkRequest deleteReq = opsOS.createBulkRequest();
+        opsOS.addDeleteOp(deleteReq, fullName, TEST_DOC_ID);
+        opsOS.putToIndex(deleteReq);
+        refreshTestIndex(fullName);
+
+        assertEquals("Document count must be 0 after delete putToIndex", 0L,
+                opsOS.getIndexDocumentCount(fullName));
+        Logger.info(this, "✅ test_putToIndex_withDeleteOp_shouldRemoveDocument passed");
+    }
+
+    /**
+     * Given scenario: {@link ContentletIndexOperationsOS#setRefreshPolicy} is called with each
+     *                 known policy string ({@code "NONE"}, {@code "WAIT_FOR"}, {@code "IMMEDIATE"}).
+     * Expected: No exception is thrown for any policy value.
+     */
+    @Test
+    public void test_setRefreshPolicy_shouldNotThrow() {
+        final IndexBulkRequest req = opsOS.createBulkRequest();
+
+        for (final IndexBulkRequest.RefreshPolicy policy : IndexBulkRequest.RefreshPolicy.values()) {
+            opsOS.setRefreshPolicy(req, policy);
+        }
+
+        Logger.info(this, "✅ test_setRefreshPolicy_shouldNotThrow passed");
+    }
+
+    /**
+     * Given scenario: An empty bulk request is submitted via
+     *                 {@link ContentletIndexOperationsOS#putToIndex}.
+     * Expected: No exception is thrown (empty batch is a no-op).
+     */
+    @Test
+    public void test_putToIndex_withEmptyRequest_shouldBeNoOp() {
+        final IndexBulkRequest req = opsOS.createBulkRequest();
+        assertTrue("Pre-condition: request is empty", req.isEmpty());
+
+        opsOS.putToIndex(req); // must not throw
+
+        Logger.info(this, "✅ test_putToIndex_withEmptyRequest_shouldBeNoOp passed");
+    }
+
+    // =========================================================================
+    // Tests – async bulk-processor write path
+    // =========================================================================
+
+    /**
+     * Given scenario: A bulk processor is created via
+     *                 {@link ContentletIndexOperationsOS#createBulkProcessor}.
+     * Expected: The returned handle is non-null and implements {@link IndexBulkProcessor}.
+     */
+    @Test
+    public void test_createBulkProcessor_shouldReturnNonNullProcessor() {
+        final IndexBulkListener listener = noOpListener();
+        final IndexBulkProcessor proc = opsOS.createBulkProcessor(listener);
+
+        assertNotNull("createBulkProcessor must never return null", proc);
+        Logger.info(this, "✅ test_createBulkProcessor_shouldReturnNonNullProcessor passed");
+    }
+
+    /**
+     * Given scenario: An index operation is added to the bulk processor via
+     *                 {@link ContentletIndexOperationsOS#addIndexOpToProcessor}, then the processor
+     *                 is closed (which triggers a flush).
+     * Expected: The document is visible in the index after close.
+     */
+    @Test
+    public void test_addIndexOpToProcessor_andClose_shouldFlushDocument() throws Exception {
+        osIndexAPI.createIndex(IDX_WORKING, 1);
+        final String fullName = osIndexAPI.getNameWithClusterIDPrefix(IDX_WORKING);
+        assertTrue("Pre-condition: index must exist", osIndexAPI.indexExists(IDX_WORKING));
+        assertEquals("Pre-condition: index must be empty", 0L,
+                opsOS.getIndexDocumentCount(fullName));
+
+        final IndexBulkListener listener = noOpListener();
+        final IndexBulkProcessor proc = opsOS.createBulkProcessor(listener);
+        opsOS.addIndexOpToProcessor(proc, fullName, TEST_DOC_ID, TEST_DOC_JSON);
+        proc.close(); // flushes remaining operations
+        refreshTestIndex(fullName);
+
+        assertEquals("Document count must be 1 after processor flush", 1L,
+                opsOS.getIndexDocumentCount(fullName));
+        Logger.info(this, "✅ test_addIndexOpToProcessor_andClose_shouldFlushDocument passed");
+    }
+
+    /**
+     * Given scenario: A document is indexed and then a delete operation is added to the processor
+     *                 via {@link ContentletIndexOperationsOS#addDeleteOpToProcessor}, then closed.
+     * Expected: The document count drops to 0 after the processor flush.
+     */
+    @Test
+    public void test_addDeleteOpToProcessor_andClose_shouldFlushDeletion() throws Exception {
+        osIndexAPI.createIndex(IDX_WORKING, 1);
+        final String fullName = osIndexAPI.getNameWithClusterIDPrefix(IDX_WORKING);
+
+        // Index the document directly
+        final IndexBulkRequest indexReq = opsOS.createBulkRequest();
+        opsOS.addIndexOp(indexReq, fullName, TEST_DOC_ID, TEST_DOC_JSON);
+        opsOS.putToIndex(indexReq);
+        refreshTestIndex(fullName);
+        assertEquals("Pre-condition: document must be indexed", 1L,
+                opsOS.getIndexDocumentCount(fullName));
+
+        // Delete via the async processor
+        final IndexBulkListener listener = noOpListener();
+        final IndexBulkProcessor proc = opsOS.createBulkProcessor(listener);
+        opsOS.addDeleteOpToProcessor(proc, fullName, TEST_DOC_ID);
+        proc.close(); // flushes the pending delete
+        refreshTestIndex(fullName);
+
+        assertEquals("Document count must be 0 after delete processor flush", 0L,
+                opsOS.getIndexDocumentCount(fullName));
+        Logger.info(this, "✅ test_addDeleteOpToProcessor_andClose_shouldFlushDeletion passed");
+    }
+
+    // =========================================================================
+    // Tests – getIndexDocumentCount
+    // =========================================================================
+
+    /**
+     * Given scenario: A fresh index is created with no documents.
+     * Expected: {@link ContentletIndexOperationsOS#getIndexDocumentCount} returns 0.
+     */
+    @Test
+    public void test_getIndexDocumentCount_shouldReturnZeroForEmptyIndex() throws Exception {
+        osIndexAPI.createIndex(IDX_LIVE, 1);
+        final String fullName = osIndexAPI.getNameWithClusterIDPrefix(IDX_LIVE);
+        assertTrue("Pre-condition: index must exist", osIndexAPI.indexExists(IDX_LIVE));
+
+        final long count = opsOS.getIndexDocumentCount(fullName);
+
+        assertEquals("Empty index must have document count 0", 0L, count);
+        Logger.info(this, "✅ test_getIndexDocumentCount_shouldReturnZeroForEmptyIndex passed");
+    }
+
+    /**
+     * Given scenario: Multiple documents are indexed into the same index.
+     * Expected: {@link ContentletIndexOperationsOS#getIndexDocumentCount} returns the exact count.
+     */
+    @Test
+    public void test_getIndexDocumentCount_shouldReflectIndexedDocuments() throws Exception {
+        osIndexAPI.createIndex(IDX_LIVE, 1);
+        final String fullName = osIndexAPI.getNameWithClusterIDPrefix(IDX_LIVE);
+
+        // Index 3 documents with distinct IDs
+        final IndexBulkRequest req = opsOS.createBulkRequest();
+        for (int i = 1; i <= 3; i++) {
+            final String docId = "test-doc-" + RUN_ID + "-" + i;
+            final String json  = "{\"identifier\":\"" + docId + "\","
+                    + "\"title\":\"Doc " + i + "\","
+                    + "\"language_id\":1,"
+                    + "\"contenttype\":\"testtype\"}";
+            opsOS.addIndexOp(req, fullName, docId, json);
+        }
+        opsOS.putToIndex(req);
+        refreshTestIndex(fullName);
+
+        assertEquals("Document count must equal the number of indexed documents", 3L,
+                opsOS.getIndexDocumentCount(fullName));
+        Logger.info(this, "✅ test_getIndexDocumentCount_shouldReflectIndexedDocuments passed");
+    }
+
+    // =========================================================================
+    // Tests – mirrored from ContentletIndexOperationsESTest
+    // =========================================================================
+
+    /**
+     * Given scenario: Two index operations with the same doc ID are added — first an upsert,
+     *                 then another upsert that overwrites it.
+     * Expected: The index contains exactly 1 document (the second write is an upsert, not an
+     *           insert), mirroring ES behaviour for the same pattern.
+     */
+    @Test
+    public void test_putToIndex_upsertSemantics_shouldNotDuplicateDocument() throws Exception {
+        osIndexAPI.createIndex(IDX_LIVE, 1);
+        final String fullName = osIndexAPI.getNameWithClusterIDPrefix(IDX_LIVE);
+
+        final String json1 = "{\"identifier\":\"" + TEST_DOC_ID + "\",\"title\":\"First\","
+                + "\"language_id\":1,\"contenttype\":\"testtype\"}";
+        final String json2 = "{\"identifier\":\"" + TEST_DOC_ID + "\",\"title\":\"Second\","
+                + "\"language_id\":1,\"contenttype\":\"testtype\"}";
+
+        // First write
+        final IndexBulkRequest req1 = opsOS.createBulkRequest();
+        opsOS.addIndexOp(req1, fullName, TEST_DOC_ID, json1);
+        opsOS.putToIndex(req1);
+        refreshTestIndex(fullName);
+        assertEquals("After first write: count must be 1", 1L,
+                opsOS.getIndexDocumentCount(fullName));
+
+        // Second write with the same doc ID — must be an upsert
+        final IndexBulkRequest req2 = opsOS.createBulkRequest();
+        opsOS.addIndexOp(req2, fullName, TEST_DOC_ID, json2);
+        opsOS.putToIndex(req2);
+        refreshTestIndex(fullName);
+
+        assertEquals("After upsert: count must still be 1 (no duplicate)", 1L,
+                opsOS.getIndexDocumentCount(fullName));
+        Logger.info(this, "✅ test_putToIndex_upsertSemantics_shouldNotDuplicateDocument passed");
+    }
+
+    /**
+     * Given scenario: A mixed bulk request containing both index and delete operations is
+     *                 submitted via {@link ContentletIndexOperationsOS#putToIndex}.
+     * Expected: The net result matches expectations — indexed docs appear, deleted doc is absent.
+     */
+    @Test
+    public void test_putToIndex_mixedOps_shouldApplyAll() throws Exception {
+        osIndexAPI.createIndex(IDX_LIVE, 1);
+        final String fullName = osIndexAPI.getNameWithClusterIDPrefix(IDX_LIVE);
+
+        // Pre-index a document that will be deleted in the mixed batch
+        final String deleteDocId  = "delete-me-" + RUN_ID;
+        final String deleteDocJson = "{\"identifier\":\"" + deleteDocId + "\","
+                + "\"title\":\"ToDelete\",\"language_id\":1,\"contenttype\":\"testtype\"}";
+        final IndexBulkRequest preReq = opsOS.createBulkRequest();
+        opsOS.addIndexOp(preReq, fullName, deleteDocId, deleteDocJson);
+        opsOS.putToIndex(preReq);
+        refreshTestIndex(fullName);
+        assertEquals("Pre-condition: 1 document before mixed batch", 1L,
+                opsOS.getIndexDocumentCount(fullName));
+
+        // Mixed batch: index a new doc + delete the pre-indexed doc
+        final String newDocId  = "keep-me-" + RUN_ID;
+        final String newDocJson = "{\"identifier\":\"" + newDocId + "\","
+                + "\"title\":\"ToKeep\",\"language_id\":1,\"contenttype\":\"testtype\"}";
+        final IndexBulkRequest mixedReq = opsOS.createBulkRequest();
+        opsOS.addIndexOp(mixedReq, fullName, newDocId, newDocJson);
+        opsOS.addDeleteOp(mixedReq, fullName, deleteDocId);
+        opsOS.putToIndex(mixedReq);
+        refreshTestIndex(fullName);
+
+        assertEquals("After mixed batch: net count must be 1 (1 added, 1 removed)", 1L,
+                opsOS.getIndexDocumentCount(fullName));
+        Logger.info(this, "✅ test_putToIndex_mixedOps_shouldApplyAll passed");
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    /**
+     * Returns a no-op {@link IndexBulkListener} suitable for tests that only verify the
+     * bulk-processor mechanics (flush/close) and do not assert on listener callbacks.
+     */
+    private static IndexBulkListener noOpListener() {
+        return new IndexBulkListener() {
+            @Override public void beforeBulk(final long executionId, final int actionCount) { /* no-op */ }
+            @Override public void afterBulk(final long executionId, final List<IndexBulkItemResult> results) { /* no-op */ }
+            @Override public void afterBulk(final long executionId, final Throwable failure) { /* no-op */ }
+        };
+    }
+
+    /**
+     * Forces an index refresh so documents written by {@code putToIndex} or
+     * {@code close()} become immediately visible to count queries.
+     *
+     * <p>OpenSearch does not expose a direct {@code refreshIndex} helper on
+     * {@link OSIndexAPIImpl}, so this test-only helper calls the low-level client.</p>
+     */
+    private void refreshTestIndex(final String fullIndexName) {
+        try {
+            final OpenSearchClient client = clientProvider.getClient();
+            client.indices().refresh(RefreshRequest.of(r -> r.index(fullIndexName)));
+        } catch (Exception e) {
+            Logger.warn(this, "refreshTestIndex: error refreshing '" + fullIndexName
+                    + "': " + e.getMessage());
+        }
+    }
+
+    /**
+     * Deletes every test-scoped index that actually exists in OpenSearch.
+     * Skipping the delete when the index is absent avoids noisy error logs between tests.
+     */
+    private synchronized void cleanupTestIndices() {
+        for (final String idx : List.of(IDX_LIVE, IDX_WORKING)) {
+            try {
+                if (osIndexAPI.indexExists(idx)) {
+                    osIndexAPI.delete(idx);
+                }
+            } catch (Exception e) {
+                Logger.warn(this, "Cleanup: error removing OS index '" + idx + "': " + e.getMessage());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the vendor-neutral write-side abstraction layer for the ES → OpenSearch migration. Extracts all bulk-write and mapping operations from `ContentletIndexAPIImpl` into provider-specific implementations behind a generic `PhaseRouter<T>`, completing the dual-write infrastructure needed for migration phases 1–3.

## Changes

**New abstractions (vendor-neutral contracts)**
- `ContentletIndexOperations` — write-side interface: bulk requests, bulk processor, index lifecycle, delete-by-content-type
- `IndexBulkRequest`, `IndexBulkProcessor`, `IndexBulkListener`, `IndexBulkItemResult` — DTOs replacing ES/OS vendor types in public APIs
- `IndexMappingRestOperations` — mapping REST contract (`putMapping`, `getMapping`, `getFieldMappingAsMap`)
- `PhaseRouter<T>` — generic, phase-aware dual-write router with `read()`, `write()`, `writeBoolean()`, `writeReturning()` and checked-exception variants

**Elasticsearch implementation**
- `ContentletIndexOperationsES` — wraps `BulkRequest`/`BulkProcessor` behind `ContentletIndexOperations`
- `MappingOperationsES` — wraps ES `RestHighLevelClient` mapping calls behind `IndexMappingRestOperations`

**OpenSearch implementation**
- `ContentletIndexOperationsOS` — `opensearch-java` 3.x bulk write implementation with manual `OSIndexBulkProcessor` (no built-in BulkProcessor in that SDK)
- `MappingOperationsOS` — OpenSearch mapping REST calls

**Minor changes**
- `ContentMappingAPI` — expanded with `putMapping`, `getMapping`, `toJson`, `toMap`, `toJsonString` methods
- `@IndexRouter.access` — changed from single enum value to array (`{IndexAccess.READ}`, `{IndexAccess.READ, IndexAccess.WRITE}`)
- `IndexConfigHelper` — added `isMigrationStarted()` convenience predicate

## Testing

- `ContentletIndexOperationsOSIntegrationTest` (480 lines) added to `OpenSearchUpgradeSuite`
- Tests cover: index creation, bulk index/delete, bulk processor flush, delete-by-content-type, document count
- To run locally: `./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=ContentletIndexOperationsOSIntegrationTest`

This PR fixes: #34938

This PR fixes: #34938