### PR TITLE
fix(dot-wizard): isolate output stream so cancelled wizards don't fire workflow actions

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.spec.ts
@@ -302,6 +302,13 @@ describe('DotWizardComponent', () => {
             expect(transform).toEqual('translateX(-400px)');
         }));
 
+        it('should notify the service on dismiss so leaked subscriptions unsubscribe', fakeAsync(() => {
+            const cancelSpy = jest.spyOn(dotWizardService, 'cancel');
+            spectator.component.close();
+            tick(0);
+            expect(cancelSpy).toHaveBeenCalledTimes(1);
+        }));
+
         it('should update transform property on previous', fakeAsync(() => {
             form1.valid.emit(true);
             form2.valid.emit(true);

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
@@ -103,6 +103,8 @@ export class DotWizardComponent implements AfterViewInit {
         this.updateTransform();
         this.$stepsVisible.set(false);
         if (wasOpen) {
+            // Idempotent on the submit path: sendValue() nullifies currentOutput
+            // before calling close(), so cancel() becomes a no-op there.
             this.#dotWizardService.cancel();
         }
     }

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts
@@ -97,10 +97,14 @@ export class DotWizardComponent implements AfterViewInit {
      * @memberof DotWizardComponent
      */
     close(): void {
+        const wasOpen = !!this.$data();
         this.$data.set(null);
         this.#currentStep = 0;
         this.updateTransform();
         this.$stepsVisible.set(false);
+        if (wasOpen) {
+            this.#dotWizardService.cancel();
+        }
     }
 
     /**

--- a/core-web/libs/data-access/src/lib/dot-wizard/dot-wizard.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-wizard/dot-wizard.service.spec.ts
@@ -39,4 +39,36 @@ describe('DotWizardService', () => {
         service.output$(mockOutput);
         expect(outputData).toEqual(mockOutput);
     });
+
+    it('should complete the stream without emitting when cancel is called', () => {
+        const next = jest.fn();
+        const complete = jest.fn();
+        service.open(mockWizardInput).subscribe({ next, complete });
+        service.cancel();
+        expect(next).not.toHaveBeenCalled();
+        expect(complete).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not deliver output from a new open() to a previous (cancelled) subscription', () => {
+        const firstNext = jest.fn();
+        const secondNext = jest.fn();
+
+        service.open(mockWizardInput).subscribe(firstNext);
+        service.cancel(); // user dismissed the first wizard
+
+        service.open(mockWizardInput).subscribe(secondNext);
+        service.output$(mockOutput); // user sends on the second wizard
+
+        expect(firstNext).not.toHaveBeenCalled();
+        expect(secondNext).toHaveBeenCalledWith(mockOutput);
+    });
+
+    it('should complete after output$ so take(1) consumers unsubscribe cleanly', () => {
+        const next = jest.fn();
+        const complete = jest.fn();
+        service.open(mockWizardInput).subscribe({ next, complete });
+        service.output$(mockOutput);
+        expect(next).toHaveBeenCalledWith(mockOutput);
+        expect(complete).toHaveBeenCalledTimes(1);
+    });
 });

--- a/core-web/libs/data-access/src/lib/dot-wizard/dot-wizard.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-wizard/dot-wizard.service.spec.ts
@@ -63,6 +63,20 @@ describe('DotWizardService', () => {
         expect(secondNext).toHaveBeenCalledWith(mockOutput);
     });
 
+    it('should complete a previous stream when open() is called again without cancel', () => {
+        const firstNext = jest.fn();
+        const firstComplete = jest.fn();
+        const secondNext = jest.fn();
+
+        service.open(mockWizardInput).subscribe({ next: firstNext, complete: firstComplete });
+        service.open(mockWizardInput).subscribe(secondNext);
+        service.output$(mockOutput);
+
+        expect(firstNext).not.toHaveBeenCalled();
+        expect(firstComplete).toHaveBeenCalledTimes(1);
+        expect(secondNext).toHaveBeenCalledWith(mockOutput);
+    });
+
     it('should complete after output$ so take(1) consumers unsubscribe cleanly', () => {
         const next = jest.fn();
         const complete = jest.fn();

--- a/core-web/libs/data-access/src/lib/dot-wizard/dot-wizard.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-wizard/dot-wizard.service.ts
@@ -4,37 +4,51 @@ import { Injectable } from '@angular/core';
 
 import { DotWizardInput } from '@dotcms/dotcms-models';
 
+type WizardOutput = { [key: string]: string | string[] };
+
 @Injectable({
     providedIn: 'root'
 })
 export class DotWizardService {
     private input: Subject<DotWizardInput> = new Subject<DotWizardInput>();
-    private output: Subject<{ [key: string]: string | string[] }> = new Subject<{
-        [key: string]: string | string[];
-    }>();
+    private currentOutput: Subject<WizardOutput> | null = null;
 
     get showDialog$(): Observable<DotWizardInput> {
         return this.input.asObservable();
     }
 
     /**
-     * Notify the data collected in wizard.
-     * @param {{ [key: string]: string | string[] }} form
-     * @memberof DotWizardService
+     * Emit the data collected by the wizard and close the current stream.
+     * Called by the wizard component when the user accepts/sends.
      */
-    output$(form: { [key: string]: string | string[] }): void {
-        this.output.next(form);
+    output$(form: WizardOutput): void {
+        this.currentOutput?.next(form);
+        this.currentOutput?.complete();
+        this.currentOutput = null;
     }
 
     /**
-     * Send the wizard data to in input subscription and waits for the output
-     * @param {DotWizardInput} data
-     * @returns Observable<{ [key: string]: string }>
-     * @memberof DotWizardService
+     * Close the current stream without emitting. Called by the wizard
+     * component when the user cancels or dismisses the dialog so that
+     * pending subscriptions unsubscribe instead of leaking into the next
+     * wizard invocation.
+     */
+    cancel(): void {
+        this.currentOutput?.complete();
+        this.currentOutput = null;
+    }
+
+    /**
+     * Show the wizard with the given input and return an observable that
+     * emits once when the user submits and completes, or completes without
+     * emitting if the user cancels. Each call returns an isolated stream.
      */
     open<T = { [key: string]: string }>(data: DotWizardInput): Observable<T> {
+        this.currentOutput?.complete();
+        this.currentOutput = new Subject<WizardOutput>();
+        const output$ = this.currentOutput.asObservable() as unknown as Observable<T>;
         this.input.next(data);
 
-        return this.output.asObservable() as Observable<T>;
+        return output$;
     }
 }


### PR DESCRIPTION
## Parent issue

Closes #35422

## Summary

- `DotWizardService` used a single shared `Subject` across every `open()` invocation. When the user dismissed the wizard without submitting, the consumer's subscription stayed alive and fired on the next submission — causing workflow actions (e.g. *Send for Review*, Push Publish, comment & assign) to be applied to unrelated content items the user had never touched.
- Each `open()` now creates a fresh `Subject` and returns an isolated stream. A new `cancel()` method completes the current stream without emitting; `output$()` emits and completes. The wizard component calls `cancel()` on close so `take(1)` consumers unsubscribe cleanly.
- No consumer of `DotWizardService` required changes — `DotWorkflowEventHandlerService`, `DotEmaWorkflowActionsService`, and any other caller continue to work as before.

## Files changed

- `core-web/libs/data-access/src/lib/dot-wizard/dot-wizard.service.ts` — per-invocation `Subject`, new `cancel()`, complete-on-emit semantics
- `core-web/libs/data-access/src/lib/dot-wizard/dot-wizard.service.spec.ts` — new specs for cancel, cross-invocation isolation, and complete-after-output
- `core-web/apps/dotcms-ui/src/app/view/components/_common/dot-wizard/dot-wizard.component.ts` — `close()` notifies the service via `cancel()`

## Test plan

- [x] `yarn nx test data-access --testPathPattern=dot-wizard` — passes
- [x] `yarn nx test dotcms-ui --testPathPattern=dot-wizard.component` — passes
- [x] `yarn nx lint data-access` + `yarn nx lint dotcms-ui` — no new errors
- [x] `yarn nx format:write` applied to changed files
- [x] Manual reproduction on `/dotAdmin/#/c/c_Blog-Entries`:
  - Right-click Row A → *Send for Review* → **X** to cancel
  - Right-click Row B → *Send for Review* → fill form → **Send**
  - Before: both rows move to QA · After: only Row B moves to QA ✅

## Links

- Helpdesk ticket: https://helpdesk.dotcms.com/a/tickets/36428

This PR fixes: #35422