### PR TITLE
fix(edit-content): relationship field UI improvements

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
@@ -112,14 +112,16 @@
                     @case ('title') {
                         <td class="flex-1 min-w-0" [class.cursor-not-allowed]="isDisabled">
                             <div class="flex items-center gap-2">
-                                <div
-                                    class="w-20 h-14 flex-shrink-0 rounded-md overflow-hidden bg-gray-100">
-                                    <dot-contentlet-thumbnail
-                                        [iconSize]="'24px'"
-                                        [contentlet]="item"
-                                        [playableVideo]="false"
-                                        data-testId="contentlet-thumbnail" />
-                                </div>
+                                @if (item.hasTitleImage) {
+                                    <div
+                                        class="w-20 h-14 flex-shrink-0 rounded-md overflow-hidden bg-gray-100">
+                                        <dot-contentlet-thumbnail
+                                            [iconSize]="'24px'"
+                                            [contentlet]="item"
+                                            [playableVideo]="false"
+                                            data-testId="contentlet-thumbnail" />
+                                    </div>
+                                }
                                 <p class="truncate">{{ item.title }}</p>
                             </div>
                         </td>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
@@ -13,6 +13,7 @@
     [columns]="store.columns()"
     data-testid="relationship-field-table"
     class="dot-relationship-field-table border border-solid rounded-lg overflow-hidden [&_tr:last-child_td]:!border-b-0"
+    [rowHover]="true"
     [style]="{ 'border-color': 'var(--p-inputtext-border-color)' }"
     [paginator]="false"
     [first]="pagination.offset"
@@ -110,7 +111,17 @@
                 @switch (column.type) {
                     @case ('title') {
                         <td class="flex-1 min-w-0" [class.cursor-not-allowed]="isDisabled">
-                            <p class="truncate">{{ item.title }}</p>
+                            <div class="flex items-center gap-2">
+                                <div
+                                    class="w-20 h-14 flex-shrink-0 rounded-md overflow-hidden bg-gray-100">
+                                    <dot-contentlet-thumbnail
+                                        [iconSize]="'24px'"
+                                        [contentlet]="item"
+                                        [playableVideo]="false"
+                                        data-testId="contentlet-thumbnail" />
+                                </div>
+                                <p class="truncate">{{ item.title }}</p>
+                            </div>
                         </td>
                     }
                     @case ('language') {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
@@ -39,7 +39,7 @@
                         </th>
                     }
                     @case ('status') {
-                        <th scope="col" class="w-32 min-w-32 max-w-32">
+                        <th scope="col" class="w-32 min-w-32 max-w-32 !text-right">
                             {{ 'dot.file.relationship.field.table.status' | dm }}
                         </th>
                     }
@@ -56,7 +56,7 @@
                 }
             }
 
-            <th scope="col" class="w-16 min-w-16" alignFrozen="right" pFrozenColumn [frozen]="true">
+            <th scope="col" class="w-10 min-w-10" alignFrozen="right" pFrozenColumn [frozen]="true">
                 <p-button
                     (onClick)="menu.toggle($event)"
                     size="small"
@@ -87,15 +87,22 @@
         <tr
             [pReorderableRow]="index"
             [class.opacity-50]="isDisabled"
-            [class.cursor-not-allowed]="isDisabled">
+            [class.cursor-not-allowed]="isDisabled"
+            class="group">
             <td class="w-12 min-w-12">
                 @if (!isDisabled) {
                     <span
-                        class="pi pi-bars text-[var(--gray-600)]"
+                        class="flex items-center cursor-grab text-[var(--gray-600)]"
                         pReorderableRowHandle
-                        data-testid="relationship-drag-handle"></span>
+                        data-testid="relationship-drag-handle">
+                        <i class="pi pi-ellipsis-v text-[14px]"></i>
+                        <i class="pi pi-ellipsis-v -ml-2 text-[14px]"></i>
+                    </span>
                 } @else {
-                    <span class="pi pi-bars text-[var(--gray-600)] cursor-not-allowed"></span>
+                    <span class="flex items-center text-[var(--gray-600)] cursor-not-allowed">
+                        <i class="pi pi-ellipsis-v text-[14px]"></i>
+                        <i class="pi pi-ellipsis-v -ml-2 text-[14px]"></i>
+                    </span>
                 }
             </td>
 
