### PR TITLE
feat(uve): Page Scanner UI feedback — DotColorIconComponent, card redesign, and dev server improvements

### DIFF
--- a/core-web/apps/dotcms-ui/project.json
+++ b/core-web/apps/dotcms-ui/project.json
@@ -131,7 +131,8 @@
                 "proxyConfig": "apps/dotcms-ui/proxy-dev.conf.mjs",
                 "buildTarget": "dotcms-ui:build:development",
                 "liveReload": true,
-                "watch": true
+                "watch": true,
+                "allowedHosts": true
             },
             "configurations": {
                 "production": {

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.html
@@ -23,7 +23,9 @@
                     class="invisible absolute top-4 right-4 group-hover:visible"
                     src="/dotAdmin/assets/logos/check-circle.svg"
                     alt="check" />
-                <img class="block mx-auto" src="/dotAdmin/assets/logos/code.svg" alt="developer" />
+                <dot-color-icon color="blue">
+                    <span class="material-icons">code</span>
+                </dot-color-icon>
                 <h3
                     class="mt-4 mb-4 text-center text-xl font-semibold leading-6 tracking-[-0.31px]">
                     Developer
@@ -42,7 +44,9 @@
                     class="invisible absolute top-4 right-4 group-hover:visible"
                     src="/dotAdmin/assets/logos/check-circle.svg"
                     alt="check" />
-                <img class="block mx-auto" src="/dotAdmin/assets/logos/marketer.svg" />
+                <dot-color-icon color="purple">
+                    <span class="material-icons">campaign</span>
+                </dot-color-icon>
                 <h3
                     class="mt-4 mb-4 text-center text-xl font-semibold leading-6 tracking-[-0.31px]">
                     Marketer

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-starter/dot-starter.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
+import { DotColorIconComponent } from '@dotcms/ui';
+
 import { DotOnboardingAuthorComponent } from './components/onboarding-author/onboarding-author.component';
 import { DotOnboardingDevComponent } from './components/onboarding-dev/onboarding-dev.component';
 
@@ -8,7 +10,7 @@ export type UserProfile = 'developer' | 'marketer';
 @Component({
     selector: 'dot-starter',
     templateUrl: './dot-starter.component.html',
-    imports: [DotOnboardingDevComponent, DotOnboardingAuthorComponent]
+    imports: [DotColorIconComponent, DotOnboardingDevComponent, DotOnboardingAuthorComponent]
 })
 export class DotStarterComponent implements OnInit {
     public profile: UserProfile = localStorage.getItem('user_profile') as UserProfile;

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-scanner-report/dot-page-scanner-a11y-report/dot-page-scanner-a11y-report.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-scanner-report/dot-page-scanner-a11y-report/dot-page-scanner-a11y-report.component.html
@@ -1,26 +1,46 @@
 <div class="flex gap-3 mb-6">
-    <div class="flex-1 p-3 rounded-lg border border-solid border-gray-200 bg-gray-50">
-        <p class="mb-1">{{ 'page.scanner.a11y.standard' | dm }}</p>
-        <p class="text-2xl font-bold">{{ a11yData().standard }}</p>
-    </div>
-    <div class="flex-1 p-3 rounded-lg border border-solid border-red-200 bg-red-50">
-        <p class="mb-1">{{ 'page.scanner.a11y.errors' | dm }}</p>
-        <p class="text-2xl font-bold text-red-700">
-            {{ a11yData().findings?.byType?.errors ?? 0 }}
-        </p>
-    </div>
-    <div class="flex-1 p-3 rounded-lg border border-solid border-yellow-200 bg-yellow-50">
-        <p class="mb-1">{{ 'page.scanner.a11y.warnings' | dm }}</p>
-        <p class="text-2xl font-bold text-yellow-700">
-            {{ a11yData().findings?.byType?.warnings ?? 0 }}
-        </p>
-    </div>
-    <div class="flex-1 p-3 rounded-lg border border-solid border-blue-200 bg-blue-50">
-        <p class="mb-1">{{ 'page.scanner.a11y.notices' | dm }}</p>
-        <p class="text-2xl font-bold text-blue-700">
-            {{ a11yData().findings?.byType?.notices ?? 0 }}
-        </p>
-    </div>
+    <p-card class="flex-1">
+        <div class="flex items-start justify-between">
+            <div>
+                <p class="text-2xl font-bold m-0 mb-1">{{ a11yData().standard }}</p>
+                <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.standard' | dm }}</p>
+            </div>
+            <span class="material-icons text-gray-400">verified</span>
+        </div>
+    </p-card>
+    <p-card class="flex-1">
+        <div class="flex items-start justify-between">
+            <div>
+                <p class="text-2xl font-bold text-red-700 m-0 mb-1">
+                    {{ a11yData().findings?.byType?.errors ?? 0 }}
+                </p>
+                <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.errors' | dm }}</p>
+            </div>
+            <span class="material-icons text-gray-400">cancel</span>
+        </div>
+    </p-card>
+    <p-card class="flex-1">
+        <div class="flex items-start justify-between">
+            <div>
+                <p class="text-2xl font-bold text-yellow-700 m-0 mb-1">
+                    {{ a11yData().findings?.byType?.warnings ?? 0 }}
+                </p>
+                <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.warnings' | dm }}</p>
+            </div>
+            <span class="material-icons text-gray-400">warning</span>
+        </div>
+    </p-card>
+    <p-card class="flex-1">
+        <div class="flex items-start justify-between">
+            <div>
+                <p class="text-2xl font-bold text-blue-700 m-0 mb-1">
+                    {{ a11yData().findings?.byType?.notices ?? 0 }}
+                </p>
+                <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.notices' | dm }}</p>
+            </div>
+            <span class="material-icons text-gray-400">info</span>
+        </div>
+    </p-card>
 </div>
 
 <h3 class="font-bold text-xl m-0 mb-4">{{ 'page.scanner.a11y.findings' | dm }}</h3>
@@ -37,23 +57,24 @@
                     <p-accordion-header>
                         <div class="flex items-center gap-2 w-full justify-between pr-4">
                             <div class="flex items-center gap-4">
-                                <div
-                                    class="w-14 h-14 rounded-2xl flex items-center justify-center text-center text-base"
-                                    [class]="
+                                <dot-color-icon
+                                    [color]="
                                         group.type === 'error'
-                                            ? 'bg-red-100'
+                                            ? 'red'
                                             : group.type === 'warning'
-                                              ? 'bg-yellow-100'
-                                              : 'bg-blue-100'
+                                              ? 'yellow'
+                                              : 'blue'
                                     ">
-                                    @if (group.type === 'error') {
-                                        <span class="material-icons text-red-500">cancel</span>
-                                    } @else if (group.type === 'warning') {
-                                        <span class="material-icons text-yellow-500">warning</span>
-                                    } @else {
-                                        <span class="material-icons text-blue-500">info</span>
-                                    }
-                                </div>
+                                    <span class="material-icons">
+                                        {{
+                                            group.type === 'error'
+                                                ? 'cancel'
+                                                : group.type === 'warning'
+                                                  ? 'warning'
+                                                  : 'info'
+                                        }}
+                                    </span>
+                                </dot-color-icon>
 
                                 <div class="flex gap-2 items-center">
                                     <span class="text-lg font-semibold text-gray-900">

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-scanner-report/dot-page-scanner-a11y-report/dot-page-scanner-a11y-report.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-scanner-report/dot-page-scanner-a11y-report/dot-page-scanner-a11y-report.component.html
@@ -1,45 +1,37 @@
 <div class="flex gap-3 mb-6">
     <p-card class="flex-1">
-        <div class="flex items-start justify-between">
-            <div>
-                <p class="text-2xl font-bold m-0 mb-1">{{ a11yData().standard }}</p>
-                <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.standard' | dm }}</p>
-            </div>
-            <span class="material-icons text-gray-400">verified</span>
+        <div class="flex items-center justify-between mb-1">
+            <p class="text-2xl font-bold m-0">{{ a11yData().standard }}</p>
+            <span class="material-icons text-gray-500">verified</span>
         </div>
+        <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.standard' | dm }}</p>
     </p-card>
     <p-card class="flex-1">
-        <div class="flex items-start justify-between">
-            <div>
-                <p class="text-2xl font-bold text-red-700 m-0 mb-1">
-                    {{ a11yData().findings?.byType?.errors ?? 0 }}
-                </p>
-                <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.errors' | dm }}</p>
-            </div>
-            <span class="material-icons text-gray-400">cancel</span>
+        <div class="flex items-center justify-between mb-1">
+            <p class="text-2xl font-bold text-red-700 m-0">
+                {{ a11yData().findings?.byType?.errors ?? 0 }}
+            </p>
+            <span class="material-icons text-red-500">cancel</span>
         </div>
+        <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.errors' | dm }}</p>
     </p-card>
     <p-card class="flex-1">
-        <div class="flex items-start justify-between">
-            <div>
-                <p class="text-2xl font-bold text-yellow-700 m-0 mb-1">
-                    {{ a11yData().findings?.byType?.warnings ?? 0 }}
-                </p>
-                <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.warnings' | dm }}</p>
-            </div>
-            <span class="material-icons text-gray-400">warning</span>
+        <div class="flex items-center justify-between mb-1">
+            <p class="text-2xl font-bold text-yellow-600 m-0">
+                {{ a11yData().findings?.byType?.warnings ?? 0 }}
+            </p>
+            <span class="material-icons text-yellow-500">warning</span>
         </div>
+        <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.warnings' | dm }}</p>
     </p-card>
     <p-card class="flex-1">
-        <div class="flex items-start justify-between">
-            <div>
-                <p class="text-2xl font-bold text-blue-700 m-0 mb-1">
-                    {{ a11yData().findings?.byType?.notices ?? 0 }}
-                </p>
-                <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.notices' | dm }}</p>
-            </div>
-            <span class="material-icons text-gray-400">info</span>
+        <div class="flex items-center justify-between mb-1">
+            <p class="text-2xl font-bold text-blue-700 m-0">
+                {{ a11yData().findings?.byType?.notices ?? 0 }}
+            </p>
+            <span class="material-icons text-blue-500">info</span>
         </div>
+        <p class="m-0 text-gray-600">{{ 'page.scanner.a11y.notices' | dm }}</p>
     </p-card>
 </div>
 

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-scanner-report/dot-page-scanner-a11y-report/dot-page-scanner-a11y-report.component.ts
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-scanner-report/dot-page-scanner-a11y-report/dot-page-scanner-a11y-report.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
 
 import { AccordionModule } from 'primeng/accordion';
+import { CardModule } from 'primeng/card';
 import { ChipModule } from 'primeng/chip';
 
-import { DotMessagePipe } from '@dotcms/ui';
+import { DotColorIconComponent, DotMessagePipe } from '@dotcms/ui';
 
 import { PageScannerA11yItem, PageScannerA11yResponse } from '../dot-page-scanner.service';
 import { A11yGroup } from '../models';
@@ -11,7 +12,7 @@ import { A11yGroup } from '../models';
 @Component({
     selector: 'dot-page-scanner-a11y-report',
     standalone: true,
-    imports: [AccordionModule, ChipModule, DotMessagePipe],
+    imports: [AccordionModule, CardModule, ChipModule, DotColorIconComponent, DotMessagePipe],
     templateUrl: './dot-page-scanner-a11y-report.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush
 })

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-scanner-report/dot-page-scanner-report.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-scanner-report/dot-page-scanner-report.component.html
@@ -1,5 +1,6 @@
 <p-dialog
     [visible]="$state.visible()"
+    [header]="($state.reportType() === 'a11y' ? 'page.scanner.a11y.dialog.title' : 'page.scanner.geo.dialog.title') | dm"
     [modal]="true"
     [closable]="true"
     [closeOnEscape]="true"
@@ -9,21 +10,6 @@
     [appendTo]="'body'"
     (onHide)="onDialogHide()"
     (visibleChange)="onVisibleChange($event)">
-    <ng-template pTemplate="header">
-        <div class="flex items-center gap-2">
-            @if ($state.reportType() === 'a11y') {
-                <span class="material-icons text-primary">accessibility</span>
-                <span class="font-semibold text-lg">
-                    {{ 'page.scanner.a11y.dialog.title' | dm }}
-                </span>
-            } @else {
-                <span class="material-icons text-primary">smart_toy</span>
-                <span class="font-semibold text-lg">
-                    {{ 'page.scanner.geo.dialog.title' | dm }}
-                </span>
-            }
-        </div>
-    </ng-template>
 
     <div class="p-4 h-full">
         @switch ($state.status()) {

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.html
@@ -16,10 +16,10 @@
                 <div class="flex flex-col gap-3 mb-10">
                     <button
                         type="button"
-                        class="flex items-center gap-3 p-4 pr-6 rounded-xl bg-blue-50 border-none cursor-pointer hover:bg-blue-100 transition-colors w-full text-left"
+                        class="flex items-center gap-4 p-5 rounded-xl bg-blue-50 border-none cursor-pointer hover:bg-blue-100 transition-colors w-full text-left"
                         data-testid="page-scanner-a11y-btn"
                         (click)="onScannerToolClick('a11y')">
-                        <dot-color-icon color="blue">
+                        <dot-color-icon color="blue" variant="solid" size="sm">
                             <span class="material-icons">accessibility</span>
                         </dot-color-icon>
                         <div class="flex flex-col flex-1">
@@ -30,16 +30,14 @@
                                 {{ 'page.tools.scanner.a11y.subtitle' | dm }}
                             </span>
                         </div>
-                        <span class="font-semibold text-lg text-blue-600 shrink-0">
-                            {{ 'page.tools.scanner.a11y.run' | dm }} →
-                        </span>
+                        <span class="font-semibold text-blue-700 shrink-0">→</span>
                     </button>
                     <button
                         type="button"
-                        class="flex items-center gap-3 p-4 pr-6 rounded-xl bg-green-50 border-none cursor-pointer hover:bg-green-100 transition-colors w-full text-left"
+                        class="flex items-center gap-4 p-5 rounded-xl bg-green-50 border-none cursor-pointer hover:bg-green-100 transition-colors w-full text-left"
                         data-testid="page-scanner-geo-btn"
                         (click)="onScannerToolClick('geo')">
-                        <dot-color-icon color="green">
+                        <dot-color-icon color="green" variant="solid" size="sm">
                             <span class="material-icons">smart_toy</span>
                         </dot-color-icon>
                         <div class="flex flex-col flex-1">
@@ -50,9 +48,7 @@
                                 {{ 'page.tools.scanner.geo.subtitle' | dm }}
                             </span>
                         </div>
-                        <span class="font-semibold text-lg text-green-600 shrink-0">
-                            {{ 'page.tools.scanner.geo.run' | dm }} →
-                        </span>
+                        <span class="font-semibold text-green-700 shrink-0">→</span>
                     </button>
                 </div>
             }

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.html
@@ -19,10 +19,9 @@
                         class="flex items-center gap-3 p-4 pr-6 rounded-xl bg-blue-50 border-none cursor-pointer hover:bg-blue-100 transition-colors w-full text-left"
                         data-testid="page-scanner-a11y-btn"
                         (click)="onScannerToolClick('a11y')">
-                        <div
-                            class="w-14 h-14 rounded-xl bg-blue-500 flex items-center justify-center shrink-0">
-                            <span class="material-icons text-4xl text-white">accessibility</span>
-                        </div>
+                        <dot-color-icon color="blue">
+                            <span class="material-icons">accessibility</span>
+                        </dot-color-icon>
                         <div class="flex flex-col flex-1">
                             <span class="font-bold text-xl text-blue-900">
                                 {{ 'page.tools.scanner.a11y.title' | dm }}
@@ -40,10 +39,9 @@
                         class="flex items-center gap-3 p-4 pr-6 rounded-xl bg-green-50 border-none cursor-pointer hover:bg-green-100 transition-colors w-full text-left"
                         data-testid="page-scanner-geo-btn"
                         (click)="onScannerToolClick('geo')">
-                        <div
-                            class="w-14 h-14 rounded-xl bg-green-500 flex items-center justify-center shrink-0">
-                            <span class="material-icons text-4xl text-white">smart_toy</span>
-                        </div>
+                        <dot-color-icon color="green">
+                            <span class="material-icons">smart_toy</span>
+                        </dot-color-icon>
                         <div class="flex flex-col flex-1">
                             <span class="font-bold text-xl text-green-900">
                                 {{ 'page.tools.scanner.geo.title' | dm }}

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.html
@@ -23,7 +23,7 @@
                             <span class="material-icons">accessibility</span>
                         </dot-color-icon>
                         <div class="flex flex-col flex-1">
-                            <span class="font-bold text-xl text-blue-900">
+                            <span class="font-bold text-lg text-blue-900">
                                 {{ 'page.tools.scanner.a11y.title' | dm }}
                             </span>
                             <span class="text-sm text-blue-600">
@@ -41,7 +41,7 @@
                             <span class="material-icons">smart_toy</span>
                         </dot-color-icon>
                         <div class="flex flex-col flex-1">
-                            <span class="font-bold text-xl text-green-900">
+                            <span class="font-bold text-lg text-green-900">
                                 {{ 'page.tools.scanner.geo.title' | dm }}
                             </span>
                             <span class="text-sm text-green-600">

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.ts
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-page-tools-seo/dot-page-tools-seo.component.ts
@@ -7,7 +7,7 @@ import { DialogModule } from 'primeng/dialog';
 
 import { DotPageToolsService } from '@dotcms/data-access';
 import { DotPageToolUrlParams } from '@dotcms/dotcms-models';
-import { DotMessagePipe } from '@dotcms/ui';
+import { DotColorIconComponent, DotMessagePipe } from '@dotcms/ui';
 
 import { DotPageToolsSeoState, DotPageToolsSeoStore } from './store/dot-page-tools-seo.store';
 
@@ -16,7 +16,7 @@ export type PageScannerToolType = 'a11y' | 'geo';
 @Component({
     selector: 'dot-page-tools-seo',
     providers: [DotPageToolsService, DotPageToolsSeoStore],
-    imports: [AsyncPipe, DialogModule, DotMessagePipe],
+    imports: [AsyncPipe, DialogModule, DotColorIconComponent, DotMessagePipe],
     templateUrl: './dot-page-tools-seo.component.html',
     styleUrls: ['./dot-page-tools-seo.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/core-web/libs/ui/src/index.ts
+++ b/core-web/libs/ui/src/index.ts
@@ -1,4 +1,5 @@
 // Components (now standalone)
+export * from './lib/components/dot-color-icon/dot-color-icon.component';
 export * from './lib/dot-icon/dot-icon.component';
 export * from './lib/dot-spinner/dot-spinner.component';
 // Components

--- a/core-web/libs/ui/src/lib/components/dot-color-icon/dot-color-icon.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-color-icon/dot-color-icon.component.ts
@@ -5,7 +5,8 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
     standalone: true,
     template: `<ng-content />`,
     host: {
-        class: 'w-14 h-14 rounded-2xl flex items-center justify-center shrink-0',
+        class: 'rounded-xl flex items-center justify-center shrink-0',
+        '[class]': 'sizeClass()',
         '[style.background-color]': 'bgColor()',
         '[style.color]': 'fgColor()'
     },
@@ -13,7 +14,16 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
 })
 export class DotColorIconComponent {
     color = input.required<string>();
+    variant = input<'light' | 'solid'>('light');
+    size = input<'sm' | 'md'>('md');
 
-    protected bgColor = computed(() => `var(--p-${this.color()}-100)`);
-    protected fgColor = computed(() => `var(--p-${this.color()}-500)`);
+    protected sizeClass = computed(() => (this.size() === 'sm' ? 'w-12 h-12' : 'w-14 h-14'));
+    protected bgColor = computed(() =>
+        this.variant() === 'solid'
+            ? `var(--p-${this.color()}-500)`
+            : `var(--p-${this.color()}-100)`
+    );
+    protected fgColor = computed(() =>
+        this.variant() === 'solid' ? 'white' : `var(--p-${this.color()}-500)`
+    );
 }

--- a/core-web/libs/ui/src/lib/components/dot-color-icon/dot-color-icon.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-color-icon/dot-color-icon.component.ts
@@ -3,14 +3,12 @@ import { ChangeDetectionStrategy, Component, computed, input } from '@angular/co
 @Component({
     selector: 'dot-color-icon',
     standalone: true,
-    template: `
-        <div
-            class="w-14 h-14 rounded-2xl flex items-center justify-center shrink-0"
-            [style.background-color]="bgColor()"
-            [style.color]="fgColor()">
-            <ng-content />
-        </div>
-    `,
+    template: `<ng-content />`,
+    host: {
+        class: 'w-14 h-14 rounded-2xl flex items-center justify-center shrink-0',
+        '[style.background-color]': 'bgColor()',
+        '[style.color]': 'fgColor()'
+    },
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class DotColorIconComponent {

--- a/core-web/libs/ui/src/lib/components/dot-color-icon/dot-color-icon.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-color-icon/dot-color-icon.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+
+@Component({
+    selector: 'dot-color-icon',
+    standalone: true,
+    template: `
+        <div
+            class="w-14 h-14 rounded-2xl flex items-center justify-center shrink-0"
+            [style.background-color]="bgColor()"
+            [style.color]="fgColor()">
+            <ng-content />
+        </div>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DotColorIconComponent {
+    color = input.required<string>();
+
+    protected bgColor = computed(() => `var(--p-${this.color()}-100)`);
+    protected fgColor = computed(() => `var(--p-${this.color()}-500)`);
+}

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6163,7 +6163,7 @@ style.editor.text.field.default.placeholder=Enter value
 
 # Page Scanner
 page.scanner.a11y.dialog.title=Accessibility Report
-page.scanner.geo.dialog.title=Generative Engine Optimization (GEO) Report
+page.scanner.geo.dialog.title=GEO Report
 page.scanner.a11y.standard=Standard
 page.scanner.a11y.errors=Errors
 page.scanner.a11y.warnings=Warnings

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6210,8 +6210,8 @@ page.tools.external.section.title=External Tools
 page.tools.scanner.a11y.title=Accessibility
 page.tools.scanner.a11y.subtitle=Scan for WCAG compliance issues
 page.tools.scanner.a11y.run=Run Scan
-page.tools.scanner.geo.title=Generative Engine Optimization
-page.tools.scanner.geo.subtitle=Optimize content for AI-powered search engines
+page.tools.scanner.geo.title=GEO
+page.tools.scanner.geo.subtitle=Analyze for AI-powered search engines
 page.tools.scanner.geo.run=Run Scan
 # Style Editor Form Builder
 style.editor.form.builder.header=Form Appearance & Settings


### PR DESCRIPTION
## Summary

- Add reusable `DotColorIconComponent` to `libs/ui` — accepts `color`, `variant` (`light`/`solid`), and `size` (`sm`/`md`) inputs; uses `ng-content` for the icon and PrimeNG CSS vars for theming; uses host bindings instead of a wrapper div
- Refactor a11y report summary boxes to use `p-card` with colored numbers and icons
- Replace inline icon+background divs in scanner report and page-tools-seo with `DotColorIconComponent`
- Redesign page scanner tool cards: solid icon, arrow-only CTA, updated copy and sizing
- Replace profile card SVGs in `dot-starter` with `DotColorIconComponent` and material icons
- Simplify scanner dialog header to use `p-dialog [header]` binding directly
- Update i18n: GEO dialog title → "GEO Report", GEO card title → "GEO", updated subtitles
- Set `allowedHosts: true` on dev server to support Cloudflare tunnel access

## Test plan

- [ ] Open Page Tools sidebar — verify Accessibility and GEO cards render with solid colored icons and arrow-only CTA
- [ ] Click each scanner card — verify dialog opens with correct title ("Accessibility Report" / "GEO Report")
- [ ] Verify a11y report summary boxes use p-card with colored numbers and icons top-right
- [ ] Open dot-starter — verify Developer (blue/code) and Marketer (purple/campaign) icons render correctly
- [ ] Verify existing uses of `DotColorIconComponent` (a11y accordion) still render with light variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<img width="1916" height="2582" alt="CleanShot 2026-04-07 at 16 33 35@2x" src="https://github.com/user-attachments/assets/d6e12a59-60bc-4225-ab6b-f111993aede9" />

<img width="1080" height="1262" alt="CleanShot 2026-04-07 at 16 36 40@2x" src="https://github.com/user-attachments/assets/78032d3d-0605-4da1-8c7d-28f6b6fd1326" />

<img width="1926" height="2574" alt="CleanShot 2026-04-07 at 16 36 57@2x" src="https://github.com/user-attachments/assets/540cae1c-1732-4502-b56e-1ae9c35a83e2" />
