### PR TITLE
fix(opensearch): prevent ES index recreation and spurious reads in Phase 3

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -400,9 +400,16 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     @VisibleForTesting
     @CloseDBIfOpened
     public synchronized boolean indexReady() throws DotDataException {
-        if(isMigrationNotStarted()) {
+        if (isMigrationNotStarted()) {
             return indexReadyES();
         }
+        if (isMigrationComplete()) {
+            // Phase 3: ES is decommissioned — only OS must be ready.
+            // Calling indexReadyES() here would query a decommissioned cluster and
+            // incorrectly trigger bootstrapAndPoint, recreating ES indices.
+            return indexReadyOS();
+        }
+        // Phases 1 and 2: dual-write — both providers must be ready.
         return indexReadyES() && indexReadyOS();
     }
 
@@ -608,7 +615,8 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
             return IndexStartResult.empty();
         }
 
-        final boolean esNeeded = !indexReadyES();
+        // Phase 3: ES is decommissioned — never create ES indices, even if they are absent.
+        final boolean esNeeded = !isMigrationComplete() && !indexReadyES();
         final boolean osNeeded = isMigrationStarted() && !indexReadyOS();
 
         final String ts = ContentletIndexAPI.threadSafeTimestampFormatter.format(LocalDateTime.now());

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/BulkProcessorListener.java
@@ -1,5 +1,6 @@
 package com.dotmarketing.common.reindex;
 
+import com.dotcms.content.index.IndexConfigHelper;
 import com.dotcms.content.index.IndexTag;
 import com.dotcms.content.index.domain.IndexBulkItemResult;
 import com.dotcms.content.index.domain.IndexBulkListener;
@@ -45,9 +46,14 @@ public class BulkProcessorListener implements IndexBulkListener {
      */
     private final boolean shadow;
 
-    /** Default: primary ES listener (used by ReindexThread — no caller change needed). */
+    /**
+     * Creates the primary listener for the current migration phase.
+     * Phase 3 (OS only) labels itself {@link IndexTag#OS}; all other phases label
+     * themselves {@link IndexTag#ES} (ES is primary or dual-write leader).
+     */
     BulkProcessorListener() {
-        this(IndexTag.ES, false);
+        this(IndexConfigHelper.MigrationPhase.current().isMigrationComplete()
+                ? IndexTag.OS : IndexTag.ES, false);
     }
 
     private BulkProcessorListener(final IndexTag provider, final boolean shadow) {


### PR DESCRIPTION
## Summary
In Phase 3 (`PHASE_3_OPENSEARCH_ONLY`) the system was still checking ES index readiness on every `checkAndInitializeIndex()` cycle, querying the decommissioned ES cluster and recreating ES indices when none existed. This PR adds three Phase 3 guards to stop all unintended ES traffic.

Closes #34934

## Changes

**`ContentletIndexAPIImpl`**
- `indexReady()`: short-circuits to `indexReadyOS()` when `isMigrationComplete()` — no longer calls `indexReadyES()` in Phase 3
- `initIndex()`: guards `esNeeded` with `!isMigrationComplete()` so `bootstrapAndPoint` never creates ES indices in Phase 3

**`BulkProcessorListener`**
- No-arg constructor resolves the primary `IndexTag` from `MigrationPhase.current()` — Phase 3 reindex logs now correctly show `[OS]` instead of `[ES]`, and the config gate `REINDEX_BULK_LOG_OS_PROVIDER` applies instead of the ES one

## Testing
1. Start dotCMS with `FEATURE_FLAG_OPEN_SEARCH_PHASE=3`
2. Trigger a content publish — verify no ES index creation logs appear
3. Verify reindex logs show `[OS]` prefix
4. Verify no requests are made to the ES cluster (Kibana / ES logs stay silent)

## Breaking Changes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)