### PR TITLE
#34975 feat(osgi): add error notifications for async plugin operations

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/api/system/event/SystemEventType.java
+++ b/dotCMS/src/main/java/com/dotcms/api/system/event/SystemEventType.java
@@ -264,6 +264,12 @@ public enum SystemEventType {
 	// Osgi bundles push on the load folder
 	OSGI_BUNDLES_LOADED,
 
+	/**
+	 * Fired when a bundle fails to process during the async upload pipeline.
+	 * Covers failures in package extraction, file moves, and configuration updates.
+	 */
+	OSGI_BUNDLES_UPLOAD_FAILED,
+
 	// Logout Event
 	SESSION_LOGOUT,
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
@@ -407,6 +407,8 @@ public class OSGIResource {
             if (from.renameTo(to)) {
                 final String responseText = String.format("OSGI Bundle  %s Loaded", jarName);
                 Logger.info(this, responseText);
+                OSGIUtil.getInstance().sendBundleDeployedNotification(
+                        new String[]{sanitizedJarName});
                 return new ResponseEntityStringView(responseText);
             }
         }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/osgi/OSGIResource.java
@@ -601,6 +601,7 @@ public class OSGIResource {
 
         Logger.debug(this, ()->"Restarting the framework");
         OSGIUtil.getInstance().restartOsgiClusterWide();
+        OSGIUtil.getInstance().sendFrameworkRestartNotification();
         return new ResponseEntityStringView("OSGI Framework Restarted");
     }
 

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -537,7 +537,8 @@ public class OSGIUtil {
 
         } catch (Exception e) {
             Logger.error(this, e.getMessage(), e);
-            pushBundleUploadError("Failed to process OSGI bundle packages: " + getExceptionMessage(e));
+            pushBundleUploadError("Failed to process OSGI bundle packages for ["
+                    + String.join(", ", pathnames) + "]: " + getExceptionMessage(e));
         }
     }
 
@@ -648,7 +649,8 @@ public class OSGIUtil {
         } catch (IOException e) {
 
             Logger.error(this, e.getMessage(), e);
-            pushBundleUploadError("Failed to move OSGI bundle to deploy folder: " + getExceptionMessage(e));
+            pushBundleUploadError("Failed to move OSGI bundle to deploy folder ["
+                    + String.join(", ", pathnames) + "]: " + getExceptionMessage(e));
         }
     }
 
@@ -712,13 +714,6 @@ public class OSGIUtil {
 
 
     /**
-     * Pushes an {@link SystemEventType#OSGI_BUNDLES_LOADED} system event and a success toast
-     * to notify users that bundles have been deployed. Used by the deploy REST endpoint
-     * to provide notification parity with the upload pipeline.
-     *
-     * @param jarNames the jar file names that were deployed
-     */
-    /**
      * Pushes an {@link SystemEventType#OSGI_FRAMEWORK_RESTART} system event to notify
      * all connected users that the OSGI framework has been restarted.
      * Called from the REST restart endpoint so other users refresh their bundle table.
@@ -730,12 +725,21 @@ public class OSGIUtil {
                 .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
     }
 
+    /**
+     * Pushes an {@link SystemEventType#OSGI_BUNDLES_LOADED} system event and a success toast
+     * to notify users that bundles have been deployed. Used by the deploy REST endpoint
+     * to provide notification parity with the upload pipeline.
+     *
+     * @param jarNames the jar file names that were deployed
+     */
     public void sendBundleDeployedNotification(final String[] jarNames) {
 
+        // System event — frontend subscribes to OSGI_BUNDLES_LOADED to refresh the bundle table
         Try.run(() -> APILocator.getSystemEventsAPI()
                 .push(SystemEventType.OSGI_BUNDLES_LOADED, new Payload(jarNames)))
                 .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
 
+        // Success toast (MESSAGE event) — user sees confirmation notification
         Try.run(() -> sendOSGIBundlesLoadedMessage(jarNames))
                 .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
     }

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -11,6 +11,7 @@ import com.dotcms.concurrent.lock.ClusterLockManager;
 import com.dotcms.dotpubsub.DotPubSubEvent;
 import com.dotcms.dotpubsub.DotPubSubProvider;
 import com.dotcms.dotpubsub.DotPubSubProviderLocator;
+import com.dotcms.rest.ErrorEntity;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.osgi.HostActivator;
@@ -471,6 +472,8 @@ public class OSGIUtil {
 
                     Logger.error(this, "Error try to acquire the lock, uploadFolder: " + uploadFolderFile +
                             ", msg: " + e.getMessage(), e);
+                    pushBundleUploadError(
+                            "Failed to process OSGI bundles from upload folder: " + e.getMessage());
                 }
             } else {
 
@@ -534,6 +537,7 @@ public class OSGIUtil {
 
         } catch (Exception e) {
             Logger.error(this, e.getMessage(), e);
+            pushBundleUploadError("Failed to process OSGI bundle packages: " + e.getMessage());
         }
     }
 
