### PR TITLE
fix(edit-content): fix pagination in relationship field not changing displayed items

### DIFF
--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-table.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-table.spec.ts
@@ -295,16 +295,10 @@ test.describe('Table Pagination', () => {
         blogTypeVariable = blogType.variable;
     });
 
-    test.fixme('paginates at 10 items per page @smoke', async ({
-        adminPage,
-        apiHelpers,
-        testSuffix
-    }) => {
-        // BUG: pagination shows all items instead of 10 per page.
-        // Remove fixme once the bug is fixed.
+    test('paginates at 6 items per page @smoke', async ({ adminPage, apiHelpers, testSuffix }) => {
         const authors = await apiHelpers.createContentlets(
             authorTypeVariable,
-            Array.from({ length: 12 }, (_, j) => {
+            Array.from({ length: 8 }, (_, j) => {
                 const i = j + 1;
                 return {
                     title: `TablePag Author ${i} ${testSuffix}`,
@@ -324,21 +318,33 @@ test.describe('Table Pagination', () => {
 
         const relationshipField = new RelationshipField(adminPage);
 
-        await relationshipField.expectRowCount(10);
+        await relationshipField.expectRowCount(6);
         await relationshipField.expectPaginationVisible();
+
+        // Capture page 1 titles
+        const page1Titles: string[] = [];
+        for (let i = 0; i < 6; i++) {
+            page1Titles.push(await relationshipField.getRowTitle(i));
+        }
+
         await relationshipField.clickNextPage();
         await relationshipField.expectRowCount(2);
+
+        // Verify page 2 shows different items than page 1
+        const page2Titles: string[] = [];
+        for (let i = 0; i < 2; i++) {
+            page2Titles.push(await relationshipField.getRowTitle(i));
+        }
+
+        for (const title of page2Titles) {
+            expect(page1Titles).not.toContain(title);
+        }
     });
 
-    test.fixme('no pagination with 10 or fewer items', async ({
-        adminPage,
-        apiHelpers,
-        testSuffix
-    }) => {
-        // BUG: pagination appears even with fewer items. Same pagination bug as above.
+    test('no pagination with 6 or fewer items', async ({ adminPage, apiHelpers, testSuffix }) => {
         const authors = await apiHelpers.createContentlets(
             authorTypeVariable,
-            Array.from({ length: 9 }, (_, j) => {
+            Array.from({ length: 5 }, (_, j) => {
                 const i = j + 1;
                 return {
                     title: `NoPag Author ${i} ${testSuffix}`,
@@ -358,7 +364,7 @@ test.describe('Table Pagination', () => {
 
         const relationshipField = new RelationshipField(adminPage);
 
-        await relationshipField.expectRowCount(9);
+        await relationshipField.expectRowCount(5);
         await relationshipField.expectPaginationHidden();
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
@@ -1,8 +1,8 @@
 @let pagination = store.pagination();
 @let showPagination = store.totalPages() > 1;
-@let data = store.data();
+@let data = store.paginatedData();
 @let isDisabled = $isDisabled();
-@let isEmpty = data.length === 0;
+@let isEmpty = store.data().length === 0;
 @let field = $field();
 @let hintText = field.hint || null;
 @let hasError = $hasError();

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -256,10 +256,11 @@ export class DotRelationshipFieldComponent
     /**
      * Persists row order after a PrimeNG table row reorder.
      *
-     * PrimeNG mutates the bound `[value]` array in-place via `ObjectUtils.reorderArray` before
-     * emitting `onRowReorder` (see `Table.onRowDrop` in `primeng/table`). `dragIndex` / `dropIndex`
-     * describe that mutation; re-applying them here would corrupt the order. The store must only
-     * take an immutable snapshot so signal consumers re-run (`setData` clones the array).
+     * Since `[value]` is now bound to a paginated slice (a new array from a computed signal),
+     * PrimeNG mutates that transient slice in-place via `ObjectUtils.reorderArray`, leaving
+     * the full `store.data()` untouched. We translate the slice-local `dragIndex` / `dropIndex`
+     * to global indices using the current pagination offset, then apply the reorder on a copy
+     * of the full data array and persist it back to the store.
      */
     onRowReorder(event: TableRowReorderEvent) {
         const dragIndex = event?.dragIndex;
@@ -268,7 +269,15 @@ export class DotRelationshipFieldComponent
             return;
         }
 
-        this.store.setData(this.store.data());
+        const offset = this.store.pagination().offset;
+        const globalDragIndex = offset + dragIndex;
+        const globalDropIndex = offset + dropIndex;
+
+        const reorderedData = [...this.store.data()];
+        const [movedItem] = reorderedData.splice(globalDragIndex, 1);
+        reorderedData.splice(globalDropIndex, 0, movedItem);
+
+        this.store.setData(reorderedData);
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -170,6 +170,41 @@ describe('RelationshipFieldStore', () => {
                 expect(store.data().length).toBe(2);
                 expect(store.data().find((item) => item.inode === 'inode1')).toBeUndefined();
             });
+
+            it('should reset pagination when current page exceeds total after delete', () => {
+                // Create 7 items so page 2 has 1 item
+                const sevenItems = Array.from({ length: 7 }, (_, i) =>
+                    createFakeContentlet({
+                        inode: `del-inode-${i + 1}`,
+                        identifier: `del-identifier-${i + 1}`,
+                        id: `${i + 1}`
+                    })
+                );
+                store.setData(sevenItems);
+
+                // Navigate to page 2 (offset 6, only item index 6)
+                store.nextPage();
+                expect(store.pagination().currentPage).toBe(2);
+                expect(store.pagination().offset).toBe(6);
+
+                // Delete the single item on page 2
+                store.deleteItem('del-inode-7');
+
+                // Should reset to page 1
+                expect(store.pagination().currentPage).toBe(1);
+                expect(store.pagination().offset).toBe(0);
+                expect(store.data().length).toBe(6);
+            });
+
+            it('should reset pagination to page 1 when all items are deleted', () => {
+                store.setData([mockData[0]]);
+                store.nextPage(); // artificially advance
+                store.deleteItem(mockData[0].inode);
+
+                expect(store.pagination().currentPage).toBe(1);
+                expect(store.pagination().offset).toBe(0);
+                expect(store.data().length).toBe(0);
+            });
         });
 
         describe('pagination', () => {
@@ -253,6 +288,47 @@ describe('RelationshipFieldStore', () => {
                 store.setData(mockData);
 
                 expect(store.isDisabledCreateNewContent()).toBe(false);
+            });
+        });
+
+        describe('paginatedData', () => {
+            const paginatedMockData = Array.from({ length: 8 }, (_, i) =>
+                createFakeContentlet({
+                    inode: `inode-page-${i + 1}`,
+                    identifier: `identifier-page-${i + 1}`,
+                    id: `${i + 1}`
+                })
+            );
+
+            it('should return first page slice by default', () => {
+                store.setData(paginatedMockData);
+
+                const result = store.paginatedData();
+                expect(result.length).toBe(6);
+                expect(result[0].inode).toBe('inode-page-1');
+                expect(result[5].inode).toBe('inode-page-6');
+            });
+
+            it('should return second page after nextPage()', () => {
+                store.setData(paginatedMockData);
+                store.nextPage();
+
+                const result = store.paginatedData();
+                expect(result.length).toBe(2);
+                expect(result[0].inode).toBe('inode-page-7');
+                expect(result[1].inode).toBe('inode-page-8');
+            });
+
+            it('should return empty array when data is empty', () => {
+                expect(store.paginatedData()).toEqual([]);
+            });
+
+            it('should update when data changes', () => {
+                store.setData(paginatedMockData);
+                expect(store.paginatedData().length).toBe(6);
+
+                store.setData(paginatedMockData.slice(0, 3));
+                expect(store.paginatedData().length).toBe(3);
             });
         });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -43,15 +43,6 @@ describe('RelationshipFieldStore', () => {
         variable: 'relationship_field'
     });
 
-    const makeFakeContentlets = (count: number, prefix = 'item') =>
-        Array.from({ length: count }, (_, i) =>
-            createFakeContentlet({
-                inode: `${prefix}-inode-${i + 1}`,
-                identifier: `${prefix}-identifier-${i + 1}`,
-                id: `${i + 1}`
-            })
-        );
-
     const mockContentType = {
         id: 'test-content-type',
         name: 'Test Content Type',
@@ -171,7 +162,13 @@ describe('RelationshipFieldStore', () => {
             });
 
             it('should reset pagination to page 1 when data is replaced', () => {
-                const eightItems = makeFakeContentlets(8, 'set');
+                const eightItems = Array.from({ length: 8 }, (_, i) =>
+                    createFakeContentlet({
+                        inode: `set-inode-${i + 1}`,
+                        identifier: `set-identifier-${i + 1}`,
+                        id: `${i + 1}`
+                    })
+                );
                 store.setData(eightItems);
 
                 // Navigate to page 2
@@ -198,7 +195,13 @@ describe('RelationshipFieldStore', () => {
             });
 
             it('should reset pagination when current page exceeds total after delete', () => {
-                const sevenItems = makeFakeContentlets(7, 'del');
+                const sevenItems = Array.from({ length: 7 }, (_, i) =>
+                    createFakeContentlet({
+                        inode: `del-inode-${i + 1}`,
+                        identifier: `del-identifier-${i + 1}`,
+                        id: `${i + 1}`
+                    })
+                );
                 store.setData(sevenItems);
 
                 // Navigate to page 2 (offset 6, only item index 6)
@@ -216,7 +219,13 @@ describe('RelationshipFieldStore', () => {
             });
 
             it('should stay on current page when delete does not invalidate it', () => {
-                const nineItems = makeFakeContentlets(9, 'stay');
+                const nineItems = Array.from({ length: 9 }, (_, i) =>
+                    createFakeContentlet({
+                        inode: `stay-inode-${i + 1}`,
+                        identifier: `stay-identifier-${i + 1}`,
+                        id: `${i + 1}`
+                    })
+                );
                 store.setData(nineItems);
 
                 // Navigate to page 2 (offset 6, items 7-9)
@@ -234,7 +243,13 @@ describe('RelationshipFieldStore', () => {
             });
 
             it('should reset pagination to page 1 when all items are deleted', () => {
-                const sevenItems = makeFakeContentlets(7, 'all');
+                const sevenItems = Array.from({ length: 7 }, (_, i) =>
+                    createFakeContentlet({
+                        inode: `all-inode-${i + 1}`,
+                        identifier: `all-identifier-${i + 1}`,
+                        id: `${i + 1}`
+                    })
+                );
                 store.setData(sevenItems);
 
                 // Navigate to page 2
@@ -338,7 +353,13 @@ describe('RelationshipFieldStore', () => {
         });
 
         describe('paginatedData', () => {
-            const paginatedMockData = makeFakeContentlets(8, 'page');
+            const paginatedMockData = Array.from({ length: 8 }, (_, i) =>
+                createFakeContentlet({
+                    inode: `page-inode-${i + 1}`,
+                    identifier: `page-identifier-${i + 1}`,
+                    id: `${i + 1}`
+                })
+            );
 
             it('should return first page slice by default', () => {
                 store.setData(paginatedMockData);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -43,6 +43,15 @@ describe('RelationshipFieldStore', () => {
         variable: 'relationship_field'
     });
 
+    const makeFakeContentlets = (count: number, prefix = 'item') =>
+        Array.from({ length: count }, (_, i) =>
+            createFakeContentlet({
+                inode: `${prefix}-inode-${i + 1}`,
+                identifier: `${prefix}-identifier-${i + 1}`,
+                id: `${i + 1}`
+            })
+        );
+
     const mockContentType = {
         id: 'test-content-type',
         name: 'Test Content Type',
@@ -160,6 +169,23 @@ describe('RelationshipFieldStore', () => {
 
                 expect(store.data()).toEqual(mockData);
             });
+
+            it('should reset pagination to page 1 when data is replaced', () => {
+                const eightItems = makeFakeContentlets(8, 'set');
+                store.setData(eightItems);
+
+                // Navigate to page 2
+                store.nextPage();
+                expect(store.pagination().currentPage).toBe(2);
+                expect(store.pagination().offset).toBe(6);
+
+                // Replace with fewer items
+                store.setData(mockData);
+
+                expect(store.pagination().currentPage).toBe(1);
+                expect(store.pagination().offset).toBe(0);
+                expect(store.data()).toEqual(mockData);
+            });
         });
 
         describe('deleteItem', () => {
@@ -172,14 +198,7 @@ describe('RelationshipFieldStore', () => {
             });
 
             it('should reset pagination when current page exceeds total after delete', () => {
-                // Create 7 items so page 2 has 1 item
-                const sevenItems = Array.from({ length: 7 }, (_, i) =>
-                    createFakeContentlet({
-                        inode: `del-inode-${i + 1}`,
-                        identifier: `del-identifier-${i + 1}`,
-                        id: `${i + 1}`
-                    })
-                );
+                const sevenItems = makeFakeContentlets(7, 'del');
                 store.setData(sevenItems);
 
                 // Navigate to page 2 (offset 6, only item index 6)
@@ -196,10 +215,37 @@ describe('RelationshipFieldStore', () => {
                 expect(store.data().length).toBe(6);
             });
 
+            it('should stay on current page when delete does not invalidate it', () => {
+                const nineItems = makeFakeContentlets(9, 'stay');
+                store.setData(nineItems);
+
+                // Navigate to page 2 (offset 6, items 7-9)
+                store.nextPage();
+                expect(store.pagination().currentPage).toBe(2);
+                expect(store.pagination().offset).toBe(6);
+
+                // Delete one of the 3 items on page 2
+                store.deleteItem('stay-inode-8');
+
+                // Should stay on page 2
+                expect(store.pagination().currentPage).toBe(2);
+                expect(store.pagination().offset).toBe(6);
+                expect(store.data().length).toBe(8);
+            });
+
             it('should reset pagination to page 1 when all items are deleted', () => {
-                store.setData([mockData[0]]);
-                store.nextPage(); // artificially advance
-                store.deleteItem(mockData[0].inode);
+                const sevenItems = makeFakeContentlets(7, 'all');
+                store.setData(sevenItems);
+
+                // Navigate to page 2
+                store.nextPage();
+
+                // Delete all items on page 2, then all on page 1
+                store.deleteItem('all-inode-7');
+                // Now back on page 1 (auto-reset), delete remaining
+                for (let i = 1; i <= 6; i++) {
+                    store.deleteItem(`all-inode-${i}`);
+                }
 
                 expect(store.pagination().currentPage).toBe(1);
                 expect(store.pagination().offset).toBe(0);
@@ -292,21 +338,15 @@ describe('RelationshipFieldStore', () => {
         });
 
         describe('paginatedData', () => {
-            const paginatedMockData = Array.from({ length: 8 }, (_, i) =>
-                createFakeContentlet({
-                    inode: `inode-page-${i + 1}`,
-                    identifier: `identifier-page-${i + 1}`,
-                    id: `${i + 1}`
-                })
-            );
+            const paginatedMockData = makeFakeContentlets(8, 'page');
 
             it('should return first page slice by default', () => {
                 store.setData(paginatedMockData);
 
                 const result = store.paginatedData();
                 expect(result.length).toBe(6);
-                expect(result[0].inode).toBe('inode-page-1');
-                expect(result[5].inode).toBe('inode-page-6');
+                expect(result[0].inode).toBe('page-inode-1');
+                expect(result[5].inode).toBe('page-inode-6');
             });
 
             it('should return second page after nextPage()', () => {
@@ -315,8 +355,8 @@ describe('RelationshipFieldStore', () => {
 
                 const result = store.paginatedData();
                 expect(result.length).toBe(2);
-                expect(result[0].inode).toBe('inode-page-7');
-                expect(result[1].inode).toBe('inode-page-8');
+                expect(result[0].inode).toBe('page-inode-7');
+                expect(result[1].inode).toBe('page-inode-8');
             });
 
             it('should return empty array when data is empty', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -66,6 +66,16 @@ export const RelationshipFieldStore = signalStore(
          */
         totalPages: computed(() => Math.ceil(state.data().length / state.pagination().rowsPerPage)),
         /**
+         * Returns the slice of data for the current page based on offset and rowsPerPage.
+         * @returns {DotCMSContentlet[]} The items for the current page.
+         */
+        paginatedData: computed(() => {
+            const allData = state.data();
+            const { offset, rowsPerPage } = state.pagination();
+
+            return allData.slice(offset, offset + rowsPerPage);
+        }),
+        /**
          * Checks if the create new content button is disabled based on the selection mode and the number of items.
          * @returns {boolean} True if the button is disabled, false otherwise.
          */
@@ -145,13 +155,37 @@ export const RelationshipFieldStore = signalStore(
                 )
             ),
             /**
-             * Deletes an item from the store at the specified index.
-             * @param index - The index of the item to delete.
+             * Deletes an item from the store by inode.
+             * If the current page offset exceeds the new data length, pagination resets to the last valid page.
+             * @param inode - The inode of the item to delete.
              */
             deleteItem(inode: string) {
-                patchState(store, {
-                    data: store.data().filter((item) => item.inode !== inode)
-                });
+                const newData = store.data().filter((item) => item.inode !== inode);
+                const { offset, rowsPerPage } = store.pagination();
+
+                if (offset >= newData.length && newData.length > 0) {
+                    const lastPage = Math.ceil(newData.length / rowsPerPage);
+                    const newOffset = (lastPage - 1) * rowsPerPage;
+                    patchState(store, {
+                        data: newData,
+                        pagination: {
+                            ...store.pagination(),
+                            offset: newOffset,
+                            currentPage: lastPage
+                        }
+                    });
+                } else if (newData.length === 0) {
+                    patchState(store, {
+                        data: newData,
+                        pagination: {
+                            ...store.pagination(),
+                            offset: 0,
+                            currentPage: 1
+                        }
+                    });
+                } else {
+                    patchState(store, { data: newData });
+                }
             },
             /**
              * Advances the pagination to the next page and updates the state accordingly.

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -165,20 +165,30 @@ export const RelationshipFieldStore = signalStore(
             deleteItem(inode: string) {
                 const newData = store.data().filter((item) => item.inode !== inode);
                 const { offset, rowsPerPage } = store.pagination();
-                let newOffset = offset;
-                let newPage = store.pagination().currentPage;
 
-                if (newData.length === 0 || offset >= newData.length) {
-                    const lastPage =
-                        newData.length === 0 ? 1 : Math.ceil(newData.length / rowsPerPage);
-                    newOffset = (lastPage - 1) * rowsPerPage;
-                    newPage = lastPage;
+                if (offset >= newData.length && newData.length > 0) {
+                    const lastPage = Math.ceil(newData.length / rowsPerPage);
+                    const newOffset = (lastPage - 1) * rowsPerPage;
+                    patchState(store, {
+                        data: newData,
+                        pagination: {
+                            ...store.pagination(),
+                            offset: newOffset,
+                            currentPage: lastPage
+                        }
+                    });
+                } else if (newData.length === 0) {
+                    patchState(store, {
+                        data: newData,
+                        pagination: {
+                            ...store.pagination(),
+                            offset: 0,
+                            currentPage: 1
+                        }
+                    });
+                } else {
+                    patchState(store, { data: newData });
                 }
-
-                patchState(store, {
-                    data: newData,
-                    pagination: { ...store.pagination(), offset: newOffset, currentPage: newPage }
-                });
             },
             /**
              * Advances the pagination to the next page and updates the state accordingly.

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -111,7 +111,10 @@ export const RelationshipFieldStore = signalStore(
              * @param {RelationshipFieldItem[]} data - The data to be set.
              */
             setData(data: DotCMSContentlet[]) {
-                patchState(store, { data: [...data] });
+                patchState(store, {
+                    data: [...data],
+                    pagination: { ...store.pagination(), offset: 0, currentPage: 1 }
+                });
             },
             /**
              * Initializes the relationship field with the provided parameters.
@@ -162,30 +165,20 @@ export const RelationshipFieldStore = signalStore(
             deleteItem(inode: string) {
                 const newData = store.data().filter((item) => item.inode !== inode);
                 const { offset, rowsPerPage } = store.pagination();
+                let newOffset = offset;
+                let newPage = store.pagination().currentPage;
 
-                if (offset >= newData.length && newData.length > 0) {
-                    const lastPage = Math.ceil(newData.length / rowsPerPage);
-                    const newOffset = (lastPage - 1) * rowsPerPage;
-                    patchState(store, {
-                        data: newData,
-                        pagination: {
-                            ...store.pagination(),
-                            offset: newOffset,
-                            currentPage: lastPage
-                        }
-                    });
-                } else if (newData.length === 0) {
-                    patchState(store, {
-                        data: newData,
-                        pagination: {
-                            ...store.pagination(),
-                            offset: 0,
-                            currentPage: 1
-                        }
-                    });
-                } else {
-                    patchState(store, { data: newData });
+                if (newData.length === 0 || offset >= newData.length) {
+                    const lastPage =
+                        newData.length === 0 ? 1 : Math.ceil(newData.length / rowsPerPage);
+                    newOffset = (lastPage - 1) * rowsPerPage;
+                    newPage = lastPage;
                 }
+
+                patchState(store, {
+                    data: newData,
+                    pagination: { ...store.pagination(), offset: newOffset, currentPage: newPage }
+                });
             },
             /**
              * Advances the pagination to the next page and updates the state accordingly.


### PR DESCRIPTION
## Summary

- Fix relationship field pagination that showed the same items on every page because `p-table` bound the full data array with `[paginator]="false"`, ignoring `[first]` and `[rows]`
- Add a `paginatedData` computed signal that slices data by offset/rowsPerPage, fix row reorder to translate paginated indices, and reset pagination on item deletion when current page becomes invalid

Closes #35106

## Changes

| File | Change |
|------|--------|
| `core-web/.../store/relationship-field.store.ts` | Add `paginatedData` computed signal; update `deleteItem` to reset pagination when current page exceeds total |
| `core-web/.../dot-relationship-field.component.html` | Bind `[value]` to `store.paginatedData()` instead of `store.data()`; fix `isEmpty` check to use full data |
| `core-web/.../dot-relationship-field.component.ts` | Fix `onRowReorder` to translate slice-local indices to global positions using pagination offset |
| `core-web/.../store/relationship-field.store.spec.ts` | Add tests for `paginatedData` (first page, second page, empty, reactive) and `deleteItem` pagination reset |

## Acceptance Criteria

- [ ] The p-table's [value] binding receives only the items for the current page, not the entire data array
- [ ] Clicking "next page" advances to the next page and displays only that page's items
- [ ] Clicking "previous page" navigates back and displays only the previous page's items
- [ ] Each page displays at most rowsPerPage items (currently 6). Last page may display fewer
- [ ] Previous button disabled on page 1, next button disabled on last page (no regression)
- [ ] When items are deleted such that current page exceeds total pages, pagination resets to last valid page
- [ ] Drag-and-drop row reorder works correctly with paginated data (indices translated by offset)
- [ ] When ≤6 items, no pagination controls appear (no regression)
- [ ] Original bug STR no longer reproduces
- [ ] Store has unit tests for the paginatedData computed signal

## Test Plan

- [ ] Open Edit Content for a content type with a relationship field
- [ ] Add more than 6 related items — pagination should appear showing "1 of 2"
- [ ] Click next page — different items should be displayed
- [ ] Click previous page — original items should be displayed
- [ ] On page 2, delete all items — should automatically go back to page 1
- [ ] Drag-and-drop reorder items on page 1 — order should persist correctly
- [ ] With ≤6 items, no pagination controls should appear
- [ ] Run `yarn nx test edit-content --testPathPattern=relationship-field.store.spec` — all tests pass

## Visual Changes

> **Screenshots/GIFs needed:** This PR includes frontend changes. Please attach visual evidence before marking as ready for review.
>
> - [ ] Before screenshot
> - [ ] After screenshot
> - [ ] GIF of interaction (if behavioral change)

This PR fixes: #35106