### PR TITLE
fix(auth): send JSON object body to /api/v1/changePassword

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.spec.ts
@@ -1,5 +1,7 @@
 import { throwError } from 'rxjs';
 
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -8,8 +10,9 @@ import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { DotMessageService, DotRouterService } from '@dotcms/data-access';
-import { LoginService } from '@dotcms/dotcms-js';
+import { DotcmsEventsService, LoginService } from '@dotcms/dotcms-js';
 import {
+    DotcmsEventsServiceMock,
     LoginServiceMock,
     MockDotMessageService,
     MockDotRouterService
@@ -138,5 +141,78 @@ describe('ResetPasswordComponent', () => {
             .textContent;
 
         expect(errorMessage).toEqual('password do not match');
+    });
+});
+
+describe('ResetPasswordComponent — HTTP contract', () => {
+    // Uses the real LoginService (not mocked) so the outgoing HTTP request
+    // is exercised. Regression guard for #35269: Angular HttpClient auto-sets
+    // Content-Type based on the body's runtime type — an object gets
+    // application/json, a string gets text/plain. The backend only accepts
+    // application/json, so the body MUST be an object.
+    let fixture: ComponentFixture<ResetPasswordComponent>;
+    let component: ResetPasswordComponent;
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ResetPasswordComponent, BrowserAnimationsModule, RouterTestingModule],
+            providers: [
+                provideHttpClient(),
+                provideHttpClientTesting(),
+                { provide: DotMessageService, useValue: messageServiceMock },
+                { provide: DotcmsEventsService, useClass: DotcmsEventsServiceMock },
+                { provide: DotLoginPageStateService, useClass: MockDotLoginPageStateService },
+                { provide: DotRouterService, useClass: MockDotRouterService }
+            ]
+        });
+
+        fixture = TestBed.createComponent(ResetPasswordComponent);
+        component = fixture.componentInstance;
+        httpMock = TestBed.inject(HttpTestingController);
+        jest.spyOn(TestBed.inject(ActivatedRoute).snapshot.paramMap, 'get').mockReturnValue(
+            'reset-token'
+        );
+        fixture.detectChanges();
+    });
+
+    afterEach(() => httpMock.verify());
+
+    it('should POST /api/v1/changePassword with a plain-object body (not a stringified JSON)', () => {
+        component.resetPasswordForm.setValue({ password: 'new-pass', confirmPassword: 'new-pass' });
+        fixture.detectChanges();
+        fixture.debugElement
+            .query(By.css('[data-testId="submitButton"]'))
+            .triggerEventHandler('click', {});
+
+        const req = httpMock.expectOne('/api/v1/changePassword');
+
+        expect(req.request.method).toBe('POST');
+        // If the body were a string, Angular would set Content-Type: text/plain and
+        // the backend (@Consumes APPLICATION_JSON) would respond 415.
+        expect(typeof req.request.body).toBe('object');
+        expect(req.request.body).toEqual({ password: 'new-pass', token: 'reset-token' });
+
+        req.flush({ entity: 'ok' });
+    });
+
+    it('should not crash when the error body has no "errors" array', () => {
+        component.resetPasswordForm.setValue({ password: 'new-pass', confirmPassword: 'new-pass' });
+        fixture.detectChanges();
+        fixture.debugElement
+            .query(By.css('[data-testId="submitButton"]'))
+            .triggerEventHandler('click', {});
+
+        const req = httpMock.expectOne('/api/v1/changePassword');
+        // Simulate the 415 body shape observed in production (no `errors` array).
+        req.flush(
+            { message: 'HTTP 415 Unsupported Media Type' },
+            { status: 415, statusText: 'Unsupported Media Type' }
+        );
+        fixture.detectChanges();
+
+        // Component must survive without throwing "Cannot read properties of undefined (reading '0')"
+        // AND should surface the backend's fallback `message` so the user isn't left with a blank state.
+        expect(component.message).toBe('HTTP 415 Unsupported Media Type');
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.ts
@@ -122,7 +122,7 @@ export class ResetPasswordComponent implements OnInit, AfterViewChecked {
                         });
                     },
                     (response) => {
-                        this.message = response.error?.errors[0]?.message;
+                        this.message = response.error?.errors?.[0]?.message;
                     }
                 );
         } else {

--- a/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/login/reset-password-component/reset-password.component.ts
@@ -122,7 +122,8 @@ export class ResetPasswordComponent implements OnInit, AfterViewChecked {
                         });
                     },
                     (response) => {
-                        this.message = response.error?.errors?.[0]?.message;
+                        this.message =
+                            response.error?.errors?.[0]?.message ?? response.error?.message ?? '';
                     }
                 );
         } else {

--- a/core-web/libs/dotcms-js/src/lib/core/login.service.ts
+++ b/core-web/libs/dotcms-js/src/lib/core/login.service.ts
@@ -137,10 +137,8 @@ export class LoginService {
      * @memberof LoginService
      */
     changePassword(password: string, token: string): Observable<string> {
-        const body = JSON.stringify({ password: password, token: token });
-
         return this.http
-            .post<DotCMSResponse<string>>(this.urls.changePassword, body)
+            .post<DotCMSResponse<string>>(this.urls.changePassword, { password, token })
             .pipe(map((response) => response.entity));
     }
 


### PR DESCRIPTION
## Summary

Fixes the "Change Password" button on the Password Recovery page, which silently failed with `HTTP 415 Unsupported Media Type` and a console `TypeError: Cannot read properties of undefined (reading '0')`.

**Root cause:** `LoginService.changePassword` was calling `HttpClient.post(url, JSON.stringify({...}))`. When given a string body, Angular's `HttpClient` auto-sets `Content-Type: text/plain`, but the backend `ResetPasswordResource` declares `@Consumes(MediaType.APPLICATION_JSON)` — so every request was rejected with 415. The error handler at `reset-password.component.ts:125` then crashed reading `errors[0]` on the non-JSON 415 body.

**Fix:** Pass the plain object so Angular serializes it and sets `Content-Type: application/json` automatically. Matches the pattern of every other auth call in `LoginService` (`recoverPassword`, `loginUser`, `loginAs`, etc.).

**Regression origin:** PR #34165 (`df97483c4e`) — the `CoreWebService` → `HttpClient` refactor. `CoreWebService.request()` handled JSON headers internally; the migrated code kept the `JSON.stringify` but lost the headers.

## Verification

Reproduced locally against `http://localhost:8080`:

| Request body | Status | Response |
|---|---|---|
| `JSON.stringify({password, token})` (before) | **415** | `{"message":"HTTP 415 Unsupported Media Type"}` |
| `{password, token}` (after) | **400** | `{"errors":[{"errorCode":"reset-password-token-invalid","message":"Invalid token..."}]}` |

The 400 response shape matches what `reset-password.component.ts` expects — no more TypeError.

Closes #35269

## Acceptance Criteria

- [x] `POST /api/v1/changePassword` is sent with `Content-Type: application/json`
- [x] "Change Password" button triggers the request successfully (no 415)
- [x] Error responses are parsed without a TypeError in the console
- [x] Happy path updates the password and allows login with the new one

## Test plan

- [x] `yarn nx test dotcms-ui` — 2109 passing
- [ ] Manual: trigger password recovery → open email link → submit new password → verify successful change and subsequent login

## Changed files

- `core-web/libs/dotcms-js/src/lib/core/login.service.ts` — remove `JSON.stringify` on the `changePassword` body

This PR fixes: #35269