### PR TITLE
fix: raise Jackson StreamReadConstraints limit in ContentletJsonHelper (#35394)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/business/json/ContentletJsonHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/content/business/json/ContentletJsonHelper.java
@@ -3,6 +3,7 @@ package com.dotcms.content.business.json;
 import com.dotcms.content.model.Contentlet;
 import com.dotmarketing.util.Logger;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -38,6 +39,8 @@ public class ContentletJsonHelper {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.registerModule(new VersioningModule());
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        objectMapper.getFactory().setStreamReadConstraints(
+                StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
         return objectMapper;
     });
 

--- a/dotCMS/src/main/java/com/dotcms/content/business/json/ContentletJsonHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/content/business/json/ContentletJsonHelper.java
@@ -1,6 +1,7 @@
 package com.dotcms.content.business.json;
 
 import com.dotcms.content.model.Contentlet;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.StreamReadConstraints;
@@ -39,8 +40,9 @@ public class ContentletJsonHelper {
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.registerModule(new VersioningModule());
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        final int maxStringLengthMb = Config.getIntProperty("CONTENTLET_JSON_MAX_STRING_LENGTH_MB", 100);
         objectMapper.getFactory().setStreamReadConstraints(
-                StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
+                StreamReadConstraints.builder().maxStringLength(maxStringLengthMb * 1024 * 1024).build());
         return objectMapper;
     });
 