@@ -560,7 +564,6 @@ public class OSGIUtil {
             Try.run(()->APILocator.getSystemEventsAPI()
                     .push(SystemEventType.OSGI_FRAMEWORK_RESTART, new Payload(pathnames)))
                     .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
-
         }
     }
 
@@ -585,26 +588,34 @@ public class OSGIUtil {
      * Do the restart only for the current node (locally)
      */
     public void restartOsgiOnlyLocal() {
-            Logger.info(this, ()-> "Restarting OSGI Locally");
-            //Remove Portlets in the list
-            this.portletIDsStopped.stream().forEach(APILocator.getPortletAPI()::deletePortlet);
-            Logger.info(this, "Portlets Removed: " + this.portletIDsStopped.toString());
 
-            //Remove Actionlets in the list
-            if (null  != this.workflowOsgiService) {
-                this.actionletsStopped.stream().forEach(this.workflowOsgiService::removeActionlet);
-                Logger.info(this, "Actionlets Removed: " + this.actionletsStopped.toString());
-            }
+        Logger.info(this, ()-> "Restarting OSGI Locally");
 
-            //Cleanup lists
-            this.portletIDsStopped.clear();
-            this.actionletsStopped.clear();
+        //Remove Portlets in the list
+        this.portletIDsStopped.forEach(APILocator.getPortletAPI()::deletePortlet);
+        Logger.info(this, "Portlets Removed: " + this.portletIDsStopped);
 
-            //First we need to stop the framework
+        //Remove Actionlets in the list
+        if (null != this.workflowOsgiService) {
+            this.actionletsStopped.forEach(this.workflowOsgiService::removeActionlet);
+            Logger.info(this, "Actionlets Removed: " + this.actionletsStopped);
+        }
+
+        //Cleanup lists
+        this.portletIDsStopped.clear();
+        this.actionletsStopped.clear();
+
+        try {
             this.stopFramework();
-
-            //Now we need to initialize it
             this.initializeFramework();
+        } catch (final RuntimeException e) {
+            final String errorMsg = "Failed to restart OSGI framework: " + e.getMessage();
+            Logger.error(this, errorMsg, e);
+            Try.run(() -> SystemMessageEventUtil.getInstance().pushSimpleErrorEvent(
+                    new ErrorEntity("osgi-framework-restart-failed", errorMsg)))
+                    .onFailure(ex -> Logger.error(this, ex.getMessage()));
+            throw e;
+        }
     }
 
     /**
@@ -627,16 +638,17 @@ public class OSGIUtil {
 
                     moveBundle(uploadFolderFile, pathnames, deployDirectory, pathname);
                 }
-                
+
                 sendOSGIBundlesLoadedMessage(pathnames);
             } else {
 
-                Logger.warn(this, "The directory: " + this.getFelixDeployPath()
-                        + " does not exists or can not read");
+                Logger.error(this, "The OSGI deploy directory: " + this.getFelixDeployPath()
+                        + " does not exist or is not writable");
             }
         } catch (IOException e) {
 
             Logger.error(this, e.getMessage(), e);
+            pushBundleUploadError("Failed to move OSGI bundle to deploy folder: " + e.getMessage());
         }
     }
 
@@ -666,13 +678,15 @@ public class OSGIUtil {
 
         if (FileUtil.move(bundle, bundleDestination)) {
 
-            Try.run(()->APILocator.getSystemEventsAPI()					    // CLUSTER WIDE
+            Try.run(()->APILocator.getSystemEventsAPI()
                     .push(SystemEventType.OSGI_BUNDLES_LOADED, new Payload(pathnames)))
                     .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
 
             Logger.debug(this, "Moved the bundle: " + bundle + " to " + deployDirectory);
         } else {
-            Logger.debug(this, "Could not move the bundle: " + bundle + " to " + deployDirectory);
+            final String errorMsg = "Could not move the bundle: " + bundle + " to " + deployDirectory;
+            Logger.error(this, errorMsg);
+            pushBundleUploadError(errorMsg);
         }
     }
 
@@ -696,6 +710,40 @@ public class OSGIUtil {
                 .setSeverity(MessageSeverity.SUCCESS).create(), null);
     }
 
+
+    /**
+     * Pushes an {@link SystemEventType#OSGI_BUNDLES_LOADED} system event and a success toast
+     * to notify users that bundles have been deployed. Used by the deploy REST endpoint
+     * to provide notification parity with the upload pipeline.
+     *
+     * @param jarNames the jar file names that were deployed
+     */
+    public void sendBundleDeployedNotification(final String[] jarNames) {
+
+        Try.run(() -> APILocator.getSystemEventsAPI()
+                .push(SystemEventType.OSGI_BUNDLES_LOADED, new Payload(jarNames)))
+                .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
+
+        Try.run(() -> sendOSGIBundlesLoadedMessage(jarNames))
+                .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
+    }
+
+    /**
+     * Pushes both an {@link SystemEventType#OSGI_BUNDLES_UPLOAD_FAILED} system event and
+     * an error toast to notify admin users of a bundle processing failure.
+     *
+     * @param message the error message describing the failure
+     */
+    private void pushBundleUploadError(final String message) {
+
+        Try.run(() -> APILocator.getSystemEventsAPI()
+                .push(SystemEventType.OSGI_BUNDLES_UPLOAD_FAILED, new Payload(message)))
+                .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
+
+        Try.run(() -> SystemMessageEventUtil.getInstance().pushSimpleErrorEvent(
+                new ErrorEntity("osgi-bundle-upload-failed", message)))
+                .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
+    }
 
     private static Tuple2<Boolean, String[]> containsFragments(final String[] pathnamesIn) {
 

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -473,7 +473,7 @@ public class OSGIUtil {
                     Logger.error(this, "Error try to acquire the lock, uploadFolder: " + uploadFolderFile +
                             ", msg: " + e.getMessage(), e);
                     pushBundleUploadError(
-                            "Failed to process OSGI bundles from upload folder: " + e.getMessage());
+                            "Failed to process OSGI bundles from upload folder: " + getExceptionMessage(e));
                 }
             } else {
 
@@ -537,7 +537,7 @@ public class OSGIUtil {
 
         } catch (Exception e) {
             Logger.error(this, e.getMessage(), e);
-            pushBundleUploadError("Failed to process OSGI bundle packages: " + e.getMessage());
+            pushBundleUploadError("Failed to process OSGI bundle packages: " + getExceptionMessage(e));
         }
     }
 
