### PR TITLE
fix(permissions): propagate role revocation through short-term permission cache

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/business/PermissionCacheImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/PermissionCacheImpl.java
@@ -36,7 +36,7 @@ public class PermissionCacheImpl extends PermissionCache {
 	static final Lazy<Integer> EMPTY_PERMISSIONS_TTL =
 			Lazy.of(() -> Config.getIntProperty("EMPTY_PERMISSIONS_TTL", 300)); // 5 minutes default
 
-	private DotCacheAdministrator cache;
+	private final DotCacheAdministrator cache;
 
 	private final String primaryGroup = "PermissionCache";
 	private final String shortLivedGroup = "PermissionShortLived";
@@ -44,7 +44,11 @@ public class PermissionCacheImpl extends PermissionCache {
     private final String[] groupNames = {primaryGroup,shortLivedGroup};
 
 	protected PermissionCacheImpl() {
-        cache = CacheLocator.getCacheAdministrator();
+		this(CacheLocator.getCacheAdministrator());
+	}
+
+	PermissionCacheImpl(final DotCacheAdministrator cacheAdministrator) {
+		this.cache = cacheAdministrator;
 	}
 
 	/* (non-Javadoc)
@@ -92,8 +96,11 @@ public class PermissionCacheImpl extends PermissionCache {
 	 * @see com.dotmarketing.business.PermissionCache#clearCache()
 	 */
     public void clearCache() {
-        // clear the cache
+        // Both groups must be flushed. shortLivedGroup caches boolean
+        // doesUserHavePermission() decisions; leaving it here means role
+        // revocations do not propagate until a full Flush All.
         cache.flushGroup(primaryGroup);
+        cache.flushGroup(shortLivedGroup);
     }
 
     /* (non-Javadoc)

--- a/dotCMS/src/main/java/com/dotmarketing/business/RoleFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/business/RoleFactoryImpl.java
@@ -283,6 +283,7 @@ public class RoleFactoryImpl extends RoleFactory {
   		ur.setUserId(user.getUserId());
   		HibernateUtil.save(ur);
   		rc.remove(user.getUserId());
+		flushPermissionShortTermCacheOnCommit();
 
 	}
 
@@ -294,6 +295,19 @@ public class RoleFactoryImpl extends RoleFactory {
 		dc.addParam(role.getId());
 		dc.loadResult();
 		rc.remove(user.getUserId());
+		flushPermissionShortTermCacheOnCommit();
+	}
+
+	/**
+	 * Queues a post-commit flush of PermissionCache.shortLivedGroup so that
+	 * cached doesUserHavePermission() decisions are re-evaluated after a
+	 * role<->user mutation. The tag collapses bulk operations (e.g. delete
+	 * role that touches N users) to a single flush per transaction.
+	 */
+	private void flushPermissionShortTermCacheOnCommit() {
+		HibernateUtil.addCommitListener(
+				"role-mutation-flush-permission-shortterm",
+				() -> CacheLocator.getPermissionCache().flushShortTermCache());
 	}
 
 	@Override

--- a/dotCMS/src/test/java/com/dotmarketing/business/PermissionCacheImplTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/business/PermissionCacheImplTest.java
@@ -1,0 +1,78 @@
+package com.dotmarketing.business;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import com.dotmarketing.beans.Permission;
+import com.dotmarketing.business.cache.provider.MockCacheAdministrator;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link PermissionCacheImpl}.
+ *
+ * Guards against regressions of https://github.com/dotCMS/private-issues/issues/567
+ * where {@code clearCache()} did not flush {@code shortLivedGroup}, so the
+ * admin-UI "Flush Permission Cache" button left cached permission decisions
+ * in place and role revocation did not propagate.
+ *
+ * Exercises the cache administrator directly rather than going through
+ * {@code doesUserHavePermission}/{@code putUserHavePermission}, because the
+ * latter call {@code DbConnectionFactory.inTransaction()} which requires a
+ * configured data source — out of scope for a pure unit test.
+ */
+public class PermissionCacheImplTest {
+
+    private static final String PRIMARY_GROUP = "PermissionCache";
+    private static final String SHORT_LIVED_GROUP = "PermissionShortLived";
+
+    private MockCacheAdministrator mockCache;
+    private PermissionCacheImpl permissionCache;
+
+    @Before
+    public void setUp() {
+        mockCache = new MockCacheAdministrator();
+        permissionCache = new PermissionCacheImpl(mockCache);
+    }
+
+    @Test
+    public void clearCache_flushesPrimaryGroup() throws Exception {
+        permissionCache.addToPermissionCache("k1", List.of(new Permission()));
+        assertNotNull("Primary entry should be present before clearCache",
+                mockCache.get(PRIMARY_GROUP + "k1", PRIMARY_GROUP));
+
+        permissionCache.clearCache();
+
+        assertNull("Primary entry should be gone after clearCache",
+                mockCache.get(PRIMARY_GROUP + "k1", PRIMARY_GROUP));
+    }
+
+    @Test
+    public void clearCache_flushesShortLivedGroup() throws Exception {
+        // Seed shortLivedGroup directly to avoid DbConnectionFactory init via
+        // putUserHavePermission -> shortLivedKey.
+        mockCache.put("short-k1", Boolean.TRUE, SHORT_LIVED_GROUP);
+        assertNotNull("Short-lived entry should be present before clearCache",
+                mockCache.get("short-k1", SHORT_LIVED_GROUP));
+
+        permissionCache.clearCache();
+
+        assertNull("Short-lived entry must be gone after clearCache — this is the"
+                        + " fix for private-issues#567",
+                mockCache.get("short-k1", SHORT_LIVED_GROUP));
+    }
+
+    @Test
+    public void flushShortTermCache_leavesPrimaryGroupUntouched() throws Exception {
+        permissionCache.addToPermissionCache("primary-key", List.of(new Permission()));
+        mockCache.put("short-k2", Boolean.TRUE, SHORT_LIVED_GROUP);
+
+        permissionCache.flushShortTermCache();
+
+        assertNotNull("primaryGroup must be untouched by flushShortTermCache()",
+                mockCache.get(PRIMARY_GROUP + "primary-key", PRIMARY_GROUP));
+        assertNull("shortLivedGroup must be empty after flushShortTermCache()",
+                mockCache.get("short-k2", SHORT_LIVED_GROUP));
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotmarketing/business/RoleRevocationPermissionCacheTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/business/RoleRevocationPermissionCacheTest.java
@@ -1,0 +1,198 @@
+package com.dotmarketing.business;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.datagen.RoleDataGen;
+import com.dotcms.datagen.SiteDataGen;
+import com.dotcms.datagen.UserDataGen;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.beans.Permission;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.HibernateUtil;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.util.Config;
+import com.liferay.portal.model.User;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Regression tests for role-revocation propagation through
+ * {@link PermissionCache#flushShortTermCache()}.
+ *
+ * Scenario: dotCMS/private-issues#567 — a user's cached
+ * {@code doesUserHavePermission()} decision survives role revocation until a
+ * full {@code Flush All}. Root cause was two gaps:
+ * <ol>
+ *   <li>{@link PermissionCacheImpl#clearCache()} did not flush
+ *       {@code shortLivedGroup}.</li>
+ *   <li>{@link RoleFactoryImpl#addRoleToUser}/{@code removeRoleFromUser}
+ *       invalidated only the role cache, not cached permission decisions.</li>
+ * </ol>
+ *
+ * These tests verify that after both fixes, cache invalidation happens without
+ * any manual flush call.
+ */
+public class RoleRevocationPermissionCacheTest extends IntegrationTestBase {
+
+    private static PermissionAPI permissionAPI;
+    private static RoleAPI roleAPI;
+    private static User sysuser;
+    private static Host site;
+    private static int originalShortLivedSize;
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+        permissionAPI = APILocator.getPermissionAPI();
+        roleAPI = APILocator.getRoleAPI();
+        sysuser = APILocator.getUserAPI().getSystemUser();
+
+        // The short-term permission cache must be enabled for this regression
+        // to be meaningful; PermissionAPITest sets it to 0 to neutralize cache
+        // flakes, but here we are specifically validating cache behavior.
+        originalShortLivedSize = Config.getIntProperty("cache.permissionshortlived.size", 0);
+        Config.setProperty("cache.permissionshortlived.size", 1000);
+
+        site = new SiteDataGen().nextPersisted();
+        permissionAPI.permissionIndividually(site.getParentPermissionable(), site, sysuser);
+
+        CacheLocator.getPermissionCache().clearCache();
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        try {
+            HibernateUtil.startTransaction();
+            APILocator.getHostAPI().archive(site, sysuser, false);
+            APILocator.getHostAPI().delete(site, sysuser, false);
+            HibernateUtil.closeAndCommitTransaction();
+        } catch (Exception e) {
+            try {
+                HibernateUtil.rollbackTransaction();
+            } catch (Exception ignored) {
+                // best-effort cleanup
+            }
+        } finally {
+            HibernateUtil.closeSessionSilently();
+        }
+
+        Config.setProperty("cache.permissionshortlived.size", originalShortLivedSize);
+        CacheLocator.getPermissionCache().clearCache();
+    }
+
+    /**
+     * Role revocation must invalidate cached permission decisions without
+     * requiring a manual cache flush.
+     */
+    @Test
+    public void removeRoleFromUser_invalidatesShortTermPermissionCache() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().nextPersisted();
+
+        roleAPI.addRoleToUser(role, user);
+
+        final Permission p = new Permission();
+        p.setPermission(PermissionAPI.PERMISSION_READ);
+        p.setRoleId(role.getId());
+        p.setInode(site.getIdentifier());
+        permissionAPI.save(p, site, sysuser, false);
+
+        // Prime the short-term cache with a TRUE decision for this user.
+        assertTrue("Granted role should grant READ on test host",
+                permissionAPI.doesUserHavePermission(site, PermissionAPI.PERMISSION_READ, user, false));
+
+        // Revoke the role. No manual cache flush.
+        roleAPI.removeRoleFromUser(role, user);
+
+        assertFalse("Cached TRUE decision must be invalidated by removeRoleFromUser;"
+                        + " user no longer has any role granting READ on host",
+                permissionAPI.doesUserHavePermission(site, PermissionAPI.PERMISSION_READ, user, false));
+    }
+
+    /**
+     * Role grant must also invalidate cached FALSE decisions so newly granted
+     * permissions take effect immediately.
+     */
+    @Test
+    public void addRoleToUser_invalidatesShortTermPermissionCache() throws Exception {
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().nextPersisted();
+
+        final Permission p = new Permission();
+        p.setPermission(PermissionAPI.PERMISSION_READ);
+        p.setRoleId(role.getId());
+        p.setInode(site.getIdentifier());
+        permissionAPI.save(p, site, sysuser, false);
+
+        // Prime the short-term cache with a FALSE decision (user has no role yet).
+        assertFalse("User without any granting role should be denied READ",
+                permissionAPI.doesUserHavePermission(site, PermissionAPI.PERMISSION_READ, user, false));
+
+        // Grant the role. No manual cache flush.
+        roleAPI.addRoleToUser(role, user);
+
+        assertTrue("Cached FALSE decision must be invalidated by addRoleToUser;"
+                        + " user now has a role granting READ on host",
+                permissionAPI.doesUserHavePermission(site, PermissionAPI.PERMISSION_READ, user, false));
+    }
+
+    /**
+     * {@link PermissionCache#clearCache()} must flush both primaryGroup and
+     * shortLivedGroup. This is what the admin-UI "Flush Permission Cache"
+     * button ultimately calls (via {@link PermissionAPI#clearCache()}).
+     */
+    @Test
+    public void clearCache_flushesShortLivedGroup() throws DotDataException, DotSecurityException {
+        final Role role = new RoleDataGen().nextPersisted();
+        final User user = new UserDataGen().nextPersisted();
+
+        roleAPI.addRoleToUser(role, user);
+
+        final Permission p = new Permission();
+        p.setPermission(PermissionAPI.PERMISSION_READ);
+        p.setRoleId(role.getId());
+        p.setInode(site.getIdentifier());
+        permissionAPI.save(p, site, sysuser, false);
+
+        // Prime the short-lived cache.
+        assertTrue(permissionAPI.doesUserHavePermission(site, PermissionAPI.PERMISSION_READ, user, false));
+
+        // Simulate the "Flush Permission Cache" admin-UI button by calling the
+        // API-level clearCache(), which delegates to PermissionCacheImpl.
+        permissionAPI.clearCache();
+
+        // With the underlying DB state unchanged, the next check should still
+        // return TRUE — but the cached boolean must be dropped and recomputed,
+        // not served stale. We assert the permission decision remains correct
+        // post-clear (the cache was wiped and re-populated from DB truth).
+        assertTrue("Post-clear lookup should recompute from DB and still return TRUE",
+                permissionAPI.doesUserHavePermission(site, PermissionAPI.PERMISSION_READ, user, false));
+
+        // Now revoke the role without going through RoleAPI/RoleFactory, because
+        // that path has its own permission-cache invalidation. This leaves a
+        // cached TRUE permission decision in place so clearCache() is the only
+        // operation under test.
+        revokeRoleMembershipInDbOnly(role, user);
+        permissionAPI.clearCache();
+
+        assertFalse("After role revocation + clearCache, decision must be FALSE",
+                permissionAPI.doesUserHavePermission(site, PermissionAPI.PERMISSION_READ, user, false));
+    }
+
+    private void revokeRoleMembershipInDbOnly(final Role role, final User user) throws DotDataException {
+        final DotConnect dc = new DotConnect();
+        dc.setSQL("delete from users_cms_roles where user_id = ? and role_id = ?");
+        dc.addParam(user.getUserId());
+        dc.addParam(role.getId());
+        dc.loadResult();
+
+        // Keep role lookups honest after bypassing RoleFactory; do not touch
+        // PermissionCache here, because clearCache() is the behavior under test.
+        CacheLocator.getCmsRoleCache().remove(user.getUserId());
+    }
+}


### PR DESCRIPTION
## Summary

- PermissionCacheImpl.clearCache() now flushes both primaryGroup **and** shortLivedGroup. Previously only primaryGroup was flushed, so cached doesUserHavePermission boolean decisions survived calls to this method (including the admin-UI "Flush Permission Cache" button, which delegates here via PermissionBitAPIImpl.clearCache).
- RoleFactoryImpl.addRoleToUser / removeRoleFromUser now queue a post-commit flushShortTermCache via HibernateUtil.addCommitListener. The listener is tagged so bulk operations (e.g. delete-role cascading to N users, removeAllRolesFromUser) collapse to a single flush per transaction. Post-commit placement means a rolled-back transaction does not spuriously wipe the cache.

Fixes dotCMS/private-issues#567.

## Coverage audit

Every user-facing users_cms_roles mutation routes through RoleFactoryImpl.addRoleToUser / removeRoleFromUser (directly or transitively via RoleAPIImpl.delete -- per-user removeRoleFromUser, removeAllRolesFromUser, addRoleToUserWithoutEditUserValidation, and the SAML / user-resource helpers). The bulk SQL inside RoleFactoryImpl.delete is a safety-net that runs against an already-empty set after RoleAPIImpl.delete has iterated per-user removals. RoleFactoryImpl.addUserRole at user-creation time does not need invalidation (no cached decisions can exist for a brand-new user).

RoleIntegrityChecker also rewrites role_id on users_cms_roles without any cache invalidation today (not just permission cache -- role cache is untouched there too). Out of scope for this PR; worth a separate ticket.

## Test plan

- [x] Unit test PermissionCacheImplTest -- verifies clearCache flushes both groups and flushShortTermCache leaves primaryGroup alone. 3/3 passing locally.
- [x] Integration test RoleRevocationPermissionCacheTest -- covers grant, revoke, and admin-UI-style clearCache scenarios against real RoleAPI / PermissionAPI with the short-term cache enabled.
- [x] Manual end-to-end validation against a running stack.
- [ ] Reviewer: ./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=RoleRevocationPermissionCacheTest
- [ ] Reviewer: regression check against PermissionAPITest, PermissionAPIIntegrationTest, RoleAPITest