### PR TITLE
fix(vanity-url): restore /c/ trailing slash in BACKEND_FILTERED_COLLECTION

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/filters/CMSUrlUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/filters/CMSUrlUtil.java
@@ -69,7 +69,7 @@ public class CMSUrlUtil {
 	private static final String UNABLE_TO_FIND = "Unable to find ";
 
 	public static final Set<String> BACKEND_FILTERED_COLLECTION =
-			Stream.of("/api", "/webdav", "/dA", "/c", "/contentAsset", "/DOTSASS", "/DOTLESS",
+			Stream.of("/api", "/webdav", "/dA", "/c/", "/contentAsset", "/DOTSASS", "/DOTLESS",
 					"/html", "/dotAdmin", "/custom-elements","/dotcms-webcomponents","/dwr")
 					.collect(Collectors.collectingAndThen(toSet(), Collections::unmodifiableSet));
 

--- a/dotCMS/src/test/java/com/dotmarketing/filters/CMSUrlUtilTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/filters/CMSUrlUtilTest.java
@@ -79,6 +79,31 @@ public class CMSUrlUtilTest {
     }
 
     /**
+     * Method To Test: {@link CMSUrlUtil#isVanityUrlFiltered(String)}
+     * Given Scenario: URLs starting with "c" that are NOT the /c/ content asset endpoint
+     * ExpectedResult: Must return false — regression guard for PR #35151 which changed /c/ to /c,
+     * causing isVanityUrlFiltered() to match any URL beginning with "c".
+     */
+    @Test
+    public void testIsVanityUrlFiltered_vanityUrlsStartingWithC_shouldNotBeFiltered() {
+        final CMSUrlUtil util = CMSUrlUtil.getInstance();
+        assertFalse("Vanity URL /calculators should not be filtered", util.isVanityUrlFiltered("/calculators/home-loan/mortgage-calculator"));
+        assertFalse("Vanity URL /contact should not be filtered", util.isVanityUrlFiltered("/contact"));
+        assertFalse("Vanity URL /careers should not be filtered", util.isVanityUrlFiltered("/careers/open-positions"));
+    }
+
+    /**
+     * Method To Test: {@link CMSUrlUtil#isVanityUrlFiltered(String)}
+     * Given Scenario: The internal /c/ content asset endpoint
+     * ExpectedResult: Must return true so the internal endpoint is still excluded
+     */
+    @Test
+    public void testIsVanityUrlFiltered_contentAssetEndpoint_shouldBeFiltered() {
+        final CMSUrlUtil util = CMSUrlUtil.getInstance();
+        assertTrue("Internal /c/ endpoint should be filtered", util.isVanityUrlFiltered("/c/uuid-here/fileAsset/file.vtl"));
+    }
+
+    /**
      * Given scenario: Test the request comes from dotAdmin
      * Expected result: Should return true if the referer is a valid dotAdmin referer
      */


### PR DESCRIPTION
## Summary
- Restores the trailing slash on \`/c/\` in \`CMSUrlUtil.BACKEND_FILTERED_COLLECTION\` — one character change: \`/c\` → \`/c/\`
- \`isVanityUrlFiltered()\` uses raw \`url.startsWith(prefix)\`, so without the slash, prefix \`/c\` matches **any** URL beginning with the letter "c" (e.g. \`/calculators\`, \`/contact\`, \`/customers\`), causing \`VanityURLFilter\` to skip vanity URL resolution for those paths entirely
- Confirmed broken in production on \`26.04.11-01_1007280\`, working on \`26.03.27-01_73a99ad\`

## Root Cause
PR #35151 changed \`/c/\` to \`/c\` in \`BACKEND_FILTERED_COLLECTION\`. The \`internalUrl()\` method added in that PR appends \`"/"\` before calling \`startsWith()\` so it is safe — but the pre-existing \`isVanityUrlFiltered()\` does not, making \`/c\` an overly broad prefix that matches all \`c*\` URLs.

## Test plan
- [ ] Request a vanity URL whose URI starts with \`c\` (e.g. \`/calculators/home-loan/mortgage-calculator\`) — should resolve correctly instead of returning 404
- [ ] Request \`/c/<uuid>/fileAsset/...\` (content asset endpoint) — should still be excluded as an internal URL
- [ ] Run \`CMSUrlUtilTest\` — two new regression tests cover both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)