### PR TITLE
refactor(reindex): convert ReindexEntry to Immutables value object (#34934)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexEntry.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexEntry.java
@@ -78,6 +78,13 @@ public abstract class ReindexEntry {
         return getPriority() % 100;
     }
 
+    @Override
+    public String toString() {
+        return "IndexJournal [id=" + getId() + ", identToIndex=" + getIdentToIndex()
+                + ", priority=" + getPriority() + ", delete=" + isDelete()
+                + ", serverId=" + getServerId() + "]";
+    }
+
     // ── Factory ───────────────────────────────────────────────────────────────
 
     /** Returns a new builder for constructing a {@link ReindexEntry}. */

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexEntry.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexEntry.java
@@ -20,8 +20,7 @@ import org.immutables.value.Value;
  *     .id(42L)
  *     .identToIndex("abc123")
  *     .priority(0)
- *     .isDelete(false)
- *     .build();
+ *     .build();   // isDelete defaults to false
  * }</pre>
  */
 @Value.Immutable
@@ -39,8 +38,12 @@ public abstract class ReindexEntry {
     /** Priority level; also encodes error-retry count (see {@link #errorCount()}). */
     public abstract int getPriority();
 
-    /** {@code true} when the document should be deleted from the index. */
-    public abstract boolean isDelete();
+    /**
+     * {@code true} when the document should be deleted from the index.
+     * Defaults to {@code false} — failed-reindex records are never deletes.
+     */
+    @Value.Default
+    public boolean isDelete() { return false; }
 
     /** Server that owns this entry; {@code null} when not assigned to a specific node. */
     @Nullable

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexEntry.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexEntry.java
@@ -1,167 +1,94 @@
 package com.dotmarketing.common.reindex;
 
+import com.dotcms.annotations.Nullable;
 import java.util.Date;
+import org.immutables.value.Value;
 
-public class ReindexEntry {
+/**
+ * Immutable value object representing a single entry in the distributed reindex journal
+ * ({@code dist_reindex_journal}).
+ *
+ * <h3>Equality</h3>
+ * <p>Two entries are equal when they share the same {@code identToIndex}, {@code priority},
+ * {@code delete} flag, and {@code serverId} — matching the original deduplication semantics
+ * of the mutable POJO. {@code id}, {@code lastResult}, and {@code timeEntered} are
+ * {@link Value.Auxiliary auxiliary} and therefore excluded from {@code equals}/{@code hashCode}.</p>
+ *
+ * <h3>Construction</h3>
+ * <pre>{@code
+ * ReindexEntry entry = ImmutableReindexEntry.builder()
+ *     .setId(42L)
+ *     .setIdentToIndex("abc123")
+ *     .setPriority(0)
+ *     .setDelete(false)
+ *     .build();
+ * }</pre>
+ */
+@Value.Immutable
+@Value.Style(init = "set*")
+public abstract class ReindexEntry {
 
-    private long id;
-    private String identToIndex;
-    private int priority;
-    private boolean delete;
-    private String serverId;
-    private String lastResult;
-    private Date timeEntered;
-    
-    public Date getTimeEntered() {
-        return timeEntered;
-    }
+    // ── Identity / routing ────────────────────────────────────────────────────
 
-    public ReindexEntry setTimeEntered(Date timeEntered) {
-        this.timeEntered = timeEntered;
-        return this;
-    }
+    /** DB row id — excluded from equals/hashCode (auxiliary). */
+    @Value.Auxiliary
+    public abstract long getId();
 
-    public ReindexEntry() {}
+    /** Contentlet identifier to reindex. */
+    public abstract String getIdentToIndex();
 
-    public ReindexEntry(long id, String objectToIndex, int priority) {
-        this.id = id;
-        this.identToIndex = objectToIndex;
-        this.priority = priority;
-    }
+    /** Priority level; also encodes error-retry count (see {@link #errorCount()}). */
+    public abstract int getPriority();
 
-    public String getLastResult() {
-        return lastResult;
-    }
+    /** {@code true} when the document should be deleted from the index. */
+    public abstract boolean isDelete();
 
-    public ReindexEntry setLastResult(String lastResult) {
-        this.lastResult = lastResult;
-        return this;
-    }
+    /** Server that owns this entry; {@code null} when not assigned to a specific node. */
+    @Nullable
+    public abstract String getServerId();
 
-    /**
-     * @return the id
-     */
-    public long getId() {
-        return id;
-    }
+    // ── Metadata (auxiliary — excluded from equals/hashCode) ─────────────────
 
-    /**
-     * @param id the id to set
-     */
-    public ReindexEntry setId(long id) {
-        this.id = id;
-        return this;
-    }
+    /** Result of the last indexing attempt; {@code null} on first attempt. */
+    @Nullable
+    @Value.Auxiliary
+    public abstract String getLastResult();
 
-    /**
-     * @return the priority
-     */
-    public int getPriority() {
-        return priority;
-    }
+    /** When this entry was created; {@code null} when populated from the in-memory queue. */
+    @Nullable
+    @Value.Auxiliary
+    public abstract Date getTimeEntered();
 
-    /**
-     * @param priority the priority to set
-     */
-    public ReindexEntry setPriority(int priority) {
-        this.priority = priority;
-        return this;
-    }
+    // ── Derived ───────────────────────────────────────────────────────────────
 
     /**
-     * @return the delete
+     * Returns {@code true} when the priority indicates a full reindex operation
+     * rather than a single-content update.
      */
-    public boolean isDelete() {
-        return delete;
-    }
-
-    /**
-     * @param delete the delete to set
-     */
-    public ReindexEntry setDelete(boolean delete) {
-        this.delete = delete;
-        return this;
-    }
-
-    /**
-     * @return the identToIndex
-     */
-    public String getIdentToIndex() {
-        return identToIndex;
-    }
-
     public boolean isReindex() {
         return getPriority() >= ReindexQueueFactory.Priority.REINDEX.dbValue();
     }
 
     /**
-     * @param identToIndex the identToIndex to set
+     * Returns the number of previous failed attempts encoded in the priority value.
      */
-    public ReindexEntry setIdentToIndex(String identToIndex) {
-        this.identToIndex = identToIndex;
-        return this;
-    }
-
-    /**
-     * @return the serverId
-     */
-    public String getServerId() {
-        return serverId;
-    }
-
-    /**
-     * @param serverId the serverId to set
-     */
-    public ReindexEntry setServerId(String serverId) {
-        this.serverId = serverId;
-        return this;
-    }
-
     public int errorCount() {
-        return this.getPriority() % 100;
+        return getPriority() % 100;
     }
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + (delete ? 1231 : 1237);
-        result = prime * result + ((identToIndex == null) ? 0 : identToIndex.hashCode());
-        result = prime * result + (int) (priority ^ (priority >>> 32));
-        result = prime * result + ((serverId == null) ? 0 : serverId.hashCode());
-        return result;
-    }
+    // ── Factory ───────────────────────────────────────────────────────────────
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        ReindexEntry other = (ReindexEntry) obj;
-        if (delete != other.delete)
-            return false;
-        if (identToIndex == null) {
-            if (other.identToIndex != null)
-                return false;
-        } else if (!identToIndex.equals(other.identToIndex))
-            return false;
-        if (priority != other.priority)
-            return false;
-        if (serverId == null) {
-            if (other.serverId != null)
-                return false;
-        } else if (!serverId.equals(other.serverId))
-            return false;
-        return true;
+    /** Returns a new builder for constructing a {@link ReindexEntry}. */
+    public static ImmutableReindexEntry.Builder builder() {
+        return ImmutableReindexEntry.builder();
     }
 
     @Override
     public String toString() {
-        return "IndexJournal [id=" + id + ", identToIndex=" + identToIndex + ", priority=" + priority + ", delete=" + delete + ", serverId="
-                + serverId + "]";
+        return "IndexJournal [id=" + getId()
+                + ", identToIndex=" + getIdentToIndex()
+                + ", priority=" + getPriority()
+                + ", delete=" + isDelete()
+                + ", serverId=" + getServerId() + "]";
     }
-
 }

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexEntry.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexEntry.java
@@ -17,15 +17,14 @@ import org.immutables.value.Value;
  * <h3>Construction</h3>
  * <pre>{@code
  * ReindexEntry entry = ImmutableReindexEntry.builder()
- *     .setId(42L)
- *     .setIdentToIndex("abc123")
- *     .setPriority(0)
- *     .setDelete(false)
+ *     .id(42L)
+ *     .identToIndex("abc123")
+ *     .priority(0)
+ *     .isDelete(false)
  *     .build();
  * }</pre>
  */
 @Value.Immutable
-@Value.Style(init = "set*")
 public abstract class ReindexEntry {
 
     // ── Identity / routing ────────────────────────────────────────────────────
@@ -83,12 +82,4 @@ public abstract class ReindexEntry {
         return ImmutableReindexEntry.builder();
     }
 
-    @Override
-    public String toString() {
-        return "IndexJournal [id=" + getId()
-                + ", identToIndex=" + getIdentToIndex()
-                + ", priority=" + getPriority()
-                + ", delete=" + isDelete()
-                + ", serverId=" + getServerId() + "]";
-    }
 }

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexQueueFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexQueueFactory.java
@@ -217,12 +217,13 @@ public class ReindexQueueFactory {
                 priority = Integer.parseInt(map.get("priority").toString());
             }
 
-            final ReindexEntry ridx = new ReindexEntry()
+            final ReindexEntry ridx = ImmutableReindexEntry.builder()
                     .setId(identifier)
                     .setIdentToIndex((String) map.get("ident_to_index"))
                     .setPriority(priority)
                     .setTimeEntered((Date) map.get("time_entered"))
-                    .setLastResult(indexVal);
+                    .setLastResult(indexVal)
+                    .build();
             failed.add(ridx);
         }
         return failed;
