### PR TITLE
fix(edit-content): standardize column widths in relationship field tables

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
@@ -28,27 +28,27 @@
             @for (column of columns; track $index) {
                 @switch (column.type) {
                     @case ('title') {
-                        <th scope="col" [class.w-48]="!isEmpty" [class.min-w-48]="!isEmpty">
+                        <th scope="col" class="flex-1 min-w-0">
                             {{ 'dot.file.relationship.field.table.title' | dm }}
                         </th>
                     }
                     @case ('language') {
-                        <th scope="col" [class.min-w-32]="!isEmpty">
+                        <th scope="col" class="w-32 min-w-32 max-w-32">
                             {{ 'dot.file.relationship.field.table.language' | dm }}
                         </th>
                     }
                     @case ('status') {
-                        <th scope="col" [class.min-w-32]="!isEmpty">
+                        <th scope="col" class="w-32 min-w-32 max-w-32">
                             {{ 'dot.file.relationship.field.table.status' | dm }}
                         </th>
                     }
                     @case ('image') {
-                        <th scope="col" [class.w-24]="!isEmpty" [class.min-w-24]="!isEmpty">
+                        <th scope="col" class="w-24 min-w-24 max-w-24">
                             <p class="truncate capitalize">{{ column.header }}</p>
                         </th>
                     }
                     @default {
-                        <th scope="col" [class.min-w-32]="!isEmpty">
+                        <th scope="col" class="w-32 min-w-32 max-w-32">
                             <span class="capitalize">{{ column.header }}</span>
                         </th>
                     }
@@ -101,17 +101,17 @@
             @for (column of columns; track $index) {
                 @switch (column.type) {
                     @case ('title') {
-                        <td class="w-48 min-w-48" [class.cursor-not-allowed]="isDisabled">
+                        <td class="flex-1 min-w-0" [class.cursor-not-allowed]="isDisabled">
                             <p class="truncate">{{ item.title }}</p>
                         </td>
                     }
                     @case ('language') {
-                        <td class="min-w-32" [class.cursor-not-allowed]="isDisabled">
+                        <td class="w-32 min-w-32 max-w-32" [class.cursor-not-allowed]="isDisabled">
                             {{ item.language | language }}
                         </td>
                     }
                     @case ('status') {
-                        <td class="min-w-32" [class.cursor-not-allowed]="isDisabled">
+                        <td class="w-32 min-w-32 max-w-32" [class.cursor-not-allowed]="isDisabled">
                             @let status = item | contentletStatus;
                             <p-chip
                                 [class]="'p-chip-sm ' + status.classes"
@@ -119,7 +119,7 @@
                         </td>
                     }
                     @case ('image') {
-                        <td class="w-24 min-w-24" [class.cursor-not-allowed]="isDisabled">
+                        <td class="w-24 min-w-24 max-w-24" [class.cursor-not-allowed]="isDisabled">
                             <div class="flex items-center justify-center">
                                 <dot-contentlet-thumbnail
                                     [iconSize]="'30px'"
@@ -130,7 +130,7 @@
                         </td>
                     }
                     @default {
-                        <td class="min-w-32">
+                        <td class="w-32 min-w-32 max-w-32">
                             <p class="truncate">{{ item[column.nameField] }}</p>
                         </td>
                     }


### PR DESCRIPTION
## Summary

- Standardize column widths in relationship field tables so that all instances render identically regardless of content length
- Title column now uses flexible width (`flex-1`) to fill remaining space, while language, status, image, and custom columns use locked fixed widths (`w-N min-w-N max-w-N`)
- Remove conditional `!isEmpty` class bindings so column widths apply consistently in both empty and populated states

Closes #35020

## Changes

| File | Change |
|------|--------|
| `core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html` | Replace conditional width bindings with unconditional Tailwind classes; title column uses `flex-1 min-w-0`, fixed columns use triple-lock `w-N min-w-N max-w-N` pattern |

## Acceptance Criteria

- [ ] AC1: The Title (primary) column uses a flexible width that expands to fill all remaining horizontal space
- [ ] AC2: The Language column has a fixed width that remains identical across all instances
- [ ] AC3: The Status column has a fixed width that remains identical across all instances
- [ ] AC4: The drag handle column maintains a consistent fixed width of `w-12`
- [ ] AC5: The remove/add button column maintains a consistent fixed width of `w-16`
- [ ] AC6: Long titles are truncated with ellipsis and row height remains single line
- [ ] AC7: Image column displays at fixed width `w-24` without affecting other columns
- [ ] AC8: Custom text columns use fixed width consistent with Language/Status columns
- [ ] AC9: Two relationship tables on the same form render with identical column widths
- [ ] AC10: Additional columns don't affect fixed-width columns; only title adjusts

## Test Plan

- [ ] Open a content type with multiple relationship fields
- [ ] Add items with varying title lengths to each relationship field
- [ ] Verify all relationship tables show identical column widths regardless of content
- [ ] Verify long titles truncate with ellipsis
- [ ] Verify empty relationship tables have consistent header widths
- [ ] Run `yarn nx test dotcms-edit-content` — all 1652 tests pass

## Visual Changes
Before screenshot
<img width="4092" height="1280" alt="image" src="https://github.com/user-attachments/assets/ab9dc39b-a05c-457e-94ff-cd1e9b3f9a4a" />
After screenshot
<img width="2514" height="1094" alt="CleanShot 2026-03-26 at 12 22 21@2x" src="https://github.com/user-attachments/assets/287deda7-73e3-4f3a-a9a4-d6823faa5497" />


## Notes

- All changes are pure Tailwind CSS class modifications in a single HTML template — no TypeScript or logic changes
- The triple-lock pattern (`w-N min-w-N max-w-N`) follows the precedent set in PR #32604
- PrimeNG scrollable tables use flexbox on rows, so `flex-1` works correctly on table cells

This PR fixes: #35020