### PR TITLE
fix(tasks): always use legacy handler for task detail navigation

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.spec.ts
@@ -432,7 +432,7 @@ describe('DotCustomEventHandlerService', () => {
             expect(router.navigate).toHaveBeenCalledTimes(1);
         });
 
-        it('should edit a a workflow task', () => {
+        it('should edit a workflow task using legacy handler regardless of feature flag', () => {
             service.handle(
                 new CustomEvent('ng-event', {
                     detail: {
@@ -445,8 +445,8 @@ describe('DotCustomEventHandlerService', () => {
                 })
             );
 
-            expect(router.navigate).toHaveBeenCalledWith(['content/123']);
-            expect(router.navigate).toHaveBeenCalledTimes(1);
+            expect(dotRouterService.goToEditTask).toHaveBeenCalledWith('123');
+            expect(dotRouterService.goToEditTask).toHaveBeenCalledTimes(1);
         });
 
         it('should edit a contentlet', () => {
@@ -494,10 +494,7 @@ describe('DotCustomEventHandlerService', () => {
             expect(router.navigate).toHaveBeenCalledTimes(1);
         });
 
-        it('should edit a a workflow task', () => {
-            jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
-                of({ metadata } as DotCMSContentType)
-            );
+        it('should edit a workflow task using legacy handler regardless of content type metadata', () => {
             service.handle(
                 new CustomEvent('ng-event', {
                     detail: {
@@ -510,8 +507,8 @@ describe('DotCustomEventHandlerService', () => {
                 })
             );
 
-            expect(router.navigate).toHaveBeenCalledWith(['content/123']);
-            expect(router.navigate).toHaveBeenCalledTimes(1);
+            expect(dotRouterService.goToEditTask).toHaveBeenCalledWith('123');
+            expect(dotRouterService.goToEditTask).toHaveBeenCalledTimes(1);
         });
 
         it('should edit a contentlet', () => {
@@ -551,11 +548,7 @@ describe('DotCustomEventHandlerService', () => {
             expect(router.navigate).not.toHaveBeenCalledWith(['content/new/test']);
         });
 
-        it('should not edit a a workflow task', () => {
-            jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
-                of({ metadata: metadata2 } as DotCMSContentType)
-            );
-
+        it('should edit a workflow task using legacy handler even when content type is not in list', () => {
             service.handle(
                 new CustomEvent('ng-event', {
                     detail: {
@@ -568,7 +561,8 @@ describe('DotCustomEventHandlerService', () => {
                 })
             );
 
-            expect(router.navigate).not.toHaveBeenCalledWith(['content/123']);
+            expect(dotRouterService.goToEditTask).toHaveBeenCalledWith('123');
+            expect(dotRouterService.goToEditTask).toHaveBeenCalledTimes(1);
         });
 
         it('should not edit a contentlet', () => {

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
@@ -66,9 +66,7 @@ export class DotCustomEventHandlerService {
                         'edit-contentlet': contentEditorFeatureFlag
                             ? this.editContentlet.bind(this)
                             : this.editContentletLegacy.bind(this),
-                        'edit-task': contentEditorFeatureFlag
-                            ? this.editTask.bind(this)
-                            : this.editTaskLegacy.bind(this),
+                        'edit-task': this.editTaskLegacy.bind(this),
                         'create-contentlet': contentEditorFeatureFlag
                             ? this.createContentlet.bind(this)
                             : this.createContentletLegacy.bind(this),
@@ -154,19 +152,6 @@ export class DotCustomEventHandlerService {
 
     private editTaskLegacy($event: CustomEvent): void {
         this.dotRouterService.goToEditTask($event.detail.data.inode);
-    }
-
-    private editTask($event: CustomEvent): void {
-        this.dotContentTypeService
-            .getContentType($event.detail.data.contentType)
-            .pipe(take(1))
-            .subscribe((contentType) => {
-                if (this.shouldRedirectToOldContentEditor(contentType)) {
-                    return this.editTaskLegacy($event);
-                }
-
-                this.router.navigate([`content/${$event.detail.data.inode}`]);
-            });
     }
 
     private setPersonalization($event: CustomEvent): void {


### PR DESCRIPTION
## Summary

- The Tasks portlet failed to show the Task Detail dialog when clicking a task whose Content Type uses the new edit mode (`CONTENT_EDITOR2_ENABLED`)
- The `edit-task` event handler was incorrectly routing to `/content/{taskId}` (the content editor) instead of opening the legacy Task Detail dialog — this failed because it passed a workflow task ID (not a contentlet inode), and the content editor is not a task detail view
- Fix: always use the legacy task detail handler for `edit-task` events, since task detail (comments, workflow history, attached files) is independent of the content editing mode

Closes #31596

## Changes

| File | Change |
|------|--------|
| `core-web/.../dot-custom-event-handler.service.ts` | Always bind `edit-task` to `editTaskLegacy`, remove dead `editTask()` method |
| `core-web/.../dot-custom-event-handler.service.spec.ts` | Update 3 tests to assert `goToEditTask` instead of `router.navigate` for task events |

## Acceptance Criteria

- [x] Clicking a task in the Tasks portlet opens the Task Detail dialog regardless of whether the Content Type uses the new edit mode or not

## Test Plan

- [ ] Create a Content Type with the new Edit Mode enabled
- [ ] Create a Contentlet of that type and trigger a Workflow Action with comments
- [ ] Go to the Tasks portlet and click the task
- [ ] Verify the Task Detail dialog opens correctly showing comments, attached files, and workflow actions
- [ ] Repeat with a Content Type that does NOT use the new Edit Mode — verify it still works as before

## Visual Changes

https://github.com/user-attachments/assets/91f90a17-bcde-4ff6-a343-b3a17a796e8c


This PR fixes: #31596