### PR TITLE
fix(edit-content): show content type icon in relationship field table

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.html
@@ -7,6 +7,7 @@
 @let hintText = field.hint || null;
 @let hasError = $hasError();
 @let isRequired = $isRequired();
+@let showThumbnail = store.showThumbnail();
 
 <p-table
     [value]="data"
@@ -111,8 +112,8 @@
                 @switch (column.type) {
                     @case ('title') {
                         <td class="flex-1 min-w-0" [class.cursor-not-allowed]="isDisabled">
-                            <div class="flex items-center gap-2">
-                                @if (item.hasTitleImage) {
+                            <div class="flex items-center gap-3">
+                                @if (showThumbnail) {
                                     <div
                                         class="w-20 h-14 flex-shrink-0 rounded-md overflow-hidden bg-gray-100">
                                         <dot-contentlet-thumbnail

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -418,7 +418,10 @@ describe('RelationshipFieldStore', () => {
 
             it('should return true when hasTitleImage is string "true"', () => {
                 store.setData([
-                    createFakeContentlet({ inode: '1', hasTitleImage: 'true' as unknown as boolean })
+                    createFakeContentlet({
+                        inode: '1',
+                        hasTitleImage: 'true' as unknown as boolean
+                    })
                 ]);
 
                 expect(store.showThumbnail()).toBe(true);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -415,6 +415,25 @@ describe('RelationshipFieldStore', () => {
             it('should return false when data is empty', () => {
                 expect(store.showThumbnail()).toBe(false);
             });
+
+            it('should return true when hasTitleImage is string "true"', () => {
+                store.setData([
+                    createFakeContentlet({ inode: '1', hasTitleImage: 'true' as unknown as boolean })
+                ]);
+
+                expect(store.showThumbnail()).toBe(true);
+            });
+
+            it('should return false when hasTitleImage is string "false"', () => {
+                store.setData([
+                    createFakeContentlet({
+                        inode: '1',
+                        hasTitleImage: 'false' as unknown as boolean
+                    })
+                ]);
+
+                expect(store.showThumbnail()).toBe(false);
+            });
         });
 
         describe('formattedRelationship', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -393,6 +393,30 @@ describe('RelationshipFieldStore', () => {
             });
         });
 
+        describe('showThumbnail', () => {
+            it('should return false when no items have title images', () => {
+                store.setData([
+                    createFakeContentlet({ inode: '1', hasTitleImage: false }),
+                    createFakeContentlet({ inode: '2', hasTitleImage: false })
+                ]);
+
+                expect(store.showThumbnail()).toBe(false);
+            });
+
+            it('should return true when at least one item has a title image', () => {
+                store.setData([
+                    createFakeContentlet({ inode: '1', hasTitleImage: false }),
+                    createFakeContentlet({ inode: '2', hasTitleImage: true })
+                ]);
+
+                expect(store.showThumbnail()).toBe(true);
+            });
+
+            it('should return false when data is empty', () => {
+                expect(store.showThumbnail()).toBe(false);
+            });
+        });
+
         describe('formattedRelationship', () => {
             it('should format relationship IDs correctly', () => {
                 store.setData(mockData);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -99,7 +99,14 @@ export const RelationshipFieldStore = signalStore(
 
             return `${identifiers}`;
         }),
-        showThumbnail: computed(() => state.data().some((item) => item.hasTitleImage === true))
+        showThumbnail: computed(() =>
+            state
+                .data()
+                .some(
+                    (item) =>
+                        item.hasTitleImage === true || (item.hasTitleImage as unknown) === 'true'
+                )
+        )
     })),
     withMethods(
         (

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -99,11 +99,7 @@ export const RelationshipFieldStore = signalStore(
 
             return `${identifiers}`;
         }),
-        showThumbnail: computed(() =>
-            state
-                .data()
-                .some((item) => item.hasTitleImage === true || item.hasTitleImage === 'true')
-        )
+        showThumbnail: computed(() => state.data().some((item) => item.hasTitleImage === true))
     })),
     withMethods(
         (

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -99,7 +99,11 @@ export const RelationshipFieldStore = signalStore(
 
             return `${identifiers}`;
         }),
-        showThumbnail: computed(() => state.data().some((item) => item.hasTitleImage))
+        showThumbnail: computed(() =>
+            state
+                .data()
+                .some((item) => item.hasTitleImage === true || item.hasTitleImage === 'true')
+        )
     })),
     withMethods(
         (

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -98,7 +98,8 @@ export const RelationshipFieldStore = signalStore(
             const identifiers = data.map((item) => item.identifier).join(',');
 
             return `${identifiers}`;
-        })
+        }),
+        showThumbnail: computed(() => state.data().some((item) => item.hasTitleImage))
     })),
     withMethods(
         (


### PR DESCRIPTION
## Summary

- Show thumbnail/icon for all relationship items when at least one item has a title image, matching the existing content picker dialog behavior
- Items without images display the content type icon as a placeholder instead of an empty space
- Added `showThumbnail` computed signal to the store with unit tests

Closes #35258

## Changes

| File | Change |
|------|--------|
| `dot-relationship-field.component.html` | Replace per-item `hasTitleImage` check with store-level `showThumbnail` signal; increase gap between thumbnail and title |
| `relationship-field.store.ts` | Add `showThumbnail` computed: `data.some(item => item.hasTitleImage)` |
| `relationship-field.store.spec.ts` | Add 3 tests for `showThumbnail` (no images, mixed images, empty data) |

## Acceptance Criteria

- [x] When at least one relationship item has a title image, all rows show the thumbnail area (real image or content type icon placeholder)
- [x] When no relationship items have title images, only text is shown (no thumbnail area)
- [x] Fallback to content type icon when `hasTitleImage` is false (handled by `dot-contentlet-thumbnail` web component)
- [x] When a new relationship is added, the thumbnail renders immediately
- [x] When rows are reordered via drag-and-drop, icons stay with their respective rows
- [x] Unit tests cover the `showThumbnail` computed signal

## Test Plan

- [ ] Open a content item with a Relationships field pointing to a content type **with** image fields (e.g., Pages). Verify: items with images show the thumbnail, items without show the content type icon placeholder
- [ ] Open a content item with a Relationships field pointing to a content type **without** image fields (e.g., Authors). Verify: only text titles are shown, no thumbnail area
- [ ] Add a new relationship via the content picker. Verify the icon/image appears immediately
- [ ] Reorder rows via drag-and-drop. Verify icons stay with their rows

## Visual Changes
<img width="2444" height="1136" alt="CleanShot 2026-04-10 at 11 47 48@2x" src="https://github.com/user-attachments/assets/d8ad2d12-0604-4686-af5e-4ffd986085a1" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/state change limited to relationship field rendering; main risk is minor visual/layout regressions due to new computed `showThumbnail` condition.
> 
> **Overview**
> Updates the relationship field table so the title column renders the thumbnail/icon area for *all* rows whenever any item in the relationship has a title image, rather than deciding per-row, matching picker behavior.
> 
> Adds a store-level computed signal `showThumbnail` (treating `hasTitleImage` as boolean or string) with new unit tests to cover mixed/empty data scenarios, and slightly increases spacing between thumbnail and title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 420ef0923b3e61a08d0fe0bd065107f9c1a867b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

This PR fixes: #35258