### PR TITLE
fix(edit-content): parse block editor JSON strings when translating content

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
@@ -406,7 +406,6 @@ describe('DotEditContentFormResolutions', () => {
                 FIELD_TYPES.BINARY,
                 FIELD_TYPES.FILE,
                 FIELD_TYPES.IMAGE,
-                FIELD_TYPES.BLOCK_EDITOR,
                 FIELD_TYPES.CHECKBOX,
                 FIELD_TYPES.CONSTANT,
                 FIELD_TYPES.CUSTOM_FIELD,
@@ -422,6 +421,45 @@ describe('DotEditContentFormResolutions', () => {
 
             defaultFieldTypes.forEach((fieldType) => {
                 expect(resolutionValue[fieldType]).toBe(resolutionValue[FIELD_TYPES.TEXTAREA]);
+            });
+        });
+
+        describe('blockEditorResolutionFn', () => {
+            const blockField = {
+                ...mockField,
+                fieldType: FIELD_TYPES.BLOCK_EDITOR,
+                variable: 'blockContent'
+            } as DotCMSContentTypeField;
+
+            it('should parse JSON string values from the API', () => {
+                const jsonObj = { type: 'doc', content: [{ type: 'paragraph' }] };
+                const contentlet = {
+                    ...mockContentlet,
+                    blockContent: JSON.stringify(jsonObj)
+                };
+                const result = resolutionValue[FIELD_TYPES.BLOCK_EDITOR](contentlet, blockField);
+                expect(result).toEqual(jsonObj);
+            });
+
+            it('should return object values as-is', () => {
+                const jsonObj = { type: 'doc', content: [{ type: 'paragraph' }] };
+                const contentlet = { ...mockContentlet, blockContent: jsonObj };
+                const result = resolutionValue[FIELD_TYPES.BLOCK_EDITOR](
+                    contentlet as unknown as DotCMSContentlet,
+                    blockField
+                );
+                expect(result).toEqual(jsonObj);
+            });
+
+            it('should return non-JSON strings as-is', () => {
+                const contentlet = { ...mockContentlet, blockContent: 'plain text' };
+                const result = resolutionValue[FIELD_TYPES.BLOCK_EDITOR](contentlet, blockField);
+                expect(result).toBe('plain text');
+            });
+
+            it('should return defaultValue when contentlet is null', () => {
+                const result = resolutionValue[FIELD_TYPES.BLOCK_EDITOR](null, blockField);
+                expect(result).toBe(blockField.defaultValue);
             });
         });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.spec.ts
@@ -457,6 +457,12 @@ describe('DotEditContentFormResolutions', () => {
                 expect(result).toBe('plain text');
             });
 
+            it('should return invalid JSON-looking strings as-is', () => {
+                const contentlet = { ...mockContentlet, blockContent: '{invalid' };
+                const result = resolutionValue[FIELD_TYPES.BLOCK_EDITOR](contentlet, blockField);
+                expect(result).toBe('{invalid');
+            });
+
             it('should return defaultValue when contentlet is null', () => {
                 const result = resolutionValue[FIELD_TYPES.BLOCK_EDITOR](null, blockField);
                 expect(result).toBe(blockField.defaultValue);

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.ts
@@ -215,7 +215,10 @@ const relationshipResolutionFn: FnResolutionValue<string> = (contentlet, field) 
  * The API may return block editor content as a JSON string when copying/translating.
  * This function parses the string to an object so the block editor component receives structured data.
  */
-const blockEditorResolutionFn: FnResolutionValue<string | object> = (contentlet, field) => {
+const blockEditorResolutionFn: FnResolutionValue<string | Record<string, unknown>> = (
+    contentlet,
+    field
+) => {
     const value = contentlet
         ? (contentlet[field.variable] ?? field.defaultValue)
         : field.defaultValue;
@@ -250,7 +253,7 @@ const selectResolutionFn: FnResolutionValue<string> = (contentlet, field) => {
  */
 export const resolutionValue: Record<
     FIELD_TYPES,
-    FnResolutionValue<string | string[] | Date | number | null>
+    FnResolutionValue<string | string[] | Date | number | Record<string, unknown> | null>
 > = {
     [FIELD_TYPES.BINARY]: defaultResolutionFn,
     [FIELD_TYPES.FILE]: defaultResolutionFn,

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form-resolutions.ts
@@ -210,6 +210,27 @@ const relationshipResolutionFn: FnResolutionValue<string> = (contentlet, field) 
     return relationship.map((item) => item.identifier).join(',');
 };
 
+/**
+ * Resolution function for block editor fields.
+ * The API may return block editor content as a JSON string when copying/translating.
+ * This function parses the string to an object so the block editor component receives structured data.
+ */
+const blockEditorResolutionFn: FnResolutionValue<string | object> = (contentlet, field) => {
+    const value = contentlet
+        ? (contentlet[field.variable] ?? field.defaultValue)
+        : field.defaultValue;
+
+    if (typeof value === 'string' && value.trim().startsWith('{')) {
+        try {
+            return JSON.parse(value);
+        } catch {
+            return value;
+        }
+    }
+
+    return value;
+};
+
 const selectResolutionFn: FnResolutionValue<string> = (contentlet, field) => {
     const value = contentlet
         ? (contentlet[field.variable] ?? field.defaultValue)
@@ -234,7 +255,7 @@ export const resolutionValue: Record<
     [FIELD_TYPES.BINARY]: defaultResolutionFn,
     [FIELD_TYPES.FILE]: defaultResolutionFn,
     [FIELD_TYPES.IMAGE]: defaultResolutionFn,
-    [FIELD_TYPES.BLOCK_EDITOR]: defaultResolutionFn,
+    [FIELD_TYPES.BLOCK_EDITOR]: blockEditorResolutionFn,
     [FIELD_TYPES.CHECKBOX]: defaultResolutionFn,
     [FIELD_TYPES.CONSTANT]: defaultResolutionFn,
     [FIELD_TYPES.CUSTOM_FIELD]: defaultResolutionFn,

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -440,10 +440,7 @@ export class DotEditContentFormComponent implements OnInit {
      * @returns {FormValues} The processed form value ready for submission
      */
     private processFormValue(
-        value: Record<
-            string,
-            string | string[] | Date | number | Record<string, unknown> | null | undefined
-        >
+        value: Record<string, string | string[] | Date | number | null | undefined>
     ): FormValues {
         return Object.fromEntries(
             Object.entries(value).map(([key, fieldValue]) => {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -440,7 +440,10 @@ export class DotEditContentFormComponent implements OnInit {
      * @returns {FormValues} The processed form value ready for submission
      */
     private processFormValue(
-        value: Record<string, string | string[] | Date | number | null | undefined>
+        value: Record<
+            string,
+            string | string[] | Date | number | Record<string, unknown> | null | undefined
+        >
     ): FormValues {
         return Object.fromEntries(
             Object.entries(value).map(([key, fieldValue]) => {

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -1751,6 +1751,41 @@ describe('Utils Functions', () => {
                 });
             });
 
+            describe('Block Editor fields', () => {
+                it('should stringify object values so the backend does not store them as Map.toString()', () => {
+                    const field = {
+                        fieldType: FIELD_TYPES.BLOCK_EDITOR,
+                        variable: 'blockEditor'
+                    } as unknown as DotCMSContentTypeField;
+                    const objectValue = {
+                        type: 'doc',
+                        content: [{ type: 'paragraph' }]
+                    };
+
+                    expect(processFieldValue(objectValue, field)).toBe(JSON.stringify(objectValue));
+                });
+
+                it('should pass through JSON string values unchanged', () => {
+                    const field = {
+                        fieldType: FIELD_TYPES.BLOCK_EDITOR,
+                        variable: 'blockEditor'
+                    } as unknown as DotCMSContentTypeField;
+                    const stringValue = '{"type":"doc","content":[{"type":"paragraph"}]}';
+
+                    expect(processFieldValue(stringValue, field)).toBe(stringValue);
+                });
+
+                it('should pass through null and undefined unchanged', () => {
+                    const field = {
+                        fieldType: FIELD_TYPES.BLOCK_EDITOR,
+                        variable: 'blockEditor'
+                    } as unknown as DotCMSContentTypeField;
+
+                    expect(processFieldValue(null, field)).toBeNull();
+                    expect(processFieldValue(undefined, field)).toBeUndefined();
+                });
+            });
+
             describe('edge cases', () => {
                 it('should handle fields without specific processing', () => {
                     const field = {

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -597,6 +597,7 @@ export const processCalendarFieldValue = (
  * Applies appropriate transformations for different field types:
  * - Flattened fields: Joins arrays with commas
  * - Calendar fields: Converts to numeric timestamps
+ * - Block Editor: Stringifies object values (see details below)
  * - Other fields: Returns as-is
  *
  * @param fieldValue - The raw field value
@@ -604,7 +605,7 @@ export const processCalendarFieldValue = (
  * @returns The processed field value
  */
 export const processFieldValue = (
-    fieldValue: string | string[] | Date | number | null | undefined,
+    fieldValue: string | string[] | Date | number | Record<string, unknown> | null | undefined,
     field: DotCMSContentTypeField
 ): string | number | null | undefined => {
     // Handle flattened fields (multi-select, etc.)
@@ -620,6 +621,19 @@ export const processFieldValue = (
     // Handle calendar fields (date, datetime, time)
     if (isCalendarField(field)) {
         return processCalendarFieldValue(fieldValue, field.variable);
+    }
+
+    // Handle Block Editor: the FormControl may hold an object when the form is
+    // initialized from a translated contentlet (blockEditorResolutionFn parses
+    // the JSON string to an object so the editor can render it). The backend
+    // expects a JSON string — sending an object causes it to be stored as
+    // Map.toString(), corrupting the field on save.
+    if (
+        field.fieldType === FIELD_TYPES.BLOCK_EDITOR &&
+        fieldValue &&
+        typeof fieldValue === 'object'
+    ) {
+        return JSON.stringify(fieldValue);
     }
 
     // For all other fields, return as-is

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -608,34 +608,40 @@ export const processFieldValue = (
     fieldValue: string | string[] | Date | number | Record<string, unknown> | null | undefined,
     field: DotCMSContentTypeField
 ): string | number | null | undefined => {
-    // Handle flattened fields (multi-select, etc.)
-    if (isFlattenedField(fieldValue, field)) {
-        return (fieldValue as string[]).join(',');
-    }
-
-    // Handle category fields: join inode array into comma-separated string for the API
-    if (field.fieldType === FIELD_TYPES.CATEGORY && Array.isArray(fieldValue)) {
-        return fieldValue.join(',');
-    }
-
-    // Handle calendar fields (date, datetime, time)
-    if (isCalendarField(field)) {
-        return processCalendarFieldValue(fieldValue, field.variable);
-    }
-
-    // Handle Block Editor: the FormControl may hold an object when the form is
-    // initialized from a translated contentlet (blockEditorResolutionFn parses
+    // Handle Block Editor first: the FormControl may hold an object when the form
+    // is initialized from a translated contentlet (blockEditorResolutionFn parses
     // the JSON string to an object so the editor can render it). The backend
     // expects a JSON string — sending an object causes it to be stored as
     // Map.toString(), corrupting the field on save.
+    // Handling it up front also keeps downstream branches operating on primitive
+    // types only, so their narrower signatures remain accurate.
     if (
         field.fieldType === FIELD_TYPES.BLOCK_EDITOR &&
         fieldValue &&
-        typeof fieldValue === 'object'
+        typeof fieldValue === 'object' &&
+        !Array.isArray(fieldValue) &&
+        !(fieldValue instanceof Date)
     ) {
         return JSON.stringify(fieldValue);
     }
 
+    const primitiveValue = fieldValue as string | string[] | Date | number | null | undefined;
+
+    // Handle flattened fields (multi-select, etc.)
+    if (isFlattenedField(primitiveValue, field)) {
+        return (primitiveValue as string[]).join(',');
+    }
+
+    // Handle category fields: join inode array into comma-separated string for the API
+    if (field.fieldType === FIELD_TYPES.CATEGORY && Array.isArray(primitiveValue)) {
+        return primitiveValue.join(',');
+    }
+
+    // Handle calendar fields (date, datetime, time)
+    if (isCalendarField(field)) {
+        return processCalendarFieldValue(primitiveValue, field.variable);
+    }
+
     // For all other fields, return as-is
-    return fieldValue as string | number | null | undefined;
+    return primitiveValue as string | number | null | undefined;
 };

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -505,7 +505,7 @@ export const createCustomFieldConfig = (
  * @returns True if the field should be flattened
  */
 export const isFlattenedField = (
-    fieldValue: string | string[] | Date | number | null | undefined,
+    fieldValue: unknown,
     field: DotCMSContentTypeField
 ): fieldValue is string[] => {
     return (
@@ -533,7 +533,7 @@ export const isCalendarField = (field: DotCMSContentTypeField): boolean => {
  * @returns Numeric timestamp or null/undefined
  */
 export const processCalendarFieldValue = (
-    fieldValue: string | string[] | Date | number | null | undefined,
+    fieldValue: unknown,
     fieldName: string
 ): number | null | undefined => {
     // Handle null/undefined values
@@ -608,40 +608,34 @@ export const processFieldValue = (
     fieldValue: string | string[] | Date | number | Record<string, unknown> | null | undefined,
     field: DotCMSContentTypeField
 ): string | number | null | undefined => {
-    // Handle Block Editor first: the FormControl may hold an object when the form
-    // is initialized from a translated contentlet (blockEditorResolutionFn parses
-    // the JSON string to an object so the editor can render it). The backend
-    // expects a JSON string — sending an object causes it to be stored as
-    // Map.toString(), corrupting the field on save.
-    // Handling it up front also keeps downstream branches operating on primitive
-    // types only, so their narrower signatures remain accurate.
-    if (
-        field.fieldType === FIELD_TYPES.BLOCK_EDITOR &&
-        fieldValue &&
-        typeof fieldValue === 'object' &&
-        !Array.isArray(fieldValue) &&
-        !(fieldValue instanceof Date)
-    ) {
-        return JSON.stringify(fieldValue);
-    }
-
-    const primitiveValue = fieldValue as string | string[] | Date | number | null | undefined;
-
     // Handle flattened fields (multi-select, etc.)
-    if (isFlattenedField(primitiveValue, field)) {
-        return (primitiveValue as string[]).join(',');
+    if (isFlattenedField(fieldValue, field)) {
+        return fieldValue.join(',');
     }
 
     // Handle category fields: join inode array into comma-separated string for the API
-    if (field.fieldType === FIELD_TYPES.CATEGORY && Array.isArray(primitiveValue)) {
-        return primitiveValue.join(',');
+    if (field.fieldType === FIELD_TYPES.CATEGORY && Array.isArray(fieldValue)) {
+        return fieldValue.join(',');
     }
 
     // Handle calendar fields (date, datetime, time)
     if (isCalendarField(field)) {
-        return processCalendarFieldValue(primitiveValue, field.variable);
+        return processCalendarFieldValue(fieldValue, field.variable);
+    }
+
+    // Handle Block Editor: the FormControl may hold an object when the form is
+    // initialized from a translated contentlet (blockEditorResolutionFn parses
+    // the JSON string to an object so the editor can render it). The backend
+    // expects a JSON string — sending an object causes it to be stored as
+    // Map.toString(), corrupting the field on save.
+    if (
+        field.fieldType === FIELD_TYPES.BLOCK_EDITOR &&
+        fieldValue &&
+        typeof fieldValue === 'object'
+    ) {
+        return JSON.stringify(fieldValue);
     }
 
     // For all other fields, return as-is
-    return primitiveValue as string | number | null | undefined;
+    return fieldValue as string | number | null | undefined;
 };


### PR DESCRIPTION
## Summary

- Add `blockEditorResolutionFn` that `JSON.parse()`s block editor values when they come as JSON strings from the API (happens during content translation/copy to new language)
- Previously, the block editor used `defaultResolutionFn` which returned the raw JSON string, causing the editor to display it as plain text instead of structured content

Closes #34025

## Acceptance Criteria

- [x] Block editor content is preserved as structured data when translating to a new language
- [x] Object values (already parsed) pass through unchanged
- [x] Non-JSON strings are returned as-is (no error)
- [x] Null contentlet falls back to defaultValue

## Test Plan

- [x] `yarn nx test edit-content --testPathPattern=dot-edit-content-form-resolutions` — all tests pass
- [x] 4 new tests for blockEditorResolutionFn
- [ ] Manual: Create content with block editor, translate to new language, verify formatting preserved

## Changed Files

| File | Change |
|------|--------|
| `libs/edit-content/.../dot-edit-content-form-resolutions.ts` | Added `blockEditorResolutionFn`, mapped to `FIELD_TYPES.BLOCK_EDITOR` |
| `libs/edit-content/.../dot-edit-content-form-resolutions.spec.ts` | Added 4 tests, removed BLOCK_EDITOR from default fn group |

This PR fixes: #34025