### PR TITLE
fix(edit-content): preserve pagination on row reorder in relationship field

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-relationship-field/dot-relationship-field.component.ts
@@ -303,7 +303,7 @@ export class DotRelationshipFieldComponent
         const [movedItem] = reorderedData.splice(globalDragIndex, 1);
         reorderedData.splice(globalDropIndex, 0, movedItem);
 
-        this.store.setData(reorderedData);
+        this.store.reorderData(reorderedData);
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.spec.ts
@@ -28,6 +28,8 @@ import { PaginationComponent } from './components/pagination/pagination.componen
 import { DotEditContentRelationshipFieldComponent } from './dot-edit-content-relationship-field.component';
 import { RelationshipFieldStore } from './store/relationship-field.store';
 
+import { DotEditContentStore } from '../../store/edit-content.store';
+
 import { DotCardFieldContentComponent } from '../dot-card-field/components/dot-card-field-content.component';
 import { DotCardFieldComponent } from '../dot-card-field/dot-card-field.component';
 
@@ -93,7 +95,7 @@ export class MockFormComponent {
     contentlet: DotCMSContentlet;
 }
 
-xdescribe('DotEditContentRelationshipFieldComponent', () => {
+describe('DotEditContentRelationshipFieldComponent', () => {
     let spectator: SpectatorHost<DotEditContentRelationshipFieldComponent, MockFormComponent>;
     let store: InstanceType<typeof RelationshipFieldStore>;
     let dialogService: DialogService;
@@ -117,6 +119,10 @@ xdescribe('DotEditContentRelationshipFieldComponent', () => {
                 handle: jest.fn()
             }),
             mockProvider(DotCurrentUserService),
+            mockProvider(DotEditContentStore, {
+                contentType: jest.fn().mockReturnValue(null),
+                currentLocale: jest.fn().mockReturnValue(null)
+            }),
             DialogService
         ]
     });
@@ -365,13 +371,13 @@ xdescribe('DotEditContentRelationshipFieldComponent', () => {
                     .mockReturnValue(mockDialogRef as unknown as DynamicDialogRef);
             });
 
-            it('should open the new content dialog when the feature flag is enabled', () => {
+            it('should open the new content dialog when the feature flag is enabled', async () => {
                 // Check initial state
                 const fieldComponent = spectator.query(DotRelationshipFieldComponent);
                 expect(fieldComponent.$isDisabled()).toBe(false);
                 expect(store.contentType()).toEqual(mockContentType);
 
-                fieldComponent.showCreateNewContentDialog();
+                await fieldComponent.showCreateNewContentDialog();
                 spectator.flushEffects();
 
                 expect(openSpy).toHaveBeenCalledTimes(1);
@@ -416,12 +422,12 @@ xdescribe('DotEditContentRelationshipFieldComponent', () => {
                 expect(openSpy).not.toHaveBeenCalled();
             });
 
-            it('should handle content creation callback', () => {
+            it('should handle content creation callback', async () => {
                 const newContentlet = createFakeContentlet({ title: 'New Content', inode: '3' });
                 const setDataSpy = jest.spyOn(store, 'setData');
 
                 const fieldComponent = spectator.query(DotRelationshipFieldComponent);
-                fieldComponent.showCreateNewContentDialog();
+                await fieldComponent.showCreateNewContentDialog();
                 spectator.flushEffects();
 
                 // Verify that the dialog was opened

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.spec.ts
@@ -16,10 +16,10 @@ import {
 } from '@dotcms/data-access';
 import {
     DotCMSClazzes,
-    DotCMSContentType,
-    FeaturedFlags,
     DotCMSContentlet,
-    DotCMSContentTypeField
+    DotCMSContentType,
+    DotCMSContentTypeField,
+    FeaturedFlags
 } from '@dotcms/dotcms-models';
 import { createFakeContentlet, createFakeRelationshipField } from '@dotcms/utils-testing';
 
@@ -29,7 +29,6 @@ import { DotEditContentRelationshipFieldComponent } from './dot-edit-content-rel
 import { RelationshipFieldStore } from './store/relationship-field.store';
 
 import { DotEditContentStore } from '../../store/edit-content.store';
-
 import { DotCardFieldContentComponent } from '../dot-card-field/components/dot-card-field-content.component';
 import { DotCardFieldComponent } from '../dot-card-field/dot-card-field.component';
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/dot-edit-content-relationship-field.component.spec.ts
@@ -188,14 +188,14 @@ xdescribe('DotEditContentRelationshipFieldComponent', () => {
             });
 
             it('should not reorder items when disabled', () => {
-                const setDataSpy = jest.spyOn(store, 'setData');
+                const reorderDataSpy = jest.spyOn(store, 'reorderData');
                 spectator.hostComponent.formGroup.disable();
                 spectator.detectChanges();
 
                 const fieldComponent = spectator.query(DotRelationshipFieldComponent);
 
                 fieldComponent.onRowReorder({ dragIndex: 0, dropIndex: 1 });
-                expect(setDataSpy).not.toHaveBeenCalled();
+                expect(reorderDataSpy).not.toHaveBeenCalled();
             });
 
             it('should not show existing content dialog when disabled', () => {
@@ -235,21 +235,21 @@ xdescribe('DotEditContentRelationshipFieldComponent', () => {
             });
 
             it('should reorder items when not disabled', () => {
-                const setDataSpy = jest.spyOn(store, 'setData');
+                const reorderDataSpy = jest.spyOn(store, 'reorderData');
                 const fieldComponent = spectator.query(DotRelationshipFieldComponent);
                 fieldComponent.onRowReorder({ dragIndex: 0, dropIndex: 1 });
-                expect(setDataSpy).toHaveBeenCalledWith(store.data());
+                expect(reorderDataSpy).toHaveBeenCalledWith(store.data());
             });
 
             it('should not reorder items with invalid indices', () => {
-                const setDataSpy = jest.spyOn(store, 'setData');
+                const reorderDataSpy = jest.spyOn(store, 'reorderData');
 
                 const fieldComponent = spectator.query(DotRelationshipFieldComponent);
                 fieldComponent.onRowReorder({ dragIndex: null, dropIndex: 1 });
-                expect(setDataSpy).not.toHaveBeenCalled();
+                expect(reorderDataSpy).not.toHaveBeenCalled();
 
                 fieldComponent.onRowReorder({ dragIndex: 0, dropIndex: null });
-                expect(setDataSpy).not.toHaveBeenCalled();
+                expect(reorderDataSpy).not.toHaveBeenCalled();
             });
         });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.spec.ts
@@ -185,6 +185,59 @@ describe('RelationshipFieldStore', () => {
             });
         });
 
+        describe('reorderData', () => {
+            it('should update data without resetting pagination', () => {
+                const eightItems = Array.from({ length: 8 }, (_, i) =>
+                    createFakeContentlet({
+                        inode: `reorder-inode-${i + 1}`,
+                        identifier: `reorder-identifier-${i + 1}`,
+                        id: `${i + 1}`
+                    })
+                );
+                store.setData(eightItems);
+
+                // Navigate to page 2
+                store.nextPage();
+                expect(store.pagination().currentPage).toBe(2);
+                expect(store.pagination().offset).toBe(6);
+
+                // Reorder items (swap first two)
+                const reordered = [...eightItems];
+                [reordered[0], reordered[1]] = [reordered[1], reordered[0]];
+                store.reorderData(reordered);
+
+                // Pagination should be preserved
+                expect(store.pagination().currentPage).toBe(2);
+                expect(store.pagination().offset).toBe(6);
+                expect(store.data()[0].inode).toBe('reorder-inode-2');
+                expect(store.data()[1].inode).toBe('reorder-inode-1');
+            });
+
+            it('should update data on page 1 without changing pagination', () => {
+                const items = Array.from({ length: 8 }, (_, i) =>
+                    createFakeContentlet({
+                        inode: `p1-inode-${i + 1}`,
+                        identifier: `p1-identifier-${i + 1}`,
+                        id: `${i + 1}`
+                    })
+                );
+                store.setData(items);
+
+                expect(store.pagination().currentPage).toBe(1);
+                expect(store.pagination().offset).toBe(0);
+
+                // Reorder items
+                const reordered = [...items];
+                [reordered[0], reordered[1]] = [reordered[1], reordered[0]];
+                store.reorderData(reordered);
+
+                // Should stay on page 1
+                expect(store.pagination().currentPage).toBe(1);
+                expect(store.pagination().offset).toBe(0);
+                expect(store.data()[0].inode).toBe('p1-inode-2');
+            });
+        });
+
         describe('deleteItem', () => {
             it('should delete item by inode', () => {
                 store.setData(mockData);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/store/relationship-field.store.ts
@@ -191,6 +191,14 @@ export const RelationshipFieldStore = signalStore(
                 }
             },
             /**
+             * Reorders the data without resetting the current pagination.
+             * Used after drag-and-drop row reorder to preserve the current page.
+             * @param {DotCMSContentlet[]} data - The reordered data array.
+             */
+            reorderData(data: DotCMSContentlet[]) {
+                patchState(store, { data: [...data] });
+            },
+            /**
              * Advances the pagination to the next page and updates the state accordingly.
              */
             nextPage: () => {


### PR DESCRIPTION
## Summary

- Fixed drag-and-drop row reorder in paginated relationship fields resetting to page 1
- Root cause: `onRowReorder` called `setData()` which unconditionally resets pagination offset and currentPage to 0/1
- Added `reorderData()` store method that updates the data array without touching pagination state

Closes #35106

## Changes

| File | Change |
|------|--------|
| `core-web/.../store/relationship-field.store.ts` | Added `reorderData()` method that patches data without resetting pagination |
| `core-web/.../dot-relationship-field.component.ts` | Changed `onRowReorder` to call `reorderData()` instead of `setData()` |
| `core-web/.../store/relationship-field.store.spec.ts` | Added tests for `reorderData()` preserving pagination on page 1 and page 2+ |
| `core-web/.../dot-edit-content-relationship-field.component.spec.ts` | Updated reorder tests to verify `reorderData()` is called |

## Acceptance Criteria

- [ ] When the user drags and drops a row to reorder on any paginated page other than page 1, the table remains on the same page after the reorder completes (pagination offset and currentPage are preserved)
- [ ] When the user drags and drops a row to reorder on page 1 of a paginated relationship field, the table remains on page 1 (no regression from current behavior)
- [ ] After a successful reorder on a non-first page, the page indicator still displays the correct current page number
- [ ] After a successful reorder on a non-first page, the items displayed are still the correct items for that page
- [ ] Adding new items via the "Existing Content" or "New Content" dialogs still resets pagination to page 1 (existing setData behavior preserved)
- [ ] Deleting an item on the last page that causes the page to become empty still falls back to the previous valid page (existing deleteItem logic preserved)

## Test Plan

- [ ] Create a Content Type with a Relationship field (Many-to-Many)
- [ ] Create an entry and add 13+ items to the relationship field (triggers 3 pages)
- [ ] Navigate to page 2 or 3
- [ ] Drag and drop to reorder items — verify you stay on the same page
- [ ] Navigate to page 1 and reorder — verify no regression
- [ ] Add new items via "Existing Content" dialog — verify pagination resets to page 1
- [ ] Delete items on the last page until the page becomes empty — verify fallback to previous page

## Visual Changes

https://github.com/user-attachments/assets/67ec996b-8e20-40cf-b20f-49d87ef72d73



This PR fixes: #35106