--- a/dotCMS/src/test/java/com/dotcms/content/business/json/ContentletJsonHelperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/business/json/ContentletJsonHelperTest.java
@@ -1,0 +1,60 @@
+package com.dotcms.content.business.json;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ContentletJsonHelper}.
+ */
+public class ContentletJsonHelperTest {
+
+    /**
+     * Verifies that the ObjectMapper's factory has no effective string-length cap
+     * (Integer.MAX_VALUE), so that contentlets with very large field values (e.g. >20 MB)
+     * do not fail with a StreamConstraintsException during JSON serialization.
+     *
+     * <p>Background: Jackson 2.15 introduced a default 20,000,000-character limit via
+     * {@link StreamReadConstraints}. The {@code VersionedModelSerializer} re-parses the
+     * serialized JSON during version migration, triggering the read constraint.  Without
+     * an explicit override, any contentlet whose JSON representation exceeds ~20 MB will
+     * cause {@code PopulateContentletAsJSONJob} to abort entirely.
+     *
+     * @see <a href="https://github.com/dotCMS/core/issues/35394">Issue #35394</a>
+     */
+    @Test
+    public void testObjectMapperHasUnboundedStringReadConstraint() {
+        final StreamReadConstraints constraints = ContentletJsonHelper.INSTANCE.get()
+                .objectMapper()
+                .getFactory()
+                .streamReadConstraints();
+
+        assertNotNull("StreamReadConstraints must be configured on the ObjectMapper factory", constraints);
+        assertEquals(
+                "maxStringLength must be Integer.MAX_VALUE to support large contentlet fields (>20 MB)",
+                Integer.MAX_VALUE,
+                constraints.getMaxStringLength());
+    }
+
+    /**
+     * Verifies that {@link ContentletJsonHelper#writeAsString(Object)} can serialize a plain
+     * string value that exceeds Jackson's previous default 20 MB limit without throwing a
+     * {@link com.fasterxml.jackson.core.exc.StreamConstraintsException}.
+     */
+    @Test
+    public void testWriteAsStringHandlesValueExceeding20MBLimit() throws JsonProcessingException {
+        // Build a string just over the old 20,000,000-character default limit
+        final int targetLength = 20_100_000;
+        final String largeValue = "x".repeat(targetLength);
+
+        // Must not throw StreamConstraintsException
+        final String json = ContentletJsonHelper.INSTANCE.get().writeAsString(largeValue);
+
+        assertNotNull("Serialized JSON must not be null", json);
+        // The resulting JSON wraps the string in quotes, so length > targetLength
+        assertEquals(targetLength + 2, json.length());
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/content/business/json/ContentletJsonHelperTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/business/json/ContentletJsonHelperTest.java
@@ -13,39 +13,27 @@ import org.junit.Test;
 public class ContentletJsonHelperTest {
 
     /**
-     * Verifies that the ObjectMapper's factory has no effective string-length cap
-     * (Integer.MAX_VALUE), so that contentlets with very large field values (e.g. >20 MB)
-     * do not fail with a StreamConstraintsException during JSON serialization.
-     *
-     * <p>Background: Jackson 2.15 introduced a default 20,000,000-character limit via
-     * {@link StreamReadConstraints}. The {@code VersionedModelSerializer} re-parses the
-     * serialized JSON during version migration, triggering the read constraint.  Without
-     * an explicit override, any contentlet whose JSON representation exceeds ~20 MB will
-     * cause {@code PopulateContentletAsJSONJob} to abort entirely.
+     * Verifies the ObjectMapper has a raised string-length cap to handle large contentlet fields.
+     * Jackson 2.15+ defaults to 20 MB; without an explicit override PopulateContentletAsJSONJob
+     * aborts when VersionedModelSerializer re-parses the serialized JSON during version migration.
      *
      * @see <a href="https://github.com/dotCMS/core/issues/35394">Issue #35394</a>
      */
     @Test
-    public void testObjectMapperHasUnboundedStringReadConstraint() {
+    public void testObjectMapper_WhenConfigured_ShouldHaveRaisedStringReadConstraint() {
         final StreamReadConstraints constraints = ContentletJsonHelper.INSTANCE.get()
                 .objectMapper()
                 .getFactory()
                 .streamReadConstraints();
 
         assertNotNull("StreamReadConstraints must be configured on the ObjectMapper factory", constraints);
-        assertEquals(
-                "maxStringLength must be Integer.MAX_VALUE to support large contentlet fields (>20 MB)",
-                Integer.MAX_VALUE,
-                constraints.getMaxStringLength());
+        // Default Jackson 2.15 cap is 20,000,000 — must be higher than that
+        assertEquals(100 * 1024 * 1024, constraints.getMaxStringLength());
     }
 
-    /**
-     * Verifies that {@link ContentletJsonHelper#writeAsString(Object)} can serialize a plain
-     * string value that exceeds Jackson's previous default 20 MB limit without throwing a
-     * {@link com.fasterxml.jackson.core.exc.StreamConstraintsException}.
-     */
     @Test
-    public void testWriteAsStringHandlesValueExceeding20MBLimit() throws JsonProcessingException {
+    public void testWriteAsString_WhenValueExceeds20MBLimit_ShouldNotThrowStreamConstraintsException()
+            throws JsonProcessingException {
         // Build a string just over the old 20,000,000-character default limit
         final int targetLength = 20_100_000;
         final String largeValue = "x".repeat(targetLength);


### PR DESCRIPTION
## Summary

- `ContentletJsonHelper`'s `ObjectMapper` was not configuring `StreamReadConstraints`, so it defaulted to Jackson 2.15+'s 20 MB string-length cap
- `VersionedModelSerializer.doSerialize()` re-parses the serialized JSON during version migration, triggering the read constraint on large contentlets
- `PopulateContentletAsJSONJob` aborted entirely when hitting inode `ff4bc56e-53f5-4b3c-b7cf-df39f7294fc5` (~20.02 MB) at a customer (Deutsche Bank)
- Fix: set `maxStringLength(Integer.MAX_VALUE)` on the `ObjectMapper` factory in `ContentletJsonHelper`

## Changes

- `ContentletJsonHelper.java` — configure `StreamReadConstraints` with `Integer.MAX_VALUE` on the lazy `ObjectMapper` factory
- `ContentletJsonHelperTest.java` — new unit test asserting the constraint is set and that strings >20 MB serialize without error

## Test plan

- [ ] Run `ContentletJsonHelperTest` unit tests pass
- [ ] Re-run `PopulateContentletAsJSONJob` against the affected instance — job completes without `StreamConstraintsException`

Closes #35394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35394