### PR TITLE
feat(uve): Fix same-page navigation handling with anchors with id

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-iframe/dot-uve-iframe.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-iframe/dot-uve-iframe.component.ts
@@ -4,13 +4,13 @@ import {
     ChangeDetectionStrategy,
     Component,
     DestroyRef,
-    ElementRef,
-    OnDestroy,
-    ViewChild,
     effect,
+    ElementRef,
     inject,
     input,
-    output
+    OnDestroy,
+    output,
+    ViewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
@@ -196,7 +196,13 @@ export class DotUveIframeComponent implements OnDestroy {
             .pipe(
                 filter((e) => {
                     const target = e.target as HTMLElement;
-                    const hasLink = !!target.closest('a')?.getAttribute('href');
+                    const linkElement = target.closest('a');
+                    const href = linkElement?.getAttribute('href');
+
+                    // Exclude hash-only links (e.g., #sectionA) - these are same-page anchors
+                    const isHashOnly = href?.startsWith('#');
+
+                    const hasLink = !!href && !isHashOnly;
                     const hasInlineEditTarget =
                         !!target.closest('[data-mode]') || !!target.dataset?.mode;
                     return hasLink || hasInlineEditTarget;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2343,6 +2343,104 @@ describe('EditEmaEditorComponent', () => {
                     expect(mockEvent.preventDefault).toHaveBeenCalled();
                 });
 
+                describe('same-page navigation (hash-only and query-only)', () => {
+                    let pageParamsSpy: jest.SpyInstance;
+
+                    beforeEach(() => {
+                        pageParamsSpy = jest
+                            .spyOn(store, 'pageParams')
+                            .mockReturnValue({ url: '/current-page' });
+                    });
+
+                    it('should not trigger pageLoad for hash-only navigation on same page', () => {
+                        const hashUrl = 'http://localhost:3000/current-page#sectionA';
+                        const mockEvent = createMockEvent(hashUrl);
+
+                        spectator.component.handleInternalNav(mockEvent);
+
+                        expect(pageLoadSpy).not.toHaveBeenCalled();
+                        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+                    });
+
+                    it('should not trigger pageLoad for hash-only with complex id', () => {
+                        const hashUrl = 'http://localhost:3000/current-page#section-123_complex';
+                        const mockEvent = createMockEvent(hashUrl);
+
+                        spectator.component.handleInternalNav(mockEvent);
+
+                        expect(pageLoadSpy).not.toHaveBeenCalled();
+                    });
+
+                    it('should not trigger pageLoad for query-only navigation on same page', () => {
+                        const queryUrl = 'http://localhost:3000/current-page?tab=2';
+                        const mockEvent = createMockEvent(queryUrl);
+
+                        spectator.component.handleInternalNav(mockEvent);
+
+                        expect(pageLoadSpy).not.toHaveBeenCalled();
+                        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
+                    });
+
+                    it('should not trigger pageLoad for multiple query params on same page', () => {
+                        const queryUrl =
+                            'http://localhost:3000/current-page?filter=value&sort=date';
+                        const mockEvent = createMockEvent(queryUrl);
+
+                        spectator.component.handleInternalNav(mockEvent);
+
+                        expect(pageLoadSpy).not.toHaveBeenCalled();
+                    });
+
+                    it('should trigger pageLoad when both hash and query are present', () => {
+                        const combinedUrl = 'http://localhost:3000/current-page?tab=2#section';
+                        const mockEvent = createMockEvent(combinedUrl);
+
+                        spectator.component.handleInternalNav(mockEvent);
+
+                        expect(pageLoadSpy).toHaveBeenCalledWith({
+                            url: '/current-page',
+                            tab: '2'
+                        });
+                        expect(mockEvent.preventDefault).toHaveBeenCalled();
+                    });
+
+                    it('should trigger pageLoad when navigating to different page with hash', () => {
+                        const differentPageUrl = 'http://localhost:3000/other-page#section';
+                        const mockEvent = createMockEvent(differentPageUrl);
+
+                        spectator.component.handleInternalNav(mockEvent);
+
+                        expect(pageLoadSpy).toHaveBeenCalledWith({
+                            url: '/other-page'
+                        });
+                        expect(mockEvent.preventDefault).toHaveBeenCalled();
+                    });
+
+                    it('should trigger pageLoad when navigating to different page with query', () => {
+                        const differentPageUrl = 'http://localhost:3000/other-page?tab=1';
+                        const mockEvent = createMockEvent(differentPageUrl);
+
+                        spectator.component.handleInternalNav(mockEvent);
+
+                        expect(pageLoadSpy).toHaveBeenCalledWith({
+                            url: '/other-page',
+                            tab: '1'
+                        });
+                        expect(mockEvent.preventDefault).toHaveBeenCalled();
+                    });
+
+                    it('should handle root path hash navigation', () => {
+                        jest.spyOn(store, 'pageParams').mockReturnValue({ url: '/' });
+
+                        const hashUrl = 'http://localhost:3000/#top';
+                        const mockEvent = createMockEvent(hashUrl);
+
+                        spectator.component.handleInternalNav(mockEvent);
+
+                        expect(pageLoadSpy).not.toHaveBeenCalled();
+                    });
+                });
+
                 afterEach(() => {
                     jest.clearAllMocks();
                 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2343,7 +2343,7 @@ describe('EditEmaEditorComponent', () => {
                     expect(mockEvent.preventDefault).toHaveBeenCalled();
                 });
 
-                describe('same-page navigation (hash-only and query-only)', () => {
+                describe('same-page navigation (same pathname)', () => {
                     let pageParamsSpy: jest.SpyInstance;
 
                     beforeEach(() => {
@@ -2391,17 +2391,14 @@ describe('EditEmaEditorComponent', () => {
                         expect(pageLoadSpy).not.toHaveBeenCalled();
                     });
 
-                    it('should trigger pageLoad when both hash and query are present', () => {
+                    it('should not trigger pageLoad when both hash and query are present on same path', () => {
                         const combinedUrl = 'http://localhost:3000/current-page?tab=2#section';
                         const mockEvent = createMockEvent(combinedUrl);
 
                         spectator.component.handleInternalNav(mockEvent);
 
-                        expect(pageLoadSpy).toHaveBeenCalledWith({
-                            url: '/current-page',
-                            tab: '2'
-                        });
-                        expect(mockEvent.preventDefault).toHaveBeenCalled();
+                        expect(pageLoadSpy).not.toHaveBeenCalled();
+                        expect(mockEvent.preventDefault).not.toHaveBeenCalled();
                     });
 
                     it('should trigger pageLoad when navigating to different page with hash', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -92,7 +92,7 @@ import { EditEmaEditorComponent } from './edit-ema-editor.component';
 import { DotBlockEditorSidebarComponent } from '../components/dot-block-editor-sidebar/dot-block-editor-sidebar.component';
 import { DotEmaDialogComponent } from '../components/dot-ema-dialog/dot-ema-dialog.component';
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
-import { DotPageApiService } from '../services/dot-page-api/dot-page-api.service';
+import { DotPageApiParams, DotPageApiService } from '../services/dot-page-api/dot-page-api.service';
 import { DotUveActionsHandlerService } from '../services/dot-uve-actions-handler/dot-uve-actions-handler.service';
 import { DotUveDragDropService } from '../services/dot-uve-drag-drop/dot-uve-drag-drop.service';
 import { InlineEditService } from '../services/inline-edit/inline-edit.service';
@@ -152,7 +152,7 @@ const mockGlobalStore = {
 };
 
 const mockDotUveActionsHandlerService = {
-    handleAction: jest.fn(() => of({}))
+    handleAction: jest.fn((_message: unknown, _deps: unknown) => of({}))
 };
 
 const mockDotUveDragDropService = {
@@ -2344,12 +2344,14 @@ describe('EditEmaEditorComponent', () => {
                 });
 
                 describe('same-page navigation (same pathname)', () => {
-                    let pageParamsSpy: jest.SpyInstance;
+                    const samePathPageParams = (): DotPageApiParams => ({
+                        url: '/current-page',
+                        language_id: '1',
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier
+                    });
 
                     beforeEach(() => {
-                        pageParamsSpy = jest
-                            .spyOn(store, 'pageParams')
-                            .mockReturnValue({ url: '/current-page' });
+                        jest.spyOn(store, 'pageParams').mockReturnValue(samePathPageParams());
                     });
 
                     it('should not trigger pageLoad for hash-only navigation on same page', () => {
@@ -2427,7 +2429,11 @@ describe('EditEmaEditorComponent', () => {
                     });
 
                     it('should handle root path hash navigation', () => {
-                        jest.spyOn(store, 'pageParams').mockReturnValue({ url: '/' });
+                        jest.spyOn(store, 'pageParams').mockReturnValue({
+                            url: '/',
+                            language_id: '1',
+                            [PERSONA_KEY]: DEFAULT_PERSONA.identifier
+                        });
 
                         const hashUrl = 'http://localhost:3000/#top';
                         const mockEvent = createMockEvent(hashUrl);

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -630,8 +630,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
             return;
         }
 
-        // Check if this is a same-page navigation (hash-only or query-only changes)
-        // For same-page navigation, let the browser handle it naturally (scroll to anchor)
+        // Same pathname (any hash/query): let the browser handle it (anchors, query-driven UI)
         if (isSamePageNavigation(href, this.uveStore.pageParams()?.url)) {
             return;
         }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -111,6 +111,7 @@ import {
     getTargetUrl,
     getWrapperMeasures,
     insertContentletInContainer,
+    isSamePageNavigation,
     shouldNavigate
 } from '../utils';
 
@@ -626,6 +627,12 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
         if (url.hostname !== this.window.location.hostname) {
             this.window.open(href, '_blank');
 
+            return;
+        }
+
+        // Check if this is a same-page navigation (hash-only or query-only changes)
+        // For same-page navigation, let the browser handle it naturally (scroll to anchor)
+        if (isSamePageNavigation(href, this.uveStore.pageParams()?.url)) {
             return;
         }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.spec.ts
@@ -264,4 +264,228 @@ describe('DotUveActionsHandlerService – SECTION_OFFSET', () => {
             language_id: 1
         });
     });
+
+    describe('NAVIGATION_UPDATE', () => {
+        it('should call pageLoad when navigating to a different page', () => {
+            const pageLoad = jest.fn();
+            const mockStore = {
+                ...buildMockStore(),
+                pageParams: jest.fn().mockReturnValue({ url: '/home' }),
+                pageLoad
+            };
+
+            service.handleAction(
+                {
+                    action: DotCMSUVEAction.NAVIGATION_UPDATE,
+                    payload: { url: '/about' }
+                },
+                {
+                    uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                    dialog: null,
+                    inlineEditingService: null,
+                    contentWindow: null,
+                    host: 'http://localhost',
+                    onCopyContent: jest.fn()
+                }
+            );
+
+            expect(pageLoad).toHaveBeenCalledWith({
+                url: '/about',
+                'com.dotmarketing.persona.id': 'modes.persona.no.persona'
+            });
+        });
+
+        it('should call pageLoad when navigating to a different page with hash', () => {
+            const pageLoad = jest.fn();
+            const mockStore = {
+                ...buildMockStore(),
+                pageParams: jest.fn().mockReturnValue({ url: '/home' }),
+                pageLoad
+            };
+
+            service.handleAction(
+                {
+                    action: DotCMSUVEAction.NAVIGATION_UPDATE,
+                    payload: { url: '/about#section' }
+                },
+                {
+                    uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                    dialog: null,
+                    inlineEditingService: null,
+                    contentWindow: null,
+                    host: 'http://localhost',
+                    onCopyContent: jest.fn()
+                }
+            );
+
+            expect(pageLoad).toHaveBeenCalledWith(
+                expect.objectContaining({ url: '/about#section' })
+            );
+        });
+
+        describe('same-page navigation', () => {
+            it('should not call pageLoad for hash-only navigation on same page', () => {
+                const pageLoad = jest.fn();
+                const setEditorState = jest.fn();
+                const mockStore = {
+                    ...buildMockStore(),
+                    pageParams: jest.fn().mockReturnValue({ url: '/home' }),
+                    pageLoad,
+                    setEditorState
+                };
+
+                service.handleAction(
+                    {
+                        action: DotCMSUVEAction.NAVIGATION_UPDATE,
+                        payload: { url: '#sectionA' }
+                    },
+                    {
+                        uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                        dialog: null,
+                        inlineEditingService: null,
+                        contentWindow: null,
+                        host: 'http://localhost',
+                        onCopyContent: jest.fn()
+                    }
+                );
+
+                expect(pageLoad).not.toHaveBeenCalled();
+                expect(setEditorState).not.toHaveBeenCalled();
+            });
+
+            it('should not call pageLoad for hash with full path on same page', () => {
+                const pageLoad = jest.fn();
+                const mockStore = {
+                    ...buildMockStore(),
+                    pageParams: jest.fn().mockReturnValue({ url: '/home' }),
+                    pageLoad
+                };
+
+                service.handleAction(
+                    {
+                        action: DotCMSUVEAction.NAVIGATION_UPDATE,
+                        payload: { url: '/home#faq' }
+                    },
+                    {
+                        uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                        dialog: null,
+                        inlineEditingService: null,
+                        contentWindow: null,
+                        host: 'http://localhost',
+                        onCopyContent: jest.fn()
+                    }
+                );
+
+                expect(pageLoad).not.toHaveBeenCalled();
+            });
+
+            it('should not call pageLoad for query-only navigation on same page', () => {
+                const pageLoad = jest.fn();
+                const mockStore = {
+                    ...buildMockStore(),
+                    pageParams: jest.fn().mockReturnValue({ url: '/home' }),
+                    pageLoad
+                };
+
+                service.handleAction(
+                    {
+                        action: DotCMSUVEAction.NAVIGATION_UPDATE,
+                        payload: { url: '/home?tab=2' }
+                    },
+                    {
+                        uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                        dialog: null,
+                        inlineEditingService: null,
+                        contentWindow: null,
+                        host: 'http://localhost',
+                        onCopyContent: jest.fn()
+                    }
+                );
+
+                expect(pageLoad).not.toHaveBeenCalled();
+            });
+
+            it('should not call pageLoad for multiple query params on same page', () => {
+                const pageLoad = jest.fn();
+                const mockStore = {
+                    ...buildMockStore(),
+                    pageParams: jest.fn().mockReturnValue({ url: '/search' }),
+                    pageLoad
+                };
+
+                service.handleAction(
+                    {
+                        action: DotCMSUVEAction.NAVIGATION_UPDATE,
+                        payload: { url: '/search?query=test&sort=date' }
+                    },
+                    {
+                        uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                        dialog: null,
+                        inlineEditingService: null,
+                        contentWindow: null,
+                        host: 'http://localhost',
+                        onCopyContent: jest.fn()
+                    }
+                );
+
+                expect(pageLoad).not.toHaveBeenCalled();
+            });
+
+            it('should set editor state to IDLE when both hash and query are present on same page', () => {
+                const pageLoad = jest.fn();
+                const setEditorState = jest.fn();
+                const mockStore = {
+                    ...buildMockStore(),
+                    setEditorState,
+                    pageParams: jest.fn().mockReturnValue({ url: '/home' }),
+                    pageLoad
+                };
+
+                service.handleAction(
+                    {
+                        action: DotCMSUVEAction.NAVIGATION_UPDATE,
+                        payload: { url: '/home?tab=2#section' }
+                    },
+                    {
+                        uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                        dialog: null,
+                        inlineEditingService: null,
+                        contentWindow: null,
+                        host: 'http://localhost',
+                        onCopyContent: jest.fn()
+                    }
+                );
+
+                // Same pathname (/home), so compareUrlPaths returns true → setEditorState(IDLE), not pageLoad
+                expect(pageLoad).not.toHaveBeenCalled();
+                expect(setEditorState).toHaveBeenCalledWith(EDITOR_STATE.IDLE);
+            });
+
+            it('should handle root path hash navigation', () => {
+                const pageLoad = jest.fn();
+                const mockStore = {
+                    ...buildMockStore(),
+                    pageParams: jest.fn().mockReturnValue({ url: '/' }),
+                    pageLoad
+                };
+
+                service.handleAction(
+                    {
+                        action: DotCMSUVEAction.NAVIGATION_UPDATE,
+                        payload: { url: '/#top' }
+                    },
+                    {
+                        uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                        dialog: null,
+                        inlineEditingService: null,
+                        contentWindow: null,
+                        host: 'http://localhost',
+                        onCopyContent: jest.fn()
+                    }
+                );
+
+                expect(pageLoad).not.toHaveBeenCalled();
+            });
+        });
+    });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.spec.ts
@@ -431,7 +431,7 @@ describe('DotUveActionsHandlerService – SECTION_OFFSET', () => {
                 expect(pageLoad).not.toHaveBeenCalled();
             });
 
-            it('should set editor state to IDLE when both hash and query are present on same page', () => {
+            it('should not call pageLoad or setEditorState when both hash and query are present on same page', () => {
                 const pageLoad = jest.fn();
                 const setEditorState = jest.fn();
                 const mockStore = {
@@ -456,9 +456,8 @@ describe('DotUveActionsHandlerService – SECTION_OFFSET', () => {
                     }
                 );
 
-                // Same pathname (/home), so compareUrlPaths returns true → setEditorState(IDLE), not pageLoad
                 expect(pageLoad).not.toHaveBeenCalled();
-                expect(setEditorState).toHaveBeenCalledWith(EDITOR_STATE.IDLE);
+                expect(setEditorState).not.toHaveBeenCalled();
             });
 
             it('should handle root path hash navigation', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.ts
@@ -77,8 +77,7 @@ export class DotUveActionsHandlerService {
                 const currentPageUrl = uveStore.pageParams()?.url;
                 const incomingUrl = payload.url;
 
-                // Check if this is a same-page navigation (hash-only or query-only)
-                // For same-page navigation, let the client handle it naturally
+                // Same pathname (any hash/query): let the client handle it; do not pageLoad
                 if (isSamePageNavigation(incomingUrl, currentPageUrl)) {
                     return;
                 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.ts
@@ -34,7 +34,8 @@ import { PageType } from '../../store/models';
 import {
     compareUrlPaths,
     convertClientParamsToPageParams,
-    createReorderMenuURL
+    createReorderMenuURL,
+    isSamePageNavigation
 } from '../../utils';
 import { InlineEditService } from '../inline-edit/inline-edit.service';
 
@@ -73,7 +74,16 @@ export class DotUveActionsHandlerService {
 
         const CLIENT_ACTIONS_FUNC_MAP: Record<DotCMSUVEAction, (payload: unknown) => void> = {
             [DotCMSUVEAction.NAVIGATION_UPDATE]: (payload: SetUrlPayload) => {
-                const isSameUrl = compareUrlPaths(uveStore.pageParams()?.url, payload.url);
+                const currentPageUrl = uveStore.pageParams()?.url;
+                const incomingUrl = payload.url;
+
+                // Check if this is a same-page navigation (hash-only or query-only)
+                // For same-page navigation, let the client handle it naturally
+                if (isSamePageNavigation(incomingUrl, currentPageUrl)) {
+                    return;
+                }
+
+                const isSameUrl = compareUrlPaths(currentPageUrl, incomingUrl);
 
                 if (isSameUrl) {
                     uveStore.setEditorState(EDITOR_STATE.IDLE);

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -1130,3 +1130,34 @@ export const convertClientParamsToPageParams = (params) => {
 
     return removeUndefinedValues(pageParams);
 };
+
+/**
+ * Checks if a URL represents a same-page navigation (hash-only or query-only change).
+ *
+ * Same-page navigations should be handled by the browser/client naturally and should
+ * not trigger a full page reload in the editor.
+ *
+ * @param {string} incomingUrl - The URL to check (e.g., '#section', '/page?tab=2', '/other-page')
+ * @param {string} currentUrl - The current page URL for comparison
+ * @returns {boolean} True if the URL is a same-page navigation (hash-only or query-only)
+ *
+ * @example
+ * isSamePageNavigation('#faq', '/home') // true - hash-only
+ * isSamePageNavigation('/home?tab=2', '/home') // true - query-only
+ * isSamePageNavigation('/other-page', '/home') // false - different page
+ * isSamePageNavigation('/home#section', '/home?tab=1') // false - path same but has hash AND query
+ */
+export const isSamePageNavigation = (incomingUrl: string, currentUrl: string): boolean => {
+    if (!incomingUrl || !currentUrl) return false;
+
+    const current = new URL(currentUrl, window.origin);
+    // Resolve incomingUrl relative to the current page URL so bare hashes like
+    // '#section' become '<current-path>#section' instead of resolving to the origin root.
+    const target = new URL(incomingUrl, current.href);
+
+    const isSamePathname = target.pathname === current.pathname;
+    const isHashOnly = isSamePathname && !!target.hash && !target.search;
+    const isQueryOnly = isSamePathname && !target.hash && !!target.search;
+
+    return isHashOnly || isQueryOnly;
+};

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/index.ts
@@ -1132,20 +1132,20 @@ export const convertClientParamsToPageParams = (params) => {
 };
 
 /**
- * Checks if a URL represents a same-page navigation (hash-only or query-only change).
+ * Checks if a URL targets the same pathname as the current page (any hash or query change).
  *
- * Same-page navigations should be handled by the browser/client naturally and should
- * not trigger a full page reload in the editor.
+ * These navigations should be handled by the browser/client naturally and should not
+ * trigger a full page reload in the editor.
  *
  * @param {string} incomingUrl - The URL to check (e.g., '#section', '/page?tab=2', '/other-page')
  * @param {string} currentUrl - The current page URL for comparison
- * @returns {boolean} True if the URL is a same-page navigation (hash-only or query-only)
+ * @returns {boolean} True when resolved `URL.pathname` values are equal
  *
  * @example
- * isSamePageNavigation('#faq', '/home') // true - hash-only
- * isSamePageNavigation('/home?tab=2', '/home') // true - query-only
- * isSamePageNavigation('/other-page', '/home') // false - different page
- * isSamePageNavigation('/home#section', '/home?tab=1') // false - path same but has hash AND query
+ * isSamePageNavigation('#faq', '/home') // true - same path, hash change
+ * isSamePageNavigation('/home?tab=2', '/home') // true - same path, query change
+ * isSamePageNavigation('/home#section', '/home?tab=1') // true - same path, hash and/or query differ
+ * isSamePageNavigation('/other-page', '/home') // false - different path
  */
 export const isSamePageNavigation = (incomingUrl: string, currentUrl: string): boolean => {
     if (!incomingUrl || !currentUrl) return false;
@@ -1155,9 +1155,5 @@ export const isSamePageNavigation = (incomingUrl: string, currentUrl: string): b
     // '#section' become '<current-path>#section' instead of resolving to the origin root.
     const target = new URL(incomingUrl, current.href);
 
-    const isSamePathname = target.pathname === current.pathname;
-    const isHashOnly = isSamePathname && !!target.hash && !target.search;
-    const isQueryOnly = isSamePathname && !target.hash && !!target.search;
-
-    return isHashOnly || isQueryOnly;
+    return target.pathname === current.pathname;
 };

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -30,7 +30,8 @@ import {
     getWrapperMeasures,
     normalizeQueryParams,
     convertUTCToLocalTime,
-    escapeHtmlAttributeValue
+    escapeHtmlAttributeValue,
+    isSamePageNavigation
 } from '.';
 
 import { DEFAULT_PERSONA, PERSONA_KEY } from '../shared/consts';
@@ -1168,6 +1169,89 @@ describe('utils functions', () => {
 
         it('should return false when the paths are not equal', () => {
             expect(compareUrlPaths('/test', '/test2')).toBe(false);
+        });
+    });
+
+    describe('isSamePageNavigation', () => {
+        describe('hash-only navigation (same page anchors)', () => {
+            it('should return true for hash-only link on same page', () => {
+                expect(isSamePageNavigation('#sectionA', '/home')).toBe(true);
+            });
+
+            it('should return true for hash-only link matching current path', () => {
+                expect(isSamePageNavigation('/home#faq', '/home')).toBe(true);
+            });
+
+            it('should return true for hash with complex id', () => {
+                expect(isSamePageNavigation('#section-123_complex', '/about')).toBe(true);
+            });
+        });
+
+        describe('query-only navigation (same page with different params)', () => {
+            it('should return true for query-only change on same page', () => {
+                expect(isSamePageNavigation('/home?tab=2', '/home')).toBe(true);
+            });
+
+            it('should return true for multiple query params on same page', () => {
+                expect(
+                    isSamePageNavigation('/search?query=test&sort=date', '/search?query=test')
+                ).toBe(true);
+            });
+
+            it('should return true for query params with special characters', () => {
+                expect(
+                    isSamePageNavigation('/page?filter=%7B%22type%22%3A%22test%22%7D', '/page')
+                ).toBe(true);
+            });
+        });
+
+        describe('different page navigation', () => {
+            it('should return false when navigating to different page', () => {
+                expect(isSamePageNavigation('/other-page', '/home')).toBe(false);
+            });
+
+            it('should return false when navigating to different page with hash', () => {
+                expect(isSamePageNavigation('/other-page#section', '/home')).toBe(false);
+            });
+
+            it('should return false when navigating to different page with query', () => {
+                expect(isSamePageNavigation('/other-page?tab=1', '/home')).toBe(false);
+            });
+
+            it('should return false when navigating to different page with hash and query', () => {
+                expect(isSamePageNavigation('/other-page#section?foo=bar', '/home')).toBe(false);
+            });
+        });
+
+        describe('combined hash and query (should trigger navigation)', () => {
+            it('should return false when both hash and query are present', () => {
+                expect(isSamePageNavigation('/home?tab=2#section', '/home')).toBe(false);
+            });
+
+            it('should return false when both hash and query are present on same path', () => {
+                expect(isSamePageNavigation('/page?filter=value#result', '/page')).toBe(false);
+            });
+        });
+
+        describe('edge cases', () => {
+            it('should handle root path correctly', () => {
+                expect(isSamePageNavigation('/#top', '/')).toBe(true);
+            });
+
+            it('should handle path without trailing slash vs with trailing slash', () => {
+                expect(isSamePageNavigation('/home#section', '/home/')).toBe(false);
+            });
+
+            it('should handle empty strings gracefully', () => {
+                expect(isSamePageNavigation('', '/home')).toBe(false);
+                expect(isSamePageNavigation('/home', '')).toBe(false);
+            });
+
+            it('should handle undefined-like values', () => {
+                expect(isSamePageNavigation('#section', undefined as unknown as string)).toBe(
+                    false
+                );
+            });
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/utils/utils.spec.ts
@@ -1173,7 +1173,7 @@ describe('utils functions', () => {
     });
 
     describe('isSamePageNavigation', () => {
-        describe('hash-only navigation (same page anchors)', () => {
+        describe('same pathname (hash and/or query)', () => {
             it('should return true for hash-only link on same page', () => {
                 expect(isSamePageNavigation('#sectionA', '/home')).toBe(true);
             });
@@ -1185,9 +1185,7 @@ describe('utils functions', () => {
             it('should return true for hash with complex id', () => {
                 expect(isSamePageNavigation('#section-123_complex', '/about')).toBe(true);
             });
-        });
 
-        describe('query-only navigation (same page with different params)', () => {
             it('should return true for query-only change on same page', () => {
                 expect(isSamePageNavigation('/home?tab=2', '/home')).toBe(true);
             });
@@ -1202,6 +1200,18 @@ describe('utils functions', () => {
                 expect(
                     isSamePageNavigation('/page?filter=%7B%22type%22%3A%22test%22%7D', '/page')
                 ).toBe(true);
+            });
+
+            it('should return true when path matches and only hash vs query differs', () => {
+                expect(isSamePageNavigation('/home#section', '/home?tab=1')).toBe(true);
+            });
+
+            it('should return true when both hash and query are present on the same path', () => {
+                expect(isSamePageNavigation('/home?tab=2#section', '/home')).toBe(true);
+            });
+
+            it('should return true when both hash and query change on the same path', () => {
+                expect(isSamePageNavigation('/page?filter=value#result', '/page')).toBe(true);
             });
         });
 
@@ -1220,16 +1230,6 @@ describe('utils functions', () => {
 
             it('should return false when navigating to different page with hash and query', () => {
                 expect(isSamePageNavigation('/other-page#section?foo=bar', '/home')).toBe(false);
-            });
-        });
-
-        describe('combined hash and query (should trigger navigation)', () => {
-            it('should return false when both hash and query are present', () => {
-                expect(isSamePageNavigation('/home?tab=2#section', '/home')).toBe(false);
-            });
-
-            it('should return false when both hash and query are present on same path', () => {
-                expect(isSamePageNavigation('/page?filter=value#result', '/page')).toBe(false);
             });
         });
 


### PR DESCRIPTION
- Added  utility to determine if a URL change is a same-page navigation (hash-only or query-only).
- Updated  to prevent triggering page load for same-page navigations.
- Enhanced tests in  to cover various same-page navigation scenarios.
- Modified  to utilize the new utility for navigation updates.
- Updated  to exclude hash-only links from triggering navigation actions.

This change improves user experience by preventing unnecessary page reloads during internal navigation events.

https://github.com/user-attachments/assets/e4c9c2c5-3422-4054-9040-167a70ed5731


This PR fixes: #35324

This PR fixes: #35324