### PR TITLE
feat(block-editor): image text wrap and alignment controls

### DIFF
--- a/core-web/libs/block-editor/CLAUDE.md
+++ b/core-web/libs/block-editor/CLAUDE.md
@@ -1,0 +1,35 @@
+# Block Editor Library
+
+TipTap-based rich text editor for dotCMS. Built on ProseMirror + Angular.
+
+## Structure
+
+```
+src/lib/
+├── nodes/          # Custom block types
+├── extensions/     # TipTap extensions
+├── components/     # Editor shell (DotBlockEditorComponent)
+├── shared/         # Directives, services, utilities reused across nodes/extensions
+├── elements/       # Low-level UI (menus, tables, buttons)
+└── assets/         # SVG icons
+```
+
+## Adding a New Node
+
+1. Create `nodes/{name}/{name}.node.ts` — use DOM-based `addNodeView()` for simple blocks, or `AngularNodeViewRenderer` + a component (extending `AngularNodeViewComponent`) when Angular DI or complex UI is needed. See `contentlet-block` as the reference for Angular-based nodes.
+2. Export from `nodes/index.ts`.
+3. Register in `DotBlockEditorComponent._customNodes` map (`components/dot-block-editor/dot-block-editor.component.ts`).
+4. If the block should appear in the slash-command palette, add it to `shared/utils/suggestion.utils.ts`.
+
+## Node `content` Expressions
+
+Never hardcode a static list of node types in a node's `content` expression. TipTap's `StarterKit` removes disabled nodes from the schema at init time — any `content` that references a removed type throws a schema validation error and the editor renders broken.
+
+When a node's allowed children depend on editor configuration, build the content expression dynamically from the active allowed list. See `createGridColumn(allowedBlocks)` in `grid-column.node.ts` as the pattern to follow.
+
+## GridColumn Rules
+
+- Always instantiate via `createGridColumn(this.allowedBlocks)` inside `DotBlockEditorComponent`, never use the bare `GridColumn` export directly.
+- To allow a new node type inside grid columns, add it to `GRID_COLUMN_CONTENT_MAP` in `grid-column.node.ts`.
+- `aiContent` and `loader` are intentionally absent from `GRID_COLUMN_CONTENT_MAP` — they are editor-level utilities, not column content.
+- Nested grids are intentionally disabled. Do not add `gridBlock` to `GRID_COLUMN_CONTENT_MAP` — the resize plugin does not support nesting.

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.css
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.css
@@ -448,11 +448,11 @@ tiptap-editor::ng-deep .ProseMirror pre code {
 }
 
 tiptap-editor::ng-deep .ProseMirror img.dot-image {
-    @apply block p-0 max-w-[50%] h-auto rounded;
+    @apply block p-0 max-w-[50%] h-auto rounded max-h-[300px];
 }
 
