### PR TITLE
fix(uve): scope radio and checkbox inputs by field variable name

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.html
@@ -115,6 +115,7 @@
                                     @for (option of field.options; track option.value) {
                                         <p-checkbox
                                             [formControlName]="field.variable"
+                                            [name]="field.variable"
                                             [value]="option.value"
                                             [inputId]="field.variable + '-' + option.value"
                                             [binary]="false" />
@@ -146,6 +147,7 @@
                                 @for (option of field.options; track option.value) {
                                     <p-radioButton
                                         [formControlName]="field.variable"
+                                        [name]="field.variable"
                                         [value]="option.value"
                                         [inputId]="field.variable + '-' + option.value"
                                         [disabled]="field.readOnly"></p-radioButton>

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.html
@@ -127,6 +127,7 @@
                             } @else {
                                 <p-checkbox
                                     [formControlName]="field.variable"
+                                    [name]="field.variable"
                                     [inputId]="field.variable"
                                     [binary]="true"></p-checkbox>
                             }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.spec.ts
@@ -670,38 +670,41 @@ describe('DotUveContentletQuickEditComponent', () => {
             expect(spectator.queryAll('p-checkbox').length).toBe(2);
         }));
 
-        it('should set the name attribute on multi-option checkbox inputs to match the field variable', fakeAsync(() => {
-            contentTypeCacheSignal.set(
-                makeCache('TestType', [
-                    {
-                        name: 'Colors',
-                        variable: 'colors',
-                        clazz: DotCMSClazzes.CHECKBOX,
-                        required: false,
-                        readOnly: false,
-                        dataType: 'TEXT',
-                        fieldVariables: [],
-                        fieldType: 'Checkbox',
-                        values: 'Red|red\nBlue|blue'
+        it.each([['red'], ['blue']])(
+            'should set name="colors" on checkbox input for option value=%s',
+            fakeAsync((value: string) => {
+                contentTypeCacheSignal.set(
+                    makeCache('TestType', [
+                        {
+                            name: 'Colors',
+                            variable: 'colors',
+                            clazz: DotCMSClazzes.CHECKBOX,
+                            required: false,
+                            readOnly: false,
+                            dataType: 'TEXT',
+                            fieldVariables: [],
+                            fieldType: 'Checkbox',
+                            values: 'Red|red\nBlue|blue'
+                        }
+                    ])
+                );
+                fixture.componentRef.setInput('data', {
+                    ...mockContentletEditData,
+                    contentlet: {
+                        ...mockContentlet,
+                        identifier: `checkbox-name-${value}-id`,
+                        inode: `checkbox-name-${value}-inode`
                     }
-                ])
-            );
-            fixture.componentRef.setInput('data', {
-                ...mockContentletEditData,
-                contentlet: {
-                    ...mockContentlet,
-                    identifier: 'checkbox-name-id',
-                    inode: 'checkbox-name-inode'
-                }
-            });
-            spectator.detectChanges();
-            flushMicrotasks();
-            spectator.detectChanges();
+                });
+                spectator.detectChanges();
+                flushMicrotasks();
+                spectator.detectChanges();
 
-            const inputs = spectator.queryAll<HTMLInputElement>('input[type="checkbox"]');
-            expect(inputs.length).toBe(2);
-            inputs.forEach((input) => expect(input.getAttribute('name')).toBe('colors'));
-        }));
+                expect(
+                    spectator.query<HTMLInputElement>(`#colors-${value}`)?.getAttribute('name')
+                ).toBe('colors');
+            })
+        );
 
         it('should set the name attribute on binary checkbox to match the field variable', fakeAsync(() => {
             contentTypeCacheSignal.set(
@@ -842,38 +845,41 @@ describe('DotUveContentletQuickEditComponent', () => {
             expect(spectator.queryAll('p-radiobutton').length).toBe(2);
         }));
 
-        it('should set the name attribute on radio inputs to match the field variable', fakeAsync(() => {
-            contentTypeCacheSignal.set(
-                makeCache('TestType', [
-                    {
-                        name: 'Priority',
-                        variable: 'priority',
-                        clazz: DotCMSClazzes.RADIO,
-                        required: false,
-                        readOnly: false,
-                        dataType: 'TEXT',
-                        fieldVariables: [],
-                        fieldType: 'Radio',
-                        values: 'High|high\nLow|low'
+        it.each([['high'], ['low']])(
+            'should set name="priority" on radio input for option value=%s',
+            fakeAsync((value: string) => {
+                contentTypeCacheSignal.set(
+                    makeCache('TestType', [
+                        {
+                            name: 'Priority',
+                            variable: 'priority',
+                            clazz: DotCMSClazzes.RADIO,
+                            required: false,
+                            readOnly: false,
+                            dataType: 'TEXT',
+                            fieldVariables: [],
+                            fieldType: 'Radio',
+                            values: 'High|high\nLow|low'
+                        }
+                    ])
+                );
+                fixture.componentRef.setInput('data', {
+                    ...mockContentletEditData,
+                    contentlet: {
+                        ...mockContentlet,
+                        identifier: `radio-name-${value}-id`,
+                        inode: `radio-name-${value}-inode`
                     }
-                ])
-            );
-            fixture.componentRef.setInput('data', {
-                ...mockContentletEditData,
-                contentlet: {
-                    ...mockContentlet,
-                    identifier: 'radio-name-id',
-                    inode: 'radio-name-inode'
-                }
-            });
-            spectator.detectChanges();
-            flushMicrotasks();
-            spectator.detectChanges();
+                });
+                spectator.detectChanges();
+                flushMicrotasks();
+                spectator.detectChanges();
 
-            const inputs = spectator.queryAll<HTMLInputElement>('input[type="radio"]');
-            expect(inputs.length).toBe(2);
-            inputs.forEach((input) => expect(input.getAttribute('name')).toBe('priority'));
-        }));
+                expect(
+                    spectator.query<HTMLInputElement>(`#priority-${value}`)?.getAttribute('name')
+                ).toBe('priority');
+            })
+        );
 
         it('should scope radio groups so different radio fields do not interfere', fakeAsync(() => {
             contentTypeCacheSignal.set(

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.spec.ts
@@ -669,6 +669,120 @@ describe('DotUveContentletQuickEditComponent', () => {
 
             expect(spectator.queryAll('p-checkbox').length).toBe(2);
         }));
+
+        it('should set the name attribute on multi-option checkbox inputs to match the field variable', fakeAsync(() => {
+            contentTypeCacheSignal.set(
+                makeCache('TestType', [
+                    {
+                        name: 'Colors',
+                        variable: 'colors',
+                        clazz: DotCMSClazzes.CHECKBOX,
+                        required: false,
+                        readOnly: false,
+                        dataType: 'TEXT',
+                        fieldVariables: [],
+                        fieldType: 'Checkbox',
+                        values: 'Red|red\nBlue|blue'
+                    }
+                ])
+            );
+            fixture.componentRef.setInput('data', {
+                ...mockContentletEditData,
+                contentlet: {
+                    ...mockContentlet,
+                    identifier: 'checkbox-name-id',
+                    inode: 'checkbox-name-inode'
+                }
+            });
+            spectator.detectChanges();
+            flushMicrotasks();
+            spectator.detectChanges();
+
+            const inputs = spectator.queryAll<HTMLInputElement>('input[type="checkbox"]');
+            expect(inputs.length).toBe(2);
+            inputs.forEach((input) => expect(input.getAttribute('name')).toBe('colors'));
+        }));
+
+        it('should set the name attribute on binary checkbox to match the field variable', fakeAsync(() => {
+            contentTypeCacheSignal.set(
+                makeCache('TestType', [
+                    {
+                        name: 'Active',
+                        variable: 'active',
+                        clazz: DotCMSClazzes.CHECKBOX,
+                        required: false,
+                        readOnly: false,
+                        dataType: 'TEXT',
+                        fieldVariables: [],
+                        fieldType: 'Checkbox'
+                    }
+                ])
+            );
+            fixture.componentRef.setInput('data', {
+                ...mockContentletEditData,
+                contentlet: {
+                    ...mockContentlet,
+                    identifier: 'checkbox-binary-name-id',
+                    inode: 'checkbox-binary-name-inode'
+                }
+            });
+            spectator.detectChanges();
+            flushMicrotasks();
+            spectator.detectChanges();
+
+            const input = spectator.query<HTMLInputElement>('input[type="checkbox"]');
+            expect(input?.getAttribute('name')).toBe('active');
+        }));
+
+        it('should scope checkbox groups so different checkbox fields do not interfere', fakeAsync(() => {
+            contentTypeCacheSignal.set(
+                makeCache('TestType', [
+                    {
+                        name: 'Colors',
+                        variable: 'colors',
+                        clazz: DotCMSClazzes.CHECKBOX,
+                        required: false,
+                        readOnly: false,
+                        dataType: 'TEXT',
+                        fieldVariables: [],
+                        fieldType: 'Checkbox',
+                        values: 'Red|red\nBlue|blue'
+                    },
+                    {
+                        name: 'Sizes',
+                        variable: 'sizes',
+                        clazz: DotCMSClazzes.CHECKBOX,
+                        required: false,
+                        readOnly: false,
+                        dataType: 'TEXT',
+                        fieldVariables: [],
+                        fieldType: 'Checkbox',
+                        values: 'Small|small\nLarge|large'
+                    }
+                ])
+            );
+            fixture.componentRef.setInput('data', {
+                ...mockContentletEditData,
+                contentlet: {
+                    ...mockContentlet,
+                    identifier: 'checkbox-isolation-id',
+                    inode: 'checkbox-isolation-inode'
+                }
+            });
+            spectator.detectChanges();
+            flushMicrotasks();
+            spectator.detectChanges();
+
+            const colorInputs = spectator.queryAll<HTMLInputElement>(
+                'input[type="checkbox"][name="colors"]'
+            );
+            const sizeInputs = spectator.queryAll<HTMLInputElement>(
+                'input[type="checkbox"][name="sizes"]'
+            );
+
+            expect(colorInputs.length).toBe(2);
+            expect(sizeInputs.length).toBe(2);
+        }));
     });
 
     describe('SELECT field', () => {
@@ -726,6 +840,89 @@ describe('DotUveContentletQuickEditComponent', () => {
             spectator.detectChanges();
 
             expect(spectator.queryAll('p-radiobutton').length).toBe(2);
+        }));
+
+        it('should set the name attribute on radio inputs to match the field variable', fakeAsync(() => {
+            contentTypeCacheSignal.set(
+                makeCache('TestType', [
+                    {
+                        name: 'Priority',
+                        variable: 'priority',
+                        clazz: DotCMSClazzes.RADIO,
+                        required: false,
+                        readOnly: false,
+                        dataType: 'TEXT',
+                        fieldVariables: [],
+                        fieldType: 'Radio',
+                        values: 'High|high\nLow|low'
+                    }
+                ])
+            );
+            fixture.componentRef.setInput('data', {
+                ...mockContentletEditData,
+                contentlet: {
+                    ...mockContentlet,
+                    identifier: 'radio-name-id',
+                    inode: 'radio-name-inode'
+                }
+            });
+            spectator.detectChanges();
+            flushMicrotasks();
+            spectator.detectChanges();
+
+            const inputs = spectator.queryAll<HTMLInputElement>('input[type="radio"]');
+            expect(inputs.length).toBe(2);
+            inputs.forEach((input) => expect(input.getAttribute('name')).toBe('priority'));
+        }));
+
+        it('should scope radio groups so different radio fields do not interfere', fakeAsync(() => {
+            contentTypeCacheSignal.set(
+                makeCache('TestType', [
+                    {
+                        name: 'Priority',
+                        variable: 'priority',
+                        clazz: DotCMSClazzes.RADIO,
+                        required: false,
+                        readOnly: false,
+                        dataType: 'TEXT',
+                        fieldVariables: [],
+                        fieldType: 'Radio',
+                        values: 'High|high\nLow|low'
+                    },
+                    {
+                        name: 'Status',
+                        variable: 'status',
+                        clazz: DotCMSClazzes.RADIO,
+                        required: false,
+                        readOnly: false,
+                        dataType: 'TEXT',
+                        fieldVariables: [],
+                        fieldType: 'Radio',
+                        values: 'Active|active\nInactive|inactive'
+                    }
+                ])
+            );
+            fixture.componentRef.setInput('data', {
+                ...mockContentletEditData,
+                contentlet: {
+                    ...mockContentlet,
+                    identifier: 'radio-isolation-id',
+                    inode: 'radio-isolation-inode'
+                }
+            });
+            spectator.detectChanges();
+            flushMicrotasks();
+            spectator.detectChanges();
+
+            const priorityInputs = spectator.queryAll<HTMLInputElement>(
+                'input[type="radio"][name="priority"]'
+            );
+            const statusInputs = spectator.queryAll<HTMLInputElement>(
+                'input[type="radio"][name="status"]'
+            );
+
+            expect(priorityInputs.length).toBe(2);
+            expect(statusInputs.length).toBe(2);
         }));
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-quick-edit/dot-uve-contentlet-quick-edit.component.spec.ts
@@ -733,7 +733,7 @@ describe('DotUveContentletQuickEditComponent', () => {
             flushMicrotasks();
             spectator.detectChanges();
 
-            const input = spectator.query<HTMLInputElement>('input[type="checkbox"]');
+            const input = spectator.query<HTMLInputElement>('#active');
             expect(input?.getAttribute('name')).toBe('active');
         }));
 
@@ -785,6 +785,13 @@ describe('DotUveContentletQuickEditComponent', () => {
 
             expect(colorInputs.length).toBe(2);
             expect(sizeInputs.length).toBe(2);
+
+            // Behavioral: changing colors must not affect sizes form control
+            const form = spectator.component.$contentletForm();
+            form?.get('colors')?.setValue(['red']);
+            spectator.detectChanges();
+
+            expect(form?.get('sizes')?.value).toEqual([]);
         }));
     });
 
@@ -929,6 +936,13 @@ describe('DotUveContentletQuickEditComponent', () => {
 
             expect(priorityInputs.length).toBe(2);
             expect(statusInputs.length).toBe(2);
+
+            // Behavioral: changing priority must not affect status form control
+            const form = spectator.component.$contentletForm();
+            form?.get('priority')?.setValue('high');
+            spectator.detectChanges();
+
+            expect(form?.get('status')?.value).toBe('');
         }));
     });
 


### PR DESCRIPTION
## Summary

- Radio buttons and checkboxes in the UVE quick-edit form were sharing the same browser input group across different fields, causing selections in one field to affect another
- Added `[name]="field.variable"` to `p-radioButton` and `p-checkbox` in the `@for` loop so each field's inputs are scoped independently by their unique variable name

Closes #35432

## Test plan

- [ ] Open UVE and click a contentlet with multiple Radio fields — selecting an option in one field should not affect another
- [ ] Open UVE and click a contentlet with multiple Checkbox fields — checking/unchecking in one field should not affect another
- [ ] Verify single-option binary checkboxes still work correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)