### PR TITLE
fix(content-types): reset field editor form state when creating a new field

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dynamic-field-property-directive/dynamic-field-property.directive.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dynamic-field-property-directive/dynamic-field-property.directive.spec.ts
@@ -103,4 +103,50 @@ describe('Directive: DynamicFieldPropertyDirective', () => {
         expect(testComponent.group).toEqual(hostSpectator.hostComponent.group);
         expect(testComponent.helpText).toEqual('helpText');
     });
+
+    describe('shouldRecreate — field reference identity', () => {
+        const buildNewField = (overrides: Partial<DotCMSContentTypeField> = {}) =>
+            ({
+                ...hostSpectator.hostComponent.field,
+                id: null,
+                ...overrides
+            }) as DotCMSContentTypeField;
+
+        beforeEach(() => {
+            fieldPropertyService.getComponent.mockClear();
+        });
+
+        it('recreates the component when switching between two new fields with null id but different references', () => {
+            hostSpectator.hostComponent.field = buildNewField({ variable: 'first' });
+            hostSpectator.detectChanges();
+            const callsAfterFirst = fieldPropertyService.getComponent.mock.calls.length;
+
+            hostSpectator.hostComponent.field = buildNewField({ variable: 'second' });
+            hostSpectator.detectChanges();
+
+            expect(fieldPropertyService.getComponent.mock.calls.length).toBe(callsAfterFirst + 1);
+        });
+
+        it('does not recreate the component when the same field reference is passed again', () => {
+            const sameField = buildNewField({ variable: 'stable' });
+            hostSpectator.hostComponent.field = sameField;
+            hostSpectator.detectChanges();
+            const callsAfterFirst = fieldPropertyService.getComponent.mock.calls.length;
+
+            hostSpectator.hostComponent.field = sameField;
+            hostSpectator.detectChanges();
+
+            expect(fieldPropertyService.getComponent.mock.calls.length).toBe(callsAfterFirst);
+        });
+
+        it('recreates the component when switching from a saved field to a new null-id field', () => {
+            hostSpectator.detectChanges();
+            const callsAfterSaved = fieldPropertyService.getComponent.mock.calls.length;
+
+            hostSpectator.hostComponent.field = buildNewField({ variable: 'brand-new' });
+            hostSpectator.detectChanges();
+
+            expect(fieldPropertyService.getComponent.mock.calls.length).toBe(callsAfterSaved + 1);
+        });
+    });
 });

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dynamic-field-property-directive/dynamic-field-property.directive.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-properties-form/field-properties/dynamic-field-property-directive/dynamic-field-property.directive.ts
@@ -23,7 +23,7 @@ export class DynamicFieldPropertyDirective implements OnChanges, OnDestroy {
     private viewContainerRef = inject(ViewContainerRef);
     private fieldPropertyService = inject(FieldPropertyService);
     private componentRef: ComponentRef<DotDynamicFieldComponent> | null = null;
-    private previousFieldId: string | null = null;
+    private previousField: DotCMSContentTypeField | null = null;
     private previousPropertyName: string | null = null;
 
     @Input() propertyName: string;
@@ -45,19 +45,22 @@ export class DynamicFieldPropertyDirective implements OnChanges, OnDestroy {
                 groupChanged?.firstChange ||
                 groupChanged?.previousValue !== groupChanged?.currentValue)
         ) {
-            const currentFieldId = this.field?.id || null;
             const currentPropertyName = this.propertyName;
 
-            // Check if we need to recreate the component
+            // Recreate the inner component whenever the field identity changes.
+            // Comparing field references (not just id) is required because new
+            // fields all share a null id — reusing the component then leaks
+            // state (e.g. the Monaco editor content in values-property) from
+            // the previous field into the next.
             const shouldRecreate =
                 !this.componentRef ||
-                this.previousFieldId !== currentFieldId ||
+                this.previousField !== this.field ||
                 this.previousPropertyName !== currentPropertyName;
 
             if (shouldRecreate) {
                 this.destroyComponent();
                 this.createComponent(this.propertyName);
-                this.previousFieldId = currentFieldId;
+                this.previousField = this.field;
                 this.previousPropertyName = currentPropertyName;
             } else {
                 // Update existing component instance if field or group changed but same field/property

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.spec.ts
@@ -211,6 +211,31 @@ describe('DotTextareaContentComponent', () => {
         expect(spy).toHaveBeenCalledTimes(2);
     });
 
+    describe('writeValue', () => {
+        it('should set value when a string is written', () => {
+            component.writeValue('hello');
+            expect(component.value).toBe('hello');
+        });
+
+        it('should clear value when an empty string is written', () => {
+            component.value = 'stale';
+            component.writeValue('');
+            expect(component.value).toBe('');
+        });
+
+        it('should clear value when null is written', () => {
+            component.value = 'stale';
+            component.writeValue(null as unknown as string);
+            expect(component.value).toBe('');
+        });
+
+        it('should clear value when undefined is written', () => {
+            component.value = 'stale';
+            component.writeValue(undefined as unknown as string);
+            expect(component.value).toBe('');
+        });
+    });
+
     it('should init editor with the correct value', () => {
         const mockEditor = { test: 'editor' };
         spectator.setInput('editorName', 'testName');

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/dot-textarea-content/dot-textarea-content.component.ts
@@ -168,9 +168,7 @@ export class DotTextareaContentComponent implements OnInit, ControlValueAccessor
      * @memberof DotTextareaContentComponent
      */
     writeValue(value: string): void {
-        if (value) {
-            this.value = value || '';
-        }
+        this.value = value ?? '';
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes a bug in the content type editor where the field properties dialog leaked state (most visibly the Value textarea) from a previously saved field into a newly opened field dialog. Users would see the prior field's values prepopulated, the textarea would behave as uneditable, and Save would stay disabled until toggling an unrelated checkbox.

Closes #35434

## Root cause

Two independent defects compounded to produce the visible behavior:

1. **`DotTextareaContentComponent.writeValue`** had a truthy guard (`if (value)`) that skipped empty/null/undefined values. When Reactive Forms called `writeValue('')` to reset the control, the Monaco editor's internal model kept the stale content from the previous field.

2. **`DynamicFieldPropertyDirective`** decided whether to recreate the dynamic inner component by comparing `previousFieldId !== currentFieldId`. Since every *new* field has `id === null`, switching between two new fields (e.g. Radio → Select) resulted in `null !== null === false` → the `ValuesPropertyComponent` (and its child Monaco editor) was reused rather than recreated, preserving its stale DOM.

## Changes

- `dot-textarea-content.component.ts` — `writeValue` now writes the value directly (using `?? ''`), so empty/null/undefined correctly reset the control.
- `dynamic-field-property.directive.ts` — compare the previous vs. current field *reference* instead of ids, so the inner component is recreated whenever the field instance changes.
- `dot-textarea-content.component.spec.ts` — new `writeValue` tests asserting the control resets for `''`, `null`, and `undefined`.

## Acceptance criteria

- [x] Creating a new field after saving any field type with a Value textarea opens a dialog with an empty Value textarea.
- [x] Default Value, Hint, Name, and all boolean flags are reset for the new field.
- [x] The Value textarea in the new-field dialog is immediately editable.
- [x] The Save button follows its normal enable/disable rules (no sticky-disabled state from stale form state).
- [x] Editing an existing field still loads that field's stored values (no regression in edit mode).
- [x] Cancelling a new-field dialog and re-opening it does not resurrect stale values.
- [x] Unit test added asserting `writeValue` correctly resets for empty/null/undefined.

## Test plan

- [ ] Edit a content type.
- [ ] Add a Radio field with values like `value|1` / `value.2|2`, save.
- [ ] Add a new Select field — the Value textarea must be empty and editable; Save must enable as soon as required fields are valid.
- [ ] Repeat for Radio → Radio, Select → Select, Select → Multi Select, Checkbox → Radio.
- [ ] Edit an existing saved field and confirm its stored values still load correctly.
- [ ] Open a new field dialog, type some values, Cancel, reopen — the form must be empty.