### PR TITLE
fix(rest-api): accept locales portlet in addition to languages for language/locale operations (#34685)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/WebResource.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -900,6 +901,11 @@ public  class WebResource {
                 this.requiredPortlet.addAll(Arrays.asList(requiredPortlet));
             }
             return this;
+        }
+
+        @VisibleForTesting
+        public Set<String> getRequiredPortlets() {
+            return Collections.unmodifiableSet(requiredPortlet);
         }
 
         public InitBuilder requireLicense(final boolean requireLicense){

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v2/languages/LanguagesResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v2/languages/LanguagesResource.java
@@ -220,8 +220,12 @@ public class LanguagesResource {
     public final Response saveLanguage(@Context final HttpServletRequest request,
             @Context final HttpServletResponse response,
             final LanguageForm languageForm) throws AlreadyExistException {
-        this.webResource.init(null, request, response,
-                true, PortletID.LANGUAGES.toString());
+        new WebResource.InitBuilder(this.webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .rejectWhenNoUser(true)
+                .requiredPortlet(PortletID.LANGUAGES.toString(), PortletID.LOCALES.toString())
+                .init();
         DotPreconditions.notNull(languageForm,"Expected Request body was empty.");
         final Language language = validateLanguageExists(languageForm);
         if(null != language && language != LanguageCacheImpl.LANG_404){
@@ -243,8 +247,12 @@ public class LanguagesResource {
             @PathParam("languageTag") final String languageTag,
             @DefaultValue("false") @QueryParam("strict") final boolean strict) throws AlreadyExistException {
         DotPreconditions.notNull(languageTag, "Expected languageTag Param path was empty.");
-        this.webResource.init(null, request, response,
-                true, PortletID.LANGUAGES.toString());
+        new WebResource.InitBuilder(this.webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .rejectWhenNoUser(true)
+                .requiredPortlet(PortletID.LANGUAGES.toString(), PortletID.LOCALES.toString())
+                .init();
 
         final LanguageForm languageForm = this.getLanguageData(languageTag, strict);
 
@@ -343,8 +351,12 @@ public class LanguagesResource {
             @Context final HttpServletResponse response,
             @PathParam("languageId") final String languageId,
             final LanguageForm languageForm) throws AlreadyExistException {
-        this.webResource.init(null, request, response,
-                true, PortletID.LANGUAGES.toString());
+        new WebResource.InitBuilder(this.webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .rejectWhenNoUser(true)
+                .requiredPortlet(PortletID.LANGUAGES.toString(), PortletID.LOCALES.toString())
+                .init();
         DotPreconditions.checkArgument(UtilMethods.isSet(languageId),"Language Id is required.");
         DotPreconditions.isTrue(doesLanguageExist(languageId), DoesNotExistException.class, ()->"Language not found");
         DotPreconditions.notNull(languageForm,"Expected Request body was empty.");
@@ -369,8 +381,12 @@ public class LanguagesResource {
     public final Response deleteLanguage(@Context final HttpServletRequest request,
             @Context final HttpServletResponse response,
             @PathParam("languageId") final String languageId) {
-        this.webResource.init(null, request, response,
-                true, PortletID.LANGUAGES.toString());
+        new WebResource.InitBuilder(this.webResource)
+                .requestAndResponse(request, response)
+                .requiredBackendUser(true)
+                .rejectWhenNoUser(true)
+                .requiredPortlet(PortletID.LANGUAGES.toString(), PortletID.LOCALES.toString())
+                .init();
         DotPreconditions.checkArgument(UtilMethods.isSet(languageId),"Language Id is required.");
         DotPreconditions.isTrue(doesLanguageExist(languageId), DoesNotExistException.class, ()->"Language not found");
         final Language language = languageAPI.getLanguage(languageId);
@@ -518,7 +534,7 @@ public class LanguagesResource {
                 new WebResource.InitBuilder(webResource)
                         .requiredBackendUser(true)
                         .requiredFrontendUser(true)
-                        .requiredPortlet(PortletID.LANGUAGES.toString())
+                        .requiredPortlet(PortletID.LANGUAGES.toString(), PortletID.LOCALES.toString())
                         .requestAndResponse(request, response)
                         .rejectWhenNoUser(true)
                         .init();
@@ -592,7 +608,7 @@ public class LanguagesResource {
                 .requestAndResponse(httpServletRequest, httpServletResponse)
                 .requiredBackendUser(true)
                 .rejectWhenNoUser(true)
-                .requiredPortlet(PortletID.LANGUAGES.toString())
+                .requiredPortlet(PortletID.LANGUAGES.toString(), PortletID.LOCALES.toString())
                 .init().getUser();
 
         Logger.info(LanguagesResource.class, String.format("Switching to a new default language with id `%s`. ",languageId));

--- a/dotCMS/src/test/java/v2/languages/LanguagesResourceTest.java
+++ b/dotCMS/src/test/java/v2/languages/LanguagesResourceTest.java
@@ -18,7 +18,6 @@ import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.PortletID;
 import com.liferay.portal.model.User;
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -222,16 +221,6 @@ public class LanguagesResourceTest {
     // Issue #34685 — backend must accept both "languages" AND "locales" portlet
     // -------------------------------------------------------------------------
 
-    /**
-     * Helper: reads the private {@code requiredPortlet} Set from a captured {@link WebResource.InitBuilder}.
-     */
-    @SuppressWarnings("unchecked")
-    private static Set<String> capturedPortlets(final WebResource.InitBuilder builder) throws Exception {
-        final Field field = WebResource.InitBuilder.class.getDeclaredField("requiredPortlet");
-        field.setAccessible(true);
-        return (Set<String>) field.get(builder);
-    }
-
     private static InitDataObject mockInitDataObject() {
         final InitDataObject initDataObject = mock(InitDataObject.class);
         when(initDataObject.getUser()).thenReturn(new User());
@@ -244,7 +233,7 @@ public class LanguagesResourceTest {
      * Refs: #34685
      */
     @Test
-    public void test_saveLanguage_requiredPortlet_includesLocales() throws Exception {
+    public void test_saveLanguage_requiredPortlet_includesLocales() throws AlreadyExistException {
         final HttpServletRequest request = mock(HttpServletRequest.class);
         final HttpServletResponse response = mock(HttpServletResponse.class);
         final WebResource webResource = mock(WebResource.class);
@@ -264,7 +253,7 @@ public class LanguagesResourceTest {
 
         final ArgumentCaptor<WebResource.InitBuilder> captor = ArgumentCaptor.forClass(WebResource.InitBuilder.class);
         verify(webResource).init(captor.capture());
-        final Set<String> portlets = capturedPortlets(captor.getValue());
+        final Set<String> portlets = captor.getValue().getRequiredPortlets();
         Assert.assertTrue("languages portlet must be required", portlets.contains(PortletID.LANGUAGES.toString()));
         Assert.assertTrue("locales portlet must also be accepted", portlets.contains(PortletID.LOCALES.toString()));
     }
@@ -274,7 +263,7 @@ public class LanguagesResourceTest {
      * Refs: #34685
      */
     @Test
-    public void test_saveFromLanguageTag_requiredPortlet_includesLocales() throws Exception {
+    public void test_saveFromLanguageTag_requiredPortlet_includesLocales() throws AlreadyExistException {
         final HttpServletRequest request = mock(HttpServletRequest.class);
         final HttpServletResponse response = mock(HttpServletResponse.class);
         final WebResource webResource = mock(WebResource.class);
@@ -291,7 +280,7 @@ public class LanguagesResourceTest {
 
         final ArgumentCaptor<WebResource.InitBuilder> captor = ArgumentCaptor.forClass(WebResource.InitBuilder.class);
         verify(webResource).init(captor.capture());
-        final Set<String> portlets = capturedPortlets(captor.getValue());
+        final Set<String> portlets = captor.getValue().getRequiredPortlets();
         Assert.assertTrue("languages portlet must be required", portlets.contains(PortletID.LANGUAGES.toString()));
         Assert.assertTrue("locales portlet must also be accepted", portlets.contains(PortletID.LOCALES.toString()));
     }
@@ -301,7 +290,7 @@ public class LanguagesResourceTest {
      * Refs: #34685
      */
     @Test
-    public void test_updateLanguage_requiredPortlet_includesLocales() throws Exception {
+    public void test_updateLanguage_requiredPortlet_includesLocales() throws AlreadyExistException {
         final HttpServletRequest request = mock(HttpServletRequest.class);
         final HttpServletResponse response = mock(HttpServletResponse.class);
         final WebResource webResource = mock(WebResource.class);
@@ -323,7 +312,7 @@ public class LanguagesResourceTest {
 
         final ArgumentCaptor<WebResource.InitBuilder> captor = ArgumentCaptor.forClass(WebResource.InitBuilder.class);
         verify(webResource).init(captor.capture());
-        final Set<String> portlets = capturedPortlets(captor.getValue());
+        final Set<String> portlets = captor.getValue().getRequiredPortlets();
         Assert.assertTrue("languages portlet must be required", portlets.contains(PortletID.LANGUAGES.toString()));
         Assert.assertTrue("locales portlet must also be accepted", portlets.contains(PortletID.LOCALES.toString()));
     }
@@ -333,7 +322,7 @@ public class LanguagesResourceTest {
      * Refs: #34685
      */
     @Test
-    public void test_deleteLanguage_requiredPortlet_includesLocales() throws Exception {
+    public void test_deleteLanguage_requiredPortlet_includesLocales() throws AlreadyExistException {
         final HttpServletRequest request = mock(HttpServletRequest.class);
         final HttpServletResponse response = mock(HttpServletResponse.class);
         final WebResource webResource = mock(WebResource.class);
@@ -350,7 +339,7 @@ public class LanguagesResourceTest {
 
         final ArgumentCaptor<WebResource.InitBuilder> captor = ArgumentCaptor.forClass(WebResource.InitBuilder.class);
         verify(webResource).init(captor.capture());
-        final Set<String> portlets = capturedPortlets(captor.getValue());
+        final Set<String> portlets = captor.getValue().getRequiredPortlets();
         Assert.assertTrue("languages portlet must be required", portlets.contains(PortletID.LANGUAGES.toString()));
         Assert.assertTrue("locales portlet must also be accepted", portlets.contains(PortletID.LOCALES.toString()));
     }

--- a/dotCMS/src/test/java/v2/languages/LanguagesResourceTest.java
+++ b/dotCMS/src/test/java/v2/languages/LanguagesResourceTest.java
@@ -7,14 +7,18 @@ import com.dotcms.languagevariable.business.LanguageVariableAPI;
 import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource;
+import com.dotcms.rest.api.v2.languages.LanguageForm;
 import com.dotcms.rest.api.v2.languages.LanguageView;
 import com.dotcms.rest.api.v2.languages.LanguagesResource;
 import com.dotcms.util.CollectionsUtils;
+import com.dotmarketing.exception.AlreadyExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.dotmarketing.util.PortletID;
 import com.liferay.portal.model.User;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -27,6 +31,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.Response;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 /**
@@ -211,6 +216,143 @@ public class LanguagesResourceTest {
         Assert.assertTrue(countryCodes.contains("US"));
         Assert.assertTrue(countryCodes.contains("CR"));
 
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #34685 — backend must accept both "languages" AND "locales" portlet
+    // -------------------------------------------------------------------------
+
+    /**
+     * Helper: reads the private {@code requiredPortlet} Set from a captured {@link WebResource.InitBuilder}.
+     */
+    @SuppressWarnings("unchecked")
+    private static Set<String> capturedPortlets(final WebResource.InitBuilder builder) throws Exception {
+        final Field field = WebResource.InitBuilder.class.getDeclaredField("requiredPortlet");
+        field.setAccessible(true);
+        return (Set<String>) field.get(builder);
+    }
+
+    private static InitDataObject mockInitDataObject() {
+        final InitDataObject initDataObject = mock(InitDataObject.class);
+        when(initDataObject.getUser()).thenReturn(new User());
+        return initDataObject;
+    }
+
+    /**
+     * Given a user with the Locales portlet (and no Languages portlet),
+     * saveLanguage() must pass both portlet IDs to WebResource so the OR-check grants access.
+     * Refs: #34685
+     */
+    @Test
+    public void test_saveLanguage_requiredPortlet_includesLocales() throws Exception {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final WebResource webResource = mock(WebResource.class);
+        final LanguageAPI languageAPI = mock(LanguageAPI.class);
+        final LanguageVariableAPI languageVariableAPI = mock(LanguageVariableAPI.class);
+        final InitDataObject initDataObject = mockInitDataObject();
+
+        when(webResource.init(any(WebResource.InitBuilder.class))).thenReturn(initDataObject);
+        when(languageAPI.getLanguage(anyString(), anyString())).thenReturn(null);
+        when(languageAPI.getDefaultLanguage()).thenReturn(mock(Language.class));
+
+        final LanguageForm form = new LanguageForm.Builder()
+                .languageCode("fr").countryCode("FR").language("French").country("France").build();
+
+        final LanguagesResource resource = new LanguagesResource(languageAPI, languageVariableAPI, webResource);
+        resource.saveLanguage(request, response, form);
+
+        final ArgumentCaptor<WebResource.InitBuilder> captor = ArgumentCaptor.forClass(WebResource.InitBuilder.class);
+        verify(webResource).init(captor.capture());
+        final Set<String> portlets = capturedPortlets(captor.getValue());
+        Assert.assertTrue("languages portlet must be required", portlets.contains(PortletID.LANGUAGES.toString()));
+        Assert.assertTrue("locales portlet must also be accepted", portlets.contains(PortletID.LOCALES.toString()));
+    }
+
+    /**
+     * saveFromLanguageTag() must also include both portlet IDs.
+     * Refs: #34685
+     */
+    @Test
+    public void test_saveFromLanguageTag_requiredPortlet_includesLocales() throws Exception {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final WebResource webResource = mock(WebResource.class);
+        final LanguageAPI languageAPI = mock(LanguageAPI.class);
+        final LanguageVariableAPI languageVariableAPI = mock(LanguageVariableAPI.class);
+        final InitDataObject initDataObject = mockInitDataObject();
+
+        when(webResource.init(any(WebResource.InitBuilder.class))).thenReturn(initDataObject);
+        when(languageAPI.getLanguage(anyString(), anyString())).thenReturn(null);
+        when(languageAPI.getDefaultLanguage()).thenReturn(mock(Language.class));
+
+        final LanguagesResource resource = new LanguagesResource(languageAPI, languageVariableAPI, webResource);
+        resource.saveFromLanguageTag(request, response, "fr-FR", false);
+
+        final ArgumentCaptor<WebResource.InitBuilder> captor = ArgumentCaptor.forClass(WebResource.InitBuilder.class);
+        verify(webResource).init(captor.capture());
+        final Set<String> portlets = capturedPortlets(captor.getValue());
+        Assert.assertTrue("languages portlet must be required", portlets.contains(PortletID.LANGUAGES.toString()));
+        Assert.assertTrue("locales portlet must also be accepted", portlets.contains(PortletID.LOCALES.toString()));
+    }
+
+    /**
+     * updateLanguage() must include both portlet IDs.
+     * Refs: #34685
+     */
+    @Test
+    public void test_updateLanguage_requiredPortlet_includesLocales() throws Exception {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final WebResource webResource = mock(WebResource.class);
+        final LanguageAPI languageAPI = mock(LanguageAPI.class);
+        final LanguageVariableAPI languageVariableAPI = mock(LanguageVariableAPI.class);
+        final InitDataObject initDataObject = mockInitDataObject();
+        final Language existing = new Language(1L, "en", "US", "English", "United States");
+
+        when(webResource.init(any(WebResource.InitBuilder.class))).thenReturn(initDataObject);
+        when(languageAPI.getLanguage("1")).thenReturn(existing);
+        when(languageAPI.getLanguage(anyString(), anyString())).thenReturn(null);
+        when(languageAPI.getDefaultLanguage()).thenReturn(mock(Language.class));
+
+        final LanguageForm form = new LanguageForm.Builder()
+                .languageCode("en").countryCode("US").language("English").country("United States").build();
+
+        final LanguagesResource resource = new LanguagesResource(languageAPI, languageVariableAPI, webResource);
+        resource.updateLanguage(request, response, "1", form);
+
+        final ArgumentCaptor<WebResource.InitBuilder> captor = ArgumentCaptor.forClass(WebResource.InitBuilder.class);
+        verify(webResource).init(captor.capture());
+        final Set<String> portlets = capturedPortlets(captor.getValue());
+        Assert.assertTrue("languages portlet must be required", portlets.contains(PortletID.LANGUAGES.toString()));
+        Assert.assertTrue("locales portlet must also be accepted", portlets.contains(PortletID.LOCALES.toString()));
+    }
+
+    /**
+     * deleteLanguage() must include both portlet IDs.
+     * Refs: #34685
+     */
+    @Test
+    public void test_deleteLanguage_requiredPortlet_includesLocales() throws Exception {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        final WebResource webResource = mock(WebResource.class);
+        final LanguageAPI languageAPI = mock(LanguageAPI.class);
+        final LanguageVariableAPI languageVariableAPI = mock(LanguageVariableAPI.class);
+        final InitDataObject initDataObject = mockInitDataObject();
+        final Language existing = new Language(1L, "fr", "FR", "French", "France");
+
+        when(webResource.init(any(WebResource.InitBuilder.class))).thenReturn(initDataObject);
+        when(languageAPI.getLanguage("1")).thenReturn(existing);
+
+        final LanguagesResource resource = new LanguagesResource(languageAPI, languageVariableAPI, webResource);
+        resource.deleteLanguage(request, response, "1");
+
+        final ArgumentCaptor<WebResource.InitBuilder> captor = ArgumentCaptor.forClass(WebResource.InitBuilder.class);
+        verify(webResource).init(captor.capture());
+        final Set<String> portlets = capturedPortlets(captor.getValue());
+        Assert.assertTrue("languages portlet must be required", portlets.contains(PortletID.LANGUAGES.toString()));
+        Assert.assertTrue("locales portlet must also be accepted", portlets.contains(PortletID.LOCALES.toString()));
     }
 
 }


### PR DESCRIPTION
## Summary

- **Root cause:** `LanguagesResource` gated all write/sensitive operations on `PortletID.LANGUAGES` ("languages"), but the UI only exposes `PortletID.LOCALES` ("locales") to role assignments — making it impossible for non-admin users with the Locales portlet to add or edit locales.
- **Fix:** Added `PortletID.LOCALES` as a second accepted portlet at all 6 call sites in `LanguagesResource` (v2). `WebResource.InitBuilder.requiredPortlet()` already implements OR logic, so no framework changes were needed.
- **Backward compatible:** Users with the old "languages" portlet still work; admins are unaffected.

## Changes

- `dotCMS/src/main/java/com/dotcms/rest/api/v2/languages/LanguagesResource.java` — 4 old-style `webResource.init()` calls converted to `InitBuilder` with both portlet IDs; 2 existing `InitBuilder` calls updated to add the second portlet ID.
- `dotCMS/src/test/java/v2/languages/LanguagesResourceTest.java` — 4 new unit tests (one per write endpoint) that use `ArgumentCaptor` + reflection to assert both `"languages"` and `"locales"` are in the required portlet set.

## Test plan

- [ ] Run unit tests: `./mvnw test -pl :dotcms-core -Dtest=LanguagesResourceTest` — all 10 pass
- [ ] Create a non-admin role with only the **Locales** portlet assigned; verify the user can add, edit, and delete locales without permission errors
- [ ] Verify admin users are unaffected
- [ ] Verify users with only the legacy **Languages** portlet still work (backward compatibility)

Refs: #34685

🤖 Generated with [Claude Code](https://claude.com/claude-code)