### PR TITLE
fix: add flag to enable the use of rendered HTML title (#35153)

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/sitesearch/ESSiteSearchPublisher.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/sitesearch/ESSiteSearchPublisher.java
@@ -30,6 +30,7 @@ import com.dotcms.storage.model.Metadata;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.UserAPI;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
@@ -409,7 +410,16 @@ public class ESSiteSearchPublisher extends Publisher {
                     res.setLanguage(((Contentlet) page).getLanguageId());
                     // map contains [fileSize, content, author, title, keywords,
                     // description, contentType, contentEncoding]
-                    res.setTitle(page.getTitle());
+                    // When SITE_SEARCH_USE_HTML_TITLE=true, prefer the rendered <title> from Tika
+                    // metadata (same source as legacy StaticHTMLPageBundler behavior and URLMap
+                    // pages), falling back to page.getTitle() only when absent.
+                    // Default is false to preserve current behavior.
+                    if (Config.getBooleanProperty("SITE_SEARCH_USE_HTML_TITLE", false)
+                            && UtilMethods.isSet((String) map.get("title"))) {
+                        res.setTitle((String) map.get("title"));
+                    } else {
+                        res.setTitle(page.getTitle());
+                    }
 
                     res.setContentLength(htmlFile.length());
                     res.setMimeType((String)map.get("contentType"));


### PR DESCRIPTION
## Problem

For non–URL-mapped HTML pages, site search was unconditionally overwriting the title parsed from the rendered HTML (via Tika metadata) with `page.getTitle()` — the CMS Page Title field from page properties.

Legacy site search (`StaticHTMLPageBundler`) indexed Tika metadata from the bundled HTML file, so the indexed title followed the rendered `<title>` tag (as produced by theme / `html_head.vtl` / dotSeo). URL-mapped pages already preserved this behavior through a conditional fallback. Normal HTML pages did not.

This meant partners and clients who built pages assuming site search matched the rendered `<title>` (which often differs from the CMS Title field due to SEO themes) would get unexpected results after migrating to the current publisher.

Fixes #35153

## What Was Done

Introduced a backward-compatible opt-in config flag `SITE_SEARCH_USE_HTML_TITLE` (default `false`) in `ESSiteSearchPublisher.processHTMLPageAsContent()`.

**Before:** the title was always set from `page.getTitle()`, discarding whatever Tika parsed from the rendered HTML.

**After:**
- `SITE_SEARCH_USE_HTML_TITLE=false` (default): behavior is identical to today — `page.getTitle()` is always used. No impact on existing installs.
- `SITE_SEARCH_USE_HTML_TITLE=true`: the rendered `<title>` from Tika metadata is used when present, falling back to `page.getTitle()` only when absent. This matches the existing logic already in place for URL-mapped pages (`processUrlMap`) and the legacy bundler behavior.

The change is localized to a single conditional block in `ESSiteSearchPublisher`. No schema changes, no new APIs, no behavioral change unless the flag is explicitly enabled.

> **Note:** Changing this flag requires a full site search re-index to take effect. Incremental indexing will not backfill pages that have not changed.

## Test Plan

- [ ] Create a non–URL-mapped HTML page. Set **Page Title** (page properties) to `CMS_TITLE_FOR_SEARCH_TEST`.
- [ ] Assign a template that hardcodes `<title>HTML_TITLE_IN_HEAD_ONLY</title>` in `<head>`. Publish the page.
- [ ] Verify via View Source that the live URL renders `<title>HTML_TITLE_IN_HEAD_ONLY</title>`.
- [ ] Run a full site search index with `SITE_SEARCH_USE_HTML_TITLE=false` (default). Confirm search result title is `CMS_TITLE_FOR_SEARCH_TEST`.
- [ ] Set `SITE_SEARCH_USE_HTML_TITLE=true`, re-run full index. Confirm search result title is `HTML_TITLE_IN_HEAD_ONLY`.
- [ ] Verify URL-mapped pages are unaffected by the flag (they follow their own existing path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35153