### PR TITLE
feat(identifier): denormalize base_type onto identifier table

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/beans/Identifier.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/Identifier.java
@@ -61,6 +61,7 @@ public class Identifier implements UUIDable,Serializable,Permissionable,Categori
     private String owner;
     private Date createDate;
     private String assetSubType;
+    private Integer baseType;
     
     /**
      * @deprecated As of 2016-05-16, replaced by {@link #getId()}
@@ -296,6 +297,14 @@ public class Identifier implements UUIDable,Serializable,Permissionable,Categori
 
     public void setAssetSubType(String assetSubType) {
         this.assetSubType = assetSubType;
+    }
+
+    public Integer getBaseType() {
+        return baseType;
+    }
+
+    public void setBaseType(final Integer baseType) {
+        this.baseType = baseType;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotmarketing/beans/transform/IdentifierTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/beans/transform/IdentifierTransformer.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import static com.dotmarketing.business.IdentifierFactory.ASSET_NAME;
 import static com.dotmarketing.business.IdentifierFactory.ASSET_SUBTYPE;
 import static com.dotmarketing.business.IdentifierFactory.ASSET_TYPE;
+import static com.dotmarketing.business.IdentifierFactory.BASE_TYPE;
 import static com.dotmarketing.business.IdentifierFactory.CREATE_DATE;
 import static com.dotmarketing.business.IdentifierFactory.HOST_INODE;
 import static com.dotmarketing.business.IdentifierFactory.ID;
@@ -60,6 +61,10 @@ public class IdentifierTransformer implements DBTransformer<Identifier> {
         identifier.setOwner((String) map.get(OWNER));
         identifier.setCreateDate((Date) map.get(CREATE_DATE));
         identifier.setAssetSubType((String) map.get(ASSET_SUBTYPE));
+        final Object baseTypeObj = map.get(BASE_TYPE);
+        if (baseTypeObj != null) {
+            identifier.setBaseType(((Number) baseTypeObj).intValue());
+        }
         return identifier;
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactory.java
@@ -30,6 +30,7 @@ public abstract class IdentifierFactory {
 	public static final String OWNER = "owner";
 	public static final String CREATE_DATE = "create_date";
 	public static final String ASSET_SUBTYPE = "asset_subtype";
+	public static final String BASE_TYPE = "base_type";
 
 	/**
 	 * Retrieves all identifiers matching a URI pattern.

--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
@@ -358,6 +358,7 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
 			identifier.setParentPath(folder.getPath());
 			identifier.setAssetName(uri);
 			identifier.setAssetSubType(contentlet.getContentType().variable());
+			identifier.setBaseType(contentlet.getContentType().baseType().getType());
 		} else if (versionable instanceof WebAsset) {
 			identifier.setURI(((WebAsset) versionable).getURI(folder));
 			identifier.setAssetType(versionable.getVersionType());
@@ -440,6 +441,7 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
 				identifier.setParentPath("/");
 				identifier.setAssetName(uri);
 				identifier.setAssetSubType(cont.getContentType().variable());
+				identifier.setBaseType(cont.getContentType().baseType().getType());
 			} else if (versionable instanceof Link) {
 				identifier.setAssetName(versionable.getInode());
 				identifier.setParentPath("/");
@@ -448,6 +450,7 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
 				identifier.setAssetType(Identifier.ASSET_TYPE_CONTENTLET);
 				identifier.setParentPath("/");
 				identifier.setAssetSubType(Host.HOST_VELOCITY_VAR_NAME);
+				identifier.setBaseType(((Contentlet) versionable).getContentType().baseType().getType());
 			} else {
 				identifier.setURI(uri);
 			}
@@ -517,13 +520,13 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
         String query;
         if (UtilMethods.isSet(id.getId())) {
             if (isIdentifier(id.getId())) {
-                query = "UPDATE identifier set parent_path=?, asset_name=?, host_inode=?, asset_type=?, syspublish_date=?, sysexpire_date=?, owner=?, create_date=?, asset_subtype=? where id=?";
+                query = "UPDATE identifier set parent_path=?, asset_name=?, host_inode=?, asset_type=?, syspublish_date=?, sysexpire_date=?, owner=?, create_date=?, asset_subtype=?, base_type=? where id=?";
             } else {
-                query = "INSERT INTO identifier (parent_path,asset_name,host_inode,asset_type,syspublish_date,sysexpire_date,owner,create_date,asset_subtype,id) values (?,?,?,?,?,?,?,?,?,?)";
+                query = "INSERT INTO identifier (parent_path,asset_name,host_inode,asset_type,syspublish_date,sysexpire_date,owner,create_date,asset_subtype,base_type,id) values (?,?,?,?,?,?,?,?,?,?,?)";
             }
         } else {
             id.setId(UUIDGenerator.generateUuid());
-            query = "INSERT INTO identifier (parent_path,asset_name,host_inode,asset_type,syspublish_date,sysexpire_date,owner,create_date,asset_subtype,id) values (?,?,?,?,?,?,?,?,?,?)";
+            query = "INSERT INTO identifier (parent_path,asset_name,host_inode,asset_type,syspublish_date,sysexpire_date,owner,create_date,asset_subtype,base_type,id) values (?,?,?,?,?,?,?,?,?,?,?)";
         }
 
         DotConnect dc = new DotConnect();
@@ -539,6 +542,7 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
         dc.addParam(id.getOwner());
         dc.addParam(id.getCreateDate());
         dc.addParam(id.getAssetSubType());
+        dc.addParam(id.getBaseType());
         dc.addParam(id.getId());
 
         

--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
@@ -521,29 +521,29 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
         if (UtilMethods.isSet(id.getId())) {
             if (isIdentifier(id.getId())) {
                 query = "UPDATE identifier set parent_path=?, asset_name=?, host_inode=?, asset_type=?, syspublish_date=?, sysexpire_date=?, owner=?, create_date=?, asset_subtype=?, base_type=? where id=?";
+                // Guard against stale cached Identifiers (loaded before base_type was
+                // denormalized) writing null back and temporarily undoing the backfill.
+                // Only needed on UPDATE — INSERT callers must always supply base_type.
+                if (id.getBaseType() == null && UtilMethods.isSet(id.getAssetSubType())) {
+                    final Integer resolvedBaseType = Try.of(() ->
+                            APILocator.getContentTypeAPI(APILocator.systemUser())
+                                    .find(id.getAssetSubType())
+                                    .baseType()
+                                    .getType())
+                            .onFailure(e -> Logger.warn(IdentifierFactoryImpl.class,
+                                    "Could not resolve base_type for asset_subtype=" + id.getAssetSubType()
+                                    + " on identifier=" + id.getId() + ": " + e.getMessage()))
+                            .getOrNull();
+                    if (resolvedBaseType != null) {
+                        id.setBaseType(resolvedBaseType);
+                    }
+                }
             } else {
                 query = "INSERT INTO identifier (parent_path,asset_name,host_inode,asset_type,syspublish_date,sysexpire_date,owner,create_date,asset_subtype,base_type,id) values (?,?,?,?,?,?,?,?,?,?,?)";
             }
         } else {
             id.setId(UUIDGenerator.generateUuid());
             query = "INSERT INTO identifier (parent_path,asset_name,host_inode,asset_type,syspublish_date,sysexpire_date,owner,create_date,asset_subtype,base_type,id) values (?,?,?,?,?,?,?,?,?,?,?)";
-        }
-
-        // Guard against stale cached Identifiers (loaded before base_type was denormalized)
-        // writing null back and temporarily undoing the backfill for this row.
-        if (id.getBaseType() == null && UtilMethods.isSet(id.getAssetSubType())) {
-            final Integer resolvedBaseType = Try.of(() ->
-                    APILocator.getContentTypeAPI(APILocator.systemUser())
-                            .find(id.getAssetSubType())
-                            .baseType()
-                            .getType())
-                    .onFailure(e -> Logger.warn(IdentifierFactoryImpl.class,
-                            "Could not resolve base_type for asset_subtype=" + id.getAssetSubType()
-                            + " on identifier=" + id.getId() + ": " + e.getMessage()))
-                    .getOrNull();
-            if (resolvedBaseType != null) {
-                id.setBaseType(resolvedBaseType);
-            }
         }
 
         DotConnect dc = new DotConnect();

--- a/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/IdentifierFactoryImpl.java
@@ -529,6 +529,23 @@ public class IdentifierFactoryImpl extends IdentifierFactory {
             query = "INSERT INTO identifier (parent_path,asset_name,host_inode,asset_type,syspublish_date,sysexpire_date,owner,create_date,asset_subtype,base_type,id) values (?,?,?,?,?,?,?,?,?,?,?)";
         }
 
+        // Guard against stale cached Identifiers (loaded before base_type was denormalized)
+        // writing null back and temporarily undoing the backfill for this row.
+        if (id.getBaseType() == null && UtilMethods.isSet(id.getAssetSubType())) {
+            final Integer resolvedBaseType = Try.of(() ->
+                    APILocator.getContentTypeAPI(APILocator.systemUser())
+                            .find(id.getAssetSubType())
+                            .baseType()
+                            .getType())
+                    .onFailure(e -> Logger.warn(IdentifierFactoryImpl.class,
+                            "Could not resolve base_type for asset_subtype=" + id.getAssetSubType()
+                            + " on identifier=" + id.getId() + ": " + e.getMessage()))
+                    .getOrNull();
+            if (resolvedBaseType != null) {
+                id.setBaseType(resolvedBaseType);
+            }
+        }
+
         DotConnect dc = new DotConnect();
         dc.setSQL(query);
 

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJob.java
@@ -132,7 +132,7 @@ public class PopulateIdentifierBaseTypeJob extends DotStatefulJob {
      * that the populate query can actually complete. Orphaned rows (asset_subtype with no
      * matching structure entry) are excluded so they cannot keep the job running indefinitely.
      */
