### PR TITLE
fix(edit-content): exclude disabled items from Select All in relationship picker

### DIFF
--- a/core-web/apps/dotcms-ui-e2e/CLAUDE.md
+++ b/core-web/apps/dotcms-ui-e2e/CLAUDE.md
@@ -391,7 +391,7 @@ page.getByTestId('show-selected-switch') // Toggle selected items
 
 Radio buttons (single mode): `row.locator('p-tableradiobutton')`
 Checkboxes (multiple mode): `row.locator('p-tablecheckbox')`
-Header checkbox (select all): `table.locator('p-tableheadercheckbox')`
+Header checkbox (select all): `table.locator('[data-testid="header-checkbox"]')`
 
 ## waitForResponse Pattern
 

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/helpers/select-existing-content-dialog.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/relationship-field/helpers/select-existing-content-dialog.ts
@@ -61,7 +61,7 @@ export class SelectExistingContentDialog {
     }
 
     async toggleSelectAll(): Promise<void> {
-        await this.table.locator('p-tableheadercheckbox').click();
+        await this.table.locator('[data-testid="header-checkbox"]').click();
     }
 
     async expectCheckboxes(): Promise<void> {
@@ -69,7 +69,7 @@ export class SelectExistingContentDialog {
     }
 
     async expectHeaderCheckbox(): Promise<void> {
-        await expect(this.table.locator('p-tableheadercheckbox')).toBeVisible();
+        await expect(this.table.locator('[data-testid="header-checkbox"]')).toBeVisible();
     }
 
     // ─── Apply / Cancel ─────────────────────────────────────────────

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -17,8 +17,6 @@
             [value]="data"
             [selectionMode]="selectionMode"
             [(selection)]="$selectionItems"
-            [selectAll]="$selectAll()"
-            (selectAllChange)="onSelectAllChange($event)"
             dataKey="inode"
             [loading]="store.isLoading()"
             [paginator]="true"
@@ -68,7 +66,12 @@
                         alignFrozen="left"
                         [frozen]="true">
                         @if (selectionMode === 'multiple') {
-                            <p-tableHeaderCheckbox />
+                            <p-checkbox
+                                [binary]="true"
+                                [ngModel]="$selectAll()"
+                                [disabled]="$selectableItems().length === 0"
+                                (onChange)="onSelectAllChange($event)"
+                                data-testid="header-checkbox" />
                         }
                     </th>
                     <th scope="col" [colSpan]="2" class="w-full" [pSortableColumn]="'title'">

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -17,6 +17,8 @@
             [value]="data"
             [selectionMode]="selectionMode"
             [(selection)]="$selectionItems"
+            [selectAll]="$selectAll()"
+            (selectAllChange)="onSelectAllChange($event)"
             [loading]="store.isLoading()"
             [paginator]="true"
             [first]="pagination.offset"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -69,6 +69,7 @@
                             <p-checkbox
                                 [binary]="true"
                                 [ngModel]="$selectAll()"
+                                [indeterminate]="$isPartiallySelected()"
                                 [disabled]="$selectableItems().length === 0"
                                 (onChange)="onSelectAllChange($event)"
                                 data-testid="header-checkbox" />

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.html
@@ -19,6 +19,7 @@
             [(selection)]="$selectionItems"
             [selectAll]="$selectAll()"
             (selectAllChange)="onSelectAllChange($event)"
+            dataKey="inode"
             [loading]="store.isLoading()"
             [paginator]="true"
             [first]="pagination.offset"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
@@ -189,7 +189,7 @@ describe('DotSelectExistingContentComponent', () => {
             expect(selection.map((i) => i.identifier).sort()).toEqual(['id-1', 'id-2', 'id-3']);
         });
 
-        it('clears the selection when Select All is unchecked', () => {
+        it('clears the visible selection when Select All is unchecked', () => {
             spectator.component.$selectionItems.set([item1, item2]);
 
             spectator.component.onSelectAllChange({
@@ -198,6 +198,43 @@ describe('DotSelectExistingContentComponent', () => {
             });
 
             expect(spectator.component.$selectionItems()).toEqual([]);
+        });
+
+        it('preserves selections from other pages when Select All is checked', () => {
+            const offPageItem = createFakeContentlet({ inode: '99', identifier: 'id-99' });
+            spectator.component.$selectionItems.set([offPageItem]);
+            spectator.detectChanges();
+
+            spectator.component.onSelectAllChange({
+                originalEvent: new Event('click'),
+                checked: true
+            });
+
+            const selection = spectator.component.$selectionItems() as ReturnType<
+                typeof createFakeContentlet
+            >[];
+            expect(selection.map((i) => i.identifier).sort()).toEqual([
+                'id-1',
+                'id-2',
+                'id-3',
+                'id-99'
+            ]);
+        });
+
+        it('preserves selections from other pages when Select All is unchecked', () => {
+            const offPageItem = createFakeContentlet({ inode: '99', identifier: 'id-99' });
+            spectator.component.$selectionItems.set([item1, item2, offPageItem]);
+            spectator.detectChanges();
+
+            spectator.component.onSelectAllChange({
+                originalEvent: new Event('click'),
+                checked: false
+            });
+
+            const selection = spectator.component.$selectionItems() as ReturnType<
+                typeof createFakeContentlet
+            >[];
+            expect(selection.map((i) => i.identifier)).toEqual(['id-99']);
         });
 
         it('reports $selectAll as false when no selectable items exist', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
@@ -206,6 +206,21 @@ describe('DotSelectExistingContentComponent', () => {
             expect(spectator.component.$selectAll()).toBe(false);
         });
 
+        it('reports $isPartiallySelected when some (not all) selectable items are selected', () => {
+            spectator.component.$selectionItems.set([item1]);
+            spectator.detectChanges();
+
+            expect(spectator.component.$isPartiallySelected()).toBe(true);
+            expect(spectator.component.$selectAll()).toBe(false);
+        });
+
+        it('reports $isPartiallySelected false when every selectable item is selected', () => {
+            spectator.component.$selectionItems.set([item1, item2, item3]);
+            spectator.detectChanges();
+
+            expect(spectator.component.$isPartiallySelected()).toBe(false);
+        });
+
         it('reports $selectAll as true when every selectable item is selected', () => {
             markConstrained(['id-2']);
             spectator.component.$selectionItems.set([item1, item3]);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
@@ -1,4 +1,5 @@
 import { Spectator, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
+import { patchState } from '@ngrx/signals';
 import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 
@@ -117,6 +118,100 @@ describe('DotSelectExistingContentComponent', () => {
             spectator.detectChanges();
 
             expect(store.selectionItems()).toEqual(mockItems);
+        });
+    });
+
+    describe('Select All excludes constrained items', () => {
+        const item1 = createFakeContentlet({ inode: '1', identifier: 'id-1' });
+        const item2 = createFakeContentlet({ inode: '2', identifier: 'id-2' });
+        const item3 = createFakeContentlet({ inode: '3', identifier: 'id-3' });
+
+        const markConstrained = (ids: string[]) => {
+            patchState(store, { constrainedIdentifiers: new Set(ids) });
+        };
+
+        beforeEach(() => {
+            patchState(store, { searchData: [item1, item2, item3] });
+            markConstrained([]);
+            spectator.detectChanges();
+        });
+
+        it('selects only non-constrained items when checked', () => {
+            markConstrained(['id-2']);
+
+            spectator.component.onSelectAllChange({
+                originalEvent: new Event('click'),
+                checked: true
+            });
+
+            const selection = spectator.component.$selectionItems() as ReturnType<
+                typeof createFakeContentlet
+            >[];
+            expect(selection.map((i) => i.identifier)).toEqual(['id-1', 'id-3']);
+        });
+
+        it('leaves constrained items unselected when Select All is checked', () => {
+            markConstrained(['id-2']);
+
+            spectator.component.onSelectAllChange({
+                originalEvent: new Event('click'),
+                checked: true
+            });
+
+            const selection = spectator.component.$selectionItems() as ReturnType<
+                typeof createFakeContentlet
+            >[];
+            expect(selection.some((i) => i.identifier === 'id-2')).toBe(false);
+        });
+
+        it('selects zero items when all rows are constrained', () => {
+            markConstrained(['id-1', 'id-2', 'id-3']);
+
+            spectator.component.onSelectAllChange({
+                originalEvent: new Event('click'),
+                checked: true
+            });
+
+            expect(spectator.component.$selectionItems()).toEqual([]);
+        });
+
+        it('selects every item when no row is constrained', () => {
+            markConstrained([]);
+
+            spectator.component.onSelectAllChange({
+                originalEvent: new Event('click'),
+                checked: true
+            });
+
+            const selection = spectator.component.$selectionItems() as ReturnType<
+                typeof createFakeContentlet
+            >[];
+            expect(selection.map((i) => i.identifier).sort()).toEqual(['id-1', 'id-2', 'id-3']);
+        });
+
+        it('clears the selection when Select All is unchecked', () => {
+            spectator.component.$selectionItems.set([item1, item2]);
+
+            spectator.component.onSelectAllChange({
+                originalEvent: new Event('click'),
+                checked: false
+            });
+
+            expect(spectator.component.$selectionItems()).toEqual([]);
+        });
+
+        it('reports $selectAll as false when no selectable items exist', () => {
+            markConstrained(['id-1', 'id-2', 'id-3']);
+
+            expect(spectator.component.$selectAll()).toBe(false);
+        });
+
+        it('reports $selectAll as true when every selectable item is selected', () => {
+            markConstrained(['id-2']);
+            spectator.component.$selectionItems.set([item1, item3]);
+            spectator.detectChanges();
+
+            expect(spectator.component.$selectAll()).toBe(true);
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.spec.ts
@@ -213,6 +213,15 @@ describe('DotSelectExistingContentComponent', () => {
 
             expect(spectator.component.$selectAll()).toBe(true);
         });
+
+        it('forces $selectAll to false in selected-view mode to avoid wiping the selection', () => {
+            spectator.component.$selectionItems.set([item1, item2, item3]);
+            patchState(store, { viewMode: 'selected' });
+            spectator.detectChanges();
+
+            expect(store.isSelectedView()).toBe(true);
+            expect(spectator.component.$selectAll()).toBe(false);
+        });
     });
 
     describe('Item Selection', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -2,6 +2,7 @@ import { DatePipe } from '@angular/common';
 import {
     ChangeDetectionStrategy,
     Component,
+    computed,
     CUSTOM_ELEMENTS_SCHEMA,
     effect,
     inject,
@@ -92,6 +93,33 @@ export class DotSelectExistingContentComponent implements OnInit {
      */
     $staticColumns = signal(STATIC_COLUMNS);
 
+    /**
+     * Items that are selectable — excludes rows marked as constrained
+     * (already related under a cardinality-restricted relationship).
+     */
+    $selectableItems = computed(() => {
+        const isConstrained = this.store.isItemConstrained();
+
+        return this.store.filteredData().filter((item) => !isConstrained(item.identifier));
+    });
+
+    /**
+     * State of the header "Select All" checkbox. True when there is at least one
+     * selectable item and every selectable item is currently selected.
+     */
+    $selectAll = computed(() => {
+        const selectable = this.$selectableItems();
+
+        if (selectable.length === 0) {
+            return false;
+        }
+
+        const selection = this.store.currentItems();
+        const selectedInodes = new Set(selection.map((item) => item.inode));
+
+        return selectable.every((item) => selectedInodes.has(item.inode));
+    });
+
     constructor() {
         effect(() => {
             // Sync the selection items with the store
@@ -142,5 +170,14 @@ export class DotSelectExistingContentComponent implements OnInit {
         const items = this.store.currentItems();
 
         return items.some((selectedItem) => selectedItem.inode === item.inode);
+    }
+
+    /**
+     * Handles the header "Select All" toggle, excluding constrained (already related) rows
+     * so they are never added to the selection regardless of the default p-tableHeaderCheckbox
+     * behavior, which would otherwise ignore per-row [disabled] state.
+     */
+    onSelectAllChange({ checked }: { originalEvent: Event; checked: boolean }) {
+        this.$selectionItems.set(checked ? [...this.$selectableItems()] : []);
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -106,6 +106,31 @@ export class DotSelectExistingContentComponent implements OnInit {
     });
 
     /**
+     * True when some — but not all — selectable items are currently selected.
+     * Drives the header checkbox's indeterminate state for parity with the
+     * native p-tableHeaderCheckbox it replaces.
+     */
+    $isPartiallySelected = computed(() => {
+        if (this.store.isSelectedView()) {
+            return false;
+        }
+
+        const selectable = this.$selectableItems();
+
+        if (selectable.length === 0) {
+            return false;
+        }
+
+        const selectedInodes = new Set(this.store.currentItems().map((item) => item.inode));
+        const matchCount = selectable.reduce(
+            (acc, item) => (selectedInodes.has(item.inode) ? acc + 1 : acc),
+            0
+        );
+
+        return matchCount > 0 && matchCount < selectable.length;
+    });
+
+    /**
      * State of the header "Select All" checkbox. True when there is at least one
      * selectable item and every selectable item is currently selected.
      *

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -13,6 +13,7 @@ import {
 import { FormsModule } from '@angular/forms';
 
 import { ButtonModule } from 'primeng/button';
+import { CheckboxModule } from 'primeng/checkbox';
 import { ChipModule } from 'primeng/chip';
 import { DialogModule } from 'primeng/dialog';
 import { DynamicDialogConfig } from 'primeng/dynamicdialog';
@@ -47,6 +48,7 @@ const STATIC_COLUMNS = 6;
     imports: [
         TableModule,
         ButtonModule,
+        CheckboxModule,
         MenuModule,
         DotMessagePipe,
         DialogModule,
@@ -182,10 +184,10 @@ export class DotSelectExistingContentComponent implements OnInit {
 
     /**
      * Handles the header "Select All" toggle, excluding constrained (already related) rows
-     * so they are never added to the selection regardless of the default p-tableHeaderCheckbox
-     * behavior, which would otherwise ignore per-row [disabled] state.
+     * so they are never added to the selection. A custom p-checkbox is used instead of
+     * p-tableHeaderCheckbox because the latter ignores per-row [disabled] state.
      */
-    onSelectAllChange({ checked }: { originalEvent: Event; checked: boolean }) {
-        this.$selectionItems.set(checked ? [...this.$selectableItems()] : []);
+    onSelectAllChange(event: { checked: boolean }) {
+        this.$selectionItems.set(event.checked ? [...this.$selectableItems()] : []);
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -106,8 +106,16 @@ export class DotSelectExistingContentComponent implements OnInit {
     /**
      * State of the header "Select All" checkbox. True when there is at least one
      * selectable item and every selectable item is currently selected.
+     *
+     * Forced to false in "selected view" mode to avoid a trivially-checked state
+     * (filteredData is already filtered to the current selection), which would
+     * otherwise let a single header click wipe the whole selection.
      */
     $selectAll = computed(() => {
+        if (this.store.isSelectedView()) {
+            return false;
+        }
+
         const selectable = this.$selectableItems();
 
         if (selectable.length === 0) {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts
@@ -211,8 +211,18 @@ export class DotSelectExistingContentComponent implements OnInit {
      * Handles the header "Select All" toggle, excluding constrained (already related) rows
      * so they are never added to the selection. A custom p-checkbox is used instead of
      * p-tableHeaderCheckbox because the latter ignores per-row [disabled] state.
+     *
+     * Operates only on items in the current view — selections from other pages or prior
+     * searches are preserved so a Select All / Unselect All in one page never silently
+     * discards items picked elsewhere.
      */
     onSelectAllChange(event: { checked: boolean }) {
-        this.$selectionItems.set(event.checked ? [...this.$selectableItems()] : []);
+        const current = this.store.currentItems();
+        const visibleInodes = new Set(this.store.filteredData().map((item) => item.inode));
+        const preserved = current.filter((item) => !visibleInodes.has(item.inode));
+
+        this.$selectionItems.set(
+            event.checked ? [...preserved, ...this.$selectableItems()] : preserved
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fix the **New Content Editor** relationship picker so that the **Select All** checkbox respects the per-row disabled state and skips items that are already related under a cardinality-restricted relationship.

## Problem

When a One-to-Many relationship field lists content items in the picker dialog, rows that are already related to another parent are rendered as disabled (grayed out, `[disabled]` on the per-row checkbox). However, PrimeNG's built-in `p-tableHeaderCheckbox` ignores each row's `[disabled]` flag — clicking **Select All** would therefore include the disabled items in the selection, which then failed on save with `Relationship cardinality violated` (500).

## Fix

Override PrimeNG's default Select All handling on `<p-table>`:

- Bind `[selectAll]` to a computed signal `$selectAll` that is true only when every **selectable** (non-constrained) item is selected.
- Handle `(selectAllChange)` via `onSelectAllChange`, which sets the selection to the filtered list of non-constrained items (or empty on uncheck).

Files changed:

- `core-web/libs/edit-content/src/lib/fields/dot-edit-content-relationship-field/components/dot-select-existing-content/dot-select-existing-content.component.ts` — new `$selectableItems`, `$selectAll`, `onSelectAllChange`.
- `.../dot-select-existing-content.component.html` — wire `[selectAll]` / `(selectAllChange)` on `p-table`.
- `.../dot-select-existing-content.component.spec.ts` — tests covering Select All behavior with mixed / all-disabled / none-disabled rows and uncheck.

Closes #35325

## Acceptance Criteria

- [x] Clicking **Select All** in the relationship picker selects only non-disabled (available) items.
- [x] Disabled items (already related) remain unchecked after **Select All** is clicked.
- [x] If every item is disabled, **Select All** yields zero selected items.
- [x] If no items are disabled, **Select All** selects all items (existing behavior preserved).
- [x] Saving a One-to-Many relationship after **Select All** persists only the selected enabled items.

## Test plan

- [ ] Unit tests pass: `yarn nx test edit-content --testPathPattern=dot-select-existing-content.component.spec`
- [ ] Manually verify in the New Edit Content experience:
  - [ ] Open a One-to-Many relationship picker with a mix of enabled and disabled rows → **Select All** only selects the enabled rows.
  - [ ] With all rows disabled → **Select All** selects zero.
  - [ ] With no rows disabled → **Select All** selects every row.
  - [ ] Save after **Select All** succeeds without a cardinality violation.

## Visual Changes

<img width="2434" height="1848" alt="CleanShot 2026-04-20 at 11 52 52@2x" src="https://github.com/user-attachments/assets/2b41b113-666e-4d20-9301-b0e62749acfd" />

