### PR TITLE
chore: bump starter version to 20260331 across Docker Compose examples

### DIFF
--- a/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
@@ -44,7 +44,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/cluster-mode/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/cluster-mode/docker-compose-node-2.yml
@@ -21,7 +21,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     volumes:
       #- {local_data_path}:/data/shared
       #- {license_local_path}/license.zip:/data/shared/assets/license.zip

--- a/docker/docker-compose-examples/push-publish/docker-compose.yml
+++ b/docker/docker-compose-examples/push-publish/docker-compose.yml
@@ -50,7 +50,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch-sender:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-sender'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     depends_on:
       - opensearch-sender
       - db-sender
@@ -115,7 +115,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch-receiver:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-receiver'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     depends_on:
       - opensearch-receiver
       - db-receiver

--- a/docker/docker-compose-examples/single-node-debug-mode/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-debug-mode/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       DOT_ES_ENDPOINTS: 'https://opensearch:9200'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-production'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     depends_on:
       - db
       - opensearch      

--- a/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       DOT_ES_ENDPOINTS: 'https://opensearch:9200'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-production'
-      CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+      CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     depends_on:
       - db
       - opensearch

--- a/docker/docker-compose-examples/single-node/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       GLOWROOT_WEB_UI_ENABLED: 'true' # Enable glowroot web ui on localhost.  do not use in production
       #CMS_SSL_CERTIFICATE_FILE: '/certs/localhost.pem'    # Can create cert with mkcert tool
       #CMS_SSL_CERTIFICATE_KEY_FILE: '/certs/localhost-key.pem'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     depends_on:
       - db
       - opensearch      

--- a/docker/docker-compose-examples/with-opensearch-dashboard/docker-compose.yml
+++ b/docker/docker-compose-examples/with-opensearch-dashboard/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       DOT_ES_ENDPOINTS: 'https://opensearch:9200'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-production'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     depends_on:
       - db
       - opensearch

--- a/docker/docker-compose-examples/with-redis-session/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/with-redis-session/docker-compose-node-1.yml
@@ -51,7 +51,7 @@ services:
         DOT_ES_AUTH_BASIC_PASSWORD: 'admin'
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/with-redis/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/with-redis/docker-compose-node-1.yml
@@ -48,7 +48,7 @@ services:
         DOT_DOT_PUBSUB_PROVIDER_OVERRIDE: 'com.dotcms.dotpubsub.RedisPubSubImpl'
         DOT_REDIS_LETTUCECLIENT_URLS: 'redis://MY_SECRET_P4SS@redis'
         DOT_CACHE_DEFAULT_CHAIN: 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/with-redis/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/with-redis/docker-compose-node-2.yml
@@ -26,7 +26,7 @@ services:
         DOT_DOT_PUBSUB_PROVIDER_OVERRIDE: 'com.dotcms.dotpubsub.RedisPubSubImpl'
         DOT_REDIS_LETTUCECLIENT_URLS: 'redis://MY_SECRET_P4SS@redis'
         DOT_CACHE_DEFAULT_CHAIN: 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260326/starter-20260326.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260331/starter-20260331.zip'
     volumes:
       #- {local_data_path}:/data/shared
       #- {license_local_path}/license.zip:/data/shared/assets/license.zip


### PR DESCRIPTION
## Summary

- Updates `CUSTOM_STARTER_URL` across all Docker Compose example configurations from version `20260326` to `20260331`
- Keeps example configurations aligned with the latest starter release
- Follows the same pattern as #35135

Closes #34732


This PR fixes: #34732