### PR TITLE
feat(dot-browser-selector): auto-select uploaded file and enable Add button

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-browser-selector/components/dot-dataview/dot-dataview.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-browser-selector/components/dot-dataview/dot-dataview.component.html
@@ -10,7 +10,7 @@
     [rows]="rowsPerPage"
     selectionMode="single"
     dataKey="identifier"
-    [(selection)]="$selectedProduct"
+    [(selection)]="$selectedContent"
     [globalFilterFields]="['title', 'modUserName']"
     (onRowSelect)="onRowSelect.emit($event.data)"
     styleClass="flex flex-col h-full justify-between">

--- a/core-web/libs/ui/src/lib/components/dot-browser-selector/components/dot-dataview/dot-dataview.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-browser-selector/components/dot-dataview/dot-dataview.component.ts
@@ -74,10 +74,10 @@ export class DotDataViewComponent {
     $rowsPerPage = signal<number>(9);
 
     /**
-     * Reactive model holding the currently selected product.
+     * Reactive model holding the currently selected content row.
      * Can be a `DotCMSContentlet` or `null`.
      */
-    $selectedProduct = model<DotCMSContentlet | null>(null);
+    $selectedContent = model<DotCMSContentlet | null>(null, { alias: 'selectedContent' });
 
     /**
      * Emits the selected `DotCMSContentlet` when a row is selected.

--- a/core-web/libs/ui/src/lib/components/dot-browser-selector/dot-browser-selector.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-browser-selector/dot-browser-selector.component.html
@@ -17,6 +17,7 @@
                 [error]="content.error"
                 [accept]="$acceptAttr()"
                 [uploadDisabled]="$uploadDisabled()"
+                [selectedContent]="store.selectedContent()"
                 (onRowSelect)="store.setSelectedContent($event)"
                 (onUploadFile)="onFileUpload($event)" />
         </div>

--- a/core-web/libs/ui/src/lib/components/dot-browser-selector/dot-browser-selector.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-browser-selector/dot-browser-selector.component.ts
@@ -95,6 +95,7 @@ export class DotBrowserSelectorComponent implements OnInit {
         }
 
         this.$folderParams.update((prev) => ({ ...prev, hostFolderId: id }));
+        this.store.setSelectedContent(null);
     }
 
     /**

--- a/core-web/libs/ui/src/lib/components/dot-browser-selector/store/browser.store.test.ts
+++ b/core-web/libs/ui/src/lib/components/dot-browser-selector/store/browser.store.test.ts
@@ -566,6 +566,32 @@ describe('DotBrowserSelectorStore', () => {
             expect(store.content().status).toBe(ComponentStatus.LOADED);
         }));
 
+        it('should auto-select the uploaded contentlet on success', fakeAsync(() => {
+            const mockFile = new File(['content'], 'photo.png', { type: 'image/png' });
+            const uploadedContentlet = createFakeContentlet({ title: 'Uploaded' });
+
+            dotUploadFileService.uploadDotAsset.mockReturnValue(of(uploadedContentlet));
+            dotBrowsingService.getContentByFolder.mockReturnValue(of([uploadedContentlet]));
+
+            store.uploadFile({ file: mockFile, folderParams });
+            tick(50);
+
+            expect(store.selectedContent()).toEqual(uploadedContentlet);
+        }));
+
+        it('should not auto-select anything when upload fails', fakeAsync(() => {
+            const mockFile = new File(['content'], 'photo.png', { type: 'image/png' });
+
+            dotUploadFileService.uploadDotAsset.mockReturnValue(
+                throwError({ status: 500, message: 'Server error' })
+            );
+
+            store.uploadFile({ file: mockFile, folderParams });
+            tick(50);
+
+            expect(store.selectedContent()).toBeNull();
+        }));
+
         it('should preserve existing content and show generic error when upload fails', fakeAsync(() => {
             const existingContentlets = [createFakeContentlet({ title: 'Existing' })];
             patchState(unprotected(store), {

--- a/core-web/libs/ui/src/lib/components/dot-browser-selector/store/browser.store.ts
+++ b/core-web/libs/ui/src/lib/components/dot-browser-selector/store/browser.store.ts
@@ -76,7 +76,7 @@ export const DotBrowserSelectorStore = signalStore(
         const dotBrowsingService = inject(DotBrowsingService);
 
         return {
-            setSelectedContent: (selectedContent: DotCMSContentlet) => {
+            setSelectedContent: (selectedContent: DotCMSContentlet | null) => {
                 patchState(store, {
                     selectedContent
                 });

--- a/core-web/libs/ui/src/lib/components/dot-browser-selector/store/browser.store.ts
+++ b/core-web/libs/ui/src/lib/components/dot-browser-selector/store/browser.store.ts
@@ -222,7 +222,10 @@ export const DotBrowserSelectorStore = signalStore(
                             .uploadDotAsset(file, { hostFolder: folderParams.hostFolderId })
                             .pipe(
                                 tapResponse({
-                                    next: () => store.loadContent(folderParams),
+                                    next: (uploadedContentlet) => {
+                                        store.setSelectedContent(uploadedContentlet);
+                                        store.loadContent(folderParams);
+                                    },
                                     error: (err: { status?: number }) =>
                                         patchState(store, {
                                             content: {


### PR DESCRIPTION
## Summary

Follow-up UX improvement to #35221.

After a successful upload, the newly uploaded file is now **automatically selected** in the file list and the **Add button is immediately enabled** — eliminating the extra click that was previously required.

### Changes

- **`browser.store.ts`** — `uploadFile`: captures the `DotCMSContentlet` returned by `uploadDotAsset` and calls `setSelectedContent(uploadedContentlet)` before reloading the content list, so `selectedContent` is populated as soon as the upload succeeds.

- **`dot-dataview.component.ts`** — Renamed `$selectedProduct` → `$selectedContent` and added `alias: 'selectedContent'` so the parent can drive the table's visual selection from outside the component.

- **`dot-browser-selector.component.html`** — Added `[selectedContent]="store.selectedContent()"` binding on `dot-dataview`. This feeds the store's selection state into the PrimeNG table's `[(selection)]` binding, highlighting the uploaded row automatically after the content list refreshes.

### Before / After

| | Before | After |
|---|---|---|
| Upload file | File appears in list, nothing selected, Add disabled | File appears in list, **row highlighted**, Add enabled |

## Video

https://github.com/user-attachments/assets/8c5d4fd0-2dfa-40f4-8031-d5f0b9e34c3e


## Test plan

- [ ] Upload a file → it appears in the list highlighted and Add button is enabled
- [ ] Clicking a different row still selects it and keeps Add enabled
- [ ] Upload error (403 / generic) shows the inline error message and does not auto-select anything
- [ ] Cancelling the dialog after upload works normally



This PR fixes: #33103

This PR fixes: #33103