### PR TITLE
fix(index): clean up indicies DB rows on all physical delete paths (DO NOT MERGE)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1285,8 +1285,17 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
 
     }
 
-    public boolean delete(String indexName) {
-        return indexAPI.delete(indexName);
+    public boolean delete(final String indexName) {
+        final boolean deleted = indexAPI.delete(indexName);
+        if (deleted) {
+            try {
+                versionedIndicesAPI.removeByIndexName(indexName);
+            } catch (DotDataException e) {
+                Logger.error(this, "Index [" + indexName + "] was physically deleted but the " +
+                        "indices DB row could not be removed: " + e.getMessage(), e);
+            }
+        }
+        return deleted;
     }
 
     public boolean optimize(List<String> indexNames) {

--- a/dotCMS/src/main/java/com/dotcms/content/index/IndicesFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/IndicesFactory.java
@@ -127,4 +127,14 @@ public interface IndicesFactory {
     void insertIndexIfPresent(String indexName, String indexType,
             String version) throws DotDataException;
 
+    /**
+     * Removes the {@code indicies} table row for the given index name.
+     * Handles both plain and {@code os::}-prefixed forms of the name so that
+     * callers do not need to know how the name is stored in the database.
+     *
+     * @param indexName the physical index name (with or without vendor tag)
+     * @throws DotDataException if the name is blank or a SQL error occurs
+     */
+    void removeByIndexName(String indexName) throws DotDataException;
+
 }

--- a/dotCMS/src/main/java/com/dotcms/content/index/IndicesFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/IndicesFactoryImpl.java
@@ -43,6 +43,8 @@ public class IndicesFactoryImpl implements IndicesFactory {
         "SELECT COUNT(*) as count FROM indicies WHERE index_version = ? AND index_version IS NOT NULL";
     private static final String COUNT_INDICES_BY_VERSION_SQL =
         "SELECT COUNT(*) as count FROM indicies WHERE index_version = ? AND index_version IS NOT NULL";
+    private static final String DELETE_INDEX_BY_NAME_SQL =
+        "DELETE FROM indicies WHERE index_name = ? OR index_name = ?";
 
     @Override
     public Optional<VersionedIndices> loadIndices(String version) throws DotDataException {
@@ -357,6 +359,24 @@ public class IndicesFactoryImpl implements IndicesFactory {
             } catch (Exception e) {
                 throw new DotDataException("Failed to insert index: " + indexName, e);
             }
+        }
+    }
+
+    @Override
+    public void removeByIndexName(final String indexName) throws DotDataException {
+        if (!UtilMethods.isSet(indexName)) {
+            throw new DotDataException("Index name cannot be null or empty");
+        }
+        // Always work from the bare name so we can reliably compute both DB forms
+        final String bareName   = IndexTag.strip(indexName);
+        final String taggedName = IndexTag.OS.tag(bareName);
+        try {
+            final DotConnect dotConnect = new DotConnect();
+            final int deleted = dotConnect.executeUpdate(DELETE_INDEX_BY_NAME_SQL, bareName, taggedName);
+            Logger.info(this, "Removed " + deleted + " row(s) from indicies for index: " + bareName);
+        } catch (Exception e) {
+            Logger.error(this, "Failed to remove indicies row for index: " + bareName, e);
+            throw new DotDataException("Failed to remove indicies row for index: " + bareName, e);
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/content/index/VersionedIndicesAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/VersionedIndicesAPI.java
@@ -105,6 +105,16 @@ public interface VersionedIndicesAPI {
     Optional<VersionedIndices> loadDefaultVersionedIndices() throws DotDataException;
 
     /**
+     * Removes the {@code indicies} table row for the given index name.
+     * Handles both plain and {@code os::}-prefixed forms of the name so that
+     * callers do not need to know how the name is stored in the database.
+     *
+     * @param indexName the physical index name (with or without vendor tag)
+     * @throws DotDataException if the name is blank or a SQL error occurs
+     */
+    void removeByIndexName(String indexName) throws DotDataException;
+
+    /**
      * Clears all cached indices data.
      * This should be called when indices are modified outside of this API
      * to ensure cache consistency.

--- a/dotCMS/src/main/java/com/dotcms/content/index/VersionedIndicesAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/VersionedIndicesAPIImpl.java
@@ -229,6 +229,23 @@ public class VersionedIndicesAPIImpl implements VersionedIndicesAPI {
     /**
      * {@inheritDoc}
      */
+    @WrapInTransaction
+    @Override
+    public void removeByIndexName(final String indexName) throws DotDataException {
+        Logger.debug(this, "Removing indices row for index: " + indexName);
+        indicesFactory.removeByIndexName(indexName);
+        // Flush all index-related caches so no stale names survive the deletion:
+        // 1. VersionedIndicesCache — our own versioned-index cache
+        cache.clearCache();
+        // 2. IndiciesCache — legacy (ES, non-versioned) index cache used by IndiciesFactory
+        CacheLocator.getIndiciesCache().clearCache();
+        // 3. ESQueryCache — cached search queries that may reference the deleted index name
+        CacheLocator.getESQueryCache().clearCache();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public void clearCache() {
         cache.clearCache();
         Logger.info(this, "VersionedIndicesAPI cache cleared");

--- a/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImplTest.java
@@ -374,6 +374,15 @@ public class ContentletIndexAPIImplTest extends IntegrationTestBase {
 
         //Verify we just added two more indices
         assertEquals(oldIndices, newIndices);
+
+        // Verify the indicies table has no orphan rows for the deleted indices
+        final DotConnect dc = new DotConnect();
+        dc.setSQL("SELECT COUNT(*) AS cnt FROM indicies WHERE index_name = ? OR index_name = ?");
+        dc.addParam(workingIndex);
+        dc.addParam(liveIndex);
+        final List<Map<String, Object>> rows = dc.loadResults();
+        assertEquals("indicies table must have no orphan rows after delete",
+                0L, Long.parseLong(rows.get(0).get("cnt").toString()));
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes #35306 — `ContentletIndexAPIImpl.delete()` physically removed the index from the search provider but never deleted the corresponding row from the `indicies` table.

After a successful physical delete, a stale DB entry would remain pointing to a non-existent index, which could cause startup failures or silent inconsistencies on the next boot.

## Root cause

The bug only occurs when `delete()` is called on an **active** index without a prior `deactivateIndex()` call (e.g., direct REST call to `DELETE /api/v1/esindex/{name}`). In the normal UI workflow, `deactivateIndex()` clears the DB row via `point()` before `delete()` is called, so no orphan is left.

## Fix

After a successful physical delete, `versionedIndicesAPI.removeByIndexName()` is called to clean up the `indicies` row.

**Phase safety:**
- **Physical delete**: `indexAPI` resolves to `IndexAPIImpl` (the phase-aware router) — fans out to ES, OS, or both depending on the active migration phase.
- **DB cleanup**: `versionedIndicesAPI.removeByIndexName()` issues `DELETE FROM indicies WHERE index_name = ? OR index_name = ?` (bare + `os::` tagged forms), covering both legacy non-versioned rows (ES, phases 0/1/2) and versioned OS rows (phase 3) in a single call. The deprecated `legacyIndiciesAPI` is not involved.

## Test plan

- [ ] `DELETE /api/v1/esindex/{name}` on an active index → row removed from `indicies` table
- [ ] `DELETE /api/v1/esindex/{name}` on an already-deactivated index → no error (row already gone, `removeByIndexName` is a no-op)
- [ ] Verify across all phases (0, 1, 2, 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)