### PR TITLE
fix(reindex): eliminate TOCTOU race in ReindexThread BulkProcessor rebuild

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
@@ -97,9 +97,11 @@ public class BulkProcessorListener implements BulkProcessor.Listener {
             }
         }
         handleSuccess(successful);
-        // 50% failure rate forces a rebuild of the BulkProcessor
-        if(totalResponses==0 || (successful.size() / totalResponses < .5)) {
-          ReindexThread.rebuildBulkIndexer();
+        // 50% failure rate: log a warning. No explicit rebuild needed — per-batch processing
+        // means the next batch will already use a fresh processor.
+        if (totalResponses > 0 && (successful.size() / totalResponses < .5)) {
+            Logger.warn(this.getClass(),
+                    "High bulk-index failure rate detected (>50%) — next batch will use a fresh processor.");
         }
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexThread.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -122,13 +121,6 @@ public class ReindexThread {
     private final static String REINDEX_THREAD_PAUSED = "REINDEX_THREAD_PAUSED";
     private final static Lazy<SystemCache> cache = Lazy.of(() -> CacheLocator.getSystemCache());
 
-    private final static AtomicBoolean rebuildBulkIndexer = new AtomicBoolean(false);
-
-    public static void rebuildBulkIndexer() {
-        Logger.warn(ReindexThread.class, "--- ReindexThread BulkProcessor needs to be Rebuilt");
-        ReindexThread.rebuildBulkIndexer.set(true);
-    }
-
     private ReindexThread() {
 
         this(APILocator.getReindexQueueAPI(), APILocator.getNotificationAPI(),
@@ -172,25 +164,16 @@ public class ReindexThread {
     }
 
 
-    private BulkProcessor closeBulkProcessor(final BulkProcessor bulkProcessor)
-            throws InterruptedException {
-        if (bulkProcessor != null) {
-            bulkProcessor.awaitClose(BULK_PROCESSOR_AWAIT_TIMEOUT, TimeUnit.SECONDS);
-        }
-        rebuildBulkIndexer.set(false);
-        return null;
-    }
-
-
-    private BulkProcessor finalizeReIndex(BulkProcessor bulkProcessor)
+    /**
+     * Handles queue-drained logic: attempts index switchover and pauses the thread
+     * if no full reindex is in progress.
+     */
+    private void finalizeReIndex()
             throws InterruptedException, LanguageException, DotDataException, SQLException {
-        bulkProcessor = closeBulkProcessor(bulkProcessor);
         switchOverIfNeeded();
         if (!indexAPI.isInFullReindex()) {
             ReindexThread.pause();
         }
-        return bulkProcessor;
-
     }
 
 
@@ -200,35 +183,37 @@ public class ReindexThread {
      * Elastic index. If that's not possible, a notification containing the content identifier will
      * be sent to the user via the Notifications API to take care of the problem as soon as
      * possible.
+     *
+     * <p><strong>Thread-safety:</strong> each batch gets its own {@link BulkProcessorListener}
+     * and {@link BulkProcessor}. The processor is closed (blocking via {@code awaitClose} until
+     * {@code afterBulk} completes) before the next batch starts, so there is no shared mutable
+     * state between consecutive batches and no TOCTOU race on the processor reference.</p>
      */
     private void runReindexLoop() {
-        BulkProcessor bulkProcessor = null;
-        BulkProcessorListener bulkProcessorListener = null;
         while (state.get() != ThreadState.STOPPED) {
             try {
 
                 final Map<String, ReindexEntry> workingRecords = queueApi.findContentToReindex();
 
                 if (workingRecords.isEmpty()) {
-                    bulkProcessor = finalizeReIndex(bulkProcessor);
-                }
+                    finalizeReIndex();
+                } else if (!ElasticReadOnlyCommand.getInstance().isIndexOrClusterReadOnly()) {
+                    Logger.debug(this, "Found  " + workingRecords + " index items to process");
 
-                if (!workingRecords.isEmpty() && !ElasticReadOnlyCommand.getInstance()
-                        .isIndexOrClusterReadOnly()) {
-                    Logger.debug(this,
-                            "Found  " + workingRecords + " index items to process");
-
-                    if (bulkProcessor == null || rebuildBulkIndexer.get()) {
-                        closeBulkProcessor(bulkProcessor);
-                        bulkProcessorListener = new BulkProcessorListener();
-                        bulkProcessor = indexAPI.createBulkProcessor(bulkProcessorListener);
+                    // Fresh listener per batch: each afterBulk callback resolves against its own
+                    // immutable workingRecords snapshot — no race with the next putAll.
+                    final BulkProcessorListener batchListener = new BulkProcessorListener();
+                    batchListener.workingRecords.putAll(workingRecords);
+                    final BulkProcessor batchProcessor = indexAPI.createBulkProcessor(batchListener);
+                    try {
+                        indexAPI.appendToBulkProcessor(batchProcessor, workingRecords.values());
+                    } finally {
+                        // awaitClose blocks until afterBulk completes before the next batch starts
+                        batchProcessor.awaitClose(BULK_PROCESSOR_AWAIT_TIMEOUT, TimeUnit.SECONDS);
                     }
-                    bulkProcessorListener.workingRecords.putAll(workingRecords);
-                    indexAPI.appendToBulkProcessor(bulkProcessor, workingRecords.values());
-                    contentletsIndexed += bulkProcessorListener.getContentletsIndexed();
-                    // otherwise, reindex normally
-
+                    contentletsIndexed += batchListener.getContentletsIndexed();
                 }
+
             } catch (Throwable ex) {
                 Logger.error(this, "ReindexThread Exception", ex);
                 ThreadUtils.sleep(SLEEP_ON_ERROR);


### PR DESCRIPTION
## Summary

Fixes the TOCTOU (Time-Of-Check To Time-Of-Use) race condition in `ReindexThread.runReindexLoop()` identified in issue #35313.

### Root cause

Two concurrent hazards on lines 221–228 of `ReindexThread.java`:

**1. Null-check / rebuild not atomic (`rebuildBulkIndexer`)**
```java
if (bulkProcessor == null || rebuildBulkIndexer.get()) {  // CHECK
    closeBulkProcessor(bulkProcessor);
    bulkProcessorListener = new BulkProcessorListener();
    bulkProcessor = indexAPI.createBulkProcessor(bulkProcessorListener); // USE
}
```
An external thread calling `rebuildBulkIndexer()` between the check and the creation can leave callbacks pointing to a stale listener.

**2. `putAll` vs `afterBulk` callback race**
```java
bulkProcessorListener.workingRecords.putAll(workingRecords); // ReindexThread
// meanwhile: afterBulk() reads workingRecords on BulkProcessor callback thread
```
In back-to-back loop iterations, `putAll(batch N+1)` can interleave with `afterBulk(batch N)` reading `workingRecords`, causing batch N's callback to resolve entries from batch N+1.

### Fix

- Create a fresh `BulkProcessorListener` and `BulkProcessor` per batch
- `awaitClose()` blocks until `afterBulk` completes before the next batch starts — each batch owns its immutable `workingRecords` snapshot
- `rebuildBulkIndexer` flag, `rebuildBulkIndexer()` method, and `closeBulkProcessor()` helper removed (all made unnecessary by per-batch approach)
- `finalizeReIndex()` simplified: no longer manages a `BulkProcessor` parameter
- `BulkProcessorListener.afterBulk`: logs warning on >50% failure rate instead of signalling a rebuild (added empty-batch guard: `totalResponses > 0`)

### Scope

Only 2 files changed (`ReindexThread.java` + `BulkProcessorListener.java`). No unrelated changes bundled.

## Test plan

- [ ] Existing `ReindexThread` integration tests pass
- [ ] Manual concurrent-reindex scenario: trigger multiple concurrent reindex operations — no `ConcurrentModificationException`, no silent record loss
- [ ] Verify full reindex switchover still works correctly (queue empties → `finalizeReIndex` → switchover)

Closes #35313