### PR TITLE
fix(inline-edit): disable TinyMCE URL conversion to preserve absolute asset paths on blur

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.spec.ts
@@ -2,7 +2,11 @@ import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 
 import { ElementRef } from '@angular/core';
 
-import { INLINE_CONTENT_STYLES, InlineEditService } from './inline-edit.service';
+import {
+    INLINE_CONTENT_STYLES,
+    INLINE_EDIT_TINYMCE_BASE_OPTIONS,
+    InlineEditService
+} from './inline-edit.service';
 
 import { InlineEditingContentletDataset } from '../../edit-ema-editor/components/ema-page-dropzone/types';
 
@@ -11,6 +15,10 @@ describe('InlineEditService', () => {
     const createService = createServiceFactory(InlineEditService);
 
     beforeEach(() => (spectator = createService()));
+
+    it('should disable TinyMCE URL conversion so root-relative paths are preserved on serialize', () => {
+        expect(INLINE_EDIT_TINYMCE_BASE_OPTIONS.convert_urls).toBe(false);
+    });
 
     it('should inject inline edit', () => {
         const iframe = document.createElement('iframe');

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.spec.ts
@@ -2,11 +2,7 @@ import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 
 import { ElementRef } from '@angular/core';
 
-import {
-    INLINE_CONTENT_STYLES,
-    INLINE_EDIT_TINYMCE_BASE_OPTIONS,
-    InlineEditService
-} from './inline-edit.service';
+import { INLINE_CONTENT_STYLES, InlineEditService } from './inline-edit.service';
 
 import { InlineEditingContentletDataset } from '../../edit-ema-editor/components/ema-page-dropzone/types';
 
@@ -16,8 +12,28 @@ describe('InlineEditService', () => {
 
     beforeEach(() => (spectator = createService()));
 
-    it('should disable TinyMCE URL conversion so root-relative paths are preserved on serialize', () => {
-        expect(INLINE_EDIT_TINYMCE_BASE_OPTIONS.convert_urls).toBe(false);
+    it.each([
+        { mode: 'minimal', label: 'minimal' },
+        { mode: 'full', label: 'full' },
+        { mode: '', label: 'default (minimal)' }
+    ])('should pass convert_urls: false to tinymce.init ($label)', ({ mode }) => {
+        const initMock = jest.fn().mockResolvedValue([]);
+        const iframeWindow = {
+            tinymce: { init: initMock }
+        } as unknown as Window;
+
+        spectator.service.setIframeWindow(iframeWindow);
+        spectator.service.setTargetInlineMCEDataset({
+            inode: '1',
+            fieldName: 'body',
+            language: 'en',
+            mode
+        });
+
+        spectator.service.initEditor();
+
+        expect(initMock).toHaveBeenCalledTimes(1);
+        expect(initMock.mock.calls[0][0].convert_urls).toBe(false);
     });
 
     it('should inject inline edit', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.ts
@@ -30,10 +30,7 @@ export const INLINE_CONTENT_STYLES = `
     }    
 `;
 
-/**
- * Shared TinyMCE options for EMA inline editing (excluding per-instance `setup`).
- * Exported so URL-handling defaults (e.g. convert_urls) stay covered by unit tests.
- */
+/** Shared TinyMCE options for EMA inline editing (excluding per-instance `setup`). */
 export const INLINE_EDIT_TINYMCE_BASE_OPTIONS = {
     menubar: false,
     inline: true,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.ts
@@ -30,6 +30,22 @@ export const INLINE_CONTENT_STYLES = `
     }    
 `;
 
+/**
+ * Shared TinyMCE options for EMA inline editing (excluding per-instance `setup`).
+ * Exported so URL-handling defaults (e.g. convert_urls) stay covered by unit tests.
+ */
+export const INLINE_EDIT_TINYMCE_BASE_OPTIONS = {
+    menubar: false,
+    inline: true,
+    // Avoid rewriting root-relative URLs (e.g. /dA/...) to ../... on serialize; iframe base differs from site root.
+    convert_urls: false,
+    valid_styles: {
+        '*': 'font-size,font-family,color,text-decoration,text-align'
+    },
+    powerpaste_word_import: 'clean',
+    powerpaste_html_import: 'clean'
+} as const;
+
 @Injectable({
     providedIn: 'root'
 })
@@ -39,17 +55,11 @@ export class InlineEditService {
     private $inlineEditingTargetDataset = signal<InlineEditingContentletDataset | null>(null);
 
     private readonly DEFAULT_TINYMCE_CONFIG = {
-        menubar: false,
-        inline: true,
-        valid_styles: {
-            '*': 'font-size,font-family,color,text-decoration,text-align'
-        },
-        powerpaste_word_import: 'clean',
-        powerpaste_html_import: 'clean',
+        ...INLINE_EDIT_TINYMCE_BASE_OPTIONS,
         setup: this.#handleInlineEditEvents
     };
 
-    private readonly TINYCME_CONFIG = {
+    private readonly TINYMCE_CONFIG = {
         minimal: {
             plugins: ['link', 'autolink'],
             toolbar: 'bold italic underline | link',
@@ -162,7 +172,7 @@ export class InlineEditService {
 
         this.$iframeWindow()
             .tinymce.init({
-                ...this.TINYCME_CONFIG[dataset.mode || 'minimal'],
+                ...this.TINYMCE_CONFIG[dataset.mode || 'minimal'],
                 selector: dataSelector
             })
             .then(([ed]) => {


### PR DESCRIPTION
Fixes #34807

## Problem

When a user clicks on an image inside the Rich Text inline editor and then clicks outside (triggering `blur`), TinyMCE's default `convert_urls: true` behavior rewrites root-relative asset paths:

- **Before blur:** `/dA/9bf3ad75d5/dog 2.webp?language_id=1`
- **After blur:** `../dA/9bf3ad75d5/dog 2.webp?language_id=1`

This happens because the editor runs inside an iframe whose base URL differs from the site root, so TinyMCE incorrectly calculates a relative path on `getContent()`. The result is broken images whose severity depends on the page's URL depth.

## Root Cause

`convert_urls` defaults to `true` in TinyMCE. When the editor serializes content on blur, it resolves all URLs relative to the iframe's base — not the site root — silently corrupting absolute paths.

## Solution

Set `convert_urls: false` in the shared TinyMCE base options. This tells TinyMCE to leave all URLs exactly as authored, which is the correct behavior for a CMS where asset paths are always root-relative.

The base options are extracted into an exported constant (`INLINE_EDIT_TINYMCE_BASE_OPTIONS`) so the URL-handling behavior is covered by unit tests independently of the editor lifecycle.

## Testing

- Open a Rich Text contentlet with an image using an absolute path (`/dA/...`)
- Click the image to focus the inline editor
- Click outside to trigger blur
- Verify the `src` attribute is unchanged in both the DOM and after saving


### Video


https://github.com/user-attachments/assets/5ad0a2af-f0f5-49b6-af7b-9aa8a2bb3aed



This PR fixes: #34807