### PR TITLE
fix(ci): forward artifact-run-id to deploy-jfrog in deployment phase (masked bug)

### DIFF
--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -322,6 +322,7 @@ jobs:
           artifactory-username: ${{ secrets.EE_REPO_USERNAME }}
           artifactory-password: ${{ secrets.EE_REPO_PASSWORD }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-run-id: ${{ inputs.artifact-run-id }}
 
       # Publish CLI to NPM (if required)
       # Skipped when java-version is overridden (CLI not built due to GraalVM/Quarkus compatibility)


### PR DESCRIPTION
## Summary
- The `CLI Deploy` step in `cicd_comp_deployment-phase.yml` was calling `deploy-jfrog` without passing `artifact-run-id`
- When `Trunk Build` is skipped (build reuse enabled), `deploy-jfrog` fell back to `github.run_id` (current run) to find `maven-repo`
- Since the build was skipped, no `maven-repo` artifact exists in the current run → deployment failure
- Fix: forward `artifact-run-id: ${{ inputs.artifact-run-id }}` to the `deploy-jfrog` step, matching the pattern already used by `deploy-docker`

Diagnosed from run [23469253088](https://github.com/dotCMS/core/actions/runs/23469253088) — also reproduced in run [23460195801](https://github.com/dotCMS/core/actions/runs/23460195801).

## Test plan
- [ ] Trigger a Trunk run with build reuse enabled and confirm `deployment / deployment` passes
- [ ] Verify `maven-repo` is downloaded from the correct previous build run ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)