### PR TITLE
fix(workflow): bind WorkflowTool to triggering user in Velocity Script actionlet

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/VelocityScriptActionlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/workflows/actionlet/VelocityScriptActionlet.java
@@ -19,10 +19,12 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.collect.ImmutableList;
 import com.liferay.portal.model.User;
+import com.liferay.portal.util.WebKeys;
 import com.liferay.util.StringPool;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.io.Reader;
 import java.io.StringReader;
 import java.util.HashMap;
@@ -109,6 +111,17 @@ public class VelocityScriptActionlet extends WorkFlowActionlet {
                                     : APILocator.systemHost().getHostname(),
                             StringPool.FORWARD_SLASH).request()
               ).request()).request();
+
+            // Propagate the workflow processor's user onto the mock request so viewtools that
+            // resolve the user via PortalUtil.getUser(req) — e.g. WorkflowTool.init() — see the
+            // actual triggering user instead of falling back to anonymous (issue #35347).
+            if (null != currentUser) {
+                request.setAttribute(WebKeys.USER, currentUser);
+                final HttpSession session = request.getSession(false);
+                if (null != session) {
+                    session.setAttribute(WebKeys.USER, currentUser);
+                }
+            }
 
             final Map<String, Object> contextParams = new HashMap<>(Map.of("workflow", processor,
                     "user", currentUser,

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/workflows/actionlet/VelocityScriptActionletTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/workflows/actionlet/VelocityScriptActionletTest.java
@@ -287,4 +287,106 @@ public class VelocityScriptActionletTest extends BaseWorkflowIntegrationTest {
         Assert.assertEquals(expectedTitle, DotJSON.class.cast(result.get("dotJSON")).get("title"));
     }
 
+    /**
+     * Regression test for #35347. The mock request the actionlet builds for the script
+     * engine had no {@code WebKeys.USER} attribute, so any viewtool resolving the user via
+     * {@code PortalUtil.getUser(req)} — including {@code WorkflowTool.init()} — fell back
+     * to the anonymous user and {@code $workflowtool.fire(...)} 403'd whenever the target
+     * action wasn't readable by anonymous. The fix sets {@code WebKeys.USER} on the mock
+     * request before the script runs; this test reads that attribute back from inside the
+     * script and asserts it resolves to the firing user.
+     */
+    @Test
+    public void Test_Velocity_Script_Actionlet_PropagatesTriggeringUser_OntoMockRequest() throws Exception {
+
+        final User admin = APILocator.systemUser();
+
+        WorkflowScheme userBindScheme = null;
+        ContentType userBindContentType = null;
+        Contentlet checkedIn = null;
+
+        try {
+            userBindContentType = contentTypeAPI.save(
+                    ContentTypeBuilder.builder(BaseContentType.CONTENT.immutableClass())
+                            .folder(FolderAPI.SYSTEM_FOLDER)
+                            .host(Host.SYSTEM_HOST)
+                            .name("UserBindTest" + System.currentTimeMillis())
+                            .variable("UserBindTest" + System.currentTimeMillis())
+                            .build());
+
+            final CreateSchemeStepActionResult userBindResult = createSchemeStepActionActionlet(
+                    "UserBindScheme" + UUIDGenerator.generateUuid(), "step1", "action1",
+                    VelocityScriptActionlet.class);
+            userBindScheme = userBindResult.getScheme();
+
+            // Read WebKeys.USER ("USER") off the mock request the actionlet builds.
+            // Pre-fix: this attribute was never set, so getAttribute returned null and
+            // PortalUtil.getUser(req) — used by WorkflowTool.init() — fell through to the
+            // anonymous user.
+            final String script =
+                    "#set($attrUser = $request.getAttribute(\"USER\"))\n" +
+                    "#if($attrUser)\n" +
+                    "$dotJSON.put(\"userId\", $attrUser.getUserId())\n" +
+                    "$dotJSON.put(\"isAnonymous\", $attrUser.isAnonymousUser())\n" +
+                    "#else\n" +
+                    "$dotJSON.put(\"userId\", \"MISSING\")\n" +
+                    "$dotJSON.put(\"isAnonymous\", true)\n" +
+                    "#end\n";
+
+            final WorkflowActionClass actionClass = userBindResult.getActionClass();
+            final List<WorkflowActionClassParameter> params = new ArrayList<>();
+            final WorkflowActionClassParameter scriptParam = new WorkflowActionClassParameter();
+            scriptParam.setActionClassId(actionClass.getId());
+            scriptParam.setKey("script");
+            scriptParam.setValue(script);
+            params.add(scriptParam);
+            final WorkflowActionClassParameter resultKeyParam = new WorkflowActionClassParameter();
+            resultKeyParam.setActionClassId(actionClass.getId());
+            resultKeyParam.setKey("resultKey");
+            resultKeyParam.setValue("result");
+            params.add(resultKeyParam);
+            workflowAPI.saveWorkflowActionClassParameters(params, admin);
+
+            workflowAPI.saveSchemesForStruct(
+                    new StructureTransformer(userBindContentType).asStructure(),
+                    List.of(userBindScheme));
+
+            final Contentlet contentlet = new Contentlet();
+            contentlet.setContentType(userBindContentType);
+            checkedIn = contentletAPI.checkin(contentlet, admin, false);
+
+            final Contentlet result = workflowAPI.fireContentWorkflow(checkedIn,
+                    new ContentletDependencies.Builder()
+                            .modUser(admin)
+                            .workflowActionId(userBindResult.getAction().getId())
+                            .build());
+
+            Assert.assertNotNull(result);
+            final Map<String, Object> resultMap = (Map<String, Object>) result.get("result");
+            Assert.assertNotNull("Actionlet must store a result map", resultMap);
+            final DotJSON dotJSON = (DotJSON) resultMap.get("dotJSON");
+            Assert.assertNotNull("dotJSON must be present in the result", dotJSON);
+            Assert.assertEquals(
+                    "WebKeys.USER on the mock request must be the triggering admin, not missing or anonymous",
+                    admin.getUserId(), dotJSON.get("userId"));
+            Assert.assertEquals(
+                    "Triggering user must not resolve to anonymous",
+                    false, dotJSON.get("isAnonymous"));
+
+        } finally {
+            try {
+                if (null != checkedIn) {
+                    contentletAPI.destroy(checkedIn, admin, false);
+                }
+            } catch (Exception ignored) { /* best-effort */ }
+
+            if (null != userBindScheme) {
+                cleanScheme(userBindScheme);
+            }
+            if (null != userBindContentType) {
+                contentTypeAPI.delete(userBindContentType);
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

- `VelocityScriptActionlet.executeAction` was building a mock request with no `WebKeys.USER` attribute, so any viewtool that resolves the user via `PortalUtil.getUser(request)` — including `WorkflowTool.init()` — fell back to the anonymous user. `$workflowtool.fire()` then failed with `User 'anonymous user anonymous ...' cannot read action: <Name>` whenever the target action wasn't readable by anonymous.
- Regression came from `89f3527bc8` / #35158, which switched to an unconditional mock request to fix site-scoped secrets in background jobs but never propagated `processor.getUser()` onto it.
- Fix: after building the mock request, set `WebKeys.USER` on the request and (when present) the session — both are checked by `PortalUtil.getUser`. Site scoping is unaffected because `request.getServerName()` still comes from the contentlet's host.

Fixes #35347.

## How to set up a manual repro / test

The fix is reproducible end-to-end via REST. On a stock dotCMS:

1. **Create a VanityUrl** (any uri/forwardTo). Note its identifier — call it `$VANITY`.
2. **Create a Generic content** (`webPageContent`) — note its identifier as `$OUTER`.
3. **Create a workflow action** on System Workflow with a `VelocityScriptActionlet` sub-actionlet. Show the action on the steps the outer content can reach (e.g. New, Published). Set the script to:
   ```vtl
   #set(\$newcon = {})
   #set(\$dummy = \$newcon.put(\"contentType\", \"Vanityurl\"))
   #set(\$dummy = \$newcon.put(\"identifier\", \"\$VANITY\"))
   #set(\$dummy = \$newcon.put(\"forwardTo\", \"/about-us-updated\"))
   \$workflowtool.fire(\$newcon, \"b9d89c80-3d88-4311-8365-187323c96436\")
   ```
   (`b9d89c80-…` is the System Workflow Publish action ID.)
4. **Fire the action on the outer content** as an authenticated admin:
   ```bash
   curl -X PUT -H \"Authorization: Bearer \$TOKEN\" -H \"Content-Type: application/json\" \\
     \"http://localhost:8080/api/v1/workflow/actions/<action-id>/fire?identifier=\$OUTER\" \\
     -d '{\"contentlet\":{}}'
   ```

| Before fix | After fix |
|---|---|
| HTTP 403 + `cannot read action: Publish` | HTTP 200; VanityUrl's `forwardTo` flips to `/about-us-updated`, new live inode, `modUserName` = the firing user |

## Regression test added

`VelocityScriptActionletTest.Test_Velocity_Script_Actionlet_PropagatesTriggeringUser_OntoMockRequest` reads `WebKeys.USER` off the mock request from inside the script (`$request.getAttribute("USER")`) and asserts it resolves to the firing admin's userId — exactly the slot `PortalUtil.getUser(req)` checks first. Pre-fix the attribute was unset, so the test would observe `MISSING` instead.

## Don't-regress check (#35158 — site-scoped secrets in background jobs)

Ran the integration tests gating that fix plus the new one:

```
./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false \\
  -Dit.test='VelocityScriptActionletTest,VelocityScriptActionletAbortTest'
```

| Test | Result |
|---|---|
| `Test_Velocity_Script_Actionlet_PropagatesTriggeringUser_OntoMockRequest` *(new)* | ✅ PASS |
| `Test_Velocity_Script_Get_ResolvesSiteSpecificSecret_InBackgroundJob` | ✅ PASS |
| `Test_Velocity_Script_Actionlet_Expect_Success` | ✅ PASS |
| `Test_Velocity_Script_Actionlet_Abort_Stopped` | ✅ PASS |
| `Test_Velocity_Script_Actionlet_Abort_Non_Stopped` | ✅ PASS |

(Maven exited non-zero on a flaky `@AfterClass` cleanup — `Workflow-delete-step-reference-by-contentlet-error` from a contentlet still referencing a workflow step at teardown. That's pre-existing and not related to the actionlet code change; every actual test assertion passed.)

## Test plan

- [x] Manual repro setup as above — fire returns 403 on `main`, 200 with this fix; VanityUrl `forwardTo` actually mutates and new live inode is created.
- [x] `$workflowtool` is bound to the firing user, not anonymous (verified via `modUserName` on the resulting contentlet).
- [x] `VelocityScriptActionletTest` + `VelocityScriptActionletAbortTest` integration tests all pass — site-scoped secret resolution from #35158 is intact.
- [x] New regression test (`Test_Velocity_Script_Actionlet_PropagatesTriggeringUser_OntoMockRequest`) pins `WebKeys.USER` propagation onto the mock request so the same class of regression can't sneak back in.
- [ ] Reviewer: sanity-check that any existing scripts relying on anonymous-user behavior in the script (unlikely) are aware permissions are now back to pre-#35158 (i.e., the actual triggering user).

This PR fixes: #35347