### PR TITLE
fix(edit-content): guard against non-array category values when translating

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -37,6 +37,7 @@ import {
 } from '@dotcms/data-access';
 import {
     DotCMSContentlet,
+    DotCMSContentTypeField,
     DotCMSWorkflowAction,
     DotContentletCanLock,
     DotContentletDepths
@@ -853,6 +854,59 @@ describe('DotFormComponent', () => {
 
             // Check that the event was emitted
             expect(changeValueSpy).toHaveBeenCalledWith(expect.objectContaining(testValues));
+        });
+
+        it('should convert non-array category values to empty array in processed form values', () => {
+            // Add a Category field to $formFields
+            const categoryField = {
+                fieldType: 'Category',
+                variable: 'categories',
+                readOnly: false,
+                required: false
+            } as unknown as DotCMSContentTypeField;
+
+            const originalFormFields = component.$formFields();
+            jest.spyOn(component, '$formFields').mockReturnValue([
+                ...originalFormFields,
+                categoryField
+            ]);
+
+            const changeValueSpy = jest.fn();
+            spectator.output('changeValue').subscribe(changeValueSpy);
+
+            // Simulate the translation scenario where categories is an empty string
+            component.onFormChange({ text1: 'value', categories: '' });
+
+            expect(changeValueSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ categories: [] })
+            );
+        });
+
+        it('should preserve array category values in processed form values', () => {
+            const categoryField = {
+                fieldType: 'Category',
+                variable: 'categories',
+                readOnly: false,
+                required: false
+            } as unknown as DotCMSContentTypeField;
+
+            const originalFormFields = component.$formFields();
+            jest.spyOn(component, '$formFields').mockReturnValue([
+                ...originalFormFields,
+                categoryField
+            ]);
+
+            const changeValueSpy = jest.fn();
+            spectator.output('changeValue').subscribe(changeValueSpy);
+
+            component.onFormChange({
+                text1: 'value',
+                categories: ['inode1', 'inode2']
+            });
+
+            expect(changeValueSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ categories: ['inode1', 'inode2'] })
+            );
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -456,6 +456,11 @@ export class DotEditContentFormComponent implements OnInit {
                 }
 
                 const processedValue = processFieldValue(fieldValue, field);
+
+                if (field.fieldType === FIELD_TYPES.CATEGORY) {
+                    return [key, Array.isArray(processedValue) ? processedValue : []];
+                }
+
                 return [key, processedValue ?? ''];
             })
         );

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -455,11 +455,11 @@ export class DotEditContentFormComponent implements OnInit {
                     return [key, fieldValue];
                 }
 
-                const processedValue = processFieldValue(fieldValue, field);
-
                 if (field.fieldType === FIELD_TYPES.CATEGORY) {
-                    return [key, Array.isArray(processedValue) ? processedValue : []];
+                    return [key, Array.isArray(fieldValue) ? fieldValue : []];
                 }
+
+                const processedValue = processFieldValue(fieldValue, field);
 
                 return [key, processedValue ?? ''];
             })

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.spec.ts
@@ -621,6 +621,18 @@ describe('CategoryFieldUtils', () => {
             expect(result).toEqual([]);
         });
 
+        it('should return an empty array if categories is an empty string (translation scenario)', () => {
+            const contentletWithStringCategories: DotCMSContentlet = {
+                ...CATEGORY_FIELD_CONTENTLET_MOCK,
+                [CATEGORY_FIELD_VARIABLE_NAME]: '' as unknown as DotCategoryFieldKeyValueObj[]
+            };
+            const result = getSelectedFromContentlet(
+                CATEGORY_FIELD_MOCK,
+                contentletWithStringCategories
+            );
+            expect(result).toEqual([]);
+        });
+
         it('should return the same array if there are no empty arrays', () => {
             const array: DotCategory[][] = [
                 [{ key: '1', categoryName: 'Category 1' } as DotCategory],

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.ts
@@ -27,7 +27,11 @@ export const getSelectedFromContentlet = (
         return [];
     }
 
-    const selectedCategories = contentlet[variable] || [];
+    const selectedCategories = contentlet[variable];
+
+    if (!Array.isArray(selectedCategories)) {
+        return [];
+    }
 
     return selectedCategories.map((obj: DotCategoryFieldKeyValueObj) => {
         const key = Object.keys(obj)[0];

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -1722,14 +1722,14 @@ describe('Utils Functions', () => {
             });
 
             describe('category fields', () => {
-                it('should return array values as-is for category fields', () => {
+                it('should join array values into comma-separated string for category fields', () => {
                     const field = {
                         fieldType: FIELD_TYPES.CATEGORY,
                         variable: 'categories'
                     } as unknown as DotCMSContentTypeField;
                     const arrayValue = ['inode1', 'inode2'];
 
-                    expect(processFieldValue(arrayValue, field)).toBe(arrayValue);
+                    expect(processFieldValue(arrayValue, field)).toBe('inode1,inode2');
                 });
 
                 it('should return empty string as-is for category fields (not flattened)', () => {

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -1721,6 +1721,36 @@ describe('Utils Functions', () => {
                 });
             });
 
+            describe('category fields', () => {
+                it('should return array values as-is for category fields', () => {
+                    const field = {
+                        fieldType: FIELD_TYPES.CATEGORY,
+                        variable: 'categories'
+                    } as unknown as DotCMSContentTypeField;
+                    const arrayValue = ['inode1', 'inode2'];
+
+                    expect(processFieldValue(arrayValue, field)).toBe(arrayValue);
+                });
+
+                it('should return empty string as-is for category fields (not flattened)', () => {
+                    const field = {
+                        fieldType: FIELD_TYPES.CATEGORY,
+                        variable: 'categories'
+                    } as unknown as DotCMSContentTypeField;
+
+                    expect(processFieldValue('', field)).toBe('');
+                });
+
+                it('should return null as-is for category fields', () => {
+                    const field = {
+                        fieldType: FIELD_TYPES.CATEGORY,
+                        variable: 'categories'
+                    } as unknown as DotCMSContentTypeField;
+
+                    expect(processFieldValue(null, field)).toBeNull();
+                });
+            });
+
             describe('edge cases', () => {
                 it('should handle fields without specific processing', () => {
                     const field = {


### PR DESCRIPTION
## Summary

- Add `Array.isArray()` guard in `getSelectedFromContentlet()` to prevent `.map()` crash when the category field value is not an array (e.g., during content translation when the field is empty or has unexpected type)

Closes #33932

## Acceptance Criteria

- [x] Translation no longer crashes when Categories field is empty
- [x] Existing category selection behavior unchanged
- [x] Empty/null/non-array values return empty array

## Test Plan

- [x] `yarn nx test edit-content --testPathPattern=category-field.utils` — all tests pass
- [ ] Manual: Create content with empty categories, translate to new language

## Changed Files

| File | Change |
|------|--------|
| `libs/edit-content/.../category-field.utils.ts:30-34` | Added `Array.isArray()` guard |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds defensive type checks and normalization for category field values to prevent crashes when translation returns unexpected types.
> 
> **Overview**
> Prevents edit-content translation flows from crashing when Category fields come back as non-arrays (e.g., empty string).
> 
> `getSelectedFromContentlet()` now returns `[]` unless the contentlet value is an array, and `DotEditContentFormComponent.processFormValue()` normalizes processed Category values to an array (non-arrays become `[]`). Tests were extended to cover these translation/edge cases and ensure array values are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60f2f724dc228277ec73babcae814ddd85686a93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

This PR fixes: #33932