### PR TITLE
fix(url-title): enhance suggestion display logic in url-title_old.vtl

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_old.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_old.vtl
@@ -23,14 +23,21 @@
         
         if (!newSlug || newSlug === currentValue) {
             suggestion.style.display = 'none';
+            suggestion.innerHTML = '';
             return;
         }
 
-        suggestion.innerHTML = `
-            <a href="#" onclick="applySuggestion('${newSlug}'); return false">
-                Use: ${newSlug}
-            </a>
-        `;
+        suggestion.innerHTML = '';
+
+        const link = document.createElement('a');
+        link.href = '#';
+        link.textContent = `Use: ${newSlug}`;
+        link.addEventListener('click', event => {
+            event.preventDefault();
+            applySuggestion(newSlug);
+        });
+
+        suggestion.appendChild(link);
         suggestion.style.display = 'block';
     };
 
@@ -65,13 +72,14 @@
                 const newSlug = slugifyText(value);
                 showSuggestion(newSlug);
         });
+
+        input.addEventListener('keyup', handleInput);
     });
 </script>
 
 <input 
     type="text" 
     id="slugInput" 
-    onkeyup="handleInput()" 
     class="dijitTextBox" 
     style="background:#FAFAFA"
 />


### PR DESCRIPTION
This pull request refactors the way the slug suggestion link is created and displayed in the `url-title_old.vtl` file. The changes improve the code's robustness and maintainability by replacing direct HTML string manipulation with safe DOM methods, and by updating event handling for the input field.

**Refactoring and event handling improvements:**

- Replaced direct assignment of HTML strings to `suggestion.innerHTML` with programmatic creation and configuration of the `<a>` element using DOM methods, reducing the risk of XSS and improving code clarity.
- Added a `keyup` event listener to the input field via JavaScript instead of using the inline `onkeyup` attribute, promoting separation of concerns and making the code easier to maintain.