### PR TITLE
ci: upgrade Claude orchestrator to v2.1.0 — graceful API unavailability skip

### DIFF
--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -80,7 +80,7 @@ jobs:
           )
         )
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.1.0
     with:
       trigger_mode: interactive
       claude_args: '--allowedTools "Bash(git status),Bash(git diff)"'
@@ -108,7 +108,7 @@ jobs:
       !contains(github.event.pull_request.body, '@claude') &&
       !contains(github.event.pull_request.body, '@Claude') &&
       !contains(github.event.pull_request.body, '@CLAUDE')
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.1.0
     with:
       trigger_mode: automatic
       prompt: |
@@ -135,7 +135,7 @@ jobs:
       id-token: write
       pull-requests: write
       issues: write
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v2.1.0
     with:
       trigger_mode: automatic
       prompt: |


### PR DESCRIPTION
## Summary

- Bump `ai-workflows` reference from `v2.0.0` → `v2.1.0` in `ai_claude-orchestrator.yml`
- `v2.1.0` adds pre-flight Anthropic API availability check + runtime error triage

## Problem

When the Claude service has an outage, all PR pipelines fail with:
```
API Error: 500 {"type":"error","error":{"type":"api_error","message":"Internal server error"}} · check status.claude.com
```

Example blocked run: https://github.com/dotCMS/core/actions/runs/24461196854

## What changed in `v2.1.0` (`ai-workflows`)

**Pre-flight check (Layer 1):**
- Calls `GET /v1/models` before running claude-code-action (15s timeout, 2 retries)
- 5xx or network failure → `available=false` → skip Claude step gracefully with `::warning::`
- 401/403/429 or other codes → proceed so the action surfaces the specific error

**Runtime protection (Layer 2):**
- `continue-on-error: true` on the Claude step
- Post-execution step re-checks the API if Claude failed
- API available after failure → re-fail the job ("legitimate error")
- API unavailable after failure → skip gracefully ("service degradation")

## Test

Validated in dotCMS/core-workflow-test#460 (also updated to `v2.1.0`):
- Pre-flight check correctly identifies API availability
- Legitimate errors still surface and fail the job (correct)
- Service outage path is code-correct (pre-flight would skip before Claude runs)

Fixes #35328