### PR TITLE
feat(edit-content): auto-populate Site/Folder field when relating content

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-field/dot-edit-content-field.component.spec.ts
@@ -94,7 +94,15 @@ const FIELD_TYPES_COMPONENTS: Record<FIELD_TYPES, Type<unknown> | DotEditFieldTe
     [FIELD_TYPES.TEXT]: DotEditContentTextFieldComponent,
     [FIELD_TYPES.RELATIONSHIP]: {
         component: DotEditContentRelationshipFieldComponent,
-        providers: [mockProvider(DialogService)]
+        providers: [
+            mockProvider(DialogService),
+            {
+                provide: DotEditContentStore,
+                useValue: {
+                    contentType: signal(null)
+                }
+            }
+        ]
     },
     [FIELD_TYPES.FILE]: {
         component: DotEditContentFileFieldComponent,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -24,7 +24,7 @@ import { TableModule, TableRowReorderEvent } from 'primeng/table';
 import { filter } from 'rxjs/operators';
 
 import { DotMessageService } from '@dotcms/data-access';
-import { DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
+import { DotCMSContentlet, DotCMSContentTypeField, DotCMSFieldTypes } from '@dotcms/dotcms-models';
 import { DotMessagePipe } from '@dotcms/ui';
 
 import { RelationshipFieldStore } from './../../store/relationship-field.store';
@@ -34,6 +34,7 @@ import { DotSelectExistingContentComponent } from './../dot-select-existing-cont
 import { PaginationComponent } from './../pagination/pagination.component';
 
 import { EditContentDialogData } from '../../../../models/dot-edit-content-dialog.interface';
+import { DotEditContentStore } from '../../../../store/edit-content.store';
 import { ContentletStatusPipe } from '../../../../pipes/contentlet-status.pipe';
 import { LanguagePipe } from '../../../../pipes/language.pipe';
 import { BaseControlValueAccessor } from '../../../shared/base-control-value-accesor';
@@ -77,6 +78,12 @@ export class DotRelationshipFieldComponent
      * This service is used for handling message-related functionalities within the component.
      */
     readonly #dotMessageService = inject(DotMessageService);
+
+    /**
+     * A readonly instance of the DotEditContentStore injected into the component.
+     * Used to access the parent content type and determine host/folder preselection.
+     */
+    readonly #editContentStore = inject(DotEditContentStore);
 
     /**
      * A readonly private field that holds a reference to the `DestroyRef` service.
@@ -219,6 +226,27 @@ export class DotRelationshipFieldComponent
             return;
         }
 
+        const contentlet = this.$contentlet();
+        const parentContentType = this.#editContentStore.contentType();
+        const hasHostFolderField =
+            parentContentType?.fields?.some((f) => f.fieldType === DotCMSFieldTypes.HOST_FOLDER) ??
+            false;
+
+        let siteOrFolderPreselection = null;
+        if (hasHostFolderField && contentlet) {
+            if (contentlet.folder && contentlet.folder !== 'SYSTEM_FOLDER') {
+                siteOrFolderPreselection = {
+                    value: `folder:${contentlet.folder}`,
+                    label: contentlet.hostName || contentlet.host
+                };
+            } else if (contentlet.host) {
+                siteOrFolderPreselection = {
+                    value: `site:${contentlet.host}`,
+                    label: contentlet.hostName || contentlet.host
+                };
+            }
+        }
+
         this.#dialogRef = this.#dialogService.open(DotSelectExistingContentComponent, {
             appendTo: 'body',
             baseZIndex: 10000,
@@ -235,7 +263,8 @@ export class DotRelationshipFieldComponent
             data: {
                 contentTypeId: contentType.id,
                 selectionMode: this.store.selectionMode(),
-                currentItemsIds: this.store.data().map((item) => item.inode)
+                currentItemsIds: this.store.data().map((item) => item.inode),
+                siteOrFolderPreselection
             },
             templates: {
                 header: HeaderComponent,

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.spec.ts
@@ -8,6 +8,7 @@ import { TreeSelectModule } from 'primeng/treeselect';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { TreeNodeItem, TreeNodeSelectItem } from '@dotcms/dotcms-models';
+import { GlobalStore } from '@dotcms/store';
 import { DotMessagePipe, DotTruncatePathPipe, DotBrowsingService } from '@dotcms/ui';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 
@@ -70,6 +71,14 @@ describe('SiteFieldComponent', () => {
             mockProvider(DotBrowsingService, {
                 getSitesTreePath: jest.fn().mockReturnValue(of(mockSites)),
                 getFoldersTreeNode: jest.fn().mockReturnValue(of(mockFolders))
+            }),
+            mockProvider(GlobalStore, {
+                siteDetails: jest.fn().mockReturnValue({
+                    identifier: '123',
+                    hostname: 'demo.dotcms.com',
+                    aliases: null
+                }),
+                currentSiteId: jest.fn().mockReturnValue('123')
             })
         ]
     });
@@ -226,6 +235,28 @@ describe('SiteFieldComponent', () => {
 
     describe('ControlValueAccessor Implementation', () => {
         const testValue = 'test-site-id';
+
+        it('should handle writeValue with a valid site value', () => {
+            const setInitialSelectionSpy = jest.spyOn(store, 'setInitialSelection');
+            spectator.detectChanges();
+
+            component.writeValue('site:123');
+
+            expect(setInitialSelectionSpy).toHaveBeenCalledWith('123', 'site', 'demo.dotcms.com');
+        });
+
+        it('should handle writeValue with a folder value', () => {
+            const setInitialSelectionSpy = jest.spyOn(store, 'setInitialSelection');
+            spectator.detectChanges();
+
+            component.writeValue('folder:folder-456');
+
+            expect(setInitialSelectionSpy).toHaveBeenCalledWith(
+                'folder-456',
+                'folder',
+                'folder-456'
+            );
+        });
 
         it('should write value to form control', () => {
             spectator.detectChanges();

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.spec.ts
@@ -12,6 +12,8 @@ import { GlobalStore } from '@dotcms/store';
 import { DotMessagePipe, DotTruncatePathPipe, DotBrowsingService } from '@dotcms/ui';
 import { MockDotMessageService } from '@dotcms/utils-testing';
 
+import { ExistingContentStore } from '../../../../store/existing-content.store';
+
 import { SiteFieldComponent } from './site-field.component';
 import { SiteFieldStore } from './site-field.store';
 
@@ -79,6 +81,10 @@ describe('SiteFieldComponent', () => {
                     aliases: null
                 }),
                 currentSiteId: jest.fn().mockReturnValue('123')
+            }),
+            mockProvider(ExistingContentStore, {
+                siteOrFolderPreselection: jest.fn().mockReturnValue(null),
+                isLoading: jest.fn().mockReturnValue(false)
             })
         ]
     });
@@ -356,5 +362,102 @@ describe('SiteFieldComponent', () => {
 
             expect(onChangeSpy).not.toHaveBeenCalled();
         });
+    });
+});
+
+describe('SiteFieldComponent - Dialog Config Preselection', () => {
+    const MOCK_SITE_ID = '123';
+    const MOCK_HOSTNAME = 'demo.dotcms.com';
+    const MOCK_FOLDER_ID = 'folder-789';
+
+    let spectator: Spectator<SiteFieldComponent>;
+    let component: SiteFieldComponent;
+    let store: InstanceType<typeof SiteFieldStore>;
+
+    const messageServiceMock = new MockDotMessageService({
+        'dot.file.relationship.dialog.search.language.failed': 'Failed to load languages'
+    });
+
+    const mockSites: TreeNodeItem[] = [
+        {
+            label: MOCK_HOSTNAME,
+            data: {
+                id: MOCK_SITE_ID,
+                hostname: MOCK_HOSTNAME,
+                path: '',
+                type: 'site'
+            },
+            icon: 'pi pi-globe',
+            leaf: false,
+            children: []
+        }
+    ];
+
+    const mockFolders = {
+        parent: {
+            id: 'parent-id',
+            hostName: MOCK_HOSTNAME,
+            path: '/parent',
+            addChildrenAllowed: true
+        },
+        folders: []
+    };
+
+    const createComponent = createComponentFactory({
+        component: SiteFieldComponent,
+        imports: [ReactiveFormsModule, TreeSelectModule, DotTruncatePathPipe, DotMessagePipe],
+        componentProviders: [SiteFieldStore],
+        providers: [
+            { provide: DotMessageService, useValue: messageServiceMock },
+            mockProvider(DotBrowsingService, {
+                getSitesTreePath: jest.fn().mockReturnValue(of(mockSites)),
+                getFoldersTreeNode: jest.fn().mockReturnValue(of(mockFolders))
+            }),
+            mockProvider(GlobalStore, {
+                siteDetails: jest.fn().mockReturnValue({
+                    identifier: MOCK_SITE_ID,
+                    hostname: MOCK_HOSTNAME,
+                    aliases: null
+                }),
+                currentSiteId: jest.fn().mockReturnValue(MOCK_SITE_ID)
+            }),
+            mockProvider(ExistingContentStore, {
+                siteOrFolderPreselection: jest.fn().mockReturnValue({
+                    value: `folder:${MOCK_FOLDER_ID}`,
+                    label: MOCK_HOSTNAME
+                }),
+                isLoading: jest.fn().mockReturnValue(false)
+            })
+        ]
+    });
+
+    beforeEach(() => {
+        spectator = createComponent({
+            detectChanges: false
+        });
+        component = spectator.component;
+        store = spectator.inject(SiteFieldStore, true);
+    });
+
+    it('should use preselection label from dialog config when value matches', () => {
+        const setInitialSelectionSpy = jest.spyOn(store, 'setInitialSelection');
+        spectator.detectChanges();
+
+        component.writeValue(`folder:${MOCK_FOLDER_ID}`);
+
+        expect(setInitialSelectionSpy).toHaveBeenCalledWith(
+            MOCK_FOLDER_ID,
+            'folder',
+            MOCK_HOSTNAME
+        );
+    });
+
+    it('should fall back to GlobalStore when value does not match preselection', () => {
+        const setInitialSelectionSpy = jest.spyOn(store, 'setInitialSelection');
+        spectator.detectChanges();
+
+        component.writeValue(`site:${MOCK_SITE_ID}`);
+
+        expect(setInitialSelectionSpy).toHaveBeenCalledWith(MOCK_SITE_ID, 'site', MOCK_HOSTNAME);
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
@@ -2,6 +2,7 @@ import {
     ChangeDetectionStrategy,
     Component,
     OnInit,
+    computed,
     effect,
     forwardRef,
     inject,
@@ -20,6 +21,7 @@ import { GlobalStore } from '@dotcms/store';
 import { DotMessagePipe, DotTruncatePathPipe } from '@dotcms/ui';
 
 import { SiteFieldStore } from './site-field.store';
+import { ExistingContentStore } from '../../../../store/existing-content.store';
 
 /**
  * Component for selecting a site from a tree structure.
@@ -53,10 +55,20 @@ export class SiteFieldComponent implements ControlValueAccessor, OnInit {
     readonly #globalStore = inject(GlobalStore);
 
     /**
+     * Existing content store for accessing preselection data passed from the relationship field.
+     */
+    readonly #existingContentStore = inject(ExistingContentStore);
+
+    /**
      * Form control for the site selection.
      * Binds to the TreeSelect component and manages the selected site value.
      */
     readonly siteControl = new FormControl<string>('');
+
+    /**
+     * Computed property that returns the selected node.
+     */
+    readonly $nodeSelected = computed(() => this.store.nodeSelected());
 
     /**
      * View child for the TreeSelect component.
@@ -125,11 +137,20 @@ export class SiteFieldComponent implements ControlValueAccessor, OnInit {
         if (value.includes(':')) {
             const [type, id] = value.split(':');
             if (id && (type === 'site' || type === 'folder')) {
-                const siteDetails = this.#globalStore.siteDetails();
-                const label =
-                    type === 'site' && siteDetails?.identifier === id ? siteDetails.hostname : id;
+                const preselection = this.#existingContentStore.siteOrFolderPreselection();
+                let label: string;
+
+                if (preselection?.value === value && preselection?.label) {
+                    label = preselection.label;
+                } else {
+                    const siteDetails = this.#globalStore.siteDetails();
+                    label =
+                        type === 'site' && siteDetails?.identifier === id
+                            ? siteDetails.hostname
+                            : id;
+                }
+
                 this.store.setInitialSelection(id, type, label);
-                // Set siteControl to the TreeNodeItem so PrimeNG TreeSelect displays it
                 this.siteControl.setValue(this.store.nodeSelected() as unknown as string);
             }
         }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
@@ -16,6 +16,7 @@ import {
 
 import { TreeSelect, TreeSelectModule } from 'primeng/treeselect';
 
+import { GlobalStore } from '@dotcms/store';
 import { DotMessagePipe, DotTruncatePathPipe } from '@dotcms/ui';
 
 import { SiteFieldStore } from './site-field.store';
@@ -45,6 +46,11 @@ export class SiteFieldComponent implements ControlValueAccessor, OnInit {
      * Handles loading sites and managing selection state.
      */
     protected readonly store = inject(SiteFieldStore);
+
+    /**
+     * Global store for accessing current site details when pre-populating.
+     */
+    readonly #globalStore = inject(GlobalStore);
 
     /**
      * Form control for the site selection.
@@ -106,11 +112,24 @@ export class SiteFieldComponent implements ControlValueAccessor, OnInit {
     /**
      * Writes a new value to the form control.
      * Implements ControlValueAccessor method to update the control's value programmatically.
+     * Handles both clearing (falsy value) and pre-populating (e.g., "site:{id}").
      */
     writeValue(value: string): void {
         if (!value) {
             this.siteControl.setValue('');
             this.store.clearSelection();
+
+            return;
+        }
+
+        if (value.includes(':')) {
+            const [type, id] = value.split(':');
+            if (id && (type === 'site' || type === 'folder')) {
+                const siteDetails = this.#globalStore.siteDetails();
+                const label =
+                    type === 'site' && siteDetails?.identifier === id ? siteDetails.hostname : id;
+                this.store.setInitialSelection(id, type, label);
+            }
         }
     }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.component.ts
@@ -129,6 +129,8 @@ export class SiteFieldComponent implements ControlValueAccessor, OnInit {
                 const label =
                     type === 'site' && siteDetails?.identifier === id ? siteDetails.hostname : id;
                 this.store.setInitialSelection(id, type, label);
+                // Set siteControl to the TreeNodeItem so PrimeNG TreeSelect displays it
+                this.siteControl.setValue(this.store.nodeSelected() as unknown as string);
             }
         }
     }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.store.spec.ts
