### PR TITLE
fix(experiments): support /cmsHomePage vanity for experiment URL matching

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -86,7 +86,7 @@ public enum ExperimentUrlPatternCalculator {
                 .findByForward(host, language, htmlPageAsset.getURI(), 200);
 
         final Stream<String> vanityPatterns = vanityUrls.stream()
-                .map(vanity -> String.format(DEFAULT_URL_REGEX_TEMPLATE, vanity.pattern));
+                .map(vanity -> String.format(DEFAULT_URL_REGEX_TEMPLATE, vanity.pattern.pattern()));
 
         // A /cmsHomePage vanity is reached when a visitor requests "/" (see
         // VanityUrlAPIImpl.resolveVanityUrl legacy fallback), so the browser URL

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -7,7 +7,7 @@ import static com.dotcms.util.CollectionsUtils.list;
 
 import com.dotcms.analytics.metrics.*;
 import com.dotcms.experiments.model.Experiment;
-import com.dotcms.vanityurl.business.VanityUrlAPIImpl;
+import com.dotcms.vanityurl.business.VanityUrlAPI;
 import com.dotcms.vanityurl.model.CachedVanityUrl;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
@@ -92,7 +92,7 @@ public enum ExperimentUrlPatternCalculator {
         // VanityUrlAPIImpl.resolveVanityUrl legacy fallback), so the browser URL
         // at the experiment page stays "/" — add it as an extra alternative.
         final Stream<String> cmsHomePageFallback = vanityUrls.stream()
-                .anyMatch(vanity -> VanityUrlAPIImpl.LEGACY_CMS_HOME_PAGE.equals(vanity.url))
+                .anyMatch(vanity -> VanityUrlAPI.LEGACY_CMS_HOME_PAGE.equals(vanity.url))
                 ? Stream.of(String.format(DEFAULT_URL_REGEX_TEMPLATE, "\\/?"))
                 : Stream.empty();
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -53,6 +53,14 @@ public enum ExperimentUrlPatternCalculator {
      * If the page use inside the Experiment isuse as Detail Page on any Content Type then is even
      * more complicated.
      *
+     * <p><b>Security note:</b> The returned pattern is serialized to the
+     * Experiments Analytics SDK and evaluated client-side via
+     * {@code new RegExp(...).test(...)}. Because Vanity URL URIs can contain
+     * admin-authored regex, the assembled pattern is NOT protected by
+     * {@link com.dotcms.regex.MatcherTimeoutFactory} (which only guards the
+     * server-side Vanity URL resolver). Client-side ReDoS protection is tracked
+     * as a follow-up in <a href="https://github.com/dotCMS/core/issues/35379">#35379</a>.
+     *
      * @param experiment
      * @return
      */
@@ -85,16 +93,22 @@ public enum ExperimentUrlPatternCalculator {
         final List<CachedVanityUrl> vanityUrls = APILocator.getVanityUrlAPI()
                 .findByForward(host, language, htmlPageAsset.getURI(), 200);
 
+        // Exact match is intentional — regex-based cmsHomePage URIs (e.g. "/cmsHome.*")
+        // are unsupported here. VanityUrlAPIImpl.resolveVanityUrl's legacy fallback
+        // looks up the literal LEGACY_CMS_HOME_PAGE string, so only vanities whose
+        // URI equals it (case-insensitive) actually participate in the "/" fallback.
+        final boolean hasCmsHomePageVanity = vanityUrls.stream()
+                .anyMatch(vanity -> VanityUrlAPI.LEGACY_CMS_HOME_PAGE.equalsIgnoreCase(vanity.url));
+
         // When a /cmsHomePage vanity forwards to the experiment page, visitors
         // reach it at "/" (see VanityUrlAPIImpl.resolveVanityUrl legacy fallback)
         // — add "/" as an extra alternative so the regex still matches.
         final String vanityUrlRegex = Stream.concat(
                 vanityUrls.stream()
                         .map(vanity -> String.format(DEFAULT_URL_REGEX_TEMPLATE, vanity.pattern.pattern())),
-                vanityUrls.stream()
-                        .anyMatch(vanity -> VanityUrlAPI.LEGACY_CMS_HOME_PAGE.equalsIgnoreCase(vanity.url))
-                                ? Stream.of(String.format(DEFAULT_URL_REGEX_TEMPLATE, "\\/?"))
-                                : Stream.empty()
+                hasCmsHomePageVanity
+                        ? Stream.of(String.format(DEFAULT_URL_REGEX_TEMPLATE, "\\/?"))
+                        : Stream.empty()
         ).collect(Collectors.joining(StringPool.PIPE));
 
         // Lowercase the assembled vanity regex for parity with the experiment

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -119,6 +119,11 @@ public enum ExperimentUrlPatternCalculator {
         // — add "/" as an extra alternative so the regex still matches.
         final String vanityUrlRegex = Stream.concat(
                 vanityUrls.stream()
+                        // Skip vanities whose URI failed CachedVanityUrl.normalize
+                        // (VanityUrlUtil.isValidRegex returned false) — their
+                        // compiled Pattern's source is "", which would otherwise
+                        // expand the URL template into a catch-all.
+                        .filter(vanity -> !vanity.pattern.pattern().isEmpty())
                         .map(vanity -> String.format(DEFAULT_URL_REGEX_TEMPLATE, vanity.pattern.pattern())),
                 hasCmsHomePageVanity
                         ? Stream.of(String.format(DEFAULT_URL_REGEX_TEMPLATE, "\\/?"))

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -7,6 +7,7 @@ import static com.dotcms.util.CollectionsUtils.list;
 
 import com.dotcms.analytics.metrics.*;
 import com.dotcms.experiments.model.Experiment;
+import com.dotcms.vanityurl.business.VanityUrlAPIImpl;
 import com.dotcms.vanityurl.model.CachedVanityUrl;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
@@ -21,6 +22,7 @@ import com.liferay.util.StringPool;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Util class to calculate the regex pattern for a given {@link HTMLPageAsset}
@@ -80,11 +82,23 @@ public enum ExperimentUrlPatternCalculator {
     private static String getVanityUrlsRegex(final Host host, final Language language,
                                              final HTMLPageAsset htmlPageAsset) throws DotDataException {
 
-        final String vanityUrlRegex = APILocator.getVanityUrlAPI()
-                .findByForward(host, language, htmlPageAsset.getURI(), 200)
-                .stream()
-                .map(vanitysUrls -> String.format(DEFAULT_URL_REGEX_TEMPLATE, vanitysUrls.pattern))
+        final List<CachedVanityUrl> vanityUrls = APILocator.getVanityUrlAPI()
+                .findByForward(host, language, htmlPageAsset.getURI(), 200);
+
+        final Stream<String> vanityPatterns = vanityUrls.stream()
+                .map(vanity -> String.format(DEFAULT_URL_REGEX_TEMPLATE, vanity.pattern));
+
+        // A /cmsHomePage vanity is reached when a visitor requests "/" (see
+        // VanityUrlAPIImpl.resolveVanityUrl legacy fallback), so the browser URL
+        // at the experiment page stays "/" — add it as an extra alternative.
+        final Stream<String> cmsHomePageFallback = vanityUrls.stream()
+                .anyMatch(vanity -> VanityUrlAPIImpl.LEGACY_CMS_HOME_PAGE.equals(vanity.url))
+                ? Stream.of(String.format(DEFAULT_URL_REGEX_TEMPLATE, "\\/?"))
+                : Stream.empty();
+
+        final String vanityUrlRegex = Stream.concat(vanityPatterns, cmsHomePageFallback)
                 .collect(Collectors.joining(StringPool.PIPE));
+
         return vanityUrlRegex.isEmpty() ? StringPool.BLANK : String.format("^%s$", vanityUrlRegex);
     }
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -61,6 +61,17 @@ public enum ExperimentUrlPatternCalculator {
      * server-side Vanity URL resolver). Client-side ReDoS protection is tracked
      * as a follow-up in <a href="https://github.com/dotCMS/core/issues/35379">#35379</a>.
      *
+     * <p><b>Case folding:</b> The returned pattern is emitted entirely in
+     * lowercase — both the experiment-page alternative and every Vanity URL
+     * alternative — to match the SDK tracker, which lowercases the incoming
+     * URL path before calling {@code test}. As a side effect, any admin-authored
+     * vanity URI that relies on uppercase characters or uppercase-only
+     * character classes (e.g. {@code [A-Z]+}) is folded to lowercase in this
+     * path; such patterns are unsupported here. This is consistent with the
+     * server-side resolver, which already compiles vanity patterns with
+     * {@link java.util.regex.Pattern#CASE_INSENSITIVE} so case-sensitive regex
+     * constructs do not influence vanity matching in any consumer.
+     *
      * @param experiment
      * @return
      */
@@ -111,11 +122,16 @@ public enum ExperimentUrlPatternCalculator {
                         : Stream.empty()
         ).collect(Collectors.joining(StringPool.PIPE));
 
-        // Lowercase the assembled vanity regex for parity with the experiment
-        // page regex (see calculatePageUrlRegexPattern) and to align with the
-        // SDK's verifyRegex, which lowercases the incoming URL path before
-        // matching. Without this, a mixed-case vanity URI stored by the admin
-        // would never match the lowercased client-side path.
+        // Lowercase the ENTIRE assembled vanity regex — this affects every
+        // vanity pattern joined above, not just the /cmsHomePage fallback. The
+        // SDK (parser.ts#verifyRegex) lowercases the incoming URL path before
+        // calling RegExp.test, so a mixed-case vanity URI stored by the admin
+        // would otherwise never match. Consequence: any admin-authored regex
+        // construct that depends on uppercase characters (e.g. "[A-Z]+") is
+        // folded to lowercase here and is unsupported in this path. This is
+        // consistent with CachedVanityUrl, which compiles each vanity's URI
+        // pattern with Pattern.CASE_INSENSITIVE — server-side vanity matching
+        // is already case-insensitive, so no consumer loses functionality.
         return vanityUrlRegex.isEmpty() ? StringPool.BLANK : String.format("^%s$", vanityUrlRegex).toLowerCase();
     }
 

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -85,19 +85,17 @@ public enum ExperimentUrlPatternCalculator {
         final List<CachedVanityUrl> vanityUrls = APILocator.getVanityUrlAPI()
                 .findByForward(host, language, htmlPageAsset.getURI(), 200);
 
-        final Stream<String> vanityPatterns = vanityUrls.stream()
-                .map(vanity -> String.format(DEFAULT_URL_REGEX_TEMPLATE, vanity.pattern.pattern()));
-
-        // A /cmsHomePage vanity is reached when a visitor requests "/" (see
-        // VanityUrlAPIImpl.resolveVanityUrl legacy fallback), so the browser URL
-        // at the experiment page stays "/" — add it as an extra alternative.
-        final Stream<String> cmsHomePageFallback = vanityUrls.stream()
-                .anyMatch(vanity -> VanityUrlAPI.LEGACY_CMS_HOME_PAGE.equals(vanity.url))
-                ? Stream.of(String.format(DEFAULT_URL_REGEX_TEMPLATE, "\\/?"))
-                : Stream.empty();
-
-        final String vanityUrlRegex = Stream.concat(vanityPatterns, cmsHomePageFallback)
-                .collect(Collectors.joining(StringPool.PIPE));
+        // When a /cmsHomePage vanity forwards to the experiment page, visitors
+        // reach it at "/" (see VanityUrlAPIImpl.resolveVanityUrl legacy fallback)
+        // — add "/" as an extra alternative so the regex still matches.
+        final String vanityUrlRegex = Stream.concat(
+                vanityUrls.stream()
+                        .map(vanity -> String.format(DEFAULT_URL_REGEX_TEMPLATE, vanity.pattern.pattern())),
+                vanityUrls.stream()
+                        .anyMatch(vanity -> VanityUrlAPI.LEGACY_CMS_HOME_PAGE.equals(vanity.url))
+                                ? Stream.of(String.format(DEFAULT_URL_REGEX_TEMPLATE, "\\/?"))
+                                : Stream.empty()
+        ).collect(Collectors.joining(StringPool.PIPE));
 
         return vanityUrlRegex.isEmpty() ? StringPool.BLANK : String.format("^%s$", vanityUrlRegex);
     }

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -97,7 +97,12 @@ public enum ExperimentUrlPatternCalculator {
                                 : Stream.empty()
         ).collect(Collectors.joining(StringPool.PIPE));
 
-        return vanityUrlRegex.isEmpty() ? StringPool.BLANK : String.format("^%s$", vanityUrlRegex);
+        // Lowercase the assembled vanity regex for parity with the experiment
+        // page regex (see calculatePageUrlRegexPattern) and to align with the
+        // SDK's verifyRegex, which lowercases the incoming URL path before
+        // matching. Without this, a mixed-case vanity URI stored by the admin
+        // would never match the lowercased client-side path.
+        return vanityUrlRegex.isEmpty() ? StringPool.BLANK : String.format("^%s$", vanityUrlRegex).toLowerCase();
     }
 
     private HTMLPageAsset getHtmlPageAsset(final Experiment experiment) {

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -92,7 +92,7 @@ public enum ExperimentUrlPatternCalculator {
                 vanityUrls.stream()
                         .map(vanity -> String.format(DEFAULT_URL_REGEX_TEMPLATE, vanity.pattern.pattern())),
                 vanityUrls.stream()
-                        .anyMatch(vanity -> VanityUrlAPI.LEGACY_CMS_HOME_PAGE.equals(vanity.url))
+                        .anyMatch(vanity -> VanityUrlAPI.LEGACY_CMS_HOME_PAGE.equalsIgnoreCase(vanity.url))
                                 ? Stream.of(String.format(DEFAULT_URL_REGEX_TEMPLATE, "\\/?"))
                                 : Stream.empty()
         ).collect(Collectors.joining(StringPool.PIPE));

--- a/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
+++ b/dotCMS/src/main/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculator.java
@@ -101,8 +101,11 @@ public enum ExperimentUrlPatternCalculator {
     private static String getVanityUrlsRegex(final Host host, final Language language,
                                              final HTMLPageAsset htmlPageAsset) throws DotDataException {
 
+        // includeSystemHost=true: a /cmsHomePage vanity forwarding to the
+        // experiment page may be published on SYSTEM_HOST (site-wide), so we
+        // need those matches as well. Mirrors resolveVanityUrl's host fallback.
         final List<CachedVanityUrl> vanityUrls = APILocator.getVanityUrlAPI()
-                .findByForward(host, language, htmlPageAsset.getURI(), 200);
+                .findByForward(host, language, htmlPageAsset.getURI(), 200, true);
 
         // Exact match is intentional — regex-based cmsHomePage URIs (e.g. "/cmsHome.*")
         // are unsupported here. VanityUrlAPIImpl.resolveVanityUrl's legacy fallback

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
@@ -119,25 +119,28 @@ public interface VanityUrlAPI {
      * Look up all published {@link VanityUrl}s whose {@code forwardTo} matches the
      * given {@code forward} and whose action equals {@code action}.
      *
-     * <p>Mirrors the host resolution semantics of {@link #resolveVanityUrl}:
-     * matches are collected both from the specified host and from {@code SYSTEM_HOST},
-     * since vanities published on {@code SYSTEM_HOST} apply across all sites.
+     * <p>When {@code includeSystemHost} is {@code true} the result also contains
+     * vanities published on {@code SYSTEM_HOST}, mirroring the host-resolution
+     * fallback in {@link #resolveVanityUrl}. Callers that only care about the
+     * given host should pass {@code false}. The flag is explicit (rather than a
+     * default) so the widened result scope is visible at every call site.
      *
      * <p><b>Authorization:</b> This method is intended for system-user / internal
      * routing contexts (e.g. the Experiments URL pattern engine) where the caller
      * represents the platform itself rather than an end user. It performs no
-     * permission check and returns vanities from {@code SYSTEM_HOST} in addition
-     * to the given host. Do not use it where the caller lacks {@code READ}
+     * permission check. Do not use it where the caller lacks {@code READ}
      * permission on the host, or where results are exposed directly to an
-     * end user.
+     * end user — especially when {@code includeSystemHost} is {@code true}.
      *
      * @param host {@link VanityUrl}'s Host
      * @param language {@link VanityUrl}'s Language
      * @param forward forward target to look for
      * @param action HTTP action code to look for (e.g. 200, 301, 302)
-     * @return the matching {@link CachedVanityUrl}s from the given host and from SYSTEM_HOST
+     * @param includeSystemHost if {@code true}, also return vanities published on {@code SYSTEM_HOST}
+     * @return the matching {@link CachedVanityUrl}s from the given host, and optionally from {@code SYSTEM_HOST}
      */
-    List<CachedVanityUrl> findByForward(Host host, Language language, String forward, int action);
+    List<CachedVanityUrl> findByForward(Host host, Language language, String forward, int action,
+                                        boolean includeSystemHost);
 
     /**
      *

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
@@ -123,6 +123,14 @@ public interface VanityUrlAPI {
      * matches are collected both from the specified host and from {@code SYSTEM_HOST},
      * since vanities published on {@code SYSTEM_HOST} apply across all sites.
      *
+     * <p><b>Authorization:</b> This method is intended for system-user / internal
+     * routing contexts (e.g. the Experiments URL pattern engine) where the caller
+     * represents the platform itself rather than an end user. It performs no
+     * permission check and returns vanities from {@code SYSTEM_HOST} in addition
+     * to the given host. Do not use it where the caller lacks {@code READ}
+     * permission on the host, or where results are exposed directly to an
+     * end user.
+     *
      * @param host {@link VanityUrl}'s Host
      * @param language {@link VanityUrl}'s Language
      * @param forward forward target to look for

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
@@ -116,13 +116,18 @@ public interface VanityUrlAPI {
 
 
     /**
-     * Look all the {@link VanityUrl} that are equals to forward
+     * Look up all published {@link VanityUrl}s whose {@code forwardTo} matches the
+     * given {@code forward} and whose action equals {@code action}.
+     *
+     * <p>Mirrors the host resolution semantics of {@link #resolveVanityUrl}:
+     * matches are collected both from the specified host and from {@code SYSTEM_HOST},
+     * since vanities published on {@code SYSTEM_HOST} apply across all sites.
      *
      * @param host {@link VanityUrl}'s Host
      * @param language {@link VanityUrl}'s Language
-     * @param forward forward to look for
-     * @param language action to look for
-     * @return
+     * @param forward forward target to look for
+     * @param action HTTP action code to look for (e.g. 200, 301, 302)
+     * @return the matching {@link CachedVanityUrl}s from the given host and from SYSTEM_HOST
      */
     List<CachedVanityUrl> findByForward(Host host, Language language, String forward, int action);
 

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
@@ -116,17 +116,38 @@ public interface VanityUrlAPI {
 
 
     /**
-     * Look up all published {@link VanityUrl}s whose {@code forwardTo} matches the
-     * given {@code forward} and whose action equals {@code action}.
+     * Look up all published {@link VanityUrl}s on the given host whose
+     * {@code forwardTo} equals {@code forward} and whose action equals
+     * {@code action}.
      *
-     * <p>When {@code includeSystemHost} is {@code true} the result also contains
-     * vanities published on {@code SYSTEM_HOST}, mirroring the host-resolution
-     * fallback in {@link #resolveVanityUrl}. Callers that only care about the
-     * given host should pass {@code false}. The flag is explicit (rather than a
-     * default) so the widened result scope is visible at every call site.
+     * <p>This is the pre-PR canonical form — it only searches the specified
+     * host. Callers that also want vanities from {@code SYSTEM_HOST} should use
+     * {@link #findByForward(Host, Language, String, int, boolean)} with
+     * {@code includeSystemHost = true}.
      *
-     * <p><b>Authorization:</b> This method is intended for system-user / internal
-     * routing contexts (e.g. the Experiments URL pattern engine) where the caller
+     * @param host {@link VanityUrl}'s Host
+     * @param language {@link VanityUrl}'s Language
+     * @param forward forward target to look for
+     * @param action HTTP action code to look for (e.g. 200, 301, 302)
+     * @return the matching {@link CachedVanityUrl}s from the given host only
+     */
+    List<CachedVanityUrl> findByForward(Host host, Language language, String forward, int action);
+
+    /**
+     * Extended overload of {@link #findByForward(Host, Language, String, int)}
+     * that can also include vanities published on {@code SYSTEM_HOST}, mirroring
+     * the host-resolution fallback in {@link #resolveVanityUrl}. The flag is
+     * explicit so the widened result scope is visible at every call site.
+     *
+     * <p>The default implementation delegates to the 4-arg overload (host-only
+     * results), so existing {@link VanityUrlAPI} implementors — including OSGi
+     * alternative providers — that did not override this method continue to
+     * work without throwing {@code AbstractMethodError}. Concrete
+     * implementations such as {@link VanityUrlAPIImpl} override this default
+     * with {@code SYSTEM_HOST}-aware logic when the flag is {@code true}.
+     *
+     * <p><b>Authorization:</b> Intended for system-user / internal routing
+     * contexts (e.g. the Experiments URL pattern engine) where the caller
      * represents the platform itself rather than an end user. It performs no
      * permission check. Do not use it where the caller lacks {@code READ}
      * permission on the host, or where results are exposed directly to an
@@ -139,26 +160,10 @@ public interface VanityUrlAPI {
      * @param includeSystemHost if {@code true}, also return vanities published on {@code SYSTEM_HOST}
      * @return the matching {@link CachedVanityUrl}s from the given host, and optionally from {@code SYSTEM_HOST}
      */
-    List<CachedVanityUrl> findByForward(Host host, Language language, String forward, int action,
-                                        boolean includeSystemHost);
-
-    /**
-     * Backward-compatible overload of
-     * {@link #findByForward(Host, Language, String, int, boolean)} that only
-     * searches the specified host ({@code includeSystemHost = false}). Preserves
-     * the behavior that existed before the {@code SYSTEM_HOST} fallback was
-     * added. New callers should prefer the 5-arg form and choose the flag
-     * explicitly.
-     *
-     * @param host     {@link VanityUrl}'s Host
-     * @param language {@link VanityUrl}'s Language
-     * @param forward  forward target to look for
-     * @param action   HTTP action code to look for (e.g. 200, 301, 302)
-     * @return the matching {@link CachedVanityUrl}s from the given host only
-     */
     default List<CachedVanityUrl> findByForward(final Host host, final Language language,
-                                                final String forward, final int action) {
-        return findByForward(host, language, forward, action, false);
+                                                final String forward, final int action,
+                                                final boolean includeSystemHost) {
+        return findByForward(host, language, forward, action);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
@@ -143,6 +143,25 @@ public interface VanityUrlAPI {
                                         boolean includeSystemHost);
 
     /**
+     * Backward-compatible overload of
+     * {@link #findByForward(Host, Language, String, int, boolean)} that only
+     * searches the specified host ({@code includeSystemHost = false}). Preserves
+     * the behavior that existed before the {@code SYSTEM_HOST} fallback was
+     * added. New callers should prefer the 5-arg form and choose the flag
+     * explicitly.
+     *
+     * @param host     {@link VanityUrl}'s Host
+     * @param language {@link VanityUrl}'s Language
+     * @param forward  forward target to look for
+     * @param action   HTTP action code to look for (e.g. 200, 301, 302)
+     * @return the matching {@link CachedVanityUrl}s from the given host only
+     */
+    default List<CachedVanityUrl> findByForward(final Host host, final Language language,
+                                                final String forward, final int action) {
+        return findByForward(host, language, forward, action, false);
+    }
+
+    /**
      *
      * @param vanityUrl
      * @param uri

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPI.java
@@ -29,6 +29,13 @@ public interface VanityUrlAPI {
     String VANITY_URL_RESPONSE_HEADER = "X-DOT-VanityUrl";
 
     /**
+     * Legacy Vanity URL URI used as the fallback home page. When the incoming
+     * request path is "/" and no other Vanity URL matches, implementations
+     * resolve this URI instead to support the historical cmsHomePage behavior.
+     */
+    String LEGACY_CMS_HOME_PAGE = "/cmsHomePage";
+
+    /**
      * Verifies that the Vanity URL as Contentlet has all the required fields. the list of mandatory fields can be
      * verified in the Content Type's definition.
      *

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
@@ -460,6 +460,16 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
     }
 
     @Override
+    public List<CachedVanityUrl> findByForward(final Host host, final Language language, final String forward,
+                                               final int action) {
+        // Delegate to the 5-arg overload with host-only semantics (no SYSTEM_HOST).
+        // The 5-arg method carries @CloseDBIfOpened; ByteBuddy advice fires on the
+        // self-invocation, so this delegation keeps connection lifecycle correct
+        // without duplicating the annotation.
+        return findByForward(host, language, forward, action, false);
+    }
+
+    @Override
     @CloseDBIfOpened
     public List<CachedVanityUrl> findByForward(final Host host, final Language language, final String forward,
                                                final int action, final boolean includeSystemHost) {

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
@@ -70,6 +70,13 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
      + " (select velocity_var_name from structure where structuretype=7)";
   
 
+  /**
+   * Retained for source compatibility with callers that referenced
+   * {@code VanityUrlAPIImpl.LEGACY_CMS_HOME_PAGE} before the constant was
+   * promoted to the {@link VanityUrlAPI} interface. Points at the canonical
+   * interface constant; new code should use {@link VanityUrlAPI#LEGACY_CMS_HOME_PAGE}.
+   */
+  public static final String   LEGACY_CMS_HOME_PAGE = VanityUrlAPI.LEGACY_CMS_HOME_PAGE;
   private final ContentletAPI  contentletAPI;
   private final VanityUrlCache cache;
   private final LanguageAPI    languageAPI;
@@ -257,7 +264,7 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
     // if this is the /cmsHomePage vanity
     if (matched.isEmpty() && StringPool.FORWARD_SLASH.equals(url)) {
 
-        matched = resolveVanityUrl(LEGACY_CMS_HOME_PAGE, site, language);
+        matched = resolveVanityUrl(VanityUrlAPI.LEGACY_CMS_HOME_PAGE, site, language);
     }
     
     

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
@@ -69,7 +69,6 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
      + " (select velocity_var_name from structure where structuretype=7)";
   
 
-  public static final String   LEGACY_CMS_HOME_PAGE = "/cmsHomePage";
   private final ContentletAPI  contentletAPI;
   private final VanityUrlCache cache;
   private final LanguageAPI    languageAPI;

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
@@ -455,14 +455,14 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
     @Override
     @CloseDBIfOpened
     public List<CachedVanityUrl> findByForward(final Host host, final Language language, final String forward,
-                                               int action) {
-        // Mirror resolveVanityUrl's SYSTEM_HOST fallback: vanities published on
-        // SYSTEM_HOST apply across all sites, so include them alongside the
-        // host-specific matches.
+                                               final int action, final boolean includeSystemHost) {
+        // When includeSystemHost is true, also pull vanities published on
+        // SYSTEM_HOST — they apply site-wide, mirroring resolveVanityUrl's
+        // SYSTEM_HOST fallback.
         final Host systemHost = APILocator.systemHost();
-        final Stream<CachedVanityUrl> systemHostVanities = systemHost.equals(host)
-                ? Stream.empty()
-                : load(systemHost, language).stream();
+        final Stream<CachedVanityUrl> systemHostVanities = includeSystemHost && !systemHost.equals(host)
+                ? load(systemHost, language).stream()
+                : Stream.empty();
 
         return Stream.concat(load(host, language).stream(), systemHostVanities)
                 .filter(cachedVanityUrl -> cachedVanityUrl.response == action)

--- a/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java
@@ -46,6 +46,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Implementation class for the {@link VanityUrlAPI}.
@@ -455,8 +456,15 @@ public class VanityUrlAPIImpl implements VanityUrlAPI {
     @CloseDBIfOpened
     public List<CachedVanityUrl> findByForward(final Host host, final Language language, final String forward,
                                                int action) {
-        return load(host, language)
-                .stream()
+        // Mirror resolveVanityUrl's SYSTEM_HOST fallback: vanities published on
+        // SYSTEM_HOST apply across all sites, so include them alongside the
+        // host-specific matches.
+        final Host systemHost = APILocator.systemHost();
+        final Stream<CachedVanityUrl> systemHostVanities = systemHost.equals(host)
+                ? Stream.empty()
+                : load(systemHost, language).stream();
+
+        return Stream.concat(load(host, language).stream(), systemHostVanities)
                 .filter(cachedVanityUrl -> cachedVanityUrl.response == action)
                 .filter(cachedVanityUrl -> cachedVanityUrl.forwardTo.equals(forward))
                 .collect(Collectors.toList());

--- a/dotCMS/src/main/java/com/dotcms/visitor/filter/servlet/VisitorFilter.java
+++ b/dotCMS/src/main/java/com/dotcms/visitor/filter/servlet/VisitorFilter.java
@@ -19,7 +19,6 @@ import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.filters.CMSUrlUtil;
 
-import com.dotmarketing.logConsole.model.LogMapper;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.util.Logger;
 import java.io.IOException;
@@ -45,7 +44,6 @@ public class VisitorFilter implements Filter {
 
     private final LanguageWebAPI languageWebAPI;
     private final UserWebAPI userWebAPI;
-    private final static String CMS_HOME_PAGE = "/cmsHomePage";
     public  final static  String VANITY_URL_ATTRIBUTE="VANITY_URL_ATTRIBUTE";
     public  final static  String DOTPAGE_PROCESSING_TIME="DOTPAGE_PROCESSING_TIME";
 

--- a/dotcms-integration/src/test/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculatorIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculatorIntegrationTest.java
@@ -8,6 +8,7 @@ import com.dotcms.experiments.model.Goals;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.vanityurl.model.VanityUrl;
 import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.htmlpageasset.model.HTMLPageAsset;
@@ -347,6 +348,60 @@ public class ExperimentUrlPatternCalculatorIntegrationTest {
                 .forwardTo(experimentPage.getURI())
                 .action(200)
                 .host(host)
+                .languageId(experimentPage.getLanguageId())
+                .nextPersistedAndPublish();
+
+        final String regex = ExperimentUrlPatternCalculator.INSTANCE.calculatePageUrlRegexPattern(experiment);
+
+        assertTrue(("http://localhost:8080/" + experimentPage.getPageUrl()).matches(regex));
+        assertTrue(("http://localhost:8080/cmsHomePage").matches(regex));
+        assertTrue(("http://localhost:8080/").matches(regex));
+        assertTrue(("http://localhost:8080").matches(regex));
+    }
+
+    /**
+     * Method to test: {@link ExperimentUrlPatternCalculator#calculatePageUrlRegexPattern(Experiment)}
+     * When: A Published Vanity Url with URI "/cmsHomePage" and action 200 is published
+     * on SYSTEM_HOST (rather than on the experiment page's host) and forwards to the
+     * Experiment's Page. Vanities on SYSTEM_HOST apply site-wide, so the "/" fallback
+     * still applies.
+     * Should: The regex returned by the method should match the Experiment Page URL
+     * and the root URL "/".
+     *
+     * See issue https://github.com/dotCMS/core/issues/34747
+     *
+     * @throws DotDataException
+     */
+    @Test
+    public void experimentWithSystemHostCmsHomePageVanity() throws DotDataException {
+
+        final Host host = new SiteDataGen().nextPersisted();
+        final Template template = new TemplateDataGen().host(host).nextPersisted();
+
+        final HTMLPageAsset experimentPage = new HTMLPageDataGen(host, template).nextPersisted();
+
+        final Condition<Object> condition = Condition.builder()
+                .parameter("url")
+                .value("testing")
+                .operator(AbstractCondition.Operator.CONTAINS)
+                .build();
+
+        final Metric metric = Metric.builder()
+                .name("Testing Metric")
+                .type(MetricType.REACH_PAGE)
+                .addConditions(condition).build();
+
+        final Goals goal = Goals.builder().primary(GoalFactory.create(metric)).build();
+        final Experiment experiment = new ExperimentDataGen()
+                .page(experimentPage)
+                .addGoal(goal)
+                .nextPersisted();
+
+        final Contentlet vanityUrl = new VanityUrlDataGen()
+                .uri("/cmsHomePage")
+                .forwardTo(experimentPage.getURI())
+                .action(200)
+                .host(APILocator.systemHost())
                 .languageId(experimentPage.getLanguageId())
                 .nextPersistedAndPublish();
 

--- a/dotcms-integration/src/test/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculatorIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculatorIntegrationTest.java
@@ -353,8 +353,11 @@ public class ExperimentUrlPatternCalculatorIntegrationTest {
 
         final String regex = ExperimentUrlPatternCalculator.INSTANCE.calculatePageUrlRegexPattern(experiment);
 
+        // The SDK lowercases incoming URL paths before matching (see
+        // verifyRegex in parser.ts), and the server lowercases the assembled
+        // regex, so test with lowercased URLs that mirror runtime behavior.
         assertTrue(("http://localhost:8080/" + experimentPage.getPageUrl()).matches(regex));
-        assertTrue(("http://localhost:8080/cmsHomePage").matches(regex));
+        assertTrue(("http://localhost:8080/cmshomepage").matches(regex));
         assertTrue(("http://localhost:8080/").matches(regex));
         assertTrue(("http://localhost:8080").matches(regex));
     }
@@ -408,7 +411,7 @@ public class ExperimentUrlPatternCalculatorIntegrationTest {
         final String regex = ExperimentUrlPatternCalculator.INSTANCE.calculatePageUrlRegexPattern(experiment);
 
         assertTrue(("http://localhost:8080/" + experimentPage.getPageUrl()).matches(regex));
-        assertTrue(("http://localhost:8080/cmsHomePage").matches(regex));
+        assertTrue(("http://localhost:8080/cmshomepage").matches(regex));
         assertTrue(("http://localhost:8080/").matches(regex));
         assertTrue(("http://localhost:8080").matches(regex));
     }

--- a/dotcms-integration/src/test/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculatorIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/experiments/business/ExperimentUrlPatternCalculatorIntegrationTest.java
@@ -305,6 +305,61 @@ public class ExperimentUrlPatternCalculatorIntegrationTest {
 
     /**
      * Method to test: {@link ExperimentUrlPatternCalculator#calculatePageUrlRegexPattern(Experiment)}
+     * When: A Published Vanity Url with URI "/cmsHomePage" and action 200 forwards to
+     * the Experiment's Page. Per the legacy fallback in
+     * {@link com.dotcms.vanityurl.business.VanityUrlAPIImpl#resolveVanityUrl}, a visitor
+     * requesting "/" is transparently forwarded to the target page, so the browser URL
+     * stays "/".
+     * Should: The regex returned by the method should match the Experiment Page URL,
+     * the "/cmsHomePage" URL, and the root URL "/".
+     *
+     * See issue https://github.com/dotCMS/core/issues/34747
+     *
+     * @throws DotDataException
+     */
+    @Test
+    public void experimentWithCmsHomePageVanity() throws DotDataException {
+
+        final Host host = new SiteDataGen().nextPersisted();
+        final Template template = new TemplateDataGen().host(host).nextPersisted();
+
+        final HTMLPageAsset experimentPage = new HTMLPageDataGen(host, template).nextPersisted();
+
+        final Condition<Object> condition = Condition.builder()
+                .parameter("url")
+                .value("testing")
+                .operator(AbstractCondition.Operator.CONTAINS)
+                .build();
+
+        final Metric metric = Metric.builder()
+                .name("Testing Metric")
+                .type(MetricType.REACH_PAGE)
+                .addConditions(condition).build();
+
+        final Goals goal = Goals.builder().primary(GoalFactory.create(metric)).build();
+        final Experiment experiment = new ExperimentDataGen()
+                .page(experimentPage)
+                .addGoal(goal)
+                .nextPersisted();
+
+        final Contentlet vanityUrl = new VanityUrlDataGen()
+                .uri("/cmsHomePage")
+                .forwardTo(experimentPage.getURI())
+                .action(200)
+                .host(host)
+                .languageId(experimentPage.getLanguageId())
+                .nextPersistedAndPublish();
+
+        final String regex = ExperimentUrlPatternCalculator.INSTANCE.calculatePageUrlRegexPattern(experiment);
+
+        assertTrue(("http://localhost:8080/" + experimentPage.getPageUrl()).matches(regex));
+        assertTrue(("http://localhost:8080/cmsHomePage").matches(regex));
+        assertTrue(("http://localhost:8080/").matches(regex));
+        assertTrue(("http://localhost:8080").matches(regex));
+    }
+
+    /**
+     * Method to test: {@link ExperimentUrlPatternCalculator#calculatePageUrlRegexPattern(Experiment)}
      * When: Exists a Published Vanity Url with the forwardTo equals to the URI og the Experiment's Page but with not 200 action
      * Should: The regex returned by the method should NOT match the VanityUrl's URI
      *

--- a/dotcms-integration/src/test/java/com/dotcms/vanityurl/business/VanityUrlAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/vanityurl/business/VanityUrlAPITest.java
@@ -1150,7 +1150,7 @@ public class VanityUrlAPITest {
                 .nextPersistedAndPublish();
 
         final List<CachedVanityUrl> byForward = APILocator.getVanityUrlAPI().findByForward(host, language,
-                "/Testing", 200);
+                "/Testing", 200, false);
 
         assertEquals(2, byForward.size());
 
@@ -1213,7 +1213,7 @@ public class VanityUrlAPITest {
                 .nextPersistedAndPublish();
 
         final List<CachedVanityUrl> byForward = APILocator.getVanityUrlAPI().findByForward(host, language,
-                "/Testing", 200);
+                "/Testing", 200, false);
 
         assertEquals(1, byForward.size());
 
@@ -1282,7 +1282,7 @@ public class VanityUrlAPITest {
                 .nextPersistedAndPublish();
 
         final List<CachedVanityUrl> byForward = APILocator.getVanityUrlAPI().findByForward(host, language,
-                "/Testing", 200);
+                "/Testing", 200, false);
 
         assertTrue(byForward.isEmpty());
     }

--- a/dotcms-integration/src/test/java/com/dotmarketing/filters/FiltersTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/filters/FiltersTest.java
@@ -1,7 +1,7 @@
 package com.dotmarketing.filters;
 
 import static com.dotcms.datagen.TestDataUtils.getNewsLikeContentType;
-import static com.dotcms.vanityurl.business.VanityUrlAPIImpl.LEGACY_CMS_HOME_PAGE;
+import static com.dotcms.vanityurl.business.VanityUrlAPI.LEGACY_CMS_HOME_PAGE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.startsWith;


### PR DESCRIPTION
## Summary

Fixes the remaining scope of #34747 — Experiments not firing when the experiment page is reached via the legacy `/cmsHomePage` vanity URL fallback.

- `VanityUrlAPIImpl.resolveVanityUrl` has a legacy fallback (dotCMS/src/main/java/com/dotcms/vanityurl/business/VanityUrlAPIImpl.java:257-261) that, when a visitor requests `/` and no vanity directly matches, resolves `/cmsHomePage` instead and forwards (action=200) to the configured target page. The browser URL bar stays at `/`.
- `ExperimentUrlPatternCalculator.getVanityUrlsRegex` was only adding the vanity's own URI (`/cmsHomePage`) as a regex alternative — so the incoming analytics URL `http://site/` (or `http://site`) never matched and the Experiment engine always served the Original variant.
- This PR adds a `/?` alternative (matching `/` and empty) to the generated regex when any returned vanity has URI `/cmsHomePage`. The approach mirrors the existing permissive pattern used in `RootIndexRegexUrlPatterStrategy` for the real root-index page.

An earlier PR (#26803, commit 53718e0f50) fixed the common vanity-URL case but did not cover the `/cmsHomePage` legacy fallback — details in the issue comment thread.

Also removes an unused `CMS_HOME_PAGE` constant from `VisitorFilter`.

## Test plan

- [x] New integration test `ExperimentUrlPatternCalculatorIntegrationTest#experimentWithCmsHomePageVanity` — fails on main, passes on this branch.
- [x] Regression run of the four pre-existing vanity tests in the same class — all still pass (`Tests run: 5, Failures: 0, Errors: 0`).
- [ ] QA: see "Notes for QA" on the issue — confirm fix for the `/cmsHomePage` scenario and regression-check other vanity-URL + Experiment combinations.

Refs: #34747

🤖 Generated with [Claude Code](https://claude.com/claude-code)