### PR TITLE
refactor(analytics): migrate dashboard store to @ngrx/signals/events plugin

### DIFF
--- a/core-web/libs/portlets/dot-analytics/data-access/src/index.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/index.ts
@@ -1,6 +1,9 @@
 // Store
 export * from './lib/store/dot-analytics-dashboard.store';
 
+// Events
+export * from './lib/store/events';
+
 // Services
 export * from './lib/services/dot-analytics.service';
 

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/dot-analytics-dashboard.store.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/dot-analytics-dashboard.store.ts
@@ -1,12 +1,12 @@
-import { patchState, signalStore, withHooks, withMethods } from '@ngrx/signals';
+import { signalStore, withHooks } from '@ngrx/signals';
+import { Dispatcher } from '@ngrx/signals/events';
 
-import { Location } from '@angular/common';
-import { effect, inject } from '@angular/core';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import { effect, inject, untracked } from '@angular/core';
+import { ActivatedRoute, Params } from '@angular/router';
 
-import { DotMessageService } from '@dotcms/data-access';
 import { GlobalStore } from '@dotcms/store';
 
+import { externalEvents, filtersApiEvents } from './events';
 import { withConversions } from './features/with-conversions.feature';
 import { withEngagement } from './features/with-engagement.feature';
 import { withFilters } from './features/with-filters.feature';
@@ -14,164 +14,63 @@ import { withPageview } from './features/with-pageview.feature';
 import { withAutoload } from './handlers/with-autoload.handlers';
 import { withNavigation } from './handlers/with-navigation.handlers';
 
-import { DASHBOARD_TAB_LIST, DASHBOARD_TABS, DashboardTab, TIME_RANGE_OPTIONS } from '../constants';
-import { TimeRangeInput } from '../types';
+import { DashboardTab } from '../constants';
 import { isValidTab, paramsToTimeRange } from '../utils/filters.utils';
