### PR TITLE
fix(examples): restore nextjs example to use published SDK packages

### DIFF
--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -11,9 +11,9 @@
     "dependencies": {
         "@dotcms/client": "latest",
         "@dotcms/experiments": "latest",
-        "@dotcms/react": "file:../../../../../dotcms-react-1.2.6.tgz",
-        "@dotcms/types": "file:../../../../../dotcms-types-1.1.1.tgz",
-        "@dotcms/uve": "file:../../../../../dotcms-uve-1.1.1.tgz",
+        "@dotcms/react": "latest",
+        "@dotcms/types": "latest",
+        "@dotcms/uve": "latest",
         "@tinymce/tinymce-react": "6.2.1",
         "next": "^15.5.9",
         "react": "19.2.1",


### PR DESCRIPTION
## Summary

- Reverts `@dotcms/react`, `@dotcms/types`, and `@dotcms/uve` in the Next.js example from local `.tgz` file references back to `latest` published versions
- Local `.tgz` references were pointing to files that don't exist in the repo and break the example for anyone cloning it

## Test plan

- [ ] Run `npm install` in `examples/nextjs` and verify dependencies resolve correctly
- [ ] Confirm the example starts with `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34555

This PR fixes: #34555