### PR TITLE
maintenance portlet |  Implement Cache Management Apis #35190

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/AbstractCacheProviderStatsView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/AbstractCacheProviderStatsView.java
@@ -1,0 +1,44 @@
+package com.dotcms.rest.api.v1.system.cache;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.immutables.value.Value;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Per-provider cache statistics view. Each provider reports its own set of
+ * stat columns, so individual stat rows are represented as {@code Map<String, String>}
+ * keyed by column name.
+ *
+ * @author hassandotcms
+ */
+@Value.Style(typeImmutable = "*", typeAbstract = "Abstract*")
+@Value.Immutable
+@JsonSerialize(as = CacheProviderStatsView.class)
+@JsonDeserialize(as = CacheProviderStatsView.class)
+@Schema(description = "Cache statistics for a single cache provider")
+public interface AbstractCacheProviderStatsView {
+
+    @Schema(
+            description = "Cache provider display name",
+            example = "Guava Memory Cache",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String providerName();
+
+    @Schema(
+            description = "Ordered list of stat column names reported by this provider",
+            example = "[\"Region\", \"Configured Size\", \"Memory Used\", \"Is Default\", \"Hit Count\", \"Miss Count\"]",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    List<String> columns();
+
+    @Schema(
+            description = "Per-region statistics, each row keyed by column name",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    List<Map<String, String>> stats();
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/AbstractCacheStatsView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/AbstractCacheStatsView.java
@@ -17,8 +17,29 @@ import java.util.List;
 @Value.Immutable
 @JsonSerialize(as = CacheStatsView.class)
 @JsonDeserialize(as = CacheStatsView.class)
-@Schema(description = "Cache statistics including JVM memory and per-provider region stats")
+@Schema(description = "Cache statistics including cluster/server identity, JVM memory, and per-provider region stats")
 public interface AbstractCacheStatsView {
+
+    @Schema(
+            description = "Cluster identifier (shared across all nodes in the cluster)",
+            example = "b1c2d3e4-f5a6-7890-abcd-ef1234567890",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String clusterId();
+
+    @Schema(
+            description = "Server identifier (unique per node — identifies which node reported these stats)",
+            example = "a9f3c1d2-e456-7890-bcde-f12345678901",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String serverId();
+
+    @Schema(
+            description = "Server hostname",
+            example = "dotcms-node-1.example.com",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String serverName();
 
     @Schema(
             description = "JVM memory statistics",

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/AbstractCacheStatsView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/AbstractCacheStatsView.java
@@ -1,0 +1,34 @@
+package com.dotcms.rest.api.v1.system.cache;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+/**
+ * Top-level cache statistics view combining JVM memory info
+ * with per-provider cache statistics.
+ *
+ * @author hassandotcms
+ */
+@Value.Style(typeImmutable = "*", typeAbstract = "Abstract*")
+@Value.Immutable
+@JsonSerialize(as = CacheStatsView.class)
+@JsonDeserialize(as = CacheStatsView.class)
+@Schema(description = "Cache statistics including JVM memory and per-provider region stats")
+public interface AbstractCacheStatsView {
+
+    @Schema(
+            description = "JVM memory statistics",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    JvmMemoryView memory();
+
+    @Schema(
+            description = "Per-provider cache statistics",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    List<CacheProviderStatsView> providers();
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/AbstractJvmMemoryView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/AbstractJvmMemoryView.java
@@ -1,0 +1,47 @@
+package com.dotcms.rest.api.v1.system.cache;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.immutables.value.Value;
+
+/**
+ * JVM memory statistics view.
+ *
+ * @author hassandotcms
+ */
+@Value.Style(typeImmutable = "*", typeAbstract = "Abstract*")
+@Value.Immutable
+@JsonSerialize(as = JvmMemoryView.class)
+@JsonDeserialize(as = JvmMemoryView.class)
+@Schema(description = "JVM memory statistics in bytes")
+public interface AbstractJvmMemoryView {
+
+    @Schema(
+            description = "Maximum memory the JVM will attempt to use (Xmx)",
+            example = "8589934592",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    long maxMemory();
+
+    @Schema(
+            description = "Total memory currently allocated by the JVM",
+            example = "4294967296",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    long allocatedMemory();
+
+    @Schema(
+            description = "Memory currently in use (allocated minus free)",
+            example = "2147483648",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    long usedMemory();
+
+    @Schema(
+            description = "Available memory (max minus used)",
+            example = "6442450944",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    long freeMemory();
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheMaintenanceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheMaintenanceHelper.java
@@ -1,0 +1,110 @@
+package com.dotcms.rest.api.v1.system.cache;
+
+import com.dotcms.config.DotInitializer;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.MaintenanceUtil;
+import com.google.common.annotations.VisibleForTesting;
+
+import com.dotcms.rest.exception.BadRequestException;
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Encapsulates cache flush business logic and post-flush side effects
+ * (permission reference reset and PushPublishing filter reload).
+ * Shared by both the flush-region and flush-all REST endpoints.
+ *
+ * @author hassandotcms
+ */
+@ApplicationScoped
+public class CacheMaintenanceHelper {
+
+    private final PermissionAPI permissionAPI;
+
+    public CacheMaintenanceHelper() {
+        this(APILocator.getPermissionAPI());
+    }
+
+    @VisibleForTesting
+    public CacheMaintenanceHelper(final PermissionAPI permissionAPI) {
+        this.permissionAPI = permissionAPI;
+    }
+
+    /**
+     * Flushes a specific cache region by name, then performs post-flush side effects.
+     * Validates the region name against known {@code CacheIndex} values.
+     *
+     * @param regionName the cache region name (must match a {@code CacheIndex} value)
+     * @throws BadRequestException if the region name is not recognized
+     */
+    public void flushRegion(final String regionName) {
+
+        if (!isValidRegion(regionName)) {
+            throw new BadRequestException("Unknown cache region: " + regionName);
+        }
+
+        CacheLocator.getCache(regionName).clearCache();
+
+        performPostFlushActions(regionName);
+    }
+
+    /**
+     * Flushes all caches via {@link MaintenanceUtil#flushCache()},
+     * then performs post-flush side effects including PushPublishing reload.
+     */
+    public void flushAllCaches() {
+
+        MaintenanceUtil.flushCache();
+
+        try {
+            permissionAPI.resetAllPermissionReferences();
+        } catch (DotDataException e) {
+            Logger.error(this, "Error resetting permission references after flushing all caches", e);
+        }
+
+        reloadPublishingFilters();
+    }
+
+    /**
+     * Returns the set of valid cache region names derived from {@code CacheLocator.getCacheIndexes()}.
+     */
+    public Set<String> getValidRegionNames() {
+
+        final Object[] caches = CacheLocator.getCacheIndexes();
+        return Stream.of(caches)
+                .map(Object::toString)
+                .collect(Collectors.toSet());
+    }
+
+    private boolean isValidRegion(final String regionName) {
+
+        final Object[] caches = CacheLocator.getCacheIndexes();
+        return Stream.of(caches)
+                .anyMatch(idx -> idx.toString().equals(regionName));
+    }
+
+    private void performPostFlushActions(final String regionName) {
+
+        try {
+            permissionAPI.resetAllPermissionReferences();
+        } catch (DotDataException e) {
+            Logger.error(this, "Error resetting permission references after flushing " + regionName, e);
+        }
+
+        if ("system".equalsIgnoreCase(regionName)) {
+            reloadPublishingFilters();
+        }
+    }
+
+    private void reloadPublishingFilters() {
+
+        DotInitializer.class.cast(APILocator.getPublisherAPI()).init();
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheMaintenanceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheMaintenanceHelper.java
@@ -10,7 +10,6 @@ import com.dotmarketing.util.MaintenanceUtil;
 import com.google.common.annotations.VisibleForTesting;
 
 import com.dotcms.rest.exception.BadRequestException;
-import javax.enterprise.context.ApplicationScoped;
 import java.util.stream.Stream;
 
 /**
@@ -20,7 +19,6 @@ import java.util.stream.Stream;
  *
  * @author hassandotcms
  */
-@ApplicationScoped
 public class CacheMaintenanceHelper {
 
     private final PermissionAPI permissionAPI;
@@ -36,20 +34,24 @@ public class CacheMaintenanceHelper {
 
     /**
      * Flushes a specific cache region by name, then performs post-flush side effects.
-     * Validates the region name against known {@code CacheIndex} values.
+     * Region name lookup is case-insensitive; the canonical name from {@code CacheIndex} is used.
      *
-     * @param regionName the cache region name (must match a {@code CacheIndex} value)
+     * @param regionName the cache region name (case-insensitive)
+     * @return the canonical region name that was flushed
      * @throws BadRequestException if the region name is not recognized
      */
-    public void flushRegion(final String regionName) {
+    public String flushRegion(final String regionName) {
 
-        if (!isValidRegion(regionName)) {
+        final String canonical = resolveRegionName(regionName);
+        if (canonical == null) {
             throw new BadRequestException("Unknown cache region: " + regionName);
         }
 
-        CacheLocator.getCache(regionName).clearCache();
+        CacheLocator.getCache(canonical).clearCache();
 
-        performPostFlushActions(regionName);
+        performPostFlushActions(canonical);
+
+        return canonical;
     }
 
     /**
@@ -69,11 +71,19 @@ public class CacheMaintenanceHelper {
         reloadPublishingFilters();
     }
 
-    private boolean isValidRegion(final String regionName) {
+    /**
+     * Resolves a region name case-insensitively to its canonical {@code CacheIndex} value.
+     *
+     * @return the canonical region name, or {@code null} if not found
+     */
+    private String resolveRegionName(final String regionName) {
 
         final Object[] caches = CacheLocator.getCacheIndexes();
         return Stream.of(caches)
-                .anyMatch(idx -> idx.toString().equals(regionName));
+                .map(Object::toString)
+                .filter(name -> name.equalsIgnoreCase(regionName))
+                .findFirst()
+                .orElse(null);
     }
 
     private void performPostFlushActions(final String regionName) {
@@ -91,7 +101,11 @@ public class CacheMaintenanceHelper {
 
     private void reloadPublishingFilters() {
 
-        DotInitializer.class.cast(APILocator.getPublisherAPI()).init();
+        try {
+            DotInitializer.class.cast(APILocator.getPublisherAPI()).init();
+        } catch (Exception e) {
+            Logger.error(this, "Error reloading PushPublishing filters", e);
+        }
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheMaintenanceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheMaintenanceHelper.java
@@ -11,8 +11,6 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.dotcms.rest.exception.BadRequestException;
 import javax.enterprise.context.ApplicationScoped;
-import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -69,17 +67,6 @@ public class CacheMaintenanceHelper {
         }
 
         reloadPublishingFilters();
-    }
-
-    /**
-     * Returns the set of valid cache region names derived from {@code CacheLocator.getCacheIndexes()}.
-     */
-    public Set<String> getValidRegionNames() {
-
-        final Object[] caches = CacheLocator.getCacheIndexes();
-        return Stream.of(caches)
-                .map(Object::toString)
-                .collect(Collectors.toSet());
     }
 
     private boolean isValidRegion(final String regionName) {

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
@@ -6,7 +6,6 @@ import com.dotcms.rest.ResponseEntityStringView;
 import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
-import com.dotcms.rest.annotation.SwaggerCompliant;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.DotStateException;
@@ -53,7 +52,6 @@ import java.util.stream.Stream;
  * @author jsanca
  */
 @Path("/v1/caches")
-@SwaggerCompliant(value = "System maintenance APIs", batch = 3)
 @Tag(name = "Cache Management", description = "Cache provider management and operations")
 public class CacheResource {
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
@@ -480,13 +480,14 @@ public class CacheResource {
             @ApiResponse(responseCode = "403", description = "Forbidden - requires maintenance portlet access")
     })
     @DELETE
-    @Path("/region/{regionName}")
+    @Path("/region/{regionName: .*}")
     @NoCache
     @Produces({MediaType.APPLICATION_JSON})
     public ResponseEntityStringView flushRegion(
             @Parameter(hidden = true) @Context final HttpServletRequest request,
             @Parameter(hidden = true) @Context final HttpServletResponse response,
-            @Parameter(description = "Cache region name or 'all' to flush all caches",
+            @Parameter(description = "Cache region name (case-insensitive, as returned by "
+                    + "GET /api/v1/caches) or 'all' to flush all caches",
                     required = true, example = "Permission")
             @PathParam("regionName") final String regionName) {
 
@@ -503,9 +504,9 @@ public class CacheResource {
             return new ResponseEntityStringView("Flushed all caches");
         }
 
-        Logger.info(this, "Flushing cache region: " + regionName);
-        cacheMaintenanceHelper.flushRegion(regionName);
-        return new ResponseEntityStringView("Flushed " + regionName);
+        final String canonical = cacheMaintenanceHelper.flushRegion(regionName);
+        Logger.info(this, "Flushed cache region: " + canonical);
+        return new ResponseEntityStringView("Flushed " + canonical);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
@@ -341,12 +341,25 @@ public class CacheResource {
     }
 
     /**
-     * Deletes an objects for a provider (will clean all group and generates a new key)
+     * Flushes all caches across all providers, resets permission references,
+     * and reloads PushPublishing filters. The provider path parameter is ignored —
+     * all caches are flushed regardless.
+     *
      *  @param request   {@link HttpServletRequest}
      *  @param response  {@link HttpServletResponse}
-     *  @param provider {@link String}
+     *  @param provider {@link String} ignored — all providers are flushed
      * @return Response
      */
+    @Operation(
+            summary = "Flush all caches",
+            description = "Flushes all caches across all providers, resets permission references, "
+                    + "and reloads PushPublishing filters. The provider path parameter is ignored."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "All caches flushed successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - authentication required"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - requires maintenance portlet access")
+    })
     @NoCache
     @DELETE
     @Path("/provider/{provider: .*}/flush")

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
@@ -1,22 +1,28 @@
 package com.dotcms.rest.api.v1.system.cache;
 
 import com.dotcms.enterprise.cache.provider.CacheProviderAPIImpl;
+import com.dotcms.rest.ResponseEntityListStringView;
 import com.dotcms.rest.ResponseEntityStringView;
 import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
-import com.dotcms.rest.api.v1.workflow.ResponseEntityWorkflowHistoryCommentsView;
+import com.dotcms.rest.annotation.SwaggerCompliant;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.DotStateException;
 import com.dotmarketing.business.cache.provider.CacheProvider;
+import com.dotmarketing.business.cache.provider.CacheProviderStats;
+import com.dotmarketing.business.cache.provider.CacheStats;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.MaintenanceUtil;
 import com.dotmarketing.util.PortletID;
 import com.google.common.annotations.VisibleForTesting;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import javax.servlet.http.HttpServletRequest;
@@ -29,36 +35,48 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.glassfish.jersey.server.JSONP;
+
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Cache Resource for diff provides
  * @author jsanca
  */
 @Path("/v1/caches")
+@SwaggerCompliant(value = "System maintenance APIs", batch = 3)
 @Tag(name = "Cache Management", description = "Cache provider management and operations")
 public class CacheResource {
 
-    private final WebResource          webResource;
+    private final WebResource webResource;
     private final CacheProviderAPIImpl providerAPI;
+    private final CacheMaintenanceHelper cacheMaintenanceHelper;
     private Method method = null;
 
     public CacheResource() {
 
-        this(new WebResource(), (CacheProviderAPIImpl) APILocator.getCacheProviderAPI());
+        this(new WebResource(),
+             (CacheProviderAPIImpl) APILocator.getCacheProviderAPI(),
+             new CacheMaintenanceHelper());
     }
 
     @VisibleForTesting
     public CacheResource(final WebResource webResource,
-                         final CacheProviderAPIImpl providerAPI) {
+                         final CacheProviderAPIImpl providerAPI,
+                         final CacheMaintenanceHelper cacheMaintenanceHelper) {
 
         this.webResource = webResource;
         this.providerAPI = providerAPI;
+        this.cacheMaintenanceHelper = cacheMaintenanceHelper;
     }
 
     private final List<CacheProvider> getProviders(final String group) {
@@ -348,10 +366,196 @@ public class CacheResource {
 
         Logger.debug(this, ()-> "Deletes all objects on  cache provider = " + provider);
 
-        MaintenanceUtil.flushCache();
+        cacheMaintenanceHelper.flushAllCaches();
         return Response.ok(new ResponseEntityView("flushed all")).build();
     }
 
+
+    /**
+     * Returns an alphabetically sorted list of all cache region names.
+     * Used to populate the flush-cache dropdown in the Cache tab.
+     *
+     * @param request  {@link HttpServletRequest}
+     * @param response {@link HttpServletResponse}
+     * @return sorted list of region names
+     */
+    @Operation(
+            summary = "List cache region names",
+            description = "Returns an alphabetically sorted list of all cache region names. "
+                    + "Used to populate the flush-cache dropdown in the Maintenance portlet Cache tab."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Cache regions retrieved successfully",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseEntityListStringView.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - authentication required"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - requires maintenance portlet access")
+    })
+    @GET
+    @JSONP
+    @NoCache
+    @Produces({MediaType.APPLICATION_JSON})
+    public ResponseEntityListStringView listRegions(
+            @Parameter(hidden = true) @Context final HttpServletRequest request,
+            @Parameter(hidden = true) @Context final HttpServletResponse response) {
+
+        new WebResource.InitBuilder(webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .requiredFrontendUser(false)
+                .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
+                .rejectWhenNoUser(true).init();
+
+        Logger.debug(this, () -> "Listing cache regions");
+
+        final Object[] caches = CacheLocator.getCacheIndexes();
+        final List<String> regions = Stream.of(caches)
+                .map(Object::toString)
+                .sorted()
+                .collect(Collectors.toList());
+
+        return new ResponseEntityListStringView(regions);
+    }
+
+    /**
+     * Returns JVM memory information and per-provider per-region cache statistics.
+     * Used to render the Cache Stats section in the Maintenance portlet.
+     *
+     * @param request  {@link HttpServletRequest}
+     * @param response {@link HttpServletResponse}
+     * @return cache statistics with memory and provider details
+     */
+    @Operation(
+            summary = "Get cache statistics",
+            description = "Returns JVM memory information and per-provider per-region cache statistics "
+                    + "including hit counts, miss counts, and memory usage."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Cache statistics retrieved successfully",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseEntityCacheStatsView.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - authentication required"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - requires maintenance portlet access")
+    })
+    @GET
+    @Path("/stats")
+    @JSONP
+    @NoCache
+    @Produces({MediaType.APPLICATION_JSON})
+    public ResponseEntityCacheStatsView getCacheStats(
+            @Parameter(hidden = true) @Context final HttpServletRequest request,
+            @Parameter(hidden = true) @Context final HttpServletResponse response) {
+
+        new WebResource.InitBuilder(webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .requiredFrontendUser(false)
+                .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
+                .rejectWhenNoUser(true).init();
+
+        Logger.debug(this, () -> "Retrieving cache statistics");
+
+        return new ResponseEntityCacheStatsView(buildCacheStatsView());
+    }
+
+    /**
+     * Flushes a specific cache region across all providers, resets permission references,
+     * and conditionally reloads PushPublishing filters. Pass {@code "all"} to flush all caches.
+     *
+     * @param request    {@link HttpServletRequest}
+     * @param response   {@link HttpServletResponse}
+     * @param regionName the cache region name or {@code "all"}
+     * @return confirmation message
+     */
+    @Operation(
+            summary = "Flush a cache region",
+            description = "Flushes a specific cache region across all providers, resets permission "
+                    + "references, and conditionally reloads PushPublishing filters. "
+                    + "Pass 'all' to flush all caches."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Cache region flushed successfully",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseEntityStringView.class))),
+            @ApiResponse(responseCode = "400", description = "Bad request - unknown cache region name"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized - authentication required"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - requires maintenance portlet access")
+    })
+    @DELETE
+    @Path("/region/{regionName}")
+    @NoCache
+    @Produces({MediaType.APPLICATION_JSON})
+    public ResponseEntityStringView flushRegion(
+            @Parameter(hidden = true) @Context final HttpServletRequest request,
+            @Parameter(hidden = true) @Context final HttpServletResponse response,
+            @Parameter(description = "Cache region name or 'all' to flush all caches",
+                    required = true, example = "Permission")
+            @PathParam("regionName") final String regionName) {
+
+        new WebResource.InitBuilder(webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .requiredFrontendUser(false)
+                .requiredPortlet(PortletID.MAINTENANCE.toString().toLowerCase())
+                .rejectWhenNoUser(true).init();
+
+        if ("all".equalsIgnoreCase(regionName)) {
+            Logger.info(this, "Flushing all caches");
+            cacheMaintenanceHelper.flushAllCaches();
+            return new ResponseEntityStringView("Flushed all caches");
+        }
+
+        Logger.info(this, "Flushing cache region: " + regionName);
+        cacheMaintenanceHelper.flushRegion(regionName);
+        return new ResponseEntityStringView("Flushed " + regionName);
+    }
+
+    /**
+     * Builds the full cache statistics view from JVM runtime memory and cache provider stats.
+     */
+    private CacheStatsView buildCacheStatsView() {
+
+        final long maxMemory = Runtime.getRuntime().maxMemory();
+        final long allocatedMemory = Runtime.getRuntime().totalMemory();
+        final long usedMemory = allocatedMemory - Runtime.getRuntime().freeMemory();
+        final long freeMemory = maxMemory - usedMemory;
+
+        final JvmMemoryView memory = JvmMemoryView.builder()
+                .maxMemory(maxMemory)
+                .allocatedMemory(allocatedMemory)
+                .usedMemory(usedMemory)
+                .freeMemory(freeMemory)
+                .build();
+
+        final List<CacheProviderStats> providerStatsList =
+                CacheLocator.getCacheAdministrator().getCacheStatsList();
+
+        final List<CacheProviderStatsView> providers = new ArrayList<>();
+        for (final CacheProviderStats ps : providerStatsList) {
+
+            final List<String> columns = new ArrayList<>(ps.getStatColumns());
+            final List<Map<String, String>> stats = new ArrayList<>();
+
+            for (final CacheStats cs : ps.getStats()) {
+                final Map<String, String> row = new LinkedHashMap<>();
+                for (final String col : ps.getStatColumns()) {
+                    row.put(col, cs.getStatValue(col));
+                }
+                stats.add(row);
+            }
+
+            providers.add(CacheProviderStatsView.builder()
+                    .providerName(ps.getProviderName())
+                    .columns(columns)
+                    .stats(stats)
+                    .build());
+        }
+
+        return CacheStatsView.builder()
+                .memory(memory)
+                .providers(providers)
+                .build();
+    }
 
     /**
      * Deletes the menu cache

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/CacheResource.java
@@ -1,6 +1,7 @@
 package com.dotcms.rest.api.v1.system.cache;
 
 import com.dotcms.enterprise.cache.provider.CacheProviderAPIImpl;
+import com.dotcms.enterprise.cluster.ClusterFactory;
 import com.dotcms.rest.ResponseEntityListStringView;
 import com.dotcms.rest.ResponseEntityStringView;
 import com.dotcms.rest.ResponseEntityView;
@@ -563,7 +564,17 @@ public class CacheResource {
                     .build());
         }
 
+        String hostName = "localhost";
+        try {
+            hostName = java.net.InetAddress.getLocalHost().getHostName();
+        } catch (java.net.UnknownHostException e) {
+            Logger.debug(this, "Unable to resolve hostname", e);
+        }
+
         return CacheStatsView.builder()
+                .clusterId(ClusterFactory.getClusterId())
+                .serverId(APILocator.getServerAPI().readServerId())
+                .serverName(hostName)
                 .memory(memory)
                 .providers(providers)
                 .build();

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/ResponseEntityCacheStatsView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/cache/ResponseEntityCacheStatsView.java
@@ -1,0 +1,15 @@
+package com.dotcms.rest.api.v1.system.cache;
+
+import com.dotcms.rest.ResponseEntityView;
+
+/**
+ * Response wrapper for the cache statistics endpoint.
+ *
+ * @author hassandotcms
+ */
+public class ResponseEntityCacheStatsView extends ResponseEntityView<CacheStatsView> {
+
+    public ResponseEntityCacheStatsView(final CacheStatsView entity) {
+        super(entity);
+    }
+}

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -4205,6 +4205,114 @@ paths:
           description: default response
       tags:
       - Browser Tree
+  /v1/bundles/assets:
+    post:
+      description: "Adds assets to an existing bundle or creates a new bundle. Bundle\
+        \ resolution: (1) look up by bundleId, (2) if not found, look up unsent bundles\
+        \ by bundleName, (3) if still not found, auto-create a new bundle. A non-matching\
+        \ bundleId does NOT return 404 — it falls through to name lookup and then\
+        \ auto-creation. Assets already in the bundle are silently skipped (idempotent).\
+        \ Individual asset failures (e.g., no publish permission) are reported in\
+        \ the errors list as human-readable strings, not as HTTP errors."
+      operationId: addAssetsToBundle
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddAssetsToBundleForm"
+        description: Assets to add and target bundle information
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityAddAssetsToBundleView"
+          description: Assets processed (check errors list for per-asset failures)
+        "400":
+          content:
+            application/json: {}
+          description: "Invalid request (e.g., empty assetIds)"
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: Forbidden - insufficient permissions
+        "404":
+          content:
+            application/json: {}
+          description: bundleId provided but not found and no bundleName fallback
+        "409":
+          content:
+            application/json: {}
+          description: "Cannot add assets while bundle is in BUNDLING, SENDING_TO_ENDPOINTS,\
+            \ or PUBLISHING_BUNDLE status"
+        "500":
+          content:
+            application/json: {}
+          description: Internal server error
+      summary: Add assets to a bundle
+      tags:
+      - Publishing
+  /v1/bundles/{bundleId}/assets:
+    delete:
+      description: Removes one or more assets from an unpushed bundle. Each asset
+        is processed independently with per-asset results. Assets not found in the
+        bundle return success=false.
+      operationId: removeAssetsFromBundle
+      parameters:
+      - description: Bundle identifier
+        example: 550e8400-e29b-41d4-a716-446655440000
+        in: path
+        name: bundleId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RemoveAssetsFromBundleForm"
+        description: Assets to remove from the bundle
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityRemoveAssetsFromBundleView"
+          description: Removal completed (check per-asset success flags)
+        "400":
+          content:
+            application/json: {}
+          description: "Invalid request (e.g., blank bundleId, empty assetIds)"
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: Forbidden - insufficient permissions
+        "404":
+          content:
+            application/json: {}
+          description: Bundle not found
+        "409":
+          content:
+            application/json: {}
+          description: "Cannot remove assets while bundle is in BUNDLING, SENDING_TO_ENDPOINTS,\
+            \ or PUBLISHING_BUNDLE status"
+        "500":
+          content:
+            application/json: {}
+          description: Internal server error
+      summary: Remove assets from an unpushed bundle
+      tags:
+      - Publishing
   /v1/caches:
     get:
       description: Returns an alphabetically sorted list of all cache region names.
@@ -22302,6 +22410,76 @@ components:
             type: object
         id:
           type: string
+    AddAssetsToBundleForm:
+      type: object
+      description: Form for adding assets to a bundle
+      properties:
+        assetIds:
+          type: array
+          description: List of asset identifiers to add to the bundle
+          example:
+          - asset-123
+          - asset-456
+          items:
+            type: string
+            description: List of asset identifiers to add to the bundle
+            example: "[\"asset-123\",\"asset-456\"]"
+        bundleId:
+          type: string
+          description: "Optional bundle ID. If provided and found, assets are added\
+            \ to this bundle. If not found, falls through to bundleName lookup, then\
+            \ auto-creation — does NOT return 404"
+          example: 550e8400-e29b-41d4-a716-446655440000
+        bundleName:
+          type: string
+          description: "Optional bundle name. Used as fallback when bundleId is not\
+            \ provided or not found. Searches unsent bundles by name (case-insensitive).\
+            \ If no match, a new bundle is created with this name"
+          example: My Content Bundle
+      required:
+      - assetIds
+    AddAssetsToBundleView:
+      type: object
+      properties:
+        bundleId:
+          type: string
+          description: Bundle identifier (new or existing)
+          example: 550e8400-e29b-41d4-a716-446655440000
+        bundleName:
+          type: string
+          description: Name of the bundle
+          example: My Content Bundle
+        created:
+          type: boolean
+          description: Whether a new bundle was created by this call
+          example: false
+        errors:
+          type: array
+          description: Per-asset error messages as human-readable strings. Empty list
+            = all assets added successfully
+          items:
+            type: string
+            description: Per-asset error messages as human-readable strings. Empty
+              list = all assets added successfully
+          properties:
+            empty:
+              type: boolean
+            first:
+              type: string
+            last:
+              type: string
+        total:
+          type: integer
+          format: int32
+          description: Total non-duplicate assets processed (subtract errors count
+            for successful adds). Assets already in the bundle are skipped and excluded
+            from this count.
+          example: 5
+      required:
+      - bundleId
+      - created
+      - errors
+      - total
     AddVariantForm:
       type: object
       properties:
@@ -22884,6 +23062,10 @@ components:
     CacheStatsView:
       type: object
       properties:
+        clusterId:
+          type: string
+          description: Cluster identifier (shared across all nodes in the cluster)
+          example: b1c2d3e4-f5a6-7890-abcd-ef1234567890
         memory:
           $ref: "#/components/schemas/JvmMemoryView"
         providers:
@@ -22898,9 +23080,21 @@ components:
               $ref: "#/components/schemas/CacheProviderStatsView"
             last:
               $ref: "#/components/schemas/CacheProviderStatsView"
+        serverId:
+          type: string
+          description: Server identifier (unique per node — identifies which node
+            reported these stats)
+          example: a9f3c1d2-e456-7890-bcde-f12345678901
+        serverName:
+          type: string
+          description: Server hostname
+          example: dotcms-node-1.example.com
       required:
+      - clusterId
       - memory
       - providers
+      - serverId
+      - serverName
     CachedVanityUrl:
       type: object
       properties:
@@ -28917,6 +29111,47 @@ components:
         urlTimeoutSeconds:
           type: integer
           format: int32
+    RemoveAssetResultView:
+      type: object
+      properties:
+        assetId:
+          type: string
+          description: The asset identifier that was processed
+          example: 550e8400-e29b-41d4-a716-446655440000
+        message:
+          type: string
+          description: Human-readable result message
+          example: Asset removed from bundle
+        success:
+          type: boolean
+          description: Whether the asset was successfully removed from the bundle
+          example: true
+      required:
+      - assetId
+      - message
+      - success
+    RemoveAssetsFromBundleForm:
+      type: object
+      properties:
+        assetIds:
+          type: array
+          description: List of asset identifiers to remove from the bundle
+          example:
+          - asset-123
+          - asset-456
+          items:
+            type: string
+            description: List of asset identifiers to remove from the bundle
+            example: "[\"asset-123\",\"asset-456\"]"
+          properties:
+            empty:
+              type: boolean
+            first:
+              type: string
+            last:
+              type: string
+      required:
+      - assetIds
     ReportResponseEntityView:
       type: object
       properties:
@@ -28980,6 +29215,29 @@ components:
       properties:
         entity:
           $ref: "#/components/schemas/ContentletWorkflowStatusView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityAddAssetsToBundleView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/AddAssetsToBundleView"
         errors:
           type: array
           items:
@@ -30723,6 +30981,31 @@ components:
       properties:
         entity:
           $ref: "#/components/schemas/PushBundleResultView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityRemoveAssetsFromBundleView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/RemoveAssetResultView"
         errors:
           type: array
           items:

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -4244,6 +4244,8 @@ paths:
       - Cache Management
   /v1/caches/provider/{provider}/flush:
     delete:
+      description: "Flushes all caches across all providers, resets permission references,\
+        \ and reloads PushPublishing filters. The provider path parameter is ignored."
       operationId: flushAll
       parameters:
       - in: path
@@ -4253,11 +4255,13 @@ paths:
           type: string
           pattern: .*
       responses:
-        default:
-          content:
-            application/javascript: {}
-            application/json: {}
-          description: default response
+        "200":
+          description: All caches flushed successfully
+        "401":
+          description: Unauthorized - authentication required
+        "403":
+          description: Forbidden - requires maintenance portlet access
+      summary: Flush all caches
       tags:
       - Cache Management
   /v1/caches/provider/{provider}/flush/{group}:

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -4205,114 +4205,26 @@ paths:
           description: default response
       tags:
       - Browser Tree
-  /v1/bundles/assets:
-    post:
-      description: "Adds assets to an existing bundle or creates a new bundle. Bundle\
-        \ resolution: (1) look up by bundleId, (2) if not found, look up unsent bundles\
-        \ by bundleName, (3) if still not found, auto-create a new bundle. A non-matching\
-        \ bundleId does NOT return 404 — it falls through to name lookup and then\
-        \ auto-creation. Assets already in the bundle are silently skipped (idempotent).\
-        \ Individual asset failures (e.g., no publish permission) are reported in\
-        \ the errors list as human-readable strings, not as HTTP errors."
-      operationId: addAssetsToBundle
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AddAssetsToBundleForm"
-        description: Assets to add and target bundle information
-        required: true
+  /v1/caches:
+    get:
+      description: Returns an alphabetically sorted list of all cache region names.
+        Used to populate the flush-cache dropdown in the Maintenance portlet Cache
+        tab.
+      operationId: listRegions
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ResponseEntityAddAssetsToBundleView"
-          description: Assets processed (check errors list for per-asset failures)
-        "400":
-          content:
-            application/json: {}
-          description: "Invalid request (e.g., empty assetIds)"
+                $ref: "#/components/schemas/ResponseEntityListStringView"
+          description: Cache regions retrieved successfully
         "401":
-          content:
-            application/json: {}
           description: Unauthorized - authentication required
         "403":
-          content:
-            application/json: {}
-          description: Forbidden - insufficient permissions
-        "404":
-          content:
-            application/json: {}
-          description: bundleId provided but not found and no bundleName fallback
-        "409":
-          content:
-            application/json: {}
-          description: "Cannot add assets while bundle is in BUNDLING, SENDING_TO_ENDPOINTS,\
-            \ or PUBLISHING_BUNDLE status"
-        "500":
-          content:
-            application/json: {}
-          description: Internal server error
-      summary: Add assets to a bundle
+          description: Forbidden - requires maintenance portlet access
+      summary: List cache region names
       tags:
-      - Publishing
-  /v1/bundles/{bundleId}/assets:
-    delete:
-      description: Removes one or more assets from an unpushed bundle. Each asset
-        is processed independently with per-asset results. Assets not found in the
-        bundle return success=false.
-      operationId: removeAssetsFromBundle
-      parameters:
-      - description: Bundle identifier
-        example: 550e8400-e29b-41d4-a716-446655440000
-        in: path
-        name: bundleId
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/RemoveAssetsFromBundleForm"
-        description: Assets to remove from the bundle
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ResponseEntityRemoveAssetsFromBundleView"
-          description: Removal completed (check per-asset success flags)
-        "400":
-          content:
-            application/json: {}
-          description: "Invalid request (e.g., blank bundleId, empty assetIds)"
-        "401":
-          content:
-            application/json: {}
-          description: Unauthorized - authentication required
-        "403":
-          content:
-            application/json: {}
-          description: Forbidden - insufficient permissions
-        "404":
-          content:
-            application/json: {}
-          description: Bundle not found
-        "409":
-          content:
-            application/json: {}
-          description: "Cannot remove assets while bundle is in BUNDLING, SENDING_TO_ENDPOINTS,\
-            \ or PUBLISHING_BUNDLE status"
-        "500":
-          content:
-            application/json: {}
-          description: Internal server error
-      summary: Remove assets from an unpushed bundle
-      tags:
-      - Publishing
+      - Cache Management
   /v1/caches/menucache:
     delete:
       description: Just deletes the menu cache by request
@@ -4520,6 +4432,55 @@ paths:
             application/javascript: {}
             application/json: {}
           description: default response
+      tags:
+      - Cache Management
+  /v1/caches/region/{regionName}:
+    delete:
+      description: "Flushes a specific cache region across all providers, resets permission\
+        \ references, and conditionally reloads PushPublishing filters. Pass 'all'\
+        \ to flush all caches."
+      operationId: flushRegion
+      parameters:
+      - description: Cache region name or 'all' to flush all caches
+        example: Permission
+        in: path
+        name: regionName
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Cache region flushed successfully
+        "400":
+          description: Bad request - unknown cache region name
+        "401":
+          description: Unauthorized - authentication required
+        "403":
+          description: Forbidden - requires maintenance portlet access
+      summary: Flush a cache region
+      tags:
+      - Cache Management
+  /v1/caches/stats:
+    get:
+      description: "Returns JVM memory information and per-provider per-region cache\
+        \ statistics including hit counts, miss counts, and memory usage."
+      operationId: getCacheStats
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityCacheStatsView"
+          description: Cache statistics retrieved successfully
+        "401":
+          description: Unauthorized - authentication required
+        "403":
+          description: Forbidden - requires maintenance portlet access
+      summary: Get cache statistics
       tags:
       - Cache Management
   /v1/categories:
@@ -22335,76 +22296,6 @@ components:
             type: object
         id:
           type: string
-    AddAssetsToBundleForm:
-      type: object
-      description: Form for adding assets to a bundle
-      properties:
-        assetIds:
-          type: array
-          description: List of asset identifiers to add to the bundle
-          example:
-          - asset-123
-          - asset-456
-          items:
-            type: string
-            description: List of asset identifiers to add to the bundle
-            example: "[\"asset-123\",\"asset-456\"]"
-        bundleId:
-          type: string
-          description: "Optional bundle ID. If provided and found, assets are added\
-            \ to this bundle. If not found, falls through to bundleName lookup, then\
-            \ auto-creation — does NOT return 404"
-          example: 550e8400-e29b-41d4-a716-446655440000
-        bundleName:
-          type: string
-          description: "Optional bundle name. Used as fallback when bundleId is not\
-            \ provided or not found. Searches unsent bundles by name (case-insensitive).\
-            \ If no match, a new bundle is created with this name"
-          example: My Content Bundle
-      required:
-      - assetIds
-    AddAssetsToBundleView:
-      type: object
-      properties:
-        bundleId:
-          type: string
-          description: Bundle identifier (new or existing)
-          example: 550e8400-e29b-41d4-a716-446655440000
-        bundleName:
-          type: string
-          description: Name of the bundle
-          example: My Content Bundle
-        created:
-          type: boolean
-          description: Whether a new bundle was created by this call
-          example: false
-        errors:
-          type: array
-          description: Per-asset error messages as human-readable strings. Empty list
-            = all assets added successfully
-          items:
-            type: string
-            description: Per-asset error messages as human-readable strings. Empty
-              list = all assets added successfully
-          properties:
-            empty:
-              type: boolean
-            first:
-              type: string
-            last:
-              type: string
-        total:
-          type: integer
-          format: int32
-          description: Total non-duplicate assets processed (subtract errors count
-            for successful adds). Assets already in the bundle are skipped and excluded
-            from this count.
-          example: 5
-      required:
-      - bundleId
-      - created
-      - errors
-      - total
     AddVariantForm:
       type: object
       properties:
@@ -22931,6 +22822,79 @@ components:
           type: boolean
         version:
           type: string
+    CacheProviderStatsView:
+      type: object
+      properties:
+        columns:
+          type: array
+          description: Ordered list of stat column names reported by this provider
+          example:
+          - Region
+          - Configured Size
+          - Memory Used
+          - Is Default
+          - Hit Count
+          - Miss Count
+          items:
+            type: string
+            description: Ordered list of stat column names reported by this provider
+            example: "[\"Region\",\"Configured Size\",\"Memory Used\",\"Is Default\"\
+              ,\"Hit Count\",\"Miss Count\"]"
+          properties:
+            empty:
+              type: boolean
+            first:
+              type: string
+            last:
+              type: string
+        providerName:
+          type: string
+          description: Cache provider display name
+          example: Guava Memory Cache
+        stats:
+          type: array
+          description: "Per-region statistics, each row keyed by column name"
+          items:
+            type: object
+            additionalProperties:
+              type: string
+              description: "Per-region statistics, each row keyed by column name"
+            description: "Per-region statistics, each row keyed by column name"
+          properties:
+            empty:
+              type: boolean
+            first:
+              type: object
+              additionalProperties:
+                type: string
+            last:
+              type: object
+              additionalProperties:
+                type: string
+      required:
+      - columns
+      - providerName
+      - stats
+    CacheStatsView:
+      type: object
+      properties:
+        memory:
+          $ref: "#/components/schemas/JvmMemoryView"
+        providers:
+          type: array
+          description: Per-provider cache statistics
+          items:
+            $ref: "#/components/schemas/CacheProviderStatsView"
+          properties:
+            empty:
+              type: boolean
+            first:
+              $ref: "#/components/schemas/CacheProviderStatsView"
+            last:
+              $ref: "#/components/schemas/CacheProviderStatsView"
+      required:
+      - memory
+      - providers
     CachedVanityUrl:
       type: object
       properties:
@@ -26703,6 +26667,18 @@ components:
           $ref: "#/components/schemas/AssetPreviewView"
         last:
           $ref: "#/components/schemas/AssetPreviewView"
+    ImmutableListCacheProviderStatsView:
+      type: array
+      description: Per-provider cache statistics
+      items:
+        $ref: "#/components/schemas/CacheProviderStatsView"
+      properties:
+        empty:
+          type: boolean
+        first:
+          $ref: "#/components/schemas/CacheProviderStatsView"
+        last:
+          $ref: "#/components/schemas/CacheProviderStatsView"
     ImmutableListCondition:
       type: array
       items:
@@ -26760,6 +26736,26 @@ components:
           $ref: "#/components/schemas/JobView"
         last:
           $ref: "#/components/schemas/JobView"
+    ImmutableListMapStringString:
+      type: array
+      description: "Per-region statistics, each row keyed by column name"
+      items:
+        type: object
+        additionalProperties:
+          type: string
+          description: "Per-region statistics, each row keyed by column name"
+        description: "Per-region statistics, each row keyed by column name"
+      properties:
+        empty:
+          type: boolean
+        first:
+          type: object
+          additionalProperties:
+            type: string
+        last:
+          type: object
+          additionalProperties:
+            type: string
     ImmutableListRolePermissionView:
       type: array
       description: Paginated list of role permissions assigned to this asset
@@ -26774,14 +26770,19 @@ components:
           $ref: "#/components/schemas/RolePermissionView"
     ImmutableListString:
       type: array
-      description: List of bundle identifiers to retry
+      description: Ordered list of stat column names reported by this provider
       example:
-      - 01KJWNJM2C67DM56GHBJ4S7B89
-      - 01KJWNJM2C67DM56GHBJ4S7B90
+      - Region
+      - Configured Size
+      - Memory Used
+      - Is Default
+      - Hit Count
+      - Miss Count
       items:
         type: string
-        description: List of bundle identifiers to retry
-        example: "[\"01KJWNJM2C67DM56GHBJ4S7B89\",\"01KJWNJM2C67DM56GHBJ4S7B90\"]"
+        description: Ordered list of stat column names reported by this provider
+        example: "[\"Region\",\"Configured Size\",\"Memory Used\",\"Is Default\",\"\
+          Hit Count\",\"Miss Count\"]"
       properties:
         empty:
           type: boolean
@@ -27225,6 +27226,35 @@ components:
                 type: object
             empty:
               type: boolean
+    JvmMemoryView:
+      type: object
+      description: JVM memory statistics
+      properties:
+        allocatedMemory:
+          type: integer
+          format: int64
+          description: Total memory currently allocated by the JVM
+          example: 4294967296
+        freeMemory:
+          type: integer
+          format: int64
+          description: Available memory (max minus used)
+          example: 6442450944
+        maxMemory:
+          type: integer
+          format: int64
+          description: Maximum memory the JVM will attempt to use (Xmx)
+          example: 8589934592
+        usedMemory:
+          type: integer
+          format: int64
+          description: Memory currently in use (allocated minus free)
+          example: 2147483648
+      required:
+      - allocatedMemory
+      - freeMemory
+      - maxMemory
+      - usedMemory
     KeyValueContentType:
       type: object
       allOf:
@@ -28881,47 +28911,6 @@ components:
         urlTimeoutSeconds:
           type: integer
           format: int32
-    RemoveAssetResultView:
-      type: object
-      properties:
-        assetId:
-          type: string
-          description: The asset identifier that was processed
-          example: 550e8400-e29b-41d4-a716-446655440000
-        message:
-          type: string
-          description: Human-readable result message
-          example: Asset removed from bundle
-        success:
-          type: boolean
-          description: Whether the asset was successfully removed from the bundle
-          example: true
-      required:
-      - assetId
-      - message
-      - success
-    RemoveAssetsFromBundleForm:
-      type: object
-      properties:
-        assetIds:
-          type: array
-          description: List of asset identifiers to remove from the bundle
-          example:
-          - asset-123
-          - asset-456
-          items:
-            type: string
-            description: List of asset identifiers to remove from the bundle
-            example: "[\"asset-123\",\"asset-456\"]"
-          properties:
-            empty:
-              type: boolean
-            first:
-              type: string
-            last:
-              type: string
-      required:
-      - assetIds
     ReportResponseEntityView:
       type: object
       properties:
@@ -28985,29 +28974,6 @@ components:
       properties:
         entity:
           $ref: "#/components/schemas/ContentletWorkflowStatusView"
-        errors:
-          type: array
-          items:
-            $ref: "#/components/schemas/ErrorEntity"
-        i18nMessagesMap:
-          type: object
-          additionalProperties:
-            type: string
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/MessageEntity"
-        pagination:
-          $ref: "#/components/schemas/Pagination"
-        permissions:
-          type: array
-          items:
-            type: string
-    ResponseEntityAddAssetsToBundleView:
-      type: object
-      properties:
-        entity:
-          $ref: "#/components/schemas/AddAssetsToBundleView"
         errors:
           type: array
           items:
@@ -29175,6 +29141,29 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BundleMap"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntityCacheStatsView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/CacheStatsView"
         errors:
           type: array
           items:
@@ -30094,6 +30083,31 @@ components:
           type: array
           items:
             type: string
+    ResponseEntityListStringView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            type: string
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
     ResponseEntityListTemplateView:
       type: object
       properties:
@@ -30703,31 +30717,6 @@ components:
       properties:
         entity:
           $ref: "#/components/schemas/PushBundleResultView"
-        errors:
-          type: array
-          items:
-            $ref: "#/components/schemas/ErrorEntity"
-        i18nMessagesMap:
-          type: object
-          additionalProperties:
-            type: string
-        messages:
-          type: array
-          items:
-            $ref: "#/components/schemas/MessageEntity"
-        pagination:
-          $ref: "#/components/schemas/Pagination"
-        permissions:
-          type: array
-          items:
-            type: string
-    ResponseEntityRemoveAssetsFromBundleView:
-      type: object
-      properties:
-        entity:
-          type: array
-          items:
-            $ref: "#/components/schemas/RemoveAssetResultView"
         errors:
           type: array
           items:

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -4441,13 +4441,15 @@ paths:
         \ to flush all caches."
       operationId: flushRegion
       parameters:
-      - description: Cache region name or 'all' to flush all caches
+      - description: "Cache region name (case-insensitive, as returned by GET /api/v1/caches)\
+          \ or 'all' to flush all caches"
         example: Permission
         in: path
         name: regionName
         required: true
         schema:
           type: string
+          pattern: .*
       responses:
         "200":
           content:

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
@@ -223,10 +223,10 @@ public class CacheResourceIntegrationTest {
     /**
      * Given: Valid region name "System"
      * When: flushRegion is called
-     * Then: Flushes successfully (System triggers PushPublishing reload)
+     * Then: Flushes successfully (System region also triggers PushPublishing reload internally)
      */
     @Test
-    public void test_flushRegion_system_triggers_publishing_reload() {
+    public void test_flushRegion_system_returns_success() {
 
         final ResponseEntityStringView result =
                 cacheResource.flushRegion(

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
@@ -118,6 +118,11 @@ public class CacheResourceIntegrationTest {
         final CacheStatsView stats = result.getEntity();
         assertNotNull(stats);
 
+        assertNotNull("clusterId should be present", stats.clusterId());
+        assertFalse("clusterId should not be empty", stats.clusterId().isEmpty());
+        assertNotNull("serverId should be present", stats.serverId());
+        assertFalse("serverId should not be empty", stats.serverId().isEmpty());
+
         final JvmMemoryView memory = stats.memory();
         assertNotNull(memory);
         assertTrue("maxMemory should be positive", memory.maxMemory() > 0);

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
@@ -209,6 +209,22 @@ public class CacheResourceIntegrationTest {
     }
 
     /**
+     * Given: Region name in wrong case ("permission" instead of "Permission")
+     * When: flushRegion is called
+     * Then: Resolves case-insensitively and returns canonical name in response
+     */
+    @Test
+    public void test_flushRegion_case_insensitive_resolves_to_canonical() {
+
+        final ResponseEntityStringView result =
+                cacheResource.flushRegion(
+                        mockAuthenticatedRequest(), mockResponse, "permission");
+
+        assertNotNull(result);
+        assertEquals("Flushed Permission", result.getEntity());
+    }
+
+    /**
      * Given: Unknown/invalid region name
      * When: flushRegion is called
      * Then: BadRequestException is thrown

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
@@ -1,0 +1,275 @@
+package com.dotcms.rest.api.v1.system.cache;
+
+import com.dotcms.datagen.TestUserUtils;
+import com.dotcms.mock.request.MockAttributeRequest;
+import com.dotcms.mock.request.MockHeaderRequest;
+import com.dotcms.mock.request.MockHttpRequestIntegrationTest;
+import com.dotcms.mock.request.MockSessionRequest;
+import com.dotcms.mock.response.MockHttpResponse;
+import com.dotcms.rest.ResponseEntityListStringView;
+import com.dotcms.rest.ResponseEntityStringView;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.CacheLocator;
+import com.dotmarketing.business.Role;
+import com.liferay.portal.model.User;
+import com.liferay.portal.util.WebKeys;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.dotcms.rest.exception.BadRequestException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for the Cache Management REST endpoints in {@link CacheResource}.
+ * Tests verify endpoint behavior with real cache infrastructure.
+ *
+ * @author hassandotcms
+ */
+public class CacheResourceIntegrationTest {
+
+    private static CacheResource cacheResource;
+    private static HttpServletResponse mockResponse;
+    private static User adminUser;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+        adminUser = TestUserUtils.getAdminUser();
+
+        final Role backendRole = TestUserUtils.getBackendRole();
+        APILocator.getRoleAPI().addRoleToUser(backendRole, adminUser);
+
+        cacheResource = new CacheResource();
+        mockResponse = new MockHttpResponse();
+    }
+
+    // =========================================================================
+    // GET /api/v1/caches — List Cache Regions
+    // =========================================================================
+
+    /**
+     * Given: Authenticated admin user with maintenance portlet access
+     * When: listRegions is called
+     * Then: Returns non-empty sorted list of cache region names
+     */
+    @Test
+    public void test_listRegions_returns_sorted_list() {
+
+        final ResponseEntityListStringView result =
+                cacheResource.listRegions(mockAuthenticatedRequest(), mockResponse);
+
+        assertNotNull(result);
+        final List<String> regions = result.getEntity();
+        assertNotNull(regions);
+        assertFalse("Regions list should not be empty", regions.isEmpty());
+
+        // Verify sorting
+        for (int i = 1; i < regions.size(); i++) {
+            assertTrue(
+                    "Regions should be alphabetically sorted, but found '"
+                            + regions.get(i - 1) + "' before '" + regions.get(i) + "'",
+                    regions.get(i - 1).compareTo(regions.get(i)) <= 0);
+        }
+
+        // Verify well-known regions are present
+        assertTrue("Should contain 'Permission' region", regions.contains("Permission"));
+        assertTrue("Should contain 'System' region", regions.contains("System"));
+        assertTrue("Should contain 'Contentlet' region", regions.contains("Contentlet"));
+    }
+
+    /**
+     * Given: Authenticated admin user
+     * When: listRegions is called
+     * Then: Region count matches CacheLocator.getCacheIndexes() length
+     */
+    @Test
+    public void test_listRegions_count_matches_cache_indexes() {
+
+        final ResponseEntityListStringView result =
+                cacheResource.listRegions(mockAuthenticatedRequest(), mockResponse);
+
+        final Object[] cacheIndexes = CacheLocator.getCacheIndexes();
+        assertEquals("Region count should match CacheIndex enum values",
+                cacheIndexes.length, result.getEntity().size());
+    }
+
+    // =========================================================================
+    // GET /api/v1/caches/stats — Cache Statistics
+    // =========================================================================
+
+    /**
+     * Given: Authenticated admin user
+     * When: getCacheStats is called
+     * Then: Returns valid JVM memory stats with all fields positive
+     */
+    @Test
+    public void test_getCacheStats_returns_valid_memory() {
+
+        final ResponseEntityCacheStatsView result =
+                cacheResource.getCacheStats(mockAuthenticatedRequest(), mockResponse);
+
+        assertNotNull(result);
+        final CacheStatsView stats = result.getEntity();
+        assertNotNull(stats);
+
+        final JvmMemoryView memory = stats.memory();
+        assertNotNull(memory);
+        assertTrue("maxMemory should be positive", memory.maxMemory() > 0);
+        assertTrue("allocatedMemory should be positive", memory.allocatedMemory() > 0);
+        assertTrue("usedMemory should be positive", memory.usedMemory() > 0);
+        assertTrue("freeMemory should be positive", memory.freeMemory() > 0);
+        assertEquals("freeMemory should equal maxMemory minus usedMemory",
+                memory.maxMemory() - memory.usedMemory(), memory.freeMemory());
+    }
+
+    /**
+     * Given: Authenticated admin user
+     * When: getCacheStats is called
+     * Then: Returns at least one provider with columns and stats
+     */
+    @Test
+    public void test_getCacheStats_returns_provider_stats() {
+
+        final ResponseEntityCacheStatsView result =
+                cacheResource.getCacheStats(mockAuthenticatedRequest(), mockResponse);
+
+        final List<CacheProviderStatsView> providers = result.getEntity().providers();
+        assertNotNull(providers);
+        assertFalse("Should have at least one cache provider", providers.isEmpty());
+
+        final CacheProviderStatsView firstProvider = providers.get(0);
+        assertNotNull("Provider name should not be null", firstProvider.providerName());
+        assertFalse("Provider should report columns", firstProvider.columns().isEmpty());
+        assertFalse("Provider should have stats entries", firstProvider.stats().isEmpty());
+
+        // Verify stat rows have the same keys as columns
+        final Map<String, String> firstRow = firstProvider.stats().get(0);
+        for (final String column : firstProvider.columns()) {
+            assertTrue("Stat row should contain column '" + column + "'",
+                    firstRow.containsKey(column));
+        }
+    }
+
+    // =========================================================================
+    // DELETE /api/v1/caches/region/{regionName} — Flush Region
+    // =========================================================================
+
+    /**
+     * Given: Valid cache region name "Permission"
+     * When: flushRegion is called
+     * Then: Returns success message confirming the region was flushed
+     */
+    @Test
+    public void test_flushRegion_valid_returns_success() {
+
+        final ResponseEntityStringView result =
+                cacheResource.flushRegion(
+                        mockAuthenticatedRequest(), mockResponse, "Permission");
+
+        assertNotNull(result);
+        assertEquals("Flushed Permission", result.getEntity());
+    }
+
+    /**
+     * Given: regionName is "all"
+     * When: flushRegion is called
+     * Then: Returns success message confirming all caches were flushed
+     */
+    @Test
+    public void test_flushRegion_all_returns_success() {
+
+        final ResponseEntityStringView result =
+                cacheResource.flushRegion(
+                        mockAuthenticatedRequest(), mockResponse, "all");
+
+        assertNotNull(result);
+        assertEquals("Flushed all caches", result.getEntity());
+    }
+
+    /**
+     * Given: regionName is "ALL" (uppercase)
+     * When: flushRegion is called
+     * Then: Case-insensitive match flushes all caches
+     */
+    @Test
+    public void test_flushRegion_all_case_insensitive() {
+
+        final ResponseEntityStringView result =
+                cacheResource.flushRegion(
+                        mockAuthenticatedRequest(), mockResponse, "ALL");
+
+        assertNotNull(result);
+        assertEquals("Flushed all caches", result.getEntity());
+    }
+
+    /**
+     * Given: Unknown/invalid region name
+     * When: flushRegion is called
+     * Then: BadRequestException is thrown
+     */
+    @Test(expected = BadRequestException.class)
+    public void test_flushRegion_unknown_returns_400() {
+
+        cacheResource.flushRegion(
+                mockAuthenticatedRequest(), mockResponse, "NonExistentRegion123");
+    }
+
+    /**
+     * Given: Valid region name "System"
+     * When: flushRegion is called
+     * Then: Flushes successfully (System triggers PushPublishing reload)
+     */
+    @Test
+    public void test_flushRegion_system_triggers_publishing_reload() {
+
+        final ResponseEntityStringView result =
+                cacheResource.flushRegion(
+                        mockAuthenticatedRequest(), mockResponse, "System");
+
+        assertNotNull(result);
+        assertEquals("Flushed System", result.getEntity());
+    }
+
+    // =========================================================================
+    // Existing flushAll() — Modified endpoint
+    // =========================================================================
+
+    /**
+     * Given: Authenticated admin user calls the existing flush-all endpoint
+     * When: flushAll is called
+     * Then: Returns success (verifies the helper integration works)
+     */
+    @Test
+    public void test_flushAll_existing_endpoint_returns_success() {
+
+        final javax.ws.rs.core.Response result =
+                cacheResource.flushAll(
+                        mockAuthenticatedRequest(), mockResponse, "any-provider");
+
+        assertNotNull(result);
+        assertEquals(200, result.getStatus());
+    }
+
+    // =========================================================================
+    // Helper
+    // =========================================================================
+
+    private HttpServletRequest mockAuthenticatedRequest() {
+        final MockHeaderRequest request = new MockHeaderRequest(
+                new MockSessionRequest(
+                        new MockAttributeRequest(
+                                new MockHttpRequestIntegrationTest("localhost", "/api/v1/caches")
+                                        .request())
+                                .request())
+                        .request());
+
+        request.setAttribute(WebKeys.USER, adminUser);
+        return request;
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/system/cache/CacheResourceIntegrationTest.java
@@ -123,7 +123,7 @@ public class CacheResourceIntegrationTest {
         assertTrue("maxMemory should be positive", memory.maxMemory() > 0);
         assertTrue("allocatedMemory should be positive", memory.allocatedMemory() > 0);
         assertTrue("usedMemory should be positive", memory.usedMemory() > 0);
-        assertTrue("freeMemory should be positive", memory.freeMemory() > 0);
+        assertTrue("freeMemory should be non-negative", memory.freeMemory() >= 0);
         assertEquals("freeMemory should equal maxMemory minus usedMemory",
                 memory.maxMemory() - memory.usedMemory(), memory.freeMemory());
     }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                     
                                                                  
  Add 3 new REST endpoints to `CacheResource` and fix missing side effects on the existing flush-all endpoint, replacing legacy JSP/Struts cache management with modern REST APIs for the Maintenance portlet    
  Cache tab.                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  **New endpoints:**                                              
  - `GET /api/v1/caches` — Alphabetically sorted list of cache region names (replaces JSP scriptlet calling `CacheLocator.getCacheIndexes()`)
  - `GET /api/v1/caches/stats` — JVM memory stats + per-provider per-region cache statistics (replaces `cachestats_guava.jsp`)                                                                                   
  - `DELETE /api/v1/caches/region/{regionName}` — Flush a specific cache region across all providers, or pass `"all"` to flush everything. Includes permission reference reset and conditional PushPublishing    
  filter reload                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  **Bug fix:**                                                                                                                                                                                                   
  - `DELETE /api/v1/caches/provider/{p}/flush` — Added `resetAllPermissionReferences()` + PushPublishing filter reload that were missing vs the legacy Struts action (`ViewCMSMaintenanceAction._flush()`)
                                                                                                                                                                                                                 
  **Implementation details:**
  - `CacheMaintenanceHelper` (`@ApplicationScoped`) extracts shared flush side-effect logic used by both the new and existing flush endpoints                                                                    
  - Typed `@Value.Immutable` views (`JvmMemoryView`, `CacheProviderStatsView`, `CacheStatsView`) with full Swagger/OpenAPI annotations                                                                           
  - Region name validation against `CacheIndex` — unknown names return 400 instead of silently flushing all caches (legacy NPE-catching behavior)                                                                
  - `/region/` path prefix avoids JAX-RS conflict with existing `DELETE /api/v1/caches/menucache`                                                                                                                
                                                                                                                                                                                                                 
  ## Test plan                                                                                                                                                                                                   
                                                                                                                                                                                                                 
  - [ ] Integration tests pass: `./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=CacheResourceIntegrationTest`                                                                          
  - [ ] `GET /api/v1/caches` returns sorted region list matching the Cache tab dropdown
  - [ ] `GET /api/v1/caches/stats` returns memory + provider stats matching `cachestats_guava.jsp` output                                                                                                        
  - [ ] `DELETE /api/v1/caches/region/Permission` flushes Permission cache and returns 200                                                                                                                       
  - [ ] `DELETE /api/v1/caches/region/all` flushes all caches and returns 200                                                                                                                                    
  - [ ] `DELETE /api/v1/caches/region/InvalidName` returns 400                                                                                                                                                   
  - [ ] `DELETE /api/v1/caches/region/System` triggers PushPublishing filter reload                                                                                                                              
  - [ ] Existing `DELETE /api/v1/caches/provider/{p}/flush` still returns 200 with "flushed all"                                                                                                                 
  - [ ] Existing Postman collection `CacheResource.postman_collection.json` passes unchanged                                                                                                                     
                                                                                                                                                                                                                 
  Closes #35196, Closes #35197, Closes #35198

This PR fixes: #35190