### PR TITLE
fix(rest-api): allow non-admin users to issue their own API tokens (#35094)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
@@ -68,6 +68,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -460,7 +461,7 @@ public class ApiTokenResource implements Serializable {
             return ExceptionMapperUtil.createResponse(new DotStateException("No user found"), Response.Status.NOT_FOUND);
         }
 
-        if (!requestingUser.getUserId().equals(forUser.getUserId()) && !requestingUser.isAdmin()) {
+        if (!Objects.equals(requestingUser.getUserId(), forUser.getUserId()) && !requestingUser.isAdmin()) {
             throw new DotDataException("Only Admin user can request a token for another user");
         }
 
@@ -493,6 +494,8 @@ public class ApiTokenResource implements Serializable {
 
         token = this.tokenApi.persistApiToken(token, requestingUser);
         final String jwt = this.tokenApi.getJWT(token, requestingUser);
+        SecurityLogger.logInfo(this.getClass(), "API token issued for user: " + forUser.getUserId()
+                + " by: " + requestingUser.getUserId() + " ip: " + request.getRemoteAddr());
         return Response.ok(new ResponseEntityMapView(Map.of("token", token, "jwt", jwt)))
                 .build(); // 200
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/authentication/ApiTokenResource.java
@@ -460,7 +460,7 @@ public class ApiTokenResource implements Serializable {
             return ExceptionMapperUtil.createResponse(new DotStateException("No user found"), Response.Status.NOT_FOUND);
         }
 
-        if (requestingUser != forUser && !requestingUser.isAdmin()) {
+        if (!requestingUser.getUserId().equals(forUser.getUserId()) && !requestingUser.isAdmin()) {
             throw new DotDataException("Only Admin user can request a token for another user");
         }
 

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/authentication/ApiTokenResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/authentication/ApiTokenResourceTest.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.Response;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -105,13 +106,10 @@ public class ApiTokenResourceTest {
                 .expirationSeconds(3600)
                 .build();
 
-        try {
-            resource.issueApiToken(request, response, form);
-            Assert.fail("Expected DotDataException when non-admin requests token for another user");
-        } catch (DotDataException e) {
-            assertTrue("Exception message should indicate admin-only restriction",
-                    e.getMessage().contains("Only Admin user"));
-        }
+        final DotDataException e = assertThrows(DotDataException.class,
+                () -> resource.issueApiToken(request, response, form));
+        assertTrue("Exception message should indicate admin-only restriction",
+                e.getMessage().contains("Only Admin user"));
     }
 
     @Test()

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/authentication/ApiTokenResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/authentication/ApiTokenResourceTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -38,6 +39,79 @@ public class ApiTokenResourceTest {
     public static void prepare() throws Exception{
         //Setting web app environment
         IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Method to test: {@link ApiTokenResource#issueApiToken}
+     * Given Scenario: A non-admin user explicitly passes their own userId in the form body.
+     *                 Before the fix, getUserById() returned a new DB object (different reference),
+     *                 causing the requestingUser != forUser reference check to fire incorrectly.
+     * ExpectedResult: The token is issued successfully (HTTP 200).
+     * @see <a href="https://github.com/dotCMS/core/issues/35094">Issue #35094</a>
+     */
+    @Test
+    public void test_issueApiToken_nonAdminUser_canCreateOwnToken()
+            throws DotDataException, DotSecurityException {
+
+        final User limitedUser = new UserDataGen().active(true).nextPersisted();
+
+        final HttpServletRequest  request     = mock(HttpServletRequest.class);
+        final HttpServletResponse response    = mock(HttpServletResponse.class);
+        final WebResource         webResource = mock(WebResource.class);
+        final ApiTokenResource    resource    = new ApiTokenResource(APILocator.getApiTokenAPI(), webResource);
+
+        final InitDataObject initData = new InitDataObject();
+        initData.setUser(limitedUser);
+        // issueApiToken uses the 5-param init overload
+        when(webResource.init(any(), anyBoolean(), any(), anyBoolean(), any())).thenReturn(initData);
+
+        // Pass the user's OWN userId explicitly — this is what the UI does and what triggered the bug
+        final ApiTokenForm form = new ApiTokenForm.Builder()
+                .userId(limitedUser.getUserId())
+                .expirationSeconds(3600)
+                .build();
+
+        final Response restResponse = resource.issueApiToken(request, response, form);
+        assertNotNull(restResponse);
+        assertEquals("Non-admin user should be able to issue a token for themselves",
+                Response.Status.OK.getStatusCode(), restResponse.getStatus());
+    }
+
+    /**
+     * Method to test: {@link ApiTokenResource#issueApiToken}
+     * Given Scenario: A non-admin user tries to create a token for a different user.
+     * ExpectedResult: The request is rejected — only admins can issue tokens for other users.
+     * @see <a href="https://github.com/dotCMS/core/issues/35094">Issue #35094</a>
+     */
+    @Test
+    public void test_issueApiToken_nonAdminUser_cannotCreateTokenForOtherUser()
+            throws DotDataException, DotSecurityException {
+
+        final User limitedUser  = new UserDataGen().active(true).nextPersisted();
+        final User anotherUser  = new UserDataGen().active(true).nextPersisted();
+
+        final HttpServletRequest  request     = mock(HttpServletRequest.class);
+        final HttpServletResponse response    = mock(HttpServletResponse.class);
+        final WebResource         webResource = mock(WebResource.class);
+        final ApiTokenResource    resource    = new ApiTokenResource(APILocator.getApiTokenAPI(), webResource);
+
+        final InitDataObject initData = new InitDataObject();
+        initData.setUser(limitedUser);
+        when(webResource.init(any(), anyBoolean(), any(), anyBoolean(), any())).thenReturn(initData);
+
+        // Attempt to create a token for a different user
+        final ApiTokenForm form = new ApiTokenForm.Builder()
+                .userId(anotherUser.getUserId())
+                .expirationSeconds(3600)
+                .build();
+
+        try {
+            resource.issueApiToken(request, response, form);
+            Assert.fail("Expected DotDataException when non-admin requests token for another user");
+        } catch (DotDataException e) {
+            assertTrue("Exception message should indicate admin-only restriction",
+                    e.getMessage().contains("Only Admin user"));
+        }
     }
 
     @Test()


### PR DESCRIPTION
Closes #35094

### Proposed Changes
* Replace reference equality (`!=`) with value equality (`getUserId().equals()`) in the `issueApiToken` guard at `ApiTokenResource.java:463`.
* Add two integration tests to `ApiTokenResourceTest` covering both the fixed case and the preserved security rule.

### Root Cause
When a non-admin user submitted their own `userId` in the request body, `getUserById()` called `loadUserById()` which returned a fresh `User` object from the database — a different Java reference than `requestingUser`. The `requestingUser != forUser` check fired incorrectly, throwing `"Only Admin user can request a token for another user"` even though the user was requesting a token for themselves.

### Checklist
- [x] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (no security impact — the fix preserves the existing rule that non-admins cannot create tokens for other users; it only corrects the self-token case)

### Additional Info
The fix is a single character change (`!=` → `!...equals()`). The security boundary is unchanged: non-admins can only issue tokens for themselves, admins can issue for anyone.