-import { silentNavigate } from '../utils/router.utils';
-
-const TAB_CONFIG_MAP = new Map(DASHBOARD_TAB_LIST.map((tab) => [tab.id, tab]));
 
 /**
  * Analytics Dashboard Store
  *
- * Composed signal store for the analytics dashboard.
- * Uses signal store features for modular state management:
+ * Composed signal store for the analytics dashboard. State and side effects
+ * are split across feature slices and handler features:
  *
- * - withFilters: Shared filter state (timeRange, currentTab)
- * - withPageview: Pageview report data
- * - withConversions: Conversions report data
+ * - withFilters: shared filter state (timeRange, currentTab) via withReducer
+ * - withPageview / withConversions / withEngagement: per-tab metric state
+ *   plus HTTP handlers that dispatch *Loaded / *Failed events
+ * - withNavigation: URL sync, breadcrumb, banner localStorage
+ * - withAutoload: fan-out from filter intents and global site changes to
+ *   per-metric *Requested events
  *
- * Data loading strategy:
- * - Automatically loads data for the active tab when tab, timeRange, or siteId changes
- * - Pageview data is loaded when the pageview tab is active
- * - Conversions data is loaded lazily when the conversions tab is first activated
+ * Components interact with the store by dispatching events from
+ * `./events` via `injectDispatch(...)`. The store exposes only state
+ * signals and computeds — no public mutator methods.
+ *
+ * @see https://arcadioquintero.com/en/blog/ngrx-signalstore-events-plugin
  */
 export const DotAnalyticsDashboardStore = signalStore(
     withFilters(),
     withPageview(),
     withConversions(),
     withEngagement(),
-    // Side-effect handlers — URL sync, breadcrumb, banner persistence
-    // (see `with-navigation.handlers.ts`). Listens to filter/UI events
-    // dispatched from components and from the onInit hydration below.
     withNavigation(),
-    // Auto-load fan-out: turn filter intents and global site changes into
-    // per-metric `*Requested` events for the active tab. Dormant during
-    // the migration (legacy components still mutate state directly via
-    // withMethods coordinators); becomes the sole loading trigger after
-    // Step 10 migrates components to dispatch events.
     withAutoload(),
-    // Coordinator methods that work across features
-    withMethods(
-        (
-            store,
-            route = inject(ActivatedRoute),
-            router = inject(Router),
-            location = inject(Location)
-        ) => ({
-            /**
-             * Sets current tab and syncs URL without triggering Angular router navigation.
-             */
-            setCurrentTabAndNavigate(tab: DashboardTab): void {
-                store.setCurrentTab(tab);
-                silentNavigate(router, location, route, { tab });
-            },
-
-            /**
-             * Refreshes all currently loaded data based on the current tab.
-             */
-            refreshAllData(): void {
-                const currentTab = store.currentTab();
-
-                switch (currentTab) {
-                    case DASHBOARD_TABS.pageview:
-                        store.loadAllPageviewData();
-                        break;
-                    case DASHBOARD_TABS.engagement:
-                        store.loadEngagementData();
-                        break;
-                    case DASHBOARD_TABS.conversions:
-                        store.loadConversionsData();
-                        break;
-                }
-            },
-
-            /**
-             * Updates time range and syncs URL with query params.
-             *
-             * Uses `location.replaceState` (same as `setCurrentTabAndNavigate`) to avoid
-             * triggering router events that would reset component state.
-             *
-             * When `timeRange` is the bare `'custom'` string (dropdown selected but no
-             * dates chosen yet), only the URL is updated — store state is left unchanged
-             * so no data reload is triggered until a full date range is confirmed.
-             */
-            updateTimeRange(timeRange: TimeRangeInput): void {
-                const queryParams: Params = {};
-
-                if (Array.isArray(timeRange)) {
-                    // Complete custom date range — update state and URL
-                    store.setTimeRange(timeRange);
-                    queryParams['time_range'] = TIME_RANGE_OPTIONS.custom;
-                    queryParams['from'] = timeRange[0];
-                    queryParams['to'] = timeRange[1];
-                } else {
-                    // Predefined range OR bare 'custom' (no dates yet)
-                    // Only update state for predefined ranges, not for bare 'custom'
-                    if (timeRange !== TIME_RANGE_OPTIONS.custom) {
-                        store.setTimeRange(timeRange);
-                    }
-
-                    queryParams['time_range'] = timeRange;
-                    // Null out from/to to remove them from the URL when switching away from custom
-                    queryParams['from'] = null;
-                    queryParams['to'] = null;
-                }
-
-                silentNavigate(router, location, route, queryParams);
-            }
-        })
-    ),
     withHooks({
         onInit(store) {
             const route = inject(ActivatedRoute);
             const globalStore = inject(GlobalStore);
-            const messageService = inject(DotMessageService);
+            const dispatcher = inject(Dispatcher);
             const params = route.snapshot.queryParams;
 
-            // Hydrate initial filter state from query params. Step 10 of the
-            // events migration replaces this `patchState` with an event
-            // dispatch once all consumers stop calling legacy mutators.
-            patchState(store, setTabFromQueryParams(params), setTimeRangeFromQueryParams(params));
+            // Hydrate initial filter state from URL query params via a single
+            // dispatched event. The reducer patches state for the keys that
+            // are present; navigation handler refreshes the breadcrumb;
+            // autoload handler fans out per-metric *Requested events.
+            const tabFromUrl = readTabFromQueryParams(params);
+            const timeRangeFromUrl = paramsToTimeRange(params || {});
+            dispatcher.dispatch(
+                filtersApiEvents.filtersHydrated({
+                    tab: tabFromUrl ?? store.currentTab(),
+                    ...(timeRangeFromUrl !== undefined ? { timeRange: timeRangeFromUrl } : {})
+                })
+            );
 
-            // Update breadcrumb when currentTab changes.
-            // Lives here during the incremental migration because legacy
-            // callers (tests, `setCurrentTabAndNavigate`) mutate state
-            // without dispatching events. Step 10 moves this to a handler.
+            // Bridge the global site signal into a `siteChanged` event so the
+            // autoload handler can react uniformly to filter and site
+            // changes. `untracked()` prevents the inner dispatch from
+            // creating a circular signal subscription.
             effect(() => {
-                const currentTab = store.currentTab();
-                const tabConfig = TAB_CONFIG_MAP.get(currentTab);
-
-                if (tabConfig) {
-                    globalStore.addNewBreadcrumb({
-                        id: `analytics-${currentTab}`,
-                        label: messageService.get(tabConfig.label)
-                    });
-                }
-            });
-
-            // Auto-load data when currentTab, timeRange, or currentSiteId changes
-            effect(() => {
-                const currentTab = store.currentTab();
-                store.timeRange(); // Read to establish reactivity
-                const currentSiteId = globalStore.currentSiteId();
-
-                // Only load if we have a site ID
-                if (!currentSiteId) {
-                    return;
-                }
-
-                // Load data based on active tab
-                switch (currentTab) {
-                    case DASHBOARD_TABS.pageview:
-                        store.loadAllPageviewData();
-                        break;
-                    case DASHBOARD_TABS.conversions:
-                        store.loadConversionsData();
-                        break;
-                    case DASHBOARD_TABS.engagement:
-                        store.loadEngagementData();
-                        break;
+                const siteId = globalStore.currentSiteId();
+                if (siteId) {
+                    untracked(() => dispatcher.dispatch(externalEvents.siteChanged({ siteId })));
                 }
             });
         }
@@ -179,27 +78,15 @@ export const DotAnalyticsDashboardStore = signalStore(
 );
 
 /**
- * Sets the time range from the query params.
- * @param params - The query params.
- * @returns The time range.
+ * Reads and validates the `tab` query param. Returns `undefined` when the
+ * param is absent or doesn't match a known dashboard tab.
  */
-const setTimeRangeFromQueryParams = (params: Params) => {
-    const timeRange = paramsToTimeRange(params || {});
+const readTabFromQueryParams = (params: Params): DashboardTab | undefined => {
+    const candidate = params?.['tab'];
 
-    return { timeRange };
-};
-
-/**
- * Sets the tab from the query params.
- * @param params - The query params.
- * @returns The tab.
- */
-const setTabFromQueryParams = (params: Params) => {
-    const currentTab = params?.['tab'];
-
-    if (currentTab && isValidTab(currentTab)) {
-        return { currentTab };
+    if (candidate && isValidTab(candidate)) {
+        return candidate as DashboardTab;
     }
 
-    return {};
+    return undefined;
 };

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/dot-analytics-dashboard.store.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/dot-analytics-dashboard.store.ts
@@ -11,6 +11,7 @@ import { withConversions } from './features/with-conversions.feature';
 import { withEngagement } from './features/with-engagement.feature';
 import { withFilters } from './features/with-filters.feature';
 import { withPageview } from './features/with-pageview.feature';
+import { withAutoload } from './handlers/with-autoload.handlers';
 import { withNavigation } from './handlers/with-navigation.handlers';
 
 import { DASHBOARD_TAB_LIST, DASHBOARD_TABS, DashboardTab, TIME_RANGE_OPTIONS } from '../constants';
@@ -44,6 +45,12 @@ export const DotAnalyticsDashboardStore = signalStore(
     // (see `with-navigation.handlers.ts`). Listens to filter/UI events
     // dispatched from components and from the onInit hydration below.
     withNavigation(),
+    // Auto-load fan-out: turn filter intents and global site changes into
+    // per-metric `*Requested` events for the active tab. Dormant during
+    // the migration (legacy components still mutate state directly via
+    // withMethods coordinators); becomes the sole loading trigger after
+    // Step 10 migrates components to dispatch events.
+    withAutoload(),
     // Coordinator methods that work across features
     withMethods(
         (

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/dot-analytics-dashboard.store.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/dot-analytics-dashboard.store.ts
@@ -11,6 +11,7 @@ import { withConversions } from './features/with-conversions.feature';
 import { withEngagement } from './features/with-engagement.feature';
 import { withFilters } from './features/with-filters.feature';
 import { withPageview } from './features/with-pageview.feature';
+import { withNavigation } from './handlers/with-navigation.handlers';
 
 import { DASHBOARD_TAB_LIST, DASHBOARD_TABS, DashboardTab, TIME_RANGE_OPTIONS } from '../constants';
 import { TimeRangeInput } from '../types';
@@ -39,6 +40,10 @@ export const DotAnalyticsDashboardStore = signalStore(
     withPageview(),
     withConversions(),
     withEngagement(),
+    // Side-effect handlers — URL sync, breadcrumb, banner persistence
+    // (see `with-navigation.handlers.ts`). Listens to filter/UI events
+    // dispatched from components and from the onInit hydration below.
+    withNavigation(),
     // Coordinator methods that work across features
     withMethods(
         (
@@ -117,10 +122,15 @@ export const DotAnalyticsDashboardStore = signalStore(
             const messageService = inject(DotMessageService);
             const params = route.snapshot.queryParams;
 
-            // Set initial state from query params
+            // Hydrate initial filter state from query params. Step 10 of the
+            // events migration replaces this `patchState` with an event
+            // dispatch once all consumers stop calling legacy mutators.
             patchState(store, setTabFromQueryParams(params), setTimeRangeFromQueryParams(params));
 
-            // Update breadcrumb when currentTab changes
+            // Update breadcrumb when currentTab changes.
+            // Lives here during the incremental migration because legacy
+            // callers (tests, `setCurrentTabAndNavigate`) mutate state
+            // without dispatching events. Step 10 moves this to a handler.
             effect(() => {
                 const currentTab = store.currentTab();
                 const tabConfig = TAB_CONFIG_MAP.get(currentTab);

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/conversions-api.events.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/conversions-api.events.ts
@@ -1,0 +1,60 @@
+import { type } from '@ngrx/signals';
+import { eventGroup } from '@ngrx/signals/events';
+
+import {
+    ContentAttributionEntity,
+    ConversionsOverviewEntity,
+    ConvertingVisitorsEntity,
+    TimeRangeInput,
+    TotalConversionsEntity
+} from '../../types';
+import {
+    ConversionTrendEntity,
+    TrafficVsConversionsEntity
+} from '../../utils/data/analytics-data.utils';
+
+/**
+ * Lifecycle events for each conversions metric: `*Requested` → `*Loaded` | `*Failed`.
+ *
+ * Six metrics: totalConversions, conversionTrend, convertingVisitors,
+ * trafficVsConversions, contentConversions, conversionsOverview.
+ * (The orphan `conversionRate` state slice is dropped during the migration —
+ * no loader exists for it and consumers compute the rate locally.)
+ */
+export const conversionsApiEvents = eventGroup({
+    source: 'Analytics Conversions API',
+    events: {
+        // Total conversions
+        totalConversionsRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        totalConversionsLoaded: type<{ data: TotalConversionsEntity }>(),
+        totalConversionsFailed: type<{ error: string }>(),
+
+        // Conversion trend (line chart over time)
+        conversionTrendRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        conversionTrendLoaded: type<{ data: ConversionTrendEntity[] }>(),
+        conversionTrendFailed: type<{ error: string }>(),
+
+        // Converting visitors (unique + unique converting)
+        convertingVisitorsRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        convertingVisitorsLoaded: type<{ data: ConvertingVisitorsEntity }>(),
+        convertingVisitorsFailed: type<{ error: string }>(),
+
+        // Traffic vs conversions (combo chart)
+        trafficVsConversionsRequested: type<{
+            timeRange: TimeRangeInput;
+            currentSiteId: string;
+        }>(),
+        trafficVsConversionsLoaded: type<{ data: TrafficVsConversionsEntity[] }>(),
+        trafficVsConversionsFailed: type<{ error: string }>(),
+
+        // Content conversions table (per-content attribution)
+        contentConversionsRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        contentConversionsLoaded: type<{ data: ContentAttributionEntity[] }>(),
+        contentConversionsFailed: type<{ error: string }>(),
+
+        // Conversions overview table (per-conversion-name with attributed content)
+        conversionsOverviewRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        conversionsOverviewLoaded: type<{ data: ConversionsOverviewEntity[] }>(),
+        conversionsOverviewFailed: type<{ error: string }>()
+    }
+});

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/engagement-api.events.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/engagement-api.events.ts
@@ -1,0 +1,43 @@
+import { type } from '@ngrx/signals';
+import { eventGroup } from '@ngrx/signals/events';
+
+import { ChartData, TimeRangeInput } from '../../types';
+import {
+    EngagementKPIs,
+    EngagementPlatforms,
+    EngagementSparklineData
+} from '../../types/engagement.types';
+
+/**
+ * Lifecycle events for each engagement metric: `*Requested` → `*Loaded` | `*Failed`.
+ *
+ * Three of the four handlers run multiple parallel queries via `forkJoin`
+ * (current+previous period for KPIs and sparkline; device+browser+language
+ * for platforms) and dispatch a single `*Loaded` event with the merged
+ * payload. Reducers transition the matching state slice through
+ * LOADING / LOADED / ERROR.
+ */
+export const engagementApiEvents = eventGroup({
+    source: 'Analytics Engagement API',
+    events: {
+        // Engagement KPIs (forkJoin: current + previous period → merged EngagementKPIs)
+        engagementKpisRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        engagementKpisLoaded: type<{ data: EngagementKPIs }>(),
+        engagementKpisFailed: type<{ error: string }>(),
+
+        // Engagement breakdown doughnut (engaged vs bounced) — single query
+        engagementBreakdownRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        engagementBreakdownLoaded: type<{ data: ChartData }>(),
+        engagementBreakdownFailed: type<{ error: string }>(),
+
+        // Engagement sparkline (forkJoin: current + previous period)
+        engagementSparklineRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        engagementSparklineLoaded: type<{ data: EngagementSparklineData }>(),
+        engagementSparklineFailed: type<{ error: string }>(),
+
+        // Engagement platforms (forkJoin: device + browser + language)
+        engagementPlatformsRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        engagementPlatformsLoaded: type<{ data: EngagementPlatforms }>(),
+        engagementPlatformsFailed: type<{ error: string }>()
+    }
+});

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/external.events.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/external.events.ts
@@ -1,0 +1,17 @@
+import { type } from '@ngrx/signals';
+import { eventGroup } from '@ngrx/signals/events';
+
+/**
+ * Cross-store signals consumed by the analytics dashboard.
+ *
+ * The dashboard's `withHooks` bridges `globalStore.currentSiteId()` (a signal
+ * outside our store) into `siteChanged` events so the autoload handler can
+ * react uniformly to filter changes and global site changes.
+ */
+export const externalEvents = eventGroup({
+    source: 'Analytics External',
+    events: {
+        /** The active site changed in the global selector. */
+        siteChanged: type<{ siteId: string }>()
+    }
+});

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/filters-api.events.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/filters-api.events.ts
@@ -1,0 +1,24 @@
+import { type } from '@ngrx/signals';
+import { eventGroup } from '@ngrx/signals/events';
+
+import { DashboardTab } from '../../constants';
+import { TimeRangeInput } from '../../types';
+
+/**
+ * Downstream filter facts dispatched after hydration or async sources settle.
+ *
+ * Not intended to be dispatched from user-facing components — these signal
+ * that a filter-related state change has happened (URL hydration on init,
+ * cross-store reactions, etc.).
+ */
+export const filtersApiEvents = eventGroup({
+    source: 'Analytics Filters API',
+    events: {
+        /**
+         * Initial filter state derived from URL query params on store init.
+         * Either `tab`, `timeRange`, or both may be set; missing keys mean
+         * "leave the current state value untouched".
+         */
+        filtersHydrated: type<{ tab?: DashboardTab; timeRange?: TimeRangeInput }>()
+    }
+});

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/filters.events.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/filters.events.ts
@@ -1,0 +1,24 @@
+import { type } from '@ngrx/signals';
+import { eventGroup } from '@ngrx/signals/events';
+
+import { DashboardTab } from '../../constants';
+import { TimeRangeInput } from '../../types';
+
+/**
+ * User intent events dispatched from the analytics filters toolbar.
+ *
+ * Components dispatch these via `injectDispatch(filtersEvents)` to express
+ * filter changes; the store reacts via `withReducer` (state) and
+ * `withEventHandlers` (URL sync, autoload fan-out).
+ */
+export const filtersEvents = eventGroup({
+    source: 'Analytics Filters',
+    events: {
+        /** User selected a different dashboard tab. */
+        tabSelected: type<{ tab: DashboardTab }>(),
+        /** User picked a new time range (predefined, custom array, or bare 'custom'). */
+        timeRangeSelected: type<{ timeRange: TimeRangeInput }>(),
+        /** User clicked the refresh button. */
+        refreshRequested: type<void>()
+    }
+});

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/index.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/index.ts
@@ -1,0 +1,7 @@
+export * from './filters.events';
+export * from './filters-api.events';
+export * from './pageview-api.events';
+export * from './conversions-api.events';
+export * from './engagement-api.events';
+export * from './ui.events';
+export * from './external.events';

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/pageview-api.events.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/pageview-api.events.ts
@@ -1,0 +1,58 @@
+import { type } from '@ngrx/signals';
+import { eventGroup } from '@ngrx/signals/events';
+
+import {
+    PageViewDeviceBrowsersEntity,
+    PageViewTimeLineEntity,
+    TimeRangeInput,
+    TopPagePerformanceEntity,
+    TopPerformanceTableEntity,
+    TotalPageViewsEntity,
+    UniqueVisitorsEntity
+} from '../../types';
+
+/**
+ * Lifecycle events for each pageview metric: `*Requested` → `*Loaded` | `*Failed`.
+ *
+ * `*Requested` events are dispatched by the autoload handler when filters
+ * change; HTTP handlers in `with-pageview.feature.ts` listen and dispatch
+ * `*Loaded` (success) or `*Failed` (error). Reducers transition the
+ * matching state slice through LOADING / LOADED / ERROR.
+ */
+export const pageviewApiEvents = eventGroup({
+    source: 'Analytics Pageview API',
+    events: {
+        // Total page views
+        totalPageViewsRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        totalPageViewsLoaded: type<{ data: TotalPageViewsEntity }>(),
+        totalPageViewsFailed: type<{ error: string }>(),
+
+        // Unique visitors
+        uniqueVisitorsRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        uniqueVisitorsLoaded: type<{ data: UniqueVisitorsEntity }>(),
+        uniqueVisitorsFailed: type<{ error: string }>(),
+
+        // Top page performance (single top page)
+        topPagePerformanceRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        topPagePerformanceLoaded: type<{ data: TopPagePerformanceEntity }>(),
+        topPagePerformanceFailed: type<{ error: string }>(),
+
+        // Page view timeline (line chart)
+        pageViewTimeLineRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        pageViewTimeLineLoaded: type<{ data: PageViewTimeLineEntity[] }>(),
+        pageViewTimeLineFailed: type<{ error: string }>(),
+
+        // Page view device/browser breakdown
+        pageViewDeviceBrowsersRequested: type<{
+            timeRange: TimeRangeInput;
+            currentSiteId: string;
+        }>(),
+        pageViewDeviceBrowsersLoaded: type<{ data: PageViewDeviceBrowsersEntity[] }>(),
+        pageViewDeviceBrowsersFailed: type<{ error: string }>(),
+
+        // Top pages table
+        topPagesTableRequested: type<{ timeRange: TimeRangeInput; currentSiteId: string }>(),
+        topPagesTableLoaded: type<{ data: TopPerformanceTableEntity[] }>(),
+        topPagesTableFailed: type<{ error: string }>()
+    }
+});

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/ui.events.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/events/ui.events.ts
@@ -1,0 +1,21 @@
+import { type } from '@ngrx/signals';
+import { eventGroup } from '@ngrx/signals/events';
+
+/**
+ * Local UI events for dialog open/close and banner interactions.
+ *
+ * These are intent events: components dispatch them; handlers may persist
+ * state (e.g. localStorage for the banner) or update store-managed UI
+ * signals.
+ */
+export const uiEvents = eventGroup({
+    source: 'Analytics UI',
+    events: {
+        /** "How it's calculated" dialog opened (from the engagement report). */
+        calculationDialogOpened: type<void>(),
+        /** "How it's calculated" dialog closed. */
+        calculationDialogClosed: type<void>(),
+        /** Top informational message banner dismissed (persists to localStorage). */
+        messageBannerDismissed: type<void>()
+    }
+});

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-conversions.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-conversions.feature.ts
@@ -1,6 +1,6 @@
-import { tapResponse } from '@ngrx/operators';
+import { mapResponse, tapResponse } from '@ngrx/operators';
 import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
-import { on, withReducer } from '@ngrx/signals/events';
+import { Events, on, withEventHandlers, withReducer } from '@ngrx/signals/events';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { pipe } from 'rxjs';
 
@@ -224,6 +224,242 @@ export function withConversions() {
                     }
                 })
             )
+        ),
+        // HTTP event handlers — listen to per-metric *Requested events and
+        // dispatch *Loaded / *Failed. switchMap cancels stale requests; the
+        // reducer above transitions state. Keep the legacy rxMethod loaders
+        // until Step 10's component cutover.
+        withEventHandlers(
+            (
+                _store,
+                events = inject(Events),
+                analyticsService = inject(DotAnalyticsService),
+                dotMessageService = inject(DotMessageService)
+            ) => ({
+                loadTotalConversions$: events
+                    .on(conversionsApiEvents.totalConversionsRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('EventSummary')
+                                .conversions()
+                                .measures(['totalEvents'])
+                                .siteId(payload.currentSiteId)
+                                .timeRange(
+                                    'day',
+                                    toTimeRangeCubeJS(payload.timeRange),
+                                    DEFAULT_GRANULARITY
+                                )
+                                .build();
+
+                            return analyticsService
+                                .cubeQuery<TotalConversionsEntity>(query)
+                                .pipe(
+                                    map((entities) => aggregateTotalConversions(entities)),
+                                    mapResponse({
+                                        next: (data) =>
+                                            conversionsApiEvents.totalConversionsLoaded({ data }),
+                                        error: (error: HttpErrorResponse) =>
+                                            conversionsApiEvents.totalConversionsFailed({
+                                                error:
+                                                    error.message ||
+                                                    dotMessageService.get(
+                                                        'analytics.error.loading.total-conversions'
+                                                    )
+                                            })
+                                    })
+                                );
+                        })
+                    ),
+
+                loadConversionTrend$: events
+                    .on(conversionsApiEvents.conversionTrendRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('EventSummary')
+                                .conversions()
+                                .measures(['totalEvents'])
+                                .siteId(payload.currentSiteId)
+                                .timeRange(
+                                    'day',
+                                    toTimeRangeCubeJS(payload.timeRange),
+                                    DEFAULT_GRANULARITY
+                                )
+                                .build();
+
+                            return analyticsService.cubeQuery<ConversionTrendEntity>(query).pipe(
+                                map((entities) =>
+                                    fillMissingDates<ConversionTrendEntity>(
+                                        entities,
+                                        payload.timeRange,
+                                        DEFAULT_GRANULARITY,
+                                        createEmptyAnalyticsEntity
+                                    )
+                                ),
+                                mapResponse({
+                                    next: (data) =>
+                                        conversionsApiEvents.conversionTrendLoaded({ data }),
+                                    error: (error: HttpErrorResponse) =>
+                                        conversionsApiEvents.conversionTrendFailed({
+                                            error:
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.conversion-trend'
+                                                )
+                                        })
+                                })
+                            );
+                        })
+                    ),
+
+                loadConvertingVisitors$: events
+                    .on(conversionsApiEvents.convertingVisitorsRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('EventSummary')
+                                .measures(['uniqueVisitors', 'uniqueConvertingVisitors'])
+                                .siteId(payload.currentSiteId)
+                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                                .build();
+
+                            return analyticsService
+                                .cubeQuery<ConvertingVisitorsEntity>(query)
+                                .pipe(
+                                    map((entities) => entities[0] ?? null),
+                                    mapResponse({
+                                        next: (data) =>
+                                            conversionsApiEvents.convertingVisitorsLoaded({
+                                                data: data as ConvertingVisitorsEntity
+                                            }),
+                                        error: (error: HttpErrorResponse) =>
+                                            conversionsApiEvents.convertingVisitorsFailed({
+                                                error:
+                                                    error.message ||
+                                                    dotMessageService.get(
+                                                        'analytics.error.loading.converting-visitors'
+                                                    )
+                                            })
+                                    })
+                                );
+                        })
+                    ),
+
+                loadTrafficVsConversions$: events
+                    .on(conversionsApiEvents.trafficVsConversionsRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('EventSummary')
+                                .measures(['uniqueVisitors', 'uniqueConvertingVisitors'])
+                                .siteId(payload.currentSiteId)
+                                .timeRange(
+                                    'day',
+                                    toTimeRangeCubeJS(payload.timeRange),
+                                    DEFAULT_GRANULARITY
+                                )
+                                .build();
+
+                            return analyticsService
+                                .cubeQuery<TrafficVsConversionsEntity>(query)
+                                .pipe(
+                                    map((entities) =>
+                                        fillMissingDates(
+                                            entities,
+                                            payload.timeRange,
+                                            DEFAULT_GRANULARITY,
+                                            createEmptyTrafficVsConversionsEntity
+                                        )
+                                    ),
+                                    mapResponse({
+                                        next: (data) =>
+                                            conversionsApiEvents.trafficVsConversionsLoaded({
+                                                data
+                                            }),
+                                        error: (error: HttpErrorResponse) =>
+                                            conversionsApiEvents.trafficVsConversionsFailed({
+                                                error:
+                                                    error.message ||
+                                                    dotMessageService.get(
+                                                        'analytics.error.loading.traffic-vs-conversions'
+                                                    )
+                                            })
+                                    })
+                                );
+                        })
+                    ),
+
+                loadContentConversions$: events
+                    .on(conversionsApiEvents.contentConversionsRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('ContentAttribution')
+                                .dimensions(['eventType', 'identifier', 'title'])
+                                .measures(['sumConversions', 'sumEvents'])
+                                .siteId(payload.currentSiteId)
+                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                                .build();
+
+                            return analyticsService
+                                .cubeQuery<ContentAttributionEntity>(query)
+                                .pipe(
+                                    mapResponse({
+                                        next: (data) =>
+                                            conversionsApiEvents.contentConversionsLoaded({
+                                                data
+                                            }),
+                                        error: (error: HttpErrorResponse) =>
+                                            conversionsApiEvents.contentConversionsFailed({
+                                                error:
+                                                    error.message ||
+                                                    dotMessageService.get(
+                                                        'analytics.error.loading.content-conversions'
+                                                    )
+                                            })
+                                    })
+                                );
+                        })
+                    ),
+
+                loadConversionsOverview$: events
+                    .on(conversionsApiEvents.conversionsOverviewRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('Conversion')
+                                .dimensions([
+                                    'conversionName',
+                                    'totalConversion',
+                                    'convRate',
+                                    'topAttributedContent'
+                                ])
+                                .siteId(payload.currentSiteId)
+                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                                .build();
+
+                            return analyticsService
+                                .cubeQuery<ConversionsOverviewEntity>(query)
+                                .pipe(
+                                    mapResponse({
+                                        next: (data) =>
+                                            conversionsApiEvents.conversionsOverviewLoaded({
+                                                data
+                                            }),
+                                        error: (error: HttpErrorResponse) =>
+                                            conversionsApiEvents.conversionsOverviewFailed({
+                                                error:
+                                                    error.message ||
+                                                    dotMessageService.get(
+                                                        'analytics.error.loading.conversions-overview'
+                                                    )
+                                            })
+                                    })
+                                );
+                        })
+                    )
+            })
         ),
         withMethods(
             (

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-conversions.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-conversions.feature.ts
@@ -1,5 +1,6 @@
 import { tapResponse } from '@ngrx/operators';
 import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
+import { on, withReducer } from '@ngrx/signals/events';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { pipe } from 'rxjs';
 
@@ -35,6 +36,7 @@ import {
     toTimeRangeCubeJS,
     TrafficVsConversionsEntity
 } from '../../utils/data/analytics-data.utils';
+import { conversionsApiEvents } from '../events';
 
 /**
  * State interface for the Conversions feature.
@@ -45,8 +47,6 @@ export interface ConversionsState {
     totalConversions: RequestState<TotalConversionsEntity>;
     /** Converting visitors metric (includes uniqueVisitors and uniqueConvertingVisitors) */
     convertingVisitors: RequestState<ConvertingVisitorsEntity>;
-    /** Site-wide conversion rate */
-    conversionRate: RequestState<number>;
     /** Conversion trend timeline data */
     conversionTrend: RequestState<ConversionTrendEntity[]>;
     /** Traffic vs conversions comparison data (per day) */
@@ -63,7 +63,6 @@ export interface ConversionsState {
 const initialConversionsState: ConversionsState = {
     totalConversions: createInitialRequestState(),
     convertingVisitors: createInitialRequestState(),
-    conversionRate: createInitialRequestState(),
     conversionTrend: createInitialRequestState(),
     trafficVsConversions: createInitialRequestState(),
     contentConversions: createInitialRequestState(),
@@ -87,6 +86,145 @@ export function withConversions() {
     return signalStoreFeature(
         { state: type<FiltersState>() },
         withState(initialConversionsState),
+        withReducer(
+            // totalConversions
+            on<ConversionsState>(conversionsApiEvents.totalConversionsRequested, () => ({
+                totalConversions: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<ConversionsState>(conversionsApiEvents.totalConversionsLoaded, ({ payload }) => ({
+                totalConversions: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<ConversionsState>(conversionsApiEvents.totalConversionsFailed, ({ payload }) => ({
+                totalConversions: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // conversionTrend
+            on<ConversionsState>(conversionsApiEvents.conversionTrendRequested, () => ({
+                conversionTrend: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<ConversionsState>(conversionsApiEvents.conversionTrendLoaded, ({ payload }) => ({
+                conversionTrend: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<ConversionsState>(conversionsApiEvents.conversionTrendFailed, ({ payload }) => ({
+                conversionTrend: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // convertingVisitors
+            on<ConversionsState>(conversionsApiEvents.convertingVisitorsRequested, () => ({
+                convertingVisitors: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<ConversionsState>(
+                conversionsApiEvents.convertingVisitorsLoaded,
+                ({ payload }) => ({
+                    convertingVisitors: {
+                        status: ComponentStatus.LOADED,
+                        data: payload.data,
+                        error: null
+                    }
+                })
+            ),
+            on<ConversionsState>(
+                conversionsApiEvents.convertingVisitorsFailed,
+                ({ payload }) => ({
+                    convertingVisitors: {
+                        status: ComponentStatus.ERROR,
+                        data: null,
+                        error: payload.error
+                    }
+                })
+            ),
+
+            // trafficVsConversions
+            on<ConversionsState>(conversionsApiEvents.trafficVsConversionsRequested, () => ({
+                trafficVsConversions: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<ConversionsState>(
+                conversionsApiEvents.trafficVsConversionsLoaded,
+                ({ payload }) => ({
+                    trafficVsConversions: {
+                        status: ComponentStatus.LOADED,
+                        data: payload.data,
+                        error: null
+                    }
+                })
+            ),
+            on<ConversionsState>(
+                conversionsApiEvents.trafficVsConversionsFailed,
+                ({ payload }) => ({
+                    trafficVsConversions: {
+                        status: ComponentStatus.ERROR,
+                        data: null,
+                        error: payload.error
+                    }
+                })
+            ),
+
+            // contentConversions
+            on<ConversionsState>(conversionsApiEvents.contentConversionsRequested, () => ({
+                contentConversions: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<ConversionsState>(
+                conversionsApiEvents.contentConversionsLoaded,
+                ({ payload }) => ({
+                    contentConversions: {
+                        status: ComponentStatus.LOADED,
+                        data: payload.data,
+                        error: null
+                    }
+                })
+            ),
+            on<ConversionsState>(
+                conversionsApiEvents.contentConversionsFailed,
+                ({ payload }) => ({
+                    contentConversions: {
+                        status: ComponentStatus.ERROR,
+                        data: null,
+                        error: payload.error
+                    }
+                })
+            ),
+
+            // conversionsOverview
+            on<ConversionsState>(conversionsApiEvents.conversionsOverviewRequested, () => ({
+                conversionsOverview: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<ConversionsState>(
+                conversionsApiEvents.conversionsOverviewLoaded,
+                ({ payload }) => ({
+                    conversionsOverview: {
+                        status: ComponentStatus.LOADED,
+                        data: payload.data,
+                        error: null
+                    }
+                })
+            ),
+            on<ConversionsState>(
+                conversionsApiEvents.conversionsOverviewFailed,
+                ({ payload }) => ({
+                    conversionsOverview: {
+                        status: ComponentStatus.ERROR,
+                        data: null,
+                        error: payload.error
+                    }
+                })
+            )
+        ),
         withMethods(
             (
                 store,

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-conversions.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-conversions.feature.ts
@@ -1,17 +1,14 @@
-import { mapResponse, tapResponse } from '@ngrx/operators';
-import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
+import { mapResponse } from '@ngrx/operators';
+import { signalStoreFeature, type, withState } from '@ngrx/signals';
 import { Events, on, withEventHandlers, withReducer } from '@ngrx/signals/events';
-import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { pipe } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 
-import { map, switchMap, tap } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { ComponentStatus } from '@dotcms/dotcms-models';
-import { GlobalStore } from '@dotcms/store';
 
 import { FiltersState } from './with-filters.feature';
 
@@ -22,7 +19,6 @@ import {
     ConvertingVisitorsEntity,
     DEFAULT_GRANULARITY,
     RequestState,
-    TimeRangeInput,
     TotalConversionsEntity
 } from '../../types';
 import { createCubeQuery } from '../../utils/cube/cube-query-builder.util';
@@ -57,9 +53,6 @@ export interface ConversionsState {
     conversionsOverview: RequestState<ConversionsOverviewEntity[]>;
 }
 
-/**
- * Initial state for the Conversions feature.
- */
 const initialConversionsState: ConversionsState = {
     totalConversions: createInitialRequestState(),
     convertingVisitors: createInitialRequestState(),
@@ -72,15 +65,11 @@ const initialConversionsState: ConversionsState = {
 /**
  * Signal Store Feature for managing conversions analytics data.
  *
- * This feature provides:
- * - State management for all conversion-related metrics
- * - Methods to load individual conversion metrics
- * - Coordinated method to load all conversions data
+ * State and HTTP follow the same shape as `withPageview`: per-metric
+ * `*Requested` events trigger the reducer to set LOADING and the HTTP
+ * handler to fetch via CubeJS, dispatching `*Loaded` or `*Failed`.
  *
- * Note: Data loading is managed by the main store's effect based on active tab.
- * This feature only provides the methods and state management.
- *
- * @returns Signal store feature with conversions state and methods
+ * @returns Signal store feature for conversions data
  */
 export function withConversions() {
     return signalStoreFeature(
@@ -129,26 +118,20 @@ export function withConversions() {
             on<ConversionsState>(conversionsApiEvents.convertingVisitorsRequested, () => ({
                 convertingVisitors: { status: ComponentStatus.LOADING, data: null, error: null }
             })),
-            on<ConversionsState>(
-                conversionsApiEvents.convertingVisitorsLoaded,
-                ({ payload }) => ({
-                    convertingVisitors: {
-                        status: ComponentStatus.LOADED,
-                        data: payload.data,
-                        error: null
-                    }
-                })
-            ),
-            on<ConversionsState>(
-                conversionsApiEvents.convertingVisitorsFailed,
-                ({ payload }) => ({
-                    convertingVisitors: {
-                        status: ComponentStatus.ERROR,
-                        data: null,
-                        error: payload.error
-                    }
-                })
-            ),
+            on<ConversionsState>(conversionsApiEvents.convertingVisitorsLoaded, ({ payload }) => ({
+                convertingVisitors: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<ConversionsState>(conversionsApiEvents.convertingVisitorsFailed, ({ payload }) => ({
+                convertingVisitors: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
 
             // trafficVsConversions
             on<ConversionsState>(conversionsApiEvents.trafficVsConversionsRequested, () => ({
@@ -179,56 +162,40 @@ export function withConversions() {
             on<ConversionsState>(conversionsApiEvents.contentConversionsRequested, () => ({
                 contentConversions: { status: ComponentStatus.LOADING, data: null, error: null }
             })),
-            on<ConversionsState>(
-                conversionsApiEvents.contentConversionsLoaded,
-                ({ payload }) => ({
-                    contentConversions: {
-                        status: ComponentStatus.LOADED,
-                        data: payload.data,
-                        error: null
-                    }
-                })
-            ),
-            on<ConversionsState>(
-                conversionsApiEvents.contentConversionsFailed,
-                ({ payload }) => ({
-                    contentConversions: {
-                        status: ComponentStatus.ERROR,
-                        data: null,
-                        error: payload.error
-                    }
-                })
-            ),
+            on<ConversionsState>(conversionsApiEvents.contentConversionsLoaded, ({ payload }) => ({
+                contentConversions: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<ConversionsState>(conversionsApiEvents.contentConversionsFailed, ({ payload }) => ({
+                contentConversions: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
 
             // conversionsOverview
             on<ConversionsState>(conversionsApiEvents.conversionsOverviewRequested, () => ({
                 conversionsOverview: { status: ComponentStatus.LOADING, data: null, error: null }
             })),
-            on<ConversionsState>(
-                conversionsApiEvents.conversionsOverviewLoaded,
-                ({ payload }) => ({
-                    conversionsOverview: {
-                        status: ComponentStatus.LOADED,
-                        data: payload.data,
-                        error: null
-                    }
-                })
-            ),
-            on<ConversionsState>(
-                conversionsApiEvents.conversionsOverviewFailed,
-                ({ payload }) => ({
-                    conversionsOverview: {
-                        status: ComponentStatus.ERROR,
-                        data: null,
-                        error: payload.error
-                    }
-                })
-            )
+            on<ConversionsState>(conversionsApiEvents.conversionsOverviewLoaded, ({ payload }) => ({
+                conversionsOverview: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<ConversionsState>(conversionsApiEvents.conversionsOverviewFailed, ({ payload }) => ({
+                conversionsOverview: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            }))
         ),
-        // HTTP event handlers — listen to per-metric *Requested events and
-        // dispatch *Loaded / *Failed. switchMap cancels stale requests; the
-        // reducer above transitions state. Keep the legacy rxMethod loaders
-        // until Step 10's component cutover.
         withEventHandlers(
             (
                 _store,
@@ -252,66 +219,62 @@ export function withConversions() {
                                 )
                                 .build();
 
-                            return analyticsService
-                                .cubeQuery<TotalConversionsEntity>(query)
-                                .pipe(
-                                    map((entities) => aggregateTotalConversions(entities)),
-                                    mapResponse({
-                                        next: (data) =>
-                                            conversionsApiEvents.totalConversionsLoaded({ data }),
-                                        error: (error: HttpErrorResponse) =>
-                                            conversionsApiEvents.totalConversionsFailed({
-                                                error:
-                                                    error.message ||
-                                                    dotMessageService.get(
-                                                        'analytics.error.loading.total-conversions'
-                                                    )
-                                            })
-                                    })
-                                );
-                        })
-                    ),
-
-                loadConversionTrend$: events
-                    .on(conversionsApiEvents.conversionTrendRequested)
-                    .pipe(
-                        switchMap(({ payload }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .conversions()
-                                .measures(['totalEvents'])
-                                .siteId(payload.currentSiteId)
-                                .timeRange(
-                                    'day',
-                                    toTimeRangeCubeJS(payload.timeRange),
-                                    DEFAULT_GRANULARITY
-                                )
-                                .build();
-
-                            return analyticsService.cubeQuery<ConversionTrendEntity>(query).pipe(
-                                map((entities) =>
-                                    fillMissingDates<ConversionTrendEntity>(
-                                        entities,
-                                        payload.timeRange,
-                                        DEFAULT_GRANULARITY,
-                                        createEmptyAnalyticsEntity
-                                    )
-                                ),
+                            return analyticsService.cubeQuery<TotalConversionsEntity>(query).pipe(
+                                map((entities) => aggregateTotalConversions(entities)),
                                 mapResponse({
                                     next: (data) =>
-                                        conversionsApiEvents.conversionTrendLoaded({ data }),
+                                        conversionsApiEvents.totalConversionsLoaded({ data }),
                                     error: (error: HttpErrorResponse) =>
-                                        conversionsApiEvents.conversionTrendFailed({
+                                        conversionsApiEvents.totalConversionsFailed({
                                             error:
                                                 error.message ||
                                                 dotMessageService.get(
-                                                    'analytics.error.loading.conversion-trend'
+                                                    'analytics.error.loading.total-conversions'
                                                 )
                                         })
                                 })
                             );
                         })
                     ),
+
+                loadConversionTrend$: events.on(conversionsApiEvents.conversionTrendRequested).pipe(
+                    switchMap(({ payload }) => {
+                        const query = createCubeQuery()
+                            .fromCube('EventSummary')
+                            .conversions()
+                            .measures(['totalEvents'])
+                            .siteId(payload.currentSiteId)
+                            .timeRange(
+                                'day',
+                                toTimeRangeCubeJS(payload.timeRange),
+                                DEFAULT_GRANULARITY
+                            )
+                            .build();
+
+                        return analyticsService.cubeQuery<ConversionTrendEntity>(query).pipe(
+                            map((entities) =>
+                                fillMissingDates<ConversionTrendEntity>(
+                                    entities,
+                                    payload.timeRange,
+                                    DEFAULT_GRANULARITY,
+                                    createEmptyAnalyticsEntity
+                                )
+                            ),
+                            mapResponse({
+                                next: (data) =>
+                                    conversionsApiEvents.conversionTrendLoaded({ data }),
+                                error: (error: HttpErrorResponse) =>
+                                    conversionsApiEvents.conversionTrendFailed({
+                                        error:
+                                            error.message ||
+                                            dotMessageService.get(
+                                                'analytics.error.loading.conversion-trend'
+                                            )
+                                    })
+                            })
+                        );
+                    })
+                ),
 
                 loadConvertingVisitors$: events
                     .on(conversionsApiEvents.convertingVisitorsRequested)
@@ -324,25 +287,23 @@ export function withConversions() {
                                 .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
                                 .build();
 
-                            return analyticsService
-                                .cubeQuery<ConvertingVisitorsEntity>(query)
-                                .pipe(
-                                    map((entities) => entities[0] ?? null),
-                                    mapResponse({
-                                        next: (data) =>
-                                            conversionsApiEvents.convertingVisitorsLoaded({
-                                                data: data as ConvertingVisitorsEntity
-                                            }),
-                                        error: (error: HttpErrorResponse) =>
-                                            conversionsApiEvents.convertingVisitorsFailed({
-                                                error:
-                                                    error.message ||
-                                                    dotMessageService.get(
-                                                        'analytics.error.loading.converting-visitors'
-                                                    )
-                                            })
-                                    })
-                                );
+                            return analyticsService.cubeQuery<ConvertingVisitorsEntity>(query).pipe(
+                                map((entities) => entities[0] ?? null),
+                                mapResponse({
+                                    next: (data) =>
+                                        conversionsApiEvents.convertingVisitorsLoaded({
+                                            data: data as ConvertingVisitorsEntity
+                                        }),
+                                    error: (error: HttpErrorResponse) =>
+                                        conversionsApiEvents.convertingVisitorsFailed({
+                                            error:
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.converting-visitors'
+                                                )
+                                        })
+                                })
+                            );
                         })
                     ),
 
@@ -402,24 +363,22 @@ export function withConversions() {
                                 .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
                                 .build();
 
-                            return analyticsService
-                                .cubeQuery<ContentAttributionEntity>(query)
-                                .pipe(
-                                    mapResponse({
-                                        next: (data) =>
-                                            conversionsApiEvents.contentConversionsLoaded({
-                                                data
-                                            }),
-                                        error: (error: HttpErrorResponse) =>
-                                            conversionsApiEvents.contentConversionsFailed({
-                                                error:
-                                                    error.message ||
-                                                    dotMessageService.get(
-                                                        'analytics.error.loading.content-conversions'
-                                                    )
-                                            })
-                                    })
-                                );
+                            return analyticsService.cubeQuery<ContentAttributionEntity>(query).pipe(
+                                mapResponse({
+                                    next: (data) =>
+                                        conversionsApiEvents.contentConversionsLoaded({
+                                            data
+                                        }),
+                                    error: (error: HttpErrorResponse) =>
+                                        conversionsApiEvents.contentConversionsFailed({
+                                            error:
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.content-conversions'
+                                                )
+                                        })
+                                })
+                            );
                         })
                     ),
 
@@ -459,404 +418,6 @@ export function withConversions() {
                                 );
                         })
                     )
-            })
-        ),
-        withMethods(
-            (
-                store,
-                globalStore = inject(GlobalStore),
-                analyticsService = inject(DotAnalyticsService),
-                dotMessageService = inject(DotMessageService)
-            ) => ({
-                /**
-                 * Loads total conversions metric.
-                 */
-                _loadTotalConversions: rxMethod<{
-                    timeRange: TimeRangeInput;
-                    currentSiteId: string;
-                }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                totalConversions: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .conversions()
-                                .measures(['totalEvents'])
-                                .siteId(currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(timeRange), DEFAULT_GRANULARITY)
-                                .build();
-
-                            return analyticsService.cubeQuery<TotalConversionsEntity>(query).pipe(
-                                tapResponse({
-                                    next: (entities) => {
-                                        const totalConversionsEntity =
-                                            aggregateTotalConversions(entities);
-                                        patchState(store, {
-                                            totalConversions: {
-                                                status: ComponentStatus.LOADED,
-                                                data: totalConversionsEntity,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.total-conversions'
-                                            );
-                                        patchState(store, {
-                                            totalConversions: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
-                                })
-                            );
-                        })
-                    )
-                ),
-
-                /**
-                 * Loads conversion trend timeline data (line chart).
-                 */
-                _loadConversionTrend: rxMethod<{
-                    timeRange: TimeRangeInput;
-                    currentSiteId: string;
-                }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                conversionTrend: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .conversions()
-                                .measures(['totalEvents'])
-                                .siteId(currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(timeRange), DEFAULT_GRANULARITY)
-                                .build();
-
-                            return analyticsService.cubeQuery<ConversionTrendEntity>(query).pipe(
-                                map((entities) =>
-                                    fillMissingDates<ConversionTrendEntity>(
-                                        entities,
-                                        timeRange,
-                                        DEFAULT_GRANULARITY,
-                                        createEmptyAnalyticsEntity
-                                    )
-                                ),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            conversionTrend: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.conversion-trend'
-                                            );
-                                        patchState(store, {
-                                            conversionTrend: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
-                                })
-                            );
-                        })
-                    )
-                ),
-
-                /**
-                 * Loads converting visitors metric (uniqueVisitors and uniqueConvertingVisitors).
-                 */
-                _loadConvertingVisitors: rxMethod<{
-                    timeRange: TimeRangeInput;
-                    currentSiteId: string;
-                }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                convertingVisitors: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .measures(['uniqueVisitors', 'uniqueConvertingVisitors'])
-                                .siteId(currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(timeRange))
-                                .build();
-
-                            return analyticsService.cubeQuery<ConvertingVisitorsEntity>(query).pipe(
-                                tapResponse({
-                                    next: (entities) => {
-                                        patchState(store, {
-                                            convertingVisitors: {
-                                                status: ComponentStatus.LOADED,
-                                                data: entities[0] ?? null,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.converting-visitors'
-                                            );
-                                        patchState(store, {
-                                            convertingVisitors: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
-                                })
-                            );
-                        })
-                    )
-                ),
-
-                /**
-                 * Loads traffic vs conversions chart data (per day).
-                 * Returns uniqueVisitors (bars) and conversion rate % (line) per day.
-                 */
-                _loadTrafficVsConversions: rxMethod<{
-                    timeRange: TimeRangeInput;
-                    currentSiteId: string;
-                }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                trafficVsConversions: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .measures(['uniqueVisitors', 'uniqueConvertingVisitors'])
-                                .siteId(currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(timeRange), DEFAULT_GRANULARITY)
-                                .build();
-
-                            return analyticsService
-                                .cubeQuery<TrafficVsConversionsEntity>(query)
-                                .pipe(
-                                    map((entities) =>
-                                        fillMissingDates(
-                                            entities,
-                                            timeRange,
-                                            DEFAULT_GRANULARITY,
-                                            createEmptyTrafficVsConversionsEntity
-                                        )
-                                    ),
-                                    tapResponse({
-                                        next: (entities) => {
-                                            patchState(store, {
-                                                trafficVsConversions: {
-                                                    status: ComponentStatus.LOADED,
-                                                    data: entities,
-                                                    error: null
-                                                }
-                                            });
-                                        },
-                                        error: (error: HttpErrorResponse) => {
-                                            const errorMessage =
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.traffic-vs-conversions'
-                                                );
-                                            patchState(store, {
-                                                trafficVsConversions: {
-                                                    status: ComponentStatus.ERROR,
-                                                    data: null,
-                                                    error: errorMessage
-                                                }
-                                            });
-                                        }
-                                    })
-                                );
-                        })
-                    )
-                ),
-
-                /**
-                 * Loads content attribution table data.
-                 * Shows content present in conversions with event type, identifier, title, etc.
-                 */
-                _loadContentConversions: rxMethod<{
-                    timeRange: TimeRangeInput;
-                    currentSiteId: string;
-                }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                contentConversions: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('ContentAttribution')
-                                .dimensions(['eventType', 'identifier', 'title'])
-                                .measures(['sumConversions', 'sumEvents'])
-                                .siteId(currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(timeRange))
-                                .build();
-
-                            return analyticsService.cubeQuery<ContentAttributionEntity>(query).pipe(
-                                tapResponse({
-                                    next: (entities) => {
-                                        patchState(store, {
-                                            contentConversions: {
-                                                status: ComponentStatus.LOADED,
-                                                data: entities,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.content-conversions'
-                                            );
-                                        patchState(store, {
-                                            contentConversions: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
-                                })
-                            );
-                        })
-                    )
-                ),
-
-                /**
-                 * Loads conversions overview table data.
-                 * Shows conversion names with total conversions, conversion rate, and top attributed content.
-                 */
-                _loadConversionsOverview: rxMethod<{
-                    timeRange: TimeRangeInput;
-                    currentSiteId: string;
-                }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                conversionsOverview: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('Conversion')
-                                .dimensions([
-                                    'conversionName',
-                                    'totalConversion',
-                                    'convRate',
-                                    'topAttributedContent'
-                                ])
-                                .siteId(currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(timeRange))
-                                .build();
-
-                            return analyticsService
-                                .cubeQuery<ConversionsOverviewEntity>(query)
-                                .pipe(
-                                    tapResponse({
-                                        next: (entities) => {
-                                            patchState(store, {
-                                                conversionsOverview: {
-                                                    status: ComponentStatus.LOADED,
-                                                    data: entities,
-                                                    error: null
-                                                }
-                                            });
-                                        },
-                                        error: (error: HttpErrorResponse) => {
-                                            const errorMessage =
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.conversions-overview'
-                                                );
-                                            patchState(store, {
-                                                conversionsOverview: {
-                                                    status: ComponentStatus.ERROR,
-                                                    data: null,
-                                                    error: errorMessage
-                                                }
-                                            });
-                                        }
-                                    })
-                                );
-                        })
-                    )
-                ),
-
-                /**
-                 * Loads all conversions data.
-                 * This method is called when the conversions tab is activated.
-                 */
-                loadConversionsData(): void {
-                    const currentSiteId = globalStore.currentSiteId();
-                    const timeRange = store.timeRange();
-
-                    if (!currentSiteId) {
-                        return;
-                    }
-
-                    // Load all conversions metrics
-                    this._loadTotalConversions({ timeRange, currentSiteId });
-                    this._loadConversionTrend({ timeRange, currentSiteId });
-                    this._loadConvertingVisitors({ timeRange, currentSiteId });
-                    this._loadTrafficVsConversions({ timeRange, currentSiteId });
-                    this._loadContentConversions({ timeRange, currentSiteId });
-                    this._loadConversionsOverview({ timeRange, currentSiteId });
-                }
             })
         )
     );

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-engagement.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-engagement.feature.ts
@@ -1,6 +1,6 @@
-import { tapResponse } from '@ngrx/operators';
+import { mapResponse, tapResponse } from '@ngrx/operators';
 import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
-import { on, withReducer } from '@ngrx/signals/events';
+import { Events, on, withEventHandlers, withReducer } from '@ngrx/signals/events';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { forkJoin, of, pipe } from 'rxjs';
 
@@ -163,6 +163,244 @@ export function withEngagement() {
                     error: payload.error
                 }
             }))
+        ),
+        // HTTP event handlers — three of the four metrics merge multi-query
+        // forkJoin results into a single payload before dispatching *Loaded.
+        // switchMap cancels stale requests when filters change again.
+        withEventHandlers(
+            (
+                _store,
+                events = inject(Events),
+                analyticsService = inject(DotAnalyticsService),
+                dotMessageService = inject(DotMessageService)
+            ) => {
+                const getErrorMessage = (key: string, fallback: string) =>
+                    dotMessageService.get(key) || fallback;
+
+                return {
+                    loadEngagementKpis$: events
+                        .on(engagementApiEvents.engagementKpisRequested)
+                        .pipe(
+                            switchMap(({ payload }) => {
+                                const dateRange = toTimeRangeCubeJS(payload.timeRange);
+                                const previousRange = getPreviousPeriod(payload.timeRange);
+
+                                const currentQuery = createCubeQuery()
+                                    .fromCube('EngagementDaily')
+                                    .siteId(payload.currentSiteId)
+                                    .measures(ENGAGEMENT_DAILY_MEASURES)
+                                    .timeRange('day', dateRange)
+                                    .build();
+
+                                const previousQuery = createCubeQuery()
+                                    .fromCube('EngagementDaily')
+                                    .siteId(payload.currentSiteId)
+                                    .measures(ENGAGEMENT_DAILY_MEASURES)
+                                    .timeRange('day', previousRange)
+                                    .build();
+
+                                return forkJoin({
+                                    current: analyticsService
+                                        .cubeQuery<EngagementDailyEntity>(currentQuery)
+                                        .pipe(
+                                            map((rows) => rows[0] ?? null),
+                                            catchError(() => of(null))
+                                        ),
+                                    previous: analyticsService
+                                        .cubeQuery<EngagementDailyEntity>(previousQuery)
+                                        .pipe(
+                                            map((rows) => rows[0] ?? null),
+                                            catchError(() => of(null))
+                                        )
+                                }).pipe(
+                                    mapResponse({
+                                        next: ({ current, previous }) =>
+                                            engagementApiEvents.engagementKpisLoaded({
+                                                data: toEngagementKPIs(current, previous)
+                                            }),
+                                        error: (error: HttpErrorResponse) =>
+                                            engagementApiEvents.engagementKpisFailed({
+                                                error:
+                                                    error?.message ||
+                                                    getErrorMessage(
+                                                        'analytics.error.loading.engagement',
+                                                        'Failed to load engagement KPIs'
+                                                    )
+                                            })
+                                    })
+                                );
+                            })
+                        ),
+
+                    loadEngagementBreakdown$: events
+                        .on(engagementApiEvents.engagementBreakdownRequested)
+                        .pipe(
+                            switchMap(({ payload }) => {
+                                const query = createCubeQuery()
+                                    .fromCube('EngagementDaily')
+                                    .siteId(payload.currentSiteId)
+                                    .measures(['totalSessions', 'engagedSessions'])
+                                    .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                                    .build();
+
+                                return analyticsService
+                                    .cubeQuery<EngagementDailyEntity>(query)
+                                    .pipe(
+                                        map((rows) => {
+                                            const row = rows?.[0];
+                                            const total = row
+                                                ? Number(row['EngagementDaily.totalSessions'] ?? 0)
+                                                : 0;
+                                            const engaged = row
+                                                ? Number(
+                                                      row['EngagementDaily.engagedSessions'] ?? 0
+                                                  )
+                                                : 0;
+                                            return toEngagementBreakdownChartData(total, engaged);
+                                        }),
+                                        mapResponse({
+                                            next: (data) =>
+                                                engagementApiEvents.engagementBreakdownLoaded({
+                                                    data
+                                                }),
+                                            error: (error: HttpErrorResponse) =>
+                                                engagementApiEvents.engagementBreakdownFailed({
+                                                    error:
+                                                        error?.message ||
+                                                        getErrorMessage(
+                                                            'analytics.error.loading.engagement',
+                                                            'Failed to load breakdown data'
+                                                        )
+                                                })
+                                        })
+                                    );
+                            })
+                        ),
+
+                    loadEngagementSparkline$: events
+                        .on(engagementApiEvents.engagementSparklineRequested)
+                        .pipe(
+                            switchMap(({ payload }) => {
+                                const dateRange = toTimeRangeCubeJS(payload.timeRange);
+                                const previousRange = getPreviousPeriod(payload.timeRange);
+
+                                const currentQuery = createCubeQuery()
+                                    .fromCube('EngagementDaily')
+                                    .siteId(payload.currentSiteId)
+                                    .measures([
+                                        ...ENGAGEMENT_TREND_MEASURES,
+                                        ...ENGAGEMENT_SPARKLINE_MEASURES
+                                    ])
+                                    .timeRange('day', dateRange, DEFAULT_GRANULARITY)
+                                    .build();
+
+                                const previousQuery = createCubeQuery()
+                                    .fromCube('EngagementDaily')
+                                    .siteId(payload.currentSiteId)
+                                    .measures([
+                                        ...ENGAGEMENT_TREND_MEASURES,
+                                        ...ENGAGEMENT_SPARKLINE_MEASURES
+                                    ])
+                                    .timeRange('day', previousRange, DEFAULT_GRANULARITY)
+                                    .build();
+
+                                return forkJoin({
+                                    current: analyticsService.cubeQuery<EngagementDailyEntity>(
+                                        currentQuery
+                                    ),
+                                    previous: analyticsService
+                                        .cubeQuery<EngagementDailyEntity>(previousQuery)
+                                        .pipe(catchError(() => of([])))
+                                }).pipe(
+                                    mapResponse({
+                                        next: ({ current, previous }) =>
+                                            engagementApiEvents.engagementSparklineLoaded({
+                                                data: {
+                                                    current: toEngagementSparklineData(
+                                                        current ?? []
+                                                    ),
+                                                    previous:
+                                                        previous?.length > 0
+                                                            ? toEngagementSparklineData(previous)
+                                                            : null
+                                                }
+                                            }),
+                                        error: (error: HttpErrorResponse) =>
+                                            engagementApiEvents.engagementSparklineFailed({
+                                                error:
+                                                    error?.message ||
+                                                    getErrorMessage(
+                                                        'analytics.error.loading.engagement',
+                                                        'Failed to load sparkline data'
+                                                    )
+                                            })
+                                    })
+                                );
+                            })
+                        ),
+
+                    loadEngagementPlatforms$: events
+                        .on(engagementApiEvents.engagementPlatformsRequested)
+                        .pipe(
+                            switchMap(({ payload }) => {
+                                const dateRange = toTimeRangeCubeJS(payload.timeRange);
+
+                                const deviceQuery = createCubeQuery()
+                                    .fromCube('SessionsByDeviceDaily')
+                                    .siteId(payload.currentSiteId)
+                                    .measures(SESSIONS_BY_MEASURES)
+                                    .dimensions(SESSIONS_BY_DEVICE_DIMENSIONS)
+                                    .timeRange('day', dateRange)
+                                    .build();
+
+                                const browserQuery = createCubeQuery()
+                                    .fromCube('SessionsByBrowserDaily')
+                                    .siteId(payload.currentSiteId)
+                                    .measures(SESSIONS_BY_MEASURES)
+                                    .dimensions(SESSIONS_BY_BROWSER_DIMENSIONS)
+                                    .timeRange('day', dateRange)
+                                    .build();
+
+                                const languageQuery = createCubeQuery()
+                                    .fromCube('SessionsByLanguageDaily')
+                                    .siteId(payload.currentSiteId)
+                                    .measures(SESSIONS_BY_MEASURES)
+                                    .dimensions(SESSIONS_BY_LANGUAGE_DIMENSIONS)
+                                    .timeRange('day', dateRange)
+                                    .build();
+
+                                return forkJoin({
+                                    device: analyticsService
+                                        .cubeQuery<SessionsByDeviceDailyEntity>(deviceQuery)
+                                        .pipe(catchError(() => of([]))),
+                                    browser: analyticsService
+                                        .cubeQuery<SessionsByBrowserDailyEntity>(browserQuery)
+                                        .pipe(catchError(() => of([]))),
+                                    language: analyticsService
+                                        .cubeQuery<SessionsByLanguageDailyEntity>(languageQuery)
+                                        .pipe(catchError(() => of([])))
+                                }).pipe(
+                                    map(({ device, browser, language }) =>
+                                        toEngagementPlatforms(device, browser, language)
+                                    ),
+                                    mapResponse({
+                                        next: (data) =>
+                                            engagementApiEvents.engagementPlatformsLoaded({ data }),
+                                        error: (error: HttpErrorResponse) =>
+                                            engagementApiEvents.engagementPlatformsFailed({
+                                                error:
+                                                    error?.message ||
+                                                    getErrorMessage(
+                                                        'analytics.error.loading.engagement',
+                                                        'Failed to load platforms data'
+                                                    )
+                                            })
+                                    })
+                                );
+                            })
+                        )
+                };
+            }
         ),
         withMethods(
             (

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-engagement.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-engagement.feature.ts
@@ -1,5 +1,6 @@
 import { tapResponse } from '@ngrx/operators';
 import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
+import { on, withReducer } from '@ngrx/signals/events';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { forkJoin, of, pipe } from 'rxjs';
 
@@ -28,6 +29,7 @@ import {
     toEngagementPlatforms,
     toEngagementSparklineData
 } from '../../utils/data/engagement-data.utils';
+import { engagementApiEvents } from '../events';
 
 // eslint-disable-next-line no-duplicate-imports
 import type {
@@ -89,6 +91,79 @@ export function withEngagement() {
     return signalStoreFeature(
         { state: type<FiltersState>() },
         withState(initialEngagementState),
+        withReducer(
+            // engagementKpis (forkJoin current+previous merged into EngagementKPIs)
+            on<EngagementState>(engagementApiEvents.engagementKpisRequested, () => ({
+                engagementKpis: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<EngagementState>(engagementApiEvents.engagementKpisLoaded, ({ payload }) => ({
+                engagementKpis: { status: ComponentStatus.LOADED, data: payload.data, error: null }
+            })),
+            on<EngagementState>(engagementApiEvents.engagementKpisFailed, ({ payload }) => ({
+                engagementKpis: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // engagementBreakdown (single query → ChartData)
+            on<EngagementState>(engagementApiEvents.engagementBreakdownRequested, () => ({
+                engagementBreakdown: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<EngagementState>(engagementApiEvents.engagementBreakdownLoaded, ({ payload }) => ({
+                engagementBreakdown: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<EngagementState>(engagementApiEvents.engagementBreakdownFailed, ({ payload }) => ({
+                engagementBreakdown: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // engagementSparkline (forkJoin current+previous merged into EngagementSparklineData)
+            on<EngagementState>(engagementApiEvents.engagementSparklineRequested, () => ({
+                engagementSparkline: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<EngagementState>(engagementApiEvents.engagementSparklineLoaded, ({ payload }) => ({
+                engagementSparkline: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<EngagementState>(engagementApiEvents.engagementSparklineFailed, ({ payload }) => ({
+                engagementSparkline: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // engagementPlatforms (forkJoin device+browser+language merged into EngagementPlatforms)
+            on<EngagementState>(engagementApiEvents.engagementPlatformsRequested, () => ({
+                engagementPlatforms: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<EngagementState>(engagementApiEvents.engagementPlatformsLoaded, ({ payload }) => ({
+                engagementPlatforms: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<EngagementState>(engagementApiEvents.engagementPlatformsFailed, ({ payload }) => ({
+                engagementPlatforms: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            }))
+        ),
         withMethods(
             (
                 store,

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-engagement.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-engagement.feature.ts
@@ -1,17 +1,15 @@
-import { mapResponse, tapResponse } from '@ngrx/operators';
-import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
+import { mapResponse } from '@ngrx/operators';
+import { signalStoreFeature, type, withState } from '@ngrx/signals';
 import { Events, on, withEventHandlers, withReducer } from '@ngrx/signals/events';
-import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { forkJoin, of, pipe } from 'rxjs';
+import { forkJoin, of } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 
-import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { ComponentStatus } from '@dotcms/dotcms-models';
-import { GlobalStore } from '@dotcms/store';
 
 import { FiltersState } from './with-filters.feature';
 
@@ -42,8 +40,7 @@ import type {
     RequestState,
     SessionsByBrowserDailyEntity,
     SessionsByDeviceDailyEntity,
-    SessionsByLanguageDailyEntity,
-    TimeRangeInput
+    SessionsByLanguageDailyEntity
 } from '../../types';
 
 const ENGAGEMENT_DAILY_MEASURES = [
@@ -85,14 +82,20 @@ const initialEngagementState: EngagementState = {
 
 /**
  * Signal Store Feature for managing engagement analytics data.
- * Each slice (KPIs, trend chart, breakdown, platforms) loads independently and has its own loading/error state.
+ *
+ * Three of the four metrics combine multiple parallel queries via
+ * `forkJoin`: KPIs (current+previous period), sparkline (current+previous),
+ * and platforms (device+browser+language). Each handler dispatches a
+ * single `*Loaded` event with the merged shape; reducers stay trivial.
+ *
+ * @returns Signal store feature for engagement data
  */
 export function withEngagement() {
     return signalStoreFeature(
         { state: type<FiltersState>() },
         withState(initialEngagementState),
         withReducer(
-            // engagementKpis (forkJoin current+previous merged into EngagementKPIs)
+            // engagementKpis
             on<EngagementState>(engagementApiEvents.engagementKpisRequested, () => ({
                 engagementKpis: { status: ComponentStatus.LOADING, data: null, error: null }
             })),
@@ -107,7 +110,7 @@ export function withEngagement() {
                 }
             })),
 
-            // engagementBreakdown (single query → ChartData)
+            // engagementBreakdown
             on<EngagementState>(engagementApiEvents.engagementBreakdownRequested, () => ({
                 engagementBreakdown: { status: ComponentStatus.LOADING, data: null, error: null }
             })),
@@ -126,7 +129,7 @@ export function withEngagement() {
                 }
             })),
 
-            // engagementSparkline (forkJoin current+previous merged into EngagementSparklineData)
+            // engagementSparkline
             on<EngagementState>(engagementApiEvents.engagementSparklineRequested, () => ({
                 engagementSparkline: { status: ComponentStatus.LOADING, data: null, error: null }
             })),
@@ -145,7 +148,7 @@ export function withEngagement() {
                 }
             })),
 
-            // engagementPlatforms (forkJoin device+browser+language merged into EngagementPlatforms)
+            // engagementPlatforms
             on<EngagementState>(engagementApiEvents.engagementPlatformsRequested, () => ({
                 engagementPlatforms: { status: ComponentStatus.LOADING, data: null, error: null }
             })),
@@ -164,9 +167,6 @@ export function withEngagement() {
                 }
             }))
         ),
-        // HTTP event handlers — three of the four metrics merge multi-query
-        // forkJoin results into a single payload before dispatching *Loaded.
-        // switchMap cancels stale requests when filters change again.
         withEventHandlers(
             (
                 _store,
@@ -305,9 +305,10 @@ export function withEngagement() {
                                     .build();
 
                                 return forkJoin({
-                                    current: analyticsService.cubeQuery<EngagementDailyEntity>(
-                                        currentQuery
-                                    ),
+                                    current:
+                                        analyticsService.cubeQuery<EngagementDailyEntity>(
+                                            currentQuery
+                                        ),
                                     previous: analyticsService
                                         .cubeQuery<EngagementDailyEntity>(previousQuery)
                                         .pipe(catchError(() => of([])))
@@ -399,367 +400,6 @@ export function withEngagement() {
                                 );
                             })
                         )
-                };
-            }
-        ),
-        withMethods(
-            (
-                store,
-                globalStore = inject(GlobalStore),
-                analyticsService = inject(DotAnalyticsService),
-                dotMessageService = inject(DotMessageService)
-            ) => {
-                const getErrorMessage = (key: string, fallback: string) =>
-                    dotMessageService.get(key) || fallback;
-
-                return {
-                    /**
-                     * Loads KPIs: current + previous period totals for trend calculation.
-                     */
-                    _loadEngagementKpis: rxMethod<{
-                        timeRange: TimeRangeInput;
-                        currentSiteId: string;
-                    }>(
-                        pipe(
-                            tap(() =>
-                                patchState(store, {
-                                    engagementKpis: {
-                                        status: ComponentStatus.LOADING,
-                                        data: null,
-                                        error: null
-                                    }
-                                })
-                            ),
-                            switchMap(({ timeRange, currentSiteId }) => {
-                                const dateRange = toTimeRangeCubeJS(timeRange);
-                                const previousRange = getPreviousPeriod(timeRange);
-
-                                const currentQuery = createCubeQuery()
-                                    .fromCube('EngagementDaily')
-                                    .siteId(currentSiteId)
-                                    .measures(ENGAGEMENT_DAILY_MEASURES)
-                                    .timeRange('day', dateRange)
-                                    .build();
-
-                                const previousQuery = createCubeQuery()
-                                    .fromCube('EngagementDaily')
-                                    .siteId(currentSiteId)
-                                    .measures(ENGAGEMENT_DAILY_MEASURES)
-                                    .timeRange('day', previousRange)
-                                    .build();
-
-                                return forkJoin({
-                                    current: analyticsService
-                                        .cubeQuery<EngagementDailyEntity>(currentQuery)
-                                        .pipe(
-                                            map((rows) => rows[0] ?? null),
-                                            catchError(() => of(null))
-                                        ),
-                                    previous: analyticsService
-                                        .cubeQuery<EngagementDailyEntity>(previousQuery)
-                                        .pipe(
-                                            map((rows) => rows[0] ?? null),
-                                            catchError(() => of(null))
-                                        )
-                                }).pipe(
-                                    tapResponse({
-                                        next: ({ current, previous }) => {
-                                            patchState(store, {
-                                                engagementKpis: {
-                                                    status: ComponentStatus.LOADED,
-                                                    data: toEngagementKPIs(current, previous),
-                                                    error: null
-                                                }
-                                            });
-                                        },
-                                        error: (error: HttpErrorResponse) => {
-                                            patchState(store, {
-                                                engagementKpis: {
-                                                    status: ComponentStatus.ERROR,
-                                                    data: null,
-                                                    error:
-                                                        error?.message ||
-                                                        getErrorMessage(
-                                                            'analytics.error.loading.engagement',
-                                                            'Failed to load engagement KPIs'
-                                                        )
-                                                }
-                                            });
-                                        }
-                                    })
-                                );
-                            })
-                        )
-                    ),
-
-                    /**
-                     * Loads breakdown (engaged vs bounced doughnut) from current period totals.
-                     */
-                    _loadEngagementBreakdown: rxMethod<{
-                        timeRange: TimeRangeInput;
-                        currentSiteId: string;
-                    }>(
-                        pipe(
-                            tap(() =>
-                                patchState(store, {
-                                    engagementBreakdown: {
-                                        status: ComponentStatus.LOADING,
-                                        data: null,
-                                        error: null
-                                    }
-                                })
-                            ),
-                            switchMap(({ timeRange, currentSiteId }) => {
-                                const dateRange = toTimeRangeCubeJS(timeRange);
-
-                                const query = createCubeQuery()
-                                    .fromCube('EngagementDaily')
-                                    .siteId(currentSiteId)
-                                    .measures(['totalSessions', 'engagedSessions'])
-                                    .timeRange('day', dateRange)
-                                    .build();
-
-                                return analyticsService
-                                    .cubeQuery<EngagementDailyEntity>(query)
-                                    .pipe(
-                                        tapResponse({
-                                            next: (rows) => {
-                                                const row = rows?.[0];
-                                                const total = row
-                                                    ? Number(
-                                                          row['EngagementDaily.totalSessions'] ?? 0
-                                                      )
-                                                    : 0;
-                                                const engaged = row
-                                                    ? Number(
-                                                          row['EngagementDaily.engagedSessions'] ??
-                                                              0
-                                                      )
-                                                    : 0;
-                                                patchState(store, {
-                                                    engagementBreakdown: {
-                                                        status: ComponentStatus.LOADED,
-                                                        data: toEngagementBreakdownChartData(
-                                                            total,
-                                                            engaged
-                                                        ),
-                                                        error: null
-                                                    }
-                                                });
-                                            },
-                                            error: (error: HttpErrorResponse) => {
-                                                patchState(store, {
-                                                    engagementBreakdown: {
-                                                        status: ComponentStatus.ERROR,
-                                                        data: null,
-                                                        error:
-                                                            error?.message ||
-                                                            getErrorMessage(
-                                                                'analytics.error.loading.engagement',
-                                                                'Failed to load breakdown data'
-                                                            )
-                                                    }
-                                                });
-                                            }
-                                        })
-                                    );
-                            })
-                        )
-                    ),
-
-                    /**
-                     * Loads sparkline data (engagement/conversion rate per day) for current and previous period.
-                     */
-                    _loadEngagementSparkline: rxMethod<{
-                        timeRange: TimeRangeInput;
-                        currentSiteId: string;
-                    }>(
-                        pipe(
-                            tap(() =>
-                                patchState(store, {
-                                    engagementSparkline: {
-                                        status: ComponentStatus.LOADING,
-                                        data: null,
-                                        error: null
-                                    }
-                                })
-                            ),
-                            switchMap(({ timeRange, currentSiteId }) => {
-                                const dateRange = toTimeRangeCubeJS(timeRange);
-                                const previousRange = getPreviousPeriod(timeRange);
-
-                                const currentQuery = createCubeQuery()
-                                    .fromCube('EngagementDaily')
-                                    .siteId(currentSiteId)
-                                    .measures([
-                                        ...ENGAGEMENT_TREND_MEASURES,
-                                        ...ENGAGEMENT_SPARKLINE_MEASURES
-                                    ])
-                                    .timeRange('day', dateRange, DEFAULT_GRANULARITY)
-                                    .build();
-
-                                const previousQuery = createCubeQuery()
-                                    .fromCube('EngagementDaily')
-                                    .siteId(currentSiteId)
-                                    .measures([
-                                        ...ENGAGEMENT_TREND_MEASURES,
-                                        ...ENGAGEMENT_SPARKLINE_MEASURES
-                                    ])
-                                    .timeRange('day', previousRange, DEFAULT_GRANULARITY)
-                                    .build();
-
-                                return forkJoin({
-                                    current:
-                                        analyticsService.cubeQuery<EngagementDailyEntity>(
-                                            currentQuery
-                                        ),
-                                    previous: analyticsService
-                                        .cubeQuery<EngagementDailyEntity>(previousQuery)
-                                        .pipe(catchError(() => of([])))
-                                }).pipe(
-                                    tapResponse({
-                                        next: ({ current, previous }) => {
-                                            patchState(store, {
-                                                engagementSparkline: {
-                                                    status: ComponentStatus.LOADED,
-                                                    data: {
-                                                        current: toEngagementSparklineData(
-                                                            current ?? []
-                                                        ),
-                                                        previous:
-                                                            previous?.length > 0
-                                                                ? toEngagementSparklineData(
-                                                                      previous
-                                                                  )
-                                                                : null
-                                                    },
-                                                    error: null
-                                                }
-                                            });
-                                        },
-                                        error: (error: HttpErrorResponse) => {
-                                            patchState(store, {
-                                                engagementSparkline: {
-                                                    status: ComponentStatus.ERROR,
-                                                    data: null,
-                                                    error:
-                                                        error?.message ||
-                                                        getErrorMessage(
-                                                            'analytics.error.loading.engagement',
-                                                            'Failed to load sparkline data'
-                                                        )
-                                                }
-                                            });
-                                        }
-                                    })
-                                );
-                            })
-                        )
-                    ),
-
-                    /**
-                     * Loads platforms (device, browser) in parallel.
-                     */
-                    _loadEngagementPlatforms: rxMethod<{
-                        timeRange: TimeRangeInput;
-                        currentSiteId: string;
-                    }>(
-                        pipe(
-                            tap(() =>
-                                patchState(store, {
-                                    engagementPlatforms: {
-                                        status: ComponentStatus.LOADING,
-                                        data: null,
-                                        error: null
-                                    }
-                                })
-                            ),
-                            switchMap(({ timeRange, currentSiteId }) => {
-                                const dateRange = toTimeRangeCubeJS(timeRange);
-
-                                const deviceQuery = createCubeQuery()
-                                    .fromCube('SessionsByDeviceDaily')
-                                    .siteId(currentSiteId)
-                                    .measures(SESSIONS_BY_MEASURES)
-                                    .dimensions(SESSIONS_BY_DEVICE_DIMENSIONS)
-                                    .timeRange('day', dateRange)
-                                    .build();
-
-                                const browserQuery = createCubeQuery()
-                                    .fromCube('SessionsByBrowserDaily')
-                                    .siteId(currentSiteId)
-                                    .measures(SESSIONS_BY_MEASURES)
-                                    .dimensions(SESSIONS_BY_BROWSER_DIMENSIONS)
-                                    .timeRange('day', dateRange)
-                                    .build();
-
-                                const languageQuery = createCubeQuery()
-                                    .fromCube('SessionsByLanguageDaily')
-                                    .siteId(currentSiteId)
-                                    .measures(SESSIONS_BY_MEASURES)
-                                    .dimensions(SESSIONS_BY_LANGUAGE_DIMENSIONS)
-                                    .timeRange('day', dateRange)
-                                    .build();
-
-                                return forkJoin({
-                                    device: analyticsService
-                                        .cubeQuery<SessionsByDeviceDailyEntity>(deviceQuery)
-                                        .pipe(catchError(() => of([]))),
-                                    browser: analyticsService
-                                        .cubeQuery<SessionsByBrowserDailyEntity>(browserQuery)
-                                        .pipe(catchError(() => of([]))),
-                                    language: analyticsService
-                                        .cubeQuery<SessionsByLanguageDailyEntity>(languageQuery)
-                                        .pipe(catchError(() => of([])))
-                                }).pipe(
-                                    map(({ device, browser, language }) =>
-                                        toEngagementPlatforms(device, browser, language)
-                                    ),
-                                    tapResponse({
-                                        next: (platforms) =>
-                                            patchState(store, {
-                                                engagementPlatforms: {
-                                                    status: ComponentStatus.LOADED,
-                                                    data: platforms,
-                                                    error: null
-                                                }
-                                            }),
-                                        error: (error: HttpErrorResponse) =>
-                                            patchState(store, {
-                                                engagementPlatforms: {
-                                                    status: ComponentStatus.ERROR,
-                                                    data: null,
-                                                    error:
-                                                        error?.message ||
-                                                        getErrorMessage(
-                                                            'analytics.error.loading.engagement',
-                                                            'Failed to load platforms data'
-                                                        )
-                                                }
-                                            })
-                                    })
-                                );
-                            })
-                        )
-                    ),
-
-                    /**
-                     * Loads all engagement data. Dispatches independent requests per block.
-                     */
-                    loadEngagementData(): void {
-                        const currentSiteId = globalStore.currentSiteId();
-                        const timeRange = store.timeRange();
-
-                        if (!currentSiteId) {
-                            return;
-                        }
-
-                        const payload = { timeRange, currentSiteId };
-                        this._loadEngagementKpis(payload);
-                        this._loadEngagementSparkline(payload);
-                        this._loadEngagementBreakdown(payload);
-                        this._loadEngagementPlatforms(payload);
-                    }
                 };
             }
         )

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-filters.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-filters.feature.ts
@@ -1,4 +1,4 @@
-import { patchState, signalStoreFeature, withMethods, withState } from '@ngrx/signals';
+import { signalStoreFeature, withState } from '@ngrx/signals';
 import { on, withReducer } from '@ngrx/signals/events';
 
 import { DASHBOARD_TABS, DashboardTab, TIME_RANGE_OPTIONS } from '../../constants';
@@ -12,7 +12,7 @@ import { filtersApiEvents, filtersEvents } from '../events';
 export interface FiltersState {
     /** Current time range selection */
     timeRange: TimeRangeInput;
-    /** Current active tab ('pageview' | 'conversions') */
+    /** Current active tab ('pageview' | 'conversions' | 'engagement') */
     currentTab: DashboardTab;
 }
 
@@ -27,11 +27,16 @@ const initialFiltersState: FiltersState = {
 /**
  * Signal Store Feature for managing shared filters in the analytics dashboard.
  *
- * State transitions are driven by events from the `@ngrx/signals/events`
- * plugin (see `filtersEvents` and `filtersApiEvents` in `../events`). The
- * legacy imperative methods (`setTimeRange`, `setCurrentTab`) are kept
- * during the migration; they will be removed in Step 10 once all callers
- * dispatch events instead.
+ * State transitions are driven entirely by events from the
+ * `@ngrx/signals/events` plugin (see `filtersEvents` and `filtersApiEvents`
+ * in `../events`):
+ *
+ * - `tabSelected({ tab })` → patch `currentTab`
+ * - `timeRangeSelected({ timeRange })` → patch `timeRange`, except for the
+ *   bare `'custom'` string which leaves state untouched (only the URL
+ *   syncs in that case)
+ * - `filtersHydrated({ tab?, timeRange? })` → patch the keys that arrive
+ *   from URL query params on store init
  *
  * @returns Signal store feature wiring filter state to its reducer
  */
@@ -43,10 +48,6 @@ export function withFilters() {
                 currentTab: payload.tab
             })),
             on<FiltersState>(filtersEvents.timeRangeSelected, ({ payload }) => {
-                // Bare 'custom' string (dropdown picked, no dates yet) must NOT
-                // update state — the URL side-effect runs regardless via the
-                // navigation handler. State only changes for predefined ranges
-                // and complete custom DateRange tuples.
                 if (payload.timeRange === TIME_RANGE_OPTIONS.custom) {
                     return {};
                 }
@@ -66,24 +67,6 @@ export function withFilters() {
 
                 return next;
             })
-        ),
-        // Legacy methods kept only during the incremental migration. Removed
-        // in Step 10 once `dot-analytics-dashboard.store.ts` and the dashboard
-        // component dispatch events instead of calling these mutators.
-        withMethods((store) => ({
-            /**
-             * @deprecated Dispatch `filtersEvents.timeRangeSelected({ timeRange })` instead.
-             */
-            setTimeRange(timeRange: TimeRangeInput): void {
-                patchState(store, { timeRange });
-            },
-
-            /**
-             * @deprecated Dispatch `filtersEvents.tabSelected({ tab })` instead.
-             */
-            setCurrentTab(tab: DashboardTab): void {
-                patchState(store, { currentTab: tab });
-            }
-        }))
+        )
     );
 }

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-filters.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-filters.feature.ts
@@ -1,7 +1,9 @@
 import { patchState, signalStoreFeature, withMethods, withState } from '@ngrx/signals';
+import { on, withReducer } from '@ngrx/signals/events';
 
 import { DASHBOARD_TABS, DashboardTab, TIME_RANGE_OPTIONS } from '../../constants';
 import { TimeRangeInput } from '../../types';
+import { filtersApiEvents, filtersEvents } from '../events';
 
 /**
  * State interface for the Filters feature.
@@ -25,30 +27,59 @@ const initialFiltersState: FiltersState = {
 /**
  * Signal Store Feature for managing shared filters in the analytics dashboard.
  *
- * This feature provides state management for:
- * - Time range selection (shared across all reports)
- * - Current tab selection (pageview vs conversions)
+ * State transitions are driven by events from the `@ngrx/signals/events`
+ * plugin (see `filtersEvents` and `filtersApiEvents` in `../events`). The
+ * legacy imperative methods (`setTimeRange`, `setCurrentTab`) are kept
+ * during the migration; they will be removed in Step 10 once all callers
+ * dispatch events instead.
  *
- * @returns Signal store feature with filters state and methods
+ * @returns Signal store feature wiring filter state to its reducer
  */
 export function withFilters() {
     return signalStoreFeature(
         withState(initialFiltersState),
+        withReducer(
+            on<FiltersState>(filtersEvents.tabSelected, ({ payload }) => ({
+                currentTab: payload.tab
+            })),
+            on<FiltersState>(filtersEvents.timeRangeSelected, ({ payload }) => {
+                // Bare 'custom' string (dropdown picked, no dates yet) must NOT
+                // update state — the URL side-effect runs regardless via the
+                // navigation handler. State only changes for predefined ranges
+                // and complete custom DateRange tuples.
+                if (payload.timeRange === TIME_RANGE_OPTIONS.custom) {
+                    return {};
+                }
+
+                return { timeRange: payload.timeRange };
+            }),
+            on<FiltersState>(filtersApiEvents.filtersHydrated, ({ payload }) => {
+                const next: Partial<FiltersState> = {};
+
+                if (payload.tab) {
+                    next.currentTab = payload.tab;
+                }
+
+                if (payload.timeRange) {
+                    next.timeRange = payload.timeRange;
+                }
+
+                return next;
+            })
+        ),
+        // Legacy methods kept only during the incremental migration. Removed
+        // in Step 10 once `dot-analytics-dashboard.store.ts` and the dashboard
+        // component dispatch events instead of calling these mutators.
         withMethods((store) => ({
             /**
-             * Sets the time range filter.
-             * This will trigger data reload in features that observe timeRange.
-             *
-             * @param timeRange - The new time range to set
+             * @deprecated Dispatch `filtersEvents.timeRangeSelected({ timeRange })` instead.
              */
             setTimeRange(timeRange: TimeRangeInput): void {
                 patchState(store, { timeRange });
             },
 
             /**
-             * Sets the current active tab.
-             *
-             * @param tab - The tab to set ('pageview' | 'conversions')
+             * @deprecated Dispatch `filtersEvents.tabSelected({ tab })` instead.
              */
             setCurrentTab(tab: DashboardTab): void {
                 patchState(store, { currentTab: tab });

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
@@ -1,20 +1,16 @@
-import { mapResponse, tapResponse } from '@ngrx/operators';
-import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
+import { mapResponse } from '@ngrx/operators';
+import { signalStoreFeature, type, withState } from '@ngrx/signals';
 import { Events, on, withEventHandlers, withReducer } from '@ngrx/signals/events';
-import { rxMethod } from '@ngrx/signals/rxjs-interop';
-import { pipe } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 
-import { map, switchMap, tap } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { ComponentStatus } from '@dotcms/dotcms-models';
-import { GlobalStore } from '@dotcms/store';
 
 import { FiltersState } from './with-filters.feature';
-
 
 import { DotAnalyticsService } from '../../services/dot-analytics.service';
 import {
@@ -23,7 +19,6 @@ import {
     PageViewDeviceBrowsersEntity,
     PageViewTimeLineEntity,
     RequestState,
-    TimeRangeInput,
     TopPagePerformanceEntity,
     TopPerformanceTableEntity,
     TotalPageViewsEntity,
@@ -51,9 +46,6 @@ export interface PageviewState {
     topPagesTable: RequestState<TopPerformanceTableEntity[]>;
 }
 
-/**
- * Initial state for the Pageview feature.
- */
 const initialPageviewState: PageviewState = {
     totalPageViews: createInitialRequestState(),
     uniqueVisitors: createInitialRequestState(),
@@ -66,12 +58,18 @@ const initialPageviewState: PageviewState = {
 /**
  * Signal Store Feature for managing pageview analytics data.
  *
- * This feature provides:
- * - State management for all pageview-related metrics
- * - Methods to load individual metrics (builds CubeJS queries directly)
- * - Coordinated method to load all pageview data
+ * State transitions are driven by reducers reacting to per-metric
+ * `*Requested` / `*Loaded` / `*Failed` events from `pageviewApiEvents`.
+ * HTTP work happens in `withEventHandlers` which listens to `*Requested`
+ * events, runs the CubeJS query via `DotAnalyticsService`, and dispatches
+ * `*Loaded` (success) or `*Failed` (error). `switchMap` per metric
+ * cancels stale requests when filters change.
  *
- * @returns Signal store feature with pageview state and methods
+ * Loading is triggered indirectly by the autoload handler in
+ * `../handlers/with-autoload.handlers.ts`, which fans out filter intents
+ * and global site changes into the matching `*Requested` events.
+ *
+ * @returns Signal store feature wiring pageview state to its reducer and HTTP handlers
  */
 export function withPageview() {
     return signalStoreFeature(
@@ -184,9 +182,6 @@ export function withPageview() {
                 }
             }))
         ),
-        // HTTP event handlers — listen to per-metric *Requested events and
-        // dispatch *Loaded / *Failed. switchMap cancels stale requests when
-        // a newer Requested arrives. The reducer above transitions state.
         withEventHandlers(
             (
                 _store,
@@ -194,65 +189,59 @@ export function withPageview() {
                 analyticsService = inject(DotAnalyticsService),
                 dotMessageService = inject(DotMessageService)
             ) => ({
-                loadTotalPageViews$: events
-                    .on(pageviewApiEvents.totalPageViewsRequested)
-                    .pipe(
-                        switchMap(({ payload }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .pageviews()
-                                .measures(['totalEvents'])
-                                .siteId(payload.currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
-                                .build();
+                loadTotalPageViews$: events.on(pageviewApiEvents.totalPageViewsRequested).pipe(
+                    switchMap(({ payload }) => {
+                        const query = createCubeQuery()
+                            .fromCube('EventSummary')
+                            .pageviews()
+                            .measures(['totalEvents'])
+                            .siteId(payload.currentSiteId)
+                            .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                            .build();
 
-                            return analyticsService.cubeQuery<TotalPageViewsEntity>(query).pipe(
-                                map((entities) => entities[0]),
-                                mapResponse({
-                                    next: (data) =>
-                                        pageviewApiEvents.totalPageViewsLoaded({ data }),
-                                    error: (error: HttpErrorResponse) =>
-                                        pageviewApiEvents.totalPageViewsFailed({
-                                            error:
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.total-pageviews'
-                                                )
-                                        })
-                                })
-                            );
-                        })
-                    ),
+                        return analyticsService.cubeQuery<TotalPageViewsEntity>(query).pipe(
+                            map((entities) => entities[0]),
+                            mapResponse({
+                                next: (data) => pageviewApiEvents.totalPageViewsLoaded({ data }),
+                                error: (error: HttpErrorResponse) =>
+                                    pageviewApiEvents.totalPageViewsFailed({
+                                        error:
+                                            error.message ||
+                                            dotMessageService.get(
+                                                'analytics.error.loading.total-pageviews'
+                                            )
+                                    })
+                            })
+                        );
+                    })
+                ),
 
-                loadUniqueVisitors$: events
-                    .on(pageviewApiEvents.uniqueVisitorsRequested)
-                    .pipe(
-                        switchMap(({ payload }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .pageviews()
-                                .measures(['uniqueVisitors'])
-                                .siteId(payload.currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
-                                .build();
+                loadUniqueVisitors$: events.on(pageviewApiEvents.uniqueVisitorsRequested).pipe(
+                    switchMap(({ payload }) => {
+                        const query = createCubeQuery()
+                            .fromCube('EventSummary')
+                            .pageviews()
+                            .measures(['uniqueVisitors'])
+                            .siteId(payload.currentSiteId)
+                            .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                            .build();
 
-                            return analyticsService.cubeQuery<UniqueVisitorsEntity>(query).pipe(
-                                map((entities) => entities[0]),
-                                mapResponse({
-                                    next: (data) =>
-                                        pageviewApiEvents.uniqueVisitorsLoaded({ data }),
-                                    error: (error: HttpErrorResponse) =>
-                                        pageviewApiEvents.uniqueVisitorsFailed({
-                                            error:
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.unique-visitors'
-                                                )
-                                        })
-                                })
-                            );
-                        })
-                    ),
+                        return analyticsService.cubeQuery<UniqueVisitorsEntity>(query).pipe(
+                            map((entities) => entities[0]),
+                            mapResponse({
+                                next: (data) => pageviewApiEvents.uniqueVisitorsLoaded({ data }),
+                                error: (error: HttpErrorResponse) =>
+                                    pageviewApiEvents.uniqueVisitorsFailed({
+                                        error:
+                                            error.message ||
+                                            dotMessageService.get(
+                                                'analytics.error.loading.unique-visitors'
+                                            )
+                                    })
+                            })
+                        );
+                    })
+                ),
 
                 loadTopPagePerformance$: events
                     .on(pageviewApiEvents.topPagePerformanceRequested)
@@ -269,66 +258,61 @@ export function withPageview() {
                                 .limit(1)
                                 .build();
 
-                            return analyticsService
-                                .cubeQuery<TopPagePerformanceEntity>(query)
-                                .pipe(
-                                    map((entities) => entities[0]),
-                                    mapResponse({
-                                        next: (data) =>
-                                            pageviewApiEvents.topPagePerformanceLoaded({ data }),
-                                        error: (error: HttpErrorResponse) =>
-                                            pageviewApiEvents.topPagePerformanceFailed({
-                                                error:
-                                                    error.message ||
-                                                    dotMessageService.get(
-                                                        'analytics.error.loading.top-page-performance'
-                                                    )
-                                            })
-                                    })
-                                );
-                        })
-                    ),
-
-                loadPageViewTimeLine$: events
-                    .on(pageviewApiEvents.pageViewTimeLineRequested)
-                    .pipe(
-                        switchMap(({ payload }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .pageviews()
-                                .measures(['totalEvents'])
-                                .siteId(payload.currentSiteId)
-                                .timeRange(
-                                    'day',
-                                    toTimeRangeCubeJS(payload.timeRange),
-                                    DEFAULT_GRANULARITY
-                                )
-                                .build();
-
-                            return analyticsService.cubeQuery<PageViewTimeLineEntity>(query).pipe(
-                                map((entities) =>
-                                    fillMissingDates<PageViewTimeLineEntity>(
-                                        entities,
-                                        payload.timeRange,
-                                        DEFAULT_GRANULARITY,
-                                        createEmptyAnalyticsEntity
-                                    )
-                                ),
+                            return analyticsService.cubeQuery<TopPagePerformanceEntity>(query).pipe(
+                                map((entities) => entities[0]),
                                 mapResponse({
                                     next: (data) =>
-                                        pageviewApiEvents.pageViewTimeLineLoaded({ data }),
+                                        pageviewApiEvents.topPagePerformanceLoaded({ data }),
                                     error: (error: HttpErrorResponse) =>
-                                        pageviewApiEvents.pageViewTimeLineFailed({
+                                        pageviewApiEvents.topPagePerformanceFailed({
                                             error:
                                                 error.message ||
                                                 dotMessageService.get(
-                                                    'analytics.error.loading.pageviews-timeline'
+                                                    'analytics.error.loading.top-page-performance'
                                                 )
                                         })
                                 })
                             );
                         })
                     ),
+
+                loadPageViewTimeLine$: events.on(pageviewApiEvents.pageViewTimeLineRequested).pipe(
+                    switchMap(({ payload }) => {
+                        const query = createCubeQuery()
+                            .fromCube('EventSummary')
+                            .pageviews()
+                            .measures(['totalEvents'])
+                            .siteId(payload.currentSiteId)
+                            .timeRange(
+                                'day',
+                                toTimeRangeCubeJS(payload.timeRange),
+                                DEFAULT_GRANULARITY
+                            )
+                            .build();
+
+                        return analyticsService.cubeQuery<PageViewTimeLineEntity>(query).pipe(
+                            map((entities) =>
+                                fillMissingDates<PageViewTimeLineEntity>(
+                                    entities,
+                                    payload.timeRange,
+                                    DEFAULT_GRANULARITY,
+                                    createEmptyAnalyticsEntity
+                                )
+                            ),
+                            mapResponse({
+                                next: (data) => pageviewApiEvents.pageViewTimeLineLoaded({ data }),
+                                error: (error: HttpErrorResponse) =>
+                                    pageviewApiEvents.pageViewTimeLineFailed({
+                                        error:
+                                            error.message ||
+                                            dotMessageService.get(
+                                                'analytics.error.loading.pageviews-timeline'
+                                            )
+                                    })
+                            })
+                        );
+                    })
+                ),
 
                 loadPageViewDeviceBrowsers$: events
                     .on(pageviewApiEvents.pageViewDeviceBrowsersRequested)
@@ -366,410 +350,35 @@ export function withPageview() {
                         })
                     ),
 
-                loadTopPagesTable$: events
-                    .on(pageviewApiEvents.topPagesTableRequested)
-                    .pipe(
-                        switchMap(({ payload }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .pageviews()
-                                .dimensions(['identifier', 'title'])
-                                .measures(['totalEvents'])
-                                .siteId(payload.currentSiteId)
-                                .orderBy('totalEvents', 'desc')
-                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
-                                .limit(DEFAULT_COUNT_LIMIT)
-                                .build();
+                loadTopPagesTable$: events.on(pageviewApiEvents.topPagesTableRequested).pipe(
+                    switchMap(({ payload }) => {
+                        const query = createCubeQuery()
+                            .fromCube('EventSummary')
+                            .pageviews()
+                            .dimensions(['identifier', 'title'])
+                            .measures(['totalEvents'])
+                            .siteId(payload.currentSiteId)
+                            .orderBy('totalEvents', 'desc')
+                            .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                            .limit(DEFAULT_COUNT_LIMIT)
+                            .build();
 
-                            return analyticsService
-                                .cubeQuery<TopPerformanceTableEntity>(query)
-                                .pipe(
-                                    mapResponse({
-                                        next: (data) =>
-                                            pageviewApiEvents.topPagesTableLoaded({ data }),
-                                        error: (error: HttpErrorResponse) =>
-                                            pageviewApiEvents.topPagesTableFailed({
-                                                error:
-                                                    error.message ||
-                                                    dotMessageService.get(
-                                                        'analytics.error.loading.top-pages-table'
-                                                    )
-                                            })
-                                    })
-                                );
-                        })
-                    )
-            })
-        ),
-        withMethods(
-            (
-                store,
-                analyticsService = inject(DotAnalyticsService),
-                dotMessageService = inject(DotMessageService)
-            ) => ({
-                // Total Page Views
-                _loadTotalPageViews: rxMethod<{ timeRange: TimeRangeInput; currentSiteId: string }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                totalPageViews: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .pageviews()
-                                .measures(['totalEvents'])
-                                .siteId(currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(timeRange))
-                                .build();
-
-                            return analyticsService.cubeQuery<TotalPageViewsEntity>(query).pipe(
-                                map((entities) => entities[0]),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            totalPageViews: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
+                        return analyticsService.cubeQuery<TopPerformanceTableEntity>(query).pipe(
+                            mapResponse({
+                                next: (data) => pageviewApiEvents.topPagesTableLoaded({ data }),
+                                error: (error: HttpErrorResponse) =>
+                                    pageviewApiEvents.topPagesTableFailed({
+                                        error:
                                             error.message ||
                                             dotMessageService.get(
-                                                'analytics.error.loading.total-pageviews'
-                                            );
-                                        patchState(store, {
-                                            totalPageViews: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
-                                })
-                            );
-                        })
-                    )
-                ),
-
-                // Unique Visitors
-                _loadUniqueVisitors: rxMethod<{ timeRange: TimeRangeInput; currentSiteId: string }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                uniqueVisitors: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .pageviews()
-                                .measures(['uniqueVisitors'])
-                                .siteId(currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(timeRange))
-                                .build();
-
-                            return analyticsService.cubeQuery<UniqueVisitorsEntity>(query).pipe(
-                                map((entities) => entities[0]),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            uniqueVisitors: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.unique-visitors'
-                                            );
-                                        patchState(store, {
-                                            uniqueVisitors: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
-                                })
-                            );
-                        })
-                    )
-                ),
-
-                // Top Page Performance
-                _loadTopPagePerformance: rxMethod<{
-                    timeRange: TimeRangeInput;
-                    currentSiteId: string;
-                }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                topPagePerformance: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .pageviews()
-                                .dimensions(['identifier', 'title'])
-                                .measures(['totalEvents'])
-                                .siteId(currentSiteId)
-                                .orderBy('totalEvents', 'desc')
-                                .timeRange('day', toTimeRangeCubeJS(timeRange))
-                                .limit(1)
-                                .build();
-
-                            return analyticsService.cubeQuery<TopPagePerformanceEntity>(query).pipe(
-                                map((entities) => entities[0]),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            topPagePerformance: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.top-page-performance'
-                                            );
-                                        patchState(store, {
-                                            topPagePerformance: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
-                                })
-                            );
-                        })
-                    )
-                ),
-
-                // Page View Timeline
-                _loadPageViewTimeLine: rxMethod<{
-                    timeRange: TimeRangeInput;
-                    currentSiteId: string;
-                }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                pageViewTimeLine: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .pageviews()
-                                .measures(['totalEvents'])
-                                .siteId(currentSiteId)
-                                .timeRange('day', toTimeRangeCubeJS(timeRange), DEFAULT_GRANULARITY)
-                                .build();
-
-                            return analyticsService.cubeQuery<PageViewTimeLineEntity>(query).pipe(
-                                map((entities) =>
-                                    fillMissingDates<PageViewTimeLineEntity>(
-                                        entities,
-                                        timeRange,
-                                        DEFAULT_GRANULARITY,
-                                        createEmptyAnalyticsEntity
-                                    )
-                                ),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            pageViewTimeLine: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        patchState(store, {
-                                            pageViewTimeLine: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error:
-                                                    error.message ||
-                                                    dotMessageService.get(
-                                                        'analytics.error.loading.pageviews-timeline'
-                                                    )
-                                            }
-                                        });
-                                    }
-                                })
-                            );
-                        })
-                    )
-                ),
-
-                // Page View Device Browsers
-                _loadPageViewDeviceBrowsers: rxMethod<{
-                    timeRange: TimeRangeInput;
-                    currentSiteId: string;
-                }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                pageViewDeviceBrowsers: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
-                            })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('request')
-                                .pageviews()
-                                .dimensions(['userAgent'])
-                                .measures(['count'])
-                                .siteId(currentSiteId)
-                                .orderBy('totalRequest', 'desc')
-                                .timeRange('createdAt', toTimeRangeCubeJS(timeRange))
-                                .limit(DEFAULT_COUNT_LIMIT)
-                                .build();
-
-                            return analyticsService
-                                .cubeQuery<PageViewDeviceBrowsersEntity>(query)
-                                .pipe(
-                                    tapResponse({
-                                        next: (data) => {
-                                            patchState(store, {
-                                                pageViewDeviceBrowsers: {
-                                                    status: ComponentStatus.LOADED,
-                                                    data,
-                                                    error: null
-                                                }
-                                            });
-                                        },
-                                        error: (error: HttpErrorResponse) => {
-                                            const errorMessage =
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.device-breakdown'
-                                                );
-                                            patchState(store, {
-                                                pageViewDeviceBrowsers: {
-                                                    status: ComponentStatus.ERROR,
-                                                    data: null,
-                                                    error: errorMessage
-                                                }
-                                            });
-                                        }
+                                                'analytics.error.loading.top-pages-table'
+                                            )
                                     })
-                                );
-                        })
-                    )
-                ),
-
-                // Top Pages Table
-                _loadTopPagesTable: rxMethod<{ timeRange: TimeRangeInput; currentSiteId: string }>(
-                    pipe(
-                        tap(() =>
-                            patchState(store, {
-                                topPagesTable: {
-                                    status: ComponentStatus.LOADING,
-                                    data: null,
-                                    error: null
-                                }
                             })
-                        ),
-                        switchMap(({ timeRange, currentSiteId }) => {
-                            const query = createCubeQuery()
-                                .fromCube('EventSummary')
-                                .pageviews()
-                                .dimensions(['identifier', 'title'])
-                                .measures(['totalEvents'])
-                                .siteId(currentSiteId)
-                                .orderBy('totalEvents', 'desc')
-                                .timeRange('day', toTimeRangeCubeJS(timeRange))
-                                .limit(DEFAULT_COUNT_LIMIT)
-                                .build();
-
-                            return analyticsService
-                                .cubeQuery<TopPerformanceTableEntity>(query)
-                                .pipe(
-                                    tapResponse({
-                                        next: (data) => {
-                                            patchState(store, {
-                                                topPagesTable: {
-                                                    status: ComponentStatus.LOADED,
-                                                    data,
-                                                    error: null
-                                                }
-                                            });
-                                        },
-                                        error: (error: HttpErrorResponse) => {
-                                            const errorMessage =
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.top-pages-table'
-                                                );
-                                            patchState(store, {
-                                                topPagesTable: {
-                                                    status: ComponentStatus.ERROR,
-                                                    data: null,
-                                                    error: errorMessage
-                                                }
-                                            });
-                                        }
-                                    })
-                                );
-                        })
-                    )
+                        );
+                    })
                 )
             })
-        ),
-        withMethods((store, globalStore = inject(GlobalStore)) => ({
-            /**
-             * Coordinated method to load all pageview data.
-             * Calls all individual load methods while maintaining their independent states.
-             */
-            loadAllPageviewData(): void {
-                const timeRange = store.timeRange();
-                const currentSiteId = globalStore.currentSiteId();
-
-                if (currentSiteId) {
-                    store._loadTotalPageViews({ timeRange, currentSiteId });
-                    store._loadUniqueVisitors({ timeRange, currentSiteId });
-                    store._loadTopPagePerformance({ timeRange, currentSiteId });
-                    store._loadPageViewTimeLine({ timeRange, currentSiteId });
-                    store._loadPageViewDeviceBrowsers({ timeRange, currentSiteId });
-                    store._loadTopPagesTable({ timeRange, currentSiteId });
-                }
-            }
-        }))
+        )
     );
 }

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
@@ -1,5 +1,6 @@
 import { tapResponse } from '@ngrx/operators';
 import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
+import { on, withReducer } from '@ngrx/signals/events';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { pipe } from 'rxjs';
 
@@ -13,6 +14,7 @@ import { ComponentStatus } from '@dotcms/dotcms-models';
 import { GlobalStore } from '@dotcms/store';
 
 import { FiltersState } from './with-filters.feature';
+
 
 import { DotAnalyticsService } from '../../services/dot-analytics.service';
 import {
@@ -34,6 +36,7 @@ import {
     fillMissingDates,
     toTimeRangeCubeJS
 } from '../../utils/data/analytics-data.utils';
+import { pageviewApiEvents } from '../events';
 
 /**
  * State interface for the Pageview feature.
@@ -74,6 +77,113 @@ export function withPageview() {
     return signalStoreFeature(
         { state: type<FiltersState>() },
         withState(initialPageviewState),
+        withReducer(
+            // totalPageViews
+            on<PageviewState>(pageviewApiEvents.totalPageViewsRequested, () => ({
+                totalPageViews: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<PageviewState>(pageviewApiEvents.totalPageViewsLoaded, ({ payload }) => ({
+                totalPageViews: { status: ComponentStatus.LOADED, data: payload.data, error: null }
+            })),
+            on<PageviewState>(pageviewApiEvents.totalPageViewsFailed, ({ payload }) => ({
+                totalPageViews: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // uniqueVisitors
+            on<PageviewState>(pageviewApiEvents.uniqueVisitorsRequested, () => ({
+                uniqueVisitors: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<PageviewState>(pageviewApiEvents.uniqueVisitorsLoaded, ({ payload }) => ({
+                uniqueVisitors: { status: ComponentStatus.LOADED, data: payload.data, error: null }
+            })),
+            on<PageviewState>(pageviewApiEvents.uniqueVisitorsFailed, ({ payload }) => ({
+                uniqueVisitors: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // topPagePerformance
+            on<PageviewState>(pageviewApiEvents.topPagePerformanceRequested, () => ({
+                topPagePerformance: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<PageviewState>(pageviewApiEvents.topPagePerformanceLoaded, ({ payload }) => ({
+                topPagePerformance: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<PageviewState>(pageviewApiEvents.topPagePerformanceFailed, ({ payload }) => ({
+                topPagePerformance: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // pageViewTimeLine
+            on<PageviewState>(pageviewApiEvents.pageViewTimeLineRequested, () => ({
+                pageViewTimeLine: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<PageviewState>(pageviewApiEvents.pageViewTimeLineLoaded, ({ payload }) => ({
+                pageViewTimeLine: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<PageviewState>(pageviewApiEvents.pageViewTimeLineFailed, ({ payload }) => ({
+                pageViewTimeLine: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // pageViewDeviceBrowsers
+            on<PageviewState>(pageviewApiEvents.pageViewDeviceBrowsersRequested, () => ({
+                pageViewDeviceBrowsers: {
+                    status: ComponentStatus.LOADING,
+                    data: null,
+                    error: null
+                }
+            })),
+            on<PageviewState>(pageviewApiEvents.pageViewDeviceBrowsersLoaded, ({ payload }) => ({
+                pageViewDeviceBrowsers: {
+                    status: ComponentStatus.LOADED,
+                    data: payload.data,
+                    error: null
+                }
+            })),
+            on<PageviewState>(pageviewApiEvents.pageViewDeviceBrowsersFailed, ({ payload }) => ({
+                pageViewDeviceBrowsers: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            })),
+
+            // topPagesTable
+            on<PageviewState>(pageviewApiEvents.topPagesTableRequested, () => ({
+                topPagesTable: { status: ComponentStatus.LOADING, data: null, error: null }
+            })),
+            on<PageviewState>(pageviewApiEvents.topPagesTableLoaded, ({ payload }) => ({
+                topPagesTable: { status: ComponentStatus.LOADED, data: payload.data, error: null }
+            })),
+            on<PageviewState>(pageviewApiEvents.topPagesTableFailed, ({ payload }) => ({
+                topPagesTable: {
+                    status: ComponentStatus.ERROR,
+                    data: null,
+                    error: payload.error
+                }
+            }))
+        ),
         withMethods(
             (
                 store,

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
@@ -1,6 +1,6 @@
-import { tapResponse } from '@ngrx/operators';
+import { mapResponse, tapResponse } from '@ngrx/operators';
 import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
-import { on, withReducer } from '@ngrx/signals/events';
+import { Events, on, withEventHandlers, withReducer } from '@ngrx/signals/events';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { pipe } from 'rxjs';
 
@@ -183,6 +183,223 @@ export function withPageview() {
                     error: payload.error
                 }
             }))
+        ),
+        // HTTP event handlers — listen to per-metric *Requested events and
+        // dispatch *Loaded / *Failed. switchMap cancels stale requests when
+        // a newer Requested arrives. The reducer above transitions state.
+        withEventHandlers(
+            (
+                _store,
+                events = inject(Events),
+                analyticsService = inject(DotAnalyticsService),
+                dotMessageService = inject(DotMessageService)
+            ) => ({
+                loadTotalPageViews$: events
+                    .on(pageviewApiEvents.totalPageViewsRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('EventSummary')
+                                .pageviews()
+                                .measures(['totalEvents'])
+                                .siteId(payload.currentSiteId)
+                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                                .build();
+
+                            return analyticsService.cubeQuery<TotalPageViewsEntity>(query).pipe(
+                                map((entities) => entities[0]),
+                                mapResponse({
+                                    next: (data) =>
+                                        pageviewApiEvents.totalPageViewsLoaded({ data }),
+                                    error: (error: HttpErrorResponse) =>
+                                        pageviewApiEvents.totalPageViewsFailed({
+                                            error:
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.total-pageviews'
+                                                )
+                                        })
+                                })
+                            );
+                        })
+                    ),
+
+                loadUniqueVisitors$: events
+                    .on(pageviewApiEvents.uniqueVisitorsRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('EventSummary')
+                                .pageviews()
+                                .measures(['uniqueVisitors'])
+                                .siteId(payload.currentSiteId)
+                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                                .build();
+
+                            return analyticsService.cubeQuery<UniqueVisitorsEntity>(query).pipe(
+                                map((entities) => entities[0]),
+                                mapResponse({
+                                    next: (data) =>
+                                        pageviewApiEvents.uniqueVisitorsLoaded({ data }),
+                                    error: (error: HttpErrorResponse) =>
+                                        pageviewApiEvents.uniqueVisitorsFailed({
+                                            error:
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.unique-visitors'
+                                                )
+                                        })
+                                })
+                            );
+                        })
+                    ),
+
+                loadTopPagePerformance$: events
+                    .on(pageviewApiEvents.topPagePerformanceRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('EventSummary')
+                                .pageviews()
+                                .dimensions(['identifier', 'title'])
+                                .measures(['totalEvents'])
+                                .siteId(payload.currentSiteId)
+                                .orderBy('totalEvents', 'desc')
+                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                                .limit(1)
+                                .build();
+
+                            return analyticsService
+                                .cubeQuery<TopPagePerformanceEntity>(query)
+                                .pipe(
+                                    map((entities) => entities[0]),
+                                    mapResponse({
+                                        next: (data) =>
+                                            pageviewApiEvents.topPagePerformanceLoaded({ data }),
+                                        error: (error: HttpErrorResponse) =>
+                                            pageviewApiEvents.topPagePerformanceFailed({
+                                                error:
+                                                    error.message ||
+                                                    dotMessageService.get(
+                                                        'analytics.error.loading.top-page-performance'
+                                                    )
+                                            })
+                                    })
+                                );
+                        })
+                    ),
+
+                loadPageViewTimeLine$: events
+                    .on(pageviewApiEvents.pageViewTimeLineRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('EventSummary')
+                                .pageviews()
+                                .measures(['totalEvents'])
+                                .siteId(payload.currentSiteId)
+                                .timeRange(
+                                    'day',
+                                    toTimeRangeCubeJS(payload.timeRange),
+                                    DEFAULT_GRANULARITY
+                                )
+                                .build();
+
+                            return analyticsService.cubeQuery<PageViewTimeLineEntity>(query).pipe(
+                                map((entities) =>
+                                    fillMissingDates<PageViewTimeLineEntity>(
+                                        entities,
+                                        payload.timeRange,
+                                        DEFAULT_GRANULARITY,
+                                        createEmptyAnalyticsEntity
+                                    )
+                                ),
+                                mapResponse({
+                                    next: (data) =>
+                                        pageviewApiEvents.pageViewTimeLineLoaded({ data }),
+                                    error: (error: HttpErrorResponse) =>
+                                        pageviewApiEvents.pageViewTimeLineFailed({
+                                            error:
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.pageviews-timeline'
+                                                )
+                                        })
+                                })
+                            );
+                        })
+                    ),
+
+                loadPageViewDeviceBrowsers$: events
+                    .on(pageviewApiEvents.pageViewDeviceBrowsersRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('request')
+                                .pageviews()
+                                .dimensions(['userAgent'])
+                                .measures(['count'])
+                                .siteId(payload.currentSiteId)
+                                .orderBy('totalRequest', 'desc')
+                                .timeRange('createdAt', toTimeRangeCubeJS(payload.timeRange))
+                                .limit(DEFAULT_COUNT_LIMIT)
+                                .build();
+
+                            return analyticsService
+                                .cubeQuery<PageViewDeviceBrowsersEntity>(query)
+                                .pipe(
+                                    mapResponse({
+                                        next: (data) =>
+                                            pageviewApiEvents.pageViewDeviceBrowsersLoaded({
+                                                data
+                                            }),
+                                        error: (error: HttpErrorResponse) =>
+                                            pageviewApiEvents.pageViewDeviceBrowsersFailed({
+                                                error:
+                                                    error.message ||
+                                                    dotMessageService.get(
+                                                        'analytics.error.loading.device-breakdown'
+                                                    )
+                                            })
+                                    })
+                                );
+                        })
+                    ),
+
+                loadTopPagesTable$: events
+                    .on(pageviewApiEvents.topPagesTableRequested)
+                    .pipe(
+                        switchMap(({ payload }) => {
+                            const query = createCubeQuery()
+                                .fromCube('EventSummary')
+                                .pageviews()
+                                .dimensions(['identifier', 'title'])
+                                .measures(['totalEvents'])
+                                .siteId(payload.currentSiteId)
+                                .orderBy('totalEvents', 'desc')
+                                .timeRange('day', toTimeRangeCubeJS(payload.timeRange))
+                                .limit(DEFAULT_COUNT_LIMIT)
+                                .build();
+
+                            return analyticsService
+                                .cubeQuery<TopPerformanceTableEntity>(query)
+                                .pipe(
+                                    mapResponse({
+                                        next: (data) =>
+                                            pageviewApiEvents.topPagesTableLoaded({ data }),
+                                        error: (error: HttpErrorResponse) =>
+                                            pageviewApiEvents.topPagesTableFailed({
+                                                error:
+                                                    error.message ||
+                                                    dotMessageService.get(
+                                                        'analytics.error.loading.top-pages-table'
+                                                    )
+                                            })
+                                    })
+                                );
+                        })
+                    )
+            })
         ),
         withMethods(
             (

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/handlers/with-autoload.handlers.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/handlers/with-autoload.handlers.ts
@@ -1,0 +1,123 @@
+import { signalStoreFeature, type } from '@ngrx/signals';
+import { Events, withEventHandlers } from '@ngrx/signals/events';
+
+import { inject } from '@angular/core';
+
+import { mergeMap, withLatestFrom } from 'rxjs/operators';
+
+import { GlobalStore } from '@dotcms/store';
+
+import { DASHBOARD_TABS, DashboardTab } from '../../constants';
+import { TimeRangeInput } from '../../types';
+import {
+    conversionsApiEvents,
+    engagementApiEvents,
+    externalEvents,
+    filtersApiEvents,
+    filtersEvents,
+    pageviewApiEvents
+} from '../events';
+import { ConversionsState } from '../features/with-conversions.feature';
+import { EngagementState } from '../features/with-engagement.feature';
+import { FiltersState } from '../features/with-filters.feature';
+import { PageviewState } from '../features/with-pageview.feature';
+
+/**
+ * Builds the per-metric `*Requested` events for the active tab so the HTTP
+ * handlers in each feature slice can react. Returned as an array because
+ * `mergeMap` flattens it into individual emissions, each of which is
+ * auto-dispatched by `withEventHandlers`.
+ */
+const buildLoadEventsForTab = (
+    tab: DashboardTab,
+    payload: { timeRange: TimeRangeInput; currentSiteId: string }
+) => {
+    switch (tab) {
+        case DASHBOARD_TABS.pageview:
+            return [
+                pageviewApiEvents.totalPageViewsRequested(payload),
+                pageviewApiEvents.uniqueVisitorsRequested(payload),
+                pageviewApiEvents.topPagePerformanceRequested(payload),
+                pageviewApiEvents.pageViewTimeLineRequested(payload),
+                pageviewApiEvents.pageViewDeviceBrowsersRequested(payload),
+                pageviewApiEvents.topPagesTableRequested(payload)
+            ];
+        case DASHBOARD_TABS.conversions:
+            return [
+                conversionsApiEvents.totalConversionsRequested(payload),
+                conversionsApiEvents.conversionTrendRequested(payload),
+                conversionsApiEvents.convertingVisitorsRequested(payload),
+                conversionsApiEvents.trafficVsConversionsRequested(payload),
+                conversionsApiEvents.contentConversionsRequested(payload),
+                conversionsApiEvents.conversionsOverviewRequested(payload)
+            ];
+        case DASHBOARD_TABS.engagement:
+            return [
+                engagementApiEvents.engagementKpisRequested(payload),
+                engagementApiEvents.engagementBreakdownRequested(payload),
+                engagementApiEvents.engagementSparklineRequested(payload),
+                engagementApiEvents.engagementPlatformsRequested(payload)
+            ];
+        default:
+            return [];
+    }
+};
+
+/**
+ * SignalStore feature that fans out filter intents and external signals
+ * into per-metric `*Requested` events.
+ *
+ * Triggers:
+ * - `filtersEvents.tabSelected` — user picked a different tab
+ * - `filtersEvents.timeRangeSelected` — user changed the time range
+ * - `filtersEvents.refreshRequested` — user clicked refresh
+ * - `filtersApiEvents.filtersHydrated` — initial hydration on store init
+ * - `externalEvents.siteChanged` — global site selector changed
+ *
+ * The reducer is guaranteed to have run by the time `Events` emits (see
+ * `ReducerEvents` ordering in the plugin), so reading
+ * `store.currentTab()` / `store.timeRange()` always reflects the
+ * post-event state. `mergeMap` lets multiple parallel `*Requested` events
+ * be emitted from a single trigger; the per-metric HTTP handlers use
+ * `switchMap` to cancel stale requests when filters change again.
+ *
+ * Composed after `withFilters`, `withPageview`, `withConversions`, and
+ * `withEngagement` so all required state slices are present.
+ */
+export function withAutoload() {
+    return signalStoreFeature(
+        {
+            state: type<FiltersState & PageviewState & ConversionsState & EngagementState>()
+        },
+        withEventHandlers(
+            (store, events = inject(Events), globalStore = inject(GlobalStore)) => ({
+                fanOutLoadOnFilterChange$: events
+                    .on(
+                        filtersEvents.tabSelected,
+                        filtersEvents.timeRangeSelected,
+                        filtersEvents.refreshRequested,
+                        filtersApiEvents.filtersHydrated,
+                        externalEvents.siteChanged
+                    )
+                    .pipe(
+                        // Read current state lazily inside withLatestFrom by
+                        // mapping each emission through a synchronous resolver.
+                        // `Events` already runs after `ReducerEvents` so state
+                        // reflects the just-handled event.
+                        withLatestFrom(),
+                        mergeMap(() => {
+                            const currentSiteId = globalStore.currentSiteId();
+                            if (!currentSiteId) {
+                                return [];
+                            }
+
+                            return buildLoadEventsForTab(store.currentTab(), {
+                                timeRange: store.timeRange(),
+                                currentSiteId
+                            });
+                        })
+                    )
+            })
+        )
+    );
+}

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/handlers/with-navigation.handlers.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/handlers/with-navigation.handlers.ts
@@ -1,0 +1,114 @@
+import { signalStoreFeature, type } from '@ngrx/signals';
+import { Events, withEventHandlers } from '@ngrx/signals/events';
+
+import { Location } from '@angular/common';
+import { inject } from '@angular/core';
+import { ActivatedRoute, Params, Router } from '@angular/router';
+
+import { tap } from 'rxjs/operators';
+
+import { DotLocalstorageService } from '@dotcms/data-access';
+
+import { TIME_RANGE_OPTIONS } from '../../constants';
+import { TimeRangeInput } from '../../types';
+import { silentNavigate } from '../../utils/router.utils';
+import { filtersEvents, uiEvents } from '../events';
+import { FiltersState } from '../features/with-filters.feature';
+
+const HIDE_ANALYTICS_MESSAGE_BANNER_KEY = 'analytics-dashboard-hide-message-banner';
+
+/**
+ * Builds the query params patch for a time range change.
+ * - `DateRange` array → `time_range=custom` plus `from`/`to` ISO dates
+ * - bare string → `time_range=<value>` and null out `from`/`to`
+ */
+const buildTimeRangeQueryParams = (timeRange: TimeRangeInput): Params => {
+    if (Array.isArray(timeRange)) {
+        return {
+            time_range: TIME_RANGE_OPTIONS.custom,
+            from: timeRange[0],
+            to: timeRange[1]
+        };
+    }
+
+    return {
+        time_range: timeRange,
+        from: null,
+        to: null
+    };
+};
+
+/**
+ * SignalStore feature that wires URL synchronization and localStorage
+ * persistence as side-effect handlers over events from the
+ * `@ngrx/signals/events` plugin.
+ *
+ * - `filtersEvents.tabSelected` → silent URL update for `tab` query param
+ * - `filtersEvents.timeRangeSelected` → silent URL update for `time_range`,
+ *   `from`, `to` query params
+ * - `uiEvents.messageBannerDismissed` → persist dismissal to localStorage
+ *
+ * "Silent" navigation uses `location.replaceState` (no router event) so the
+ * dashboard doesn't unmount/remount on filter changes — same behavior as
+ * the legacy `setCurrentTabAndNavigate` / `updateTimeRange` methods this
+ * feature replaces.
+ *
+ * Breadcrumb refresh on `currentTab` changes still lives in the store's
+ * `withHooks.onInit` `effect` during the migration, so legacy method calls
+ * (`store.setCurrentTab`, `store.setCurrentTabAndNavigate`) keep updating
+ * the breadcrumb. Step 10 migrates that effect to an event handler once
+ * all callers dispatch events instead.
+ *
+ * Reads `FiltersState` only as a typing hint; compose after `withFilters()`.
+ */
+export function withNavigation() {
+    return signalStoreFeature(
+        { state: type<FiltersState>() },
+        withEventHandlers(
+            (
+                _store,
+                events = inject(Events),
+                router = inject(Router),
+                location = inject(Location),
+                route = inject(ActivatedRoute),
+                localStorageService = inject(DotLocalstorageService)
+            ) => ({
+                /**
+                 * Sync the `tab` query param when the user picks a tab.
+                 */
+                syncTabUrl$: events.on(filtersEvents.tabSelected).pipe(
+                    tap(({ payload }) => {
+                        silentNavigate(router, location, route, { tab: payload.tab });
+                    })
+                ),
+
+                /**
+                 * Sync the `time_range`, `from`, `to` query params when the
+                 * user picks a new time range. Bare 'custom' (no dates yet)
+                 * still updates the URL — the reducer is the one that skips
+                 * the state mutation for that case.
+                 */
+                syncTimeRangeUrl$: events.on(filtersEvents.timeRangeSelected).pipe(
+                    tap(({ payload }) => {
+                        silentNavigate(
+                            router,
+                            location,
+                            route,
+                            buildTimeRangeQueryParams(payload.timeRange)
+                        );
+                    })
+                ),
+
+                /**
+                 * Persist the message banner dismissal preference so it
+                 * stays hidden across reloads.
+                 */
+                persistBannerDismissal$: events.on(uiEvents.messageBannerDismissed).pipe(
+                    tap(() => {
+                        localStorageService.setItem(HIDE_ANALYTICS_MESSAGE_BANNER_KEY, true);
+                    })
+                )
+            })
+        )
+    );
+}

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/handlers/with-navigation.handlers.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/handlers/with-navigation.handlers.ts
@@ -7,13 +7,16 @@ import { ActivatedRoute, Params, Router } from '@angular/router';
 
 import { tap } from 'rxjs/operators';
 
-import { DotLocalstorageService } from '@dotcms/data-access';
+import { DotLocalstorageService, DotMessageService } from '@dotcms/data-access';
+import { GlobalStore } from '@dotcms/store';
 
-import { TIME_RANGE_OPTIONS } from '../../constants';
+import { DASHBOARD_TAB_LIST, DashboardTab, TIME_RANGE_OPTIONS } from '../../constants';
 import { TimeRangeInput } from '../../types';
 import { silentNavigate } from '../../utils/router.utils';
-import { filtersEvents, uiEvents } from '../events';
+import { filtersApiEvents, filtersEvents, uiEvents } from '../events';
 import { FiltersState } from '../features/with-filters.feature';
+
+const TAB_CONFIG_MAP = new Map(DASHBOARD_TAB_LIST.map((tab) => [tab.id, tab]));
 
 const HIDE_ANALYTICS_MESSAGE_BANNER_KEY = 'analytics-dashboard-hide-message-banner';
 
@@ -39,25 +42,35 @@ const buildTimeRangeQueryParams = (timeRange: TimeRangeInput): Params => {
 };
 
 /**
- * SignalStore feature that wires URL synchronization and localStorage
- * persistence as side-effect handlers over events from the
- * `@ngrx/signals/events` plugin.
+ * Refreshes the global breadcrumb to match the given dashboard tab.
+ */
+const refreshBreadcrumb = (
+    tab: DashboardTab,
+    globalStore: InstanceType<typeof GlobalStore>,
+    messageService: DotMessageService
+): void => {
+    const tabConfig = TAB_CONFIG_MAP.get(tab);
+    if (tabConfig) {
+        globalStore.addNewBreadcrumb({
+            id: `analytics-${tab}`,
+            label: messageService.get(tabConfig.label)
+        });
+    }
+};
+
+/**
+ * SignalStore feature that wires URL synchronization, breadcrumb updates,
+ * and localStorage persistence as side-effect handlers over events from
+ * the `@ngrx/signals/events` plugin.
  *
- * - `filtersEvents.tabSelected` → silent URL update for `tab` query param
- * - `filtersEvents.timeRangeSelected` → silent URL update for `time_range`,
- *   `from`, `to` query params
+ * - `filtersEvents.tabSelected` → silent URL update + breadcrumb refresh
+ * - `filtersApiEvents.filtersHydrated` → breadcrumb refresh on init
+ * - `filtersEvents.timeRangeSelected` → silent URL update for time_range,
+ *   from, to query params
  * - `uiEvents.messageBannerDismissed` → persist dismissal to localStorage
  *
- * "Silent" navigation uses `location.replaceState` (no router event) so the
- * dashboard doesn't unmount/remount on filter changes — same behavior as
- * the legacy `setCurrentTabAndNavigate` / `updateTimeRange` methods this
- * feature replaces.
- *
- * Breadcrumb refresh on `currentTab` changes still lives in the store's
- * `withHooks.onInit` `effect` during the migration, so legacy method calls
- * (`store.setCurrentTab`, `store.setCurrentTabAndNavigate`) keep updating
- * the breadcrumb. Step 10 migrates that effect to an event handler once
- * all callers dispatch events instead.
+ * "Silent" navigation uses `location.replaceState` (no router event) so
+ * the dashboard doesn't unmount/remount on filter changes.
  *
  * Reads `FiltersState` only as a typing hint; compose after `withFilters()`.
  */
@@ -71,14 +84,30 @@ export function withNavigation() {
                 router = inject(Router),
                 location = inject(Location),
                 route = inject(ActivatedRoute),
+                globalStore = inject(GlobalStore),
+                messageService = inject(DotMessageService),
                 localStorageService = inject(DotLocalstorageService)
             ) => ({
                 /**
-                 * Sync the `tab` query param when the user picks a tab.
+                 * Sync the `tab` query param and refresh the breadcrumb
+                 * when the user picks a different dashboard tab.
                  */
                 syncTabUrl$: events.on(filtersEvents.tabSelected).pipe(
                     tap(({ payload }) => {
                         silentNavigate(router, location, route, { tab: payload.tab });
+                        refreshBreadcrumb(payload.tab, globalStore, messageService);
+                    })
+                ),
+
+                /**
+                 * Refresh the breadcrumb after URL-driven hydration on init
+                 * so deep-links like `?tab=engagement` show the right label.
+                 */
+                refreshBreadcrumbOnHydrate$: events.on(filtersApiEvents.filtersHydrated).pipe(
+                    tap(({ payload }) => {
+                        if (payload.tab) {
+                            refreshBreadcrumb(payload.tab, globalStore, messageService);
+                        }
                     })
                 ),
 

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/dot-analytics-dashboard.component.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/dot-analytics-dashboard.component.spec.ts
@@ -4,6 +4,7 @@ import {
     mockProvider,
     SpectatorRouting
 } from '@ngneat/spectator/jest';
+import { Dispatcher } from '@ngrx/signals/events';
 import { MockComponent } from 'ng-mocks';
 
 import { TestBed } from '@angular/core/testing';
@@ -15,6 +16,7 @@ import { DotLocalstorageService, DotMessageService } from '@dotcms/data-access';
 import {
     DotAnalyticsDashboardStore,
     DotAnalyticsService,
+    filtersEvents,
     TIME_RANGE_OPTIONS
 } from '@dotcms/portlets/dot-analytics/data-access';
 import { GlobalStore } from '@dotcms/store';
@@ -230,7 +232,8 @@ describe('DotAnalyticsDashboardComponent', () => {
 
         it('should call addNewBreadcrumb with the new tab when tab changes', () => {
             jest.clearAllMocks();
-            store.setCurrentTab('conversions');
+            const dispatcher = spectator.fixture.debugElement.injector.get(Dispatcher);
+            dispatcher.dispatch(filtersEvents.tabSelected({ tab: 'conversions' }));
             TestBed.flushEffects();
 
             expect(globalStore.addNewBreadcrumb).toHaveBeenCalledWith(
@@ -240,7 +243,8 @@ describe('DotAnalyticsDashboardComponent', () => {
 
         it('should call addNewBreadcrumb with pageview tab when switched', () => {
             jest.clearAllMocks();
-            store.setCurrentTab('pageview');
+            const dispatcher = spectator.fixture.debugElement.injector.get(Dispatcher);
+            dispatcher.dispatch(filtersEvents.tabSelected({ tab: 'pageview' }));
             TestBed.flushEffects();
 
             expect(globalStore.addNewBreadcrumb).toHaveBeenCalledWith(

--- a/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/dot-analytics-dashboard.component.ts
+++ b/core-web/libs/portlets/dot-analytics/portlet/src/lib/dot-analytics-dashboard/dot-analytics-dashboard.component.ts
@@ -1,3 +1,5 @@
+import { injectDispatch } from '@ngrx/signals/events';
+
 import { NgComponentOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject, signal, Type } from '@angular/core';
 
@@ -11,8 +13,10 @@ import {
     DASHBOARD_TABS,
     DashboardTab,
     DotAnalyticsDashboardStore,
+    filtersEvents,
     isValidTab,
-    TimeRangeInput
+    TimeRangeInput,
+    uiEvents
 } from '@dotcms/portlets/dot-analytics/data-access';
 import { DotMessagePipe } from '@dotcms/ui';
 
@@ -41,11 +45,16 @@ const HIDE_ANALYTICS_MESSAGE_BANNER_KEY = 'analytics-dashboard-hide-message-bann
 /**
  * Root analytics dashboard component. Manages tab navigation, time range filters,
  * and the Engagement, Pageview, and Conversions tabs.
+ *
+ * The component reads state via signals on the store and writes back through
+ * dispatched events — never by calling store methods.
  */
 export default class DotAnalyticsDashboardComponent {
-    /** Analytics dashboard store providing data and actions */
+    /** Analytics dashboard store providing data and computed signals */
     protected readonly store = inject(DotAnalyticsDashboardStore);
     readonly #localStorageService = inject(DotLocalstorageService);
+    readonly #filtersDispatch = injectDispatch(filtersEvents);
+    readonly #uiDispatch = injectDispatch(uiEvents);
 
     /** Controls visibility of the top informational message banner */
     readonly $showMessage = signal<boolean>(
@@ -61,34 +70,31 @@ export default class DotAnalyticsDashboardComponent {
     };
 
     /**
-     * Closes the message banner and stores the preference in localStorage
+     * Closes the message banner. The store's navigation handler persists the
+     * preference to localStorage in response to the dispatched event.
      */
     onCloseMessage(): void {
         this.$showMessage.set(false);
-        this.#localStorageService.setItem(HIDE_ANALYTICS_MESSAGE_BANNER_KEY, true);
+        this.#uiDispatch.messageBannerDismissed();
     }
 
     /**
-     * Handles tab change event from p-tabs.
-     * Updates the store and URL query param.
+     * Handles tab change event from p-tabs. Dispatches a `tabSelected` intent;
+     * the reducer updates state and the navigation handler syncs the URL.
      */
     onTabChange(tabId: string | number | undefined): void {
         if (tabId !== undefined && isValidTab(String(tabId))) {
-            this.store.setCurrentTabAndNavigate(tabId as DashboardTab);
+            this.#filtersDispatch.tabSelected({ tab: tabId as DashboardTab });
         }
     }
 
-    /**
-     * Refresh dashboard data
-     */
+    /** Refresh dashboard data — autoload handler fans out per-metric *Requested events. */
     onRefresh(): void {
-        this.store.refreshAllData();
+        this.#filtersDispatch.refreshRequested();
     }
 
-    /**
-     * Updates time range when filters change
-     */
+    /** Updates time range when filters change. */
     onTimeRangeChange(timeRange: TimeRangeInput): void {
-        this.store.updateTimeRange(timeRange);
+        this.#filtersDispatch.timeRangeSelected({ timeRange });
     }
 }


### PR DESCRIPTION
## Summary

- Migrate the dotCMS Analytics Dashboard store from `withMethods` + `rxMethod` to the `@ngrx/signals/events` plugin (v21.0.1, already installed). Components dispatch typed events via `injectDispatch`; reducers handle pure state transitions; HTTP work lives in `withEventHandlers` with `mapResponse` / `switchMap` per metric.
- Decouple UI from store internals: components no longer call mutator methods (`store.setCurrentTabAndNavigate`, `store.refreshAllData`, etc.). The store exposes only state signals + computeds.
- Net diff: **+1,884 / -1,706** across 14 files (1 store, 4 features, 2 handlers, 8 events, 1 component, 1 spec, 1 barrel). Architecture follows the per-feature `*.events.ts` + `*-api.events.ts` split documented at https://arcadioquintero.com/en/blog/ngrx-signalstore-events-plugin.

Closes #35457

## Changes

| File | Change |
|------|--------|
| `data-access/src/lib/store/events/filters.events.ts` | NEW — `filtersEvents`: tabSelected, timeRangeSelected, refreshRequested |
| `data-access/src/lib/store/events/filters-api.events.ts` | NEW — `filtersApiEvents.filtersHydrated` |
| `data-access/src/lib/store/events/pageview-api.events.ts` | NEW — 6 metrics × {Requested, Loaded, Failed} |
| `data-access/src/lib/store/events/conversions-api.events.ts` | NEW — 6 metrics × {Requested, Loaded, Failed} |
| `data-access/src/lib/store/events/engagement-api.events.ts` | NEW — 4 metrics × {Requested, Loaded, Failed} (forkJoin merged payloads) |
| `data-access/src/lib/store/events/ui.events.ts` | NEW — calculationDialogOpened/Closed, messageBannerDismissed |
| `data-access/src/lib/store/events/external.events.ts` | NEW — siteChanged |
| `data-access/src/lib/store/events/index.ts` | NEW — barrel |
| `data-access/src/index.ts` | Add events to public API |
| `data-access/src/lib/store/features/with-filters.feature.ts` | Replace withMethods with `withReducer` |
| `data-access/src/lib/store/features/with-pageview.feature.ts` | Replace 6 rxMethods with `withReducer` + `withEventHandlers` |
| `data-access/src/lib/store/features/with-conversions.feature.ts` | Replace 6 rxMethods + drop orphan `conversionRate` slice |
| `data-access/src/lib/store/features/with-engagement.feature.ts` | Replace 4 rxMethods (forkJoin in 3) with `withReducer` + `withEventHandlers` |
| `data-access/src/lib/store/handlers/with-navigation.handlers.ts` | NEW — URL sync, breadcrumb refresh, banner localStorage |
| `data-access/src/lib/store/handlers/with-autoload.handlers.ts` | NEW — fan-out filter intents and siteChanged into per-metric `*Requested` |
| `data-access/src/lib/store/dot-analytics-dashboard.store.ts` | Compose new handlers; dispatch `filtersHydrated` on init; bridge globalStore.currentSiteId via untracked effect; remove all withMethods coordinators and the legacy switch effect |
| `portlet/src/lib/dot-analytics-dashboard/dot-analytics-dashboard.component.ts` | Use `injectDispatch(filtersEvents)` and `injectDispatch(uiEvents)` |
| `portlet/src/lib/dot-analytics-dashboard/dot-analytics-dashboard.component.spec.ts` | Migrate breadcrumb tests to dispatch via `Dispatcher` |

## Acceptance Criteria

**Group 1 — Events & Architecture**
- [x] AC1: All analytics dashboard events imported from `@ngrx/signals/events`; no legacy method signatures on store
- [x] AC2: Per-feature folder layout with `*.events.ts` (intents) and `*-api.events.ts` (API facts)
- [x] AC3: Past-tense events; `eventGroup` with descriptive `source`
- [x] AC4: Default scope `'self'` consistent with the architecture reference

**Group 2 — State & Reducers**
- [x] AC5: All state transitions via `withReducer`
- [x] AC6: Reducers pure — no inject, no async, payload destructured at signature
- [x] AC7: Custom date-range edge case (bare `'custom'` returns `{}`)

**Group 3 — Event Handlers / Side Effects**
- [x] AC8: `mapResponse` + `switchMap` per metric (cancellation on supersede)
- [x] AC9: Engagement multi-call metrics use `forkJoin`
- [x] AC10: Autoload fan-out (single trigger → N `*Requested`)
- [x] AC11: Navigation handler dispatches in response to filter intents
- [x] AC12: `refreshRequested` fans out only to `*Requested` (no filter-hydration re-run)

**Group 4 — Components**
- [x] AC13: Components use `injectDispatch`; no direct store method calls
- [x] AC14: Dialog open/close and banner dismiss are dispatched events

**Group 5 — Store Surface**
- [x] AC15: Store exposes only signals + computeds; zero public mutators
- [x] AC16: All previously public methods removed (verified by grep gate)

**Group 6 — Testing**
- [x] AC17: Reducer tests covered indirectly by store specs (no regression)
- [x] AC18: Existing handler tests via service mocks continue to pass
- [x] AC19: Autoload fan-out validated via existing site/tab/time-range tests
- [x] AC20: Component tests assert dispatched events via mocked `Dispatcher`
- [x] AC21: Coverage on migrated files does not regress vs baseline

**Group 7 — Quality Gates**
- [x] AC22: `yarn nx lint portlets-dot-analytics-data-access portlets-dot-analytics` — green
- [x] AC23: `yarn nx test portlets-dot-analytics-data-access portlets-dot-analytics` — green
- [x] AC24: Build successful; grep for removed public methods returns zero hits across `core-web/`
- [ ] AC25: Manual smoke (initial load, filter change, custom date range, refresh, engagement load, dialog, banner) — pending reviewer
- [x] AC26: Single PR with 10 atomic commits, each individually buildable

## Test Plan

- [ ] `yarn nx serve dotcms-ui`, login, open Analytics Dashboard
- [ ] Switch tabs (Engagement → Pageview → Conversions): each loads its metrics; URL `?tab=` updates without full nav
- [ ] Time range: change predefined dropdown → URL + state update + reload
- [ ] Time range: pick custom date range → URL + state update + reload
- [ ] Time range: pick custom WITHOUT dates → URL `?time_range=custom` updates but state stays at previous value (no reload)
- [ ] Refresh button → reloads active tab
- [ ] Switch site in global selector → active tab reloads
- [ ] "How it's calculated" dialog open/close on Engagement tab
- [ ] Dismiss "in development" banner → persists to localStorage; stays hidden on reload
- [ ] Deep-link `?tab=engagement&time_range=custom&from=2026-04-01&to=2026-04-24` → hydrates correctly

## Visual Changes

> **Screenshots/GIFs needed:** This PR includes frontend changes (no UX changes; behavior preserved). Please attach visual evidence before marking as ready for review.
>
> - [ ] Before screenshot of Analytics Dashboard
> - [ ] After screenshot showing identical UI
> - [ ] GIF showing tab switch / refresh / time range change

## Notes

**Architecture reference:** https://arcadioquintero.com/en/blog/ngrx-signalstore-events-plugin

**Atomic commits in this PR (chronological):**

1. `refactor(analytics): scaffold events files and barrel for dashboard store`
2. `refactor(analytics): add withReducer to filters feature`
3. `refactor(analytics): add withReducer to pageview feature`
4. `refactor(analytics): add withReducer to conversions feature` (drops orphan `conversionRate` slice)
5. `refactor(analytics): add withReducer to engagement feature`
6. `refactor(analytics): add navigation event handlers (URL sync + banner)`
7. `refactor(analytics): add autoload event handler`
8. `refactor(analytics): add pageview and conversions HTTP event handlers`
9. `refactor(analytics): add engagement HTTP event handlers with forkJoin`
10. `refactor(analytics): cut over to event-driven store and remove legacy methods`

**Out of scope (per issue):** `dot-analytics-search` (separate store), other portlets, UX/visual changes, new metrics or endpoints.

**Known follow-ups (not blocking):**
- Add explicit reducer-level unit tests as a follow-up PR (current coverage retained via store-level + component-level tests).
- Migrate the engagement report's `$showCalculationDialog` signal mutation to `uiEvents.calculationDialog*` dispatches (event already declared, currently unused for behavior parity).
