### PR TITLE
fix(inline-edit): fix TinyMCE blur not saving when isNotDirty flag is unreliable

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.spec.ts
@@ -2,9 +2,74 @@ import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 
 import { ElementRef } from '@angular/core';
 
+import { DotCMSUVEAction } from '@dotcms/types';
+
 import { INLINE_CONTENT_STYLES, InlineEditService } from './inline-edit.service';
 
 import { InlineEditingContentletDataset } from '../../edit-ema-editor/components/ema-page-dropzone/types';
+
+/**
+ * Runs the service TinyMCE `setup` with a stub editor and exposes the `blur` handler
+ * so tests can control `getContent` / `startContent` / `isNotDirty` before invoking blur.
+ */
+function bindBlurHarness(setup: (editor: TinyMceEditorStub) => void): {
+    editor: TinyMceEditorStub;
+    invokeBlur: () => void;
+} {
+    const targetElm = document.createElement('span');
+    targetElm.dataset.inode = '1';
+    targetElm.dataset.fieldName = 'body';
+
+    const container = document.createElement('div');
+    container.setAttribute('data-dot-object', 'container');
+    const bodyElement = document.createElement('div');
+    bodyElement.classList.add('active');
+    container.appendChild(bodyElement);
+
+    const editor: TinyMceEditorStub = {
+        on: jest.fn(),
+        targetElm,
+        bodyElement,
+        getContent: jest.fn().mockReturnValue(''),
+        startContent: '',
+        isNotDirty: true,
+        target: document.createElement('div'),
+        destroy: jest.fn()
+    };
+
+    setup(editor);
+
+    const blurCall = editor.on.mock.calls.find(([evt]) => evt === 'blur');
+    expect(blurCall).toBeDefined();
+
+    const blurHandler = blurCall[1] as (e: BlurEventStub) => void;
+
+    const invokeBlur = (): void =>
+        blurHandler({
+            target: editor,
+            type: 'blur',
+            stopImmediatePropagation: jest.fn()
+        });
+
+    return { editor, invokeBlur };
+}
+
+interface BlurEventStub {
+    target: TinyMceEditorStub;
+    type: string;
+    stopImmediatePropagation: jest.Mock;
+}
+
+interface TinyMceEditorStub {
+    on: jest.Mock;
+    targetElm: HTMLElement;
+    bodyElement: HTMLElement;
+    getContent: jest.Mock;
+    startContent: string;
+    isNotDirty: boolean;
+    target: HTMLElement;
+    destroy: jest.Mock;
+}
 
 describe('InlineEditService', () => {
     let spectator: SpectatorService<InlineEditService>;
@@ -136,5 +201,109 @@ describe('InlineEditService', () => {
         spectator.service.setIframeWindow(iframeWindowMock);
 
         expect(spectator.service['$iframeWindow']()).toBe(iframeWindowMock);
+    });
+
+    describe('TinyMCE blur → update-contentlet-inline-editing', () => {
+        let postMessageSpy: jest.SpyInstance;
+
+        beforeEach(() => {
+            postMessageSpy = jest.spyOn(window.parent, 'postMessage').mockImplementation();
+        });
+
+        afterEach(() => {
+            postMessageSpy.mockRestore();
+        });
+
+        function initAndGetSetup(): (editor: TinyMceEditorStub) => void {
+            const initMock = jest.fn().mockResolvedValue([]);
+            const iframeWindow = {
+                tinymce: { init: initMock }
+            } as unknown as Window;
+
+            spectator.service.setIframeWindow(iframeWindow);
+            spectator.service.setTargetInlineMCEDataset({
+                inode: '1',
+                fieldName: 'body',
+                language: 'en',
+                mode: 'minimal'
+            });
+
+            spectator.service.initEditor();
+
+            expect(initMock).toHaveBeenCalledTimes(1);
+
+            return initMock.mock.calls[0][0].setup as (editor: TinyMceEditorStub) => void;
+        }
+
+        it('should post null payload on blur when editor is clean and HTML matches startContent', () => {
+            const setup = initAndGetSetup();
+            const { editor, invokeBlur } = bindBlurHarness(setup);
+
+            const html = '<p>unchanged</p>';
+            editor.getContent.mockReturnValue(html);
+            editor.startContent = html;
+            editor.isNotDirty = true;
+
+            invokeBlur();
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                {
+                    action: DotCMSUVEAction.UPDATE_CONTENTLET_INLINE_EDITING,
+                    payload: null
+                },
+                '*'
+            );
+            expect(editor.destroy).toHaveBeenCalledWith(false);
+        });
+
+        it('should post payload on blur when TinyMCE is still "not dirty" but HTML differs from startContent', () => {
+            const setup = initAndGetSetup();
+            const { editor, invokeBlur } = bindBlurHarness(setup);
+
+            editor.startContent = '<ul><li></li></ul>';
+            editor.getContent.mockReturnValue('<p></p>');
+            editor.isNotDirty = true;
+
+            invokeBlur();
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                {
+                    action: DotCMSUVEAction.UPDATE_CONTENTLET_INLINE_EDITING,
+                    payload: expect.objectContaining({
+                        content: '<p></p>',
+                        eventType: 'blur',
+                        dataset: expect.objectContaining({
+                            inode: '1',
+                            fieldName: 'body'
+                        }),
+                        isNotDirty: true
+                    })
+                },
+                '*'
+            );
+        });
+
+        it('should post payload on blur when isNotDirty is false even if HTML matches startContent', () => {
+            const setup = initAndGetSetup();
+            const { editor, invokeBlur } = bindBlurHarness(setup);
+
+            const html = '<p>same</p>';
+            editor.getContent.mockReturnValue(html);
+            editor.startContent = html;
+            editor.isNotDirty = false;
+
+            invokeBlur();
+
+            expect(postMessageSpy).toHaveBeenCalledWith(
+                {
+                    action: DotCMSUVEAction.UPDATE_CONTENTLET_INLINE_EDITING,
+                    payload: expect.objectContaining({
+                        content: html,
+                        isNotDirty: false
+                    })
+                },
+                '*'
+            );
+        });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/inline-edit/inline-edit.service.ts
@@ -251,10 +251,16 @@ export class InlineEditService {
                 isNotDirty: ed.isNotDirty
             };
 
+            // TinyMCE sometimes leaves `isNotDirty` true after edits (e.g. removing an empty list);
+            // compare to initial HTML so blur still persists real changes.
+            const startContent = typeof ed.startContent === 'string' ? ed.startContent : '';
+            const shouldSendUpdate =
+                eventType === 'blur' && (!ed.isNotDirty || content !== startContent);
+
             window.parent.postMessage(
                 {
                     action: 'update-contentlet-inline-editing',
-                    payload: eventType === 'blur' && !ed.isNotDirty ? data : null
+                    payload: shouldSendUpdate ? data : null
                 },
                 '*'
             );


### PR DESCRIPTION
## Problem

In the UVE inline WYSIWYG editor (TinyMCE), certain edit operations — such as deleting the content of an empty list — left TinyMCE's internal `isNotDirty` flag set to `true` even though the content had actually changed. The blur handler relied solely on this flag to decide whether to post an update, so those changes were silently discarded and never saved.

Fixes #35220

## Root Cause

The blur handler in `InlineEditService` used:

```ts
payload: eventType === 'blur' && !ed.isNotDirty ? data : null
```

TinyMCE does not always flip `isNotDirty` to `false` for every edit (e.g. removing an empty `<ul><li></li></ul>` leaves the flag untouched). The result: real content changes were treated as "no change" and dropped.

## Solution

Added a secondary comparison against `ed.startContent` (the initial HTML snapshot TinyMCE stores when the editor opens). An update is now posted on blur if **either** the dirty flag is set **or** the current HTML differs from the initial snapshot:

```ts
const startContent = typeof ed.startContent === 'string' ? ed.startContent : '';
const shouldSendUpdate = eventType === 'blur' && (!ed.isNotDirty || content !== startContent);
```

## Changes

* **`inline-edit.service.ts`** — Updated blur payload logic to compare `getContent()` against `startContent` in addition to the `isNotDirty` flag.
* **`inline-edit.service.spec.ts`** — Added a dedicated `describe` block for TinyMCE blur behavior with:
  - A reusable `bindBlurHarness` test helper that wires up a TinyMCE editor stub and exposes the registered blur handler.
  - Typed stubs (`TinyMceEditorStub`, `BlurEventStub`) for reliable, type-safe tests.
  - Three cases: clean + unchanged content → null payload; `isNotDirty: true` but content changed → update payload; `isNotDirty: false` regardless of content → update payload.

### Video


https://github.com/user-attachments/assets/adcbdc40-21a4-490a-98e4-847d8c434d8b


This PR fixes: #35220