### PR TITLE
Update starter deploy version in pom.xml

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -84,7 +84,7 @@
         <docker.jacoco.skip>true</docker.jacoco.skip>
         <!-- starter -->
         <starter.download.folder>${project.build.directory}/starter</starter.download.folder>
-        <starter.deploy.version>empty_20260225</starter.deploy.version>
+        <starter.deploy.version>empty_20260331</starter.deploy.version>
         <starter.deploy.filename>starter.zip</starter.deploy.filename>
         <starter.run.version>${starter.deploy.version}</starter.run.version>
         <starter.run.filename>starter-${starter.run.version}.zip</starter.run.filename>


### PR DESCRIPTION
closes #35097

## Summary

Updates the empty starter deploy version from `empty_20260225` to `empty_20260331` in `parent/pom.xml`.

This change is part of the **Modernization Team** effort to ensure fresh DotCMS installs include the updated starter data that ships with the correct Plugins portlet layout configuration. It is a follow-up to the work done in #35097, which fixed the root cause (missing `plugins` portlet in fresh-install layouts), and ensures the bundled empty starter reflects those fixes so new installs are no longer affected.

Related task: https://github.com/dotCMS/core/issues/35097

### Proposed Changes
* Bump `starter.deploy.version` from `empty_20260225` to `empty_20260331` in `parent/pom.xml`

### Checklist
- [x] Tests — no code logic changed; starter artifact version bump only
- [ ] Translations — N/A
- [x] Security Implications Contemplated — none; this is a version string update

### Additional Info
The empty starter at version `empty_20260331` includes the updated `cms_layouts_portlets` data that maps the Plugins portlet (`plugins`) correctly, so fresh installs will have the sidebar entry working out of the box without needing the upgrade task `Task260320AddPluginsPortletToMenu`.