@@ -328,6 +328,71 @@ describe('SiteFieldStore', () => {
         });
     });
 
+    describe('setInitialSelection', () => {
+        it('should set initial selection with site type', () => {
+            store.setInitialSelection('site-123', 'site', 'demo.dotcms.com');
+
+            const nodeSelected = store.nodeSelected();
+            expect(nodeSelected).toEqual({
+                label: 'demo.dotcms.com',
+                data: {
+                    id: 'site-123',
+                    type: 'site',
+                    hostname: 'demo.dotcms.com',
+                    path: ''
+                },
+                icon: 'pi pi-globe',
+                leaf: false,
+                children: []
+            });
+            expect(store.valueToSave()).toBe('site:site-123');
+        });
+
+        it('should set initial selection with folder type', () => {
+            store.setInitialSelection('folder-456', 'folder', 'my-folder');
+
+            const nodeSelected = store.nodeSelected();
+            expect(nodeSelected).toEqual({
+                label: 'my-folder',
+                data: {
+                    id: 'folder-456',
+                    type: 'folder',
+                    hostname: 'my-folder',
+                    path: ''
+                },
+                icon: 'pi pi-folder',
+                leaf: true,
+                children: []
+            });
+            expect(store.valueToSave()).toBe('folder:folder-456');
+        });
+
+        it('should overwrite previous selection', () => {
+            const mockEvent: TreeNodeSelectItem = {
+                originalEvent: createFakeEvent('click'),
+                node: {
+                    label: 'Previous Node',
+                    data: {
+                        id: 'prev-id',
+                        hostname: 'prev.com',
+                        path: 'prev',
+                        type: 'folder' as const
+                    },
+                    icon: 'pi pi-folder',
+                    leaf: true,
+                    children: []
+                }
+            };
+
+            store.chooseNode(mockEvent);
+            expect(store.valueToSave()).toBe('folder:prev-id');
+
+            store.setInitialSelection('new-id', 'site', 'new.dotcms.com');
+            expect(store.valueToSave()).toBe('site:new-id');
+            expect(store.nodeSelected().label).toBe('new.dotcms.com');
+        });
+    });
+
     describe('clearSelection', () => {
         it('should clear the selected node', () => {
             // First select a node

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/site-field/site-field.store.ts
@@ -136,6 +136,29 @@ export const SiteFieldStore = signalStore(
              */
             clearSelection: () => {
                 patchState(store, { nodeSelected: null });
+            },
+            /**
+             * Sets an initial selection from external data (e.g., GlobalStore current site).
+             * Creates a synthetic TreeNodeItem and patches the store state.
+             * @method setInitialSelection
+             * @param {string} id - The site or folder identifier
+             * @param {'site' | 'folder'} type - Whether this is a site or folder
+             * @param {string} label - Display label (e.g., hostname)
+             */
+            setInitialSelection: (id: string, type: 'site' | 'folder', label: string) => {
+                const nodeSelected: TreeNodeItem = {
+                    label,
+                    data: {
+                        id,
+                        type,
+                        hostname: label,
+                        path: ''
+                    },
+                    icon: type === 'site' ? 'pi pi-globe' : 'pi pi-folder',
+                    leaf: type === 'folder',
+                    children: []
+                };
+                patchState(store, { nodeSelected });
             }
         };
     })

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
@@ -920,33 +920,18 @@ describe('SearchComponent - Site Pre-population', () => {
         });
 
         it('should pre-populate siteOrFolderId when GlobalStore has current site', () => {
-            const searchSpy = jest.spyOn(component.onSearch, 'emit');
-
             spectator.detectChanges();
 
             const formValues = component.form.getRawValue();
             expect(formValues.systemSearchableFields.siteOrFolderId).toBe(`site:${MOCK_SITE_ID}`);
-            expect(searchSpy).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    systemSearchableFields: expect.objectContaining({
-                        siteId: MOCK_SITE_ID
-                    })
-                })
-            );
         });
 
