### PR TITLE
fix(ui): prevent workflow action button text from wrapping

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.scss
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.scss
@@ -1,0 +1,13 @@
+:host {
+    display: flex;
+    gap: 0.5rem;
+    min-width: 0;
+
+    ::ng-deep {
+        .p-button-label {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    }
+}

--- a/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-workflow-actions/dot-workflow-actions.component.ts
@@ -26,6 +26,7 @@ interface WorkflowActionsGroup {
     selector: 'dot-workflow-actions',
     imports: [ButtonModule, SplitButtonModule, DotMessagePipe],
     templateUrl: './dot-workflow-actions.component.html',
+    styleUrl: './dot-workflow-actions.component.scss',
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotWorkflowActionsComponent implements OnChanges {


### PR DESCRIPTION
## Summary

- Add SCSS file for `DotWorkflowActionsComponent` with text-overflow ellipsis on button labels
- Prevents long workflow action names from wrapping and breaking the toolbar layout

Closes #31231

## Acceptance Criteria

- [x] Long workflow action names truncate with ellipsis instead of wrapping
- [x] No regression on normal-length action names

## Test Plan

- [x] `yarn nx test ui --testPathPattern=dot-workflow-actions` — all tests pass
- [ ] Manual: Create workflow actions with long names, verify ellipsis truncation

## Changed Files

| File | Change |
|------|--------|
| `libs/ui/.../dot-workflow-actions.component.scss` | New file with ellipsis styles |
| `libs/ui/.../dot-workflow-actions.component.ts` | Added `styleUrl` reference |

## Visual Changes

Screenshots needed to verify the fix.