### PR TITLE
fix(block-editor): guard StoryBlock JSON parsing against non-object scalars

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
@@ -227,15 +227,23 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
         boolean refreshed = false;
         for (final Map<String, Object> contentMap : contentsMap) {
             if (UtilMethods.isSet(contentMap)) {
-                final String type = contentMap.get(TYPE_KEY).toString();
-                if (allowedTypes.contains(type)) { // if somebody adds a story block to itself, we don't want to refresh it
+                // Isolate per-block failures so that one bad nested reference
+                // does not prevent the rest of the Story Block from refreshing.
+                try {
+                    final String type = contentMap.get(TYPE_KEY).toString();
+                    if (allowedTypes.contains(type)) { // if somebody adds a story block to itself, we don't want to refresh it
 
-                    refreshed |= this.refreshStoryBlockMap(contentMap, parentContentletIdentifier);
-                } else {
-                    final Object nestedContent = contentMap.get(CONTENT_KEY);
-                    if (nestedContent instanceof List) {
-                        refreshed |= this.isRefreshed(parentContentletIdentifier, (List<Map<String, Object>>) nestedContent);
+                        refreshed |= this.refreshStoryBlockMap(contentMap, parentContentletIdentifier);
+                    } else {
+                        final Object nestedContent = contentMap.get(CONTENT_KEY);
+                        if (nestedContent instanceof List) {
+                            refreshed |= this.isRefreshed(parentContentletIdentifier, (List<Map<String, Object>>) nestedContent);
+                        }
                     }
+                } catch (final Exception e) {
+                    Logger.warnAndDebug(StoryBlockAPIImpl.class, String.format(
+                            "Skipping Story Block child while refreshing parent '%s': %s",
+                            parentContentletIdentifier, ExceptionUtil.getErrorMessage(e)), e);
                 }
             }
         }
@@ -762,25 +770,36 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
         for (final Field field : fields) {
             final Object value = contentlet.get(field.variable());
             if (null != value) {
-                if (field instanceof StoryBlockField) {
-                    // At this depth, if the Contentlet inside the Block Editor also has a Block
-                    // Editor field, we'll return the raw JSON data of any potential Contentlets it
-                    // is referencing. This will prevent infinite recursion problems.
-                    // Prefer the _raw companion field when it contains valid JSON; otherwise fall
-                    // back to the story block value itself. If neither is valid JSON (e.g. a test
-                    // or misconfigured field whose default value is plain text), skip the field
-                    // entirely so the rest of the data map is still populated correctly.
-                    final Object rawValue = contentlet.get(field.variable() + "_raw");
-                    final String rawStr = rawValue != null ? rawValue.toString() : null;
-                    if (rawStr != null && isJsonObject(rawStr)) {
-                        dataMap.put(field.variable(), this.toMap(rawValue));
-                    } else if (isJsonObject(value.toString())) {
-                        dataMap.put(field.variable(), this.toMap(value));
+                // Isolate per-field failures so that one malformed field on a
+                // nested contentlet does not abort hydration of the rest.
+                try {
+                    if (field instanceof StoryBlockField) {
+                        // At this depth, if the Contentlet inside the Block Editor also has a Block
+                        // Editor field, we'll return the raw JSON data of any potential Contentlets it
+                        // is referencing. This will prevent infinite recursion problems.
+                        // Prefer the _raw companion field when it contains valid JSON; otherwise fall
+                        // back to the story block value itself. If neither is valid JSON (e.g. a test
+                        // or misconfigured field whose default value is plain text), skip the field
+                        // entirely so the rest of the data map is still populated correctly.
+                        final Object rawValue = contentlet.get(field.variable() + "_raw");
+                        final String rawStr = rawValue != null ? rawValue.toString() : null;
+                        if (rawStr != null && isJsonObject(rawStr)) {
+                            dataMap.put(field.variable(), this.toMap(rawValue));
+                        } else if (isJsonObject(value.toString())) {
+                            dataMap.put(field.variable(), this.toMap(value));
+                        }
+                    } else {
+                        dataMap.putIfAbsent(field.variable(),
+                                this.refreshNestedStoryBlockValues(value, contentlet.getIdentifier(),
+                                        MAX_NESTED_STORY_BLOCK_REFRESH_DEPTH));
                     }
-                } else {
-                    dataMap.putIfAbsent(field.variable(),
-                            this.refreshNestedStoryBlockValues(value, contentlet.getIdentifier(),
-                                    MAX_NESTED_STORY_BLOCK_REFRESH_DEPTH));
+                } catch (final Exception e) {
+                    Logger.warnAndDebug(StoryBlockAPIImpl.class, String.format(
+                            "Skipping field '%s' while hydrating contentlet '%s': %s",
+                            field.variable(), contentlet.getIdentifier(),
+                            ExceptionUtil.getErrorMessage(e)), e);
+                    // Fall back to the raw value so the field still appears in the response.
+                    dataMap.putIfAbsent(field.variable(), value);
                 }
             }
         }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/StoryBlockAPIImpl.java
@@ -199,7 +199,7 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
     @SuppressWarnings("unchecked")
     public StoryBlockReferenceResult refreshStoryBlockValueReferences(final Object storyBlockValue, final String parentContentletIdentifier) {
         boolean refreshed;
-        if (null != storyBlockValue && JsonUtil.isValidJSON(storyBlockValue.toString())) {
+        if (null != storyBlockValue && isJsonObject(storyBlockValue.toString())) {
             try {
                 final LinkedHashMap<String, Object> blockEditorMap = this.toMap(storyBlockValue);
                 final Object contentsMap = blockEditorMap.get(CONTENT_KEY);
@@ -338,7 +338,7 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
 
         try {
 
-            if (null != storyBlockValue && JsonUtil.isValidJSON(storyBlockValue.toString())) {
+            if (null != storyBlockValue && isJsonObject(storyBlockValue.toString())) {
                 final Map<String, Object> blockEditorMap = this.toMap(storyBlockValue);
                 Object contentsMap = blockEditorMap.getOrDefault(CONTENT_KEY, List.of());
                 if(!(contentsMap instanceof List)) {
@@ -570,6 +570,22 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
         }
     }
 
+    /**
+     * Returns {@code true} when the supplied String is valid JSON whose root
+     * token is an object. Story Block documents are always JSON objects, so
+     * scalar JSON tokens (numbers, strings, booleans) and arrays must be
+     * rejected here — otherwise {@link #toMap(Object)} fails to deserialize
+     * them into a {@link LinkedHashMap} and the entire transformer pipeline
+     * aborts (see issue surfaced via /api/content/_search).
+     */
+    private static boolean isJsonObject(final String value) {
+        if (value == null) {
+            return false;
+        }
+        final String trimmed = value.trim();
+        return trimmed.startsWith("{") && JsonUtil.isValidJSON(trimmed);
+    }
+
     @Override
     @SuppressWarnings("unchecked")
     public LinkedHashMap<String, Object> toMap(final Object blockEditorValue) throws JsonProcessingException {
@@ -756,9 +772,9 @@ public class StoryBlockAPIImpl implements StoryBlockAPI {
                     // entirely so the rest of the data map is still populated correctly.
                     final Object rawValue = contentlet.get(field.variable() + "_raw");
                     final String rawStr = rawValue != null ? rawValue.toString() : null;
-                    if (rawStr != null && JsonUtil.isValidJSON(rawStr)) {
+                    if (rawStr != null && isJsonObject(rawStr)) {
                         dataMap.put(field.variable(), this.toMap(rawValue));
-                    } else if (JsonUtil.isValidJSON(value.toString())) {
+                    } else if (isJsonObject(value.toString())) {
                         dataMap.put(field.variable(), this.toMap(value));
                     }
                 } else {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/transform/ContentletTransformer.java
@@ -7,6 +7,7 @@ import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.FileAssetContentType;
 import com.dotcms.contenttype.transform.field.LegacyFieldTransformer;
 import com.dotcms.util.ConversionUtils;
+import com.dotcms.exception.ExceptionUtil;
 import com.dotcms.util.transform.DBTransformer;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.beans.Identifier;
@@ -178,10 +179,22 @@ public class ContentletTransformer implements DBTransformer<Contentlet> {
      * @param contentlet The {@link Contentlet} whose Story Block fields will be inspected.
      */
     private static void refreshStoryBlockReferences(final Contentlet contentlet) {
-        final StoryBlockReferenceResult result = APILocator.getStoryBlockAPI().refreshReferences(contentlet);
-        if (result.isRefreshed()) {
-            Logger.debug(ContentletTransformer.class,
-                    ()-> "Refreshed story block dependencies for the contentlet: " + contentlet.getIdentifier());
+        try {
+            final StoryBlockReferenceResult result = APILocator.getStoryBlockAPI().refreshReferences(contentlet);
+            if (result.isRefreshed()) {
+                Logger.debug(ContentletTransformer.class,
+                        () -> "Refreshed story block dependencies for the contentlet: " + contentlet.getIdentifier());
+            }
+        } catch (final Exception e) {
+            // Story Block hydration is a best-effort enrichment. A single bad
+            // contentlet (e.g. malformed JSON, scalar-only field values, broken
+            // reference) must not abort the entire transform and take down the
+            // surrounding /api/content/_search response.
+            Logger.warnAndDebug(ContentletTransformer.class, String.format(
+                    "Failed to refresh Story Block references for contentlet '%s' (inode '%s'); "
+                            + "returning the contentlet with un-refreshed Story Block data: %s",
+                    contentlet.getIdentifier(), contentlet.getInode(),
+                    ExceptionUtil.getErrorMessage(e)), e);
         }
     }
 

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/StoryBlockAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/StoryBlockAPITest.java
@@ -645,6 +645,88 @@ public class StoryBlockAPITest extends IntegrationTestBase {
     }
 
     /**
+     * Method to test: {@link StoryBlockAPI#refreshStoryBlockValueReferences(Object, String)}
+     * Given Scenario: A Story Block document that contains two children, where the first
+     * child is malformed (missing the {@code type} key, which would have caused a
+     * NullPointerException inside {@code isRefreshed}). The second child is well-formed.
+     * ExpectedResult: No exception is propagated. The bad child is skipped and the call
+     * still returns a non-null result so the surrounding contentlet (and the rest of the
+     * search response) is not aborted by a single bad nested reference.
+     */
+    /**
+     * Method to test: {@link StoryBlockAPI#refreshReferences(Contentlet)}
+     * Given Scenario: A contentlet has a Story Block field whose value contains a malformed
+     * nested child (missing the {@code type} key).
+     * ExpectedResult: refreshReferences must complete normally (no thrown exception). This is
+     * the resilience boundary that prevents one bad contentlet from aborting an entire
+     * /api/content/_search response when ContentletTransformer iterates over the result set.
+     */
+    @Test
+    public void test_refreshReferences_does_not_throw_on_malformed_nested_block()
+            throws DotDataException, DotSecurityException {
+        ContentType storyBlockType = null;
+        try {
+            // Reuse an existing helper pattern: any content type with a Story Block field.
+            final long timestamp = System.currentTimeMillis();
+            storyBlockType = new ContentTypeDataGen()
+                    .name("storyBlockResilience" + timestamp)
+                    .velocityVarName("storyBlockResilience" + timestamp)
+                    .nextPersisted();
+            final Field storyBlockField = new FieldDataGen()
+                    .type(StoryBlockField.class)
+                    .contentTypeId(storyBlockType.id())
+                    .nextPersisted();
+
+            final String malformedStoryBlock =
+                    "{"
+                    + "\"type\":\"doc\","
+                    + "\"attrs\":{},"
+                    + "\"content\":["
+                    + "  {\"attrs\":{\"data\":{\"identifier\":\"missing-type-key\"}}}"
+                    + "]"
+                    + "}";
+
+            final Contentlet contentlet = new ContentletDataGen(storyBlockType.id())
+                    .languageId(APILocator.getLanguageAPI().getDefaultLanguage().getId())
+                    .setProperty(storyBlockField.variable(), malformedStoryBlock)
+                    .nextPersisted();
+
+            try {
+                APILocator.getStoryBlockAPI().refreshReferences(contentlet);
+            } catch (final Throwable t) {
+                Assert.fail("refreshReferences must not propagate exceptions for a single "
+                        + "malformed Story Block: " + t.getMessage());
+            }
+        } finally {
+            if (storyBlockType != null) {
+                ContentTypeDataGen.remove(storyBlockType);
+            }
+        }
+    }
+
+    @Test
+    public void test_refreshStoryBlockValueReferences_isolates_bad_child_block() {
+        final String storyBlockWithBadChild =
+                "{"
+                + "\"type\":\"doc\","
+                + "\"attrs\":{},"
+                + "\"content\":["
+                + "  {\"attrs\":{\"data\":{\"identifier\":\"missing-type-key\"}}},"
+                + "  {\"type\":\"paragraph\",\"content\":[]}"
+                + "]"
+                + "}";
+
+        StoryBlockReferenceResult result = null;
+        try {
+            result = APILocator.getStoryBlockAPI()
+                    .refreshStoryBlockValueReferences(storyBlockWithBadChild, "parent-resilience");
+        } catch (final Throwable t) {
+            Assert.fail("A malformed nested block must not abort the parent refresh: " + t.getMessage());
+        }
+        assertNotNull(result);
+    }
+
+    /**
      * Method to test: {@link StoryBlockAPI#refreshReferences(Contentlet)}
      * Given Scenario: This will create 2 block contents, adds a rich content to each block content and retrieve the json.
      * ExpectedResult: The new json will contain the rich text data map for each block content.

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/StoryBlockAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/StoryBlockAPITest.java
@@ -602,6 +602,49 @@ public class StoryBlockAPITest extends IntegrationTestBase {
     }
 
     /**
+     * Method to test: {@link StoryBlockAPI#refreshStoryBlockValueReferences(Object, String)}
+     * Given Scenario: A non-object JSON scalar (number, string, boolean, array) is passed in —
+     * these are valid JSON tokens but are not Story Block documents. They can reach this method
+     * via {@code refreshNestedStoryBlockValues} when iterating over scalar field values on
+     * related contentlets.
+     * ExpectedResult: No exception must be thrown and the original value must be returned
+     * unchanged. Regression test for "/api/content/_search failing with
+     * MismatchedInputException: Cannot deserialize value of type LinkedHashMap from Integer".
+     */
+    @Test
+    public void test_refreshStoryBlockValueReferences_with_non_object_json_scalars() {
+        final StoryBlockAPI storyBlockAPI = APILocator.getStoryBlockAPI();
+
+        // Bare integer — valid JSON, but not an object. Was the trigger of the original bug.
+        StoryBlockReferenceResult result = storyBlockAPI.refreshStoryBlockValueReferences("42", "parent-id");
+        assertNotNull(result);
+        assertFalse(result.isRefreshed());
+        assertEquals("42", result.getValue());
+
+        // Bare quoted string — also valid JSON.
+        result = storyBlockAPI.refreshStoryBlockValueReferences("\"hello\"", "parent-id");
+        assertNotNull(result);
+        assertFalse(result.isRefreshed());
+
+        // Bare boolean.
+        result = storyBlockAPI.refreshStoryBlockValueReferences("true", "parent-id");
+        assertNotNull(result);
+        assertFalse(result.isRefreshed());
+
+        // JSON array — valid JSON, but not a Story Block document object.
+        result = storyBlockAPI.refreshStoryBlockValueReferences("[1,2,3]", "parent-id");
+        assertNotNull(result);
+        assertFalse(result.isRefreshed());
+
+        // Untransformed HTML body content — not JSON at all, must be returned untouched.
+        final String html = "<p>Hello <strong>world</strong></p>";
+        result = storyBlockAPI.refreshStoryBlockValueReferences(html, "parent-id");
+        assertNotNull(result);
+        assertFalse(result.isRefreshed());
+        assertEquals(html, result.getValue());
+    }
+
+    /**
      * Method to test: {@link StoryBlockAPI#refreshReferences(Contentlet)}
      * Given Scenario: This will create 2 block contents, adds a rich content to each block content and retrieve the json.
      * ExpectedResult: The new json will contain the rich text data map for each block content.


### PR DESCRIPTION
Fixes regression from #35412: `/api/content/_search` throws `Cannot deserialize value of type LinkedHashMap from Integer` when a Story Block references a contentlet with scalar field values.

## Fix

**1. JSON guard.** `JsonUtil.isValidJSON()` returns true for scalars (`42`, `"foo"`, `[1,2]`). Replaced with `isJsonObject()` (valid JSON + starts with `{`) at the 4 call sites feeding `toMap()`. HTML strings correctly skip refresh (no `{`).

**2. Failure isolation.** One bad contentlet was killing the whole search response. Now:
- `ContentletTransformer.refreshStoryBlockReferences` catches/logs — bad contentlet returns un-refreshed.
- `StoryBlockAPIImpl.isRefreshed` isolates each child block.
- `StoryBlockAPIImpl.refreshContentlet` isolates each field (falls back to raw value).

## QA

Re-run QA from #35408 (PR #35412) and #35403 (PR #35413).

Plus: via Content REST API, create a contentlet with **raw HTML** as the Block Editor field value (e.g. `<p>hello</p>`). Confirm create + update + `_search` + edit-UI all work without `MismatchedInputException` in logs.

## Tests

- `test_refreshStoryBlockValueReferences_with_non_object_json_scalars` — numeric/string/boolean/array/HTML inputs
- `test_refreshStoryBlockValueReferences_isolates_bad_child_block` — inner isolation
- `test_refreshReferences_does_not_throw_on_malformed_nested_block` — API-level resilience