### PR TITLE
fix(edit-content): reset workflow state when switching to untranslated locale

### DIFF
--- a/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.spec.ts
@@ -167,6 +167,7 @@ describe('LocalesFeature', () => {
             expect(store.initialContentletState()).toEqual('copy');
             expect(store.contentlet()).toEqual(expectedContentlet);
             expect(store.formValues()).toEqual(null);
+            expect(store.lastTask()).toEqual(null);
         }));
 
         it('should open dialog, update state for untranslated locale doing manual copy', fakeAsync(() => {

--- a/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.spec.ts
@@ -158,6 +158,7 @@ describe('LocalesFeature', () => {
             const expectedContentlet = {
                 identifier: '123',
                 languageId: 1,
+                inode: undefined,
                 locked: false,
                 lockedBy: undefined
             } as DotCMSContentlet;

--- a/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
@@ -235,6 +235,7 @@ export function withLocales() {
                                             currentSchemeId: defaultSchemeId,
                                             currentContentActions: parsedCurrentActions,
                                             currentStep: null,
+                                            lastTask: null,
                                             state: ComponentStatus.LOADED,
                                             initialContentletState: 'copy',
                                             error: null,

--- a/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
@@ -234,6 +234,7 @@ export function withLocales() {
                                             schemes: parsedSchemes,
                                             currentSchemeId: defaultSchemeId,
                                             currentContentActions: parsedCurrentActions,
+                                            currentStep: null,
                                             state: ComponentStatus.LOADED,
                                             initialContentletState: 'copy',
                                             error: null,

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts
@@ -1363,9 +1363,10 @@ describe('Utils Functions', () => {
     });
 
     describe('prepareContentletForCopy', () => {
-        it('should prepare a contentlet for copying by setting locked to false and removing lockedBy', () => {
+        it('should prepare a contentlet for copying by clearing inode, setting locked to false and removing lockedBy', () => {
             // Arrange
             const contentlet = createFakeContentlet({
+                inode: 'some-inode-123',
                 locked: true,
                 lockedBy: {
                     firstName: 'John',
@@ -1380,6 +1381,7 @@ describe('Utils Functions', () => {
             // Assert
             expect(result).toEqual({
                 ...contentlet,
+                inode: undefined,
                 locked: false,
                 lockedBy: undefined
             });

--- a/core-web/libs/edit-content/src/lib/utils/functions.util.ts
+++ b/core-web/libs/edit-content/src/lib/utils/functions.util.ts
@@ -424,6 +424,7 @@ export const saveStoreUIState = (state: UIState): void => {
  */
 export const prepareContentletForCopy = (contentlet: DotCMSContentlet): DotCMSContentlet => ({
     ...contentlet,
+    inode: undefined,
     locked: false,
     lockedBy: undefined
 });


### PR DESCRIPTION
## Summary

- When switching to an untranslated locale in the new Edit Content experience, workflow actions were not refreshed — they stayed tied to the original contentlet's workflow state, causing workflow action execution to fail
- Root cause: `prepareContentletForCopy` retained the original `inode`, triggering the workflow effect to overwrite default actions; additionally, `currentStep` was not reset, showing stale step info (e.g., "Published" instead of "Editing")

Closes #32982

## Changes

| File | Change |
|------|--------|
| `core-web/libs/edit-content/src/lib/utils/functions.util.ts` | Clear `inode` in `prepareContentletForCopy` so the copied contentlet is treated as new content |
| `core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts` | Reset `currentStep` to `null` in the locale switch `patchState` call |
| `core-web/libs/edit-content/src/lib/utils/functions.util.spec.ts` | Update test to expect `inode: undefined` in the prepared contentlet |
| `core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.spec.ts` | Update test to expect `inode: undefined` in the expected contentlet after locale switch |

## Acceptance Criteria

- [x] When switching to an untranslated locale, workflow actions refresh to show default actions (e.g., "Save as Draft") instead of retaining the original contentlet's actions
- [x] The workflow step resets to the initial step (e.g., "Editing") instead of showing the stale step from the original contentlet
- [x] The `inode` is cleared from the copied contentlet so the workflow effect does not re-fetch actions for the original contentlet
- [x] All existing tests pass (319 PASS, 0 FAIL)

## Test Plan

- [ ] Create a new content item in English, save and publish it
- [ ] Switch to an untranslated locale (e.g., Spanish)
- [ ] In the "Untranslated Locale" dialog, select "Continue" to populate copy
- [ ] Verify that workflow actions show "Save as Draft" (default actions), not "Reset Workflow" or other actions from the published English version
- [ ] Verify the workflow step shows "Editing" (initial step), not "Published"
- [ ] Click "Save as Draft" and verify the content saves successfully in the new locale

## Visual Changes

https://github.com/user-attachments/assets/6c5e8807-6bc1-4325-bc4e-26b98630544e



## Notes

The "Set Value ActionLet" error reported when saving content in the new locale appears to be a pre-existing backend issue unrelated to this frontend fix. The frontend correctly sends the workflow fire request without an `inode` (treating it as new content) and with the `identifier` in the request body. The backend workflow sub-action "Set Value ActionLet" failure should be investigated separately.

This PR fixes: #32982