### PR TITLE
fix(login): remove JSON.stringify in changePassword to fix 415 error

### DIFF
--- a/core-web/libs/dotcms-js/src/lib/core/login.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/login.service.ts
@@ -136,7 +136,7 @@ export class LoginService {
      * @memberof LoginService
      */
     changePassword(password: string, token: string): Observable<string> {
-        const body = JSON.stringify({ password: password, token: token });
+        const body = { password, token };
 
         return this.http
             .post<DotCMSResponse<string>>(this.urls.changePassword, body)


### PR DESCRIPTION
## Summary
- Fixes #35269 — "Change Password" button on Password Recovery page no longer works
- **Root cause**: `LoginService.changePassword()` wrapped the request body in `JSON.stringify()`, causing Angular's `HttpClient` to send `Content-Type: text/plain` instead of `application/json`. The backend endpoint (`@Consumes(MediaType.APPLICATION_JSON)`) rejected it with HTTP 415.
- **Fix**: Pass the plain `{ password, token }` object directly to `HttpClient.post()`, matching every other method in the same service.

## Test plan
- [ ] Navigate to forgot password flow → enter email → follow recovery link
- [ ] Enter new password and confirmation → click "Change Password"
- [ ] Verify request is sent with `Content-Type: application/json` (no 415 error)
- [ ] Verify successful password change redirects to login page
- [ ] Verify mismatched passwords still show client-side validation error
- [ ] Verify expired/invalid token shows appropriate error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, isolated to a single request payload formatting change in `LoginService.changePassword` that affects only the password recovery flow and should only impact HTTP content-type/serialization.
> 
> **Overview**
> Fixes the password recovery *change password* API call by sending the request body as a plain `{ password, token }` object instead of `JSON.stringify(...)`, allowing Angular `HttpClient` to serialize it as JSON (avoiding backend `415 Unsupported Media Type`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79de914d08f14d661bdbb03d8881be2c7c3471a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->