### PR TITLE
feat(cicd): Add Slack message on Manual SDK Release

### DIFF
--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -375,7 +375,7 @@ jobs:
         env:
           COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '#\K[0-9]+' | head -1)
+          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '#\K[0-9]+' | head -1 || true)
           if [ -n "$PR_NUMBER" ]; then
             echo "pr_url=${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER" >> $GITHUB_OUTPUT
             echo "pr_ref=#${PR_NUMBER}" >> $GITHUB_OUTPUT
@@ -388,6 +388,7 @@ jobs:
       # Send Slack notification for SDK publication (if required)
       - name: Slack Notification (SDK announcement)
         if: success() && steps.sdks_publish.outputs.published == 'true'
+        continue-on-error: true
         uses: ./.github/actions/core-cicd/notification/notify-slack
         with:
           channel-id: "log-sdk-libs"

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -372,8 +372,9 @@ jobs:
       - name: Extract PR from commit message
         id: pr_info
         if: success() && steps.sdks_publish.outputs.published == 'true'
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
           PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '#\K[0-9]+' | head -1)
           if [ -n "$PR_NUMBER" ]; then
             echo "pr_url=${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER" >> $GITHUB_OUTPUT

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -368,6 +368,22 @@ jobs:
             > `npm i -g @dotcms/dotcli@${{ steps.cli_publish.outputs.npm-package-version-tag }}`
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
 
+      # Extract PR info from the merge commit message for SDK notification
+      - name: Extract PR from commit message
+        id: pr_info
+        if: success() && steps.sdks_publish.outputs.published == 'true'
+        run: |
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          PR_NUMBER=$(echo "$COMMIT_MSG" | grep -oP '#\K[0-9]+' | head -1)
+          if [ -n "$PR_NUMBER" ]; then
+            echo "pr_url=${{ github.server_url }}/${{ github.repository }}/pull/$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "pr_ref=#${PR_NUMBER}" >> $GITHUB_OUTPUT
+          else
+            echo "pr_url=${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "pr_ref=$(echo '${{ github.sha }}' | cut -c1-7)" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+
       # Send Slack notification for SDK publication (if required)
       - name: Slack Notification (SDK announcement)
         if: success() && steps.sdks_publish.outputs.published == 'true'
@@ -378,4 +394,5 @@ jobs:
             > :large_orange_circle: *Attention dotters:* SDK libs (Angular, Client, Experiments and React) published!
             >
             > This automated script is happy to announce that a new *_SDK libs_* version *tagged as:* [ `${{ steps.sdks_publish.outputs.npm-package-version }}` ] is now available on the `NPM` registry :package:!
+            > *Introduced by:* <${{ steps.pr_info.outputs.pr_url }}|${{ steps.pr_info.outputs.pr_ref }}>
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/cicd_manual-release-sdks.yml
+++ b/.github/workflows/cicd_manual-release-sdks.yml
@@ -120,6 +120,19 @@ jobs:
           publish-latest: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 'Slack Notification (SDK release announcement)'
+        if: always() && steps.deploy-javascript-sdk.outputs.published == 'true'
+        uses: ./.github/actions/core-cicd/notification/notify-slack
+        with:
+          channel-id: "log-sdk-libs"
+          payload: |
+            > :large_green_circle: *Attention dotters:* SDK libs (Angular, Client, Experiments and React) officially released!
+            >
+            > This automated script is happy to announce that a new *_SDK libs_* version *tagged as:* [ `${{ steps.deploy-javascript-sdk.outputs.npm-package-version }}` ] is now available on the `NPM` registry :package:!
+            > *Release type:* `${{ inputs.version-type }}`  |  *Triggered by:* `${{ github.actor }}`
+            > <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
       - name: 'Open post-release PR to bump VERSION on main'
         env:
           RELEASE_VERSION: ${{ steps.compute_version.outputs.release_version }}

--- a/.github/workflows/cicd_manual-release-sdks.yml
+++ b/.github/workflows/cicd_manual-release-sdks.yml
@@ -122,6 +122,7 @@ jobs:
 
       - name: 'Slack Notification (SDK release announcement)'
         if: success() && steps.deploy-javascript-sdk.outputs.published == 'true'
+        continue-on-error: true
         uses: ./.github/actions/core-cicd/notification/notify-slack
         with:
           channel-id: "log-sdk-libs"

--- a/.github/workflows/cicd_manual-release-sdks.yml
+++ b/.github/workflows/cicd_manual-release-sdks.yml
@@ -121,7 +121,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Slack Notification (SDK release announcement)'
-        if: always() && steps.deploy-javascript-sdk.outputs.published == 'true'
+        if: success() && steps.deploy-javascript-sdk.outputs.published == 'true'
         uses: ./.github/actions/core-cicd/notification/notify-slack
         with:
           channel-id: "log-sdk-libs"


### PR DESCRIPTION
Here are examples of the types of messages

---
  Auto-publish — next (PR merge)

  ▎ 🟠 Attention dotters: SDK libs (Angular, Client, Experiments and React) published!
  ▎
  ▎ This automated script is happy to announce that a new SDK libs version tagged as: [ 1.5.1-next.1965 (next) ] is now available on the NPM registry 📦!
  ▎ Introduced by: [#35412](https://github.com/dotcms/core/pull/35412)

  ---
  Manual release — patch

  ▎ 🟢 Attention dotters: SDK libs (Angular, Client, Experiments and React) officially released!
  ▎
  ▎ This automated script is happy to announce that a new SDK libs version tagged as: [ 1.5.2 (latest) and 1.5.2-next.1966 (next) ] is now available on the NPM registry 📦!
  ▎ Release type: patch  |  Triggered by: kevindavila
  ▎ [View workflow run](https://github.com/dotcms/core/actions/runs/12345678)

  ---
  Manual release — minor

  ▎ 🟢 Attention dotters: SDK libs (Angular, Client, Experiments and React) officially released!
  ▎
  ▎ This automated script is happy to announce that a new SDK libs version tagged as: [ 1.6.0 (latest) and 1.6.0-next.1970 (next) ] is now available on the NPM registry 📦!
  ▎ Release type: minor  |  Triggered by: kevindavila
  ▎ [View workflow run](https://github.com/dotcms/core/actions/runs/12345678)

  ---
  Manual release — major

  ▎ 🟢 Attention dotters: SDK libs (Angular, Client, Experiments and React) officially released!
  ▎
  ▎ This automated script is happy to announce that a new SDK libs version tagged as: [ 2.0.0 (latest) and 2.0.0-next.1975 (next) ] is now available on the NPM registry 📦!
  ▎ Release type: major  |  Triggered by: kevindavila
  ▎ [View workflow run](https://github.com/dotcms/core/actions/runs/12345678)

  ---
  Manual release — custom

  ▎ 🟢 Attention dotters: SDK libs (Angular, Client, Experiments and React) officially released!
  ▎
  ▎ This automated script is happy to announce that a new SDK libs version tagged as: [ 1.5.3 (latest) and 1.5.3-next.1980 (next) ] is now available on the NPM registry 📦!
  ▎ Release type: custom  |  Triggered by: kevindavila
  ▎ [View workflow run](https://github.com/dotcms/core/actions/runs/12345678)
