### PR TITLE
fix(edit-content): show validation border on required file/image fields

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.scss
@@ -22,6 +22,11 @@
     }
 }
 
+:host.ng-invalid.ng-touched .binary-field__container,
+:host.ng-invalid.ng-dirty .binary-field__container {
+    border-color: $color-palette-red-500;
+}
+
 .binary-field__container--uploading {
     border: $field-border-size dashed $color-palette-gray-400;
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.scss
@@ -11,8 +11,8 @@
     justify-content: center;
     align-items: center;
     width: 100%;
-    border-radius: $border-radius-md;
-    border: $field-border-size solid $color-palette-gray-400;
+    border-radius: var(--p-inputtext-border-radius);
+    border: 1px solid var(--p-inputtext-border-color);
     padding: $spacing-1;
     height: 14.4rem;
     min-width: 12.5rem;
@@ -22,13 +22,12 @@
     }
 }
 
-:host.ng-invalid.ng-touched .binary-field__container,
-:host.ng-invalid.ng-dirty .binary-field__container {
-    border-color: $color-palette-red-500;
+:host.ng-invalid.ng-touched .binary-field__container {
+    border-color: var(--p-inputtext-invalid-border-color);
 }
 
 .binary-field__container--uploading {
-    border: $field-border-size dashed $color-palette-gray-400;
+    border: 1px dashed var(--p-inputtext-border-color);
 }
 
 .binary-field__actions {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.spec.ts
@@ -17,7 +17,8 @@ import {
     FormControl,
     FormGroup,
     FormGroupDirective,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    Validators
 } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
@@ -823,5 +824,65 @@ describe('DotEditContentBinaryFieldComponent - ControlValueAccessor', () => {
         spectator.component.setTempFile(TEMP_FILE_MOCK);
         const formValue = spectator.hostComponent.form.get('binaryField').value; // Get the form value
         expect(formValue).toBe(TEMP_FILE_MOCK.id); // Check if the form value was set
+    });
+});
+
+/**
+ * Mock host with required validation
+ */
+@Component({
+    standalone: false,
+    selector: 'dot-required-host',
+    template: ''
+})
+class MockRequiredFormComponent {
+    field = BINARY_FIELD_MOCK;
+    contentlet = null;
+    form = new FormGroup({
+        binaryField: new FormControl('', Validators.required)
+    });
+}
+
+describe('DotEditContentBinaryFieldComponent - Validation', () => {
+    let spectator: SpectatorHost<DotEditContentBinaryFieldComponent, MockRequiredFormComponent>;
+    const createHost = createHostFactory({
+        component: DotEditContentBinaryFieldComponent,
+        host: MockRequiredFormComponent,
+        imports: [
+            ButtonModule,
+            DialogModule,
+            MonacoEditorModule,
+            ReactiveFormsModule,
+            DotEditContentBinaryFieldComponent
+        ],
+        providers: [DotAiService, provideHttpClient()]
+    });
+
+    beforeEach(() => {
+        spectator = createHost(` <form [formGroup]="form">
+            <dot-edit-content-binary-field [contentlet]="contentlet" [field]="field" formControlName="binaryField"></dot-edit-content-binary-field>
+        </form>`);
+    });
+
+    it('should have ng-invalid class when required field is empty', () => {
+        const hostElement = spectator.query('dot-edit-content-binary-field');
+        expect(hostElement).toHaveClass('ng-invalid');
+    });
+
+    it('should show validation border when form is marked as touched with empty required field', () => {
+        spectator.hostComponent.form.markAllAsTouched();
+        spectator.detectChanges();
+
+        const hostElement = spectator.query('dot-edit-content-binary-field');
+        expect(hostElement).toHaveClass('ng-invalid');
+        expect(hostElement).toHaveClass('ng-touched');
+    });
+
+    it('should remove ng-invalid class when a file is selected', () => {
+        spectator.component.setTempFile(TEMP_FILE_MOCK);
+        spectator.detectChanges();
+
+        const hostElement = spectator.query('dot-edit-content-binary-field');
+        expect(hostElement).not.toHaveClass('ng-invalid');
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-binary-field/dot-edit-content-binary-field.component.spec.ts
@@ -865,7 +865,7 @@ describe('DotEditContentBinaryFieldComponent - Validation', () => {
     });
 
     it('should have ng-invalid class when required field is empty', () => {
-        const hostElement = spectator.query('dot-edit-content-binary-field');
+        const hostElement = spectator.queryHost('dot-edit-content-binary-field');
         expect(hostElement).toHaveClass('ng-invalid');
     });
 
@@ -873,7 +873,7 @@ describe('DotEditContentBinaryFieldComponent - Validation', () => {
         spectator.hostComponent.form.markAllAsTouched();
         spectator.detectChanges();
 
-        const hostElement = spectator.query('dot-edit-content-binary-field');
+        const hostElement = spectator.queryHost('dot-edit-content-binary-field');
         expect(hostElement).toHaveClass('ng-invalid');
         expect(hostElement).toHaveClass('ng-touched');
     });
@@ -882,7 +882,7 @@ describe('DotEditContentBinaryFieldComponent - Validation', () => {
         spectator.component.setTempFile(TEMP_FILE_MOCK);
         spectator.detectChanges();
 
-        const hostElement = spectator.query('dot-edit-content-binary-field');
+        const hostElement = spectator.queryHost('dot-edit-content-binary-field');
         expect(hostElement).not.toHaveClass('ng-invalid');
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.html
@@ -2,7 +2,8 @@
     [class.opacity-50]="$isDisabled()"
     [class.pointer-events-none]="$isDisabled()"
     [class.border-dashed]="store.isUploading()"
-    class="flex h-[14.4rem] min-w-50 w-full flex-col items-center justify-center gap-2 rounded-md border border-[var(--p-inputtext-border-color)] p-2 min-[306px]:flex-row">
+    [class.border-color-error]="$hasError()"
+    class="flex h-[14.4rem] min-w-50 w-full flex-col items-center justify-center gap-2 rounded-[var(--p-inputtext-border-radius)] border border-solid border-[var(--p-inputtext-border-color)] p-2 min-[306px]:flex-row">
     @switch (store.fileStatus()) {
         @case ('init') {
             <div

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.scss
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.scss
@@ -4,6 +4,10 @@
     container-name: dotFileField;
 }
 
+.border-color-error {
+    border-color: var(--p-inputtext-invalid-border-color);
+}
+
 /* Active state when dragging over drop zone (theme variable; not valid in [class.x] binding) */
 .dot-file-field__drop-zone--active {
     background: #fff;

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
@@ -468,12 +468,11 @@ export class DotFileFieldComponent
     }
 
     readonly handleStoreValueChange = signalMethod<string>((value) => {
-        if (value === null || value === undefined || !this.onChange || !this.onTouched) {
+        if (value === null || value === undefined || !this.onChange) {
             return;
         }
 
         this.onChange(value);
-        this.onTouched();
     });
 
     readonly handleValueChange = signalMethod<string>((value) => {


### PR DESCRIPTION
## Summary

- Show red validation border on required binary, file, and image fields when Save is clicked with empty input
- Align border styling across all field types using PrimeNG CSS variables for consistency
- Fix premature validation in file/image fields caused by `onTouched()` being called during store initialization

Closes #33682

## Changes

| File | Change |
|------|--------|
| `dot-edit-content-binary-field.component.scss` | Use PrimeNG CSS variables (`--p-inputtext-border-color`, `--p-inputtext-border-radius`, `--p-inputtext-invalid-border-color`) for border styling; add `:host.ng-invalid.ng-touched` rule for error state |
| `dot-file-field.component.html` | Use PrimeNG CSS variables for border; add `[class.border-color-error]` binding via `$hasError()` input |
| `dot-file-field.component.scss` | Add `.border-color-error` class using `--p-inputtext-invalid-border-color` |
| `dot-file-field.component.ts` | Remove `onTouched()` from `handleStoreValueChange` to prevent premature touched state on init |
| `dot-edit-content-binary-field.component.spec.ts` | Add validation tests for required field error state |

## Acceptance Criteria

- [x] When the user clicks Save without selecting an image/file, the validation border is displayed immediately
- [x] The behavior matches other input fields (Text Field), ensuring consistent UX
- [x] The validation border does not appear before the user triggers Save
- [x] The fix works for binary, file, and image field types
- [x] All field types use PrimeNG CSS variables for consistent styling
- [x] Unit tests added for validation behavior

## Test Plan

- [ ] Create a content type with required binary, file, image, and text fields
- [ ] Navigate to create new content of that type
- [ ] Verify all fields have the same gray border style on load (no error indicators)
- [ ] Click Save without filling any fields
- [ ] Verify all fields show red border and "This field is mandatory" message
- [ ] Verify the red border color is consistent across all field types
- [ ] Upload a file to one field, verify its red border clears

## Visual Changes
<img width="2444" height="1836" alt="CleanShot 2026-04-10 at 14 07 43@2x" src="https://github.com/user-attachments/assets/0f6df522-9f6c-463a-a55f-841d852379b0" />

<img width="2474" height="2046" alt="CleanShot 2026-04-10 at 14 07 48@2x" src="https://github.com/user-attachments/assets/8d1d9376-ee2d-4313-8449-be9c06251625" />

This PR fixes: #33682