@@ -352,16 +353,13 @@ public class ReindexQueueFactory {
         }
     }
 
-    private ReindexEntry mapToReindexEntry(Map<String, Object> map) {
-        final ReindexEntry entry = new ReindexEntry();
-        entry.setId(((Number) map.get("id")).longValue());
-        String identifier = (String) map.get("ident_to_index");
-        entry.setIdentToIndex(identifier);
-        entry.setPriority(((Number) (map.get("priority"))).intValue());
-        entry.setDelete(
-                ((Number) (map.get("dist_action"))).intValue() == ReindexAction.DELETE.ordinal());
-        return entry;
-
+    private ReindexEntry mapToReindexEntry(final Map<String, Object> map) {
+        return ImmutableReindexEntry.builder()
+                .setId(((Number) map.get("id")).longValue())
+                .setIdentToIndex((String) map.get("ident_to_index"))
+                .setPriority(((Number) map.get("priority")).intValue())
+                .setDelete(((Number) map.get("dist_action")).intValue() == ReindexAction.DELETE.ordinal())
+                .build();
     }
 
 

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexQueueFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexQueueFactory.java
@@ -218,11 +218,11 @@ public class ReindexQueueFactory {
             }
 
             final ReindexEntry ridx = ImmutableReindexEntry.builder()
-                    .setId(identifier)
-                    .setIdentToIndex((String) map.get("ident_to_index"))
-                    .setPriority(priority)
-                    .setTimeEntered((Date) map.get("time_entered"))
-                    .setLastResult(indexVal)
+                    .id(identifier)
+                    .identToIndex((String) map.get("ident_to_index"))
+                    .priority(priority)
+                    .timeEntered((Date) map.get("time_entered"))
+                    .lastResult(indexVal)
                     .build();
             failed.add(ridx);
         }