@@ -609,7 +609,7 @@ public class OSGIUtil {
             this.stopFramework();
             this.initializeFramework();
         } catch (final RuntimeException e) {
-            final String errorMsg = "Failed to restart OSGI framework: " + e.getMessage();
+            final String errorMsg = "Failed to restart OSGI framework: " + getExceptionMessage(e);
             Logger.error(this, errorMsg, e);
             Try.run(() -> SystemMessageEventUtil.getInstance().pushSimpleErrorEvent(
                     new ErrorEntity("osgi-framework-restart-failed", errorMsg)))
@@ -648,7 +648,7 @@ public class OSGIUtil {
         } catch (IOException e) {
 
             Logger.error(this, e.getMessage(), e);
-            pushBundleUploadError("Failed to move OSGI bundle to deploy folder: " + e.getMessage());
+            pushBundleUploadError("Failed to move OSGI bundle to deploy folder: " + getExceptionMessage(e));
         }
     }
 
@@ -755,6 +755,10 @@ public class OSGIUtil {
         Try.run(() -> SystemMessageEventUtil.getInstance().pushSimpleErrorEvent(
                 new ErrorEntity("osgi-bundle-upload-failed", message)))
                 .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
+    }
+
+    private static String getExceptionMessage(final Throwable e) {
+        return UtilMethods.isSet(e.getMessage()) ? e.getMessage() : e.getClass().getSimpleName();
     }
 
     private static Tuple2<Boolean, String[]> containsFragments(final String[] pathnamesIn) {

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -718,6 +718,18 @@ public class OSGIUtil {
      *
      * @param jarNames the jar file names that were deployed
      */
+    /**
+     * Pushes an {@link SystemEventType#OSGI_FRAMEWORK_RESTART} system event to notify
+     * all connected users that the OSGI framework has been restarted.
+     * Called from the REST restart endpoint so other users refresh their bundle table.
+     */
+    public void sendFrameworkRestartNotification() {
+
+        Try.run(() -> APILocator.getSystemEventsAPI()
+                .push(SystemEventType.OSGI_FRAMEWORK_RESTART, new Payload()))
+                .onFailure(e -> Logger.error(OSGIUtil.this, e.getMessage()));
+    }
+
     public void sendBundleDeployedNotification(final String[] jarNames) {
 
         Try.run(() -> APILocator.getSystemEventsAPI()


### PR DESCRIPTION
 ## Summary                                                                                                                                                                                                     
                                               
  - Add `OSGI_BUNDLES_UPLOAD_FAILED` system event type for async upload pipeline failures                                                                                                                        
  - Wire error notifications (system event + error toast) into 4 silent catch blocks in `OSGIUtil.java` that previously only called `Logger.error()` — making async failures visible to admin users
  - Add try/catch to `restartOsgiOnlyLocal()` with error toast on framework restart failure (rethrows to preserve existing behavior)                                                                             
  - Add deploy endpoint notification via `sendBundleDeployedNotification()` — deploy was async with zero notifications
  - Fix `move()` log level from `Logger.debug` to `Logger.error` for failed bundle file moves                                                                                                                    
  - Fix deploy directory missing log level from `Logger.warn` to `Logger.error`
                                                                                                                                                                                                                 
  ## Context                                                      

  During the Angular migration of the Plugins portlet (#34732), analysis revealed that every `catch` block in `OSGIUtil.java` only logged errors — users never saw failures in async operations like upload,     
  package processing, or bundle moves. The `SystemMessageEventUtil.pushSimpleErrorEvent()` infrastructure existed but was never wired into any OSGI code path.
                                                                                                                                                                                                                 
  ## Test plan                                                    

  - [ ] Upload a valid plugin jar → verify success toast appears
  - [ ] Upload an invalid jar → verify error toast appears (previously silent)
  - [ ] Deploy a bundle from the undeployed list → verify success toast appears
  - [ ] Stop/Start a bundle → verify operation succeeds via HTTP response (no backend toast)                                                                                                                     
  - [ ] Trigger extra packages save → verify `OSGI_FRAMEWORK_RESTART` fires after debounced restart
  - [ ] Verify no regressions: existing bundle operations (start, stop, undeploy, restart) behave as before
  
  
 Resolved #34975 

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #34975