-        it('should trigger search with site filter on init', () => {
+        it('should not trigger search automatically on init', () => {
             const searchSpy = jest.spyOn(component.onSearch, 'emit');
 
             spectator.detectChanges();
 
-            expect(searchSpy).toHaveBeenCalledTimes(1);
-            expect(searchSpy).toHaveBeenCalledWith({
-                query: '',
-                systemSearchableFields: {
-                    siteId: MOCK_SITE_ID
-                }
-            });
+            expect(searchSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
@@ -23,6 +23,8 @@ import { GlobalStore } from '@dotcms/store';
 import { DotMessagePipe, DotBrowsingService } from '@dotcms/ui';
 import { MockDotMessageService, mockLocales } from '@dotcms/utils-testing';
 
+import { ExistingContentStore } from '../../store/existing-content.store';
+
 import { LanguageFieldComponent } from './components/language-field/language-field.component';
 import { SiteFieldComponent } from './components/site-field/site-field.component';
 import { SearchComponent, DEBOUNCE_TIME } from './search.component';
@@ -150,6 +152,10 @@ describe('SearchComponent', () => {
             mockProvider(GlobalStore, {
                 siteDetails: jest.fn().mockReturnValue(null),
                 currentSiteId: jest.fn().mockReturnValue(null)
+            }),
+            mockProvider(ExistingContentStore, {
+                siteOrFolderPreselection: jest.fn().mockReturnValue(null),
+                isLoading: jest.fn().mockReturnValue(false)
             })
         ]
     });
@@ -906,6 +912,10 @@ describe('SearchComponent - Site Pre-population', () => {
                         aliases: null
                     }),
                     currentSiteId: jest.fn().mockReturnValue(MOCK_SITE_ID)
+                }),
+                mockProvider(ExistingContentStore, {
+                    siteOrFolderPreselection: jest.fn().mockReturnValue(null),
+                    isLoading: jest.fn().mockReturnValue(false)
                 })
             ]
         });
