### PR TITLE
fix(content-type): accept custom Page content types as valid detail pages

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/transform/contenttype/DetailPageTransformerImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/transform/contenttype/DetailPageTransformerImpl.java
@@ -1,6 +1,8 @@
 package com.dotcms.contenttype.transform.contenttype;
 
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
+import com.dotcms.contenttype.business.ContentTypeAPI;
+import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.rest.api.v1.contenttype.ContentTypeHelper;
 import com.dotmarketing.beans.Host;
@@ -19,8 +21,6 @@ import java.net.URISyntaxException;
 import java.util.Optional;
 
 public class DetailPageTransformerImpl implements DetailPageTransformer {
-
-    private static final String PAGE_SUBTYPE = "htmlpageasset";
 
     private final ContentType contentType;
     private final User user;
@@ -117,31 +117,41 @@ public class DetailPageTransformerImpl implements DetailPageTransformer {
     /**
      * Validates the identifier of a detail page.
      *
-     * @param detailPage                The detail page.
+     * <p>A valid detail page is any page whose content type has a base type of
+     * {@link BaseContentType#HTMLPAGE}, regardless of its velocity variable name. This
+     * correctly handles custom Page content types (e.g. "Landing Page", "Detail Page") in
+     * addition to the default "Web Page Content" type.
+     *
+     * @param detailPage                The detail page URI or identifier string.
      * @param foundDetailPageIdentifier The Identifier of the detail page.
      * @return An Optional containing the identifier value if it is valid.
-     * @throws IllegalArgumentException if the identifier is invalid.
+     * @throws DotDataException         if a database error occurs looking up the content type.
+     * @throws DotSecurityException     if a permissions error occurs looking up the content type.
+     * @throws IllegalArgumentException if the identifier is not a valid detail page.
      */
     private Optional<String> validateIdentifier(
-            String detailPage, Identifier foundDetailPageIdentifier) {
+            String detailPage, Identifier foundDetailPageIdentifier)
+            throws DotDataException, DotSecurityException {
 
-        if (null != foundDetailPageIdentifier &&
-                foundDetailPageIdentifier.exists() &&
-                foundDetailPageIdentifier.getAssetSubType().equals(PAGE_SUBTYPE)) {
-            return Optional.of(foundDetailPageIdentifier.getId());
-        } else {
-            if (null != foundDetailPageIdentifier &&
-                    foundDetailPageIdentifier.exists() &&
-                    !foundDetailPageIdentifier.getAssetSubType().equals(PAGE_SUBTYPE)) {
-                throw new IllegalArgumentException(
-                        String.format("[%s] in Content Type [%s] is not a valid detail page.",
-                                detailPage, contentType.name()));
-            }
-
+        if (null == foundDetailPageIdentifier || !foundDetailPageIdentifier.exists()) {
             throw new IllegalArgumentException(
                     String.format("Detail page [%s] in Content Type [%s] does not exist.",
                             detailPage, contentType.name()));
         }
+
+        final ContentTypeAPI contentTypeAPI = APILocator.getContentTypeAPI(
+                APILocator.getUserAPI().getSystemUser());
+        final ContentType pageContentType = contentTypeAPI.find(
+                foundDetailPageIdentifier.getAssetSubType());
+
+        if (null != pageContentType &&
+                BaseContentType.HTMLPAGE == pageContentType.baseType()) {
+            return Optional.of(foundDetailPageIdentifier.getId());
+        }
+
+        throw new IllegalArgumentException(
+                String.format("[%s] in Content Type [%s] is not a valid detail page.",
+                        detailPage, contentType.name()));
     }
 
 }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `"htmlpageasset"` subtype string check in `DetailPageTransformerImpl.validateIdentifier()` with a proper base-type lookup via `ContentTypeAPI`
- Any content type whose `BaseContentType` is `HTMLPAGE` is now accepted as a valid detail page, regardless of its velocity variable name
- Fixes a regression that blocked Content Type saves whenever a custom Page content type (e.g. "Landing Page", "Detail Page") was used as the detail page — only the default "Web Page Content" (`htmlpageasset`) was previously accepted

## Root Cause

`assetSubType` on an `Identifier` is populated from the content type's **velocity variable name** (see `IdentifierFactoryImpl`). The hardcoded check `assetSubType.equals("htmlpageasset")` therefore only passes for the single built-in "Web Page Content" type. All custom Page content types always fail, even though they are structurally identical pages.

## Changes

- `DetailPageTransformerImpl.validateIdentifier()` — replaces subtype string equality with `ContentTypeAPI.find(assetSubType).baseType() == BaseContentType.HTMLPAGE`
- Removes the now-unused `PAGE_SUBTYPE = "htmlpageasset"` constant
- Updates method signature to declare `throws DotDataException, DotSecurityException` (both already declared by callers)

## Test Plan

- [ ] Create a custom content type with base type **Page** (e.g. "Landing Page" with variable `landingPage`)
- [ ] Create a page using that custom Page content type
- [ ] Edit any Content Type and set the **Detail Page** field to that page — save should succeed
- [ ] Verify the default "Web Page Content" (`htmlpageasset`) pages still work as detail pages
- [ ] Verify a non-page asset (e.g. a File or Content) is still correctly rejected as an invalid detail page

Fixes: #35149
Freshdesk: [#36039](https://helpdesk.dotcms.com/a/tickets/36039), [#36145](https://dotcms.freshdesk.com/a/tickets/36145)