### PR TITLE
fix(docker): silence FileNotFoundException noise on opensearch-upgrade container startup

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -388,6 +388,10 @@
                                         <bootstrap.memory_lock>true</bootstrap.memory_lock>
                                         <DISABLE_SECURITY_PLUGIN>true</DISABLE_SECURITY_PLUGIN>
                                         <OPENSEARCH_JAVA_OPTS>-Xms512m -Xmx512m -XX:-UseContainerSupport</OPENSEARCH_JAVA_OPTS>
+                                        <!-- Prevents opensearch-performance-analyzer from initializing its
+                                             RCA/stats collectors, which fail on startup in the 3.x Docker
+                                             image due to a missing plugin-stats-metadata config file. -->
+                                        <DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI>true</DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI>
                                     </env>
                                     <ports>
                                         <port>os.upgrade.port:9200</port>
@@ -404,19 +408,6 @@
                                             <soft>-1</soft>
                                         </ulimit>
                                     </ulimits>
-                                    <entrypoint>
-                                        <!-- opensearch-performance-analyzer in 3.x Docker images omits
-                                             plugin-stats-metadata from the config directory, causing a
-                                             FileNotFoundException at plugin init (harmless noise, but noisy).
-                                             Override the entrypoint to create the missing file first, then
-                                             delegate to the original entrypoint. exec form avoids ENTRYPOINT
-                                             wrapping issues that occur with <cmd><shell>. -->
-                                        <exec>
-                                            <arg>/bin/sh</arg>
-                                            <arg>-c</arg>
-                                            <arg>mkdir -p /usr/share/opensearch/config/opensearch-performance-analyzer; touch /usr/share/opensearch/config/opensearch-performance-analyzer/plugin-stats-metadata; exec /usr/share/opensearch/opensearch-docker-entrypoint.sh opensearch</arg>
-                                        </exec>
-                                    </entrypoint>
                                     <wait>
                                         <http>
                                             <!--suppress UnresolvedMavenProperty -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -404,13 +404,19 @@
                                             <soft>-1</soft>
                                         </ulimit>
                                     </ulimits>
-                                    <cmd>
+                                    <entrypoint>
                                         <!-- opensearch-performance-analyzer in 3.x Docker images omits
                                              plugin-stats-metadata from the config directory, causing a
                                              FileNotFoundException at plugin init (harmless noise, but noisy).
-                                             Create the file before handing off to the normal entrypoint. -->
-                                        <shell>mkdir -p /usr/share/opensearch/config/opensearch-performance-analyzer &amp;&amp; touch /usr/share/opensearch/config/opensearch-performance-analyzer/plugin-stats-metadata &amp;&amp; /usr/share/opensearch/opensearch-docker-entrypoint.sh opensearch</shell>
-                                    </cmd>
+                                             Override the entrypoint to create the missing file first, then
+                                             delegate to the original entrypoint. exec form avoids ENTRYPOINT
+                                             wrapping issues that occur with <cmd><shell>. -->
+                                        <exec>
+                                            <arg>/bin/sh</arg>
+                                            <arg>-c</arg>
+                                            <arg>mkdir -p /usr/share/opensearch/config/opensearch-performance-analyzer; touch /usr/share/opensearch/config/opensearch-performance-analyzer/plugin-stats-metadata; exec /usr/share/opensearch/opensearch-docker-entrypoint.sh opensearch</arg>
+                                        </exec>
+                                    </entrypoint>
                                     <wait>
                                         <http>
                                             <!--suppress UnresolvedMavenProperty -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -388,10 +388,6 @@
                                         <bootstrap.memory_lock>true</bootstrap.memory_lock>
                                         <DISABLE_SECURITY_PLUGIN>true</DISABLE_SECURITY_PLUGIN>
                                         <OPENSEARCH_JAVA_OPTS>-Xms512m -Xmx512m -XX:-UseContainerSupport</OPENSEARCH_JAVA_OPTS>
-                                        <!-- Prevents opensearch-performance-analyzer from initializing its
-                                             RCA/stats collectors, which fail on startup in the 3.x Docker
-                                             image due to a missing plugin-stats-metadata config file. -->
-                                        <DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI>true</DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI>
                                     </env>
                                     <ports>
                                         <port>os.upgrade.port:9200</port>
@@ -408,6 +404,18 @@
                                             <soft>-1</soft>
                                         </ulimit>
                                     </ulimits>
+                                    <entrypoint>
+                                        <!-- opensearch-performance-analyzer in 3.x Docker images omits
+                                             plugin-stats-metadata from the config dir, causing a
+                                             FileNotFoundException at plugin init. Create the missing file
+                                             before exec-ing the original entrypoint. Using <exec> form to
+                                             avoid ENTRYPOINT/CMD wrapping issues with <cmd><shell>. -->
+                                        <exec>
+                                            <arg>/bin/sh</arg>
+                                            <arg>-c</arg>
+                                            <arg>mkdir -p /usr/share/opensearch/config/opensearch-performance-analyzer; touch /usr/share/opensearch/config/opensearch-performance-analyzer/plugin-stats-metadata; exec /usr/share/opensearch/opensearch-docker-entrypoint.sh opensearch</arg>
+                                        </exec>
+                                    </entrypoint>
                                     <wait>
                                         <http>
                                             <!--suppress UnresolvedMavenProperty -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -404,6 +404,13 @@
                                             <soft>-1</soft>
                                         </ulimit>
                                     </ulimits>
+                                    <cmd>
+                                        <!-- opensearch-performance-analyzer in 3.x Docker images omits
+                                             plugin-stats-metadata from the config directory, causing a
+                                             FileNotFoundException at plugin init (harmless noise, but noisy).
+                                             Create the file before handing off to the normal entrypoint. -->
+                                        <shell>mkdir -p /usr/share/opensearch/config/opensearch-performance-analyzer &amp;&amp; touch /usr/share/opensearch/config/opensearch-performance-analyzer/plugin-stats-metadata &amp;&amp; /usr/share/opensearch/opensearch-docker-entrypoint.sh opensearch</shell>
+                                    </cmd>
                                     <wait>
                                         <http>
                                             <!--suppress UnresolvedMavenProperty -->


### PR DESCRIPTION
## Summary

This is log noise only — OpenSearch starts and operates normally despite the error.

- The `opensearch-performance-analyzer` plugin in `opensearch:3.4.0` expects `plugin-stats-metadata` inside its config dir, but the Docker image ships without it, causing a `FileNotFoundException` stack trace on every `just dev-run` startup
- The error is thrown in `PerformanceAnalyzerPlugin.<init>()` before any env-var guard can suppress it, so `DISABLE_PERFORMANCE_ANALYZER_AGENT_CLI` is not an effective workaround
- Fix: override the container `cmd` in `parent/pom.xml` to `mkdir + touch` the missing file before delegating to `opensearch-docker-entrypoint.sh`

Closes #35358

## Test plan

- [ ] Run `just dev-run` and verify `[OS-UPGRADE]` log no longer shows the `FileNotFoundException` stack trace
- [ ] Confirm `opensearch-upgrade` container passes its health check and is reachable on port 9201

🤖 Generated with [Claude Code](https://claude.com/claude-code)