### PR TITLE
fix(ui): revalidate key input when forbidden keys change

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-key-value-ng/dot-key-value-table-header-row/dot-key-value-table-header-row.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-key-value-ng/dot-key-value-table-header-row/dot-key-value-table-header-row.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, input, output, viewChild, inject } from '@angular/core';
+import { Component, ElementRef, input, output, viewChild, inject, effect } from '@angular/core';
 import {
     AbstractControl,
     FormsModule,
@@ -59,6 +59,12 @@ export class DotKeyValueTableHeaderRowComponent {
         key: ['', [Validators.required, this.keyValidator()]],
         value: ['', Validators.required],
         hidden: [false]
+    });
+
+    /** Revalidate key control when forbidden keys change (e.g., after deleting an entry) */
+    #revalidateEffect = effect(() => {
+        this.$forbiddenkeys();
+        this.keyControl.updateValueAndValidity();
     });
 
     /** Gets the key form control */


### PR DESCRIPTION
## Summary

- Add `effect()` in `DotKeyValueTableHeaderRowComponent` that calls `updateValueAndValidity()` on the key control when `$forbiddenkeys` signal changes
- This ensures that when a key-value entry is deleted, the duplicate key validation error clears immediately

Closes #32114

## Acceptance Criteria

- [x] Deleting a key-value entry clears the "duplicate key" validation error on the input
- [x] Adding a duplicate key still shows the validation error
- [x] No regression on existing key-value behavior

## Test Plan

- [x] `yarn nx test ui --testPathPattern=dot-key-value-table-header-row` — all tests pass
- [ ] Manual: Add key-value entry, try adding duplicate, delete original, verify validation clears

## Changed Files

| File | Change |
|------|--------|
| `libs/ui/.../dot-key-value-table-header-row.component.ts` | Added `effect()` for forbidden keys revalidation |