### PR TITLE
chore(ci/cd): bring codeowners in line with reality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # and security implications of changes
 
 # Most things are related to CI/CD or actions and should have workflow devs approve
-/.github/ @dotCMS/core-workflow-developers
+/.github/ @dotCMS/dotDevelopers
 
 # Democratize the PR and Issue templates 
 /.github/PULL_REQUEST_TEMPLATE/ @dotCMS/dotDevelopers @dotCMS/dotProduct


### PR DESCRIPTION
### Proposed Changes
* allow chagnes to github actions and workflows from ALL dotDevelopers

### Checklist
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
at one point we had a specific set of folks that knew our pipelines and maintained them.  That has moved to a full stack developer concern and now shared across all dotDevelopers.  Aided by what Agentic Ai can provide, it's not reasonable for a dotCMS developer to understand the chagnes and steer the ai into what they want.

resolves dotcms/infrastructure-as-code#7498