@@ -355,10 +355,10 @@ public class ReindexQueueFactory {
 
     private ReindexEntry mapToReindexEntry(final Map<String, Object> map) {
         return ImmutableReindexEntry.builder()
-                .setId(((Number) map.get("id")).longValue())
-                .setIdentToIndex((String) map.get("ident_to_index"))
-                .setPriority(((Number) map.get("priority")).intValue())
-                .setDelete(((Number) map.get("dist_action")).intValue() == ReindexAction.DELETE.ordinal())
+                .id(((Number) map.get("id")).longValue())
+                .identToIndex((String) map.get("ident_to_index"))
+                .priority(((Number) map.get("priority")).intValue())
+                .isDelete(((Number) map.get("dist_action")).intValue() == ReindexAction.DELETE.ordinal())
                 .build();
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexQueueFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/common/reindex/ReindexQueueFactory.java
@@ -217,7 +217,7 @@ public class ReindexQueueFactory {
                 priority = Integer.parseInt(map.get("priority").toString());
             }
 
-            final ReindexEntry ridx = ImmutableReindexEntry.builder()
+            final ReindexEntry ridx = ReindexEntry.builder()
                     .id(identifier)
                     .identToIndex((String) map.get("ident_to_index"))
                     .priority(priority)
@@ -354,7 +354,7 @@ public class ReindexQueueFactory {
     }
 
     private ReindexEntry mapToReindexEntry(final Map<String, Object> map) {
-        return ImmutableReindexEntry.builder()
+        return ReindexEntry.builder()
                 .id(((Number) map.get("id")).longValue())
                 .identToIndex((String) map.get("ident_to_index"))
                 .priority(((Number) map.get("priority")).intValue())

--- a/dotcms-integration/src/test/java/com/dotmarketing/common/reindex/ReindexQueueAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/common/reindex/ReindexQueueAPITest.java
@@ -54,8 +54,9 @@ public class ReindexQueueAPITest {
             final ReindexEntry currentEntry = getReindexEntry(recordId);
 
             //marks the entry as failed and verifies it is returned
-            currentEntry.setPriority(REINDEX_MAX_FAILURE_ATTEMPTS);
-            reindexQueueAPI.markAsFailed(currentEntry, "Testing failed record");
+            reindexQueueAPI.markAsFailed(
+                    ImmutableReindexEntry.builder().from(currentEntry).priority(REINDEX_MAX_FAILURE_ATTEMPTS).build(),
+                    "Testing failed record");
 
             failedRecords = reindexQueueAPI.getFailedReindexRecords();
             assertTrue(UtilMethods.isSet(failedRecords));
@@ -91,8 +92,9 @@ public class ReindexQueueAPITest {
             ReindexEntry currentEntry = getReindexEntry(recordId);
 
             //forces the priority to be set to Priority.REINDEX
-            currentEntry.setPriority(Priority.REINDEX.ordinal() - 1);
-            reindexQueueAPI.markAsFailed(currentEntry, "Testing failed record");
+            reindexQueueAPI.markAsFailed(
+                    ImmutableReindexEntry.builder().from(currentEntry).priority(Priority.REINDEX.ordinal() - 1).build(),
+                    "Testing failed record");
             failedRecords = reindexQueueAPI.getFailedReindexRecords();
             assertFalse(UtilMethods.isSet(failedRecords));
 


### PR DESCRIPTION
## Summary

- Converts `ReindexEntry` from a mutable POJO to a `@Value.Immutable` abstract class
- Equals/hashCode match original semantics (`identToIndex`, `priority`, `delete`, `serverId`) via `@Value.Auxiliary` on `id`, `lastResult`, and `timeEntered`
- Updates both creation sites in `ReindexQueueFactory` to use `ImmutableReindexEntry.builder()...build()`
- `serverId` was never set anywhere in production code — now correctly documented as `@Nullable`
- `isReindex()` and `errorCount()` preserved as concrete methods on the abstract class
- `toString()` preserved with identical format to the original

## Notes

- `mock(ReindexEntry.class)` in `ReindexQueueAPITest` continues to work — Mockito supports abstract classes
- `ImmutableReindexEntry` is generated by the Immutables annotation processor at compile time

## Test plan

- [ ] `./mvnw install -pl :dotcms-core -DskipTests` — verifies annotation processor generates `ImmutableReindexEntry`
- [ ] `./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=ReindexQueueAPITest`
- [ ] `./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=ReindexAPITest`

Refs: #34934

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34934