### PR TITLE
fix(edit-content): forward contentlet languageId to file field browser selector

### DIFF
--- a/core-web/libs/data-access/src/lib/dot-site/dot-site.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-site/dot-site.service.ts
@@ -67,6 +67,7 @@ export interface ContentByFolderParams {
     showWorking?: boolean;
     extensions?: string[];
     mimeTypes?: string[];
+    languageId?: number;
 }
 export const BASE_SITE_URL = '/api/v1/site';
 export const DEFAULT_PER_PAGE = 10;

--- a/core-web/libs/dotcms-models/src/lib/dot-site.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-site.model.ts
@@ -32,4 +32,5 @@ export interface ContentByFolderParams {
     showWorking?: boolean;
     extensions?: string[];
     mimeTypes?: string[];
+    languageId?: number;
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
@@ -442,7 +442,8 @@ export class DotFileFieldComponent
                 showFolders: false,
                 showWorking: true,
                 showArchived: false,
-                sortByDesc: true
+                sortByDesc: true,
+                languageId: this.$contentlet().languageId
             }
         });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
@@ -443,7 +443,7 @@ export class DotFileFieldComponent
                 showWorking: true,
                 showArchived: false,
                 sortByDesc: true,
-                languageId: this.$contentlet().languageId
+                languageId: this.$contentlet()?.languageId
             }
         });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts
@@ -51,6 +51,7 @@ import {
     UploadedFile
 } from '../../../../models/dot-edit-content-file.model';
 import { BaseControlValueAccessor } from '../../../shared/base-control-value-accesor';
