### PR TITLE
feat(starter): add min starter type for minstarter.dotcms.com

### DIFF
--- a/.github/workflows/cicd_manual_publish-starter.yml
+++ b/.github/workflows/cicd_manual_publish-starter.yml
@@ -9,6 +9,7 @@ on:
         options:
           - 'full'
           - 'empty'
+          - 'min'
       old-assets:
         description: 'Include old assets'
         required: true
@@ -36,6 +37,8 @@ env:
   EMPTY_STARTER_TOKEN: ${{ secrets.DOT_EMPTY_STARTER_ACCESS_TOKEN }}
   FULL_STARTER_URL: ${{ vars.DOT_STARTER_URL }}
   FULL_STARTER_TOKEN: ${{ secrets.DOT_STARTER_ACCESS_TOKEN }}
+  MIN_STARTER_URL: ${{ vars.DOT_MIN_STARTER_URL }}
+  MIN_STARTER_TOKEN: ${{ secrets.DOT_MIN_STARTER_ACCESS_TOKEN }}
   DOWNLOAD_ENDPOINT: api/v1/maintenance/_downloadStarterWithAssets?oldAssets=${{ github.event.inputs.old-assets }}
 
 jobs:
@@ -69,11 +72,15 @@ jobs:
           if [[ "$STARTER_TYPE" == "empty" ]]; then
             echo "::debug::Empty Starter: downloading from [${{ env.EMPTY_STARTER_URL }}/${{ env.DOWNLOAD_ENDPOINT }}]"
             FILENAME="empty_${DATE}.zip"
-            RESPONSE=$(download_starter ${{ env.EMPTY_STARTER_URL }} ${{ env.EMPTY_STARTER_TOKEN }} $FILENAME)            
+            RESPONSE=$(download_starter ${{ env.EMPTY_STARTER_URL }} ${{ env.EMPTY_STARTER_TOKEN }} $FILENAME)
+          elif [[ "$STARTER_TYPE" == "min" ]]; then
+            echo "::debug::Min Starter: downloading from [${{ env.MIN_STARTER_URL }}/${{ env.DOWNLOAD_ENDPOINT }}]"
+            FILENAME="min_${DATE}.zip"
+            RESPONSE=$(download_starter ${{ env.MIN_STARTER_URL }} ${{ env.MIN_STARTER_TOKEN }} $FILENAME)
           else
-            echo "::debut::Full Starter: downloading from [${{ env.FULL_STARTER_URL }}/${{ env.DOWNLOAD_ENDPOINT }}]"
+            echo "::debug::Full Starter: downloading from [${{ env.FULL_STARTER_URL }}/${{ env.DOWNLOAD_ENDPOINT }}]"
             FILENAME="${DATE}.zip"
-            RESPONSE=$(download_starter ${{ env.FULL_STARTER_URL }} ${{ env.FULL_STARTER_TOKEN }} $FILENAME)             
+            RESPONSE=$(download_starter ${{ env.FULL_STARTER_URL }} ${{ env.FULL_STARTER_TOKEN }} $FILENAME)
           fi                    
           echo "::notice::Status Code: $RESPONSE" 
           if [[ "$RESPONSE" != "200" ]]; then


### PR DESCRIPTION
## Summary

- Adds `min` as a new starter type option to the `cicd_manual_publish-starter.yml` workflow dispatch
- Introduces `MIN_STARTER_URL` and `MIN_STARTER_TOKEN` env vars backed by `DOT_MIN_STARTER_URL` (variable) and `DOT_MIN_STARTER_ACCESS_TOKEN` (secret) in the `starter` environment
- Extends the `get-starter` job bash logic with an `elif` branch for `min`, downloading from `minstarter.dotcms.com` using the same endpoint and curl flow as the full starter, producing a `min_YYYYMMDD.zip` artifact

## Pre-merge manual steps

- [x] Create GitHub Actions variable `DOT_MIN_STARTER_URL` = `https://minstarter.dotcms.com` in the `starter` environment
- [x] Generate a dotCMS Access Key on `minstarter.dotcms.com` with permissions for `api/v1/maintenance/_downloadStarterWithAssets`
- [x] Store the Access Key as secret `DOT_MIN_STARTER_ACCESS_TOKEN` in the `starter` environment
- [ ] Whitelist GitHub Actions IP ranges on the `minstarter.dotcms.com` server firewall

## Test plan

- [ ] Trigger the workflow manually with `type=min`, `dry-run=true` — verify download from `minstarter.dotcms.com` succeeds and artifact is named `min_YYYYMMDD.zip`
- [ ] Trigger with `dry-run=false` to validate full Artifactory upload and Slack notification

Closes #35228

This PR fixes: #35228