### PR TITLE
fix(block-editor): correct image wrap icons and add missing i18n keys

### DIFF
--- a/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.html
+++ b/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.html
@@ -42,8 +42,8 @@
             title="{{ 'block-editor.bubble-menu.image.wrap-left' | dm }}"
             (onClick)="setImageTextWrap('left')"
             [class.is-active]="imageTextWrap() === 'left'">
-            <i class="pi pi-align-left"></i>
-            <i class="pi pi-image" style="margin-left: -4px"></i>
+            <i class="pi pi-image" style="margin-right: -4px"></i>
+            <i class="pi pi-align-right"></i>
         </p-button>
         <p-button
             text
@@ -51,8 +51,8 @@
             title="{{ 'block-editor.bubble-menu.image.wrap-right' | dm }}"
             (onClick)="setImageTextWrap('right')"
             [class.is-active]="imageTextWrap() === 'right'">
-            <i class="pi pi-image" style="margin-right: -4px"></i>
-            <i class="pi pi-align-right"></i>
+            <i class="pi pi-align-left"></i>
+            <i class="pi pi-image" style="margin-left: -4px"></i>
         </p-button>
 
         <div class="divider"></div>

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -5848,6 +5848,8 @@ block-editor.placeholder.code=Enter your code
 block-editor.placeholder.paragraph=Start writing or type / to choose a block
 block-editor.bubble-menu.contentlet.edit=Edit Contentlet
 block-editor.bubble-menu.image.properties=Image Properties
+block-editor.bubble-menu.image.wrap-left=Wrap Left
+block-editor.bubble-menu.image.wrap-right=Wrap Right
 
 locales.add.locale=Add Locale
 locales.edit.locale=Edit Locale


### PR DESCRIPTION
## Summary

Fixes two bugs in the Block Editor image text-wrap toolbar buttons introduced in #35211 (reported via FD #36727).

- **Icon/action mismatch**: The wrap-left button showed `pi-align-left` + `pi-image` (visually: text-left, image-right) but `setImageTextWrap('left')` produces `float: left` — image on the left, text on the right. The icons were swapped between the two buttons. Fixed by using `pi-image` + `pi-align-right` for wrap-left and `pi-align-left` + `pi-image` for wrap-right so each icon pair visually matches the layout it produces.
- **Missing i18n keys**: `Language.properties` only defined `block-editor.bubble-menu.image.properties`. The `wrap-left` and `wrap-right` keys were absent, causing the `dm` pipe to render the raw key string as the tooltip. Added `block-editor.bubble-menu.image.wrap-left=Wrap Left` and `block-editor.bubble-menu.image.wrap-right=Wrap Right`.

## Files changed

- `core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.html` — swapped icon pairs on wrap-left/wrap-right buttons
- `dotCMS/src/main/webapp/WEB-INF/messages/Language.properties` — added missing i18n keys

## Test plan

- [ ] Open Block Editor and insert an image
- [ ] Select the image to open the bubble menu
- [ ] Hover wrap-left button — tooltip shows "Wrap Left" (not raw key)
- [ ] Hover wrap-right button — tooltip shows "Wrap Right" (not raw key)
- [ ] Click wrap-left — image floats left; icon shows image on left, text lines on right
- [ ] Click wrap-right — image floats right; icon shows text lines on left, image on right

Closes #35420

🤖 Generated with [Claude Code](https://claude.com/claude-code)