### PR TITLE
fix(content-import): snapshot servlet request before async handoff to prevent recycling crash

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportAuditUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportAuditUtil.java
@@ -303,17 +303,13 @@ public class ImportAuditUtil {
 	}
 
 	@WrapInTransaction
-	public static void setAuditRecordAsFailed(long id, String errorMessage){
+	public static void setAuditRecordAsFailed(long id, String errorMessage) throws DotDataException {
 		DotConnect dc = new DotConnect();
-		try {
-			dc.setSQL("UPDATE import_audit SET status=?, errors=? where id=?");
-			dc.addParam(STATUS_FAILED);
-			dc.addParam(errorMessage);
-			dc.addParam(id);
-			dc.loadResult();
-		}catch (Exception e) {
-			Logger.error(ImportAuditUtil.class,e.getMessage(),e);
-		}
+		dc.setSQL("UPDATE import_audit SET status=?, errors=? where id=?");
+		dc.addParam(STATUS_FAILED);
+		dc.addParam(errorMessage);
+		dc.addParam(id);
+		dc.loadResult();
 	}
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportAuditUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportAuditUtil.java
@@ -303,13 +303,18 @@ public class ImportAuditUtil {
 	}
 
 	@WrapInTransaction
-	public static void setAuditRecordAsFailed(long id, String errorMessage) throws DotDataException {
+	public static void setAuditRecordAsFailed(long id, String errorMessage){
 		DotConnect dc = new DotConnect();
-		dc.setSQL("UPDATE import_audit SET status=?, errors=? where id=?");
-		dc.addParam(STATUS_FAILED);
-		dc.addParam(errorMessage);
-		dc.addParam(id);
-		dc.loadResult();
+		try {
+			dc.setSQL("UPDATE import_audit SET status=?, errors=? where id=?");
+			dc.addParam(STATUS_FAILED);
+			dc.addParam(UtilMethods.isSet(errorMessage) && errorMessage.length() > 500
+					? errorMessage.substring(0, 500) : errorMessage);
+			dc.addParam(id);
+			dc.loadResult();
+		} catch (Exception e) {
+			Logger.error(ImportAuditUtil.class, e.getMessage(), e);
+		}
 	}
 
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportAuditUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportAuditUtil.java
@@ -17,6 +17,7 @@ public class ImportAuditUtil {
 	public static final int STATUS_PENDING = 10;
 	public static final int STATUS_COMPLETED = 20;
 	public static final int STATUS_USERSTOPPED = 30;
+	public static final int STATUS_FAILED = 40;
 
 	public static LRUMap cancelledImports = new LRUMap(50);
 
@@ -300,5 +301,19 @@ public class ImportAuditUtil {
 			Logger.error(ImportAuditUtil.class,e.getMessage(),e);
 		}
 	}
-	
+
+	@WrapInTransaction
+	public static void setAuditRecordAsFailed(long id, String errorMessage){
+		DotConnect dc = new DotConnect();
+		try {
+			dc.setSQL("UPDATE import_audit SET status=?, errors=? where id=?");
+			dc.addParam(STATUS_FAILED);
+			dc.addParam(errorMessage);
+			dc.addParam(id);
+			dc.loadResult();
+		}catch (Exception e) {
+			Logger.error(ImportAuditUtil.class,e.getMessage(),e);
+		}
+	}
+
 }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
@@ -207,6 +207,10 @@ public class ImportContentletsAction extends DotPortletAction {
 				final HttpServletRequest httpReq = reqImpl.getHttpServletRequest();
 				final HttpSession httpSession = httpReq.getSession();
 				final long importId = ImportAuditUtil.createAuditRecord(user.getUserId(), (String)httpSession.getAttribute("fileName"));
+				// Snapshot the request attributes/headers/session now, while the request is still alive.
+				// The Tomcat RequestFacade will be recycled before the background thread finishes for large imports.
+				final HttpServletRequest safeHttpReq = new MockHeaderRequest(
+						new MockSessionRequest(new MockAttributeRequest(httpReq)));
 
 
 				Runnable runnable = new Runnable() {
@@ -257,7 +261,7 @@ public class ImportContentletsAction extends DotPortletAction {
 								httpSession.removeAttribute("importSession");
 								importresults = _processFile(importId, httpSession, user,
 										csvHeaders, csvreader, languageCodeHeaderColumn,
-										countryCodeHeaderColumn, reader,req);
+										countryCodeHeaderColumn, reader, safeHttpReq);
 							}
 
 							final List<String> counters= importresults.get("counters");
@@ -279,7 +283,7 @@ public class ImportContentletsAction extends DotPortletAction {
 
 
 						} catch (Exception ae) {
-							_handleException(ae, req);
+							Logger.error(this, "Error importing contentlets for import ID: " + importId, ae);
 
 						} finally{
 
@@ -486,12 +490,9 @@ public class ImportContentletsAction extends DotPortletAction {
 	 */
 	private HashMap<String, List<String>> _processFile(final long importId, final HttpSession session,
 			final User user, final String[] csvHeaders, final CsvReader csvreader,
-			final int languageCodeHeaderColumn, final int countryCodeHeaderColumn, final Reader reader, final ActionRequest req)
+			final int languageCodeHeaderColumn, final int countryCodeHeaderColumn, final Reader reader,
+			final HttpServletRequest httpReq)
 			throws Exception {
-		final ActionRequestImpl reqImpl = (ActionRequestImpl) req;
-		//This needs to be done since this is running in a thread and the request expires before ending
-		//and we need the headers and some attributes to download the file
-		final HttpServletRequest httpReq = new MockHeaderRequest(new MockSessionRequest(new MockAttributeRequest(reqImpl.getHttpServletRequest())));
 		final ImportContentletsForm importForm = (ImportContentletsForm) session
 				.getAttribute("form_to_import");
 		final String currentSiteId = (String) session

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
@@ -15,6 +15,7 @@ import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.cache.FieldsCache;
 import com.dotmarketing.db.HibernateUtil;
+import com.dotmarketing.exception.DotHibernateException;
 import com.dotmarketing.portal.struts.DotPortletAction;
 import com.dotmarketing.portlets.contentlet.action.ImportAuditUtil.ImportAuditResults;
 import com.dotmarketing.portlets.contentlet.business.ContentletCache;
@@ -219,6 +220,7 @@ public class ImportContentletsAction extends DotPortletAction {
 					@CloseDBIfOpened
 					public void run() {
 
+						boolean importFailed = false;
 						ImportContentletsForm importContentletsForm = (ImportContentletsForm) form;
 						File fileToImport = (File) httpSession.getAttribute("file_to_import");
 						Charset charset = importContentletsForm.getLanguage() == -1
@@ -284,13 +286,22 @@ public class ImportContentletsAction extends DotPortletAction {
 
 						} catch (Exception ae) {
 							Logger.error(this, "Error importing contentlets for import ID: " + importId, ae);
+							try {
+								HibernateUtil.rollbackTransaction();
+							} catch (DotHibernateException e1) {
+								Logger.error(this, "Error rolling back transaction for import ID: " + importId, e1);
+							}
+							importFailed = true;
 
 						} finally{
 
-							if(!ImportAuditUtil.cancelledImports.containsKey(importId)){
-								ImportAuditUtil.setAuditRecordCompleted(importId);
-							}else{
+							if(ImportAuditUtil.cancelledImports.containsKey(importId)){
 								ImportAuditUtil.cancelledImports.remove(importId);
+							} else if(importFailed){
+								ImportAuditUtil.setAuditRecordAsFailed(importId,
+										"Import failed due to an unexpected error. Check server logs for import ID: " + importId);
+							} else {
+								ImportAuditUtil.setAuditRecordCompleted(importId);
 							}
 						}
 					}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
@@ -221,6 +221,7 @@ public class ImportContentletsAction extends DotPortletAction {
 					public void run() {
 
 						boolean importFailed = false;
+						String importErrorMessage = null;
 						ImportContentletsForm importContentletsForm = (ImportContentletsForm) form;
 						File fileToImport = (File) httpSession.getAttribute("file_to_import");
 						Charset charset = importContentletsForm.getLanguage() == -1
@@ -292,6 +293,7 @@ public class ImportContentletsAction extends DotPortletAction {
 								Logger.error(this, "Error rolling back transaction for import ID: " + importId, e1);
 							}
 							importFailed = true;
+							importErrorMessage = ae.getMessage();
 
 						} finally{
 
@@ -299,8 +301,7 @@ public class ImportContentletsAction extends DotPortletAction {
 								if(ImportAuditUtil.cancelledImports.containsKey(importId)){
 									ImportAuditUtil.cancelledImports.remove(importId);
 								} else if(importFailed){
-									ImportAuditUtil.setAuditRecordAsFailed(importId,
-											"Import failed due to an unexpected error. Check server logs for import ID: " + importId);
+									ImportAuditUtil.setAuditRecordAsFailed(importId, importErrorMessage);
 								} else {
 									ImportAuditUtil.setAuditRecordCompleted(importId);
 								}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
@@ -295,13 +295,17 @@ public class ImportContentletsAction extends DotPortletAction {
 
 						} finally{
 
-							if(ImportAuditUtil.cancelledImports.containsKey(importId)){
-								ImportAuditUtil.cancelledImports.remove(importId);
-							} else if(importFailed){
-								ImportAuditUtil.setAuditRecordAsFailed(importId,
-										"Import failed due to an unexpected error. Check server logs for import ID: " + importId);
-							} else {
-								ImportAuditUtil.setAuditRecordCompleted(importId);
+							try {
+								if(ImportAuditUtil.cancelledImports.containsKey(importId)){
+									ImportAuditUtil.cancelledImports.remove(importId);
+								} else if(importFailed){
+									ImportAuditUtil.setAuditRecordAsFailed(importId,
+											"Import failed due to an unexpected error. Check server logs for import ID: " + importId);
+								} else {
+									ImportAuditUtil.setAuditRecordCompleted(importId);
+								}
+							} catch (Exception e) {
+								Logger.error(this, "Error updating audit record for import ID: " + importId, e);
 							}
 						}
 					}

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/action/ImportContentletsAction.java
@@ -293,14 +293,14 @@ public class ImportContentletsAction extends DotPortletAction {
 								Logger.error(this, "Error rolling back transaction for import ID: " + importId, e1);
 							}
 							importFailed = true;
-							importErrorMessage = ae.getMessage();
+							importErrorMessage = ae.getMessage() != null
+									? ae.getMessage() : ae.getClass().getSimpleName();
 
 						} finally{
 
 							try {
-								if(ImportAuditUtil.cancelledImports.containsKey(importId)){
-									ImportAuditUtil.cancelledImports.remove(importId);
-								} else if(importFailed){
+								ImportAuditUtil.cancelledImports.remove(importId);
+								if(importFailed){
 									ImportAuditUtil.setAuditRecordAsFailed(importId, importErrorMessage);
 								} else {
 									ImportAuditUtil.setAuditRecordCompleted(importId);


### PR DESCRIPTION
## Summary
- **Fixes** #33908 — Large CSV imports fail silently because Tomcat recycles the `RequestFacade` before the async import thread finishes processing.
- Moved `MockAttributeRequest`/`MockSessionRequest`/`MockHeaderRequest` construction from `_processFile()` (runs on the background thread) to `processAction()` (runs on the HTTP thread while the request is still alive).
- Replaced `_handleException(ae, req)` inside the async `Runnable` catch block with `Logger.error()` to avoid accessing the recycled request on error paths.

## Test plan
- [ ] Import a CSV with 500+ rows using a content type with many fields (18+) — verify all rows are imported successfully
- [ ] Import a small CSV (~50 rows) — verify it still works as before
- [ ] Check backend logs for absence of `IllegalStateException: The request object has been recycled`
- [ ] Verify `IMPORT_CONTENTLETS_ASYNC=true` (default) triggers the async path

Closes #33908

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the async content import execution path and its transaction/audit updates; mistakes could leave imports incorrectly marked or hide/over-report failures, especially under load.
> 
> **Overview**
> Fixes async content imports by *snapshotting* the `HttpServletRequest` (headers/session/attributes via `Mock*Request` wrappers) in `processAction()` before handing work to the background thread, and passing the safe request into `_processFile()`.
> 
> Adds an `import_audit` **FAILED** status (`STATUS_FAILED`) plus `setAuditRecordAsFailed()`, and updates the async import error/finally handling to log exceptions, attempt `HibernateUtil.rollbackTransaction()`, and mark audit records as **failed** (instead of always completed) when the import throws.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8395b5a725c52d9e54c2f8bee68e3b79f0032c67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->