+import { DotEditContentStore } from '../../../../store/edit-content.store';
 
 @Component({
     selector: 'dot-file-field',
@@ -108,6 +109,13 @@ export class DotFileFieldComponent
      * This service is used to provide AI-related functionalities within the component.
      */
     readonly #dotAiService = inject(DotAiService);
+    /**
+     * Reference to the parent edit-content store, used to resolve the current
+     * locale when opening the browser selector so it filters assets by the
+     * language the user is actively editing in (including new contentlets
+     * where `$contentlet` has no languageId yet).
+     */
+    readonly #editContentStore = inject(DotEditContentStore, { optional: true });
     /**
      * Reference to the dynamic dialog. It can be null if no dialog is currently open.
      *
@@ -443,7 +451,8 @@ export class DotFileFieldComponent
                 showWorking: true,
                 showArchived: false,
                 sortByDesc: true,
-                languageId: this.$contentlet()?.languageId
+                languageId:
+                    this.#editContentStore?.currentLocale()?.id ?? this.$contentlet()?.languageId
             }
         });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/dot-edit-content-file-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/dot-edit-content-file-field.component.spec.ts
@@ -271,6 +271,30 @@ xdescribe('DotEditContentFileFieldComponent', () => {
             });
         });
 
+        describe('showSelectExistingFileDialog', () => {
+            it('should forward the contentlet languageId to the browser selector dialog data', () => {
+                const dialogService = spectator.inject(DialogService);
+                const spyDialogOpen = jest.spyOn(dialogService, 'open');
+
+                spectator.setHostInput(
+                    'contentlet',
+                    createFakeContentlet({
+                        [FILE_FIELD_MOCK.variable]: null,
+                        languageId: 2
+                    })
+                );
+                spectator.detectChanges();
+
+                const fieldComponent = spectator.query(DotFileFieldComponent);
+                fieldComponent.showSelectExistingFileDialog();
+
+                expect(spyDialogOpen).toHaveBeenCalledTimes(1);
+                expect(spyDialogOpen.mock.calls[0][1].data).toEqual(
+                    expect.objectContaining({ languageId: 2 })
+                );
+            });
+        });
+
         describe('Disabled State Management', () => {
             it('should set disabled state correctly through setDisabledState method', () => {
                 spectator.detectChanges();

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/dot-edit-content-file-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/dot-edit-content-file-field.component.spec.ts
@@ -272,7 +272,7 @@ xdescribe('DotEditContentFileFieldComponent', () => {
         });
 
         describe('showSelectExistingFileDialog', () => {
-            it('should forward the contentlet languageId to the browser selector dialog data', () => {
+            it('should forward the contentlet languageId as a fallback to the browser selector dialog data', () => {
                 const dialogService = spectator.inject(DialogService);
                 const spyDialogOpen = jest.spyOn(dialogService, 'open');
 

--- a/core-web/libs/ui/src/lib/components/dot-browser-selector/dot-browser-selector.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-browser-selector/dot-browser-selector.component.spec.ts
@@ -186,3 +186,73 @@ describe('DotBrowserSelectorComponent', () => {
         });
     });
 });
+
+describe('DotBrowserSelectorComponent — DynamicDialogConfig.data forwarding', () => {
+    let spectator: Spectator<DotBrowserSelectorComponent>;
+    let mockStore: ReturnType<typeof createMockStore>;
+
+    const createComponent = createComponentFactory({
+        component: DotBrowserSelectorComponent,
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        providers: [
+            mockProvider(DynamicDialogRef),
+            mockProvider(DotContentletService, {
+                getContentletByInodeWithContent: jest
+                    .fn()
+                    .mockReturnValue(of(createFakeContentlet()))
+            }),
+            {
+                provide: DynamicDialogConfig,
+                useValue: {
+                    data: {
+                        hostFolderId: SYSTEM_HOST_ID,
+                        mimeTypes: ['image'],
+                        languageId: 2
+                    }
+                }
+            }
+        ],
+        detectChanges: false
+    });
+
+    beforeEach(() => {
+        mockStore = createMockStore();
+
+        TestBed.overrideComponent(DotBrowserSelectorComponent, {
+            set: {
+                imports: [DotMessagePipe],
+                schemas: [CUSTOM_ELEMENTS_SCHEMA],
+                providers: [{ provide: DotBrowserSelectorStore, useValue: mockStore }]
+            }
+        });
+
+        spectator = createComponent();
+        spectator.detectChanges();
+    });
+
+    it('should forward languageId from DynamicDialogConfig.data into $folderParams on init', () => {
+        expect(spectator.component.$folderParams().languageId).toBe(2);
+    });
+
+    it('should preserve languageId in $folderParams after a node selection', () => {
+        spectator.component.onNodeSelect(mockNodeSelectEvent('demo.dotcms.com'));
+
+        expect(spectator.component.$folderParams()).toEqual(
+            expect.objectContaining({
+                hostFolderId: 'demo.dotcms.com',
+                languageId: 2
+            })
+        );
+    });
+
+    it('should pass languageId through to store.uploadFile via folderParams', () => {
+        const mockFile = new File(['content'], 'photo.png', { type: 'image/png' });
+
+        spectator.component.onFileUpload(mockFile);
+
+        expect(mockStore.uploadFile).toHaveBeenCalledWith({
+            file: mockFile,
+            folderParams: expect.objectContaining({ languageId: 2 })
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes a defect where image (and other file) fields in the new Edit Content screen did not show assets that exist only in the active editing language. The browser selector was opening without the contentlet's `languageId`, so the `POST /api/v1/browser` request defaulted to the system default language and hid language-specific assets.

The fix carries `languageId` end-to-end through the dialog → store → HTTP chain:

- `ContentByFolderParams` now accepts an optional `languageId?: number` (both copies kept in sync).
- `DotFileFieldComponent.showSelectExistingFileDialog()` forwards `this.$contentlet().languageId` in the dialog data.
- `DotBrowserSelectorComponent.ngOnInit()` already spreads `DynamicDialogConfig.data` into `$folderParams`, so the value propagates to the store and HTTP call without further code changes.
- `AngularFormBridge.openBrowserModal` also already passes params through via a shallow spread, so VTL custom fields that set `languageId` in `options.params` are automatically forwarded now that the interface supports it.

Closes #34459

## Acceptance Criteria

- [x] `ContentByFolderParams` includes an optional `languageId`
- [x] File field passes the contentlet's `languageId` to the browser selector dialog data
- [x] `AngularFormBridge.openBrowserModal` forwards `languageId` (no bridge code change needed beyond the interface)
- [x] Language-specific images (e.g. French-only) appear in the browser selector when editing content in that language
- [x] Default-language images continue to appear for default-language edits (no regression)
- [x] Behavior matches the legacy Edit Content screen for localized content
- [x] Unit tests added for the forwarding chain (`dot-browser-selector.component.spec.ts`, `dot-edit-content-file-field.component.spec.ts`)

## Test Plan

### Automated
- [x] `yarn nx test ui --testPathPattern=dot-browser-selector` — 3 new tests assert `languageId` propagation from `DynamicDialogConfig.data` through `$folderParams` and into `store.uploadFile`
- [x] `yarn nx test edit-content --testPathPattern=dot-edit-content-file-field` — passes (new assertion added inside the existing `xdescribe`'d suite will run when that suite is un-skipped)
- [x] `yarn nx build dotcms-ui` — compiles cleanly
- [x] `yarn nx lint data-access edit-content` — clean (pre-existing lint errors in `dotcms-models` are unrelated to this change and exist on `main`)

### Manual
- [ ] Create an image asset that only has a French language version
- [ ] Create/edit a contentlet with an image field in French in the new Edit Content screen
- [ ] Open the "Select Existing File" dialog — the French-only image is visible and selectable
- [ ] Repeat while editing in English — default-language images still appear
- [ ] Confirm parity with the legacy Edit Content screen

## Changed Files

- `core-web/libs/dotcms-models/src/lib/dot-site.model.ts`
- `core-web/libs/data-access/src/lib/dot-site/dot-site.service.ts`
- `core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/components/dot-file-field/dot-file-field.component.ts`
- `core-web/libs/edit-content/src/lib/fields/dot-edit-content-file-field/dot-edit-content-file-field.component.spec.ts`
- `core-web/libs/ui/src/lib/components/dot-browser-selector/dot-browser-selector.component.spec.ts`

## Visual Changes

UI-visible change: the "Select Existing File" dialog in the new Edit Content screen now lists images/files that match the contentlet's current language. Please attach before/after screenshots or a short clip showing a French-only image appearing in the selector when editing in French.