### PR TITLE
fix: fix npe on pp after rename folder (#35260)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -8,6 +8,7 @@ import static com.dotmarketing.portlets.folders.business.FolderFactorySql.GET_CO
 import static com.dotmarketing.portlets.folders.business.FolderFactorySql.GET_CONTENT_TYPE_COUNT;
 
 import com.dotcms.browser.BrowserQuery;
+import com.dotcms.variant.VariantAPI;
 import com.dotcms.business.WrapInTransaction;
 import com.dotcms.system.SimpleMapAppContext;
 import com.dotcms.util.transform.DBTransformer;
@@ -1051,28 +1052,9 @@ public class FolderFactoryImpl extends FolderFactory {
 
     final String likeParam = escapeLikeParam(rootPath) + "%";
 
-    // Run the UPDATE first, then SELECT the affected rows for cache eviction.
-    // Reversing this order avoids a race: if we SELECT first and a concurrent INSERT lands
-    // between the SELECT and UPDATE, the new row's version_ts would be bumped but its
-    // cache entry would never be evicted. By updating first and then reading, the SELECT
-    // captures every row that was actually touched (including any concurrent inserts that
-    // committed before the UPDATE's snapshot under READ COMMITTED).
-    new DotConnect()
-        .executeUpdate(
-            "UPDATE contentlet_version_info SET version_ts = ?"
-                + " WHERE identifier IN ("
-                + "   SELECT i.id FROM identifier i"
-                + "   WHERE i.parent_path LIKE ? ESCAPE '\\'"
-                + "     AND i.host_inode = ?"
-                + "     AND i.asset_type != 'folder'"
-                + " )",
-            new Date(), likeParam, hostId);
-
-    // Evict cached ContentletVersionInfo so the next read goes to DB and picks up
-    // the bumped version_ts. Without this, DependencyModDateUtil.chekModDateInAllLanguages
-    // reads the per-language pre-bump value from cache and incorrectly excludes the content
-    // from the bundle. Per-language cache entries are keyed by identifier+lang+variant, so
-    // we must clear each language individually via the public API.
+    // Collect affected identifiers first. Using these IDs for the subsequent UPDATE
+    // avoids a duplicate scan of the identifier table and lets us pass an explicit list
+    // to the UPDATE rather than a correlated sub-select.
     final List<Map<String, Object>> affected = new DotConnect()
         .setSQL("SELECT i.id FROM identifier i"
             + " WHERE i.parent_path LIKE ? ESCAPE '\\'"
@@ -1082,17 +1064,44 @@ public class FolderFactoryImpl extends FolderFactory {
         .addParam(hostId)
         .loadObjectResults();
 
+    if (affected.isEmpty()) {
+      return;
+    }
+
+    final List<String> ids = affected.stream()
+        .map(r -> (String) r.get("id"))
+        .collect(Collectors.toList());
+
+    // Bump version_ts only for the DEFAULT variant rows. Push-publish reads the DEFAULT
+    // variant exclusively, and restricting the UPDATE to DEFAULT keeps its scope exactly
+    // aligned with the cache eviction below (which also targets DEFAULT).
+    final String placeholders = ids.stream().map(id -> "?").collect(Collectors.joining(", "));
+    final Object[] params = new Object[ids.size() + 2];
+    params[0] = new Date();
+    for (int i = 0; i < ids.size(); i++) {
+      params[i + 1] = ids.get(i);
+    }
+    params[ids.size() + 1] = VariantAPI.DEFAULT_VARIANT.name();
+    new DotConnect().executeUpdate(
+        "UPDATE contentlet_version_info SET version_ts = ?"
+            + " WHERE identifier IN (" + placeholders + ")"
+            + "   AND variant_id = ?",
+        params);
+
+    // Evict the DEFAULT-variant cache entries so the next read goes to DB and picks up
+    // the bumped version_ts. Without this, DependencyModDateUtil.chekModDateInAllLanguages
+    // reads the per-language pre-bump value from cache and incorrectly excludes the content
+    // from the bundle.
     final IdentifierCache identifierCache = CacheLocator.getIdentifierCache();
     final List<Language> languages = APILocator.getLanguageAPI().getLanguages();
-    for (final Map<String, Object> row : affected) {
-      final String identifierId = (String) row.get("id");
+    for (final String identifierId : ids) {
       for (final Language lang : languages) {
         identifierCache.removeContentletVersionInfoToCache(identifierId, lang.getId());
       }
     }
 
     Logger.debug(FolderFactoryImpl.class,
-        "Bumped version_ts and evicted version-info cache for " + affected.size()
+        "Bumped version_ts and evicted version-info cache for " + ids.size()
             + " contentlet(s) under path '" + rootPath + "'");
   }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -1051,19 +1051,12 @@ public class FolderFactoryImpl extends FolderFactory {
 
     final String likeParam = escapeLikeParam(rootPath) + "%";
 
-    // Collect the affected identifiers before the UPDATE so we can invalidate
-    // their IdentifierCache version-info entries afterwards. The raw SQL UPDATE
-    // bypasses VersionableFactory, which means IdentifierCache.getContentVersionInfo()
-    // would otherwise serve the stale version_ts to push-publish's mod-date check.
-    final List<Map<String, Object>> affected = new DotConnect()
-        .setSQL("SELECT i.id FROM identifier i"
-            + " WHERE i.parent_path LIKE ? ESCAPE '\\'"
-            + "   AND i.host_inode = ?"
-            + "   AND i.asset_type != 'folder'")
-        .addParam(likeParam)
-        .addParam(hostId)
-        .loadObjectResults();
-
+    // Run the UPDATE first, then SELECT the affected rows for cache eviction.
+    // Reversing this order avoids a race: if we SELECT first and a concurrent INSERT lands
+    // between the SELECT and UPDATE, the new row's version_ts would be bumped but its
+    // cache entry would never be evicted. By updating first and then reading, the SELECT
+    // captures every row that was actually touched (including any concurrent inserts that
+    // committed before the UPDATE's snapshot under READ COMMITTED).
     new DotConnect()
         .executeUpdate(
             "UPDATE contentlet_version_info SET version_ts = ?"
@@ -1080,6 +1073,15 @@ public class FolderFactoryImpl extends FolderFactory {
     // reads the per-language pre-bump value from cache and incorrectly excludes the content
     // from the bundle. Per-language cache entries are keyed by identifier+lang+variant, so
     // we must clear each language individually via the public API.
+    final List<Map<String, Object>> affected = new DotConnect()
+        .setSQL("SELECT i.id FROM identifier i"
+            + " WHERE i.parent_path LIKE ? ESCAPE '\\'"
+            + "   AND i.host_inode = ?"
+            + "   AND i.asset_type != 'folder'")
+        .addParam(likeParam)
+        .addParam(hostId)
+        .loadObjectResults();
+
     final IdentifierCache identifierCache = CacheLocator.getIdentifierCache();
     final List<Language> languages = APILocator.getLanguageAPI().getLanguages();
     for (final Map<String, Object> row : affected) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -42,6 +42,7 @@ import com.dotmarketing.portlets.fileassets.business.IFileAsset;
 import com.dotmarketing.portlets.folders.model.Folder;
 import com.dotmarketing.portlets.htmlpageasset.business.HTMLPageAssetAPI;
 import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
+import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.links.factories.LinkFactory;
 import com.dotmarketing.portlets.links.model.Link;
 import com.dotmarketing.util.AssetsComparator;
@@ -789,89 +790,109 @@ public class FolderFactoryImpl extends FolderFactory {
     }
     final String parentPath = ident.getParentPath();
     final String hostId = ident.getHostId();
-    // Use ident.getAssetName() (DB value) not folder.getName(): when called from saveFolder the
-    // folder object already carries the new name, which would make oldPath == newPath and leave
-    // all children with a stale parent_path pointing to a non-existent folder.
+    // Use ident.getAssetName() (DB value), not folder.getName(): the folder object may already
+    // carry the new name when called from saveFolder, which would make oldPath == newPath.
     final String oldPath = parentPath + ident.getAssetName() + "/";
     final String newPath = parentPath + newName + (newName.endsWith("/") ? "" : "/");
 
-    // Check for name collision with a different existing folder
     final Host host = APILocator.getHostAPI().find(folder.getHostId(), user, respectFrontEndPermissions);
     final Folder existing = findFolderByPath(newPath, host);
     if (UtilMethods.isSet(existing.getInode()) && !folder.getIdentifier().equals(existing.getIdentifier())) {
       return false;
     }
 
-    // Snapshot sub-folder old-path data BEFORE any update so targeted cache eviction is possible
+    // Snapshot sub-folder data before any modification so cache eviction can target old paths.
     final List<Map<String, Object>> subFolderSnapshot = loadSubFolderSnapshot(oldPath, hostId);
 
-    // Set the new name on the folder object so getNewFolderRecord() picks it up via
-    // initialFolder.getName(). Restore the original name if a subsequent DB operation fails,
-    // since @WrapInTransaction rolls back DB changes but Java object state is not automatically
-    // restored.
+    // Set the new name before creating the new record. @WrapInTransaction rolls back DB changes
+    // on failure, but Java object state is not restored — restore the name explicitly on error.
     folder.setName(newName);
 
-    // Create a new folder record
-    // getNewFolderRecord() calls IdentifierAPI.createNew() which generates the deterministic hash
-    // based on assetType:hostname:parentPath:folderName — changing the URL changes the identity.
+    // Each folder's identifier is deterministic (hash of assetType:hostname:parentPath:name),
+    // so any folder whose path changes must get a new identifier via getNewFolderRecord().
+    // Process parents before children (ascending path-length order) so findFolderByPath() inside
+    // getNewFolderRecord() can resolve the new parent record, which must already exist in the DB.
     final Folder newFolder;
     try {
       newFolder = getNewFolderRecord(folder, user, parentPath, hostId);
     } catch (final DotDataException | RuntimeException e) {
-      folder.setName(ident.getAssetName()); // restore original name
-      // A concurrent rename to the same destination path can race past the collision check and
-      // hit the DB unique constraint on identifier(parent_path, asset_name, host_inode).
-      // Treat this the same as a pre-checked collision: restore state and return false.
+      folder.setName(ident.getAssetName());
       if (DbConnectionFactory.isConstraintViolationException(e.getCause() != null ? e.getCause() : e)) {
         return false;
       }
       throw e;
     }
 
-    // Evict identifier cache for the entire old subtree BEFORE the bulk UPDATE so the eviction
-    // can reliably find the old-path-keyed cache entries.
-    clearIdentifierCacheForSubtree(oldPath, hostId);
+    final List<Map<String, Object>> sortedSnapshot = new ArrayList<>(subFolderSnapshot);
+    sortedSnapshot.sort(Comparator.comparingInt(
+        row -> ((String) row.get("parent_path") + (String) row.get("asset_name") + "/").length()));
 
-    // Bulk-update every child identifier's parent_path, processing parent folders before children.
-    // The new folder identifier already exists in the DB (created above), so the trigger's
-    // parent-path existence check passes at every depth level as parents are updated first.
+    final List<String[]> childFolderInodePairs = new ArrayList<>();
+    for (final Map<String, Object> row : sortedSnapshot) {
+      final String oldChildInode = (String) row.get("inode");
+      final String oldChildParentPath = (String) row.get("parent_path");
+      final String newChildParentPath = newPath + oldChildParentPath.substring(oldPath.length());
+      final Folder childFolder = find(oldChildInode);
+      if (childFolder == null || !InodeUtils.isSet(childFolder.getInode())) {
+        throw new DotDataException("Cannot find child folder with inode='" + oldChildInode
+            + "' while renaming '" + oldPath + "' to '" + newPath + "'");
+      }
+      final Folder newChildFolder = getNewFolderRecord(childFolder, user, newChildParentPath, hostId);
+      childFolderInodePairs.add(new String[]{oldChildInode, newChildFolder.getInode()});
+    }
+
+    // Evict caches before the bulk update so stale old-path entries are removed first.
+    clearIdentifierCacheForSubtree(oldPath, hostId);
+    evictContentletCacheForSubtree(oldPath, hostId);
+
+    // Bulk-update parent_path for non-folder identifiers. Folder identifier rows are replaced
+    // by the new records above and their old rows are deleted below, so they are excluded here.
     updateChildPaths(oldPath, newPath, hostId, subFolderSnapshot);
 
-    // Evict identifier caches rooted at the new path after the bulk update.
-    clearIdentifierCacheForSubtree(newPath, hostId);
+    // Bump contentlet version_ts so push-publish detects them as changed after the path move.
+    bumpVersionTsForSubtree(newPath, hostId);
 
-    // Targeted folder cache eviction for affected sub-folders (using old path data from snapshot).
+    clearIdentifierCacheForSubtree(newPath, hostId);
     evictSubFolderCache(subFolderSnapshot, hostId);
 
-    // Nav cache cleanup — evict the renamed folder, its parent, and every sub-folder in the tree.
-    // Uses folder.getInode() (old inode) before it is replaced below.
     CacheLocator.getNavToolCache().removeNav(folder.getHostId(), folder.getInode());
     CacheLocator.getNavToolCache().removeNavByPath(hostId, parentPath);
     for (final Map<String, Object> row : subFolderSnapshot) {
       CacheLocator.getNavToolCache().removeNav(hostId, (String) row.get("inode"));
     }
 
-    // Transfer content-type structure and permission references from old inode to new inode.
     updateOtherFolderReferences(newFolder.getInode(), folder.getInode());
-
-    // Delete old folder. All children have been moved to the new path by updateChildPaths(),
-    // so check_child_assets() finds no remaining children pointing to the old path and the
-    // delete succeeds without a constraint violation.
+    deleteOldChildFolders(childFolderInodePairs);
     delete(folder);
 
-    // Update the caller's folder reference to the new inode and identifier so that
-    // FolderAPIImpl.refreshContentUnderFolder() targets the correct renamed folder.
-    // folder.getName() was already set to newName above.
     folder.setInode(newFolder.getInode());
     folder.setIdentifier(newFolder.getIdentifier());
-
-    // Evict the new folder's own identifier cache entry. clearIdentifierCacheForSubtree()
-    // only covers items whose parent_path starts with newPath (the folder's children), not the
-    // folder itself (whose parent_path is parentPath). Without this eviction, a prior URI-keyed
-    // entry for the same path could be served until natural LRU expiry.
+    // Evict the renamed folder's own cache entry (not covered by clearIdentifierCacheForSubtree,
+    // which only targets items whose parent_path starts with newPath).
     CacheLocator.getIdentifierCache().removeFromCacheByIdentifier(newFolder.getIdentifier());
 
     return true;
+  }
+
+  /**
+   * Transfers references and deletes old folder records for replaced child subfolders, in
+   * child-before-parent (reverse) order. The DB trigger {@code check_child_assets} blocks deletion
+   * of a folder when identifiers still reference its path as {@code parent_path}, so leaves must
+   * be deleted before their parents.
+   *
+   * @param childFolderInodePairs list of {@code [oldInode, newInode]} pairs in parent-before-child order
+   */
+  private void deleteOldChildFolders(final List<String[]> childFolderInodePairs)
+      throws DotDataException {
+    final List<String[]> reversed = new ArrayList<>(childFolderInodePairs);
+    Collections.reverse(reversed);
+    for (final String[] pair : reversed) {
+      updateOtherFolderReferences(pair[1], pair[0]);
+      final Folder oldChildFolder = find(pair[0]);
+      if (oldChildFolder != null && InodeUtils.isSet(oldChildFolder.getInode())) {
+        delete(oldChildFolder);
+      }
+    }
   }
 
   /**
@@ -941,11 +962,12 @@ public class FolderFactoryImpl extends FolderFactory {
     levels.sort(Comparator.comparingInt(pair -> pair[0].length()));
 
     for (final String[] pair : levels) {
-      // No asset_type filter is intentional: every identifier that lives directly under the
-      // renamed folder path (files, pages, content, sub-folders alike) must have its
-      // parent_path updated, not just folders.
+      // Exclude folder identifiers: child subfolder records are replaced by new ones created via
+      // getNewFolderRecord() (which generates a new deterministic UUID for the changed path) and
+      // their old identifier rows are deleted afterwards. Updating them here would produce a stale
+      // row that conflicts with the newly-created identifier at the same path.
       new DotConnect().executeUpdate(
-          "UPDATE identifier SET parent_path = ? WHERE parent_path = ? AND host_inode = ?",
+          "UPDATE identifier SET parent_path = ? WHERE parent_path = ? AND host_inode = ? AND asset_type != 'folder'",
           pair[1], pair[0], hostId);
     }
   }
@@ -991,8 +1013,8 @@ public class FolderFactoryImpl extends FolderFactory {
    * entries. Because this method already iterates the full flat set of descendants, the
    * recursive re-discovery would cause O(F × depth) redundant DB queries.
    * <p>
-   * Note: {@code ContentletCache} and {@code HTMLPageCache} are keyed by inode/UUID, not by
-   * path, so no additional eviction is needed for non-folder children after a parent_path update.
+   * Note: {@code ContentletCache} is keyed by inode but stores derived fields such as the folder
+   * inode; that stale field is handled separately by {@link #evictContentletCacheForSubtree}.
    */
   private void clearIdentifierCacheForSubtree(final String rootPath, final String hostId)
       throws DotDataException {
@@ -1012,6 +1034,94 @@ public class FolderFactoryImpl extends FolderFactory {
       final String oldUri = (String) row.get("parent_path") + (String) row.get("asset_name");
       identifierCache.removeFromCacheDirect((String) row.get("id"), hostId, oldUri);
     }
+  }
+
+  /**
+   * Bumps {@code contentlet_version_info.version_ts} for every contentlet whose identifier lives
+   * directly under or anywhere beneath {@code rootPath} in the given host. Must be called after
+   * {@link #updateChildPaths} so the query finds identifiers by their post-rename
+   * {@code parent_path}. Without this bump, push-publish compares the last push date against an
+   * unchanged {@code version_ts} and concludes the content has not changed since the last push,
+   * excluding it from the bundle even though its folder path changed. The old
+   * {@code contentletAPI.move()} approach updated {@code version_ts} per-contentlet for this
+   * exact reason; this method replicates that behaviour in bulk.
+   */
+  private void bumpVersionTsForSubtree(final String rootPath, final String hostId)
+      throws DotDataException {
+
+    final String likeParam = escapeLikeParam(rootPath) + "%";
+
+    // Collect the affected identifiers before the UPDATE so we can invalidate
+    // their IdentifierCache version-info entries afterwards. The raw SQL UPDATE
+    // bypasses VersionableFactory, which means IdentifierCache.getContentVersionInfo()
+    // would otherwise serve the stale version_ts to push-publish's mod-date check.
+    final List<Map<String, Object>> affected = new DotConnect()
+        .setSQL("SELECT i.id FROM identifier i"
+            + " WHERE i.parent_path LIKE ? ESCAPE '\\'"
+            + "   AND i.host_inode = ?"
+            + "   AND i.asset_type != 'folder'")
+        .addParam(likeParam)
+        .addParam(hostId)
+        .loadObjectResults();
+
+    new DotConnect()
+        .executeUpdate(
+            "UPDATE contentlet_version_info SET version_ts = ?"
+                + " WHERE identifier IN ("
+                + "   SELECT i.id FROM identifier i"
+                + "   WHERE i.parent_path LIKE ? ESCAPE '\\'"
+                + "     AND i.host_inode = ?"
+                + "     AND i.asset_type != 'folder'"
+                + " )",
+            new Date(), likeParam, hostId);
+
+    // Evict cached ContentletVersionInfo so the next read goes to DB and picks up
+    // the bumped version_ts. Without this, DependencyModDateUtil.chekModDateInAllLanguages
+    // reads the per-language pre-bump value from cache and incorrectly excludes the content
+    // from the bundle. Per-language cache entries are keyed by identifier+lang+variant, so
+    // we must clear each language individually via the public API.
+    final IdentifierCache identifierCache = CacheLocator.getIdentifierCache();
+    final List<Language> languages = APILocator.getLanguageAPI().getLanguages();
+    for (final Map<String, Object> row : affected) {
+      final String identifierId = (String) row.get("id");
+      for (final Language lang : languages) {
+        identifierCache.removeContentletVersionInfoToCache(identifierId, lang.getId());
+      }
+    }
+
+    Logger.debug(FolderFactoryImpl.class,
+        "Bumped version_ts and evicted version-info cache for " + affected.size()
+            + " contentlet(s) under path '" + rootPath + "'");
+  }
+
+  /**
+   * Evicts from the contentlet cache every contentlet whose identifier lives directly under or
+   * anywhere beneath {@code rootPath} in the given host. Must be called before
+   * {@link #updateChildPaths} so the query matches identifiers by their pre-rename
+   * {@code parent_path}. Without this eviction, cached contentlets carry the old (now-deleted)
+   * folder inode in their {@code folder} field; the next load from DB re-derives the correct
+   * value via {@code ContentletTransformer} from the updated {@code identifier.parent_path}.
+   */
+  private void evictContentletCacheForSubtree(final String rootPath, final String hostId)
+      throws DotDataException {
+
+    final String likeParam = escapeLikeParam(rootPath) + "%";
+    final List<Map<String, Object>> rows = new DotConnect()
+        .setSQL("SELECT c.inode FROM identifier i"
+            + " JOIN contentlet c ON c.identifier = i.id"
+            + " WHERE i.parent_path LIKE ? ESCAPE '\\'"
+            + "   AND i.host_inode = ?"
+            + "   AND i.asset_type != 'folder'")
+        .addParam(likeParam)
+        .addParam(hostId)
+        .loadObjectResults();
+
+    for (final Map<String, Object> row : rows) {
+      CacheLocator.getContentletCache().remove((String) row.get("inode"));
+    }
+
+    Logger.debug(FolderFactoryImpl.class,
+        "Evicted " + rows.size() + " contentlet cache entries under path '" + rootPath + "'");
   }
 
   /**

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
@@ -76,6 +76,7 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -276,6 +277,8 @@ public class FolderAPITest extends IntegrationTestBase {//24 contentlets
 		final String parentIdentifierId = parentFolder.getIdentifier();
 		final String subIdentifierId    = subFolder.getIdentifier();
 
+		// Timestamp captured just before the rename to verify version_ts is bumped afterwards.
+		final Timestamp beforeRename = new Timestamp(System.currentTimeMillis());
 
 		final boolean renamed = folderAPI.renameFolder(parentFolder, newName, user, false);
 
@@ -320,6 +323,20 @@ public class FolderAPITest extends IntegrationTestBase {//24 contentlets
 		assertNotNull(fileInSubIdent);
 		assertEquals("File asset in sub-folder: parent_path must reflect the renamed sub-folder path",
 				"/" + newName + "/sub/", fileInSubIdent.getParentPath());
+
+		// version_ts must be bumped for all contentlets in the renamed subtree so push-publish
+		// detects them as changed. This is the core fix for issue #35260.
+		for (final String identId : new String[]{
+				fileInParent.getIdentifier(), pageInParent.getIdentifier(), fileInSub.getIdentifier()}) {
+			final List<Map<String, Object>> vtsRows = new DotConnect()
+					.setSQL("SELECT version_ts FROM contentlet_version_info WHERE identifier = ?")
+					.addParam(identId)
+					.loadResults();
+			assertFalse("contentlet_version_info row must exist for identifier " + identId, vtsRows.isEmpty());
+			final Timestamp bumped = (Timestamp) vtsRows.get(0).get("version_ts");
+			assertTrue("version_ts must be after rename start for identifier " + identId,
+					bumped.after(beforeRename));
+		}
 
 		// Folder is findable by new path and has the new identifier UUID.
 		final Folder foundByNewPath = folderAPI.findFolderByPath("/" + newName + "/", site, user, false);

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
@@ -153,9 +153,10 @@ public class FolderAPITest extends IntegrationTestBase {//24 contentlets
 	/**
 	 * Verifies the rename behavior for a folder hierarchy.
 	 * <p>
-	 * The renamed folder receives a new identifier (URL change = identity change). Sub-folder
-	 * identifiers are preserved but their {@code parent_path} values are updated consistently
-	 * via bulk SQL — no Elasticsearch dependency, so unindexed items are never missed.
+	 * Folder identifiers are deterministic (hash of assetType:hostname:parentPath:name), so every
+	 * folder whose path changes receives a new identifier. The renamed folder and all child
+	 * sub-folders go through a create+delete cycle; only non-folder asset identifiers are updated
+	 * in-place via bulk SQL.
 	 */
 	@Test
 	public void renameFolder() throws Exception {
@@ -181,20 +182,13 @@ public class FolderAPITest extends IntegrationTestBase {//24 contentlets
 		// Renamed folder has a new identifier UUID.
 		assertNotEquals(oldFtestIdentifier, ftest.getIdentifier());
 
-		// Sub-folder identifiers are preserved — only parent_path is updated via bulk SQL.
-		final Identifier ident1 = identifierAPI.loadFromDb(ftest1.getIdentifier());
-		final Identifier ident2 = identifierAPI.loadFromDb(ftest2.getIdentifier());
-		final Identifier ident3 = identifierAPI.loadFromDb(ftest3.getIdentifier());
-		assertNotNull(ident1);
-		assertNotNull(ident2);
-		assertNotNull(ident3);
+		// Sub-folder old identifiers are deleted — path change = identity change.
+		assertNull(identifierAPI.loadFromDb(ftest1.getIdentifier()));
+		assertNull(identifierAPI.loadFromDb(ftest2.getIdentifier()));
+		assertNull(identifierAPI.loadFromDb(ftest3.getIdentifier()));
 
+		// Sub-folders are findable by new paths and carry new identifier UUIDs.
 		final String newRootPath = StringPool.SLASH + newFolderName + StringPool.SLASH;
-		assertEquals(newRootPath, ident1.getParentPath());
-		assertEquals(newRootPath + "ff1" + StringPool.SLASH, ident2.getParentPath());
-		assertEquals(newRootPath + "ff1" + StringPool.SLASH + "ff2" + StringPool.SLASH, ident3.getParentPath());
-
-		// Folder and sub-folders are findable by new paths.
 		final Folder newFolder = folderAPI.findFolderByPath(newRootPath, host, user, false);
 		final Folder newFolder1 = folderAPI.findFolderByPath(newRootPath + "ff1/", host, user, false);
 		final Folder newFolder2 = folderAPI.findFolderByPath(newRootPath + "ff1/ff2/", host, user, false);
@@ -207,10 +201,10 @@ public class FolderAPITest extends IntegrationTestBase {//24 contentlets
 		// Top-level folder has a new identifier; ftest object was mutated to hold it.
 		assertEquals(ftest.getIdentifier(), newFolder.getIdentifier());
 		assertNotEquals(oldFtestIdentifier, newFolder.getIdentifier());
-		// Sub-folders retain their original identifiers.
-		assertEquals(ftest1.getIdentifier(), newFolder1.getIdentifier());
-		assertEquals(ftest2.getIdentifier(), newFolder2.getIdentifier());
-		assertEquals(ftest3.getIdentifier(), newFolder3.getIdentifier());
+		// Sub-folders have new identifiers (old ones were deleted with old records).
+		assertNotEquals(ftest1.getIdentifier(), newFolder1.getIdentifier());
+		assertNotEquals(ftest2.getIdentifier(), newFolder2.getIdentifier());
+		assertNotEquals(ftest3.getIdentifier(), newFolder3.getIdentifier());
 	}
 
 	/**
@@ -244,16 +238,14 @@ public class FolderAPITest extends IntegrationTestBase {//24 contentlets
 	 * <ul>
 	 *     <li><b>Method to test:</b> {@link FolderAPI#renameFolder(Folder, String, User, boolean)}</li>
 	 *     <li><b>Given Scenario:</b> A folder containing a file asset, an HTML page, and a
-	 *     sub-folder (which itself contains a file asset) is renamed. This exercises the fix for
-	 *     issue #34655, where the old implementation used Elasticsearch to discover children and
-	 *     missed unindexed items, causing a DB constraint violation on folder deletion.</li>
+	 *     sub-folder (which itself contains a file asset) is renamed.</li>
 	 *     <li><b>Expected Result:</b>
 	 *     <ul>
 	 *         <li>Rename returns {@code true}.</li>
-	 *         <li>The renamed folder receives a new identifier UUID (URL change = identity change).</li>
-	 *         <li>Sub-folder identifier is preserved (only {@code parent_path} is updated).</li>
-	 *         <li>All direct children's {@code parent_path} in the DB equals the new folder path.</li>
-	 *         <li>All sub-children's {@code parent_path} equals the new sub-folder path.</li>
+	 *         <li>The renamed folder and all child sub-folders receive new identifier UUIDs
+	 *         (folder identifiers are deterministic: path change = identity change).</li>
+	 *         <li>Old folder identifier rows are deleted; new ones exist at the new paths.</li>
+	 *         <li>Non-folder asset identifiers ({@code parent_path}) are updated in-place via bulk SQL.</li>
 	 *         <li>Folder is findable by new path; old path resolves to nothing.</li>
 	 *     </ul>
 	 *     </li>
@@ -300,13 +292,16 @@ public class FolderAPITest extends IntegrationTestBase {//24 contentlets
 		assertEquals("New parent folder asset_name must reflect the new name",
 				newName, newParentIdent.getAssetName());
 
-		// Sub-folder identifier is preserved and its parent_path is updated via bulk SQL.
-		final Identifier renamedSubIdent = identifierAPI.loadFromDb(subIdentifierId);
-		assertNotNull("Sub-folder identifier must still exist", renamedSubIdent);
-		assertEquals("Sub-folder identifier UUID must be unchanged",
-				subIdentifierId, renamedSubIdent.getId());
+		// Sub-folder gets a new identifier — path change = identity change, same as the parent.
+		assertNull("Old sub-folder identifier must be deleted after rename",
+				identifierAPI.loadFromDb(subIdentifierId));
+		final Folder renamedSubFolder = folderAPI.findFolderByPath("/" + newName + "/sub/", site, user, false);
+		assertNotNull("Sub-folder must be findable by new path", renamedSubFolder);
+		assertNotEquals("Sub-folder must have a new identifier UUID", subIdentifierId, renamedSubFolder.getIdentifier());
+		final Identifier newSubIdent = identifierAPI.loadFromDb(renamedSubFolder.getIdentifier());
+		assertNotNull("New sub-folder identifier must exist", newSubIdent);
 		assertEquals("Sub-folder parent_path must point to the new parent path",
-				"/" + newName + "/", renamedSubIdent.getParentPath());
+				"/" + newName + "/", newSubIdent.getParentPath());
 
 		// File asset in parent has its parent_path updated
 		final Identifier fileInParentIdent = identifierAPI.loadFromDb(fileInParent.getIdentifier());

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/folders/business/FolderAPITest.java
@@ -331,7 +331,7 @@ public class FolderAPITest extends IntegrationTestBase {//24 contentlets
 			final List<Map<String, Object>> vtsRows = new DotConnect()
 					.setSQL("SELECT version_ts FROM contentlet_version_info WHERE identifier = ?")
 					.addParam(identId)
-					.loadResults();
+					.loadObjectResults();
 			assertFalse("contentlet_version_info row must exist for identifier " + identId, vtsRows.isEmpty());
 			final Timestamp bumped = (Timestamp) vtsRows.get(0).get("version_ts");
 			assertTrue("version_ts must be after rename start for identifier " + identId,


### PR DESCRIPTION
This PR fixes: #35260

## Problem

Push-publishing a renamed folder (with content inside, or with child subfolders) failed in two ways:

1. **NPE in dependency processor** — `PushPublishigDependencyProcesor` looked up the folder by its old identifier, which no longer existed after rename, producing a `NullPointerException` on `folder.getPath()`.
2. **Content not included in bundle** — contentlets inside the renamed folder were excluded because their `version_ts` was not updated after the rename, so push-publish considered them unchanged. The same applied to content inside child subfolders.
3. **"Conflicts between Folders" on the receiver** — child subfolders were arriving in the bundle with the same UUID they had before the rename. On the receiver side this caused a path mismatch that triggered a conflict error.

### Root cause

These problems pre-date the recent folder-rename refactors (PRs #35086 and #35176). The rename workflow replaced the original per-item `move()` approach with a bulk SQL update of `identifier.parent_path`, but did not replicate two side effects that `move()` performed automatically:

- Bumping `contentlet_version_info.version_ts` so push-publish detects the content as changed.
- Giving child subfolders new deterministic identifiers (UUIDs) when their path changes.

## Fix

### Content not detected as changed
A bulk `UPDATE contentlet_version_info SET version_ts` is issued for all non-folder assets under the renamed path, followed by targeted `IdentifierCache` eviction per language. This replicates what the old per-contentlet `move()` did, but in a single SQL statement.

### Child subfolder identity
Folder identifiers in dotCMS are **deterministic**: the UUID is a hash of `assetType:hostname:parentPath:folderName`. When a parent folder is renamed, every child subfolder's path changes — meaning each child must receive a new identifier. This was the original behavior before the rename refactors.

The fix restores that original approach: for each child subfolder (sorted parent-before-child so `findFolderByPath` resolves correctly), `getNewFolderRecord()` is called to create a new record with a new deterministic UUID. The bulk `updateChildPaths` SQL is kept for non-folder identifiers only (`AND asset_type != 'folder'`), and old child folder records are deleted in child-before-parent order to satisfy the `check_child_assets` DB trigger. Because every folder in the push bundle now carries a new UUID, the receiver always takes the **create** path in `FolderHandler` — no `move()` cascade, no conflict.

### Removed `bumpSubFolderModDateForSubtree`
A previous attempt bumped `folder.mod_date` for child subfolders to force push-publish to include them. This is no longer needed: `getNewFolderRecord()` sets `modDate = new Date()`, so every new child folder record is automatically newer than any previous push date and will be included without manual bumping. The bump also caused the "Conflicts between Folders" receiver error and has been removed.

This PR fixes: #35260