### PR TITLE
#32792 Relationship Field: disable already-related items in dialog

### DIFF
--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/helpers/select-existing-content-dialog.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/helpers/select-existing-content-dialog.ts
@@ -189,6 +189,38 @@ export class SelectExistingContentDialog {
         await expect(this.dialog.locator('.p-paginator')).toBeVisible();
     }
 
+    // ─── Constrained Items (Cardinality) ──────────────────────────────
+
+    /**
+     * Returns the row at the given index.
+     */
+    getRow(index: number): Locator {
+        return this.rows.nth(index);
+    }
+
+    /**
+     * Asserts a row is constrained (disabled, grayed out — already related to another parent).
+     */
+    async expectRowConstrained(rowIndex: number): Promise<void> {
+        const row = this.rows.nth(rowIndex);
+        await expect(row).toHaveClass(/opacity-50/);
+        await expect(row).toHaveClass(/pointer-events-none/);
+
+        // Checkbox or radio should be disabled
+        const checkbox = row.getByTestId('row-checkbox');
+        const radio = row.getByTestId('row-radio');
+        const control = (await checkbox.count()) > 0 ? checkbox : radio;
+        await expect(control.locator('.p-disabled')).toBeVisible();
+    }
+
+    /**
+     * Asserts a row is NOT constrained (enabled, full opacity).
+     */
+    async expectRowSelectable(rowIndex: number): Promise<void> {
+        const row = this.rows.nth(rowIndex);
+        await expect(row).not.toHaveClass(/opacity-50/);
+    }
+
     // ─── Error State ─────────────────────────────────────────────────
 
     async expectErrorMessage(): Promise<void> {

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-cardinality.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-cardinality.spec.ts
@@ -1,0 +1,204 @@
+import {
+    CARDINALITY,
+    test,
+    expect,
+    type TestContentType,
+    type TestContentlet
+} from '@fixtures/relationship.fixture';
+import { NewEditContentFormPage } from '@pages';
+
+import { RelationshipField } from './helpers/relationship-field';
+import { SelectExistingContentDialog } from './helpers/select-existing-content-dialog';
+
+/**
+ * Tests that the "Select Existing Content" dialog disables items
+ * that are already related to another parent in ONE_TO_ONE and ONE_TO_MANY relationships.
+ */
+test.describe('Cardinality Constraints', () => {
+    let childType: TestContentType;
+    let parentType: TestContentType;
+    let children: TestContentlet[];
+
+    test.beforeEach(async ({ apiHelpers, testSuffix }) => {
+        // 1. Create child content type
+        childType = await apiHelpers.createContentType(apiHelpers.authorPayload(testSuffix));
+
+        // 2. Create parent content type with ONE_TO_MANY relationship to child
+        parentType = await apiHelpers.createContentType(
+            apiHelpers.blogPayload(
+                testSuffix,
+                'E2E_Parent',
+                'E2EParent',
+                childType.variable,
+                'relation',
+                CARDINALITY.ONE_TO_MANY
+            )
+        );
+
+        // 3. Create 3 children (sorted by title)
+        children = await apiHelpers.createContentlets(childType.variable, [
+            { title: 'Child A' },
+            { title: 'Child B' },
+            { title: 'Child C' }
+        ]);
+
+        // 4. Create Parent A and relate it to Child A
+        await apiHelpers.createContentletWithRelationship(
+            parentType.variable,
+            { title: 'Parent A' },
+            { relation: children[0].identifier }
+        );
+    });
+
+    test('constrained items disabled in ONE_TO_MANY dialog @critical', async ({ adminPage }) => {
+        const formPage = new NewEditContentFormPage(adminPage);
+        const relField = new RelationshipField(adminPage, 'relation');
+        const dialog = new SelectExistingContentDialog(adminPage);
+
+        // Navigate to create Parent B (new content)
+        await formPage.goToNew(parentType.variable);
+
+        // Open the "Select Existing Content" dialog
+        await relField.clickRelateExisting();
+        await dialog.waitForVisible();
+        await dialog.waitForContentLoaded();
+
+        // Expect 3 rows in the dialog
+        await dialog.expectRowCount(3);
+
+        // Find which row index corresponds to Child A (already taken by Parent A)
+        // Children are sorted by title: Child A, Child B, Child C
+        // The dialog may sort differently, so find by title text
+        const rowCount = await dialog.rows.count();
+        let constrainedRowIndex = -1;
+        const selectableIndices: number[] = [];
+
+        for (let i = 0; i < rowCount; i++) {
+            const rowText = await dialog.rows.nth(i).textContent();
+            if (rowText?.includes('Child A')) {
+                constrainedRowIndex = i;
+            } else {
+                selectableIndices.push(i);
+            }
+        }
+
+        expect(constrainedRowIndex, 'Child A row should exist in dialog').toBeGreaterThanOrEqual(0);
+        expect(selectableIndices, 'Should have 2 selectable rows').toHaveLength(2);
+
+        // Child A should be disabled (constrained — already related to Parent A)
+        await dialog.expectRowConstrained(constrainedRowIndex);
+
+        // Child B and Child C should be selectable
+        for (const idx of selectableIndices) {
+            await dialog.expectRowSelectable(idx);
+        }
+    });
+
+    test('constrained items disabled in ONE_TO_ONE dialog @critical', async ({
+        adminPage,
+        apiHelpers,
+        testSuffix
+    }) => {
+        // Create a separate ONE_TO_ONE setup
+        const childType11 = await apiHelpers.createContentType(
+            apiHelpers.authorPayload(`OTO${testSuffix}`)
+        );
+
+        const parentType11 = await apiHelpers.createContentType(
+            apiHelpers.blogPayload(
+                `OTO${testSuffix}`,
+                'E2E_Parent11',
+                'E2EParent11',
+                childType11.variable,
+                'relation',
+                CARDINALITY.ONE_TO_ONE
+            )
+        );
+
+        const children11 = await apiHelpers.createContentlets(childType11.variable, [
+            { title: 'Solo Child A' },
+            { title: 'Solo Child B' }
+        ]);
+
+        // Parent A takes Solo Child A
+        await apiHelpers.createContentletWithRelationship(
+            parentType11.variable,
+            { title: 'Solo Parent A' },
+            { relation: children11[0].identifier }
+        );
+
+        const formPage = new NewEditContentFormPage(adminPage);
+        const relField = new RelationshipField(adminPage, 'relation');
+        const dialog = new SelectExistingContentDialog(adminPage);
+
+        // Create new parent — open dialog
+        await formPage.goToNew(parentType11.variable);
+        await relField.clickRelateExisting();
+        await dialog.waitForVisible();
+        await dialog.waitForContentLoaded();
+
+        await dialog.expectRowCount(2);
+
+        // Find constrained row (Solo Child A)
+        const rowCount = await dialog.rows.count();
+        let constrainedIdx = -1;
+        let freeIdx = -1;
+
+        for (let i = 0; i < rowCount; i++) {
+            const text = await dialog.rows.nth(i).textContent();
+            if (text?.includes('Solo Child A')) {
+                constrainedIdx = i;
+            } else {
+                freeIdx = i;
+            }
+        }
+
+        await dialog.expectRowConstrained(constrainedIdx);
+        await dialog.expectRowSelectable(freeIdx);
+    });
+
+    test('no constraints in MANY_TO_MANY dialog', async ({ adminPage, apiHelpers, testSuffix }) => {
+        // Create MANY_TO_MANY setup — no items should be disabled
+        const childTypeMM = await apiHelpers.createContentType(
+            apiHelpers.authorPayload(`MM${testSuffix}`)
+        );
+
+        const parentTypeMM = await apiHelpers.createContentType(
+            apiHelpers.blogPayload(
+                `MM${testSuffix}`,
+                'E2E_ParentMM',
+                'E2EParentMM',
+                childTypeMM.variable,
+                'relation',
+                CARDINALITY.MANY_TO_MANY
+            )
+        );
+
+        const childrenMM = await apiHelpers.createContentlets(childTypeMM.variable, [
+            { title: 'MM Child A' },
+            { title: 'MM Child B' }
+        ]);
+
+        // Relate Child A to Parent A — but in M:M this should NOT constrain it
+        await apiHelpers.createContentletWithRelationship(
+            parentTypeMM.variable,
+            { title: 'MM Parent A' },
+            { relation: childrenMM[0].identifier }
+        );
+
+        const formPage = new NewEditContentFormPage(adminPage);
+        const relField = new RelationshipField(adminPage, 'relation');
+        const dialog = new SelectExistingContentDialog(adminPage);
+
+        await formPage.goToNew(parentTypeMM.variable);
+        await relField.clickRelateExisting();
+        await dialog.waitForVisible();
+        await dialog.waitForContentLoaded();
+
+        await dialog.expectRowCount(2);
+
+        // Both items should be selectable — no constraints in MANY_TO_MANY
+        await dialog.expectRowSelectable(0);
+        await dialog.expectRowSelectable(1);
+    });
+});

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-cardinality.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-cardinality.spec.ts
@@ -1,14 +1,15 @@
-import {
-    CARDINALITY,
-    test,
-    expect,
-    type TestContentType,
-    type TestContentlet
-} from '@fixtures/relationship.fixture';
 import { NewEditContentFormPage } from '@pages';
 
 import { RelationshipField } from './helpers/relationship-field';
 import { SelectExistingContentDialog } from './helpers/select-existing-content-dialog';
+
+import {
+    CARDINALITY,
+    expect,
+    test,
+    type TestContentType,
+    type TestContentlet
+} from '../../../../fixtures/relationship.fixture';
 
 /**
  * Tests that the "Select Existing Content" dialog disables items

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-cardinality.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-cardinality.spec.ts
@@ -12,194 +12,131 @@ import {
 } from '../../../../fixtures/relationship.fixture';
 
 /**
- * Tests that the "Select Existing Content" dialog disables items
- * that are already related to another parent in ONE_TO_ONE and ONE_TO_MANY relationships.
+ * Verifies that the "Select Existing Content" dialog disables items
+ * already related to another parent (ONE_TO_MANY cardinality).
+ *
+ * Setup:
+ *   - Comments type (title + comment field) → 3 contentlets
+ *   - Post type (title + relationship 1:M to Comments)
+ *   - Post A relates to Comment 1
+ *   - Post B has no relationships → edit this one and open dialog
+ *   - Comment 1 should be disabled, Comment 2 and 3 selectable
  */
 test.describe('Cardinality Constraints', () => {
-    let childType: TestContentType;
-    let parentType: TestContentType;
-    let children: TestContentlet[];
+    let commentsType: TestContentType;
+    let postType: TestContentType;
+    let comments: TestContentlet[];
+    let postB: TestContentlet;
 
     test.beforeEach(async ({ apiHelpers, testSuffix }) => {
-        // 1. Create child content type
-        childType = await apiHelpers.createContentType(apiHelpers.authorPayload(testSuffix));
+        // 1. Comments content type with title + comment fields
+        commentsType = await apiHelpers.createContentType({
+            clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
+            name: `E2E_Comments_${testSuffix}`,
+            variable: `E2EComments${testSuffix}`,
+            host: 'SYSTEM_HOST',
+            folder: 'SYSTEM_FOLDER',
+            metadata: { CONTENT_EDITOR2_ENABLED: true },
+            workflow: ['d61a59e1-a49c-46f2-a929-db2b4bfa88b2'],
+            fields: [
+                {
+                    clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
+                    name: 'Title',
+                    variable: 'title',
+                    sortOrder: 1
+                },
+                {
+                    clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
+                    name: 'Comment',
+                    variable: 'comment',
+                    sortOrder: 2
+                }
+            ]
+        });
 
-        // 2. Create parent content type with ONE_TO_MANY relationship to child
-        parentType = await apiHelpers.createContentType(
-            apiHelpers.blogPayload(
-                testSuffix,
-                'E2E_Parent',
-                'E2EParent',
-                childType.variable,
-                'relation',
-                CARDINALITY.ONE_TO_MANY
-            )
-        );
+        // 2. Post content type with title + relationship (1:M) to Comments
+        postType = await apiHelpers.createContentType({
+            clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
+            name: `E2E_Post_${testSuffix}`,
+            variable: `E2EPost${testSuffix}`,
+            host: 'SYSTEM_HOST',
+            folder: 'SYSTEM_FOLDER',
+            metadata: { CONTENT_EDITOR2_ENABLED: true },
+            workflow: ['d61a59e1-a49c-46f2-a929-db2b4bfa88b2'],
+            fields: [
+                {
+                    clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
+                    name: 'Title',
+                    variable: 'title',
+                    sortOrder: 1
+                },
+                {
+                    clazz: 'com.dotcms.contenttype.model.field.ImmutableRelationshipField',
+                    name: 'Comments',
+                    variable: 'comments',
+                    sortOrder: 2,
+                    relationships: {
+                        velocityVar: commentsType.variable,
+                        cardinality: CARDINALITY.ONE_TO_MANY
+                    }
+                }
+            ]
+        });
 
-        // 3. Create 3 children (sorted by title)
-        children = await apiHelpers.createContentlets(childType.variable, [
-            { title: 'Child A' },
-            { title: 'Child B' },
-            { title: 'Child C' }
+        // 3. Create 2 comments
+        comments = await apiHelpers.createContentlets(commentsType.variable, [
+            { title: 'Comment 1', comment: 'First comment' },
+            { title: 'Comment 2', comment: 'Second comment' }
         ]);
 
-        // 4. Create Parent A and relate it to Child A
+        // 4. Create Post A and relate it to Comment 1
         await apiHelpers.createContentletWithRelationship(
-            parentType.variable,
-            { title: 'Parent A' },
-            { relation: children[0].identifier }
+            postType.variable,
+            { title: 'Post A' },
+            { comments: [comments[0].identifier].join(',') }
         );
+
+        // 5. Create Post B (no relationships) — this is the one we'll edit
+        postB = await apiHelpers.createContentlet(postType.variable, { title: 'Post B' });
     });
 
-    test('constrained items disabled in ONE_TO_MANY dialog @critical', async ({ adminPage }) => {
-        const formPage = new NewEditContentFormPage(adminPage);
-        const relField = new RelationshipField(adminPage, 'relation');
-        const dialog = new SelectExistingContentDialog(adminPage);
-
-        // Navigate to create Parent B (new content)
-        await formPage.goToNew(parentType.variable);
-
-        // Open the "Select Existing Content" dialog
-        await relField.clickRelateExisting();
-        await dialog.waitForVisible();
-        await dialog.waitForContentLoaded();
-
-        // Expect 3 rows in the dialog
-        await dialog.expectRowCount(3);
-
-        // Find which row index corresponds to Child A (already taken by Parent A)
-        // Children are sorted by title: Child A, Child B, Child C
-        // The dialog may sort differently, so find by title text
-        const rowCount = await dialog.rows.count();
-        let constrainedRowIndex = -1;
-        const selectableIndices: number[] = [];
-
-        for (let i = 0; i < rowCount; i++) {
-            const rowText = await dialog.rows.nth(i).textContent();
-            if (rowText?.includes('Child A')) {
-                constrainedRowIndex = i;
-            } else {
-                selectableIndices.push(i);
-            }
-        }
-
-        expect(constrainedRowIndex, 'Child A row should exist in dialog').toBeGreaterThanOrEqual(0);
-        expect(selectableIndices, 'Should have 2 selectable rows').toHaveLength(2);
-
-        // Child A should be disabled (constrained — already related to Parent A)
-        await dialog.expectRowConstrained(constrainedRowIndex);
-
-        // Child B and Child C should be selectable
-        for (const idx of selectableIndices) {
-            await dialog.expectRowSelectable(idx);
-        }
-    });
-
-    test('constrained items disabled in ONE_TO_ONE dialog @critical', async ({
-        adminPage,
-        apiHelpers,
-        testSuffix
+    test('comment already related to another post appears disabled @critical', async ({
+        adminPage
     }) => {
-        // Create a separate ONE_TO_ONE setup
-        const childType11 = await apiHelpers.createContentType(
-            apiHelpers.authorPayload(`OTO${testSuffix}`)
-        );
-
-        const parentType11 = await apiHelpers.createContentType(
-            apiHelpers.blogPayload(
-                `OTO${testSuffix}`,
-                'E2E_Parent11',
-                'E2EParent11',
-                childType11.variable,
-                'relation',
-                CARDINALITY.ONE_TO_ONE
-            )
-        );
-
-        const children11 = await apiHelpers.createContentlets(childType11.variable, [
-            { title: 'Solo Child A' },
-            { title: 'Solo Child B' }
-        ]);
-
-        // Parent A takes Solo Child A
-        await apiHelpers.createContentletWithRelationship(
-            parentType11.variable,
-            { title: 'Solo Parent A' },
-            { relation: children11[0].identifier }
-        );
-
         const formPage = new NewEditContentFormPage(adminPage);
-        const relField = new RelationshipField(adminPage, 'relation');
+        const relField = new RelationshipField(adminPage, 'comments');
         const dialog = new SelectExistingContentDialog(adminPage);
 
-        // Create new parent — open dialog
-        await formPage.goToNew(parentType11.variable);
+        // Navigate to edit Post B
+        await formPage.goToContent(postB.inode);
+
+        // Open "Select Existing Content" dialog
         await relField.clickRelateExisting();
         await dialog.waitForVisible();
         await dialog.waitForContentLoaded();
 
+        // Should see both comments
         await dialog.expectRowCount(2);
 
-        // Find constrained row (Solo Child A)
-        const rowCount = await dialog.rows.count();
+        // Find which row is Comment 1 (taken by Post A) and which is Comment 2 (free)
         let constrainedIdx = -1;
         let freeIdx = -1;
 
-        for (let i = 0; i < rowCount; i++) {
-            const text = await dialog.rows.nth(i).textContent();
-            if (text?.includes('Solo Child A')) {
+        for (let i = 0; i < 2; i++) {
+            const rowText = await dialog.rows.nth(i).textContent();
+            if (rowText?.includes('Comment 1')) {
                 constrainedIdx = i;
             } else {
                 freeIdx = i;
             }
         }
 
+        expect(constrainedIdx, 'Comment 1 should exist in dialog').toBeGreaterThanOrEqual(0);
+
+        // Comment 1 disabled — already related to Post A
         await dialog.expectRowConstrained(constrainedIdx);
+
+        // Comment 2 selectable — free
         await dialog.expectRowSelectable(freeIdx);
-    });
-
-    test('no constraints in MANY_TO_MANY dialog', async ({ adminPage, apiHelpers, testSuffix }) => {
-        // Create MANY_TO_MANY setup — no items should be disabled
-        const childTypeMM = await apiHelpers.createContentType(
-            apiHelpers.authorPayload(`MM${testSuffix}`)
-        );
-
-        const parentTypeMM = await apiHelpers.createContentType(
-            apiHelpers.blogPayload(
-                `MM${testSuffix}`,
-                'E2E_ParentMM',
-                'E2EParentMM',
-                childTypeMM.variable,
-                'relation',
-                CARDINALITY.MANY_TO_MANY
-            )
-        );
-
-        const childrenMM = await apiHelpers.createContentlets(childTypeMM.variable, [
-            { title: 'MM Child A' },
-            { title: 'MM Child B' }
-        ]);
-
-        // Relate Child A to Parent A — but in M:M this should NOT constrain it
-        await apiHelpers.createContentletWithRelationship(
-            parentTypeMM.variable,
-            { title: 'MM Parent A' },
-            { relation: childrenMM[0].identifier }
-        );
-
-        const formPage = new NewEditContentFormPage(adminPage);
-        const relField = new RelationshipField(adminPage, 'relation');
-        const dialog = new SelectExistingContentDialog(adminPage);
-
-        await formPage.goToNew(parentTypeMM.variable);
-        await relField.clickRelateExisting();
-        await dialog.waitForVisible();
-        await dialog.waitForContentLoaded();
-
-        await dialog.expectRowCount(2);
-
-        // Both items should be selectable — no constraints in MANY_TO_MANY
-        await dialog.expectRowSelectable(0);
-        await dialog.expectRowSelectable(1);
     });
 });

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-cardinality.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/relationship-field-cardinality.spec.ts
@@ -16,127 +16,272 @@ import {
  * already related to another parent (ONE_TO_MANY cardinality).
  *
  * Setup:
- *   - Comments type (title + comment field) → 3 contentlets
+ *   - Comments type (title + comment field) → 2 contentlets
  *   - Post type (title + relationship 1:M to Comments)
  *   - Post A relates to Comment 1
  *   - Post B has no relationships → edit this one and open dialog
- *   - Comment 1 should be disabled, Comment 2 and 3 selectable
+ *   - Comment 1 should be disabled, Comment 2 selectable
  */
 test.describe('Cardinality Constraints', () => {
-    let commentsType: TestContentType;
-    let postType: TestContentType;
-    let comments: TestContentlet[];
-    let postB: TestContentlet;
+    test.describe('ONE_TO_MANY', () => {
+        let commentsType: TestContentType;
+        let postType: TestContentType;
+        let comments: TestContentlet[];
+        let postB: TestContentlet;
 
-    test.beforeEach(async ({ apiHelpers, testSuffix }) => {
-        // 1. Comments content type with title + comment fields
-        commentsType = await apiHelpers.createContentType({
-            clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
-            name: `E2E_Comments_${testSuffix}`,
-            variable: `E2EComments${testSuffix}`,
-            host: 'SYSTEM_HOST',
-            folder: 'SYSTEM_FOLDER',
-            metadata: { CONTENT_EDITOR2_ENABLED: true },
-            workflow: ['d61a59e1-a49c-46f2-a929-db2b4bfa88b2'],
-            fields: [
-                {
-                    clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
-                    name: 'Title',
-                    variable: 'title',
-                    sortOrder: 1
-                },
-                {
-                    clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
-                    name: 'Comment',
-                    variable: 'comment',
-                    sortOrder: 2
-                }
-            ]
-        });
-
-        // 2. Post content type with title + relationship (1:M) to Comments
-        postType = await apiHelpers.createContentType({
-            clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
-            name: `E2E_Post_${testSuffix}`,
-            variable: `E2EPost${testSuffix}`,
-            host: 'SYSTEM_HOST',
-            folder: 'SYSTEM_FOLDER',
-            metadata: { CONTENT_EDITOR2_ENABLED: true },
-            workflow: ['d61a59e1-a49c-46f2-a929-db2b4bfa88b2'],
-            fields: [
-                {
-                    clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
-                    name: 'Title',
-                    variable: 'title',
-                    sortOrder: 1
-                },
-                {
-                    clazz: 'com.dotcms.contenttype.model.field.ImmutableRelationshipField',
-                    name: 'Comments',
-                    variable: 'comments',
-                    sortOrder: 2,
-                    relationships: {
-                        velocityVar: commentsType.variable,
-                        cardinality: CARDINALITY.ONE_TO_MANY
+        test.beforeEach(async ({ apiHelpers, testSuffix }) => {
+            commentsType = await apiHelpers.createContentType({
+                clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
+                name: `E2E_Comments_${testSuffix}`,
+                variable: `E2EComments${testSuffix}`,
+                host: 'SYSTEM_HOST',
+                folder: 'SYSTEM_FOLDER',
+                metadata: { CONTENT_EDITOR2_ENABLED: true },
+                workflow: ['d61a59e1-a49c-46f2-a929-db2b4bfa88b2'],
+                fields: [
+                    {
+                        clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
+                        name: 'Title',
+                        variable: 'title',
+                        sortOrder: 1
+                    },
+                    {
+                        clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
+                        name: 'Comment',
+                        variable: 'comment',
+                        sortOrder: 2
                     }
-                }
-            ]
+                ]
+            });
+
+            postType = await apiHelpers.createContentType({
+                clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
+                name: `E2E_Post_${testSuffix}`,
+                variable: `E2EPost${testSuffix}`,
+                host: 'SYSTEM_HOST',
+                folder: 'SYSTEM_FOLDER',
+                metadata: { CONTENT_EDITOR2_ENABLED: true },
+                workflow: ['d61a59e1-a49c-46f2-a929-db2b4bfa88b2'],
+                fields: [
+                    {
+                        clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
+                        name: 'Title',
+                        variable: 'title',
+                        sortOrder: 1
+                    },
+                    {
+                        clazz: 'com.dotcms.contenttype.model.field.ImmutableRelationshipField',
+                        name: 'Comments',
+                        variable: 'comments',
+                        sortOrder: 2,
+                        relationships: {
+                            velocityVar: commentsType.variable,
+                            cardinality: CARDINALITY.ONE_TO_MANY
+                        }
+                    }
+                ]
+            });
+
+            comments = await apiHelpers.createContentlets(commentsType.variable, [
+                { title: 'Comment 1', comment: 'First comment' },
+                { title: 'Comment 2', comment: 'Second comment' }
+            ]);
+
+            await apiHelpers.createContentletWithRelationship(
+                postType.variable,
+                { title: 'Post A' },
+                { comments: [comments[0].identifier].join(',') }
+            );
+
+            postB = await apiHelpers.createContentlet(postType.variable, { title: 'Post B' });
         });
 
-        // 3. Create 2 comments
-        comments = await apiHelpers.createContentlets(commentsType.variable, [
-            { title: 'Comment 1', comment: 'First comment' },
-            { title: 'Comment 2', comment: 'Second comment' }
-        ]);
+        test('comment already related to another post appears disabled @critical', async ({
+            adminPage
+        }) => {
+            const formPage = new NewEditContentFormPage(adminPage);
+            const relField = new RelationshipField(adminPage, 'comments');
+            const dialog = new SelectExistingContentDialog(adminPage);
 
-        // 4. Create Post A and relate it to Comment 1
-        await apiHelpers.createContentletWithRelationship(
-            postType.variable,
-            { title: 'Post A' },
-            { comments: [comments[0].identifier].join(',') }
-        );
+            await formPage.goToContent(postB.inode);
 
-        // 5. Create Post B (no relationships) — this is the one we'll edit
-        postB = await apiHelpers.createContentlet(postType.variable, { title: 'Post B' });
+            await relField.clickRelateExisting();
+            await dialog.waitForVisible();
+            await dialog.waitForContentLoaded();
+
+            await dialog.expectRowCount(2);
+
+            let constrainedIdx = -1;
+            let freeIdx = -1;
+
+            for (let i = 0; i < 2; i++) {
+                const rowText = await dialog.rows.nth(i).textContent();
+                if (rowText?.includes('Comment 1')) {
+                    constrainedIdx = i;
+                } else {
+                    freeIdx = i;
+                }
+            }
+
+            expect(constrainedIdx, 'Comment 1 should exist in dialog').toBeGreaterThanOrEqual(0);
+
+            await dialog.expectRowConstrained(constrainedIdx);
+            await dialog.expectRowSelectable(freeIdx);
+        });
     });
 
-    test('comment already related to another post appears disabled @critical', async ({
-        adminPage
-    }) => {
-        const formPage = new NewEditContentFormPage(adminPage);
-        const relField = new RelationshipField(adminPage, 'comments');
-        const dialog = new SelectExistingContentDialog(adminPage);
+    /**
+     * ONE_TO_ONE cardinality: each child can only belong to one parent.
+     *
+     * Setup:
+     *   - ChildType (title) → 2 contentlets (Child 1, Child 2)
+     *   - ParentType (title + relationship 1:1 to ChildType)
+     *   - Parent A relates to Child 1
+     *   - Edit existing Parent B (no relationships) → Child 1 disabled, Child 2 selectable
+     *   - Create NEW Parent → Child 1 disabled, Child 2 selectable
+     */
+    test.describe('ONE_TO_ONE', () => {
+        let childType: TestContentType;
+        let parentType: TestContentType;
+        let children: TestContentlet[];
+        let parentB: TestContentlet;
 
-        // Navigate to edit Post B
-        await formPage.goToContent(postB.inode);
+        test.beforeEach(async ({ apiHelpers, testSuffix }) => {
+            childType = await apiHelpers.createContentType({
+                clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
+                name: `E2E_Child_${testSuffix}`,
+                variable: `E2EChild${testSuffix}`,
+                host: 'SYSTEM_HOST',
+                folder: 'SYSTEM_FOLDER',
+                metadata: { CONTENT_EDITOR2_ENABLED: true },
+                workflow: ['d61a59e1-a49c-46f2-a929-db2b4bfa88b2'],
+                fields: [
+                    {
+                        clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
+                        name: 'Title',
+                        variable: 'title',
+                        sortOrder: 1
+                    }
+                ]
+            });
 
-        // Open "Select Existing Content" dialog
-        await relField.clickRelateExisting();
-        await dialog.waitForVisible();
-        await dialog.waitForContentLoaded();
+            parentType = await apiHelpers.createContentType({
+                clazz: 'com.dotcms.contenttype.model.type.ImmutableSimpleContentType',
+                name: `E2E_Parent_${testSuffix}`,
+                variable: `E2EParent${testSuffix}`,
+                host: 'SYSTEM_HOST',
+                folder: 'SYSTEM_FOLDER',
+                metadata: { CONTENT_EDITOR2_ENABLED: true },
+                workflow: ['d61a59e1-a49c-46f2-a929-db2b4bfa88b2'],
+                fields: [
+                    {
+                        clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
+                        name: 'Title',
+                        variable: 'title',
+                        sortOrder: 1
+                    },
+                    {
+                        clazz: 'com.dotcms.contenttype.model.field.ImmutableRelationshipField',
+                        name: 'Rel',
+                        variable: 'rel',
+                        sortOrder: 2,
+                        relationships: {
+                            velocityVar: childType.variable,
+                            cardinality: CARDINALITY.ONE_TO_ONE
+                        }
+                    }
+                ]
+            });
 
-        // Should see both comments
-        await dialog.expectRowCount(2);
+            children = await apiHelpers.createContentlets(childType.variable, [
+                { title: 'Child 1' },
+                { title: 'Child 2' }
+            ]);
 
-        // Find which row is Comment 1 (taken by Post A) and which is Comment 2 (free)
-        let constrainedIdx = -1;
-        let freeIdx = -1;
+            // Parent A takes Child 1
+            await apiHelpers.createContentletWithRelationship(
+                parentType.variable,
+                { title: 'Parent A' },
+                { rel: children[0].identifier }
+            );
 
-        for (let i = 0; i < 2; i++) {
-            const rowText = await dialog.rows.nth(i).textContent();
-            if (rowText?.includes('Comment 1')) {
-                constrainedIdx = i;
-            } else {
-                freeIdx = i;
+            // Parent B — no relationships (for edit test)
+            parentB = await apiHelpers.createContentlet(parentType.variable, {
+                title: 'Parent B'
+            });
+        });
+
+        test('child already related to another parent appears disabled (edit existing) @critical', async ({
+            adminPage
+        }) => {
+            const formPage = new NewEditContentFormPage(adminPage);
+            const relField = new RelationshipField(adminPage, 'rel');
+            const dialog = new SelectExistingContentDialog(adminPage);
+
+            await formPage.goToContent(parentB.inode);
+
+            await relField.clickRelateExisting();
+            await dialog.waitForVisible();
+            await dialog.waitForContentLoaded();
+
+            await dialog.expectRowCount(2);
+
+            let constrainedIdx = -1;
+            let freeIdx = -1;
+
+            for (let i = 0; i < 2; i++) {
+                const rowText = await dialog.rows.nth(i).textContent();
+                if (rowText?.includes('Child 1')) {
+                    constrainedIdx = i;
+                } else {
+                    freeIdx = i;
+                }
             }
-        }
 
-        expect(constrainedIdx, 'Comment 1 should exist in dialog').toBeGreaterThanOrEqual(0);
+            expect(constrainedIdx, 'Child 1 should exist in dialog').toBeGreaterThanOrEqual(0);
 
-        // Comment 1 disabled — already related to Post A
-        await dialog.expectRowConstrained(constrainedIdx);
+            // Child 1 disabled — already related to Parent A
+            await dialog.expectRowConstrained(constrainedIdx);
 
-        // Comment 2 selectable — free
-        await dialog.expectRowSelectable(freeIdx);
+            // Child 2 selectable — free
+            await dialog.expectRowSelectable(freeIdx);
+        });
+
+        test('child already related appears disabled when creating new parent @critical', async ({
+            adminPage
+        }) => {
+            const formPage = new NewEditContentFormPage(adminPage);
+            const relField = new RelationshipField(adminPage, 'rel');
+            const dialog = new SelectExistingContentDialog(adminPage);
+
+            // Navigate to create a NEW parent contentlet
+            await formPage.goToNew(parentType.variable);
+
+            await relField.clickRelateExisting();
+            await dialog.waitForVisible();
+            await dialog.waitForContentLoaded();
+
+            await dialog.expectRowCount(2);
+
+            let constrainedIdx = -1;
+            let freeIdx = -1;
+
+            for (let i = 0; i < 2; i++) {
+                const rowText = await dialog.rows.nth(i).textContent();
+                if (rowText?.includes('Child 1')) {
+                    constrainedIdx = i;
+                } else {
+                    freeIdx = i;
+                }
+            }
+
+            expect(constrainedIdx, 'Child 1 should exist in dialog').toBeGreaterThanOrEqual(0);
+
+            // Child 1 disabled — already related to Parent A
+            await dialog.expectRowConstrained(constrainedIdx);
+
+            // Child 2 selectable — free
+            await dialog.expectRowSelectable(freeIdx);
+        });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
@@ -30,7 +30,7 @@ import {
     DotPropertiesService
 } from '@dotcms/data-access';
 import { DotCMSContentType, FeaturedFlags } from '@dotcms/dotcms-models';
-import { DotAutofocusDirective, DotClipboardUtil, DotMessagePipe } from '@dotcms/ui';
+import { DotClipboardUtil, DotMessagePipe } from '@dotcms/ui';
 
 import { DotMenuService } from '../../../../../api/services/dot-menu.service';
 import { DotInlineEditComponent } from '../../../../../view/components/_common/dot-inline-edit/dot-inline-edit.component';
@@ -53,8 +53,6 @@ import { DotStyleEditorBuilderComponent } from '../style-editor/dot-style-editor
         InputTextModule,
         MenuModule,
         DotMessagePipe,
-        DotAutofocusDirective,
-        DotInlineEditComponent,
         DotPortletBoxComponent,
         IframeComponent,
         DotAddToMenuComponent,

--- a/core-web/libs/data-access/src/lib/dot-content-search/dot-content-search.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-content-search/dot-content-search.service.ts
@@ -21,6 +21,7 @@ export interface EsQueryParamsSearch {
     limit?: number;
     sort?: string;
     sortOrder?: ESOrderDirectionSearch;
+    depth?: number;
 }
 export interface DotContentSearchParams {
     globalSearch?: string;
@@ -53,16 +54,16 @@ export class DotContentSearchService {
         query,
         limit = 0,
         offset = 0,
-        sort = 'score,modDate desc'
+        sort = 'score,modDate desc',
+        depth
     }: EsQueryParamsSearch): Observable<T> {
-        return this.#http
-            .post('/api/content/_search', {
-                query,
-                sort,
-                limit,
-                offset
-            })
-            .pipe(pluck('entity'));
+        const body: Record<string, unknown> = { query, sort, limit, offset };
+
+        if (depth != null) {
+            body['depth'] = depth;
+        }
+
+        return this.#http.post('/api/content/_search', body).pipe(pluck('entity'));
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -235,7 +235,11 @@ export class DotRelationshipFieldComponent
             data: {
                 contentTypeId: contentType.id,
                 selectionMode: this.store.selectionMode(),
-                currentItemsIds: this.store.data().map((item) => item.inode)
+                currentItemsIds: this.store.data().map((item) => item.inode),
+                cardinality: this.$field().relationships?.cardinality,
+                relationshipVariable: this.$field().relationships?.velocityVar,
+                isParentField: this.$field().relationships?.isParentField,
+                currentContentIdentifier: this.$contentlet()?.identifier ?? null
             },
             templates: {
                 header: HeaderComponent,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -237,7 +237,8 @@ export class DotRelationshipFieldComponent
                 selectionMode: this.store.selectionMode(),
                 currentItemsIds: this.store.data().map((item) => item.inode),
                 cardinality: this.$field().relationships?.cardinality,
-                relationshipVariable: this.$field().relationships?.velocityVar,
+                parentContentTypeVariable: this.$contentlet()?.contentType,
+                fieldVariable: this.$field().variable,
                 isParentField: this.$field().relationships?.isParentField,
                 currentContentIdentifier: this.$contentlet()?.identifier ?? null
             },

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -238,7 +238,6 @@ export class DotRelationshipFieldComponent
                 currentItemsIds: this.store.data().map((item) => item.inode),
                 cardinality: this.$field().relationships?.cardinality,
                 parentContentTypeId: this.$field().contentTypeId,
-                parentContentTypeVariable: this.$contentlet()?.contentType ?? null,
                 fieldVariable: this.$field().variable,
                 isParentField: this.$field().relationships?.isParentField,
                 currentContentIdentifier: this.$contentlet()?.identifier ?? null

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -237,7 +237,7 @@ export class DotRelationshipFieldComponent
                 selectionMode: this.store.selectionMode(),
                 currentItemsIds: this.store.data().map((item) => item.inode),
                 cardinality: this.$field().relationships?.cardinality,
-                parentContentTypeVariable: this.$contentlet()?.contentType,
+                parentContentTypeId: this.$field().contentTypeId,
                 fieldVariable: this.$field().variable,
                 isParentField: this.$field().relationships?.isParentField,
                 currentContentIdentifier: this.$contentlet()?.identifier ?? null

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -238,6 +238,7 @@ export class DotRelationshipFieldComponent
                 currentItemsIds: this.store.data().map((item) => item.inode),
                 cardinality: this.$field().relationships?.cardinality,
                 parentContentTypeId: this.$field().contentTypeId,
+                parentContentTypeVariable: this.$contentlet()?.contentType ?? null,
                 fieldVariable: this.$field().variable,
                 isParentField: this.$field().relationships?.isParentField,
                 currentContentIdentifier: this.$contentlet()?.identifier ?? null
@@ -294,7 +295,7 @@ export class DotRelationshipFieldComponent
             relationshipInfo: {
                 parentContentletId: this.$contentlet()?.inode,
                 relationshipName: this.$field()?.variable,
-                isParent: true // This could be determined based on relationship configuration
+                isParent: this.$field().relationships?.isParentField ?? true
             },
             onContentSaved: (contentlet: DotCMSContentlet) => {
                 // Add the created contentlet to the relationship

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -89,7 +89,8 @@
                 <tr
                     [class.p-highlight]="checkIfSelected(item)"
                     [class.opacity-50]="isConstrained"
-                    [class.pointer-events-none]="isConstrained">
+                    [class.pointer-events-none]="isConstrained"
+                    [attr.aria-disabled]="isConstrained || null">
                     <td
                         class="max-w-20"
                         pFrozenColumn

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -89,19 +89,14 @@
                 <tr
                     [class.p-highlight]="checkIfSelected(item)"
                     [class.opacity-50]="isConstrained"
-                    [class.pointer-events-none]="isConstrained"
-                    [attr.aria-disabled]="isConstrained || null">
-                    <td
-                        class="max-w-20"
-                        pFrozenColumn
-                        alignFrozen="left"
-                        [frozen]="true"
-                        [pTooltip]="
-                            isConstrained
-                                ? ('dot.file.relationship.dialog.content.already.related' | dm)
-                                : null
-                        "
-                        tooltipPosition="right">
+                    [attr.aria-disabled]="isConstrained || null"
+                    [pTooltip]="
+                        isConstrained
+                            ? ('dot.file.relationship.dialog.content.already.related' | dm)
+                            : null
+                    "
+                    tooltipPosition="top">
+                    <td class="max-w-20" pFrozenColumn alignFrozen="left" [frozen]="true">
                         @if (selectionMode === 'multiple') {
                             <p-tableCheckbox
                                 [value]="item"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -89,6 +89,7 @@
                 <tr
                     [class.p-highlight]="checkIfSelected(item)"
                     [class.opacity-50]="isConstrained"
+                    [class.pointer-events-none]="isConstrained"
                     [attr.aria-disabled]="isConstrained || null"
                     [pTooltip]="
                         isConstrained

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -85,12 +85,32 @@
                 </tr>
             </ng-template>
             <ng-template pTemplate="body" let-item let-columns="columns">
-                <tr [class.p-highlight]="checkIfSelected(item)">
-                    <td class="max-w-20" pFrozenColumn alignFrozen="left" [frozen]="true">
+                @let isConstrained = store.isItemConstrained()(item.identifier);
+                <tr
+                    [class.p-highlight]="checkIfSelected(item)"
+                    [class.opacity-50]="isConstrained"
+                    [class.pointer-events-none]="isConstrained">
+                    <td
+                        class="max-w-20"
+                        pFrozenColumn
+                        alignFrozen="left"
+                        [frozen]="true"
+                        [pTooltip]="
+                            isConstrained
+                                ? ('dot.file.relationship.dialog.content.already.related' | dm)
+                                : null
+                        "
+                        tooltipPosition="right">
                         @if (selectionMode === 'multiple') {
-                            <p-tableCheckbox [value]="item" />
+                            <p-tableCheckbox
+                                [value]="item"
+                                [disabled]="isConstrained"
+                                data-testid="row-checkbox" />
                         } @else {
-                            <p-tableRadioButton [value]="item" />
+                            <p-tableRadioButton
+                                [value]="item"
+                                [disabled]="isConstrained"
+                                data-testid="row-radio" />
                         }
                     </td>
                     <td class="w-[6rem] h-[6rem]">

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -22,6 +22,7 @@ import { InputTextModule } from 'primeng/inputtext';
 import { MenuModule } from 'primeng/menu';
 import { PopoverModule } from 'primeng/popover';
 import { TableModule } from 'primeng/table';
+import { TooltipModule } from 'primeng/tooltip';
 
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DotMessagePipe } from '@dotcms/ui';
@@ -37,6 +38,10 @@ type DialogData = {
     selectionMode: SelectionMode;
     currentItemsIds: string[];
     showFields?: string[] | null;
+    cardinality?: number;
+    relationshipVariable?: string;
+    isParentField?: boolean;
+    currentContentIdentifier?: string;
 };
 
 const STATIC_COLUMNS = 6;
@@ -58,7 +63,8 @@ const STATIC_COLUMNS = 6;
         LanguagePipe,
         DatePipe,
         ChipModule,
-        FormsModule
+        FormsModule,
+        TooltipModule
     ],
     templateUrl: './dot-select-existing-content.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -120,7 +126,11 @@ export class DotSelectExistingContentComponent implements OnInit {
             contentTypeId: data.contentTypeId,
             selectionMode: data.selectionMode,
             selectedItemsIds: data.currentItemsIds,
-            showFields: data.showFields
+            showFields: data.showFields,
+            cardinality: data.cardinality,
+            relationshipVariable: data.relationshipVariable,
+            isParentField: data.isParentField,
+            currentContentIdentifier: data.currentContentIdentifier
         });
     }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -40,6 +40,7 @@ type DialogData = {
     showFields?: string[] | null;
     cardinality?: number;
     parentContentTypeId?: string;
+    parentContentTypeVariable?: string;
     fieldVariable?: string;
     isParentField?: boolean;
     currentContentIdentifier?: string;
@@ -130,6 +131,7 @@ export class DotSelectExistingContentComponent implements OnInit {
             showFields: data.showFields,
             cardinality: data.cardinality,
             parentContentTypeId: data.parentContentTypeId,
+            parentContentTypeVariable: data.parentContentTypeVariable,
             fieldVariable: data.fieldVariable,
             isParentField: data.isParentField,
             currentContentIdentifier: data.currentContentIdentifier

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -39,7 +39,8 @@ type DialogData = {
     currentItemsIds: string[];
     showFields?: string[] | null;
     cardinality?: number;
-    relationshipVariable?: string;
+    parentContentTypeVariable?: string;
+    fieldVariable?: string;
     isParentField?: boolean;
     currentContentIdentifier?: string;
 };
@@ -128,7 +129,8 @@ export class DotSelectExistingContentComponent implements OnInit {
             selectedItemsIds: data.currentItemsIds,
             showFields: data.showFields,
             cardinality: data.cardinality,
-            relationshipVariable: data.relationshipVariable,
+            parentContentTypeVariable: data.parentContentTypeVariable,
+            fieldVariable: data.fieldVariable,
             isParentField: data.isParentField,
             currentContentIdentifier: data.currentContentIdentifier
         });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -39,7 +39,7 @@ type DialogData = {
     currentItemsIds: string[];
     showFields?: string[] | null;
     cardinality?: number;
-    parentContentTypeVariable?: string;
+    parentContentTypeId?: string;
     fieldVariable?: string;
     isParentField?: boolean;
     currentContentIdentifier?: string;
@@ -129,7 +129,7 @@ export class DotSelectExistingContentComponent implements OnInit {
             selectedItemsIds: data.currentItemsIds,
             showFields: data.showFields,
             cardinality: data.cardinality,
-            parentContentTypeVariable: data.parentContentTypeVariable,
+            parentContentTypeId: data.parentContentTypeId,
             fieldVariable: data.fieldVariable,
             isParentField: data.isParentField,
             currentContentIdentifier: data.currentContentIdentifier

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -40,7 +40,6 @@ type DialogData = {
     showFields?: string[] | null;
     cardinality?: number;
     parentContentTypeId?: string;
-    parentContentTypeVariable?: string;
     fieldVariable?: string;
     isParentField?: boolean;
     currentContentIdentifier?: string;
@@ -131,7 +130,6 @@ export class DotSelectExistingContentComponent implements OnInit {
             showFields: data.showFields,
             cardinality: data.cardinality,
             parentContentTypeId: data.parentContentTypeId,
-            parentContentTypeVariable: data.parentContentTypeVariable,
             fieldVariable: data.fieldVariable,
             isParentField: data.isParentField,
             currentContentIdentifier: data.currentContentIdentifier

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
@@ -630,7 +630,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-type-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: 'currentBlog'
                 })
@@ -658,7 +658,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-type-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
@@ -683,7 +683,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-type-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
@@ -714,7 +714,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-type-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
@@ -734,14 +734,14 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-type-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
                 .subscribe(() => {
                     expect(dotContentSearchService.get).toHaveBeenCalledWith(
                         expect.objectContaining({
-                            query: '+contentType:Blog +working:true +deleted:false',
+                            query: '+stInode:blog-type-id +working:true +deleted:false',
                             limit: 5000
                         })
                     );

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
@@ -6,10 +6,11 @@ import {
 } from '@ngneat/spectator/jest';
 import { of, throwError } from 'rxjs';
 
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 
 import {
     DotContentSearchService,
+    DotContentTypeService,
     DotFieldService,
     DotHttpErrorManagerService,
     DotLanguagesService,
@@ -25,6 +26,7 @@ describe('ExistingContentService', () => {
     let dotFieldService: SpyObject<DotFieldService>;
     let dotContentSearchService: SpyObject<DotContentSearchService>;
     let dotHttpErrorManagerService: SpyObject<DotHttpErrorManagerService>;
+    let httpClient: SpyObject<HttpClient>;
 
     const createService = createServiceFactory({
         service: ExistingContentService,
@@ -32,8 +34,12 @@ describe('ExistingContentService', () => {
             mockProvider(DotHttpErrorManagerService, {
                 handle: () => of(null)
             }),
+            mockProvider(HttpClient),
             mockProvider(DotFieldService),
             mockProvider(DotContentSearchService),
+            mockProvider(DotContentTypeService, {
+                getContentType: jest.fn().mockReturnValue(of({ variable: 'Blog' }))
+            }),
             mockProvider(DotLanguagesService, { get: () => of(mockLocales) })
         ]
     });
@@ -43,6 +49,7 @@ describe('ExistingContentService', () => {
         dotFieldService = spectator.inject(DotFieldService);
         dotContentSearchService = spectator.inject(DotContentSearchService);
         dotHttpErrorManagerService = spectator.inject(DotHttpErrorManagerService);
+        httpClient = spectator.inject(HttpClient);
     });
 
     describe('getColumns', () => {
@@ -621,10 +628,12 @@ describe('ExistingContentService', () => {
                 }
             ] as unknown as DotCMSContentlet[];
 
-            dotContentSearchService.get.mockReturnValue(
+            httpClient.post.mockReturnValue(
                 of({
-                    jsonObjectView: { contentlets: parentContentlets },
-                    resultsSize: parentContentlets.length
+                    entity: {
+                        jsonObjectView: { contentlets: parentContentlets },
+                        resultsSize: parentContentlets.length
+                    }
                 })
             );
 
@@ -649,10 +658,12 @@ describe('ExistingContentService', () => {
                 }
             ] as unknown as DotCMSContentlet[];
 
-            dotContentSearchService.get.mockReturnValue(
+            httpClient.post.mockReturnValue(
                 of({
-                    jsonObjectView: { contentlets: parentContentlets },
-                    resultsSize: 1
+                    entity: {
+                        jsonObjectView: { contentlets: parentContentlets },
+                        resultsSize: 1
+                    }
                 })
             );
 
@@ -674,10 +685,12 @@ describe('ExistingContentService', () => {
                 { identifier: 'blog2' }
             ] as unknown as DotCMSContentlet[];
 
-            dotContentSearchService.get.mockReturnValue(
+            httpClient.post.mockReturnValue(
                 of({
-                    jsonObjectView: { contentlets: parentContentlets },
-                    resultsSize: 2
+                    entity: {
+                        jsonObjectView: { contentlets: parentContentlets },
+                        resultsSize: 2
+                    }
                 })
             );
 
@@ -702,15 +715,13 @@ describe('ExistingContentService', () => {
                 })
                 .subscribe((result) => {
                     expect(result).toEqual(new Set());
-                    expect(dotContentSearchService.get).not.toHaveBeenCalled();
+                    expect(httpClient.post).not.toHaveBeenCalled();
                     done();
                 });
         });
 
         it('should return empty set on error', (done) => {
-            dotContentSearchService.get.mockReturnValue(
-                throwError(() => new Error('Network error'))
-            );
+            httpClient.post.mockReturnValue(throwError(() => new Error('Network error')));
 
             spectator.service
                 .getConstrainedIdentifiers({
@@ -724,11 +735,13 @@ describe('ExistingContentService', () => {
                 });
         });
 
-        it('should use correct Lucene query for parent content type', (done) => {
-            dotContentSearchService.get.mockReturnValue(
+        it('should use correct Lucene query with depth 0', (done) => {
+            httpClient.post.mockReturnValue(
                 of({
-                    jsonObjectView: { contentlets: [] },
-                    resultsSize: 0
+                    entity: {
+                        jsonObjectView: { contentlets: [] },
+                        resultsSize: 0
+                    }
                 })
             );
 
@@ -739,9 +752,11 @@ describe('ExistingContentService', () => {
                     currentContentIdentifier: null
                 })
                 .subscribe(() => {
-                    expect(dotContentSearchService.get).toHaveBeenCalledWith(
+                    expect(httpClient.post).toHaveBeenCalledWith(
+                        '/api/content/_search',
                         expect.objectContaining({
-                            query: '+stInode:blog-type-id +working:true +deleted:false',
+                            query: '+contentType:Blog +working:true +deleted:false',
+                            depth: 0,
                             limit: 5000
                         })
                     );

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
@@ -10,7 +10,6 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 
 import {
     DotContentSearchService,
-    DotContentTypeService,
     DotFieldService,
     DotHttpErrorManagerService,
     DotLanguagesService,
@@ -37,9 +36,6 @@ describe('ExistingContentService', () => {
             mockProvider(HttpClient),
             mockProvider(DotFieldService),
             mockProvider(DotContentSearchService),
-            mockProvider(DotContentTypeService, {
-                getContentType: jest.fn().mockReturnValue(of({ variable: 'Blog' }))
-            }),
             mockProvider(DotLanguagesService, { get: () => of(mockLocales) })
         ]
     });
@@ -639,7 +635,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeId: 'blog-type-id',
+                    parentContentTypeVariable: 'Blog',
                     fieldVariable: 'authors',
                     currentContentIdentifier: 'currentBlog'
                 })
@@ -669,7 +665,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeId: 'blog-type-id',
+                    parentContentTypeVariable: 'Blog',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
@@ -696,7 +692,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeId: 'blog-type-id',
+                    parentContentTypeVariable: 'Blog',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
@@ -725,7 +721,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeId: 'blog-type-id',
+                    parentContentTypeVariable: 'Blog',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
@@ -747,7 +743,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeId: 'blog-type-id',
+                    parentContentTypeVariable: 'Blog',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
@@ -627,7 +627,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-ct-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: 'currentBlog'
                 })
@@ -652,12 +652,66 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-ct-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
                 .subscribe((result) => {
                     expect(result).toEqual(new Set(['author1', 'author2']));
+                    done();
+                });
+        });
+
+        it('should handle ONE_TO_ONE single value (non-array) from API', (done) => {
+            // ONE_TO_ONE: backend returns a single identifier, not an array
+            const parentContentlets = [
+                createFakeContentlet({
+                    identifier: 'blog1',
+                    authors: 'author1'
+                } as Partial<DotCMSContentlet>),
+                createFakeContentlet({
+                    identifier: 'blog2',
+                    authors: 'author2'
+                } as Partial<DotCMSContentlet>)
+            ];
+
+            dotContentSearchService.get.mockReturnValue(
+                of({ jsonObjectView: { contentlets: parentContentlets } })
+            );
+
+            spectator.service
+                .getConstrainedIdentifiers({
+                    parentContentTypeId: 'blog-ct-id',
+                    fieldVariable: 'authors',
+                    currentContentIdentifier: null
+                })
+                .subscribe((result) => {
+                    expect(result).toEqual(new Set(['author1', 'author2']));
+                    done();
+                });
+        });
+
+        it('should handle ONE_TO_ONE single object value from API', (done) => {
+            // ONE_TO_ONE with depth >= 1: backend returns a single object, not an array
+            const parentContentlets = [
+                createFakeContentlet({
+                    identifier: 'blog1',
+                    authors: { identifier: 'author1' }
+                } as Partial<DotCMSContentlet>)
+            ];
+
+            dotContentSearchService.get.mockReturnValue(
+                of({ jsonObjectView: { contentlets: parentContentlets } })
+            );
+
+            spectator.service
+                .getConstrainedIdentifiers({
+                    parentContentTypeId: 'blog-ct-id',
+                    fieldVariable: 'authors',
+                    currentContentIdentifier: null
+                })
+                .subscribe((result) => {
+                    expect(result).toEqual(new Set(['author1']));
                     done();
                 });
         });
@@ -674,7 +728,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-ct-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
@@ -687,7 +741,7 @@ describe('ExistingContentService', () => {
         it('should return empty set for missing params', (done) => {
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: '',
+                    parentContentTypeId: '',
                     fieldVariable: '',
                     currentContentIdentifier: null
                 })
@@ -705,7 +759,7 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-ct-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
@@ -722,14 +776,14 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    parentContentTypeVariable: 'Blog',
+                    parentContentTypeId: 'blog-ct-id',
                     fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
                 .subscribe(() => {
                     expect(dotContentSearchService.get).toHaveBeenCalledWith(
                         expect.objectContaining({
-                            query: '+contentType:Blog +working:true +deleted:false',
+                            query: '+structureInode:blog-ct-id +working:true +deleted:false',
                             sort: 'modDate desc',
                             limit: 5000,
                             offset: 0,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@ngneat/spectator/jest';
 import { of, throwError } from 'rxjs';
 
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse } from '@angular/common/http';
 
 import {
     DotContentSearchService,
@@ -25,7 +25,6 @@ describe('ExistingContentService', () => {
     let dotFieldService: SpyObject<DotFieldService>;
     let dotContentSearchService: SpyObject<DotContentSearchService>;
     let dotHttpErrorManagerService: SpyObject<DotHttpErrorManagerService>;
-    let httpClient: SpyObject<HttpClient>;
 
     const createService = createServiceFactory({
         service: ExistingContentService,
@@ -33,7 +32,6 @@ describe('ExistingContentService', () => {
             mockProvider(DotHttpErrorManagerService, {
                 handle: () => of(null)
             }),
-            mockProvider(HttpClient),
             mockProvider(DotFieldService),
             mockProvider(DotContentSearchService),
             mockProvider(DotLanguagesService, { get: () => of(mockLocales) })
@@ -45,7 +43,6 @@ describe('ExistingContentService', () => {
         dotFieldService = spectator.inject(DotFieldService);
         dotContentSearchService = spectator.inject(DotContentSearchService);
         dotHttpErrorManagerService = spectator.inject(DotHttpErrorManagerService);
-        httpClient = spectator.inject(HttpClient);
     });
 
     describe('getColumns', () => {
@@ -624,13 +621,8 @@ describe('ExistingContentService', () => {
                 }
             ] as unknown as DotCMSContentlet[];
 
-            httpClient.post.mockReturnValue(
-                of({
-                    entity: {
-                        jsonObjectView: { contentlets: parentContentlets },
-                        resultsSize: parentContentlets.length
-                    }
-                })
+            dotContentSearchService.get.mockReturnValue(
+                of({ jsonObjectView: { contentlets: parentContentlets } })
             );
 
             spectator.service
@@ -654,13 +646,8 @@ describe('ExistingContentService', () => {
                 }
             ] as unknown as DotCMSContentlet[];
 
-            httpClient.post.mockReturnValue(
-                of({
-                    entity: {
-                        jsonObjectView: { contentlets: parentContentlets },
-                        resultsSize: 1
-                    }
-                })
+            dotContentSearchService.get.mockReturnValue(
+                of({ jsonObjectView: { contentlets: parentContentlets } })
             );
 
             spectator.service
@@ -681,13 +668,8 @@ describe('ExistingContentService', () => {
                 { identifier: 'blog2' }
             ] as unknown as DotCMSContentlet[];
 
-            httpClient.post.mockReturnValue(
-                of({
-                    entity: {
-                        jsonObjectView: { contentlets: parentContentlets },
-                        resultsSize: 2
-                    }
-                })
+            dotContentSearchService.get.mockReturnValue(
+                of({ jsonObjectView: { contentlets: parentContentlets } })
             );
 
             spectator.service
@@ -711,13 +693,15 @@ describe('ExistingContentService', () => {
                 })
                 .subscribe((result) => {
                     expect(result).toEqual(new Set());
-                    expect(httpClient.post).not.toHaveBeenCalled();
+                    expect(dotContentSearchService.get).not.toHaveBeenCalled();
                     done();
                 });
         });
 
         it('should return empty set on error', (done) => {
-            httpClient.post.mockReturnValue(throwError(() => new Error('Network error')));
+            dotContentSearchService.get.mockReturnValue(
+                throwError(() => new Error('Network error'))
+            );
 
             spectator.service
                 .getConstrainedIdentifiers({
@@ -731,14 +715,9 @@ describe('ExistingContentService', () => {
                 });
         });
 
-        it('should use correct Lucene query with depth 0', (done) => {
-            httpClient.post.mockReturnValue(
-                of({
-                    entity: {
-                        jsonObjectView: { contentlets: [] },
-                        resultsSize: 0
-                    }
-                })
+        it('should use correct Lucene query with depth 0 and limit 5000', (done) => {
+            dotContentSearchService.get.mockReturnValue(
+                of({ jsonObjectView: { contentlets: [] } })
             );
 
             spectator.service
@@ -748,12 +727,12 @@ describe('ExistingContentService', () => {
                     currentContentIdentifier: null
                 })
                 .subscribe(() => {
-                    expect(httpClient.post).toHaveBeenCalledWith(
-                        '/api/content/_search',
+                    expect(dotContentSearchService.get).toHaveBeenCalledWith(
                         expect.objectContaining({
                             query: '+contentType:Blog +working:true +deleted:false',
-                            depth: 0,
-                            limit: 5000
+                            sort: 'modDate desc',
+                            limit: 5000,
+                            depth: 0
                         })
                     );
                     done();

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
@@ -607,19 +607,19 @@ describe('ExistingContentService', () => {
     describe('getConstrainedIdentifiers', () => {
         it('should return child identifiers from parent contentlets excluding current content', (done) => {
             const parentContentlets = [
-                {
+                createFakeContentlet({
                     identifier: 'blog1',
                     authors: [{ identifier: 'author1' }, { identifier: 'author2' }]
-                },
-                {
+                } as Partial<DotCMSContentlet>),
+                createFakeContentlet({
                     identifier: 'blog2',
                     authors: [{ identifier: 'author3' }]
-                },
-                {
+                } as Partial<DotCMSContentlet>),
+                createFakeContentlet({
                     identifier: 'currentBlog',
                     authors: [{ identifier: 'author4' }]
-                }
-            ] as unknown as DotCMSContentlet[];
+                } as Partial<DotCMSContentlet>)
+            ];
 
             dotContentSearchService.get.mockReturnValue(
                 of({ jsonObjectView: { contentlets: parentContentlets } })
@@ -640,11 +640,11 @@ describe('ExistingContentService', () => {
 
         it('should handle children as string identifiers', (done) => {
             const parentContentlets = [
-                {
+                createFakeContentlet({
                     identifier: 'blog1',
                     authors: ['author1', 'author2']
-                }
-            ] as unknown as DotCMSContentlet[];
+                } as Partial<DotCMSContentlet>)
+            ];
 
             dotContentSearchService.get.mockReturnValue(
                 of({ jsonObjectView: { contentlets: parentContentlets } })
@@ -664,9 +664,9 @@ describe('ExistingContentService', () => {
 
         it('should return empty set when no parents have relationships', (done) => {
             const parentContentlets = [
-                { identifier: 'blog1' },
-                { identifier: 'blog2' }
-            ] as unknown as DotCMSContentlet[];
+                createFakeContentlet({ identifier: 'blog1' }),
+                createFakeContentlet({ identifier: 'blog2' })
+            ];
 
             dotContentSearchService.get.mockReturnValue(
                 of({ jsonObjectView: { contentlets: parentContentlets } })
@@ -715,7 +715,7 @@ describe('ExistingContentService', () => {
                 });
         });
 
-        it('should use correct Lucene query with depth 0 and limit 5000', (done) => {
+        it('should use correct Lucene query with depth 0, offset 0 and limit 5000', (done) => {
             dotContentSearchService.get.mockReturnValue(
                 of({ jsonObjectView: { contentlets: [] } })
             );
@@ -732,6 +732,7 @@ describe('ExistingContentService', () => {
                             query: '+contentType:Blog +working:true +deleted:false',
                             sort: 'modDate desc',
                             limit: 5000,
+                            offset: 0,
                             depth: 0
                         })
                     );

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
@@ -603,4 +603,144 @@ describe('ExistingContentService', () => {
             });
         });
     });
+
+    describe('getConstrainedIdentifiers', () => {
+        it('should return child identifiers from parent contentlets excluding current content', (done) => {
+            const parentContentlets = [
+                {
+                    identifier: 'blog1',
+                    authors: [{ identifier: 'author1' }, { identifier: 'author2' }]
+                },
+                {
+                    identifier: 'blog2',
+                    authors: [{ identifier: 'author3' }]
+                },
+                {
+                    identifier: 'currentBlog',
+                    authors: [{ identifier: 'author4' }]
+                }
+            ] as unknown as DotCMSContentlet[];
+
+            dotContentSearchService.get.mockReturnValue(
+                of({
+                    jsonObjectView: { contentlets: parentContentlets },
+                    resultsSize: parentContentlets.length
+                })
+            );
+
+            spectator.service
+                .getConstrainedIdentifiers({
+                    relationshipVariable: 'Blog.authors',
+                    currentContentIdentifier: 'currentBlog'
+                })
+                .subscribe((result) => {
+                    expect(result).toEqual(new Set(['author1', 'author2', 'author3']));
+                    expect(result.has('author4')).toBe(false);
+                    done();
+                });
+        });
+
+        it('should handle children as string identifiers', (done) => {
+            const parentContentlets = [
+                {
+                    identifier: 'blog1',
+                    authors: ['author1', 'author2']
+                }
+            ] as unknown as DotCMSContentlet[];
+
+            dotContentSearchService.get.mockReturnValue(
+                of({
+                    jsonObjectView: { contentlets: parentContentlets },
+                    resultsSize: 1
+                })
+            );
+
+            spectator.service
+                .getConstrainedIdentifiers({
+                    relationshipVariable: 'Blog.authors',
+                    currentContentIdentifier: null
+                })
+                .subscribe((result) => {
+                    expect(result).toEqual(new Set(['author1', 'author2']));
+                    done();
+                });
+        });
+
+        it('should return empty set when no parents have relationships', (done) => {
+            const parentContentlets = [
+                { identifier: 'blog1' },
+                { identifier: 'blog2' }
+            ] as unknown as DotCMSContentlet[];
+
+            dotContentSearchService.get.mockReturnValue(
+                of({
+                    jsonObjectView: { contentlets: parentContentlets },
+                    resultsSize: 2
+                })
+            );
+
+            spectator.service
+                .getConstrainedIdentifiers({
+                    relationshipVariable: 'Blog.authors',
+                    currentContentIdentifier: null
+                })
+                .subscribe((result) => {
+                    expect(result).toEqual(new Set());
+                    done();
+                });
+        });
+
+        it('should return empty set for invalid relationship variable', (done) => {
+            spectator.service
+                .getConstrainedIdentifiers({
+                    relationshipVariable: 'invalid',
+                    currentContentIdentifier: null
+                })
+                .subscribe((result) => {
+                    expect(result).toEqual(new Set());
+                    expect(dotContentSearchService.get).not.toHaveBeenCalled();
+                    done();
+                });
+        });
+
+        it('should return empty set on error', (done) => {
+            dotContentSearchService.get.mockReturnValue(
+                throwError(() => new Error('Network error'))
+            );
+
+            spectator.service
+                .getConstrainedIdentifiers({
+                    relationshipVariable: 'Blog.authors',
+                    currentContentIdentifier: null
+                })
+                .subscribe((result) => {
+                    expect(result).toEqual(new Set());
+                    done();
+                });
+        });
+
+        it('should use correct Lucene query for parent content type', (done) => {
+            dotContentSearchService.get.mockReturnValue(
+                of({
+                    jsonObjectView: { contentlets: [] },
+                    resultsSize: 0
+                })
+            );
+
+            spectator.service
+                .getConstrainedIdentifiers({
+                    relationshipVariable: 'Blog.authors',
+                    currentContentIdentifier: null
+                })
+                .subscribe(() => {
+                    expect(dotContentSearchService.get).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            query: '+contentType:Blog +working:true +deleted:false',
+                            limit: 5000
+                        })
+                    );
+                    done();
+                });
+        });
+    });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.spec.ts
@@ -630,7 +630,8 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    relationshipVariable: 'Blog.authors',
+                    parentContentTypeVariable: 'Blog',
+                    fieldVariable: 'authors',
                     currentContentIdentifier: 'currentBlog'
                 })
                 .subscribe((result) => {
@@ -657,7 +658,8 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    relationshipVariable: 'Blog.authors',
+                    parentContentTypeVariable: 'Blog',
+                    fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
                 .subscribe((result) => {
@@ -681,7 +683,8 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    relationshipVariable: 'Blog.authors',
+                    parentContentTypeVariable: 'Blog',
+                    fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
                 .subscribe((result) => {
@@ -690,10 +693,11 @@ describe('ExistingContentService', () => {
                 });
         });
 
-        it('should return empty set for invalid relationship variable', (done) => {
+        it('should return empty set for missing params', (done) => {
             spectator.service
                 .getConstrainedIdentifiers({
-                    relationshipVariable: 'invalid',
+                    parentContentTypeVariable: '',
+                    fieldVariable: '',
                     currentContentIdentifier: null
                 })
                 .subscribe((result) => {
@@ -710,7 +714,8 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    relationshipVariable: 'Blog.authors',
+                    parentContentTypeVariable: 'Blog',
+                    fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
                 .subscribe((result) => {
@@ -729,7 +734,8 @@ describe('ExistingContentService', () => {
 
             spectator.service
                 .getConstrainedIdentifiers({
-                    relationshipVariable: 'Blog.authors',
+                    parentContentTypeVariable: 'Blog',
+                    fieldVariable: 'authors',
                     currentContentIdentifier: null
                 })
                 .subscribe(() => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
@@ -199,25 +199,25 @@ export class ExistingContentService {
      *
      * Uses the ES search API to find parent contentlets and extract their related child identifiers.
      *
-     * @param params.parentContentTypeVariable - The variable of the parent content type (e.g., "MAIN")
+     * @param params.parentContentTypeId - The ID (inode) of the parent content type
      * @param params.fieldVariable - The relationship field variable (e.g., "relation")
      * @param params.currentContentIdentifier - The identifier of the contentlet being edited (to exclude its own children)
      * @returns Observable<Set<string>> - Set of child identifiers that are already "taken" by other parents
      */
     getConstrainedIdentifiers(params: {
-        parentContentTypeVariable: string;
+        parentContentTypeId: string;
         fieldVariable: string;
         currentContentIdentifier: string | null;
     }): Observable<Set<string>> {
-        const { parentContentTypeVariable, fieldVariable } = params;
+        const { parentContentTypeId, fieldVariable } = params;
 
-        if (!parentContentTypeVariable || !fieldVariable) {
+        if (!parentContentTypeId || !fieldVariable) {
             return of(new Set<string>());
         }
 
         return this.#contentSearchService
             .get<{ jsonObjectView: { contentlets: DotCMSContentlet[] } }>({
-                query: `+contentType:${parentContentTypeVariable} +working:true +deleted:false`,
+                query: `+structureInode:${parentContentTypeId} +working:true +deleted:false`,
                 sort: 'modDate desc',
                 limit: CONSTRAINED_QUERY_LIMIT,
                 offset: 0,
@@ -233,19 +233,25 @@ export class ExistingContentService {
                         }
 
                         const relatedChildren = parent[fieldVariable] as unknown;
-                        if (Array.isArray(relatedChildren)) {
-                            for (const child of relatedChildren as unknown[]) {
-                                const childId =
-                                    typeof child === 'string'
-                                        ? child
-                                        : child != null &&
-                                            typeof child === 'object' &&
-                                            'identifier' in child
-                                          ? (child as { identifier: string }).identifier
-                                          : null;
-                                if (childId) {
-                                    constrainedIds.add(childId);
-                                }
+
+                        // ONE_TO_ONE returns a single value; ONE_TO_MANY returns an array
+                        const children = Array.isArray(relatedChildren)
+                            ? relatedChildren
+                            : relatedChildren != null
+                              ? [relatedChildren]
+                              : [];
+
+                        for (const child of children as unknown[]) {
+                            const childId =
+                                typeof child === 'string'
+                                    ? child
+                                    : child != null &&
+                                        typeof child === 'object' &&
+                                        'identifier' in child
+                                      ? (child as { identifier: string }).identifier
+                                      : null;
+                            if (childId) {
+                                constrainedIds.add(childId);
                             }
                         }
                     }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
@@ -196,17 +196,19 @@ export class ExistingContentService {
      *
      * Uses the ES search API to find parent contentlets and extract their related child identifiers.
      *
-     * @param params.relationshipVariable - The relationship type value (e.g., "Blog.authors")
+     * @param params.parentContentTypeVariable - The variable of the parent content type (e.g., "MAIN")
+     * @param params.fieldVariable - The relationship field variable (e.g., "relation")
      * @param params.currentContentIdentifier - The identifier of the contentlet being edited (to exclude its own children)
      * @returns Observable<Set<string>> - Set of child identifiers that are already "taken" by other parents
      */
     getConstrainedIdentifiers(params: {
-        relationshipVariable: string;
+        parentContentTypeVariable: string;
+        fieldVariable: string;
         currentContentIdentifier: string | null;
     }): Observable<Set<string>> {
-        const [parentContentType, fieldVariable] = params.relationshipVariable.split('.');
+        const { parentContentTypeVariable, fieldVariable } = params;
 
-        if (!parentContentType || !fieldVariable) {
+        if (!parentContentTypeVariable || !fieldVariable) {
             return of(new Set<string>());
         }
 
@@ -215,7 +217,7 @@ export class ExistingContentService {
                 jsonObjectView: { contentlets: DotCMSContentlet[] };
                 resultsSize: number;
             }>({
-                query: `+contentType:${parentContentType} +working:true +deleted:false`,
+                query: `+contentType:${parentContentTypeVariable} +working:true +deleted:false`,
                 limit: CONSTRAINED_QUERY_LIMIT
             })
             .pipe(

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
@@ -16,6 +16,8 @@ import { DotCMSContentlet, DotCMSContentTypeField, DotLanguage } from '@dotcms/d
 
 import { Column } from '../../../models/column.model';
 
+const CONSTRAINED_QUERY_LIMIT = 5000;
+
 type LanguagesMap = Record<number, DotLanguage>;
 
 const EXCLUDED_COLUMNS = ['title', 'language', 'modDate'];
@@ -186,6 +188,61 @@ export class ExistingContentService {
                 field: column.variable,
                 header: column.name
             }));
+    }
+
+    /**
+     * Fetches identifiers of contentlets that are already related to OTHER parents
+     * through the given relationship, excluding children of the current contentlet.
+     *
+     * Uses the ES search API to find parent contentlets and extract their related child identifiers.
+     *
+     * @param params.relationshipVariable - The relationship type value (e.g., "Blog.authors")
+     * @param params.currentContentIdentifier - The identifier of the contentlet being edited (to exclude its own children)
+     * @returns Observable<Set<string>> - Set of child identifiers that are already "taken" by other parents
+     */
+    getConstrainedIdentifiers(params: {
+        relationshipVariable: string;
+        currentContentIdentifier: string | null;
+    }): Observable<Set<string>> {
+        const [parentContentType, fieldVariable] = params.relationshipVariable.split('.');
+
+        if (!parentContentType || !fieldVariable) {
+            return of(new Set<string>());
+        }
+
+        return this.#contentSearchService
+            .get<{
+                jsonObjectView: { contentlets: DotCMSContentlet[] };
+                resultsSize: number;
+            }>({
+                query: `+contentType:${parentContentType} +working:true +deleted:false`,
+                limit: CONSTRAINED_QUERY_LIMIT
+            })
+            .pipe(
+                map(({ jsonObjectView: { contentlets } }) => {
+                    const constrainedIds = new Set<string>();
+
+                    for (const parent of contentlets) {
+                        if (parent.identifier === params.currentContentIdentifier) {
+                            continue;
+                        }
+
+                        const relatedChildren = parent[fieldVariable];
+                        if (Array.isArray(relatedChildren)) {
+                            for (const child of relatedChildren) {
+                                const childId =
+                                    typeof child === 'string' ? child : child?.identifier;
+                                if (childId) {
+                                    constrainedIds.add(childId);
+                                }
+                            }
+                        }
+                    }
+
+                    return constrainedIds;
+                }),
+                catchError(() => of(new Set<string>()))
+            );
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
@@ -1,6 +1,6 @@
 import { forkJoin, Observable, of } from 'rxjs';
 
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 
 import { catchError, map, switchMap } from 'rxjs/operators';
@@ -35,7 +35,6 @@ export interface RelationshipFieldSearchResponse {
     providedIn: 'root'
 })
 export class ExistingContentService {
-    readonly #http = inject(HttpClient);
     readonly #fieldService = inject(DotFieldService);
     readonly #contentSearchService = inject(DotContentSearchService);
     readonly #dotLanguagesService = inject(DotLanguagesService);
@@ -216,12 +215,8 @@ export class ExistingContentService {
             return of(new Set<string>());
         }
 
-        return this.#http
-            .post<{
-                entity: {
-                    jsonObjectView: { contentlets: DotCMSContentlet[] };
-                };
-            }>('/api/content/_search', {
+        return this.#contentSearchService
+            .get<{ jsonObjectView: { contentlets: DotCMSContentlet[] } }>({
                 query: `+contentType:${parentContentTypeVariable} +working:true +deleted:false`,
                 sort: 'modDate desc',
                 limit: CONSTRAINED_QUERY_LIMIT,
@@ -229,7 +224,6 @@ export class ExistingContentService {
                 depth: 0
             })
             .pipe(
-                map((response) => response.entity),
                 map(({ jsonObjectView: { contentlets } }) => {
                     const constrainedIds = new Set<string>();
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
@@ -1,12 +1,13 @@
 import { forkJoin, Observable, of } from 'rxjs';
 
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 
 import { catchError, map, switchMap } from 'rxjs/operators';
 
 import {
     DotContentSearchService,
+    DotContentTypeService,
     DotFieldService,
     DotHttpErrorManagerService,
     DotLanguagesService,
@@ -35,8 +36,10 @@ export interface RelationshipFieldSearchResponse {
     providedIn: 'root'
 })
 export class ExistingContentService {
+    readonly #http = inject(HttpClient);
     readonly #fieldService = inject(DotFieldService);
     readonly #contentSearchService = inject(DotContentSearchService);
+    readonly #contentTypeService = inject(DotContentTypeService);
     readonly #dotLanguagesService = inject(DotLanguagesService);
     readonly #httpErrorManagerService = inject(DotHttpErrorManagerService);
 
@@ -212,39 +215,48 @@ export class ExistingContentService {
             return of(new Set<string>());
         }
 
-        return this.#contentSearchService
-            .get<{
-                jsonObjectView: { contentlets: DotCMSContentlet[] };
-                resultsSize: number;
-            }>({
-                query: `+stInode:${parentContentTypeId} +working:true +deleted:false`,
-                limit: CONSTRAINED_QUERY_LIMIT
-            })
-            .pipe(
-                map(({ jsonObjectView: { contentlets } }) => {
-                    const constrainedIds = new Set<string>();
+        return this.#contentTypeService.getContentType(parentContentTypeId).pipe(
+            switchMap((contentType) =>
+                this.#http
+                    .post<{
+                        entity: {
+                            jsonObjectView: { contentlets: DotCMSContentlet[] };
+                        };
+                    }>('/api/content/_search', {
+                        query: `+contentType:${contentType.variable} +working:true +deleted:false`,
+                        sort: 'modDate desc',
+                        limit: CONSTRAINED_QUERY_LIMIT,
+                        offset: 0,
+                        depth: 0
+                    })
+                    .pipe(
+                        map((response) => response.entity),
+                        map(({ jsonObjectView: { contentlets } }) => {
+                            const constrainedIds = new Set<string>();
 
-                    for (const parent of contentlets) {
-                        if (parent.identifier === params.currentContentIdentifier) {
-                            continue;
-                        }
+                            for (const parent of contentlets) {
+                                if (parent.identifier === params.currentContentIdentifier) {
+                                    continue;
+                                }
 
-                        const relatedChildren = parent[fieldVariable];
-                        if (Array.isArray(relatedChildren)) {
-                            for (const child of relatedChildren) {
-                                const childId =
-                                    typeof child === 'string' ? child : child?.identifier;
-                                if (childId) {
-                                    constrainedIds.add(childId);
+                                const relatedChildren = parent[fieldVariable];
+                                if (Array.isArray(relatedChildren)) {
+                                    for (const child of relatedChildren) {
+                                        const childId =
+                                            typeof child === 'string' ? child : child?.identifier;
+                                        if (childId) {
+                                            constrainedIds.add(childId);
+                                        }
+                                    }
                                 }
                             }
-                        }
-                    }
 
-                    return constrainedIds;
-                }),
-                catchError(() => of(new Set<string>()))
-            );
+                            return constrainedIds;
+                        })
+                    )
+            ),
+            catchError(() => of(new Set<string>()))
+        );
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
@@ -202,13 +202,13 @@ export class ExistingContentService {
      * @returns Observable<Set<string>> - Set of child identifiers that are already "taken" by other parents
      */
     getConstrainedIdentifiers(params: {
-        parentContentTypeVariable: string;
+        parentContentTypeId: string;
         fieldVariable: string;
         currentContentIdentifier: string | null;
     }): Observable<Set<string>> {
-        const { parentContentTypeVariable, fieldVariable } = params;
+        const { parentContentTypeId, fieldVariable } = params;
 
-        if (!parentContentTypeVariable || !fieldVariable) {
+        if (!parentContentTypeId || !fieldVariable) {
             return of(new Set<string>());
         }
 
@@ -217,7 +217,7 @@ export class ExistingContentService {
                 jsonObjectView: { contentlets: DotCMSContentlet[] };
                 resultsSize: number;
             }>({
-                query: `+contentType:${parentContentTypeVariable} +working:true +deleted:false`,
+                query: `+stInode:${parentContentTypeId} +working:true +deleted:false`,
                 limit: CONSTRAINED_QUERY_LIMIT
             })
             .pipe(

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
@@ -232,11 +232,17 @@ export class ExistingContentService {
                             continue;
                         }
 
-                        const relatedChildren = parent[fieldVariable];
+                        const relatedChildren = parent[fieldVariable] as unknown;
                         if (Array.isArray(relatedChildren)) {
-                            for (const child of relatedChildren) {
+                            for (const child of relatedChildren as unknown[]) {
                                 const childId =
-                                    typeof child === 'string' ? child : child?.identifier;
+                                    typeof child === 'string'
+                                        ? child
+                                        : child != null &&
+                                            typeof child === 'object' &&
+                                            'identifier' in child
+                                          ? (child as { identifier: string }).identifier
+                                          : null;
                                 if (childId) {
                                     constrainedIds.add(childId);
                                 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.service.ts
@@ -7,7 +7,6 @@ import { catchError, map, switchMap } from 'rxjs/operators';
 
 import {
     DotContentSearchService,
-    DotContentTypeService,
     DotFieldService,
     DotHttpErrorManagerService,
     DotLanguagesService,
@@ -39,7 +38,6 @@ export class ExistingContentService {
     readonly #http = inject(HttpClient);
     readonly #fieldService = inject(DotFieldService);
     readonly #contentSearchService = inject(DotContentSearchService);
-    readonly #contentTypeService = inject(DotContentTypeService);
     readonly #dotLanguagesService = inject(DotLanguagesService);
     readonly #httpErrorManagerService = inject(DotHttpErrorManagerService);
 
@@ -127,6 +125,9 @@ export class ExistingContentService {
     getColumnsAndContent(
         contentTypeId: string
     ): Observable<[Column[], RelationshipFieldSearchResponse] | null> {
+        // TODO: search() already calls #getLanguages() and #prepareContent() internally,
+        // causing duplicate language HTTP calls and double-processing of contentlets.
+        // Refactor to fetch languages once and pass them through.
         return forkJoin([
             this.getColumns(contentTypeId),
             this.search({ contentTypeId }),
@@ -205,58 +206,54 @@ export class ExistingContentService {
      * @returns Observable<Set<string>> - Set of child identifiers that are already "taken" by other parents
      */
     getConstrainedIdentifiers(params: {
-        parentContentTypeId: string;
+        parentContentTypeVariable: string;
         fieldVariable: string;
         currentContentIdentifier: string | null;
     }): Observable<Set<string>> {
-        const { parentContentTypeId, fieldVariable } = params;
+        const { parentContentTypeVariable, fieldVariable } = params;
 
-        if (!parentContentTypeId || !fieldVariable) {
+        if (!parentContentTypeVariable || !fieldVariable) {
             return of(new Set<string>());
         }
 
-        return this.#contentTypeService.getContentType(parentContentTypeId).pipe(
-            switchMap((contentType) =>
-                this.#http
-                    .post<{
-                        entity: {
-                            jsonObjectView: { contentlets: DotCMSContentlet[] };
-                        };
-                    }>('/api/content/_search', {
-                        query: `+contentType:${contentType.variable} +working:true +deleted:false`,
-                        sort: 'modDate desc',
-                        limit: CONSTRAINED_QUERY_LIMIT,
-                        offset: 0,
-                        depth: 0
-                    })
-                    .pipe(
-                        map((response) => response.entity),
-                        map(({ jsonObjectView: { contentlets } }) => {
-                            const constrainedIds = new Set<string>();
+        return this.#http
+            .post<{
+                entity: {
+                    jsonObjectView: { contentlets: DotCMSContentlet[] };
+                };
+            }>('/api/content/_search', {
+                query: `+contentType:${parentContentTypeVariable} +working:true +deleted:false`,
+                sort: 'modDate desc',
+                limit: CONSTRAINED_QUERY_LIMIT,
+                offset: 0,
+                depth: 0
+            })
+            .pipe(
+                map((response) => response.entity),
+                map(({ jsonObjectView: { contentlets } }) => {
+                    const constrainedIds = new Set<string>();
 
-                            for (const parent of contentlets) {
-                                if (parent.identifier === params.currentContentIdentifier) {
-                                    continue;
-                                }
+                    for (const parent of contentlets) {
+                        if (parent.identifier === params.currentContentIdentifier) {
+                            continue;
+                        }
 
-                                const relatedChildren = parent[fieldVariable];
-                                if (Array.isArray(relatedChildren)) {
-                                    for (const child of relatedChildren) {
-                                        const childId =
-                                            typeof child === 'string' ? child : child?.identifier;
-                                        if (childId) {
-                                            constrainedIds.add(childId);
-                                        }
-                                    }
+                        const relatedChildren = parent[fieldVariable];
+                        if (Array.isArray(relatedChildren)) {
+                            for (const child of relatedChildren) {
+                                const childId =
+                                    typeof child === 'string' ? child : child?.identifier;
+                                if (childId) {
+                                    constrainedIds.add(childId);
                                 }
                             }
+                        }
+                    }
 
-                            return constrainedIds;
-                        })
-                    )
-            ),
-            catchError(() => of(new Set<string>()))
-        );
+                    return constrainedIds;
+                }),
+                catchError(() => of(new Set<string>()))
+            );
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
@@ -358,6 +358,55 @@ describe('ExistingContentStore', () => {
             );
         }));
 
+        it('should load constrained identifiers for ONE_TO_ONE parent field', fakeAsync(() => {
+            const constrainedSet = new Set(['taken-child-1']);
+            service.getColumnsAndContent.mockReturnValue(of([mockColumns, mockData]));
+            service.getConstrainedIdentifiers.mockReturnValue(of(constrainedSet));
+
+            store.initLoad({
+                contentTypeId: '123',
+                selectionMode: 'single',
+                selectedItemsIds: [],
+                cardinality: 2, // ONE_TO_ONE
+                parentContentTypeId: 'main-type-id',
+                parentContentTypeVariable: 'Main',
+                fieldVariable: 'relation',
+                isParentField: true,
+                currentContentIdentifier: 'current-id'
+            });
+            tick();
+
+            expect(store.constrainedIdentifiers()).toEqual(constrainedSet);
+            expect(store.isItemConstrained()('taken-child-1')).toBe(true);
+            expect(store.isItemConstrained()('free-child')).toBe(false);
+            expect(service.getConstrainedIdentifiers).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    parentContentTypeVariable: 'Main',
+                    fieldVariable: 'relation'
+                })
+            );
+        }));
+
+        it('should not load constrained identifiers for child side (isParentField=false)', fakeAsync(() => {
+            service.getColumnsAndContent.mockReturnValue(of([mockColumns, mockData]));
+
+            store.initLoad({
+                contentTypeId: '123',
+                selectionMode: 'single',
+                selectedItemsIds: [],
+                cardinality: 0, // ONE_TO_MANY
+                parentContentTypeId: 'main-type-id',
+                parentContentTypeVariable: 'Main',
+                fieldVariable: 'relation',
+                isParentField: false,
+                currentContentIdentifier: 'current-id'
+            });
+            tick();
+
+            expect(store.constrainedIdentifiers()).toEqual(new Set());
+            expect(service.getConstrainedIdentifiers).not.toHaveBeenCalled();
+        }));
+
         it('should not load constrained identifiers for MANY_TO_MANY', fakeAsync(() => {
             service.getColumnsAndContent.mockReturnValue(of([mockColumns, mockData]));
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
@@ -339,6 +339,7 @@ describe('ExistingContentStore', () => {
                 selectedItemsIds: [],
                 cardinality: 0, // ONE_TO_MANY
                 parentContentTypeId: 'main-type-id',
+                parentContentTypeVariable: 'Main',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'
@@ -351,7 +352,7 @@ describe('ExistingContentStore', () => {
             expect(store.isItemConstrained()('free-child')).toBe(false);
             expect(service.getConstrainedIdentifiers).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    parentContentTypeId: 'main-type-id',
+                    parentContentTypeVariable: 'Main',
                     fieldVariable: 'relation'
                 })
             );
@@ -366,6 +367,7 @@ describe('ExistingContentStore', () => {
                 selectedItemsIds: [],
                 cardinality: 1, // MANY_TO_MANY
                 parentContentTypeId: 'main-type-id',
+                parentContentTypeVariable: 'Main',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'
@@ -400,6 +402,7 @@ describe('ExistingContentStore', () => {
                 selectedItemsIds: [],
                 cardinality: 0,
                 parentContentTypeId: 'main-type-id',
+                parentContentTypeVariable: 'Main',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
@@ -338,7 +338,7 @@ describe('ExistingContentStore', () => {
                 selectionMode: 'multiple',
                 selectedItemsIds: [],
                 cardinality: 0, // ONE_TO_MANY
-                parentContentTypeVariable: 'MAIN',
+                parentContentTypeId: 'main-type-id',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'
@@ -349,11 +349,12 @@ describe('ExistingContentStore', () => {
             expect(store.isItemConstrained()('taken-child-1')).toBe(true);
             expect(store.isItemConstrained()('taken-child-2')).toBe(true);
             expect(store.isItemConstrained()('free-child')).toBe(false);
-            expect(service.getConstrainedIdentifiers).toHaveBeenCalledWith({
-                parentContentTypeVariable: 'MAIN',
-                fieldVariable: 'relation',
-                currentContentIdentifier: 'current-id'
-            });
+            expect(service.getConstrainedIdentifiers).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    parentContentTypeId: 'main-type-id',
+                    fieldVariable: 'relation'
+                })
+            );
         }));
 
         it('should not load constrained identifiers for MANY_TO_MANY', fakeAsync(() => {
@@ -364,7 +365,7 @@ describe('ExistingContentStore', () => {
                 selectionMode: 'multiple',
                 selectedItemsIds: [],
                 cardinality: 1, // MANY_TO_MANY
-                parentContentTypeVariable: 'MAIN',
+                parentContentTypeId: 'main-type-id',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'
@@ -398,7 +399,7 @@ describe('ExistingContentStore', () => {
                 selectionMode: 'multiple',
                 selectedItemsIds: [],
                 cardinality: 0,
-                parentContentTypeVariable: 'MAIN',
+                parentContentTypeId: 'main-type-id',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
@@ -318,4 +318,97 @@ describe('ExistingContentStore', () => {
             expect(store.pagination().offset).toBe(100);
         });
     });
+
+    describe('Cardinality Constraints', () => {
+        it('should have empty constrainedIdentifiers by default', () => {
+            expect(store.constrainedIdentifiers()).toEqual(new Set());
+        });
+
+        it('should return false for isItemConstrained when no constraints loaded', () => {
+            expect(store.isItemConstrained()('any-id')).toBe(false);
+        });
+
+        it('should load constrained identifiers for ONE_TO_MANY parent field', fakeAsync(() => {
+            const constrainedSet = new Set(['taken-child-1', 'taken-child-2']);
+            service.getColumnsAndContent.mockReturnValue(of([mockColumns, mockData]));
+            service.getConstrainedIdentifiers.mockReturnValue(of(constrainedSet));
+
+            store.initLoad({
+                contentTypeId: '123',
+                selectionMode: 'multiple',
+                selectedItemsIds: [],
+                cardinality: 0, // ONE_TO_MANY
+                parentContentTypeVariable: 'MAIN',
+                fieldVariable: 'relation',
+                isParentField: true,
+                currentContentIdentifier: 'current-id'
+            });
+            tick();
+
+            expect(store.constrainedIdentifiers()).toEqual(constrainedSet);
+            expect(store.isItemConstrained()('taken-child-1')).toBe(true);
+            expect(store.isItemConstrained()('taken-child-2')).toBe(true);
+            expect(store.isItemConstrained()('free-child')).toBe(false);
+            expect(service.getConstrainedIdentifiers).toHaveBeenCalledWith({
+                parentContentTypeVariable: 'MAIN',
+                fieldVariable: 'relation',
+                currentContentIdentifier: 'current-id'
+            });
+        }));
+
+        it('should not load constrained identifiers for MANY_TO_MANY', fakeAsync(() => {
+            service.getColumnsAndContent.mockReturnValue(of([mockColumns, mockData]));
+
+            store.initLoad({
+                contentTypeId: '123',
+                selectionMode: 'multiple',
+                selectedItemsIds: [],
+                cardinality: 1, // MANY_TO_MANY
+                parentContentTypeVariable: 'MAIN',
+                fieldVariable: 'relation',
+                isParentField: true,
+                currentContentIdentifier: 'current-id'
+            });
+            tick();
+
+            expect(store.constrainedIdentifiers()).toEqual(new Set());
+            expect(service.getConstrainedIdentifiers).not.toHaveBeenCalled();
+        }));
+
+        it('should not load constrained identifiers when cardinality params are missing', fakeAsync(() => {
+            service.getColumnsAndContent.mockReturnValue(of([mockColumns, mockData]));
+
+            store.initLoad({
+                contentTypeId: '123',
+                selectionMode: 'multiple',
+                selectedItemsIds: []
+            });
+            tick();
+
+            expect(store.constrainedIdentifiers()).toEqual(new Set());
+            expect(service.getConstrainedIdentifiers).not.toHaveBeenCalled();
+        }));
+
+        it('should handle null from getColumnsAndContent gracefully', fakeAsync(() => {
+            service.getColumnsAndContent.mockReturnValue(of(null));
+            service.getConstrainedIdentifiers.mockReturnValue(of(new Set()));
+
+            store.initLoad({
+                contentTypeId: '123',
+                selectionMode: 'multiple',
+                selectedItemsIds: [],
+                cardinality: 0,
+                parentContentTypeVariable: 'MAIN',
+                fieldVariable: 'relation',
+                isParentField: true,
+                currentContentIdentifier: 'current-id'
+            });
+            tick();
+
+            expect(store.status()).toBe(ComponentStatus.ERROR);
+            expect(store.errorMessage()).toBe(
+                'dot.file.relationship.dialog.content.request.failed'
+            );
+        }));
+    });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.spec.ts
@@ -339,7 +339,6 @@ describe('ExistingContentStore', () => {
                 selectedItemsIds: [],
                 cardinality: 0, // ONE_TO_MANY
                 parentContentTypeId: 'main-type-id',
-                parentContentTypeVariable: 'Main',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'
@@ -352,7 +351,7 @@ describe('ExistingContentStore', () => {
             expect(store.isItemConstrained()('free-child')).toBe(false);
             expect(service.getConstrainedIdentifiers).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    parentContentTypeVariable: 'Main',
+                    parentContentTypeId: 'main-type-id',
                     fieldVariable: 'relation'
                 })
             );
@@ -369,7 +368,6 @@ describe('ExistingContentStore', () => {
                 selectedItemsIds: [],
                 cardinality: 2, // ONE_TO_ONE
                 parentContentTypeId: 'main-type-id',
-                parentContentTypeVariable: 'Main',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'
@@ -381,8 +379,35 @@ describe('ExistingContentStore', () => {
             expect(store.isItemConstrained()('free-child')).toBe(false);
             expect(service.getConstrainedIdentifiers).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    parentContentTypeVariable: 'Main',
+                    parentContentTypeId: 'main-type-id',
                     fieldVariable: 'relation'
+                })
+            );
+        }));
+
+        it('should load constrained identifiers for new contentlet (no currentContentIdentifier)', fakeAsync(() => {
+            const constrainedSet = new Set(['taken-child-1', 'taken-child-2']);
+            service.getColumnsAndContent.mockReturnValue(of([mockColumns, mockData]));
+            service.getConstrainedIdentifiers.mockReturnValue(of(constrainedSet));
+
+            store.initLoad({
+                contentTypeId: '123',
+                selectionMode: 'single',
+                selectedItemsIds: [],
+                cardinality: 2, // ONE_TO_ONE
+                parentContentTypeId: 'main-type-id',
+                fieldVariable: 'relation',
+                isParentField: true
+                // no currentContentIdentifier — simulates creating new content
+            });
+            tick();
+
+            expect(store.constrainedIdentifiers()).toEqual(constrainedSet);
+            expect(service.getConstrainedIdentifiers).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    parentContentTypeId: 'main-type-id',
+                    fieldVariable: 'relation',
+                    currentContentIdentifier: null
                 })
             );
         }));
@@ -396,7 +421,6 @@ describe('ExistingContentStore', () => {
                 selectedItemsIds: [],
                 cardinality: 0, // ONE_TO_MANY
                 parentContentTypeId: 'main-type-id',
-                parentContentTypeVariable: 'Main',
                 fieldVariable: 'relation',
                 isParentField: false,
                 currentContentIdentifier: 'current-id'
@@ -416,7 +440,6 @@ describe('ExistingContentStore', () => {
                 selectedItemsIds: [],
                 cardinality: 1, // MANY_TO_MANY
                 parentContentTypeId: 'main-type-id',
-                parentContentTypeVariable: 'Main',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'
@@ -451,7 +474,6 @@ describe('ExistingContentStore', () => {
                 selectedItemsIds: [],
                 cardinality: 0,
                 parentContentTypeId: 'main-type-id',
-                parentContentTypeVariable: 'Main',
                 fieldVariable: 'relation',
                 isParentField: true,
                 currentContentIdentifier: 'current-id'

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
@@ -213,6 +213,16 @@ export const ExistingContentStore = signalStore(
                         ]).pipe(
                             tapResponse({
                                 next: ([columnsAndContent, constrainedIdentifiers]) => {
+                                    if (!columnsAndContent) {
+                                        patchState(store, {
+                                            status: ComponentStatus.ERROR,
+                                            errorMessage:
+                                                'dot.file.relationship.dialog.content.request.failed'
+                                        });
+
+                                        return;
+                                    }
+
                                     const [columns, searchResponse] = columnsAndContent;
                                     const data = searchResponse.contentlets;
                                     const selectionItems =

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
@@ -158,6 +158,7 @@ export const ExistingContentStore = signalStore(
                 showFields?: string[] | null;
                 cardinality?: number;
                 parentContentTypeId?: string;
+                parentContentTypeVariable?: string;
                 fieldVariable?: string;
                 isParentField?: boolean;
                 currentContentIdentifier?: string;
@@ -187,6 +188,7 @@ export const ExistingContentStore = signalStore(
                             selectedItemsIds,
                             cardinality,
                             parentContentTypeId,
+                            parentContentTypeVariable,
                             fieldVariable,
                             isParentField,
                             currentContentIdentifier
@@ -201,7 +203,7 @@ export const ExistingContentStore = signalStore(
 
                         const constrainedIds$ = shouldCheckConstraints
                             ? existingContentService.getConstrainedIdentifiers({
-                                  parentContentTypeId,
+                                  parentContentTypeVariable: parentContentTypeVariable ?? null,
                                   fieldVariable,
                                   currentContentIdentifier: currentContentIdentifier ?? null
                               })

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
@@ -157,7 +157,7 @@ export const ExistingContentStore = signalStore(
                 selectedItemsIds: string[];
                 showFields?: string[] | null;
                 cardinality?: number;
-                parentContentTypeVariable?: string;
+                parentContentTypeId?: string;
                 fieldVariable?: string;
                 isParentField?: boolean;
                 currentContentIdentifier?: string;
@@ -186,7 +186,7 @@ export const ExistingContentStore = signalStore(
                             contentTypeId,
                             selectedItemsIds,
                             cardinality,
-                            parentContentTypeVariable,
+                            parentContentTypeId,
                             fieldVariable,
                             isParentField,
                             currentContentIdentifier
@@ -195,13 +195,13 @@ export const ExistingContentStore = signalStore(
                         const shouldCheckConstraints =
                             cardinality != null &&
                             isParentField != null &&
-                            parentContentTypeVariable &&
+                            parentContentTypeId &&
                             fieldVariable &&
                             needsCardinalityConstraintCheck(cardinality, isParentField);
 
                         const constrainedIds$ = shouldCheckConstraints
                             ? existingContentService.getConstrainedIdentifiers({
-                                  parentContentTypeVariable,
+                                  parentContentTypeId,
                                   fieldVariable,
                                   currentContentIdentifier: currentContentIdentifier ?? null
                               })

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
@@ -157,7 +157,8 @@ export const ExistingContentStore = signalStore(
                 selectedItemsIds: string[];
                 showFields?: string[] | null;
                 cardinality?: number;
-                relationshipVariable?: string;
+                parentContentTypeVariable?: string;
+                fieldVariable?: string;
                 isParentField?: boolean;
                 currentContentIdentifier?: string;
             }>(
@@ -185,7 +186,8 @@ export const ExistingContentStore = signalStore(
                             contentTypeId,
                             selectedItemsIds,
                             cardinality,
-                            relationshipVariable,
+                            parentContentTypeVariable,
+                            fieldVariable,
                             isParentField,
                             currentContentIdentifier
                         } = params;
@@ -193,12 +195,14 @@ export const ExistingContentStore = signalStore(
                         const shouldCheckConstraints =
                             cardinality != null &&
                             isParentField != null &&
-                            relationshipVariable &&
+                            parentContentTypeVariable &&
+                            fieldVariable &&
                             needsCardinalityConstraintCheck(cardinality, isParentField);
 
                         const constrainedIds$ = shouldCheckConstraints
                             ? existingContentService.getConstrainedIdentifiers({
-                                  relationshipVariable,
+                                  parentContentTypeVariable,
+                                  fieldVariable,
                                   currentContentIdentifier: currentContentIdentifier ?? null
                               })
                             : of(new Set<string>());

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
@@ -1,7 +1,7 @@
 import { tapResponse } from '@ngrx/operators';
 import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { pipe } from 'rxjs';
+import { forkJoin, of, pipe } from 'rxjs';
 
 import { computed, inject } from '@angular/core';
 
@@ -17,6 +17,7 @@ import { RelationshipFieldQueryParams, ExistingContentService } from './existing
 import { Column } from '../../../models/column.model';
 import { SelectionMode } from '../../../models/relationship.models';
 import { SearchParams } from '../../../models/search.model';
+import { needsCardinalityConstraintCheck } from '../../../utils';
 
 const ViewMode = {
     all: 'all',
@@ -33,6 +34,7 @@ export interface ExistingContentState {
     selectionMode: SelectionMode | null;
     errorMessage: string | null;
     columns: Column[];
+    constrainedIdentifiers: Set<string>;
     pagination: {
         offset: number;
         currentPage: number;
@@ -64,6 +66,7 @@ const initialState: ExistingContentState = {
     status: ComponentStatus.INIT,
     selectionMode: null,
     errorMessage: null,
+    constrainedIdentifiers: new Set<string>(),
     pagination: { ...paginationInitialState },
     previousPagination: { ...paginationInitialState },
     selectionItems: null,
@@ -128,7 +131,16 @@ export const ExistingContentStore = signalStore(
          * Computes whether the show only selected state is true.
          * @returns {boolean} True if the show only selected state is true, false otherwise.
          */
-        isSelectedView: computed(() => state.viewMode() === ViewMode.selected)
+        isSelectedView: computed(() => state.viewMode() === ViewMode.selected),
+        /**
+         * Returns a function that checks if a contentlet identifier is constrained
+         * (already related to another parent in a cardinality-restricted relationship).
+         */
+        isItemConstrained: computed(() => {
+            const constrained = state.constrainedIdentifiers();
+
+            return (identifier: string) => constrained.has(identifier);
+        })
     })),
     withMethods((store) => {
         const existingContentService = inject(ExistingContentService);
@@ -136,6 +148,7 @@ export const ExistingContentStore = signalStore(
         return {
             /**
              * Initiates the loading of content by setting the status to LOADING and fetching content from the service.
+             * Optionally loads constrained identifiers in parallel when cardinality constraints apply.
              * @returns {Observable<void>} An observable that completes when the content has been loaded.
              */
             initLoad: rxMethod<{
@@ -143,12 +156,17 @@ export const ExistingContentStore = signalStore(
                 selectionMode: SelectionMode;
                 selectedItemsIds: string[];
                 showFields?: string[] | null;
+                cardinality?: number;
+                relationshipVariable?: string;
+                isParentField?: boolean;
+                currentContentIdentifier?: string;
             }>(
                 pipe(
                     tap(({ selectionMode }) =>
                         patchState(store, {
                             status: ComponentStatus.LOADING,
                             selectionMode,
+                            constrainedIdentifiers: new Set<string>(),
                             viewMode: ViewMode.all,
                             pagination: { ...paginationInitialState }
                         })
@@ -162,10 +180,36 @@ export const ExistingContentStore = signalStore(
                         }
                     }),
                     filter(({ contentTypeId }) => !!contentTypeId),
-                    switchMap(({ contentTypeId, selectedItemsIds }) =>
-                        existingContentService.getColumnsAndContent(contentTypeId).pipe(
+                    switchMap((params) => {
+                        const {
+                            contentTypeId,
+                            selectedItemsIds,
+                            cardinality,
+                            relationshipVariable,
+                            isParentField,
+                            currentContentIdentifier
+                        } = params;
+
+                        const shouldCheckConstraints =
+                            cardinality != null &&
+                            isParentField != null &&
+                            relationshipVariable &&
+                            needsCardinalityConstraintCheck(cardinality, isParentField);
+
+                        const constrainedIds$ = shouldCheckConstraints
+                            ? existingContentService.getConstrainedIdentifiers({
+                                  relationshipVariable,
+                                  currentContentIdentifier: currentContentIdentifier ?? null
+                              })
+                            : of(new Set<string>());
+
+                        return forkJoin([
+                            existingContentService.getColumnsAndContent(contentTypeId),
+                            constrainedIds$
+                        ]).pipe(
                             tapResponse({
-                                next: ([columns, searchResponse]) => {
+                                next: ([columnsAndContent, constrainedIdentifiers]) => {
+                                    const [columns, searchResponse] = columnsAndContent;
                                     const data = searchResponse.contentlets;
                                     const selectionItems =
                                         selectedItemsIds.length > 0
@@ -181,6 +225,7 @@ export const ExistingContentStore = signalStore(
                                         searchData: data,
                                         status: ComponentStatus.LOADED,
                                         selectionItems,
+                                        constrainedIdentifiers,
                                         pagination: {
                                             ...store.pagination(),
                                             totalResults: searchResponse.totalResults
@@ -194,8 +239,8 @@ export const ExistingContentStore = signalStore(
                                             'dot.file.relationship.dialog.content.request.failed'
                                     })
                             })
-                        )
-                    )
+                        );
+                    })
                 )
             ),
             /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
@@ -158,7 +158,6 @@ export const ExistingContentStore = signalStore(
                 showFields?: string[] | null;
                 cardinality?: number;
                 parentContentTypeId?: string;
-                parentContentTypeVariable?: string;
                 fieldVariable?: string;
                 isParentField?: boolean;
                 currentContentIdentifier?: string;
@@ -188,7 +187,6 @@ export const ExistingContentStore = signalStore(
                             selectedItemsIds,
                             cardinality,
                             parentContentTypeId,
-                            parentContentTypeVariable,
                             fieldVariable,
                             isParentField,
                             currentContentIdentifier
@@ -203,7 +201,7 @@ export const ExistingContentStore = signalStore(
 
                         const constrainedIds$ = shouldCheckConstraints
                             ? existingContentService.getConstrainedIdentifiers({
-                                  parentContentTypeVariable: parentContentTypeVariable ?? null,
+                                  parentContentTypeId,
                                   fieldVariable,
                                   currentContentIdentifier: currentContentIdentifier ?? null
                               })

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.service.ts
@@ -86,7 +86,8 @@ export class RelationshipFieldService {
                     contentlet,
                     variable: field.variable
                 });
-                const selectionMode = getSelectionModeByCardinality(cardinality);
+                const isParentField = field?.relationships?.isParentField;
+                const selectionMode = getSelectionModeByCardinality(cardinality, isParentField);
                 const showFields = extractShowFields(field);
 
                 return of({ cardinality, contentTypeId, data, selectionMode, showFields });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts
@@ -1,6 +1,10 @@
 import { createFakeRelationshipField } from '@dotcms/utils-testing';
 
-import { getSelectionModeByCardinality, getContentTypeIdFromRelationship } from './index';
+import {
+    getSelectionModeByCardinality,
+    getContentTypeIdFromRelationship,
+    needsCardinalityConstraintCheck
+} from './index';
 
 import { RELATIONSHIP_OPTIONS } from '../dot-edit-content-relationship-field.constants';
 import { RelationshipTypes } from '../models/relationship.models';
@@ -112,6 +116,38 @@ describe('Relationship Field Utils', () => {
 
             const result = getContentTypeIdFromRelationship(field);
             expect(result).toBeNull();
+        });
+    });
+
+    describe('needsCardinalityConstraintCheck', () => {
+        it('should return true for ONE_TO_ONE when isParentField is true', () => {
+            expect(needsCardinalityConstraintCheck(2, true)).toBe(true);
+        });
+
+        it('should return true for ONE_TO_MANY when isParentField is true', () => {
+            expect(needsCardinalityConstraintCheck(0, true)).toBe(true);
+        });
+
+        it('should return false for ONE_TO_ONE when isParentField is false', () => {
+            expect(needsCardinalityConstraintCheck(2, false)).toBe(false);
+        });
+
+        it('should return false for ONE_TO_MANY when isParentField is false', () => {
+            expect(needsCardinalityConstraintCheck(0, false)).toBe(false);
+        });
+
+        it('should return false for MANY_TO_MANY regardless of isParentField', () => {
+            expect(needsCardinalityConstraintCheck(1, true)).toBe(false);
+            expect(needsCardinalityConstraintCheck(1, false)).toBe(false);
+        });
+
+        it('should return false for MANY_TO_ONE regardless of isParentField', () => {
+            expect(needsCardinalityConstraintCheck(3, true)).toBe(false);
+            expect(needsCardinalityConstraintCheck(3, false)).toBe(false);
+        });
+
+        it('should return false for invalid cardinality', () => {
+            expect(needsCardinalityConstraintCheck(999, true)).toBe(false);
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.spec.ts
@@ -6,36 +6,52 @@ import {
     needsCardinalityConstraintCheck
 } from './index';
 
-import { RELATIONSHIP_OPTIONS } from '../dot-edit-content-relationship-field.constants';
-import { RelationshipTypes } from '../models/relationship.models';
-
 describe('Relationship Field Utils', () => {
     describe('getSelectionModeByCardinality', () => {
-        it('should return "single" for ONE_TO_ONE relationship', () => {
-            const oneToOneCardinality = Object.entries(RELATIONSHIP_OPTIONS).find(
-                ([_, value]) => value === RelationshipTypes.ONE_TO_ONE
-            )?.[0];
+        describe('parent side (isParentField=true)', () => {
+            it('should return "single" for ONE_TO_ONE', () => {
+                expect(getSelectionModeByCardinality(2, true)).toBe('single');
+            });
 
-            const result = getSelectionModeByCardinality(Number(oneToOneCardinality));
-            expect(result).toBe('single');
+            it('should return "multiple" for ONE_TO_MANY', () => {
+                expect(getSelectionModeByCardinality(0, true)).toBe('multiple');
+            });
+
+            it('should return "multiple" for MANY_TO_MANY', () => {
+                expect(getSelectionModeByCardinality(1, true)).toBe('multiple');
+            });
+
+            it('should return "single" for MANY_TO_ONE', () => {
+                expect(getSelectionModeByCardinality(3, true)).toBe('single');
+            });
         });
 
-        it('should return "single" for MANY_TO_ONE relationship', () => {
-            const manyToOneCardinality = Object.entries(RELATIONSHIP_OPTIONS).find(
-                ([_, value]) => value === RelationshipTypes.MANY_TO_ONE
-            )?.[0];
+        describe('child side (isParentField=false)', () => {
+            it('should return "single" for ONE_TO_ONE', () => {
+                expect(getSelectionModeByCardinality(2, false)).toBe('single');
+            });
 
-            const result = getSelectionModeByCardinality(Number(manyToOneCardinality));
-            expect(result).toBe('single');
+            it('should return "single" for ONE_TO_MANY', () => {
+                expect(getSelectionModeByCardinality(0, false)).toBe('single');
+            });
+
+            it('should return "multiple" for MANY_TO_MANY', () => {
+                expect(getSelectionModeByCardinality(1, false)).toBe('multiple');
+            });
+
+            it('should return "single" for MANY_TO_ONE', () => {
+                expect(getSelectionModeByCardinality(3, false)).toBe('single');
+            });
         });
 
-        it('should return "multiple" for ONE_TO_MANY relationship', () => {
-            const oneToManyCardinality = Object.entries(RELATIONSHIP_OPTIONS).find(
-                ([_, value]) => value === RelationshipTypes.ONE_TO_MANY
-            )?.[0];
+        describe('backward compatible (no isParentField)', () => {
+            it('should return "single" for ONE_TO_ONE', () => {
+                expect(getSelectionModeByCardinality(2)).toBe('single');
+            });
 
-            const result = getSelectionModeByCardinality(Number(oneToManyCardinality));
-            expect(result).toBe('multiple');
+            it('should return "multiple" for ONE_TO_MANY', () => {
+                expect(getSelectionModeByCardinality(0)).toBe('multiple');
+            });
         });
 
         it('should throw error for invalid cardinality', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts
@@ -15,13 +15,19 @@ import { RelationshipTypes, TableColumn } from '../models/relationship.models';
 import { RelationshipFieldState } from '../store/relationship-field.store';
 
 /**
- * Get the selection mode by cardinality.
+ * Get the selection mode by cardinality and parent/child role.
  *
- * @param cardinality - The cardinality of the relationship.
+ * Mirrors the backend logic in ContentletRelationshipRecords.doesAllowOnlyOne():
+ *   - Child side (isParentField=false): only MANY_TO_MANY allows multiple
+ *   - Parent side (isParentField=true): only ONE_TO_ONE allows single
+ *
+ * @param cardinality - The cardinality of the relationship (0-3).
+ * @param isParentField - Whether this content type is the parent in the relationship.
  * @returns The selection mode.
  */
 export function getSelectionModeByCardinality(
-    cardinality: number
+    cardinality: number,
+    isParentField?: boolean
 ): RelationshipFieldState['selectionMode'] {
     const relationshipType = RELATIONSHIP_OPTIONS[cardinality];
 
@@ -29,6 +35,12 @@ export function getSelectionModeByCardinality(
         throw new Error(`Invalid relationship type for cardinality: ${cardinality}`);
     }
 
+    if (isParentField === false) {
+        // Child side: only MANY_TO_MANY allows multiple selection
+        return relationshipType === RelationshipTypes.MANY_TO_MANY ? 'multiple' : 'single';
+    }
+
+    // Parent side (or isParentField not provided - backward compatible)
     const isSingleMode =
         relationshipType === RelationshipTypes.ONE_TO_ONE ||
         relationshipType === RelationshipTypes.MANY_TO_ONE;

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/utils/index.ts
@@ -143,3 +143,27 @@ export const isImageField = (clazz: DotCMSClazz): boolean => {
 export const isNewEditorEnabled = (contentType: DotCMSContentType): boolean => {
     return contentType.metadata?.[FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED] === true;
 };
+
+/**
+ * Determines if the relationship field requires a cardinality constraint check
+ * in the "Select Existing Content" dialog.
+ *
+ * This is needed when the current content is the parent side of a ONE_TO_ONE
+ * or ONE_TO_MANY relationship, because each child can only belong to one parent.
+ *
+ * @param cardinality - The cardinality value of the relationship (0-3).
+ * @param isParentField - Whether the current content type is the parent in the relationship.
+ * @returns True if constraint check is needed, false otherwise.
+ */
+export function needsCardinalityConstraintCheck(
+    cardinality: number,
+    isParentField: boolean
+): boolean {
+    if (!isParentField) {
+        return false;
+    }
+
+    const type = RELATIONSHIP_OPTIONS[cardinality];
+
+    return type === RelationshipTypes.ONE_TO_ONE || type === RelationshipTypes.ONE_TO_MANY;
+}

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -1259,6 +1259,7 @@ dot.file.relationship.dialog.search.site.placeholder=Select Site or Folder
 dot.file.relationship.dialog.search.language.failed=Failed to load languages
 dot.file.relationship.dialog.content.id.required=ContentId is required
 dot.file.relationship.dialog.content.request.failed=Failed to load content
+dot.file.relationship.dialog.content.already.related=This content is already related to another item
 dot.file.relationship.dialog.menu.column=Menu
 dot.file.relationship.dialog.table.title=Title
 dot.file.relationship.dialog.table.type=Type


### PR DESCRIPTION
## Summary

- When a relationship field has **ONE_TO_ONE** or **ONE_TO_MANY** cardinality (parent side), the "Select Existing Content" dialog now fetches which child items are already related to OTHER parents
- Already-related items appear **disabled** (grayed out, non-clickable) with a tooltip: "This content is already related to another item"
- Uses a parallel ES search request (`forkJoin`) to find constrained identifiers without blocking the main content load
- Backend validation on save remains as the safety net for ES eventual consistency

## Changes

| File | Change |
|------|--------|
| `utils/index.ts` | New `needsCardinalityConstraintCheck()` utility |
| `existing-content.service.ts` | New `getConstrainedIdentifiers()` method using Lucene query |
| `existing-content.store.ts` | `constrainedIdentifiers` state + `isItemConstrained()` computed + parallel load in `initLoad()` |
| `dot-select-existing-content.component.*` | Extended `DialogData`, disabled rows with tooltip |
| `dot-relationship-field.component.ts` | Passes cardinality context to dialog |
| `Language.properties` | New i18n key |

## Test plan

- [x] Unit tests pass: `yarn nx test edit-content --testPathPattern=relationship` (101 suites, 1665 tests)
- [x] Lint passes with 0 errors
- [x] Build succeeds
- [ ] Manual: Create ONE_TO_ONE relationship, verify disabled items in dialog
- [ ] Manual: Create ONE_TO_MANY relationship, verify disabled items
- [ ] Manual: Verify MANY_TO_MANY has no disabled items
- [ ] Manual: Verify removing a relationship re-enables the item

Closes #32792

This PR fixes: #32792