### PR TITLE
Fix variants inline editing when using experiments

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
@@ -4654,7 +4654,7 @@ public class WorkflowResource {
      *         sibling prepared for the requested variant
      * @throws DotDataException if the {@link com.dotcms.variant.VariantAPI} cannot be queried
      */
-    private Contentlet resolveContentletByVariant(final Contentlet currentContentlet,
+    Contentlet resolveContentletByVariant(final Contentlet currentContentlet,
             final String variantName) throws DotDataException {
 
         final String resolvedVariant = UtilMethods.isSet(variantName)

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
@@ -13,9 +13,9 @@ import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
 import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.mock.response.MockHttpResponse;
 import com.dotcms.repackage.com.google.common.annotations.VisibleForTesting;
+import com.dotcms.variant.model.Variant;
 import javax.validation.constraints.NotNull;
 import com.dotcms.rest.*;
-import com.dotcms.rest.ResponseEntityMapStringObjectView;
 import com.dotcms.rest.annotation.IncludePermissions;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.rest.annotation.SwaggerCompliant;
@@ -23,7 +23,6 @@ import com.dotcms.rest.api.MultiPartUtils;
 import com.dotcms.rest.api.v1.DotObjectMapperProvider;
 import com.dotcms.rest.api.v1.authentication.RequestUtil;
 import com.dotcms.rest.api.v1.authentication.ResponseUtil;
-import com.dotcms.rest.api.v1.workflow.WorkflowActionMultipartSchema;
 import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.rest.exception.ForbiddenException;
 import com.dotcms.rest.exception.NotFoundException;
@@ -109,7 +108,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.vavr.Tuple2;
 import io.vavr.control.Try;
 import org.apache.commons.beanutils.BeanUtils;
@@ -4583,11 +4581,11 @@ public class WorkflowResource {
                                      final PageMode pageMode,
                                      final String variantName) throws DotDataException, DotSecurityException {
 
-        Contentlet contentlet = null;
+        Contentlet contentlet;
         PageMode mode = pageMode;
-        final String finalInode      = UtilMethods.isSet(inode)? inode:
+        final String finalInode = UtilMethods.isSet(inode) ? inode :
                 (String)Try.of(()->fireActionForm.getContentletFormData().get("inode")).getOrNull();
-        final String finalIdentifier = UtilMethods.isSet(identifier)? identifier:
+        final String finalIdentifier = UtilMethods.isSet(identifier) ? identifier :
                 (String)Try.of(()->fireActionForm.getContentletFormData().get("identifier")).getOrNull();
 
         if(UtilMethods.isSet(finalInode)) {
@@ -4599,7 +4597,9 @@ public class WorkflowResource {
 
             DotPreconditions.notNull(currentContentlet, ()-> "contentlet-was-not-found", DoesNotExistException.class);
 
-            contentlet = createContentlet(fireActionForm, initDataObject, currentContentlet,mode);
+            final Contentlet contentletByVariant = resolveContentletByVariant(currentContentlet, variantName);
+
+            contentlet = createContentlet(fireActionForm, initDataObject, contentletByVariant, mode);
         } else if (UtilMethods.isSet(finalIdentifier)) {
 
             Logger.debug(this, ()-> "Fire Action, looking for content by identifier: " + finalIdentifier
@@ -4628,6 +4628,57 @@ public class WorkflowResource {
     }
 
 
+
+    /**
+     * Ensures the correct contentlet is used when firing a workflow action in the context of an
+     * experiment variant. When an editor saves content inside the UVE, the frontend always sends
+     * the inode of the DEFAULT contentlet (no variant-specific copy exists yet). Without this
+     * check the save would overwrite the DEFAULT, affecting every variant and the original page.
+     *
+     * <p>Resolution rules:
+     * <ul>
+     *   <li>If {@code variantName} is blank or not found in the database, falls back to
+     *       {@code DEFAULT}.</li>
+     *   <li>If the resolved variant matches the contentlet's current variant, the contentlet is
+     *       returned unchanged (normal save).</li>
+     *   <li>If there is a mismatch, a sibling contentlet is returned: same identifier and field
+     *       values as {@code currentContentlet}, but with a {@code null} inode and the resolved
+     *       variant name. Passing a {@code null} inode signals the persistence layer to create a
+     *       new contentlet row instead of updating the existing DEFAULT one.</li>
+     * </ul>
+     *
+     * @param currentContentlet the contentlet retrieved by inode from the request.
+     * @param variantName       the variant name sent by the caller; may be {@code null}, empty, or
+     *                          point to a variant that no longer exists
+     * @return {@code currentContentlet} when no variant copy is needed, or a newly constructed
+     *         sibling prepared for the requested variant
+     * @throws DotDataException if the {@link com.dotcms.variant.VariantAPI} cannot be queried
+     */
+    private Contentlet resolveContentletByVariant(final Contentlet currentContentlet,
+            final String variantName) throws DotDataException {
+
+        final String resolvedVariant = UtilMethods.isSet(variantName)
+                // Avoids the usage of an invalid variant (non-existing).
+                ? APILocator.getVariantAPI().get(variantName)
+                        .map(Variant::name)
+                        .orElse(VariantAPI.DEFAULT_VARIANT.name())
+                : VariantAPI.DEFAULT_VARIANT.name();
+
+        if (resolvedVariant.equals(currentContentlet.getVariantId())) {
+            return currentContentlet;
+        }
+
+        Logger.debug(this, () -> String.format(
+                "Fire Action, variant mismatch: contentlet variant=%s, requested variant=%s. " +
+                "Creating new variant copy for inode: %s",
+                currentContentlet.getVariantId(), resolvedVariant, currentContentlet.getInode()));
+
+        final Contentlet variantSibling = new Contentlet();
+        variantSibling.getMap().putAll(currentContentlet.getMap());
+        variantSibling.setInode(StringPool.BLANK);
+        variantSibling.setVariantId(resolvedVariant);
+        return variantSibling;
+    }
 
     private Contentlet createContentlet(final FireActionForm fireActionForm,
                                         final InitDataObject initDataObject,

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/workflow/WorkflowResource.java
@@ -4590,7 +4590,7 @@ public class WorkflowResource {
 
         if(UtilMethods.isSet(finalInode)) {
 
-            Logger.debug(this, ()-> "Fire Action, looking for content by inode: " + finalInode);
+            Logger.debug(this, () -> "Fire Action, looking for content by inode: " + finalInode);
 
             final Contentlet currentContentlet = this.contentletAPI.find
                     (finalInode, initDataObject.getUser(), mode.respectAnonPerms);

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -11617,7 +11617,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PageScanCheckForm"
+              type: object
+              additionalProperties:
+                type: object
       responses:
         default:
           content:
@@ -11632,7 +11634,9 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PageScanCheckForm"
+              type: object
+              additionalProperties:
+                type: object
       responses:
         default:
           content:
@@ -27691,11 +27695,6 @@ components:
         renderLive:
           type: string
         renderWorking:
-          type: string
-    PageScanCheckForm:
-      type: object
-      properties:
-        url:
           type: string
     PageView:
       type: object

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -11617,9 +11617,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties:
-                type: object
+              $ref: "#/components/schemas/PageScanCheckForm"
       responses:
         default:
           content:
@@ -11634,9 +11632,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              additionalProperties:
-                type: object
+              $ref: "#/components/schemas/PageScanCheckForm"
       responses:
         default:
           content:
@@ -27695,6 +27691,11 @@ components:
         renderLive:
           type: string
         renderWorking:
+          type: string
+    PageScanCheckForm:
+      type: object
+      properties:
+        url:
           type: string
     PageView:
       type: object

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceResolveVariantTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceResolveVariantTest.java
@@ -22,8 +22,6 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
 import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
 import com.dotmarketing.portlets.workflows.util.WorkflowImportExportUtil;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.Optional;
 import org.junit.Test;
 import org.mockito.MockedStatic;
@@ -38,7 +36,7 @@ import org.mockito.Mockito;
  * <ol>
  *   <li>DEFAULT requested, contentlet is DEFAULT → no copy needed</li>
  *   <li>variant-X requested, contentlet is already variant-X → no copy needed</li>
- *   <li>variant-X requested, contentlet is DEFAULT → sibling copy created with null inode</li>
+ *   <li>variant-X requested, contentlet is DEFAULT → sibling copy created with empty inode</li>
  *   <li>Non-existent variant requested → falls back to DEFAULT → no copy needed</li>
  *   <li>Null/empty variantName → defaults to DEFAULT without querying VariantAPI</li>
  * </ol>
@@ -61,24 +59,6 @@ public class WorkflowResourceResolveVariantTest extends UnitTestBase {
                 new MultiPartUtils(mock(FileAssetAPI.class)),
                 mock(WebResource.class),
                 mock(SystemActionApiFireCommandFactory.class));
-    }
-
-    /**
-     * Reflectively invokes the private {@code resolveContentletByVariant} method so the tests
-     * can cover its logic without exposing it as part of the public API.
-     */
-    private Contentlet invokeResolveContentletForVariant(
-            final WorkflowResource resource,
-            final Contentlet contentlet,
-            final String variantName) throws Exception {
-        final Method method = WorkflowResource.class.getDeclaredMethod(
-                "resolveContentletByVariant", Contentlet.class, String.class);
-        method.setAccessible(true);
-        try {
-            return (Contentlet) method.invoke(resource, contentlet, variantName);
-        } catch (InvocationTargetException e) {
-            throw (Exception) e.getCause();
-        }
     }
 
     private Contentlet contentletWithVariant(final String variantId) {
@@ -116,7 +96,7 @@ public class WorkflowResourceResolveVariantTest extends UnitTestBase {
             final WorkflowResource resource = buildResource();
             final Contentlet defaultContentlet = contentletWithVariant(VariantAPI.DEFAULT_VARIANT.name());
 
-            final Contentlet result = invokeResolveContentletForVariant(resource, defaultContentlet, "DEFAULT");
+            final Contentlet result = resource.resolveContentletByVariant(defaultContentlet, "DEFAULT");
 
             assertSame("Should return the same contentlet instance — no copy needed", defaultContentlet, result);
             assertEquals("DEFAULT", result.getVariantId());
@@ -144,7 +124,7 @@ public class WorkflowResourceResolveVariantTest extends UnitTestBase {
             final WorkflowResource resource = buildResource();
             final Contentlet variantContentlet = contentletWithVariant(variantX);
 
-            final Contentlet result = invokeResolveContentletForVariant(resource, variantContentlet, variantX);
+            final Contentlet result = resource.resolveContentletByVariant(variantContentlet, variantX);
 
             assertSame("Should return the same contentlet instance — no copy needed", variantContentlet, result);
             assertEquals(variantX, result.getVariantId());
@@ -158,12 +138,12 @@ public class WorkflowResourceResolveVariantTest extends UnitTestBase {
 
     /**
      * Core fix scenario: the frontend always sends the DEFAULT inode because no variant copy exists
-     * yet. The method must return a sibling with a {@code null} inode (so the DB creates a new row)
-     * and the requested variant, while preserving the original identifier so both the DEFAULT and
-     * the new variant copy share the same content identity.
+     * yet. The method must return a sibling with an empty inode (so the DB creates a new row) and
+     * the requested variant, while preserving the original identifier so both the DEFAULT and the
+     * new variant copy share the same content identity.
      */
     @Test
-    public void testVariantX_contentletIsDefault_returnsSiblingWithNullInode() throws Exception {
+    public void testVariantX_contentletIsDefault_returnsSiblingWithEmptyInode() throws Exception {
         final String variantX = "experiment-variant-1";
         final VariantAPI variantAPI = mock(VariantAPI.class);
         when(variantAPI.get(variantX)).thenReturn(Optional.of(variantOf(variantX)));
@@ -174,7 +154,7 @@ public class WorkflowResourceResolveVariantTest extends UnitTestBase {
             final WorkflowResource resource = buildResource();
             final Contentlet defaultContentlet = contentletWithVariant(VariantAPI.DEFAULT_VARIANT.name());
 
-            final Contentlet result = invokeResolveContentletForVariant(resource, defaultContentlet, variantX);
+            final Contentlet result = resource.resolveContentletByVariant(defaultContentlet, variantX);
 
             assertNotSame("A new sibling must be returned, not the original DEFAULT contentlet", defaultContentlet, result);
             assertTrue("Empty inode signals the persistence layer to create a new contentlet row",
@@ -205,7 +185,7 @@ public class WorkflowResourceResolveVariantTest extends UnitTestBase {
             final WorkflowResource resource = buildResource();
             final Contentlet defaultContentlet = contentletWithVariant(VariantAPI.DEFAULT_VARIANT.name());
 
-            final Contentlet result = invokeResolveContentletForVariant(resource, defaultContentlet, "does-not-exist");
+            final Contentlet result = resource.resolveContentletByVariant(defaultContentlet, "does-not-exist");
 
             assertSame("Unknown variant must fall back to DEFAULT; original contentlet returned unchanged",
                     defaultContentlet, result);
@@ -231,7 +211,7 @@ public class WorkflowResourceResolveVariantTest extends UnitTestBase {
             final WorkflowResource resource = buildResource();
             final Contentlet defaultContentlet = contentletWithVariant(VariantAPI.DEFAULT_VARIANT.name());
 
-            final Contentlet result = invokeResolveContentletForVariant(resource, defaultContentlet, null);
+            final Contentlet result = resource.resolveContentletByVariant(defaultContentlet, null);
 
             assertSame("Null variantName must default to DEFAULT without a DB lookup",
                     defaultContentlet, result);

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceResolveVariantTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceResolveVariantTest.java
@@ -1,0 +1,241 @@
+package com.dotcms.rest.api.v1.workflow;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.dotcms.UnitTestBase;
+import com.dotcms.rest.ContentHelper;
+import com.dotcms.rest.WebResource;
+import com.dotcms.rest.api.MultiPartUtils;
+import com.dotcms.rest.api.v1.authentication.ResponseUtil;
+import com.dotcms.variant.VariantAPI;
+import com.dotcms.variant.model.Variant;
+import com.dotcms.workflow.helper.WorkflowHelper;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.business.PermissionAPI;
+import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
+import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
+import com.dotmarketing.portlets.workflows.util.WorkflowImportExportUtil;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link WorkflowResource#resolveContentletByVariant}, the guard that prevents
+ * the {@code /api/v1/workflow/actions/default/fire/EDIT} endpoint from overwriting the DEFAULT
+ * contentlet when an editor saves inside a UVE experiment variant.
+ *
+ * <p>Each test maps to one of the five resolution scenarios:
+ * <ol>
+ *   <li>DEFAULT requested, contentlet is DEFAULT → no copy needed</li>
+ *   <li>variant-X requested, contentlet is already variant-X → no copy needed</li>
+ *   <li>variant-X requested, contentlet is DEFAULT → sibling copy created with null inode</li>
+ *   <li>Non-existent variant requested → falls back to DEFAULT → no copy needed</li>
+ *   <li>Null/empty variantName → defaults to DEFAULT without querying VariantAPI</li>
+ * </ol>
+ */
+public class WorkflowResourceResolveVariantTest extends UnitTestBase {
+
+    // -----------------------------------------------------------------------
+    // Infrastructure helpers
+    // -----------------------------------------------------------------------
+
+    private WorkflowResource buildResource() {
+        return new WorkflowResource(
+                mock(WorkflowHelper.class),
+                mock(ContentHelper.class),
+                mock(WorkflowAPI.class),
+                mock(ContentletAPI.class),
+                mock(ResponseUtil.class),
+                mock(PermissionAPI.class),
+                mock(WorkflowImportExportUtil.class),
+                new MultiPartUtils(mock(FileAssetAPI.class)),
+                mock(WebResource.class),
+                mock(SystemActionApiFireCommandFactory.class));
+    }
+
+    /**
+     * Reflectively invokes the private {@code resolveContentletByVariant} method so the tests
+     * can cover its logic without exposing it as part of the public API.
+     */
+    private Contentlet invokeResolveContentletForVariant(
+            final WorkflowResource resource,
+            final Contentlet contentlet,
+            final String variantName) throws Exception {
+        final Method method = WorkflowResource.class.getDeclaredMethod(
+                "resolveContentletByVariant", Contentlet.class, String.class);
+        method.setAccessible(true);
+        try {
+            return (Contentlet) method.invoke(resource, contentlet, variantName);
+        } catch (InvocationTargetException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+
+    private Contentlet contentletWithVariant(final String variantId) {
+        final Contentlet contentlet = new Contentlet();
+        contentlet.setVariantId(variantId);
+        contentlet.setIdentifier("test-identifier");
+        contentlet.setInode("test-inode");
+        return contentlet;
+    }
+
+    private Variant variantOf(final String name) {
+        return Variant.builder()
+                .name(name)
+                .description(Optional.empty())
+                .archived(false)
+                .build();
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 1: DEFAULT requested, contentlet is DEFAULT → no mismatch
+    // -----------------------------------------------------------------------
+
+    /**
+     * When both the request and the found contentlet are on the DEFAULT variant, the original
+     * contentlet is returned unchanged — no variant copy is necessary.
+     */
+    @Test
+    public void testDefaultVariant_contentletIsDefault_returnsUnchanged() throws Exception {
+        final VariantAPI variantAPI = mock(VariantAPI.class);
+        when(variantAPI.get("DEFAULT")).thenReturn(Optional.of(VariantAPI.DEFAULT_VARIANT));
+
+        try (MockedStatic<APILocator> apiLocator = Mockito.mockStatic(APILocator.class)) {
+            apiLocator.when(APILocator::getVariantAPI).thenReturn(variantAPI);
+
+            final WorkflowResource resource = buildResource();
+            final Contentlet defaultContentlet = contentletWithVariant(VariantAPI.DEFAULT_VARIANT.name());
+
+            final Contentlet result = invokeResolveContentletForVariant(resource, defaultContentlet, "DEFAULT");
+
+            assertSame("Should return the same contentlet instance — no copy needed", defaultContentlet, result);
+            assertEquals("DEFAULT", result.getVariantId());
+            assertEquals("test-inode", result.getInode());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 2: variant-X requested, contentlet is already variant-X → no mismatch
+    // -----------------------------------------------------------------------
+
+    /**
+     * When a variant-specific copy of the contentlet already exists and the request targets that
+     * same variant, the existing copy is returned unchanged — no duplicate is created.
+     */
+    @Test
+    public void testVariantX_contentletIsAlreadyVariantX_returnsUnchanged() throws Exception {
+        final String variantX = "experiment-variant-1";
+        final VariantAPI variantAPI = mock(VariantAPI.class);
+        when(variantAPI.get(variantX)).thenReturn(Optional.of(variantOf(variantX)));
+
+        try (MockedStatic<APILocator> apiLocator = Mockito.mockStatic(APILocator.class)) {
+            apiLocator.when(APILocator::getVariantAPI).thenReturn(variantAPI);
+
+            final WorkflowResource resource = buildResource();
+            final Contentlet variantContentlet = contentletWithVariant(variantX);
+
+            final Contentlet result = invokeResolveContentletForVariant(resource, variantContentlet, variantX);
+
+            assertSame("Should return the same contentlet instance — no copy needed", variantContentlet, result);
+            assertEquals(variantX, result.getVariantId());
+            assertEquals("test-inode", result.getInode());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 3: variant-X requested, contentlet is DEFAULT → mismatch → sibling copy
+    // -----------------------------------------------------------------------
+
+    /**
+     * Core fix scenario: the frontend always sends the DEFAULT inode because no variant copy exists
+     * yet. The method must return a sibling with a {@code null} inode (so the DB creates a new row)
+     * and the requested variant, while preserving the original identifier so both the DEFAULT and
+     * the new variant copy share the same content identity.
+     */
+    @Test
+    public void testVariantX_contentletIsDefault_returnsSiblingWithNullInode() throws Exception {
+        final String variantX = "experiment-variant-1";
+        final VariantAPI variantAPI = mock(VariantAPI.class);
+        when(variantAPI.get(variantX)).thenReturn(Optional.of(variantOf(variantX)));
+
+        try (MockedStatic<APILocator> apiLocator = Mockito.mockStatic(APILocator.class)) {
+            apiLocator.when(APILocator::getVariantAPI).thenReturn(variantAPI);
+
+            final WorkflowResource resource = buildResource();
+            final Contentlet defaultContentlet = contentletWithVariant(VariantAPI.DEFAULT_VARIANT.name());
+
+            final Contentlet result = invokeResolveContentletForVariant(resource, defaultContentlet, variantX);
+
+            assertNotSame("A new sibling must be returned, not the original DEFAULT contentlet", defaultContentlet, result);
+            assertTrue("Empty inode signals the persistence layer to create a new contentlet row",
+                    result.getInode().isEmpty());
+            assertEquals("Sibling must carry the requested variant", variantX, result.getVariantId());
+            assertEquals("Sibling must inherit the DEFAULT contentlet's identifier",
+                    "test-identifier", result.getIdentifier());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 4: non-existent variantName → falls back to DEFAULT → no mismatch
+    // -----------------------------------------------------------------------
+
+    /**
+     * When the requested variant no longer exists in the database (e.g., was deleted), the method
+     * falls back to DEFAULT. If the contentlet is already on DEFAULT, no copy is created and the
+     * original is returned safely.
+     */
+    @Test
+    public void testUnknownVariant_fallsBackToDefault_returnsUnchanged() throws Exception {
+        final VariantAPI variantAPI = mock(VariantAPI.class);
+        when(variantAPI.get("does-not-exist")).thenReturn(Optional.empty());
+
+        try (MockedStatic<APILocator> apiLocator = Mockito.mockStatic(APILocator.class)) {
+            apiLocator.when(APILocator::getVariantAPI).thenReturn(variantAPI);
+
+            final WorkflowResource resource = buildResource();
+            final Contentlet defaultContentlet = contentletWithVariant(VariantAPI.DEFAULT_VARIANT.name());
+
+            final Contentlet result = invokeResolveContentletForVariant(resource, defaultContentlet, "does-not-exist");
+
+            assertSame("Unknown variant must fall back to DEFAULT; original contentlet returned unchanged",
+                    defaultContentlet, result);
+            assertEquals("test-inode", result.getInode());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Scenario 5: null variantName → defaults to DEFAULT without querying VariantAPI
+    // -----------------------------------------------------------------------
+
+    /**
+     * When no variantName is provided (null or empty string), the method defaults to DEFAULT
+     * without making a database call to validate the variant. If the contentlet is on DEFAULT, it
+     * is returned unchanged.
+     */
+    @Test
+    public void testNullVariantName_defaultsToDefault_doesNotQueryVariantAPI() throws Exception {
+        try (MockedStatic<APILocator> apiLocator = Mockito.mockStatic(APILocator.class)) {
+            apiLocator.when(APILocator::getVariantAPI)
+                    .thenThrow(new AssertionError("VariantAPI must not be queried when variantName is null"));
+
+            final WorkflowResource resource = buildResource();
+            final Contentlet defaultContentlet = contentletWithVariant(VariantAPI.DEFAULT_VARIANT.name());
+
+            final Contentlet result = invokeResolveContentletForVariant(resource, defaultContentlet, null);
+
+            assertSame("Null variantName must default to DEFAULT without a DB lookup",
+                    defaultContentlet, result);
+            assertEquals("test-inode", result.getInode());
+        }
+    }
+}


### PR DESCRIPTION
### Proposed Changes
* Add `resolveContentletByVariant()` method into `WorkflowResource`. It mirrors the logic in   `ContentletWebAPIImpl.retrieveWebAsset`:

  1. Resolves the requested variant name - validates it against the DB via VariantAPI.get(), falls back to DEFAULT if blank or not found.
  2. Compares the resolved variant against the found contentlet's variantId.
  3. No mismatch → returns the contentlet unchanged (normal save path, zero overhead).
  4. Mismatch → returns a sibling: same identifier and field values as the DEFAULT, but with an empty inode and the requested variantId. An empty inode signals the  persistence layer to create a new row instead of updating the existing DEFAULT one.

This PR solves #34555 