-    static boolean hasPendingRows() {
+    public static boolean hasPendingRows() {
         try {
             final List<?> result = new DotConnect()
                     .setSQL(PENDING_ROWS_QUERY)

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJob.java
@@ -46,21 +46,25 @@ public class PopulateIdentifierBaseTypeJob extends DotStatefulJob {
         Logger.info(this, "PopulateIdentifierBaseTypeJob: starting");
         try {
             if (!hasPendingRows()) {
-                Logger.info(this, "PopulateIdentifierBaseTypeJob: no rows with null base_type found — migration already complete, unscheduling");
+                Logger.info(this, "PopulateIdentifierBaseTypeJob: no rows with null base_type — migration already complete, unscheduling");
                 removeJob();
                 return;
             }
 
             final int updated = new PopulateIdentifierBaseTypeUtil().populate();
+            Logger.info(this, "PopulateIdentifierBaseTypeJob: populate() returned — " + updated + " rows updated");
 
-            if (updated == 0) {
-                Logger.info(this, "PopulateIdentifierBaseTypeJob: no rows updated — migration already complete, unscheduling");
+            // Only unschedule when the migration is confirmed complete.
+            // populate() may return early due to interruption, leaving pending rows;
+            // in that case we keep the job scheduled so it resumes on the next trigger.
+            if (!hasPendingRows()) {
+                Logger.info(this, "PopulateIdentifierBaseTypeJob: migration complete, unscheduling");
+                removeJob();
             } else {
-                Logger.info(this, "PopulateIdentifierBaseTypeJob: completed — " + updated + " rows updated, unscheduling");
+                Logger.info(this, "PopulateIdentifierBaseTypeJob: pending rows remain (interrupted or partial run) — will resume on next trigger");
             }
-            removeJob();
         } catch (final SchedulerException e) {
-            Logger.error(this, "PopulateIdentifierBaseTypeJob: unable to remove job after completion", e);
+            Logger.error(this, "PopulateIdentifierBaseTypeJob: unable to remove job", e);
             throw new DotRuntimeException(e);
         }
     }

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJob.java
@@ -1,0 +1,151 @@
+package com.dotmarketing.quartz.job;
+
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.quartz.DotStatefulJob;
+import com.dotmarketing.quartz.QuartzUtils;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
+import com.google.common.annotations.VisibleForTesting;
+import io.vavr.Lazy;
+import io.vavr.control.Try;
+import org.quartz.JobDataMap;
+import org.quartz.JobDetail;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleTrigger;
+import org.quartz.TriggerUtils;
+
+import java.util.Date;
+
+import java.util.List;
+
+/**
+ * Quartz job that populates the {@code base_type} column on the {@code identifier} table in the
+ * background. Scheduled by the startup task {@code Task260331AddBaseTypeColumnToIdentifier} so
+ * that large customer databases are not blocked during startup.
+ *
+ * <p>The job removes itself from the scheduler once population completes — including when it
+ * detects that no rows need updating (migration already finished).
+ */
+public class PopulateIdentifierBaseTypeJob extends DotStatefulJob {
+
+    private static final String CONFIG_PROPERTY_HOURS_INTERVAL =
+            "populateIdentifierBaseTypeJob.hours.interval";
+    private static final Lazy<Integer> HOURS_INTERVAL = Lazy.of(
+            () -> Config.getIntProperty(CONFIG_PROPERTY_HOURS_INTERVAL, 4));
+
+    private static final String PENDING_ROWS_QUERY =
+            "SELECT 1 FROM identifier " +
+            "WHERE base_type IS NULL AND asset_subtype IS NOT NULL LIMIT 1";
+
+    @Override
+    public void run(final JobExecutionContext jobContext) throws JobExecutionException {
+        Logger.info(this, "PopulateIdentifierBaseTypeJob: starting");
+        try {
+            if (!hasPendingRows()) {
+                Logger.info(this, "PopulateIdentifierBaseTypeJob: no rows with null base_type found — migration already complete, unscheduling");
+                removeJob();
+                return;
+            }
+
+            final int updated = new PopulateIdentifierBaseTypeUtil().populate();
+
+            if (updated == 0) {
+                Logger.info(this, "PopulateIdentifierBaseTypeJob: no rows updated — migration already complete, unscheduling");
+            } else {
+                Logger.info(this, "PopulateIdentifierBaseTypeJob: completed — " + updated + " rows updated, unscheduling");
+            }
+            removeJob();
+        } catch (final SchedulerException e) {
+            Logger.error(this, "PopulateIdentifierBaseTypeJob: unable to remove job after completion", e);
+            throw new DotRuntimeException(e);
+        }
+    }
+
+    /**
+     * Schedules the job. Skips scheduling if there are no rows with a null {@code base_type},
+     * meaning the migration has already been completed. Safe to call multiple times — a no-op if
+     * the job is already scheduled.
+     */
+    public static void fireJob() {
+        if (!hasPendingRows()) {
+            Logger.info(PopulateIdentifierBaseTypeJob.class,
+                    "PopulateIdentifierBaseTypeJob: no rows with null base_type — migration already complete, skipping scheduling");
+            return;
+        }
+
+        final String jobName = getJobName();
+        final String groupName = getJobGroupName();
+        final var scheduler = QuartzUtils.getScheduler();
+
+        final var jobDetail = Try.of(() -> scheduler.getJobDetail(jobName, groupName))
+                .onFailure(e -> Logger.error(PopulateIdentifierBaseTypeJob.class,
+                        String.format("Error retrieving job detail [%s, %s]", jobName, groupName), e))
+                .getOrNull();
+
+        if (jobDetail != null) {
+            Logger.info(PopulateIdentifierBaseTypeJob.class,
+                    String.format("Job [%s, %s] already scheduled — skipping", jobName, groupName));
+            return;
+        }
+
+        final var newJobDetail = new JobDetail(jobName, groupName, PopulateIdentifierBaseTypeJob.class);
+        newJobDetail.setJobDataMap(new JobDataMap());
+        newJobDetail.setDurability(false);
+        newJobDetail.setVolatility(false);
+        newJobDetail.setRequestsRecovery(true);
+
+        final var trigger = TriggerUtils.makeHourlyTrigger(HOURS_INTERVAL.get());
+        trigger.setName(jobName);
+        trigger.setGroup(groupName);
+        trigger.setJobName(jobName);
+        trigger.setJobGroup(groupName);
+        trigger.setStartTime(new Date()); // fire immediately on first schedule
+        trigger.setMisfireInstruction(SimpleTrigger.MISFIRE_INSTRUCTION_FIRE_NOW);
+
+        try {
+            scheduler.scheduleJob(newJobDetail, trigger);
+            Logger.info(PopulateIdentifierBaseTypeJob.class,
+                    "PopulateIdentifierBaseTypeJob scheduled successfully");
+        } catch (final Exception e) {
+            throw new DotRuntimeException("Error scheduling PopulateIdentifierBaseTypeJob", e);
+        }
+    }
+
+    /**
+     * Returns {@code true} if any {@code identifier} rows still have a null {@code base_type}
+     * with a non-null {@code asset_subtype} — i.e., there is migration work remaining.
+     */
+    static boolean hasPendingRows() {
+        try {
+            final List<?> result = new DotConnect()
+                    .setSQL(PENDING_ROWS_QUERY)
+                    .loadObjectResults();
+            return !result.isEmpty();
+        } catch (final DotDataException e) {
+            Logger.error(PopulateIdentifierBaseTypeJob.class,
+                    "Error checking for pending base_type rows: " + e.getMessage(), e);
+            // Err on the side of running — better to do unnecessary work than skip needed work
+            return true;
+        }
+    }
+
+    @VisibleForTesting
+    static void removeJob() throws SchedulerException {
+        QuartzUtils.removeJob(getJobName(), getJobGroupName());
+    }
+
+    @VisibleForTesting
+    static String getJobName() {
+        return PopulateIdentifierBaseTypeJob.class.getSimpleName();
+    }
+
+    @VisibleForTesting
+    static String getJobGroupName() {
+        return getJobName() + "_Group";
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJob.java
@@ -37,9 +37,16 @@ public class PopulateIdentifierBaseTypeJob extends DotStatefulJob {
     private static final Lazy<Integer> HOURS_INTERVAL = Lazy.of(
             () -> Config.getIntProperty(CONFIG_PROPERTY_HOURS_INTERVAL, 4));
 
+    /**
+     * Counts only rows that can actually be resolved by the populate query — i.e. rows with a
+     * matching entry in the structure table. Orphaned identifiers whose asset_subtype no longer
+     * exists in structure are intentionally excluded: the populate loop returns 0 for them and
+     * they must not keep the job alive indefinitely.
+     */
     private static final String PENDING_ROWS_QUERY =
-            "SELECT 1 FROM identifier " +
-            "WHERE base_type IS NULL AND asset_subtype IS NOT NULL LIMIT 1";
+            "SELECT 1 FROM identifier i " +
+            "INNER JOIN structure s ON s.velocity_var_name = i.asset_subtype " +
+            "WHERE i.base_type IS NULL LIMIT 1";
 
     @Override
     public void run(final JobExecutionContext jobContext) throws JobExecutionException {
@@ -121,7 +128,9 @@ public class PopulateIdentifierBaseTypeJob extends DotStatefulJob {
 
     /**
      * Returns {@code true} if any {@code identifier} rows still have a null {@code base_type}
-     * with a non-null {@code asset_subtype} — i.e., there is migration work remaining.
+     * and have a matching entry in the {@code structure} table — i.e., there is migration work
+     * that the populate query can actually complete. Orphaned rows (asset_subtype with no
+     * matching structure entry) are excluded so they cannot keep the job running indefinitely.
      */
     static boolean hasPendingRows() {
         try {

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeUtil.java
@@ -1,0 +1,124 @@
+package com.dotmarketing.quartz.job;
+
+import com.dotcms.business.WrapInTransaction;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
+
+/**
+ * Populates the {@code base_type} column on the {@code identifier} table in small, independently
+ * committed batches so that large customer databases (millions of rows) are not impacted by
+ * long-running locks.
+ *
+ * <h3>Algorithm</h3>
+ * <ol>
+ *   <li>Run a single-statement batched UPDATE that touches at most {@code BATCH_SIZE} rows:
+ *       <pre>
+ *       UPDATE identifier
+ *         SET base_type = s.structuretype
+ *         FROM structure s
+ *        WHERE identifier.asset_subtype = s.velocity_var_name
+ *          AND identifier.base_type IS NULL
+ *          AND identifier.id IN (
+ *              SELECT id FROM identifier
+ *               WHERE base_type IS NULL
+ *                 AND asset_subtype IS NOT NULL
+ *               LIMIT :batchSize
+ *          )
+ *       </pre>
+ *   </li>
+ *   <li>Commit immediately (each call to {@link #processBatch()} is {@code @WrapInTransaction}).</li>
+ *   <li>Sleep for {@code SLEEP_BETWEEN_BATCHES_MS} milliseconds to relieve DB pressure.</li>
+ *   <li>Repeat until no rows are updated.</li>
+ * </ol>
+ *
+ * <p>Because rows that have been assigned a {@code base_type} no longer satisfy
+ * {@code base_type IS NULL}, each iteration naturally advances to the next unprocessed set
+ * without needing OFFSET or cursor state. The operation is fully idempotent.
+ */
+public class PopulateIdentifierBaseTypeUtil {
+
+    private static final int BATCH_SIZE = Config.getIntProperty(
+            "task.populateIdentifierBaseType.batchsize", 500);
+
+    private static final long SLEEP_BETWEEN_BATCHES_MS = Config.getLongProperty(
+            "task.populateIdentifierBaseType.sleep.ms", 250L);
+
+    /**
+     * Batched UPDATE: resolves base_type from the structure table for at most BATCH_SIZE rows
+     * whose base_type is still NULL.
+     */
+    private static final String UPDATE_BATCH =
+            "UPDATE identifier " +
+            "   SET base_type = s.structuretype " +
+            "  FROM structure s " +
+            " WHERE identifier.asset_subtype = s.velocity_var_name " +
+            "   AND identifier.base_type IS NULL " +
+            "   AND identifier.id IN ( " +
+            "       SELECT id FROM identifier " +
+            "        WHERE base_type IS NULL " +
+            "          AND asset_subtype IS NOT NULL " +
+            "        LIMIT " + BATCH_SIZE +
+            "   )";
+
+    /**
+     * Runs the full population loop, committing one small batch at a time until every
+     * eligible {@code identifier} row has a non-null {@code base_type}.
+     *
+     * @return Total number of rows updated.
+     */
+    public int populate() {
+        Logger.info(this, "PopulateIdentifierBaseType: starting — batch size=" + BATCH_SIZE
+                + ", sleep between batches=" + SLEEP_BETWEEN_BATCHES_MS + "ms");
+
+        int total = 0;
+        int pass = 0;
+
+        while (true) {
+            final int updated = processBatch();
+            if (updated == 0) {
+                break;
+            }
+
+            total += updated;
+            pass++;
+
+            if (pass % 100 == 0) {
+                Logger.info(this, "PopulateIdentifierBaseType: " + total + " rows updated so far...");
+            }
+
+            if (SLEEP_BETWEEN_BATCHES_MS > 0) {
+                try {
+                    Thread.sleep(SLEEP_BETWEEN_BATCHES_MS);
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    Logger.warn(this, "PopulateIdentifierBaseType: interrupted — stopping early after "
+                            + total + " rows");
+                    break;
+                }
+            }
+        }
+
+        Logger.info(this, "PopulateIdentifierBaseType: done — total rows updated: " + total);
+        return total;
+    }
+
+    /**
+     * Executes a single batch UPDATE in its own transaction. Keeping the transaction small
+     * (at most {@code BATCH_SIZE} rows) avoids long-held row locks on busy tables.
+     *
+     * @return Number of rows updated in this batch; 0 means all rows are already populated.
+     */
+    @WrapInTransaction
+    private int processBatch() {
+        try {
+            return new DotConnect().executeUpdate(UPDATE_BATCH);
+        } catch (final DotDataException e) {
+            throw new DotRuntimeException(
+                    "PopulateIdentifierBaseType: error executing batch update", e);
+        }
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeUtil.java
@@ -2,10 +2,12 @@ package com.dotmarketing.quartz.job;
 
 import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import java.sql.Connection;
 
 /**
  * Populates the {@code base_type} column on the {@code identifier} table in small, independently
@@ -111,11 +113,13 @@ public class PopulateIdentifierBaseTypeUtil {
      *
      * @return Number of rows updated in this batch; 0 means all rows are already populated.
      */
-    @WrapInTransaction
     private int processBatch() {
-        try {
-            return new DotConnect().executeUpdate(UPDATE_BATCH);
-        } catch (final DotDataException e) {
+        try(Connection conn = DbConnectionFactory.getDataSource().getConnection()) {
+            conn.setAutoCommit(false);
+            int result= new DotConnect().executeUpdate(UPDATE_BATCH, conn);
+            conn.commit();
+            return result;
+        } catch (final Exception e) {
             throw new DotRuntimeException(
                     "PopulateIdentifierBaseType: error executing batch update", e);
         }

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeUtil.java
@@ -1,6 +1,5 @@
 package com.dotmarketing.quartz.job;
 
-import com.dotcms.business.WrapInTransaction;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
@@ -116,7 +115,7 @@ public class PopulateIdentifierBaseTypeUtil {
     private int processBatch() {
         try(Connection conn = DbConnectionFactory.getDataSource().getConnection()) {
             conn.setAutoCommit(false);
-            int result= new DotConnect().executeUpdate(UPDATE_BATCH, conn);
+            int result = new DotConnect().executeUpdate(conn, UPDATE_BATCH);
             conn.commit();
             return result;
         } catch (final Exception e) {

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifier.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifier.java
@@ -1,0 +1,79 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.quartz.job.PopulateIdentifierBaseTypeJob;
+import com.dotmarketing.startup.StartupTask;
+import com.dotmarketing.util.Logger;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Adds a {@code base_type} column to the {@code identifier} table and creates an index on it.
+ * The column is populated asynchronously by {@link PopulateIdentifierBaseTypeJob} to avoid
+ * long-running transactions on large customer databases.
+ *
+ * @since Apr 7th, 2026
+ */
+public class Task260407AddBaseTypeColumnToIdentifier implements StartupTask {
+
+    private static final String COLUMN_NAME = "base_type";
+    private static final String INDEX_NAME = "idx_identifier_base_type";
+
+    @Override
+    public boolean forceRun() {
+
+        // only run if the index has not been built yet
+        try {
+            final List<Map<String, Object>> result = new DotConnect()
+                    .setSQL("SELECT 1 FROM pg_indexes WHERE tablename = 'identifier' AND indexname = ?")
+                    .addParam(INDEX_NAME)
+                    .loadObjectResults();
+            return result.isEmpty();
+        } catch (final DotDataException e) {
+            Logger.error(this, "Error checking for index " + INDEX_NAME + ": " + e.getMessage(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public void executeUpgrade() throws DotDataException, DotRuntimeException {
+        addBaseTypeColumn();
+        createIndex();
+        PopulateIdentifierBaseTypeJob.fireJob();
+    }
+
+    /**
+     * Adds the base_type integer column to the identifier table.
+     */
+    private void addBaseTypeColumn() throws DotDataException {
+        try {
+            Logger.info(this, "Adding column " + COLUMN_NAME + " to identifier table");
+            new DotConnect().executeStatement(
+                    "ALTER TABLE identifier ADD COLUMN IF NOT EXISTS "
+                            + COLUMN_NAME + " INT4");
+        } catch (final SQLException e) {
+            throw new DotDataException(
+                    "Failed to add column " + COLUMN_NAME + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Creates an index on identifier.base_type for efficient filtering.
+     */
+    private void createIndex() throws DotDataException {
+        try {
+            Logger.info(this, "Creating index " + INDEX_NAME + " on identifier table");
+            new DotConnect().executeStatement(
+                    "CREATE INDEX IF NOT EXISTS " + INDEX_NAME
+                            + " ON identifier (" + COLUMN_NAME + ")");
+        } catch (final SQLException e) {
+            throw new DotDataException(
+                    "Failed to create index " + INDEX_NAME + ": " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifier.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifier.java
@@ -38,8 +38,10 @@ public class Task260407AddBaseTypeColumnToIdentifier implements StartupTask {
             // DDL uses IF NOT EXISTS so re-running executeUpgrade() is always safe.
             return PopulateIdentifierBaseTypeJob.hasPendingRows();
         } catch (final DotDataException e) {
-            Logger.error(this, "Error in forceRun() for " + INDEX_NAME + ": " + e.getMessage(), e);
-            return false;
+            // Fail open — a transient DB error during startup must not permanently skip the
+            // migration. executeUpgrade() uses IF NOT EXISTS so re-running is always safe.
+            Logger.error(this, "Error in forceRun() for " + INDEX_NAME + ", defaulting to run: " + e.getMessage(), e);
+            return true;
         }
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifier.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifier.java
@@ -25,16 +25,20 @@ public class Task260407AddBaseTypeColumnToIdentifier implements StartupTask {
 
     @Override
     public boolean forceRun() {
-
-        // only run if the index has not been built yet
         try {
+            // Run if the index has not been created yet
             final List<Map<String, Object>> result = new DotConnect()
                     .setSQL("SELECT 1 FROM pg_indexes WHERE tablename = 'identifier' AND indexname = ?")
                     .addParam(INDEX_NAME)
                     .loadObjectResults();
-            return result.isEmpty();
+            if (result.isEmpty()) {
+                return true;
+            }
+            // Also run if the backfill is incomplete — handles server restarts mid-migration.
+            // DDL uses IF NOT EXISTS so re-running executeUpgrade() is always safe.
+            return PopulateIdentifierBaseTypeJob.hasPendingRows();
         } catch (final DotDataException e) {
-            Logger.error(this, "Error checking for index " + INDEX_NAME + ": " + e.getMessage(), e);
+            Logger.error(this, "Error in forceRun() for " + INDEX_NAME + ": " + e.getMessage(), e);
             return false;
         }
     }

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -265,6 +265,7 @@ import com.dotmarketing.startup.runonce.Task260320AddPluginsPortletToMenu;
 import com.dotmarketing.startup.runonce.Task260324AddIdentifierPathTriggerIndex;
 import com.dotmarketing.startup.runonce.Task260403SetLz4CompressionOnTextColumns;
 import com.dotmarketing.startup.runonce.Task260403SetPermissionReferenceUnlogged;
+import com.dotmarketing.startup.runonce.Task260407AddBaseTypeColumnToIdentifier;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -604,6 +605,7 @@ public class TaskLocatorUtil {
         .add(Task260324AddIdentifierPathTriggerIndex.class)
         .add(Task260403SetLz4CompressionOnTextColumns.class)
         .add(Task260403SetPermissionReferenceUnlogged.class)
+        .add(Task260407AddBaseTypeColumnToIdentifier.class)
         .build();
 
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());

--- a/dotCMS/src/main/resources/postgres.sql
+++ b/dotCMS/src/main/resources/postgres.sql
@@ -1028,6 +1028,7 @@ create table identifier (
    owner varchar(255),
    create_date timestamptz,
    asset_subtype varchar(255),
+   base_type int4,
    primary key (id),
    unique (parent_path, asset_name, host_inode)
 );
@@ -1517,6 +1518,7 @@ create index idx_preference_1 on user_preferences (preference);
 create index idx_identifier_pub on identifier (syspublish_date);
 create index idx_identifier_exp on identifier (sysexpire_date);
 create index idx_identifier_asset_subtype on identifier (asset_subtype);
+create index idx_identifier_base_type on identifier (base_type);
 create index idx_user_clickstream11 on clickstream (host_id);
 create index idx_user_clickstream12 on clickstream (last_page_id);
 create index idx_user_clickstream15 on clickstream (browser_name);

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -31,6 +31,7 @@ import com.dotmarketing.startup.runonce.Task251103AddStylePropertiesColumnInMult
 import com.dotmarketing.startup.runonce.Task251212AddVersionColumnIndicesTableTest;
 import com.dotmarketing.startup.runonce.Task260206AddUsagePortletToMenuTest;
 import com.dotmarketing.startup.runonce.Task260320AddPluginsPortletToMenuTest;
+import com.dotmarketing.startup.runonce.Task260407AddBaseTypeColumnToIdentifierTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -73,6 +74,7 @@ import org.junit.runners.Suite;
         Task251212AddVersionColumnIndicesTableTest.class,
         Task260206AddUsagePortletToMenuTest.class,
         Task260320AddPluginsPortletToMenuTest.class,
+        Task260407AddBaseTypeColumnToIdentifierTest.class,
 })
 
 public class MainSuite3a {

--- a/dotcms-integration/src/test/java/com/dotmarketing/business/IdentifierFactoryTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/business/IdentifierFactoryTest.java
@@ -898,4 +898,104 @@ public class IdentifierFactoryTest {
         db.loadResult();
     }
 
+    /**
+     * Method to test: {@link IdentifierFactoryImpl#saveIdentifier(com.dotmarketing.beans.Identifier)}
+     * When: A new contentlet identifier is saved via createNewIdentifier
+     * Should: Persist base_type and read it back correctly via loadFromDb
+     */
+    @Test
+    public void test_saveIdentifier_persistsBaseType() throws DotDataException, DotSecurityException {
+        final Contentlet contentlet = TestDataUtils.getGenericContentContent(true,
+                APILocator.getLanguageAPI().getDefaultLanguage().getId(), defaultHost);
+
+        final String identifierId = contentlet.getIdentifier();
+        final com.dotmarketing.beans.Identifier identifier = factory.find(identifierId);
+
+        assertNotNull("Identifier should not be null", identifier);
+        assertNotNull("base_type should be set when creating a contentlet identifier",
+                identifier.getBaseType());
+        assertEquals("base_type should match CONTENT base type",
+                com.dotcms.contenttype.model.type.BaseContentType.CONTENT.getType(),
+                (int) identifier.getBaseType());
+    }
+
+    /**
+     * Method to test: {@link IdentifierFactoryImpl#saveIdentifier(com.dotmarketing.beans.Identifier)}
+     * When: A file asset contentlet identifier is created
+     * Should: Persist the FILEASSET base_type value
+     */
+    @Test
+    public void test_saveIdentifier_persistsFileAssetBaseType() throws DotDataException, DotSecurityException {
+        final Contentlet fileAsset = TestDataUtils.getFileAssetContent(true,
+                APILocator.getLanguageAPI().getDefaultLanguage().getId());
+
+        final com.dotmarketing.beans.Identifier identifier = factory.find(fileAsset.getIdentifier());
+
+        assertNotNull("Identifier should not be null", identifier);
+        assertNotNull("base_type should be set for file asset identifiers", identifier.getBaseType());
+        assertEquals("base_type should match FILEASSET base type",
+                com.dotcms.contenttype.model.type.BaseContentType.FILEASSET.getType(),
+                (int) identifier.getBaseType());
+    }
+
+    /**
+     * Method to test: {@link IdentifierFactoryImpl#saveIdentifier(com.dotmarketing.beans.Identifier)}
+     * When: An identifier is updated (round-trip)
+     * Should: Preserve base_type through update
+     */
+    @Test
+    public void test_saveIdentifier_preservesBaseTypeOnUpdate() throws DotDataException, DotSecurityException {
+        final Contentlet contentlet = TestDataUtils.getGenericContentContent(true,
+                APILocator.getLanguageAPI().getDefaultLanguage().getId(), defaultHost);
+
+        final com.dotmarketing.beans.Identifier identifier = factory.find(contentlet.getIdentifier());
+        assertNotNull(identifier.getBaseType());
+
+        // Mutate a non-base_type field and re-save
+        identifier.setOwner("test-owner-update");
+        factory.saveIdentifier(identifier);
+
+        ic.removeFromCacheByIdentifier(identifier.getId());
+        final com.dotmarketing.beans.Identifier reloaded = factory.loadFromDb(identifier.getId());
+
+        assertNotNull("base_type should survive a re-save", reloaded.getBaseType());
+        assertEquals("base_type should be unchanged after re-save",
+                identifier.getBaseType(), reloaded.getBaseType());
+    }
+
+    /**
+     * Method to test: {@link com.dotmarketing.beans.transform.IdentifierTransformer}
+     * When: An identifier row with base_type is loaded from the DB
+     * Should: Map base_type correctly into the Identifier bean
+     */
+    @Test
+    public void test_identifierTransformer_mapsBaseType() throws DotDataException, DotSecurityException {
+        final Contentlet contentlet = TestDataUtils.getGenericContentContent(true,
+                APILocator.getLanguageAPI().getDefaultLanguage().getId(), defaultHost);
+
+        // Force a direct DB read (bypass cache) to exercise the transformer
+        final com.dotmarketing.beans.Identifier identifier = factory.loadFromDb(contentlet.getIdentifier());
+
+        assertNotNull("Transformer should map base_type from DB row", identifier.getBaseType());
+        assertEquals("Transformer should map CONTENT base type correctly",
+                com.dotcms.contenttype.model.type.BaseContentType.CONTENT.getType(),
+                (int) identifier.getBaseType());
+    }
+
+    /**
+     * Method to test: folder identifier via {@link IdentifierFactoryImpl#createNewIdentifier}
+     * When: A folder identifier is created
+     * Should: Have a null base_type (folders have no structure mapping)
+     */
+    @Test
+    public void test_folderIdentifier_hasNullBaseType() throws DotDataException, DotSecurityException {
+        final com.dotmarketing.portlets.folders.model.Folder folder =
+                new com.dotcms.datagen.FolderDataGen().site(defaultHost).nextPersisted();
+
+        final com.dotmarketing.beans.Identifier identifier = factory.loadFromDb(folder.getIdentifier());
+
+        assertNotNull("Folder identifier should exist", identifier);
+        assertNull("Folder identifier should have null base_type", identifier.getBaseType());
+    }
+
 }

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJobTest.java
@@ -144,6 +144,29 @@ public class PopulateIdentifierBaseTypeJobTest extends IntegrationTestBase {
                 PopulateIdentifierBaseTypeJob.hasPendingRows());
     }
 
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeJob#hasPendingRows()}
+     * When: Identifier rows have null base_type but their asset_subtype has no matching structure
+     * Should: Return false — orphaned rows cannot be populated and must not keep the job alive
+     */
+    @Test
+    public void test_hasPendingRows_returnsFalseForOrphanedRows() throws Exception {
+        final String orphanSubtype = "zz_nonexistent_type_" + System.currentTimeMillis();
+
+        // Insert an identifier row with a bogus asset_subtype that has no structure entry
+        new DotConnect().executeStatement(
+                "INSERT INTO identifier (id, parent_path, asset_name, host_inode, asset_type, asset_subtype, syspublish_date, sysexpire_date) " +
+                "VALUES ('" + orphanSubtype + "', '/', 'orphan_test', 'SYSTEM_HOST', 'contentlet', '" + orphanSubtype + "', NULL, NULL)");
+
+        try {
+            assertFalse("hasPendingRows() should return false when only orphaned rows remain",
+                    PopulateIdentifierBaseTypeJob.hasPendingRows());
+        } finally {
+            new DotConnect().executeStatement(
+                    "DELETE FROM identifier WHERE id = '" + orphanSubtype + "'");
+        }
+    }
+
     // -----------------------------------------------------------------------
 
     private static void removeJob() throws SchedulerException {

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJobTest.java
@@ -1,0 +1,153 @@
+package com.dotmarketing.quartz.job;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.init.DotInitScheduler;
+import com.dotmarketing.quartz.QuartzUtils;
+import io.vavr.control.Try;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.quartz.SchedulerException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Integration tests for {@link PopulateIdentifierBaseTypeJob}.
+ * Verifies that the job can be scheduled, is idempotent on re-scheduling, and can be removed.
+ */
+public class PopulateIdentifierBaseTypeJobTest extends IntegrationTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+        DotInitScheduler.start();
+        removeJob();
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        removeJob();
+    }
+
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeJob#fireJob()}
+     * When: Job is not yet scheduled
+     * Should: Schedule successfully and be retrievable from the scheduler
+     */
+    @Test
+    public void test_fireJob_schedulesJob() {
+        final var jobName = PopulateIdentifierBaseTypeJob.getJobName();
+        final var groupName = PopulateIdentifierBaseTypeJob.getJobGroupName();
+
+        try {
+            PopulateIdentifierBaseTypeJob.fireJob();
+        } catch (final Exception e) {
+            fail("fireJob() should not throw: " + e.getMessage());
+        }
+
+        final var scheduler = QuartzUtils.getScheduler();
+        final var jobDetail = Try.of(() -> scheduler.getJobDetail(jobName, groupName))
+                .onFailure(e -> fail("Error retrieving job detail: " + e.getMessage()))
+                .getOrNull();
+
+        assertNotNull("Job should be present in scheduler after fireJob()", jobDetail);
+    }
+
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeJob#fireJob()}
+     * When: Job is already scheduled
+     * Should: Not throw and not create a duplicate
+     */
+    @Test
+    public void test_fireJob_isIdempotent() {
+        try {
+            PopulateIdentifierBaseTypeJob.fireJob();
+            PopulateIdentifierBaseTypeJob.fireJob(); // second call must be a no-op
+        } catch (final Exception e) {
+            fail("fireJob() called twice should not throw: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeJob#removeJob()}
+     * When: Job is scheduled
+     * Should: Remove it from the scheduler
+     */
+    @Test
+    public void test_removeJob_removesFromScheduler() throws SchedulerException {
+        PopulateIdentifierBaseTypeJob.fireJob();
+
+        removeJob();
+
+        final var jobName = PopulateIdentifierBaseTypeJob.getJobName();
+        final var groupName = PopulateIdentifierBaseTypeJob.getJobGroupName();
+        final var scheduler = QuartzUtils.getScheduler();
+
+        final var jobDetail = Try.of(() -> scheduler.getJobDetail(jobName, groupName))
+                .getOrNull();
+        assertNull("Job should not be present in scheduler after removeJob()", jobDetail);
+    }
+
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeJob#fireJob()}
+     * When: All identifier rows already have base_type set (migration complete)
+     * Should: Skip scheduling — job should NOT appear in the scheduler
+     */
+    @Test
+    public void test_fireJob_skipsSchedulingWhenNoWorkPending() throws Exception {
+        removeJob();
+
+        // Temporarily back-fill any NULLs so hasPendingRows() returns false
+        new DotConnect().executeStatement(
+                "UPDATE identifier SET base_type = 1 " +
+                "WHERE base_type IS NULL AND asset_subtype IS NOT NULL");
+
+        try {
+            assertFalse("hasPendingRows() should return false when all rows are populated",
+                    PopulateIdentifierBaseTypeJob.hasPendingRows());
+
+            PopulateIdentifierBaseTypeJob.fireJob();
+
+            final var jobName   = PopulateIdentifierBaseTypeJob.getJobName();
+            final var groupName = PopulateIdentifierBaseTypeJob.getJobGroupName();
+            final var scheduler = QuartzUtils.getScheduler();
+
+            final var jobDetail = Try.of(() -> scheduler.getJobDetail(jobName, groupName)).getOrNull();
+            assertNull("Job should NOT be scheduled when migration is already complete", jobDetail);
+        } finally {
+            // Restore NULL so other tests stay valid
+            new DotConnect().executeStatement(
+                    "UPDATE identifier SET base_type = NULL WHERE base_type = 1 AND asset_subtype IS NOT NULL");
+        }
+    }
+
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeJob#hasPendingRows()}
+     * When: At least one identifier row has a null base_type and non-null asset_subtype
+     * Should: Return true
+     */
+    @Test
+    public void test_hasPendingRows_returnsTrueWhenWorkExists() throws Exception {
+        // Force at least one NULL row
+        new DotConnect().executeStatement(
+                "UPDATE identifier SET base_type = NULL " +
+                "WHERE asset_subtype IS NOT NULL AND id = (" +
+                "  SELECT id FROM identifier WHERE asset_subtype IS NOT NULL LIMIT 1)");
+
+        assertTrue("hasPendingRows() should return true when NULL rows exist",
+                PopulateIdentifierBaseTypeJob.hasPendingRows());
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static void removeJob() throws SchedulerException {
+        PopulateIdentifierBaseTypeJob.removeJob();
+    }
+
+}

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeJobTest.java
@@ -11,6 +11,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.quartz.SchedulerException;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -103,10 +107,21 @@ public class PopulateIdentifierBaseTypeJobTest extends IntegrationTestBase {
     public void test_fireJob_skipsSchedulingWhenNoWorkPending() throws Exception {
         removeJob();
 
-        // Temporarily back-fill any NULLs so hasPendingRows() returns false
-        new DotConnect().executeStatement(
-                "UPDATE identifier SET base_type = 1 " +
-                "WHERE base_type IS NULL AND asset_subtype IS NOT NULL");
+        // Capture only the IDs that are currently NULL so we restore exactly those rows
+        final List<String> nullIds = new DotConnect()
+                .setSQL("SELECT id FROM identifier WHERE base_type IS NULL AND asset_subtype IS NOT NULL")
+                .loadObjectResults()
+                .stream()
+                .map(row -> (String) row.get("id"))
+                .collect(Collectors.toList());
+
+        if (!nullIds.isEmpty()) {
+            final String idList = nullIds.stream()
+                    .map(id -> "'" + id + "'")
+                    .collect(Collectors.joining(","));
+            new DotConnect().executeStatement(
+                    "UPDATE identifier SET base_type = 1 WHERE id IN (" + idList + ")");
+        }
 
         try {
             assertFalse("hasPendingRows() should return false when all rows are populated",
@@ -121,9 +136,14 @@ public class PopulateIdentifierBaseTypeJobTest extends IntegrationTestBase {
             final var jobDetail = Try.of(() -> scheduler.getJobDetail(jobName, groupName)).getOrNull();
             assertNull("Job should NOT be scheduled when migration is already complete", jobDetail);
         } finally {
-            // Restore NULL so other tests stay valid
-            new DotConnect().executeStatement(
-                    "UPDATE identifier SET base_type = NULL WHERE base_type = 1 AND asset_subtype IS NOT NULL");
+            // Restore only the rows we modified
+            if (!nullIds.isEmpty()) {
+                final String idList = nullIds.stream()
+                        .map(id -> "'" + id + "'")
+                        .collect(Collectors.joining(","));
+                new DotConnect().executeStatement(
+                        "UPDATE identifier SET base_type = NULL WHERE id IN (" + idList + ")");
+            }
         }
     }
 

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/PopulateIdentifierBaseTypeUtilTest.java
@@ -1,0 +1,173 @@
+package com.dotmarketing.quartz.job;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.datagen.ContentletDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.TestDataUtils;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for {@link PopulateIdentifierBaseTypeUtil}.
+ * Verifies that the batched UPDATE correctly sets {@code base_type} on the
+ * {@code identifier} table rows that have a matching {@code asset_subtype} in the
+ * {@code structure} table.
+ */
+public class PopulateIdentifierBaseTypeUtilTest extends IntegrationTestBase {
+
+    private static Host site;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+        site = new SiteDataGen().nextPersisted();
+    }
+
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeUtil#populate()}
+     * When: Contentlet identifiers have base_type set to NULL
+     * Should: Correctly populate base_type from structure.structuretype
+     */
+    @Test
+    public void test_populate_setsBaseTypeFromStructure() throws DotDataException, DotSecurityException, SQLException {
+        // Create a real contentlet so we have an identifier with asset_subtype set
+        final Contentlet contentlet = TestDataUtils.getGenericContentContent(true, APILocator.getLanguageAPI().getDefaultLanguage().getId(), site);
+        final String identifierId = contentlet.getIdentifier();
+
+        // Null out base_type to simulate un-migrated row
+        nullOutBaseType(identifierId);
+
+        assertBaseTypeIsNull(identifierId);
+
+        // Run the util
+        final int updated = new PopulateIdentifierBaseTypeUtil().populate();
+        assertTrue("Should have updated at least 1 row", updated > 0);
+
+        // Verify base_type is now set
+        final Integer baseType = fetchBaseType(identifierId);
+        assertNotNull("base_type should not be null after populate", baseType);
+        assertEquals("base_type should match CONTENT base type",
+                BaseContentType.CONTENT.getType(), (int) baseType);
+    }
+
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeUtil#populate()}
+     * When: All rows already have base_type set
+     * Should: Return 0 (nothing to do)
+     */
+    @Test
+    public void test_populate_returnsZeroWhenAlreadyPopulated() throws DotDataException, DotSecurityException, SQLException {
+        final Contentlet contentlet = TestDataUtils.getGenericContentContent(true, APILocator.getLanguageAPI().getDefaultLanguage().getId(), site);
+        final String identifierId = contentlet.getIdentifier();
+
+        // Ensure base_type is populated
+        new DotConnect()
+                .setSQL("UPDATE identifier SET base_type = 1 WHERE id = ? AND base_type IS NULL")
+                .addParam(identifierId)
+                .loadResult();
+
+        // First pass populates everything; second pass should update 0
+        new PopulateIdentifierBaseTypeUtil().populate();
+        final int secondRun = new PopulateIdentifierBaseTypeUtil().populate();
+        assertEquals("Second run should update 0 rows when all are already populated", 0, secondRun);
+    }
+
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeUtil#populate()}
+     * When: Identifier has NULL asset_subtype (e.g. folder)
+     * Should: Leave base_type NULL — folders have no structure mapping
+     */
+    @Test
+    public void test_populate_ignoresRowsWithNullAssetSubtype() throws DotDataException, SQLException {
+        // Folders have asset_subtype = NULL
+        final List<Map<String, Object>> folders = new DotConnect()
+                .setSQL("SELECT id FROM identifier WHERE asset_type = 'folder' AND asset_subtype IS NULL LIMIT 1")
+                .loadObjectResults();
+
+        if (folders.isEmpty()) {
+            return; // nothing to test in this environment
+        }
+
+        final String folderId = (String) folders.get(0).get("id");
+
+        // Ensure base_type is NULL
+        new DotConnect()
+                .setSQL("UPDATE identifier SET base_type = NULL WHERE id = ?")
+                .addParam(folderId)
+                .loadResult();
+
+        new PopulateIdentifierBaseTypeUtil().populate();
+
+        final Integer baseType = fetchBaseType(folderId);
+        assertTrue("base_type should remain NULL for folders (no asset_subtype)",
+                baseType == null);
+    }
+
+    /**
+     * Method to test: {@link PopulateIdentifierBaseTypeUtil#populate()}
+     * When: Multiple contentlets of different base types exist with NULL base_type
+     * Should: Correctly set the right base_type for each
+     */
+    @Test
+    public void test_populate_correctlyMapsMultipleBaseTypes() throws DotDataException, DotSecurityException, SQLException {
+        DbConnectionFactory.getConnection().setAutoCommit(true);
+
+        // Use a file asset (FILEASSET = 4) and a generic content (CONTENT = 1)
+        final Contentlet fileAsset = TestDataUtils.getFileAssetContent(true, APILocator.getLanguageAPI().getDefaultLanguage().getId());
+        final Contentlet content = TestDataUtils.getGenericContentContent(true, APILocator.getLanguageAPI().getDefaultLanguage().getId(), site);
+
+        nullOutBaseType(fileAsset.getIdentifier());
+        nullOutBaseType(content.getIdentifier());
+
+        new PopulateIdentifierBaseTypeUtil().populate();
+
+        assertEquals("FileAsset identifier should have FILEASSET base type",
+                BaseContentType.FILEASSET.getType(), (int) fetchBaseType(fileAsset.getIdentifier()));
+        assertEquals("Content identifier should have CONTENT base type",
+                BaseContentType.CONTENT.getType(), (int) fetchBaseType(content.getIdentifier()));
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static void nullOutBaseType(final String identifierId) throws DotDataException {
+        new DotConnect()
+                .setSQL("UPDATE identifier SET base_type = NULL WHERE id = ?")
+                .addParam(identifierId)
+                .loadResult();
+    }
+
+    private static void assertBaseTypeIsNull(final String identifierId) throws DotDataException {
+        final Integer baseType = fetchBaseType(identifierId);
+        assertTrue("base_type should be NULL before populate runs", baseType == null);
+    }
+
+    private static Integer fetchBaseType(final String identifierId) throws DotDataException {
+        final List<Map<String, Object>> rows = new DotConnect()
+                .setSQL("SELECT base_type FROM identifier WHERE id = ?")
+                .addParam(identifierId)
+                .loadObjectResults();
+        if (rows.isEmpty()) {
+            return null;
+        }
+        final Object val = rows.get(0).get("base_type");
+        return val == null ? null : ((Number) val).intValue();
+    }
+
+}

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifierTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifierTest.java
@@ -11,6 +11,8 @@ import org.junit.Test;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -73,16 +75,34 @@ public class Task260407AddBaseTypeColumnToIdentifierTest {
         final var task = new Task260407AddBaseTypeColumnToIdentifier();
         task.executeUpgrade();
 
-        // Ensure no pending rows remain
-        new DotConnect().executeStatement(
-                "UPDATE identifier SET base_type = 1 WHERE base_type IS NULL AND asset_subtype IS NOT NULL");
+        // Capture only the IDs that are currently NULL so we restore exactly those rows
+        final List<String> nullIds = new DotConnect()
+                .setSQL("SELECT id FROM identifier WHERE base_type IS NULL AND asset_subtype IS NOT NULL")
+                .loadObjectResults()
+                .stream()
+                .map(row -> (String) row.get("id"))
+                .collect(Collectors.toList());
+
+        if (!nullIds.isEmpty()) {
+            final String idList = nullIds.stream()
+                    .map(id -> "'" + id + "'")
+                    .collect(Collectors.joining(","));
+            new DotConnect().executeStatement(
+                    "UPDATE identifier SET base_type = 1 WHERE id IN (" + idList + ")");
+        }
 
         try {
             assertFalse("forceRun() should return false when index exists and no pending rows remain",
                     task.forceRun());
         } finally {
-            new DotConnect().executeStatement(
-                    "UPDATE identifier SET base_type = NULL WHERE base_type = 1 AND asset_subtype IS NOT NULL");
+            // Restore only the rows we modified
+            if (!nullIds.isEmpty()) {
+                final String idList = nullIds.stream()
+                        .map(id -> "'" + id + "'")
+                        .collect(Collectors.joining(","));
+                new DotConnect().executeStatement(
+                        "UPDATE identifier SET base_type = NULL WHERE id IN (" + idList + ")");
+            }
         }
     }
 

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifierTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifierTest.java
@@ -1,0 +1,151 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.exception.DotDataException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for {@link Task260407AddBaseTypeColumnToIdentifier}.
+ * Verifies that the {@code base_type} column and {@code idx_identifier_base_type} index are
+ * correctly created on the {@code identifier} table, and that the task is idempotent.
+ */
+public class Task260407AddBaseTypeColumnToIdentifierTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+        cleanUp();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        // Restore state — re-add column/index so other tests are not broken
+        final var task = new Task260407AddBaseTypeColumnToIdentifier();
+        if (task.forceRun()) {
+            task.executeUpgrade();
+        }
+    }
+
+    /**
+     * Method to test: {@link Task260407AddBaseTypeColumnToIdentifier#executeUpgrade()}
+     * When: Column and index do not exist
+     * Should: Add the base_type column and create idx_identifier_base_type index
+     */
+    @Test
+    public void test_executeUpgrade_addsColumnAndIndex() throws SQLException, DotDataException {
+        cleanUp();
+
+        final var metaData = new DotDatabaseMetaData();
+        assertFalse("base_type column should not exist before task runs",
+                metaData.hasColumn("identifier", "base_type"));
+        assertFalse("index should not exist before task runs", indexExists());
+
+        final var task = new Task260407AddBaseTypeColumnToIdentifier();
+        assertTrue("forceRun() should return true when index is absent", task.forceRun());
+
+        task.executeUpgrade();
+
+        assertTrue("base_type column should exist after task runs",
+                metaData.hasColumn("identifier", "base_type"));
+        assertTrue("idx_identifier_base_type index should exist after task runs", indexExists());
+    }
+
+    /**
+     * Method to test: {@link Task260407AddBaseTypeColumnToIdentifier#forceRun()}
+     * When: Index already exists
+     * Should: Return false (task should not re-run)
+     */
+    @Test
+    public void test_forceRun_returnsFalseWhenIndexExists() throws DotDataException, SQLException {
+        cleanUp();
+
+        final var task = new Task260407AddBaseTypeColumnToIdentifier();
+        task.executeUpgrade();
+
+        assertFalse("forceRun() should return false when index already exists", task.forceRun());
+    }
+
+    /**
+     * Method to test: {@link Task260407AddBaseTypeColumnToIdentifier#executeUpgrade()}
+     * When: Task is executed twice
+     * Should: Not throw any exception (idempotent via IF NOT EXISTS)
+     */
+    @Test
+    public void test_executeUpgrade_isIdempotent() throws DotDataException, SQLException {
+        cleanUp();
+
+        final var task = new Task260407AddBaseTypeColumnToIdentifier();
+        task.executeUpgrade();
+        // Second run must not throw
+        task.executeUpgrade();
+
+        assertTrue("base_type column should still exist", new DotDatabaseMetaData().hasColumn("identifier", "base_type"));
+        assertTrue("index should still exist", indexExists());
+    }
+
+    /**
+     * Method to test: {@link Task260407AddBaseTypeColumnToIdentifier#executeUpgrade()}
+     * When: Column is added
+     * Should: Column allows NULL and stores integer values
+     */
+    @Test
+    public void test_baseTypeColumn_isNullableInt() throws DotDataException, SQLException {
+        cleanUp();
+
+        new Task260407AddBaseTypeColumnToIdentifier().executeUpgrade();
+
+        final Connection conn = com.dotmarketing.db.DbConnectionFactory.getConnection();
+        final ResultSet rs = DotDatabaseMetaData.getColumnsMetaData(conn, "identifier");
+
+        boolean found = false;
+        while (rs.next()) {
+            if ("base_type".equalsIgnoreCase(rs.getString("COLUMN_NAME"))) {
+                found = true;
+                final String typeName = rs.getString("TYPE_NAME").toLowerCase();
+                assertTrue("base_type should be an integer type",
+                        typeName.contains("int") || typeName.contains("int4"));
+                final int nullable = rs.getInt("NULLABLE");
+                assertTrue("base_type should be nullable",
+                        nullable == java.sql.DatabaseMetaData.columnNullable);
+                break;
+            }
+        }
+        assertTrue("base_type column should be found in metadata", found);
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static boolean indexExists() throws DotDataException {
+        final var result = new DotConnect()
+                .setSQL("SELECT 1 FROM pg_indexes WHERE tablename = 'identifier' AND indexname = 'idx_identifier_base_type'")
+                .loadObjectResults();
+        return !result.isEmpty();
+    }
+
+    private static void cleanUp() throws SQLException {
+        try {
+            new DotConnect().executeStatement(
+                    "DROP INDEX IF EXISTS idx_identifier_base_type");
+        } catch (SQLException e) {
+            // ignore
+        }
+        try {
+            new DotConnect().executeStatement(
+                    "ALTER TABLE identifier DROP COLUMN IF EXISTS base_type");
+        } catch (SQLException e) {
+            // ignore
+        }
+    }
+
+}

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifierTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifierTest.java
@@ -63,17 +63,49 @@ public class Task260407AddBaseTypeColumnToIdentifierTest {
 
     /**
      * Method to test: {@link Task260407AddBaseTypeColumnToIdentifier#forceRun()}
-     * When: Index already exists
-     * Should: Return false (task should not re-run)
+     * When: Index exists AND all rows are already populated (migration complete)
+     * Should: Return false — no work to do
      */
     @Test
-    public void test_forceRun_returnsFalseWhenIndexExists() throws DotDataException, SQLException {
+    public void test_forceRun_returnsFalseWhenMigrationComplete() throws DotDataException, SQLException {
         cleanUp();
 
         final var task = new Task260407AddBaseTypeColumnToIdentifier();
         task.executeUpgrade();
 
-        assertFalse("forceRun() should return false when index already exists", task.forceRun());
+        // Ensure no pending rows remain
+        new DotConnect().executeStatement(
+                "UPDATE identifier SET base_type = 1 WHERE base_type IS NULL AND asset_subtype IS NOT NULL");
+
+        try {
+            assertFalse("forceRun() should return false when index exists and no pending rows remain",
+                    task.forceRun());
+        } finally {
+            new DotConnect().executeStatement(
+                    "UPDATE identifier SET base_type = NULL WHERE base_type = 1 AND asset_subtype IS NOT NULL");
+        }
+    }
+
+    /**
+     * Method to test: {@link Task260407AddBaseTypeColumnToIdentifier#forceRun()}
+     * When: Index exists BUT rows still have null base_type (server restarted mid-backfill)
+     * Should: Return true so the backfill job is re-scheduled
+     */
+    @Test
+    public void test_forceRun_returnsTrueWhenBackfillIncomplete() throws DotDataException, SQLException {
+        cleanUp();
+
+        final var task = new Task260407AddBaseTypeColumnToIdentifier();
+        task.executeUpgrade();
+
+        // Simulate mid-backfill restart: index exists but some rows are still NULL
+        new DotConnect().executeStatement(
+                "UPDATE identifier SET base_type = NULL " +
+                "WHERE asset_subtype IS NOT NULL AND id = (" +
+                "  SELECT id FROM identifier WHERE asset_subtype IS NOT NULL LIMIT 1)");
+
+        assertTrue("forceRun() should return true when index exists but backfill is incomplete",
+                task.forceRun());
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifierTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260407AddBaseTypeColumnToIdentifierTest.java
@@ -32,11 +32,8 @@ public class Task260407AddBaseTypeColumnToIdentifierTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        // Restore state — re-add column/index so other tests are not broken
-        final var task = new Task260407AddBaseTypeColumnToIdentifier();
-        if (task.forceRun()) {
-            task.executeUpgrade();
-        }
+        // Always restore — executeUpgrade() uses IF NOT EXISTS so it's safe to call unconditionally
+        new Task260407AddBaseTypeColumnToIdentifier().executeUpgrade();
     }
 
     /**


### PR DESCRIPTION
## Summary
- Adds `base_type INT4` column + `idx_identifier_base_type` index to the `identifier` table, mirroring `structure.structuretype`
- `Identifier` bean, `IdentifierFactoryImpl`, and `IdentifierTransformer` updated to read/write `base_type` on every save
- `Task260331AddBaseTypeColumnToIdentifier` adds the column and index at startup (DDL only — fast), then schedules the backfill job
- `PopulateIdentifierBaseTypeJob` / `PopulateIdentifierBaseTypeUtil` backfill existing rows in batches of 500 (250 ms sleep between batches), fire immediately at startup, and self-unschedule when complete
- `postgres.sql` updated for fresh installs

## Test plan
- [ ] `Task260331AddBaseTypeColumnToIdentifierTest` — column/index created, idempotent, correct metadata
- [ ] `PopulateIdentifierBaseTypeUtilTest` — sets correct base type per content type, ignores folders (null asset_subtype), returns 0 on second run
- [ ] `PopulateIdentifierBaseTypeJobTest` — schedules, skips when no work pending, removes itself
- [ ] `IdentifierFactoryTest` (5 new methods) — base_type persisted for CONTENT and FILEASSET, survives re-save, transformer maps it, folders get null

fixes #35162 