-tiptap-editor::ng-deep .ProseMirror :not(.has-float) img.dot-image {
-    @apply max-h-[300px];
+tiptap-editor::ng-deep .ProseMirror .has-float img.dot-image {
+    @apply max-h-none max-w-full;
 }
 
 tiptap-editor::ng-deep .ProseMirror .grid-block__column img.dot-image {

--- a/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.css
+++ b/core-web/libs/block-editor/src/lib/components/dot-block-editor/dot-block-editor.component.css
@@ -448,7 +448,11 @@ tiptap-editor::ng-deep .ProseMirror pre code {
 }
 
 tiptap-editor::ng-deep .ProseMirror img.dot-image {
-    @apply block my-6 p-0 max-h-[300px] max-w-[50%] h-auto rounded;
+    @apply block p-0 max-w-[50%] h-auto rounded;
+}
+
+tiptap-editor::ng-deep .ProseMirror :not(.has-float) img.dot-image {
+    @apply max-h-[300px];
 }
 
 tiptap-editor::ng-deep .ProseMirror .grid-block__column img.dot-image {
@@ -460,16 +464,24 @@ tiptap-editor::ng-deep .ProseMirror img.dot-image:before {
     @apply flex items-center bg-surface-200 rounded border border-surface-500 text-surface-900 h-full p-3 text-center w-full;
 }
 
-tiptap-editor::ng-deep .ProseMirror img.dot-image.dot-node-center {
-    @apply mx-auto my-6;
+tiptap-editor::ng-deep .ProseMirror .dot-node-center img.dot-image {
+    @apply mx-auto;
 }
 
-tiptap-editor::ng-deep .ProseMirror img.dot-image.dot-node-right {
+tiptap-editor::ng-deep .ProseMirror .dot-node-right img.dot-image {
     @apply ml-auto;
 }
 
-tiptap-editor::ng-deep .ProseMirror img.dot-image.dot-node-left {
+tiptap-editor::ng-deep .ProseMirror .dot-node-left img.dot-image {
     @apply mr-auto;
+}
+
+tiptap-editor::ng-deep .ProseMirror .has-float {
+    @apply w-1/2;
+}
+
+tiptap-editor::ng-deep .ProseMirror .has-float img.dot-image {
+    @apply max-w-full;
 }
 
 tiptap-editor::ng-deep .ProseMirror a:has(img.dot-image) {

--- a/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.css
+++ b/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.css
@@ -21,3 +21,7 @@
 .bubble-menu .bubble-menu-icon {
     @apply text-base w-5 h-5 inline-flex items-center justify-center leading-none;
 }
+
+.bubble-menu ::ng-deep .is-active .p-button {
+    @apply bg-blue-100;
+}

--- a/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.html
+++ b/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.html
@@ -16,22 +16,42 @@
         <p-button
             text
             size="small"
-            (onClick)="editor().chain().focus().setTextAlign('left').run()"
-            [class.is-active]="editor().isActive({ textAlign: 'left' })">
+            (onClick)="setImageTextAlign('left')"
+            [class.is-active]="imageTextAlign() === 'left'">
             <i class="pi pi-align-left"></i>
         </p-button>
         <p-button
             text
             size="small"
-            (onClick)="editor().chain().focus().setTextAlign('center').run()"
-            [class.is-active]="editor().isActive({ textAlign: 'center' })">
+            (onClick)="setImageTextAlign('center')"
+            [class.is-active]="imageTextAlign() === 'center'">
             <i class="pi pi-align-center"></i>
         </p-button>
         <p-button
             text
             size="small"
-            (onClick)="editor().chain().focus().setTextAlign('right').run()"
-            [class.is-active]="editor().isActive({ textAlign: 'right' })">
+            (onClick)="setImageTextAlign('right')"
+            [class.is-active]="imageTextAlign() === 'right'">
+            <i class="pi pi-align-right"></i>
+        </p-button>
+
+        <div class="divider"></div>
+        <p-button
+            text
+            size="small"
+            title="{{ 'block-editor.bubble-menu.image.wrap-left' | dm }}"
+            (onClick)="setImageTextWrap('left')"
+            [class.is-active]="imageTextWrap() === 'left'">
+            <i class="pi pi-align-left"></i>
+            <i class="pi pi-image" style="margin-left: -4px"></i>
+        </p-button>
+        <p-button
+            text
+            size="small"
+            title="{{ 'block-editor.bubble-menu.image.wrap-right' | dm }}"
+            (onClick)="setImageTextWrap('right')"
+            [class.is-active]="imageTextWrap() === 'right'">
+            <i class="pi pi-image" style="margin-right: -4px"></i>
             <i class="pi pi-align-right"></i>
         </p-button>
 

--- a/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.ts
+++ b/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.ts
@@ -99,7 +99,7 @@ export class DotBubbleMenuComponent implements OnInit {
     protected readonly showShould = signal<boolean>(true);
     protected readonly showImageMenu = computed(() => this.currentNodeType() === 'dotImage');
     protected readonly showContentMenu = computed(() => this.currentNodeType() === 'dotContent');
-    protected readonly imageTextWrap = signal<string>('none');
+    protected readonly imageTextWrap = signal<string | null>(null);
     protected readonly imageTextAlign = signal<string | null>(null);
 
     protected nodeTypeOptions: NodeTypeOption[] = [
@@ -287,7 +287,7 @@ export class DotBubbleMenuComponent implements OnInit {
     protected setImageTextWrap(value: 'left' | 'right') {
         this.editor().chain().focus().setImageTextWrap(value).run();
         const currentWrap = this.imageTextWrap();
-        this.imageTextWrap.set(currentWrap === value ? 'none' : value);
+        this.imageTextWrap.set(currentWrap === value ? null : value);
         this.imageTextAlign.set(null);
     }
 
@@ -301,7 +301,7 @@ export class DotBubbleMenuComponent implements OnInit {
             .updateAttributes('dotImage', { textAlign: resolvedAlign, textWrap: null })
             .run();
         this.imageTextAlign.set(resolvedAlign);
-        this.imageTextWrap.set('none');
+        this.imageTextWrap.set(null);
     }
     protected goToContentlet() {
         // Validate selection exists before proceeding
@@ -398,7 +398,7 @@ export class DotBubbleMenuComponent implements OnInit {
 
         if (baseNodeType === 'dotImage') {
             const attrs = this.editor().getAttributes('dotImage');
-            this.imageTextWrap.set(attrs?.textWrap ?? 'none');
+            this.imageTextWrap.set(attrs?.textWrap ?? null);
             this.imageTextAlign.set(attrs?.textAlign ?? null);
         }
     }

--- a/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.ts
+++ b/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.ts
@@ -292,12 +292,15 @@ export class DotBubbleMenuComponent implements OnInit {
     }
 
     protected setImageTextAlign(align: string) {
+        const isToggleOff = this.imageTextAlign() === align;
+        const resolvedAlign = isToggleOff ? null : align;
+
         this.editor()
             .chain()
             .focus()
-            .updateAttributes('dotImage', { textAlign: align, textWrap: null })
+            .updateAttributes('dotImage', { textAlign: resolvedAlign, textWrap: null })
             .run();
-        this.imageTextAlign.set(align);
+        this.imageTextAlign.set(resolvedAlign);
         this.imageTextWrap.set('none');
     }
     protected goToContentlet() {

--- a/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.ts
+++ b/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.ts
@@ -99,6 +99,8 @@ export class DotBubbleMenuComponent implements OnInit {
     protected readonly showShould = signal<boolean>(true);
     protected readonly showImageMenu = computed(() => this.currentNodeType() === 'dotImage');
     protected readonly showContentMenu = computed(() => this.currentNodeType() === 'dotContent');
+    protected readonly imageTextWrap = signal<string>('none');
+    protected readonly imageTextAlign = signal<string | null>(null);
 
     protected nodeTypeOptions: NodeTypeOption[] = [
         {
@@ -281,6 +283,23 @@ export class DotBubbleMenuComponent implements OnInit {
 
         return !!image?.href;
     }
+
+    protected setImageTextWrap(value: 'left' | 'right') {
+        this.editor().chain().focus().setImageTextWrap(value).run();
+        const currentWrap = this.imageTextWrap();
+        this.imageTextWrap.set(currentWrap === value ? 'none' : value);
+        this.imageTextAlign.set(null);
+    }
+
+    protected setImageTextAlign(align: string) {
+        this.editor()
+            .chain()
+            .focus()
+            .updateAttributes('dotImage', { textAlign: align, textWrap: null })
+            .run();
+        this.imageTextAlign.set(align);
+        this.imageTextWrap.set('none');
+    }
     protected goToContentlet() {
         // Validate selection exists before proceeding
 
@@ -373,6 +392,12 @@ export class DotBubbleMenuComponent implements OnInit {
         this.dropdownItem.set(foundOption ?? this.nodeTypeOptions[0]);
         this.currentNodeType.set(baseNodeType);
         this.showShould.set(BUBBLE_MENU_VISIBLE_NODES[baseNodeType]);
+
+        if (baseNodeType === 'dotImage') {
+            const attrs = this.editor().getAttributes('dotImage');
+            this.imageTextWrap.set(attrs?.textWrap ?? 'none');
+            this.imageTextAlign.set(attrs?.textAlign ?? null);
+        }
     }
 
     /**

--- a/core-web/libs/block-editor/src/lib/nodes/image-node/image.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/image-node/image.node.ts
@@ -6,12 +6,20 @@ import { addImageLanguageId, getImageAttr, imageElement, imageLinkElement } from
 
 import { contentletToJSON } from '../../shared';
 
+const FLOAT_STYLES: Record<'left' | 'right', string> = {
+    left: 'float: left; margin: 0 1rem 1rem 0;',
+    right: 'float: right; margin: 0 0 1rem 1rem;'
+};
+
+const IMG_ONLY_ATTRS = new Set(['textWrap', 'textAlign']);
+
 declare module '@tiptap/core' {
     interface Commands<ReturnType> {
         ImageBlock: {
             setImageLink: (attributes: { href: string; target?: string }) => ReturnType;
             unsetImageLink: () => ReturnType;
             insertImage: (attrs: DotCMSContentlet | string, position?: number) => ReturnType;
+            setImageTextWrap: (value: 'left' | 'right' | 'none') => ReturnType;
         };
     }
 }
@@ -64,6 +72,16 @@ export const ImageNode = Image.extend({
                 default: null,
                 parseHTML: (element) => element.getAttribute('target'),
                 renderHTML: (attributes) => ({ target: attributes.target })
+            },
+            textWrap: {
+                default: null,
+                parseHTML: (element) => element.getAttribute('textWrap'),
+                renderHTML: (attributes) => ({ textWrap: attributes.textWrap })
+            },
+            textAlign: {
+                default: null,
+                parseHTML: (element) => element.getAttribute('textAlign'),
+                renderHTML: (attributes) => ({ textAlign: attributes.textAlign })
             }
         };
     },
@@ -102,65 +120,89 @@ export const ImageNode = Image.extend({
                     return chain()
                         .insertContentAt(position ?? head, node)
                         .run();
+                },
+            setImageTextWrap:
+                (value) =>
+                ({ commands, editor }) => {
+                    const currentTextWrap = editor.getAttributes(ImageNode.name).textWrap;
+                    const isToggleOff = currentTextWrap === value;
+                    const resolvedWrap = isToggleOff || value === 'none' ? null : value;
+
+                    return commands.updateAttributes(ImageNode.name, {
+                        textWrap: resolvedWrap,
+                        textAlign: null
+                    });
                 }
         };
     },
 
-    /**
-     * Return the node for the renderHTML method
-     *
-     * @param {*} { HTMLAttributes }
-     * @return {*}
-     */
     renderHTML({ HTMLAttributes }) {
-        const { href = null, style } = HTMLAttributes || {};
+        const { href = null, textWrap, textAlign } = HTMLAttributes || {};
+
+        let divStyle: string | undefined;
+
+        if (textWrap === 'left' || textWrap === 'right') {
+            divStyle = FLOAT_STYLES[textWrap];
+        } else if (textAlign) {
+            divStyle = `text-align: ${textAlign};`;
+        }
 
         return [
             'div',
-            { style },
+            { style: divStyle },
             href
                 ? imageLinkElement(this.options.HTMLAttributes, HTMLAttributes)
                 : imageElement(this.options.HTMLAttributes, HTMLAttributes)
         ];
     },
 
-    /**
-     * Return the node view for Block Editor in Development mode
-     *
-     * @return {*}
-     */
     addNodeView() {
         return ({ node, HTMLAttributes }) => {
             const hasImageLink = !!HTMLAttributes.href;
             const img = document.createElement('img');
             img.classList.add(`dot-image`);
             Object.entries(HTMLAttributes).forEach(([key, value]) => {
+                if (IMG_ONLY_ATTRS.has(key)) {
+                    return;
+                }
+
                 if (typeof value === 'object' && value !== null) {
                     value = JSON.stringify(value);
                 }
 
-                img.setAttribute(key, value);
+                img.setAttribute(key, value as string);
             });
 
-            let dom;
+            let inner: HTMLElement;
             if (hasImageLink) {
                 const a = document.createElement('a');
                 a.setAttribute('href', HTMLAttributes.href);
                 a.setAttribute('target', HTMLAttributes.target);
                 a.appendChild(img);
-                dom = a;
+                inner = a;
             } else {
-                dom = img;
+                inner = img;
             }
 
-            const align = img.style.textAlign || 'left';
-            dom.classList.add(`dot-node-${align}`);
+            const wrapper = document.createElement('div');
+            const textWrap = HTMLAttributes.textWrap;
+            const textAlign = HTMLAttributes.textAlign;
 
-            // Override toJSON method to include the contentlet data
+            if (textWrap === 'left' || textWrap === 'right') {
+                wrapper.style.cssText = FLOAT_STYLES[textWrap];
+                wrapper.classList.add('has-float');
+            } else if (textAlign) {
+                wrapper.style.textAlign = textAlign;
+            }
+
+            const align = textWrap ?? textAlign ?? 'left';
+            wrapper.classList.add(`dot-node-${align}`);
+            wrapper.appendChild(inner);
+
             node.toJSON = contentletToJSON.bind({ node });
 
             return {
-                dom,
+                dom: wrapper,
                 node
             };
         };

--- a/core-web/libs/block-editor/src/lib/nodes/image-node/image.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/image-node/image.node.ts
@@ -7,8 +7,8 @@ import { addImageLanguageId, getImageAttr, imageElement, imageLinkElement } from
 import { contentletToJSON } from '../../shared';
 
 const FLOAT_STYLES: Record<'left' | 'right', string> = {
-    left: 'float: left; margin: 0 1rem 1rem 0;',
-    right: 'float: right; margin: 0 0 1rem 1rem;'
+    left: 'float: left; width: 50%; margin: 0 1rem 1rem 0;',
+    right: 'float: right; width: 50%; margin: 0 0 1rem 1rem;'
 };
 
 const IMG_ONLY_ATTRS = new Set(['textWrap', 'textAlign']);
@@ -75,13 +75,13 @@ export const ImageNode = Image.extend({
             },
             textWrap: {
                 default: null,
-                parseHTML: (element) => element.getAttribute('textWrap'),
-                renderHTML: (attributes) => ({ textWrap: attributes.textWrap })
+                parseHTML: (element) => element.getAttribute('textwrap'),
+                renderHTML: (attributes) => ({ textwrap: attributes.textWrap })
             },
             textAlign: {
                 default: null,
-                parseHTML: (element) => element.getAttribute('textAlign'),
-                renderHTML: (attributes) => ({ textAlign: attributes.textAlign })
+                parseHTML: (element) => element.getAttribute('textalign'),
+                renderHTML: (attributes) => ({ textalign: attributes.textAlign })
             }
         };
     },
@@ -148,7 +148,7 @@ export const ImageNode = Image.extend({
         }
 
         return [
-            'div',
+            'figure',
             { style: divStyle },
             href
                 ? imageLinkElement(this.options.HTMLAttributes, HTMLAttributes)
@@ -195,8 +195,10 @@ export const ImageNode = Image.extend({
                 wrapper.style.textAlign = textAlign;
             }
 
-            const align = textWrap ?? textAlign ?? 'left';
-            wrapper.classList.add(`dot-node-${align}`);
+            const align = textWrap ?? textAlign;
+            if (align) {
+                wrapper.classList.add(`dot-node-${align}`);
+            }
             wrapper.appendChild(inner);
 
             node.toJSON = contentletToJSON.bind({ node });

--- a/core-web/libs/block-editor/src/lib/nodes/image-node/image.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/image-node/image.node.ts
@@ -185,8 +185,9 @@ export const ImageNode = Image.extend({
             }
 
             const wrapper = document.createElement('div');
-            const textWrap = HTMLAttributes.textWrap;
-            const textAlign = HTMLAttributes.textAlign;
+            // Use node.attrs (camelCase) not HTMLAttributes — renderHTML lowercases keys to textwrap/textalign
+            const textWrap = node.attrs['textWrap'];
+            const textAlign = node.attrs['textAlign'];
 
             if (textWrap === 'left' || textWrap === 'right') {
                 wrapper.style.cssText = FLOAT_STYLES[textWrap];

--- a/core-web/libs/block-editor/src/lib/nodes/image-node/image.node.ts
+++ b/core-web/libs/block-editor/src/lib/nodes/image-node/image.node.ts
@@ -19,7 +19,7 @@ declare module '@tiptap/core' {
             setImageLink: (attributes: { href: string; target?: string }) => ReturnType;
             unsetImageLink: () => ReturnType;
             insertImage: (attrs: DotCMSContentlet | string, position?: number) => ReturnType;
-            setImageTextWrap: (value: 'left' | 'right' | 'none') => ReturnType;
+            setImageTextWrap: (value: 'left' | 'right' | null) => ReturnType;
         };
     }
 }
@@ -125,8 +125,7 @@ export const ImageNode = Image.extend({
                 (value) =>
                 ({ commands, editor }) => {
                     const currentTextWrap = editor.getAttributes(ImageNode.name).textWrap;
-                    const isToggleOff = currentTextWrap === value;
-                    const resolvedWrap = isToggleOff || value === 'none' ? null : value;
+                    const resolvedWrap = currentTextWrap === value ? null : value;
 
                     return commands.updateAttributes(ImageNode.name, {
                         textWrap: resolvedWrap,

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.spec.ts
@@ -1,0 +1,57 @@
+import { createComponentFactory, Spectator } from '@ngneat/spectator';
+
+import { DotImageBlock } from './image.component';
+
+describe('DotImageBlock', () => {
+    let spectator: Spectator<DotImageBlock>;
+
+    const createComponent = createComponentFactory({
+        component: DotImageBlock,
+        detectChanges: false
+    });
+
+    beforeEach(() => {
+        spectator = createComponent();
+    });
+
+    it('should render figure with img', () => {
+        spectator.setInput('attrs', { src: 'image.png', alt: 'test' });
+        spectator.detectChanges();
+        expect(spectator.query('figure')).toBeTruthy();
+        expect(spectator.query('img')).toBeTruthy();
+    });
+
+    it('should set img src from attrs', () => {
+        spectator.setInput('attrs', { src: 'image.png', alt: 'alt text' });
+        spectator.detectChanges();
+        expect(spectator.query<HTMLImageElement>('img')?.src).toContain('image.png');
+    });
+
+    it('should apply float-left style when textWrap is left', () => {
+        spectator.setInput('attrs', { src: 'image.png', alt: '', textWrap: 'left' });
+        spectator.detectChanges();
+        const figure = spectator.query<HTMLElement>('figure');
+        expect(figure?.style.float).toBe('left');
+    });
+
+    it('should apply float-right style when textWrap is right', () => {
+        spectator.setInput('attrs', { src: 'image.png', alt: '', textWrap: 'right' });
+        spectator.detectChanges();
+        const figure = spectator.query<HTMLElement>('figure');
+        expect(figure?.style.float).toBe('right');
+    });
+
+    it('should apply text-align style when textAlign is set', () => {
+        spectator.setInput('attrs', { src: 'image.png', alt: '', textAlign: 'center' });
+        spectator.detectChanges();
+        const figure = spectator.query<HTMLElement>('figure');
+        expect(figure?.style.textAlign).toBe('center');
+    });
+
+    it('should have no style when neither textWrap nor textAlign is set', () => {
+        spectator.setInput('attrs', { src: 'image.png', alt: '' });
+        spectator.detectChanges();
+        const figure = spectator.query<HTMLElement>('figure');
+        expect(figure?.getAttribute('style')).toBeFalsy();
+    });
+});

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
@@ -1,13 +1,12 @@
-import { NgStyle } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, Input } from '@angular/core';
 
 import { BlockEditorNode } from '@dotcms/types';
 
 @Component({
     selector: 'dotcms-block-editor-renderer-image',
-    imports: [NgStyle],
+    imports: [],
     template: `
-        <figure [ngStyle]="$wrapperStyle()">
+        <figure [style]="$wrapperStyle()">
             <img [alt]="attrs?.['alt']" [src]="$srcURL()" />
         </figure>
     `,

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-block-editor-renderer/blocks/image.component.ts
@@ -1,11 +1,15 @@
+import { NgStyle } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, Input } from '@angular/core';
 
 import { BlockEditorNode } from '@dotcms/types';
 
 @Component({
     selector: 'dotcms-block-editor-renderer-image',
+    imports: [NgStyle],
     template: `
-        <img [alt]="attrs?.['alt']" [src]="$srcURL()" />
+        <figure [ngStyle]="$wrapperStyle()">
+            <img [alt]="attrs?.['alt']" [src]="$srcURL()" />
+        </figure>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
@@ -13,4 +17,19 @@ export class DotImageBlock {
     @Input() attrs!: BlockEditorNode['attrs'];
 
     protected readonly $srcURL = computed(() => this.attrs?.['src']);
+
+    protected readonly $wrapperStyle = computed(() => {
+        const textWrap = this.attrs?.['textWrap'];
+        const textAlign = this.attrs?.['textAlign'];
+
+        if (textWrap === 'left') {
+            return { float: 'left', width: '50%', margin: '0 1rem 1rem 0' };
+        } else if (textWrap === 'right') {
+            return { float: 'right', width: '50%', margin: '0 0 1rem 1rem' };
+        } else if (textAlign) {
+            return { 'text-align': textAlign };
+        }
+
+        return {};
+    });
 }

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/Image.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/Image.test.tsx
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import { BlockEditorNode } from '@dotcms/types';
+
+import { DotCMSImage } from '../../components/DotCMSBlockEditorRenderer/components/blocks/Image';
+
+const baseNode = (attrs: Record<string, unknown>): BlockEditorNode => ({
+    type: 'dotImage',
+    attrs
+});
+
+describe('DotCMSImage', () => {
+    it('should render figure and img', () => {
+        const { container } = render(
+            <DotCMSImage node={baseNode({ src: 'image.png', alt: 'alt' })} />
+        );
+        expect(container.querySelector('figure')).toBeInTheDocument();
+        expect(container.querySelector('img')).toBeInTheDocument();
+    });
+
+    it('should set img src and alt', () => {
+        render(<DotCMSImage node={baseNode({ src: 'image.png', alt: 'my alt' })} />);
+        const img = screen.getByAltText('my alt');
+        expect(img).toHaveAttribute('src', 'image.png');
+    });
+
+    it('should apply float-left style when textWrap is left', () => {
+        const { container } = render(
+            <DotCMSImage node={baseNode({ src: 'img.png', alt: '', textWrap: 'left' })} />
+        );
+        const figure = container.querySelector('figure') as HTMLElement;
+        expect(figure.style.float).toBe('left');
+        expect(figure.style.width).toBe('50%');
+    });
+
+    it('should apply float-right style when textWrap is right', () => {
+        const { container } = render(
+            <DotCMSImage node={baseNode({ src: 'img.png', alt: '', textWrap: 'right' })} />
+        );
+        const figure = container.querySelector('figure') as HTMLElement;
+        expect(figure.style.float).toBe('right');
+    });
+
+    it('should apply textAlign style when textAlign is set', () => {
+        const { container } = render(
+            <DotCMSImage node={baseNode({ src: 'img.png', alt: '', textAlign: 'center' })} />
+        );
+        const figure = container.querySelector('figure') as HTMLElement;
+        expect(figure.style.textAlign).toBe('center');
+    });
+
+    it('should apply maxWidth style on img when textWrap is set', () => {
+        const { container } = render(
+            <DotCMSImage node={baseNode({ src: 'img.png', alt: '', textWrap: 'left' })} />
+        );
+        const img = container.querySelector('img') as HTMLElement;
+        expect(img.style.maxWidth).toBe('100%');
+    });
+
+    it('should have no wrapper style when neither textWrap nor textAlign is set', () => {
+        const { container } = render(<DotCMSImage node={baseNode({ src: 'img.png', alt: '' })} />);
+        const figure = container.querySelector('figure') as HTMLElement;
+        expect(figure.getAttribute('style')).toBeFalsy();
+    });
+});

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/Image.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/Image.tsx
@@ -3,6 +3,8 @@ import { BlockEditorNode } from '@dotcms/types';
 interface DotCMSImageProps {
     src: string;
     alt: string;
+    textWrap?: 'left' | 'right';
+    textAlign?: string;
 }
 
 /**
@@ -12,7 +14,21 @@ interface DotCMSImageProps {
  * @returns The rendered image component.
  */
 export const DotCMSImage = ({ node }: { node: BlockEditorNode }) => {
-    const { src, alt } = node.attrs as DotCMSImageProps;
+    const { src, alt, textWrap, textAlign } = node.attrs as DotCMSImageProps;
 
-    return <img alt={alt} src={src} />;
+    let wrapperStyle: React.CSSProperties = {};
+
+    if (textWrap === 'left') {
+        wrapperStyle = { float: 'left', width: '50%', margin: '0 1rem 1rem 0' };
+    } else if (textWrap === 'right') {
+        wrapperStyle = { float: 'right', width: '50%', margin: '0 0 1rem 1rem' };
+    } else if (textAlign) {
+        wrapperStyle = { textAlign: textAlign as React.CSSProperties['textAlign'] };
+    }
+
+    return (
+        <figure style={wrapperStyle}>
+            <img alt={alt} src={src} />
+        </figure>
+    );
 };

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/Image.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSBlockEditorRenderer/components/blocks/Image.tsx
@@ -28,7 +28,11 @@ export const DotCMSImage = ({ node }: { node: BlockEditorNode }) => {
 
     return (
         <figure style={wrapperStyle}>
-            <img alt={alt} src={src} />
+            <img
+                alt={alt}
+                src={src}
+                style={textWrap ? { maxWidth: '100%', height: 'auto' } : undefined}
+            />
         </figure>
     );
 };

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
@@ -1,17 +1,27 @@
 #set($allowedAligns = ["left", "center", "right", "justify"])
-<figure#if($item.attrs.textWrap == "left") style="float: left; width: 50%; margin: 0 1rem 1rem 0;"#elseif($item.attrs.textWrap == "right") style="float: right; width: 50%; margin: 0 0 1rem 1rem;"#elseif($allowedAligns.contains($item.attrs.textAlign)) style="text-align: $item.attrs.textAlign;"#end>
+
+#if($item.attrs.textWrap == "left")
+    #set($figureStyle = "float: left; width: 50%; margin: 0 1rem 1rem 0;")
+#elseif($item.attrs.textWrap == "right")
+    #set($figureStyle = "float: right; width: 50%; margin: 0 0 1rem 1rem;")
+#elseif($allowedAligns.contains($item.attrs.textAlign))
+    #set($figureStyle = "text-align: $item.attrs.textAlign;")
+#end
+
+<figure#if($figureStyle) style="$figureStyle"#end>
 
     #if ($!item.attrs.href != "null")
     <a href="$!item.attrs.href">
     #end
-        <img
-            src="#if($!item.attrs.src && $!item.attrs.src != "null")$!item.attrs.src#{else}$!item.attrs.data.asset#end"
-            alt="#if($!item.attrs.alt && $!item.attrs.alt != "null")$!item.attrs.alt#{else}$!item.attrs.data.title#end"
-            title="#if($!item.attrs.title && $!item.attrs.title != "null")$!item.attrs.title#{else}$!item.attrs.data.title#end"
-        />
+
+    <img
+        src="#if($!item.attrs.src && $!item.attrs.src != "null")$!item.attrs.src#{else}$!item.attrs.data.asset#end"
+        alt="#if($!item.attrs.alt && $!item.attrs.alt != "null")$!item.attrs.alt#{else}$!item.attrs.data.title#end"
+        title="#if($!item.attrs.title && $!item.attrs.title != "null")$!item.attrs.title#{else}$!item.attrs.data.title#end"
+    />
+
     #if ($!item.attrs.href != "null")
     </a>
     #end
 
 </figure>
-

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
@@ -1,4 +1,5 @@
-<figure#if($item.attrs.textWrap == "left") style="float: left; width: 50%; margin: 0 1rem 1rem 0;"#elseif($item.attrs.textWrap == "right") style="float: right; width: 50%; margin: 0 0 1rem 1rem;"#elseif($item.attrs.textAlign) style="text-align: $item.attrs.textAlign;"#end>
+#set($allowedAligns = ["left", "center", "right", "justify"])
+<figure#if($item.attrs.textWrap == "left") style="float: left; width: 50%; margin: 0 1rem 1rem 0;"#elseif($item.attrs.textWrap == "right") style="float: right; width: 50%; margin: 0 0 1rem 1rem;"#elseif($allowedAligns.contains($item.attrs.textAlign)) style="text-align: $item.attrs.textAlign;"#end>
 
     #if ($!item.attrs.href != "null")
     <a href="$!item.attrs.href">

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/storyblock/dotImage.vtl
@@ -1,4 +1,4 @@
-<div#if($item.attrs.textAlign) style="text-align: $item.attrs.textAlign;"#end>
+<figure#if($item.attrs.textWrap == "left") style="float: left; width: 50%; margin: 0 1rem 1rem 0;"#elseif($item.attrs.textWrap == "right") style="float: right; width: 50%; margin: 0 0 1rem 1rem;"#elseif($item.attrs.textAlign) style="text-align: $item.attrs.textAlign;"#end>
 
     #if ($!item.attrs.href != "null")
     <a href="$!item.attrs.href">
@@ -12,5 +12,5 @@
     </a>
     #end
 
-</div>
+</figure>
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/58e94feb-ef43-43de-991f-24047ebafd4b


## Summary

Adds text wrap and alignment controls for the image block in the Block Editor, allowing content authors to float images left/right with text wrapping around them, or align images horizontally.

- **Text wrap**: New wrap-left / wrap-right buttons in the bubble menu float the image at 50% width so surrounding text flows around it
- **Text align**: Left / center / right alignment buttons control horizontal positioning when no wrap is active
- **Mutually exclusive**: Selecting a wrap clears the alignment and vice versa — no conflicting styles
- **Active state**: The active button is highlighted with a light blue background so authors can see the current selection
- **`<figure>` element**: Replaced `<div>` wrapper with semantic `<figure>` across the editor, VTL template, and both React and Angular SDKs
- **SDK support**: React (`Image.tsx`) and Angular (`image.component.ts`) SDK image block components updated to render `textWrap` and `textAlign` attributes

## Test plan

- [ ] Insert an image block in the Block Editor
- [ ] Click wrap-left — image floats left at 50% width, text wraps around it, button shows active state
- [ ] Click wrap-left again — wrap toggles off
- [ ] Click wrap-right — image floats right, wrap-left becomes inactive
- [ ] Click an align button while wrap is active — wrap clears, align applies
- [ ] Click a wrap button while align is active — align clears, wrap applies
- [ ] Verify rendered output in VTL (dotImage.vtl) applies correct float/align styles on the `<figure>`
- [ ] Verify React and Angular SDK consumers render wrap/align styles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)