### PR TITLE
fix(key-value): revalidate key control when forbidden keys change after deletion

### DIFF
--- a/core-web/libs/ui/src/lib/components/dot-key-value-ng/dot-key-value-table-header-row/dot-key-value-table-header-row.component.spec.ts
+++ b/core-web/libs/ui/src/lib/components/dot-key-value-ng/dot-key-value-table-header-row/dot-key-value-table-header-row.component.spec.ts
@@ -90,6 +90,21 @@ describe('DotKeyValueTableHeaderRowComponent', () => {
             expect(spectator.query('small.text-red-500')).toHaveText('Key already exists');
         });
 
+        it('should clear duplicate key error when the conflicting key is removed from forbiddenkeys', () => {
+            spectator.component.keyControl.setValue('name');
+            spectator.component.keyControl.markAsDirty();
+            spectator.detectChanges();
+
+            expect(spectator.component.keyControl.hasError('duplicatedKey')).toBeTruthy();
+
+            spectator.setInput('forbiddenkeys', {});
+            spectator.flushEffects();
+            spectator.detectChanges();
+
+            expect(spectator.component.keyControl.hasError('duplicatedKey')).toBeFalsy();
+            expect(spectator.component.keyControl.errors).toBeNull();
+        });
+
         it('should invalidate form when value is empty', () => {
             spectator.component.valueControl.setValue('');
             spectator.component.valueControl.markAsDirty();

--- a/core-web/libs/ui/src/lib/components/dot-key-value-ng/dot-key-value-table-header-row/dot-key-value-table-header-row.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-key-value-ng/dot-key-value-table-header-row/dot-key-value-table-header-row.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, input, output, viewChild, inject } from '@angular/core';
+import { Component, ElementRef, effect, input, output, viewChild, inject } from '@angular/core';
 import {
     AbstractControl,
     FormsModule,
@@ -60,6 +60,13 @@ export class DotKeyValueTableHeaderRowComponent {
         value: ['', Validators.required],
         hidden: [false]
     });
+
+    constructor() {
+        effect(() => {
+            this.$forbiddenkeys();
+            this.keyControl.updateValueAndValidity({ emitEvent: false });
+        });
+    }
 
     /** Gets the key form control */
     get keyControl() {


### PR DESCRIPTION
## Problem

When a user typed a duplicate key in the Key/Value field, the `duplicatedKey` validation error appeared correctly. But if the original conflicting entry was deleted, the error **remained** on the input — preventing the user from saving — even though the conflict no longer existed.

## VIDEO

https://github.com/user-attachments/assets/0831b1ff-6360-44ae-b7e7-c597c533c2a2


## Root Cause

The `keyValidator()` in `DotKeyValueTableHeaderRowComponent` reads the `$forbiddenkeys` signal at validation time. Angular reactive forms, however, only re-run validators when the control's **value** changes — not when an external signal changes. So when `$forbiddenkeys` updated after a deletion, the key control had no reason to revalidate.

## Fix

Added a constructor `effect()` that watches `$forbiddenkeys` and calls `keyControl.updateValueAndValidity({ emitEvent: false })` whenever the forbidden keys map changes. This forces Angular to re-run the validator with the updated map.

```typescript
constructor() {
    effect(() => {
        this.$forbiddenkeys();
        this.keyControl.updateValueAndValidity({ emitEvent: false });
    });
}
```

## Test

Added a regression test that:
1. Sets key control value to a forbidden key → error appears
2. Updates `forbiddenkeys` input to empty map (simulating deletion of the conflicting entry)
3. Flushes effects and asserts the error is cleared

## Closes

Closes #32114

This PR fixes: #32114