### PR TITLE
fix(edit-content): migrate url-title VTL for new edit mode

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title.vtl
@@ -1,0 +1,5 @@
+#if( $structures.isNewEditModeEnabled() )
+    #parse('/static/htmlpage_assets/url-title_new.vtl')
+#else
+    #parse('/static/htmlpage_assets/url-title_old.vtl')
+#end

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_new.vtl
@@ -1,0 +1,96 @@
+<script type="module">
+    const SOURCE_FIELD = 'title';
+    const TARGET_FIELD = 'urlTitle';
+    const SLUG_INPUT = 'slugInput';
+    const SUGGESTION_DIV = 'slugSuggestion';
+
+    let isLocked = false;
+    let currentValue = '';
+
+    const slugifyText = text => text
+        .toLowerCase()
+        .replace(/[àáäâ]/g, 'a')
+        .replace(/[èéëê]/g, 'e')
+        .replace(/[ìíïî]/g, 'i')
+        .replace(/[òóöô]/g, 'o')
+        .replace(/[ùúüû]/g, 'u')
+        .replace(/[ñ]/g, 'n')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+    DotCustomFieldApi.ready(() => {
+        const sourceField = DotCustomFieldApi.getField(SOURCE_FIELD);
+        const targetField = DotCustomFieldApi.getField(TARGET_FIELD);
+        const input = document.getElementById(SLUG_INPUT);
+        const suggestion = document.getElementById(SUGGESTION_DIV);
+        const savedValue = targetField.getValue();
+
+        if (savedValue) {
+            input.value = savedValue;
+            currentValue = savedValue;
+        }
+
+        const hideSuggestion = () => {
+            suggestion.classList.add('hidden');
+            suggestion.classList.remove('block');
+            suggestion.innerHTML = '';
+        };
+
+        const applySuggestion = slug => {
+            input.value = slug;
+            currentValue = slug;
+            isLocked = true;
+            targetField.setValue(slug); // WRITE A VALUE
+            hideSuggestion();
+        };
+
+        const showSuggestion = newSlug => {
+            if (!newSlug || newSlug === currentValue) {
+                hideSuggestion();
+                return;
+            }
+
+            suggestion.innerHTML = '';
+
+            const link = document.createElement('a');
+            link.href = '#';
+            link.className = 'link link-primary';
+            link.textContent = `Use: ${newSlug}`;
+            link.addEventListener('click', event => {
+                event.preventDefault();
+                applySuggestion(newSlug);
+            });
+
+            suggestion.appendChild(link);
+            suggestion.classList.remove('hidden');
+            suggestion.classList.add('block');
+        };
+
+        const handleInput = () => {
+            const newSlug = slugifyText(input.value);
+            input.value = newSlug;
+            currentValue = newSlug;
+            isLocked = true;
+            targetField.setValue(newSlug); // WRITE A VALUE
+        };
+
+        sourceField.onChange(value => { // LISTEN A VALUE
+            const newSlug = slugifyText(value);
+            showSuggestion(newSlug);
+        });
+
+        input.addEventListener('keyup', handleInput);
+    });
+</script>
+
+<input
+    type="text"
+    id="slugInput"
+    class="input input-bordered w-full"
+/>
+<div
+    id="slugSuggestion"
+    class="hidden mt-2 text-primary"
+    role="region"
+    aria-live="polite"
+></div>

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_old.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_old.vtl
@@ -1,0 +1,81 @@
+<script type="module">
+    const SOURCE_FIELD = 'title';
+    const TARGET_FIELD = 'urlTitle';
+    const SLUG_INPUT = 'slugInput';
+    const SUGGESTION_DIV = 'slugSuggestion';
+
+    let isLocked = false;
+    let currentValue = '';
+
+    const slugifyText = text => text
+        .toLowerCase()
+        .replace(/[àáäâ]/g, 'a')
+        .replace(/[èéëê]/g, 'e')
+        .replace(/[ìíïî]/g, 'i')
+        .replace(/[òóöô]/g, 'o')
+        .replace(/[ùúüû]/g, 'u')
+        .replace(/[ñ]/g, 'n')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+
+    const showSuggestion = newSlug => {
+        const suggestion = document.getElementById(SUGGESTION_DIV);
+        
+        if (!newSlug || newSlug === currentValue) {
+            suggestion.style.display = 'none';
+            return;
+        }
+
+        suggestion.innerHTML = `
+            <a href="#" onclick="applySuggestion('${newSlug}'); return false">
+                Use: ${newSlug}
+            </a>
+        `;
+        suggestion.style.display = 'block';
+    };
+
+    const applySuggestion = slug => {
+        const input = document.getElementById(SLUG_INPUT);
+        input.value = slug;
+        currentValue = slug;
+        isLocked = true;
+        DotCustomFieldApi.set(TARGET_FIELD, slug); // WRITE A VALUE
+        document.getElementById(SUGGESTION_DIV).style.display = 'none';
+    };
+
+    const handleInput = () => {
+        const input = document.getElementById(SLUG_INPUT);
+        const newSlug = slugifyText(input.value);
+        input.value = newSlug;
+        currentValue = newSlug;
+        isLocked = true;
+        DotCustomFieldApi.set(TARGET_FIELD, newSlug); // WRITE A VALUE
+    };
+
+    DotCustomFieldApi.ready(() => { // WAIT UNTIL ALL IS READY
+        const input = document.getElementById(SLUG_INPUT);
+        const savedValue = DotCustomFieldApi.get(TARGET_FIELD); // GET A VALUE
+        
+        if (savedValue) {
+            input.value = savedValue;
+            currentValue = savedValue;
+        }
+
+        DotCustomFieldApi.onChangeField(SOURCE_FIELD, value => { // LISTEN A VALUE
+                const newSlug = slugifyText(value);
+                showSuggestion(newSlug);
+        });
+    });
+</script>
+
+<input 
+    type="text" 
+    id="slugInput" 
+    onkeyup="handleInput()" 
+    class="dijitTextBox" 
+    style="background:#FAFAFA"
+/>
+<div 
+    id="slugSuggestion" 
+    style="margin-top:8px; display:none; color:#2196F3;"
+></div>


### PR DESCRIPTION
This pull request introduces a new mechanism for rendering the URL title input component, allowing for both a new and legacy ("old") edit mode. Depending on whether the new edit mode is enabled, the system will load either the modernized or legacy version of the `url-title` input. Both versions provide similar slug suggestion and input handling but differ in implementation details and UI styling.

The most important changes are:

**Edit Mode Selection Logic:**
* Added conditional logic in `url-title.vtl` to dynamically include either `url-title_new.vtl` or `url-title_old.vtl` based on the status of the new edit mode feature flag.

**New Edit Mode Implementation:**
* Introduced `url-title_new.vtl` with a modern JavaScript implementation using module syntax, improved event handling, and updated UI classes for a more consistent and accessible user experience.

**Legacy Edit Mode Implementation:**
* Added `url-title_old.vtl` containing the legacy approach, which uses global functions, inline event handlers, and older styling conventions to maintain backward compatibility.

This PR fixes: #35215

This PR fixes: #35215