### PR TITLE
fix(rest-api): preserve Unicode characters in uploaded filenames (#35266)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
@@ -46,8 +46,6 @@ import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.server.JSONP;
 import org.jetbrains.annotations.NotNull;
 
-import java.nio.charset.StandardCharsets;
-import java.text.Normalizer;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.*;
@@ -60,6 +58,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
@@ -227,6 +227,9 @@ public class TempFileResource {
         // Jersey decodes multipart Content-Disposition filenames as ISO-8859-1.
         // Re-interpret those bytes as UTF-8 to recover the original filename,
         // then normalize to NFC for consistent Unicode representation.
+        // ASSUMPTION: modern browsers (HTML5 / RFC 6266) send UTF-8 bytes in
+        // Content-Disposition filenames. This round-trip silently drops high bytes
+        // from genuine ISO-8859-1 filenames sent by legacy or non-browser clients.
         final String raw = meta.getFileName();
         final String utf8Name = new String(raw.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8)
                 .replace("\uFFFD", "");

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
@@ -22,6 +22,7 @@ import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.FileUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.PageMode;
 import com.dotmarketing.util.UtilMethods;
@@ -45,6 +46,8 @@ import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.server.JSONP;
 import org.jetbrains.annotations.NotNull;
 
+import java.nio.charset.StandardCharsets;
+import java.text.Normalizer;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.*;
@@ -222,8 +225,13 @@ public class TempFileResource {
     }
 
     private static @NotNull String sanitizeFileName(ContentDisposition meta) {
-        final String sanitize = meta.getFileName().replaceAll("[^\\x00-\\x7F]", StringPool.BLANK);
-        return sanitize;
+        // Jersey decodes multipart Content-Disposition filenames as ISO-8859-1.
+        // Re-interpret those bytes as UTF-8 to recover the original filename,
+        // then normalize to NFC for consistent Unicode representation.
+        final String raw = meta.getFileName();
+        final String utf8Name = new String(raw.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+        final String nfcName = Normalizer.normalize(utf8Name, Normalizer.Form.NFC);
+        return FileUtil.sanitizeFileName(nfcName);
     }
 
     private void printResponseEntityViewResult(final OutputStream outputStream,

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
@@ -228,7 +228,8 @@ public class TempFileResource {
         // Re-interpret those bytes as UTF-8 to recover the original filename,
         // then normalize to NFC for consistent Unicode representation.
         final String raw = meta.getFileName();
-        final String utf8Name = new String(raw.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+        final String utf8Name = new String(raw.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8)
+                .replace("\uFFFD", "");
         final String nfcName = Normalizer.normalize(utf8Name, Normalizer.Form.NFC);
         return FileUtil.sanitizeFileName(nfcName);
     }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/temp/TempFileResource.java
@@ -59,7 +59,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/temp/TempFileResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/temp/TempFileResourceTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
+
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.Field;
@@ -170,6 +172,24 @@ public class TempFileResourceTest {
         assertTrue(dotTempFile.file.getName().equals(fileName));
         final Optional<DotTempFile> dotTempFileOpt = APILocator.getTempFileAPI().getTempFile(request, dotTempFile.id);
         assertTrue(dotTempFileOpt.get().length() > 0);
+    }
+
+    @Test
+    public void test_temp_resource_upload_preserves_unicode_filename() throws IOException {
+        resetTempResourceConfig();
+        Config.setProperty(TempFileAPI.TEMP_RESOURCE_ALLOW_ANONYMOUS, true);
+
+        // Jersey decodes multipart Content-Disposition filenames as ISO-8859-1.
+        // Simulate what a macOS browser sends: NFD UTF-8 bytes re-interpreted as ISO-8859-1.
+        final String expectedFileName = "Test_document_``$$#ääöüÄÖÜ.txt";
+        final String jerseyEncodedName = new String(
+                expectedFileName.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
+
+        final HttpServletRequest request = mockRequest();
+        final DotTempFile dotTempFile = saveTempFile_usingTempResource(jerseyEncodedName, request);
+
+        assertEquals("Unicode characters must be preserved in the uploaded filename",
+                expectedFileName, dotTempFile.file.getName());
     }
 
     @Test

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/temp/TempFileResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/temp/TempFileResourceTest.java
@@ -6,8 +6,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.nio.charset.StandardCharsets;
-
 import com.dotcms.api.web.HttpServletRequestThreadLocal;
 import com.dotcms.contenttype.model.field.BinaryField;
 import com.dotcms.contenttype.model.field.Field;
@@ -49,6 +47,7 @@ import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -181,9 +180,12 @@ public class TempFileResourceTest {
 
         // Jersey decodes multipart Content-Disposition filenames as ISO-8859-1.
         // Simulate what a macOS browser sends: NFD UTF-8 bytes re-interpreted as ISO-8859-1.
+        // The expected result is NFC (canonical composition); input is deliberately NFD so that
+        // the Normalizer.normalize(…, NFC) step in sanitizeFileName is exercised.
         final String expectedFileName = "Test_document_``$$#ääöüÄÖÜ.txt";
+        final String nfdFileName = Normalizer.normalize(expectedFileName, Normalizer.Form.NFD);
         final String jerseyEncodedName = new String(
-                expectedFileName.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
+                nfdFileName.getBytes(StandardCharsets.UTF_8), StandardCharsets.ISO_8859_1);
 
         final HttpServletRequest request = mockRequest();
         final DotTempFile dotTempFile = saveTempFile_usingTempResource(jerseyEncodedName, request);


### PR DESCRIPTION
Closes #35266

### Proposed Changes
* Re-interpret Jersey's ISO-8859-1 decoded filename as UTF-8 in `TempFileResource.sanitizeFileName()`
* Normalize to NFC after decoding to handle NFD filenames sent by macOS browsers
* Replace the original ASCII-stripping regex with the Unicode-safe `FileUtil.sanitizeFileName()`
* Add integration test that simulates the browser encoding and asserts the filename is preserved

### Root Cause
Jersey decodes multipart `Content-Disposition` filenames as ISO-8859-1. macOS browsers send filenames in NFD UTF-8, so bytes like `0xCC 0x88` (combining diaeresis) are misread as `Ì` (U+00CC) + an invisible control character, producing `aÌ` instead of `ä`. The original regex `[^\x00-\x7F]` then stripped everything above ASCII 127, silently truncating the filename.

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated — fix does not relax any sanitization; `FileUtil.sanitizeFileName()` still strips all illegal filesystem characters

### Additional Info
The fix is isolated to `TempFileResource` (the dotEvergreen upload path). The existing `MultiPartUtils.getBinariesFromMultipart()` path was already correct. `FileUtil.java` was left unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multipart upload filename decoding/sanitization in `TempFileResource`, which could alter stored filenames for some non-UTF-8/legacy clients and affect downstream references. Scope is small and covered by a new integration test, but it touches file creation inputs.
> 
> **Overview**
> Fixes temp-file multipart uploads to **preserve Unicode filenames** instead of stripping non-ASCII characters.
> 
> `TempFileResource.sanitizeFileName()` now re-interprets Jersey’s ISO-8859-1-decoded `Content-Disposition` filename bytes as UTF-8, normalizes to NFC, and sanitizes via `FileUtil.sanitizeFileName()`.
> 
> Adds an integration test that simulates Jersey’s filename decoding (including macOS NFD input) and asserts the uploaded temp file keeps the expected Unicode filename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d724e18f87b8bcbe0ec11a228a5112b9a296d6b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->