### PR TITLE
fix: serialize SAML NameID for Redis session storage #34700

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/saml/Attributes.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/Attributes.java
@@ -31,7 +31,7 @@ public class Attributes implements Serializable {
 	private final Object roles;
 
 	// Saml object with the NameID.
-	private final Object nameID;
+	private final Serializable nameID;
 
 	// SAML Session Index
 	private final String sessionIndex;
@@ -76,7 +76,7 @@ public class Attributes implements Serializable {
 		return roles;
 	}
 
-	public Object getNameID()
+	public Serializable getNameID()
 	{
 		return nameID;
 	}
@@ -109,7 +109,7 @@ public class Attributes implements Serializable {
 		String firstName = "";
 		boolean addRoles = false;
 		Object roles     = null;
-		Object nameID    = null;
+		Serializable nameID = null;
 		String sessionIndex;
 		Map<String, Object> additionalAttributes;
 
@@ -149,7 +149,7 @@ public class Attributes implements Serializable {
 			return this;
 		}
 
-		public Builder nameID(final Object nameID)
+		public Builder nameID(final Serializable nameID)
 		{
 			this.nameID = nameID;
 			return this;
@@ -187,7 +187,7 @@ public class Attributes implements Serializable {
 			return roles;
 		}
 
-		public Object getNameID()
+		public Serializable getNameID()
 		{
 			return nameID;
 		}

--- a/dotCMS/src/main/java/com/dotcms/saml/SamlNameID.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/SamlNameID.java
@@ -1,0 +1,69 @@
+package com.dotcms.saml;
+
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * A serializable holder for a SAML NameID's XML representation.
+ *
+ * <p>OpenSAML's concrete NameID implementation does not implement {@link Serializable},
+ * which prevents it from being stored in Redis-managed sessions. This class lives in the
+ * webapp classpath (core) so that Tomcat's session deserializer can always find it —
+ * unlike plugin bundle classes, which are invisible to the webapp classloader.
+ *
+ * <p>The full XML string is stored so that the plugin can reconstruct a live
+ * NameID on demand via {@code SamlUtils.toNameID(SamlNameID)}.
+ *
+ * <p>Usage in the plugin:
+ * <pre>
+ *     // Store:
+ *     attrBuilder.nameID(new SamlNameID(SamlUtils.toXMLObjectString(nameID)));
+ *
+ *     // Reconstruct:
+ *     NameID nameID = SamlUtils.toNameID((SamlNameID) attributes.getNameID());
+ * </pre>
+ *
+ * @author jsanca
+ */
+public final class SamlNameID implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String xmlString;
+
+    /**
+     * Constructs a {@code SamlNameID} from the XML representation of a NameID.
+     *
+     * @param xmlString the full XML string of the NameID; must not be {@code null}
+     */
+    public SamlNameID(final String xmlString) {
+        this.xmlString = Objects.requireNonNull(xmlString, "xmlString must not be null");
+    }
+
+    /**
+     * Returns the XML string representation of the NameID.
+     *
+     * @return the XML string; never {@code null}
+     */
+    public String getXmlString() {
+        return xmlString;
+    }
+
+    /**
+     * Validates invariants after Java deserialization.
+     */
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (xmlString.isBlank()) {
+            throw new InvalidObjectException("SamlNameID: xmlString must not be blank");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SamlNameID{xmlString='" + xmlString + "'}";
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/saml/SamlNameID.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/SamlNameID.java
@@ -63,7 +63,28 @@ public final class SamlNameID implements Serializable {
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SamlNameID)) {
+            return false;
+        }
+        final SamlNameID other = (SamlNameID) o;
+        return Objects.equals(xmlString, other.xmlString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(xmlString);
+    }
+
+    /**
+     * Returns a redacted representation to prevent accidental PII leakage in logs.
+     * The XML string contains the user's SAML identity value and must never appear in logs.
+     */
+    @Override
     public String toString() {
-        return "SamlNameID{xmlString='" + xmlString + "'}";
+        return "SamlNameID{xmlString='[REDACTED]'}";
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/saml/SamlNameID.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/SamlNameID.java
@@ -34,17 +34,23 @@ public final class SamlNameID implements Serializable {
 
     private final String xmlString;
 
+    /** The plain NameID value (email, persistent ID, etc.) for cheap retrieval without XML parsing. */
+    private final String value;
+
     /**
-     * Constructs a {@code SamlNameID} from the XML representation of a NameID.
+     * Constructs a {@code SamlNameID}.
      *
      * @param xmlString the full XML string of the NameID; must not be {@code null}
+     * @param value     the plain NameID value (e.g. email or opaque ID); must not be {@code null}
      */
-    public SamlNameID(final String xmlString) {
+    public SamlNameID(final String xmlString, final String value) {
         this.xmlString = Objects.requireNonNull(xmlString, "xmlString must not be null");
+        this.value     = Objects.requireNonNull(value, "value must not be null");
     }
 
     /**
-     * Returns the XML string representation of the NameID.
+     * Returns the XML string representation of the NameID, used to reconstruct a live
+     * NameID object in the SAML plugin via {@code SamlUtils.toNameID(SamlNameID)}.
      *
      * @return the XML string; never {@code null}
      */
@@ -53,12 +59,27 @@ public final class SamlNameID implements Serializable {
     }
 
     /**
+     * Returns the plain NameID value (e.g. email address or opaque persistent ID).
+     *
+     * <p>Use this for hashing, logging correlation, or any operation that needs the raw
+     * identity value without reconstructing the full OpenSAML object.
+     *
+     * @return the NameID value; never {@code null}
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
      * Validates invariants after Java deserialization.
      */
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        if (xmlString.isBlank()) {
-            throw new InvalidObjectException("SamlNameID: xmlString must not be blank");
+        if (xmlString == null || xmlString.isBlank()) {
+            throw new InvalidObjectException("SamlNameID: xmlString must not be null or blank");
+        }
+        if (value == null || value.isBlank()) {
+            throw new InvalidObjectException("SamlNameID: value must not be null or blank");
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/saml/SamlNameID.java
+++ b/dotCMS/src/main/java/com/dotcms/saml/SamlNameID.java
@@ -32,6 +32,12 @@ public final class SamlNameID implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    /** Maximum permitted length of the XML string (guards against heap exhaustion on corrupt sessions). */
+    private static final int MAX_XML_LENGTH   = 8192;
+
+    /** Maximum permitted length of the plain NameID value. */
+    private static final int MAX_VALUE_LENGTH = 1024;
+
     private final String xmlString;
 
     /** The plain NameID value (email, persistent ID, etc.) for cheap retrieval without XML parsing. */
@@ -52,6 +58,12 @@ public final class SamlNameID implements Serializable {
      * Returns the XML string representation of the NameID, used to reconstruct a live
      * NameID object in the SAML plugin via {@code SamlUtils.toNameID(SamlNameID)}.
      *
+     * <p><strong>Security warning:</strong> the XML string contains the user's SAML identity
+     * value (email address, persistent ID, etc.) and is therefore PII. It must never be
+     * written to logs, stored in plaintext audit trails, or returned in API responses.
+     * Use {@link #getValue()} only when the raw identity string is genuinely required
+     * (e.g. for hashing before storage), and {@link #toString()} for any diagnostic output.
+     *
      * @return the XML string; never {@code null}
      */
     public String getXmlString() {
@@ -61,8 +73,10 @@ public final class SamlNameID implements Serializable {
     /**
      * Returns the plain NameID value (e.g. email address or opaque persistent ID).
      *
-     * <p>Use this for hashing, logging correlation, or any operation that needs the raw
-     * identity value without reconstructing the full OpenSAML object.
+     * <p><strong>Security warning:</strong> this is raw PII. Pass it only to operations that
+     * require the actual identity (e.g. {@code SAMLHelper.hashIt()}) — never write it directly
+     * to logs or API responses. If a correlation token is needed for debugging, hash the value
+     * first and use only the first few characters of the hash.
      *
      * @return the NameID value; never {@code null}
      */
@@ -72,14 +86,25 @@ public final class SamlNameID implements Serializable {
 
     /**
      * Validates invariants after Java deserialization.
+     *
+     * <p>Length caps are enforced here in addition to the null/blank checks because
+     * {@code defaultReadObject()} can restore arbitrarily large strings from a corrupt or
+     * malicious Redis entry, potentially exhausting heap memory before any application code
+     * runs.
      */
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
         if (xmlString == null || xmlString.isBlank()) {
             throw new InvalidObjectException("SamlNameID: xmlString must not be null or blank");
         }
+        if (xmlString.length() > MAX_XML_LENGTH) {
+            throw new InvalidObjectException("SamlNameID: xmlString exceeds maximum length of " + MAX_XML_LENGTH);
+        }
         if (value == null || value.isBlank()) {
             throw new InvalidObjectException("SamlNameID: value must not be null or blank");
+        }
+        if (value.length() > MAX_VALUE_LENGTH) {
+            throw new InvalidObjectException("SamlNameID: value exceeds maximum length of " + MAX_VALUE_LENGTH);
         }
     }
 

--- a/dotcms-integration/src/test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/auth/providers/saml/v1/SAMLHelperTest.java
@@ -11,6 +11,7 @@ import com.dotcms.datagen.FieldDataGen;
 import com.dotcms.datagen.UserDataGen;
 import com.dotcms.saml.Attributes;
 import com.dotcms.saml.DotSamlConstants;
+import com.dotcms.saml.SamlNameID;
 import com.dotcms.saml.IdentityProviderConfiguration;
 import com.dotcms.saml.SamlAuthenticationService;
 import com.dotcms.saml.SamlConfigurationService;
@@ -108,6 +109,9 @@ public class SAMLHelperTest extends IntegrationTestBase {
 
         @Override
         public String getValue(Object samlObject) {
+            if (samlObject instanceof SamlNameID) {
+                return ((SamlNameID) samlObject).getValue();
+            }
             return samlObject.toString();
         }
 
@@ -116,6 +120,14 @@ public class SAMLHelperTest extends IntegrationTestBase {
 
             return Stream.of((Object[])samlObject).map(Object::toString).collect(Collectors.toList());
         }
+    }
+
+    /**
+     * Creates a minimal {@link SamlNameID} suitable for tests that do not need real SAML XML.
+     * The XML stub is not valid OpenSAML XML; it only satisfies the non-blank invariant.
+     */
+    private static SamlNameID testNameID(final String value) {
+        return new SamlNameID("<nameID>" + value + "</nameID>", value);
     }
 
     /**
@@ -204,7 +216,7 @@ public class SAMLHelperTest extends IntegrationTestBase {
         additionalAttributes.put("prop-key2", "prop-value2");
 
         final Attributes nativeUserAttributes = new Attributes.Builder().firstName(nativeFirstName + "Updated")
-                .lastName(nativeLastName).nameID(nativeUser.getUserId()).email(nativeEmailAddress).additionalAttributes(additionalAttributes).build();
+                .lastName(nativeLastName).nameID(testNameID(nativeUser.getUserId())).email(nativeEmailAddress).additionalAttributes(additionalAttributes).build();
 
         // recover with SAML the native user
         final User recoveredNativeUser = samlHelper.resolveUser(nativeUserAttributes, identityProviderConfiguration);
@@ -220,7 +232,7 @@ public class SAMLHelperTest extends IntegrationTestBase {
 
         // creates an user from saml
         final Attributes samlUserAttributes = new Attributes.Builder().firstName(samlFirstName)
-                .lastName(samlLastName).nameID(samlNameId).email(samlEmailAddress).build();
+                .lastName(samlLastName).nameID(testNameID(samlNameId)).email(samlEmailAddress).build();
 
         // recover with SAML the new saml user
         final User samlUser = samlHelper.resolveUser(samlUserAttributes, identityProviderConfiguration);
@@ -283,7 +295,7 @@ public class SAMLHelperTest extends IntegrationTestBase {
 
         // creates an user from saml
         final Attributes samlUserAttributes = new Attributes.Builder().firstName(nativeFirstName)
-                .lastName(nativeLastName).nameID("123" + nativeNameId).email(email).build(); // diff id, same email
+                .lastName(nativeLastName).nameID(testNameID("123" + nativeNameId)).email(email).build(); // diff id, same email
 
         // recover with SAML the new user
         final User recoveredNewUser = samlHelper.resolveUser(samlUserAttributes, identityProviderConfiguration);
@@ -338,7 +350,7 @@ public class SAMLHelperTest extends IntegrationTestBase {
                 .emailAddress(nativeEmailAddress).nextPersisted();
 
         final Attributes nativeUserAttributes = new Attributes.Builder().firstName(nativeFirstName + "Updated")
-                .lastName(nativeLastName).nameID("xxxxxxxxxxx").email(nativeEmailAddress).build();
+                .lastName(nativeLastName).nameID(testNameID("xxxxxxxxxxx")).email(nativeEmailAddress).build();
 
         // recover with SAML the native user
         final User recoveredNativeUser = samlHelper.resolveUser(nativeUserAttributes, identityProviderConfiguration);
@@ -423,12 +435,13 @@ public class SAMLHelperTest extends IntegrationTestBase {
         company.setAuthType(Company.AUTH_TYPE_EA);
         when(companyAPI.getDefaultCompany()).thenReturn(company);
         final IdentityProviderConfiguration identityProviderConfiguration = mock(IdentityProviderConfiguration.class);
-        final Attributes attrs = new Attributes.Builder().nameID(UUID.randomUUID()).build();
+        final String nameIdValue = UUID.randomUUID().toString();
+        final Attributes attrs = new Attributes.Builder().nameID(testNameID(nameIdValue)).build();
 
         final User user = samlHelper.createNewUser(APILocator.systemUser(), attrs, identityProviderConfiguration);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals(samlHelper.hashIt(attrs.getNameID().toString()), user.getUserId());
+        Assert.assertEquals(samlHelper.hashIt(nameIdValue), user.getUserId());
     }
 
     /**
@@ -449,12 +462,12 @@ public class SAMLHelperTest extends IntegrationTestBase {
         when(companyAPI.getDefaultCompany()).thenReturn(company);
         final IdentityProviderConfiguration identityProviderConfiguration = mock(IdentityProviderConfiguration.class);
         final String uuid = UUID.randomUUID().toString();
-        final Attributes attrs = new Attributes.Builder().nameID(uuid).email(uuid+"@dotcms.com.cr").firstName("John").lastName("Sn").build();
+        final Attributes attrs = new Attributes.Builder().nameID(testNameID(uuid)).email(uuid+"@dotcms.com.cr").firstName("John").lastName("Sn").build();
 
         final User user = samlHelper.createNewUser(APILocator.systemUser(), attrs, identityProviderConfiguration);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals(samlHelper.hashIt(attrs.getNameID().toString()), user.getUserId());
+        Assert.assertEquals(samlHelper.hashIt(uuid), user.getUserId());
         Assert.assertEquals(uuid+"@dotcms.com.cr", attrs.getEmail());
         Assert.assertEquals("John", attrs.getFirstName());
         Assert.assertEquals("Sn", attrs.getLastName());

--- a/osgi-base/system-bundles/pom.xml
+++ b/osgi-base/system-bundles/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.dotcms.samlbundle</groupId>
             <artifactId>com.dotcms.samlbundle</artifactId>
-            <version>25.06.3</version>
+            <version>26.03.17</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
## Summary

- Add `SamlNameID` to core (webapp classpath) as a serializable XML-string holder for OpenSAML's `NameID`, which itself is not `Serializable`
- Narrow `Attributes.nameID` field and builder type from `Object` → `Serializable` to enforce the contract at compile time
- Bump `com.dotcms.samlbundle` to `26.03.17` in `osgi-base/system-bundles/pom.xml`

## Problem

When dotCMS is configured with Redis session management, storing a raw OpenSAML `NameID` in the HTTP session causes the object to be removed from the session with this error message:

```
redissessions.RedisSession - Value of key 'XXXSAMLNameID' is not serializable. Removing it from Session
```

The root cause is a that OpenSAML's `NameID` class is not `Serializable`: Tomcat Redis session manager serializes and deserializes the session data to be stored/retrieved from Redis. Any class stored in the session must therefore implement the `Serializable` interface.

## Solution

`SamlNameID` (this PR) stores the NameID as its full XML string — a plain `String` with no OpenSAML dependency — so Tomcat can always resolve it. The companion PR in `dotCMS/com.dotcms.dotsaml` adds `SamlUtils.toNameID(SamlNameID)` to reconstruct a live `NameID` in the plugin when needed for logout and authentication flows.

## Test plan

- [ ] SAML login completes successfully and user session is stored in Redis
- [ ] Redis-backed session don't get the error message `Value of key 'XXXSAMLNameID' is not serializable. Removing it from Session`
- [ ] SAML logout (HTTP POST and HTTP Redirect bindings) works correctly after session restore
- [ ] No regression on non-Redis (in-memory) session storage

## Related

- Plugin PR: dotCMS/com.dotcms.dotsaml (branch [`issue-34700-saml-redis-logout`](https://github.com/dotCMS/com.dotcms.dotsaml/pull/23))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34700

This PR fixes: #34700