@@ -112,7 +119,9 @@
                         </td>
                     }
                     @case ('status') {
-                        <td class="w-32 min-w-32 max-w-32" [class.cursor-not-allowed]="isDisabled">
+                        <td
+                            class="w-32 min-w-32 max-w-32 !text-right"
+                            [class.cursor-not-allowed]="isDisabled">
                             @let status = item | contentletStatus;
                             <p-chip
                                 [class]="'p-chip-sm ' + status.classes"
@@ -139,7 +148,7 @@
             }
 
             <td
-                class="w-16 min-w-16"
+                class="w-10 min-w-10"
                 pFrozenColumn
                 alignFrozen="right"
                 [frozen]="true"
@@ -151,6 +160,7 @@
                     [text]="true"
                     [disabled]="isDisabled"
                     (onClick)="deleteItem(item.inode)"
+                    styleClass="opacity-0 group-hover:opacity-100 transition-opacity"
                     data-testid="relationship-delete-button" />
             </td>
         </tr>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/language-field/language-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/components/language-field/language-field.component.ts
@@ -101,6 +101,10 @@ export class LanguageFieldComponent implements ControlValueAccessor, OnInit {
         // noop
     };
 
+    /**
+     * Internal callback function for handling touched state.
+     * Required by ControlValueAccessor, registered via registerOnTouched.
+     */
     #onTouched = (): void => {
         // noop
     };

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/components/search/search.component.html
@@ -19,18 +19,19 @@
                 data-testid="relationship-dialog-search-query" />
         </div>
 
-        <p-inputgroup-addon>
+        <p-inputgroup-addon styleClass="!p-0">
             <p-button
                 (onClick)="popover.toggle($event, formElement)"
                 data-testid="open-filters-button"
                 size="small"
                 type="button"
                 icon="pi pi-sliders-h"
+                styleClass="!rounded-l-none"
                 [text]="true" />
         </p-inputgroup-addon>
     </p-inputgroup>
 
-    <p-popover #popover class="w-96">
+    <p-popover #popover [style]="{ width: formElement.offsetWidth + 'px' }">
         <div class="flex flex-col gap-6">
             <div class="flex flex-col gap-6" formGroupName="systemSearchableFields">
                 <dot-language-field formControlName="languageId" />

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -137,8 +137,8 @@
                         }
                     </td>
                     <td colspan="2">
-                        <div class="flex items-center gap-2">
-                            <div class="w-10 h-10 shrink-0">
+                        <div class="flex items-center gap-3">
+                            <div class="w-20 h-14 shrink-0 rounded-md overflow-hidden bg-gray-100">
                                 <dot-contentlet-thumbnail
                                     [iconSize]="'24px'"
                                     [contentlet]="item"


### PR DESCRIPTION
## Summary

- Filters popover width now matches the search input dynamically instead of fixed `w-96`
- Remove extra padding on filter button addon for cleaner hover state
- Delete button (X) only visible on row hover (new table standard)
- Replace `pi-bars` drag handle with standard 6-dot grip icon (double `pi-ellipsis-v`)
- Reduce action column width from `w-16` to `w-10`
- Right-align Status column header and chip to reduce visual gap
- Add contentlet thumbnail preview in the relationship table title column for image content types
- Enable row hover highlighting in the relationship field table
- Unify thumbnail styling in the selection dialog (larger size with rounded corners)
- Add missing JSDoc to `#onTouched` in language field component

## Test plan

- [ ] Open relationship field table → drag handle shows 6-dot grip icon, always visible
- [ ] Hover over a row → delete (X) button appears; move away → it hides
- [ ] Hover over a row → row background highlights
- [ ] Relate an image content → thumbnail preview appears next to the title
- [ ] Relate a non-image content (e.g. Blog) → only text title shown, no icon/thumbnail
- [ ] Open "Add Related Content" dialog → thumbnails show with rounded corners and gray background
- [ ] Open "Add Related Content" dialog → click filter button → popover matches search input width
- [ ] Filter button hover state covers the full addon area without extra padding
- [ ] Status column header and chip are right-aligned

Closes #33066

This PR fixes: #33066