### PR TITLE
ci(docker): add weekly rolling tag rotation workflow #35142

### DIFF
--- a/.github/workflows/cicd_weekly-rolling-tags.yml
+++ b/.github/workflows/cicd_weekly-rolling-tags.yml
@@ -20,6 +20,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Rotate weekly tags
         run: |
           set -euo pipefail
@@ -27,36 +30,29 @@ jobs:
           IMAGE="${{ env.IMAGE }}"
           MAX_WEEKS="${{ env.MAX_WEEKS }}"
 
+          # Retag manifest-side only — no layer downloads needed
+          retag() {
+            local src="$1" dst="$2"
+            echo "--- Promoting ${src} -> ${dst} ---"
+            if docker buildx imagetools inspect "${src}" > /dev/null 2>&1; then
+              docker buildx imagetools create --tag "${dst}" "${src}"
+              echo "Tagged ${dst}"
+            else
+              echo "Skipping: ${src} does not exist yet"
+            fi
+          }
+
           # Work backwards: weekly-3 -> weekly-4, weekly-2 -> weekly-3, etc.
           for (( i = MAX_WEEKS - 1; i >= 1; i-- )); do
-            SRC="${IMAGE}:weekly-${i}"
-            DST="${IMAGE}:weekly-$(( i + 1 ))"
-
-            echo "--- Promoting ${SRC} -> ${DST} ---"
-            if docker pull "${SRC}" 2>/dev/null; then
-              docker tag "${SRC}" "${DST}"
-              docker push "${DST}"
-              echo "Pushed ${DST}"
-            else
-              echo "Skipping: ${SRC} does not exist yet"
-            fi
+            retag "${IMAGE}:weekly-${i}" "${IMAGE}:weekly-$(( i + 1 ))"
           done
 
           # weekly -> weekly-1
-          echo "--- Promoting ${IMAGE}:weekly -> ${IMAGE}:weekly-1 ---"
-          if docker pull "${IMAGE}:weekly" 2>/dev/null; then
-            docker tag "${IMAGE}:weekly" "${IMAGE}:weekly-1"
-            docker push "${IMAGE}:weekly-1"
-            echo "Pushed ${IMAGE}:weekly-1"
-          else
-            echo "Skipping: ${IMAGE}:weekly does not exist yet"
-          fi
+          retag "${IMAGE}:weekly" "${IMAGE}:weekly-1"
 
           # latest -> weekly
           echo "--- Promoting ${IMAGE}:latest -> ${IMAGE}:weekly ---"
-          docker pull "${IMAGE}:latest"
-          docker tag "${IMAGE}:latest" "${IMAGE}:weekly"
-          docker push "${IMAGE}:weekly"
-          echo "Pushed ${IMAGE}:weekly"
+          docker buildx imagetools create --tag "${IMAGE}:weekly" "${IMAGE}:latest"
+          echo "Tagged ${IMAGE}:weekly"
 
           echo "=== Rolling tag rotation complete ==="

--- a/.github/workflows/cicd_weekly-rolling-tags.yml
+++ b/.github/workflows/cicd_weekly-rolling-tags.yml
@@ -1,0 +1,62 @@
+name: Weekly Rolling Docker Tags
+on:
+  schedule:
+    # Every Saturday at 06:00 UTC
+    - cron: '0 6 * * 6'
+  workflow_dispatch:
+
+env:
+  IMAGE: dotcms/dotcms
+  MAX_WEEKS: 4
+
+jobs:
+  rolling-tags:
+    name: Rotate Weekly Docker Tags
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Rotate weekly tags
+        run: |
+          set -euo pipefail
+
+          IMAGE="${{ env.IMAGE }}"
+          MAX_WEEKS="${{ env.MAX_WEEKS }}"
+
+          # Work backwards: weekly-3 -> weekly-4, weekly-2 -> weekly-3, etc.
+          for (( i = MAX_WEEKS - 1; i >= 1; i-- )); do
+            SRC="${IMAGE}:weekly-${i}"
+            DST="${IMAGE}:weekly-$(( i + 1 ))"
+
+            echo "--- Promoting ${SRC} -> ${DST} ---"
+            if docker pull "${SRC}" 2>/dev/null; then
+              docker tag "${SRC}" "${DST}"
+              docker push "${DST}"
+              echo "Pushed ${DST}"
+            else
+              echo "Skipping: ${SRC} does not exist yet"
+            fi
+          done
+
+          # weekly -> weekly-1
+          echo "--- Promoting ${IMAGE}:weekly -> ${IMAGE}:weekly-1 ---"
+          if docker pull "${IMAGE}:weekly" 2>/dev/null; then
+            docker tag "${IMAGE}:weekly" "${IMAGE}:weekly-1"
+            docker push "${IMAGE}:weekly-1"
+            echo "Pushed ${IMAGE}:weekly-1"
+          else
+            echo "Skipping: ${IMAGE}:weekly does not exist yet"
+          fi
+
+          # latest -> weekly
+          echo "--- Promoting ${IMAGE}:latest -> ${IMAGE}:weekly ---"
+          docker pull "${IMAGE}:latest"
+          docker tag "${IMAGE}:latest" "${IMAGE}:weekly"
+          docker push "${IMAGE}:weekly"
+          echo "Pushed ${IMAGE}:weekly"
+
+          echo "=== Rolling tag rotation complete ==="


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that runs every Saturday to rotate weekly Docker image tags
- Promotes `dotcms/dotcms:latest` → `weekly`, and shifts existing weekly tags: `weekly` → `weekly-1` (weekly minus 1) → `weekly-2` → `weekly-3` → `weekly-4`.
- Keeps 4 weeks of rolling history; gracefully skips tags that don't exist yet

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify tag rotation in Docker Hub
- [ ] Confirm `weekly` tag points to the same image as `latest` after run
- [ ] Verify older tags are correctly shifted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35142

This PR fixes: #35142