### PR TITLE
fix(DotPropertiesService): handle boolean values returned by config endpoint for feature flags

### DIFF
--- a/core-web/libs/data-access/src/lib/dot-containers/dot-containers.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-containers/dot-containers.service.ts
@@ -66,7 +66,7 @@ export class DotContainersService {
                     }
 
                     const searchTitle = isNotSet ? SYSTEM_CONTAINER_ID : title;
-                    return this.getContainerByTitle(searchTitle, isNotSet);
+                    return this.getContainerByTitle(searchTitle as string, isNotSet);
                 })
             )
             .subscribe((container) => {

--- a/core-web/libs/data-access/src/lib/dot-containers/dot-containers.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-containers/dot-containers.service.ts
@@ -59,6 +59,10 @@ export class DotContainersService {
             .getKey(this.#DEFAULT_CONTAINER_KEY)
             .pipe(
                 switchMap((title) => {
+                    if (typeof title !== 'string') {
+                        return of(null);
+                    }
+
                     const isNotSet = title === DEFAULT_CONTAINER_CONFIG.NOT_FOUND;
 
                     if (!title || title === DEFAULT_CONTAINER_CONFIG.NULL_VALUE) {
@@ -66,7 +70,7 @@ export class DotContainersService {
                     }
 
                     const searchTitle = isNotSet ? SYSTEM_CONTAINER_ID : title;
-                    return this.getContainerByTitle(searchTitle as string, isNotSet);
+                    return this.getContainerByTitle(searchTitle, isNotSet);
                 })
             )
             .subscribe((container) => {

--- a/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.spec.ts
@@ -124,6 +124,36 @@ describe('DotPropertiesService', () => {
         req.flush(apiResponse);
     });
 
+    it('should get feature flag as true when API returns JSON boolean true', (done) => {
+        const featureFlag = FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR_FOR_TRADITIONAL_PAGES;
+        const apiResponse: { entity: Record<string, string | boolean> } = {
+            entity: { [featureFlag]: true }
+        };
+
+        service.getFeatureFlag(featureFlag).subscribe((response) => {
+            expect(response).toBe(true);
+            done();
+        });
+        const req = httpMock.expectOne(`/api/v1/configuration/config?keys=${featureFlag}`);
+        expect(req.request.method).toBe('GET');
+        req.flush(apiResponse);
+    });
+
+    it('should get feature flag as false when API returns JSON boolean false', (done) => {
+        const featureFlag = FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR_FOR_TRADITIONAL_PAGES;
+        const apiResponse: { entity: Record<string, string | boolean> } = {
+            entity: { [featureFlag]: false }
+        };
+
+        service.getFeatureFlag(featureFlag).subscribe((response) => {
+            expect(response).toBe(false);
+            done();
+        });
+        const req = httpMock.expectOne(`/api/v1/configuration/config?keys=${featureFlag}`);
+        expect(req.request.method).toBe('GET');
+        req.flush(apiResponse);
+    });
+
     afterEach(() => {
         httpMock.verify();
     });

--- a/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.spec.ts
@@ -124,6 +124,30 @@ describe('DotPropertiesService', () => {
         req.flush(apiResponse);
     });
 
+    it('should get feature flags as booleans when API returns JSON boolean values', (done) => {
+        const featureFlags = [
+            FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR,
+            FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR_FOR_TRADITIONAL_PAGES
+        ];
+        const apiResponse: { entity: Record<string, string | boolean> } = {
+            entity: {
+                [FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR]: true,
+                [FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR_FOR_TRADITIONAL_PAGES]: false
+            }
+        };
+
+        service.getFeatureFlags(featureFlags).subscribe((response) => {
+            expect(response[FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR]).toBe(true);
+            expect(
+                response[FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR_FOR_TRADITIONAL_PAGES]
+            ).toBe(false);
+            done();
+        });
+        const req = httpMock.expectOne(`/api/v1/configuration/config?keys=${featureFlags.join()}`);
+        expect(req.request.method).toBe('GET');
+        req.flush(apiResponse);
+    });
+
     it('should get feature flag as true when API returns JSON boolean true', (done) => {
         const featureFlag = FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR_FOR_TRADITIONAL_PAGES;
         const apiResponse: { entity: Record<string, string | boolean> } = {

--- a/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.ts
@@ -37,12 +37,12 @@ export class DotPropertiesService {
      * from the dotmarketing-config.properties
      *
      * @param string[] keys
-     * @returns {Observable<Record<string, string>>}
+     * @returns {Observable<Record<string, string | boolean>>}
      * @memberof DotPropertiesService
      */
-    getKeys(keys: string[]): Observable<Record<string, string>> {
+    getKeys(keys: string[]): Observable<Record<string, string | boolean>> {
         return this.http
-            .get<DotCMSResponse<Record<string, string>>>('/api/v1/configuration/config', {
+            .get<DotCMSResponse<Record<string, string | boolean>>>('/api/v1/configuration/config', {
                 params: { keys: keys.join() }
             })
             .pipe(
@@ -101,7 +101,11 @@ export class DotPropertiesService {
             map((flags) => {
                 return Object.entries(flags).reduce(
                     (acc, [key, value]) => {
-                        acc[key] = value === 'true' ? true : value === 'false' ? false : value;
+                        if (typeof value === 'boolean') {
+                            acc[key] = value;
+                        } else {
+                            acc[key] = value === 'true' ? true : value === 'false' ? false : value;
+                        }
 
                         return acc;
                     },

--- a/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-properties/dot-properties.service.ts
@@ -18,13 +18,13 @@ export class DotPropertiesService {
      * from the dotmarketing-config.properties
      *
      * @param string key
-     * @returns {Observable<string>}
+     * @returns {Observable<string | boolean>} Value type depends on the key (e.g. feature flags as booleans).
      * @memberof DotPropertiesService
      */
-    getKey(key: string): Observable<string> {
+    getKey(key: string): Observable<string | boolean> {
         return this.http
             .get<
-                DotCMSResponse<Record<string, string>>
+                DotCMSResponse<Record<string, string | boolean>>
             >('/api/v1/configuration/config', { params: { keys: key } })
             .pipe(
                 take(1),
@@ -78,7 +78,15 @@ export class DotPropertiesService {
      */
     getFeatureFlag(key: FeaturedFlags): Observable<boolean> {
         return this.getKey(key).pipe(
-            map((value) => (value === FEATURE_FLAG_NOT_FOUND ? true : value === 'true'))
+            map((value) => {
+                // /api/v1/configuration/config returns JSON booleans for FEATURE_FLAG_* keys
+                // (see ConfigurationResource) but other keys may still come through as "true"/"false" strings.
+                if (typeof value === 'boolean') {
+                    return value;
+                }
+
+                return value === FEATURE_FLAG_NOT_FOUND ? true : value === 'true';
+            })
         );
     }
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.ts
@@ -35,9 +35,9 @@ export class DotWysiwygPluginService {
             .getKey('WYSIWYG_IMAGE_URL_PATTERN')
             .pipe(
                 takeUntilDestroyed(this.destroyRef$),
-                filter((IMAGE_URL_PATTERN) => !!IMAGE_URL_PATTERN)
+                filter((value): value is string => typeof value === 'string' && !!value)
             )
-            .subscribe((IMAGE_URL_PATTERN: string) => (this.IMAGE_URL_PATTERN = IMAGE_URL_PATTERN));
+            .subscribe((value) => (this.IMAGE_URL_PATTERN = value));
     }
 
     /**

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.ts
@@ -37,7 +37,7 @@ export class DotWysiwygPluginService {
                 takeUntilDestroyed(this.destroyRef$),
                 filter((IMAGE_URL_PATTERN) => !!IMAGE_URL_PATTERN)
             )
-            .subscribe((IMAGE_URL_PATTERN) => (this.IMAGE_URL_PATTERN = IMAGE_URL_PATTERN));
+            .subscribe((IMAGE_URL_PATTERN: string) => (this.IMAGE_URL_PATTERN = IMAGE_URL_PATTERN));
     }
 
     /**

--- a/core-web/libs/portlets/dot-experiments/data-access/src/lib/resolvers/dot-experiments-config-resolver.ts
+++ b/core-web/libs/portlets/dot-experiments/data-access/src/lib/resolvers/dot-experiments-config-resolver.ts
@@ -6,10 +6,13 @@ import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { DotPropertiesService } from '@dotcms/data-access';
 
 @Injectable()
-export class DotExperimentsConfigResolver implements Resolve<Record<string, string> | null> {
+export class DotExperimentsConfigResolver implements Resolve<Record<
+    string,
+    string | boolean
+> | null> {
     private readonly dotConfigurationService = inject(DotPropertiesService);
 
-    resolve(route: ActivatedRouteSnapshot): Observable<Record<string, string>> | null {
+    resolve(route: ActivatedRouteSnapshot): Observable<Record<string, string | boolean>> | null {
         return this.dotConfigurationService.getKeys(route.data['experimentsConfigProps']);
     }
 }

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/store/dot-experiments-configuration-store.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/dot-experiments-configuration/store/dot-experiments-configuration-store.ts
@@ -47,7 +47,7 @@ export interface DotExperimentsConfigurationState {
     experiment: DotExperiment;
     status: ComponentStatus;
     stepStatusSidebar: StepStatus;
-    configProps: Record<string, string>;
+    configProps: Record<string, string | boolean>;
     hasEnterpriseLicense: boolean;
     addToBundleContentId: string;
     pushPublishEnvironments: DotEnvironment[];

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/dot-experiment.utils.ts
@@ -59,18 +59,21 @@ export const getPropertyColors = (index: number): LineChartColorsProperties => {
  * @private
  */
 export const processExperimentConfigProps = (
-    configProps: Record<string, string>
+    configProps: Record<string, string | boolean>
 ): Record<string, number> => {
     const config: Record<string, number> = {};
 
+    const minDurationRaw = configProps['EXPERIMENTS_MIN_DURATION'];
+    const maxDurationRaw = configProps['EXPERIMENTS_MAX_DURATION'];
+
     config['EXPERIMENTS_MIN_DURATION'] =
-        configProps['EXPERIMENTS_MIN_DURATION'] === PROP_NOT_FOUND
+        typeof minDurationRaw !== 'string' || minDurationRaw === PROP_NOT_FOUND
             ? TIME_7_DAYS
-            : daysToMilliseconds(+configProps['EXPERIMENTS_MIN_DURATION']);
+            : daysToMilliseconds(+minDurationRaw);
     config['EXPERIMENTS_MAX_DURATION'] =
-        configProps['EXPERIMENTS_MAX_DURATION'] === PROP_NOT_FOUND
+        typeof maxDurationRaw !== 'string' || maxDurationRaw === PROP_NOT_FOUND
             ? TIME_90_DAYS
-            : daysToMilliseconds(+configProps['EXPERIMENTS_MAX_DURATION']);
+            : daysToMilliseconds(+maxDurationRaw);
 
     return config;
 };


### PR DESCRIPTION
## Summary

- Fixes `DotPropertiesService.getFeatureFlag()` to correctly handle native JSON boolean values (`true`/`false`) returned by `/api/v1/configuration/config` for `FEATURE_FLAG_*` keys — previously only string `"true"` was handled, causing feature flags to silently evaluate as `false` and hiding the Style Editor tab in the Content Type Builder
- Updates `getKey()` return type from `Observable<string>` to `Observable<string | boolean>` to match the actual API contract
- Fixes downstream TypeScript narrowing errors in `DotWysiwygPluginService` and `DotContainersService` caused by the widened return type

## Test plan

- [ ] `yarn nx test data-access` passes including the two new boolean `true`/`false` unit test cases
- [ ] Open the Content Type Builder and verify the **Style Editor** form tab is visible when `FEATURE_FLAG_UVE_STYLE_EDITOR_FOR_TRADITIONAL_PAGES` is enabled on the backend
- [ ] Verify feature flags that return string `"true"` / `"false"` continue to work correctly (backward compatibility)

Fixes #35331

### Video

https://github.com/user-attachments/assets/476e5ffe-a06d-4944-a30a-2223d7c7a17d



🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35331