### PR TITLE
fix(Contentlet): Host site name uses hostName field instead of first listed text field

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -372,39 +372,44 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 	private String buildName()
 			throws DotContentletStateException {
 
+		String binaryValue = null;
 		// if already set previously
 		String returnValue = (String) this.map.get(Contentlet.DOT_NAME_KEY);
 		if(isSet(returnValue)){
 			return returnValue;
 		}
 
-		// look for listed, text and binary fields
-		final List<Field> fields = FieldsCache.getFieldsByStructureInode(this.getStructureInode());
-		String binaryValue       = null;
+		//For hosts, the name is obtained from the "hostName" field
+		if (this.isHost()){
+			returnValue = this.map.get(Host.HOST_NAME_KEY).toString();
+		} else{
+			// look for listed, text and binary fields
+			final List<Field> fields = FieldsCache.getFieldsByStructureInode(this.getStructureInode());
 
-		for (final Field field : fields) {
+			for (final Field field : fields) {
 
-			try {
+				try {
 
-				if(field.isListed()  && this.map.get(field.getVelocityVarName())!=null) {
+					if(field.isListed()  && this.map.get(field.getVelocityVarName())!=null) {
 
-					if (APILocator.getContentletAPI().isFieldTypeString(field)) {
-						returnValue = this.map.get(field.getVelocityVarName()).toString();
-						break; // found one
+						if (APILocator.getContentletAPI().isFieldTypeString(field)) {
+							returnValue = this.map.get(field.getVelocityVarName()).toString();
+							break; // found one
+						}
+
+						// if it is a binary
+						if (binaryValue == null && Field.FieldType.BINARY.toString().equals(field.getFieldType()) && field.isIndexed()) {
+							final File binaryFile = this.getBinary(field.getVelocityVarName());
+							if (null != binaryFile) {
+								binaryValue = binaryFile.getName();
+							}
+						}
 					}
-
-					// if it is a binary
-					if (binaryValue == null && Field.FieldType.BINARY.toString().equals(field.getFieldType()) && field.isIndexed()) {
-					    final File binaryFile = this.getBinary(field.getVelocityVarName());
-					    if (null != binaryFile) {
-                            binaryValue = binaryFile.getName();
-                        }
-					}
+				} catch(Exception e){
+					Logger.warn(this.getClass(),
+							"unable to get field value " + field.getVelocityVarName()
+									+ " . Content inode: " + this.getInode() + ". Reason: " + e, e);
 				}
-			} catch(Exception e){
-                Logger.warn(this.getClass(),
-                        "unable to get field value " + field.getVelocityVarName()
-                                + " . Content inode: " + this.getInode() + ". Reason: " + e, e);
 			}
 		}
 

--- a/dotCMS/src/test/java/com/dotmarketing/portlets/contentlet/model/ContentletTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/portlets/contentlet/model/ContentletTest.java
@@ -4,12 +4,15 @@ import com.dotcms.contenttype.model.field.DataTypes;
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.ImmutableTextField;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.UserAPI;
+import com.dotmarketing.cache.FieldsCache;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
 import com.liferay.portal.model.User;
 import org.junit.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import java.util.List;
@@ -36,6 +39,71 @@ public class ContentletTest {
         contentlet.getMap().put("title", expectedValue );
 
         assertEquals(contentlet.getTitle(), expectedValue);
+    }
+
+    /**
+     * Regression test for <a href="https://github.com/dotCMS/core/issues/35084">Issue #35084</a>.
+     * <p>
+     * When a Host content type has the "aliases" field listed before "hostName" in the field
+     * order, {@link Contentlet#getName()} must still return the hostName value — not the aliases.
+     * The bug: {@code buildName()} iterates listed text fields in order and returns the first match,
+     * so aliases (coming first) was incorrectly used as the title.
+     */
+    @Test
+    public void testGetName_WhenHostTypeHasAliasesListedBeforeHostName_ShouldReturnHostName() throws DotDataException, DotSecurityException {
+        final ContentletAPI contentletAPI = Mockito.mock(ContentletAPI.class);
+        final UserAPI userAPI = Mockito.mock(UserAPI.class);
+        Mockito.when(userAPI.getSystemUser()).thenReturn(new User());
+        final Contentlet contentlet = Mockito.spy(Contentlet.class);
+        contentlet.setUserAPI(userAPI);
+        contentlet.setContentletAPI(contentletAPI);
+
+        // Mock content type with velocity variable "Host" and fields in order: aliases first, hostName second.
+        // Neither field variable starts with "title", so getFieldWithVarStartingWithTitleWord() returns empty.
+        final ContentType mockContentType = Mockito.mock(ContentType.class);
+        Mockito.when(mockContentType.variable()).thenReturn("Host");
+        Mockito.doReturn(mockContentType).when(contentlet).getContentType();
+        Mockito.when(mockContentType.fields()).thenReturn(List.of(
+                createFieldWithVarname("aliases"),
+                createFieldWithVarname("hostName")
+        ));
+
+        // Set field values — aliases first, hostName second — but leave the title blank.
+        final String aliasValue = "alias1.com\nalias2.com";
+        final String hostNameValue = "mysite.com";
+        contentlet.getMap().put("aliases", aliasValue);
+        contentlet.getMap().put("hostName", hostNameValue);
+        contentlet.getMap().put(Contentlet.STRUCTURE_INODE_KEY, "fake-host-structure-inode");
+
+        // Legacy Field mocks returned by FieldsCache: aliases listed first, hostName second.
+        final com.dotmarketing.portlets.structure.model.Field aliasesLegacyField =
+                Mockito.mock(com.dotmarketing.portlets.structure.model.Field.class);
+        Mockito.when(aliasesLegacyField.isListed()).thenReturn(true);
+        Mockito.when(aliasesLegacyField.getVelocityVarName()).thenReturn("aliases");
+
+        final com.dotmarketing.portlets.structure.model.Field hostNameLegacyField =
+                Mockito.mock(com.dotmarketing.portlets.structure.model.Field.class);
+        Mockito.when(hostNameLegacyField.isListed()).thenReturn(true);
+        Mockito.when(hostNameLegacyField.getVelocityVarName()).thenReturn("hostName");
+
+        Mockito.when(contentletAPI.isFieldTypeString(aliasesLegacyField)).thenReturn(true);
+        Mockito.when(contentletAPI.isFieldTypeString(hostNameLegacyField)).thenReturn(true);
+
+        try (MockedStatic<FieldsCache> fieldsCacheMock = Mockito.mockStatic(FieldsCache.class);
+             MockedStatic<APILocator> apiLocatorMock = Mockito.mockStatic(APILocator.class)) {
+
+            // aliases is listed first in the field order — this is the bug trigger
+            fieldsCacheMock.when(() -> FieldsCache.getFieldsByStructureInode(Mockito.any()))
+                    .thenReturn(List.of(aliasesLegacyField, hostNameLegacyField));
+
+            apiLocatorMock.when(APILocator::getContentletAPI).thenReturn(contentletAPI);
+
+            // getName() must return the hostName, not the aliases.
+            // This assertion currently FAILS because buildName() picks the first listed text field
+            // (aliases) instead of using hostName as the authoritative name for Host content,
+            // causing DOT_NAME_KEY to be set to the aliases value.
+            assertEquals(hostNameValue, contentlet.getName());
+        }
     }
 
     private Field createFieldWithVarname(final String varname) {

--- a/dotcms-postman/src/main/resources/postman/GraphQLTests.json
+++ b/dotcms-postman/src/main/resources/postman/GraphQLTests.json
@@ -1348,7 +1348,7 @@
 											"    pm.expect(host[\"keywords\"], 'FAILED:[keywords]').equal(\"CMS, Web Content Management, Open Source, Java, J2EE, DXP, NoCode, OSGI, Apache Velocity, Elasticsearch, RESTful Services, REST API, Workflows, Personalization, Multilingual, I18N, L10N, Internationalization, Localization, Docker CMS, Containerized CMS\");",
 											"    pm.expect(host[\"description\"], 'FAILED:[description]').equal(\"dotCMS starter site was designed to demonstrate what you can do with dotCMS.\");",
 											"    pm.expect(host[\"hostAliases\"], 'FAILED:[hostAliases]').equal(\"localhost\\n127.0.0.1\");",
-											"    pm.expect(host[\"title\"], 'FAILED:[title]').equal(\"localhost\\n127.0.0.1\");",
+											"    pm.expect(host[\"title\"], 'FAILED:[title]').equal(\"demo.dotcms.com\");",
 											"    pm.expect(host[\"baseType\"], 'FAILED:[baseType]').equal(\"CONTENT\");",
 											"    pm.expect(host[\"archived\"], 'FAILED:[archived]').equal(false);",
 											"    pm.expect(host[\"addThis\"], 'FAILED:[addThis]').equal(\"ra-4e02119211875e7b\");",


### PR DESCRIPTION
## Summary

- Fixes #35084 — Site Selector was displaying the site `name` (aliases) instead of the `hostname`
- `buildName()` returned the first listed text field as the content name; for Host content types where the `aliases` field appeared before `hostName` in field sort order, this caused `getName()` → `getTitle()` → `buildName()` to store aliases as `DOT_NAME_KEY`
- Fix short-circuits `buildName()` for Host content types using `isHost()`, always reading `hostName` directly as the authoritative name

## Test plan

- [ ] Run `ContentletTest#testGetName_WhenHostTypeHasAliasesListedBeforeHostName_ShouldReturnHostName` — verifies `getName()` returns the hostname even when `aliases` is the first listed text field in the content type
- [ ] Run existing `ContentletTest#testGetTitle_WhenExistingTitleField_returnItsValue` — confirms no regression on the explicit-title path
- [ ] Manual: open site selector in any area of the dotCMS admin, confirm sites show hostname instead of aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35084