@@ -966,6 +976,10 @@ describe('SearchComponent - Site Pre-population', () => {
                 mockProvider(GlobalStore, {
                     siteDetails: jest.fn().mockReturnValue(null),
                     currentSiteId: jest.fn().mockReturnValue(null)
+                }),
+                mockProvider(ExistingContentStore, {
+                    siteOrFolderPreselection: jest.fn().mockReturnValue(null),
+                    isLoading: jest.fn().mockReturnValue(false)
                 })
             ]
         });
@@ -987,6 +1001,166 @@ describe('SearchComponent - Site Pre-population', () => {
             const formValues = component.form.getRawValue();
             expect(formValues.systemSearchableFields.siteOrFolderId).toBe('');
             expect(searchSpy).not.toHaveBeenCalled();
+        });
+    });
+});
+
+describe('SearchComponent - Site Pre-population from Dialog Config', () => {
+    const MOCK_SITE_ID = 'site-abc-123';
+    const MOCK_HOSTNAME = 'demo.dotcms.com';
+    const MOCK_FOLDER_ID = 'folder-123';
+
+    const messageServiceMock = new MockDotMessageService({
+        'dot.file.relationship.dialog.search.language.failed': 'Failed to load languages'
+    });
+
+    const mockSites: TreeNodeItem[] = [
+        {
+            label: MOCK_HOSTNAME,
+            data: {
+                id: MOCK_SITE_ID,
+                hostname: MOCK_HOSTNAME,
+                path: '',
+                type: 'site'
+            },
+            icon: 'pi pi-globe',
+            leaf: false,
+            children: []
+        }
+    ];
+
+    const mockFolders = {
+        parent: {
+            id: 'parent-id',
+            hostName: MOCK_HOSTNAME,
+            path: '/parent',
+            addChildrenAllowed: true
+        },
+        folders: []
+    };
+
+    describe('when ExistingContentStore has siteOrFolderPreselection', () => {
+        let spectator: Spectator<SearchComponent>;
+        let component: SearchComponent;
+
+        const createComponent = createComponentFactory({
+            component: SearchComponent,
+            imports: [
+                ReactiveFormsModule,
+                ButtonModule,
+                SelectModule,
+                InputGroupModule,
+                InputTextModule,
+                PopoverModule,
+                ChipModule,
+                MockLanguageFieldComponent,
+                MockSiteFieldComponent
+            ],
+            mocks: [DotMessagePipe],
+            detectChanges: false,
+            providers: [
+                { provide: DotMessageService, useValue: messageServiceMock },
+                mockProvider(DotBrowsingService, {
+                    getSitesTreePath: jest.fn().mockReturnValue(of(mockSites)),
+                    getFoldersTreeNode: jest.fn().mockReturnValue(of(mockFolders))
+                }),
+                mockProvider(DotLanguagesService, {
+                    get: jest.fn().mockReturnValue(of(mockLocales))
+                }),
+                mockProvider(GlobalStore, {
+                    siteDetails: jest.fn().mockReturnValue({
+                        identifier: MOCK_SITE_ID,
+                        hostname: MOCK_HOSTNAME,
+                        aliases: null
+                    }),
+                    currentSiteId: jest.fn().mockReturnValue(MOCK_SITE_ID)
+                }),
+                mockProvider(ExistingContentStore, {
+                    siteOrFolderPreselection: jest.fn().mockReturnValue({
+                        value: `folder:${MOCK_FOLDER_ID}`,
+                        label: MOCK_HOSTNAME
+                    }),
+                    isLoading: jest.fn().mockReturnValue(false)
+                })
+            ]
+        });
+
+        beforeEach(() => {
+            spectator = createComponent({
+                props: {
+                    isLoading: false
+                } as unknown
+            });
+            component = spectator.component;
+        });
+
+        it('should pre-populate with store preselection instead of GlobalStore', () => {
+            spectator.detectChanges();
+
+            const formValues = component.form.getRawValue();
+            expect(formValues.systemSearchableFields.siteOrFolderId).toBe(
+                `folder:${MOCK_FOLDER_ID}`
+            );
+        });
+    });
+
+    describe('when ExistingContentStore has null preselection', () => {
+        let spectator: Spectator<SearchComponent>;
+        let component: SearchComponent;
+
+        const createComponent = createComponentFactory({
+            component: SearchComponent,
+            imports: [
+                ReactiveFormsModule,
+                ButtonModule,
+                SelectModule,
+                InputGroupModule,
+                InputTextModule,
+                PopoverModule,
+                ChipModule,
+                MockLanguageFieldComponent,
+                MockSiteFieldComponent
+            ],
+            mocks: [DotMessagePipe],
+            detectChanges: false,
+            providers: [
+                { provide: DotMessageService, useValue: messageServiceMock },
+                mockProvider(DotBrowsingService, {
+                    getSitesTreePath: jest.fn().mockReturnValue(of(mockSites)),
+                    getFoldersTreeNode: jest.fn().mockReturnValue(of(mockFolders))
+                }),
+                mockProvider(DotLanguagesService, {
+                    get: jest.fn().mockReturnValue(of(mockLocales))
+                }),
+                mockProvider(GlobalStore, {
+                    siteDetails: jest.fn().mockReturnValue({
+                        identifier: MOCK_SITE_ID,
+                        hostname: MOCK_HOSTNAME,
+                        aliases: null
+                    }),
+                    currentSiteId: jest.fn().mockReturnValue(MOCK_SITE_ID)
+                }),
+                mockProvider(ExistingContentStore, {
+                    siteOrFolderPreselection: jest.fn().mockReturnValue(null),
+                    isLoading: jest.fn().mockReturnValue(false)
+                })
+            ]
+        });
+
+        beforeEach(() => {
+            spectator = createComponent({
+                props: {
+                    isLoading: false
+                } as unknown
+            });
+            component = spectator.component;
+        });
+
+        it('should fall back to GlobalStore when preselection is null', () => {
+            spectator.detectChanges();
+
+            const formValues = component.form.getRawValue();
+            expect(formValues.systemSearchableFields.siteOrFolderId).toBe(`site:${MOCK_SITE_ID}`);
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.spec.ts
@@ -19,6 +19,7 @@ import { SelectModule } from 'primeng/select';
 
 import { DotLanguagesService, DotMessageService } from '@dotcms/data-access';
 import { TreeNodeItem } from '@dotcms/dotcms-models';
+import { GlobalStore } from '@dotcms/store';
 import { DotMessagePipe, DotBrowsingService } from '@dotcms/ui';
 import { MockDotMessageService, mockLocales } from '@dotcms/utils-testing';
 
@@ -145,6 +146,10 @@ describe('SearchComponent', () => {
             }),
             mockProvider(DotLanguagesService, {
                 get: jest.fn().mockReturnValue(of(mockLocales))
+            }),
+            mockProvider(GlobalStore, {
+                siteDetails: jest.fn().mockReturnValue(null),
+                currentSiteId: jest.fn().mockReturnValue(null)
             })
         ]
     });
@@ -829,6 +834,174 @@ describe('SearchComponent', () => {
             component.removeFilter('language');
 
             expect(searchSpy).toHaveBeenCalled();
+        });
+    });
+});
+
+describe('SearchComponent - Site Pre-population', () => {
+    const MOCK_SITE_ID = 'site-abc-123';
+    const MOCK_HOSTNAME = 'demo.dotcms.com';
+
+    const messageServiceMock = new MockDotMessageService({
+        'dot.file.relationship.dialog.search.language.failed': 'Failed to load languages'
+    });
+
+    const mockSites: TreeNodeItem[] = [
+        {
+            label: MOCK_HOSTNAME,
+            data: {
+                id: MOCK_SITE_ID,
+                hostname: MOCK_HOSTNAME,
+                path: '',
+                type: 'site'
+            },
+            icon: 'pi pi-globe',
+            leaf: false,
+            children: []
+        }
+    ];
+
+    const mockFolders = {
+        parent: {
+            id: 'parent-id',
+            hostName: MOCK_HOSTNAME,
+            path: '/parent',
+            addChildrenAllowed: true
+        },
+        folders: []
+    };
+
+    describe('when GlobalStore has current site', () => {
+        let spectator: Spectator<SearchComponent>;
+        let component: SearchComponent;
+
+        const createComponent = createComponentFactory({
+            component: SearchComponent,
+            imports: [
+                ReactiveFormsModule,
+                ButtonModule,
+                SelectModule,
+                InputGroupModule,
+                InputTextModule,
+                PopoverModule,
+                ChipModule,
+                MockLanguageFieldComponent,
+                MockSiteFieldComponent
+            ],
+            mocks: [DotMessagePipe],
+            detectChanges: false,
+            providers: [
+                { provide: DotMessageService, useValue: messageServiceMock },
+                mockProvider(DotBrowsingService, {
+                    getSitesTreePath: jest.fn().mockReturnValue(of(mockSites)),
+                    getFoldersTreeNode: jest.fn().mockReturnValue(of(mockFolders))
+                }),
+                mockProvider(DotLanguagesService, {
+                    get: jest.fn().mockReturnValue(of(mockLocales))
+                }),
+                mockProvider(GlobalStore, {
+                    siteDetails: jest.fn().mockReturnValue({
+                        identifier: MOCK_SITE_ID,
+                        hostname: MOCK_HOSTNAME,
+                        aliases: null
+                    }),
+                    currentSiteId: jest.fn().mockReturnValue(MOCK_SITE_ID)
+                })
+            ]
+        });
+
+        beforeEach(() => {
+            spectator = createComponent({
+                props: {
+                    isLoading: false
+                } as unknown
+            });
+            component = spectator.component;
+        });
+
+        it('should pre-populate siteOrFolderId when GlobalStore has current site', () => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            spectator.detectChanges();
+
+            const formValues = component.form.getRawValue();
+            expect(formValues.systemSearchableFields.siteOrFolderId).toBe(`site:${MOCK_SITE_ID}`);
+            expect(searchSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    systemSearchableFields: expect.objectContaining({
+                        siteId: MOCK_SITE_ID
+                    })
+                })
+            );
+        });
+
+        it('should trigger search with site filter on init', () => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            spectator.detectChanges();
+
+            expect(searchSpy).toHaveBeenCalledTimes(1);
+            expect(searchSpy).toHaveBeenCalledWith({
+                query: '',
+                systemSearchableFields: {
+                    siteId: MOCK_SITE_ID
+                }
+            });
+        });
+    });
+
+    describe('when GlobalStore has no current site', () => {
+        let spectator: Spectator<SearchComponent>;
+        let component: SearchComponent;
+
+        const createComponent = createComponentFactory({
+            component: SearchComponent,
+            imports: [
+                ReactiveFormsModule,
+                ButtonModule,
+                SelectModule,
+                InputGroupModule,
+                InputTextModule,
+                PopoverModule,
+                ChipModule,
+                MockLanguageFieldComponent,
+                MockSiteFieldComponent
+            ],
+            mocks: [DotMessagePipe],
+            detectChanges: false,
+            providers: [
+                { provide: DotMessageService, useValue: messageServiceMock },
+                mockProvider(DotBrowsingService, {
+                    getSitesTreePath: jest.fn().mockReturnValue(of(mockSites)),
+                    getFoldersTreeNode: jest.fn().mockReturnValue(of(mockFolders))
+                }),
+                mockProvider(DotLanguagesService, {
+                    get: jest.fn().mockReturnValue(of(mockLocales))
+                }),
+                mockProvider(GlobalStore, {
+                    siteDetails: jest.fn().mockReturnValue(null),
+                    currentSiteId: jest.fn().mockReturnValue(null)
+                })
+            ]
+        });
+
+        beforeEach(() => {
+            spectator = createComponent({
+                props: {
+                    isLoading: false
+                } as unknown
+            });
+            component = spectator.component;
+        });
+
+        it('should not pre-populate when GlobalStore has no current site', () => {
+            const searchSpy = jest.spyOn(component.onSearch, 'emit');
+
+            spectator.detectChanges();
+
+            const formValues = component.form.getRawValue();
+            expect(formValues.systemSearchableFields.siteOrFolderId).toBe('');
+            expect(searchSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
@@ -6,7 +6,8 @@ import {
     viewChild,
     signal,
     computed,
-    DestroyRef
+    DestroyRef,
+    AfterViewInit
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
@@ -22,6 +23,7 @@ import { SelectModule } from 'primeng/select';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
 import { TreeNodeItem } from '@dotcms/dotcms-models';
+import { GlobalStore } from '@dotcms/store';
 import { DotMessagePipe } from '@dotcms/ui';
 
 import { LanguageFieldComponent } from './components/language-field/language-field.component';
@@ -63,7 +65,7 @@ interface ActiveFilter {
     ],
     templateUrl: './search.component.html'
 })
-export class SearchComponent {
+export class SearchComponent implements AfterViewInit {
     /**
      * Reference to the Popover component used for advanced search options.
      */
@@ -151,6 +153,12 @@ export class SearchComponent {
     readonly #destroyRef = inject(DestroyRef);
 
     /**
+     * Global store for accessing current site information.
+     * @private
+     */
+    readonly #globalStore = inject(GlobalStore);
+
+    /**
      * Flag to track if the component has been destroyed.
      * @private
      */
@@ -187,6 +195,18 @@ export class SearchComponent {
             .subscribe(() => {
                 this.doSearch();
             });
+    }
+
+    ngAfterViewInit(): void {
+        const siteDetails = this.#globalStore.siteDetails();
+        if (siteDetails?.identifier) {
+            this.form.patchValue({
+                systemSearchableFields: {
+                    siteOrFolderId: `site:${siteDetails.identifier}`
+                }
+            });
+            this.doSearch();
+        }
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
@@ -26,6 +26,7 @@ import { TreeNodeItem } from '@dotcms/dotcms-models';
 import { GlobalStore } from '@dotcms/store';
 import { DotMessagePipe } from '@dotcms/ui';
 
+import { ExistingContentStore } from '../../store/existing-content.store';
 import { LanguageFieldComponent } from './components/language-field/language-field.component';
 import { SiteFieldComponent } from './components/site-field/site-field.component';
 
@@ -159,6 +160,12 @@ export class SearchComponent implements AfterViewInit {
     readonly #globalStore = inject(GlobalStore);
 
     /**
+     * Existing content store for accessing preselection data passed from the relationship field.
+     * @private
+     */
+    readonly #existingContentStore = inject(ExistingContentStore);
+
+    /**
      * Flag to track if the component has been destroyed.
      * @private
      */
@@ -198,13 +205,23 @@ export class SearchComponent implements AfterViewInit {
     }
 
     ngAfterViewInit(): void {
-        const siteDetails = this.#globalStore.siteDetails();
-        if (siteDetails?.identifier) {
+        const preselection = this.#existingContentStore.siteOrFolderPreselection();
+
+        if (preselection?.value) {
             this.form.patchValue({
                 systemSearchableFields: {
-                    siteOrFolderId: `site:${siteDetails.identifier}`
+                    siteOrFolderId: preselection.value
                 }
             });
+        } else {
+            const siteDetails = this.#globalStore.siteDetails();
+            if (siteDetails?.identifier) {
+                this.form.patchValue({
+                    systemSearchableFields: {
+                        siteOrFolderId: `site:${siteDetails.identifier}`
+                    }
+                });
+            }
         }
     }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.ts
@@ -205,7 +205,6 @@ export class SearchComponent implements AfterViewInit {
                     siteOrFolderId: `site:${siteDetails.identifier}`
                 }
             });
-            this.doSearch();
         }
     }
 
@@ -344,11 +343,14 @@ export class SearchComponent implements AfterViewInit {
      */
     private getSiteDisplayLabel(siteOrFolderId: string): string {
         const siteFieldValue = this.$siteField()?.siteControl?.value as TreeNodeItem;
+        const nodeSelected = this.$siteField()?.store?.nodeSelected();
         let label: string;
 
-        // Try to get the site/folder name from the child component if available
-        if (siteFieldValue) {
+        // Try to get the site/folder name from the TreeSelect control or the store
+        if (siteFieldValue?.label) {
             label = siteFieldValue.label;
+        } else if (nodeSelected?.label) {
+            label = nodeSelected.label;
         } else {
             // Fallback to ID only
             label = siteOrFolderId;

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -37,6 +37,10 @@ type DialogData = {
     selectionMode: SelectionMode;
     currentItemsIds: string[];
     showFields?: string[] | null;
+    siteOrFolderPreselection?: {
+        value: string;
+        label: string;
+    } | null;
 };
 
 const STATIC_COLUMNS = 6;
@@ -120,7 +124,8 @@ export class DotSelectExistingContentComponent implements OnInit {
             contentTypeId: data.contentTypeId,
             selectionMode: data.selectionMode,
             selectedItemsIds: data.currentItemsIds,
-            showFields: data.showFields
+            showFields: data.showFields,
+            siteOrFolderPreselection: data.siteOrFolderPreselection
         });
     }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/store/existing-content.store.ts
@@ -25,6 +25,11 @@ const ViewMode = {
 
 type ViewMode = (typeof ViewMode)[keyof typeof ViewMode];
 
+export interface SiteOrFolderPreselection {
+    value: string;
+    label: string;
+}
+
 export interface ExistingContentState {
     contentTypeId: string;
     data: DotCMSContentlet[];
@@ -47,6 +52,7 @@ export interface ExistingContentState {
     };
     selectionItems: DotCMSContentlet[] | DotCMSContentlet | null;
     viewMode: ViewMode;
+    siteOrFolderPreselection: SiteOrFolderPreselection | null;
 }
 
 const paginationInitialState: ExistingContentState['pagination'] = {
@@ -67,7 +73,8 @@ const initialState: ExistingContentState = {
     pagination: { ...paginationInitialState },
     previousPagination: { ...paginationInitialState },
     selectionItems: null,
-    viewMode: ViewMode.all
+    viewMode: ViewMode.all,
+    siteOrFolderPreselection: null
 };
 
 /**
@@ -143,14 +150,16 @@ export const ExistingContentStore = signalStore(
                 selectionMode: SelectionMode;
                 selectedItemsIds: string[];
                 showFields?: string[] | null;
+                siteOrFolderPreselection?: SiteOrFolderPreselection | null;
             }>(
                 pipe(
-                    tap(({ selectionMode }) =>
+                    tap(({ selectionMode, siteOrFolderPreselection }) =>
                         patchState(store, {
                             status: ComponentStatus.LOADING,
                             selectionMode,
                             viewMode: ViewMode.all,
-                            pagination: { ...paginationInitialState }
+                            pagination: { ...paginationInitialState },
+                            siteOrFolderPreselection: siteOrFolderPreselection ?? null
                         })
                     ),
                     tap(({ contentTypeId }) => {


### PR DESCRIPTION
## Summary

- Auto-populate the Site/Folder filter in the "Add Related Content" relationship dialog with the current site from GlobalStore
- Follows the established pattern used in `dot-tags-create` component — reads `GlobalStore.siteDetails()` synchronously, no new HTTP requests
- Users can still manually change or clear the pre-selected site

Closes #33529

## Changes

| File | Change |
|------|--------|
| `search.component.ts` | Inject GlobalStore, pre-populate `siteOrFolderId` form field in `ngAfterViewInit`, trigger initial filtered search |
| `site-field.component.ts` | Inject GlobalStore, enhance `writeValue()` to handle programmatic `site:{id}` values |
| `site-field.store.ts` | Add `setInitialSelection(id, type, label)` method to create synthetic TreeNodeItem |
| `search.component.spec.ts` | Add tests for site pre-population (with site / without site) |
| `site-field.component.spec.ts` | Add tests for `writeValue` with site and folder values |
| `site-field.store.spec.ts` | Add tests for `setInitialSelection` method |

## Acceptance Criteria

- [ ] AC1: Site/Folder tree-select is pre-populated with the current site from GlobalStore when opening "Add Related Content"
- [ ] AC2: Initial content search is filtered by the pre-selected site
- [ ] AC3: Pre-selected site appears as an active filter chip
- [ ] AC4: User can clear the pre-selected site filter
- [ ] AC5: User can change the pre-selected site to a different site or folder
- [ ] AC6: If GlobalStore has no current site, field remains empty (graceful fallback)
- [ ] AC7: No new HTTP requests — reads from existing GlobalStore signal state

## Test Plan

- [ ] Open any content in the new Edit Content experience
- [ ] Go to the Relationships tab and click "Add Related Content"
- [ ] Verify the Site/Folder field is pre-populated with the current site (from the top-bar site selector)
- [ ] Verify the initial search results are filtered by that site
- [ ] Verify you can clear the site filter and search across all sites
- [ ] Verify you can change to a different site/folder
- [ ] Switch the global site selector to a different site, open the dialog again, and verify it picks up the new site
