### PR TITLE
fix(opensearch): ensure OS indices always created with custom analyzers — fixes #35305

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOS.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ContentletIndexOperationsOS.java
@@ -206,12 +206,7 @@ public class ContentletIndexOperationsOS implements ContentletIndexOperations {
     @Override
     public boolean createContentIndex(final String indexName, final int shards)
             throws IOException {
-        String settings = null;
-        try {
-            settings = JsonUtil.getJsonFileContentAsString(OS_SETTINGS_FILE);
-        } catch (Exception e) {
-            Logger.error(this, "cannot load " + OS_SETTINGS_FILE + ", skipping", e);
-        }
+        final String settings = JsonUtil.getJsonFileContentAsString(OS_SETTINGS_FILE);
 
         final String mapping = JsonUtil.getJsonFileContentAsString(CONTENT_MAPPING_FILE);
         final CreateIndexStatus status = osIndexAPI.createIndex(indexName, settings, shards);

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/OSIndexAPIImpl.java
@@ -455,13 +455,13 @@ public class OSIndexAPIImpl implements IndexAPI {
         String settings = null;
         try {
             final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-            final URL url = classLoader.getResource("opensearch-content-settings.json");
+            final URL url = classLoader.getResource("os-content-settings.json");
             if (url != null) {
                 settings = new String(com.liferay.util.FileUtil.getBytes(new File(url.getPath())));
             }
         } catch (Exception e) {
             Logger.error(this.getClass(),
-                "Cannot load opensearch-content-settings.json file, using defaults", e);
+                "Cannot load os-content-settings.json file, using defaults", e);
         }
 
         if (settings == null) {


### PR DESCRIPTION
## Summary

- **`OSIndexAPIImpl.getDefaultIndexSettings()`**: was loading `opensearch-content-settings.json` (a file that does not exist in the classpath), silently falling back to minimal hardcoded settings without the `analysis` block. This caused `clearIndex()` to recreate OS indices without `my_analyzer`, making all subsequent `addCustomMapping()` `putMapping` calls fail with HTTP 400 on OS 3.4.0. Changed to load `os-content-settings.json` (the file that actually exists).
- **`ContentletIndexOperationsOS.createContentIndex()`**: was swallowing the `IOException` from the settings file load and continuing with `settings = null`, allowing index creation without custom analyzers. The silent `catch` is removed so the failure propagates before any `putMapping` call is made against an under-configured index.

## Root cause

`addCustomMapping` generates explicit field-level `"analyzer":"my_analyzer"` mappings for text fields (`TextField`, `TextAreaField`, `WysiwygField`, etc.). OS 3.4.0 rejects these with HTTP 400 when the index was created without defining `my_analyzer` in its analysis settings:

```
{"error":{"reason":"analyzer [my_analyzer] has not been configured in mappings"},"status":400}
```

Reproduction steps and full analysis: https://github.com/dotCMS/core/issues/35305#issuecomment-4261162837

## Test plan

- [ ] Start the `os-migration` Docker stack (OS 3.4.0 at `localhost:9201`)
- [ ] Run the curl reproduction steps from the issue comment — all `putMapping` calls should return HTTP 200
- [ ] Trigger `clearIndex()` via admin UI (System → Reindex), confirm the recreated OS index has `my_analyzer` via `GET /{index}/_settings`
- [ ] Boot dotCMS with `DOT_FEATURE_FLAG_OPEN_SEARCH_PHASE=3` and verify OS indices are created with analyzers and `addCustomMapping` logs no 400 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35305

This PR fixes: #35305