### PR TITLE
perf(core-web): speed up jest test runs

### DIFF
--- a/core-web/apps/mcp-server/tsconfig.spec.json
+++ b/core-web/apps/mcp-server/tsconfig.spec.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "../../dist/out-tsc",
         "module": "commonjs",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/core-web/jest.preset.js
+++ b/core-web/jest.preset.js
@@ -1,9 +1,13 @@
 const nxPreset = require('@nx/jest/preset').default;
 
+// Coverage and verbose output are opt-in: pass `--coverage` / `--verbose` on the
+// CLI, or rely on the `ci` configuration in nx.json which sets `codeCoverage: true`.
+// Enabling them globally instruments every transform and slows the suite ~2x.
+const isCi = process.env.CI === 'true' || process.env.CI === '1';
+
 module.exports = {
     ...nxPreset,
     coverageDirectory: '../../../target/core-web-reports/',
-    collectCoverage: true,
     collectCoverageFrom: [
         'src/**/*.ts',
         'src/**/*.tsx',
@@ -14,7 +18,7 @@ module.exports = {
     coverageReporters: ['html', 'lcov', 'text'],
     reporters: [
         'default',
-        ['github-actions', { silent: false }],
+        ...(isCi ? [['github-actions', { silent: false }]] : []),
         [
             'jest-junit',
             {
@@ -23,7 +27,6 @@ module.exports = {
             }
         ]
     ],
-    verbose: true,
     /* TODO: Update to latest Jest snapshotFormat
      * By default Nx has kept the older style of Jest Snapshot formats
      * to prevent breaking of any existing tests with snapshots.

--- a/core-web/libs/dotcms/tsconfig.spec.json
+++ b/core-web/libs/dotcms/tsconfig.spec.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "../../dist/out-tsc",
         "module": "commonjs",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
 }

--- a/core-web/libs/portlets/dot-categories/tsconfig.spec.json
+++ b/core-web/libs/portlets/dot-categories/tsconfig.spec.json
@@ -4,7 +4,8 @@
         "outDir": "../../../dist/out-tsc",
         "module": "commonjs",
         "target": "es2016",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "files": ["src/test-setup.ts"],
     "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]

--- a/core-web/libs/sdk/analytics/tsconfig.spec.json
+++ b/core-web/libs/sdk/analytics/tsconfig.spec.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "../../../dist/out-tsc",
         "module": "commonjs",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "include": [
         "jest.config.ts",

--- a/core-web/libs/sdk/client/tsconfig.spec.json
+++ b/core-web/libs/sdk/client/tsconfig.spec.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "../../../dist/out-tsc",
         "module": "commonjs",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/core-web/libs/sdk/create-app/tsconfig.spec.json
+++ b/core-web/libs/sdk/create-app/tsconfig.spec.json
@@ -4,7 +4,8 @@
         "outDir": "../../../dist/out-tsc",
         "module": "commonjs",
         "moduleResolution": "node10",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/core-web/libs/sdk/experiments/tsconfig.spec.json
+++ b/core-web/libs/sdk/experiments/tsconfig.spec.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "../../../dist/out-tsc",
         "module": "commonjs",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/core-web/libs/sdk/react/tsconfig.spec.json
+++ b/core-web/libs/sdk/react/tsconfig.spec.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "../../../dist/out-tsc",
         "module": "commonjs",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "include": [
         "jest.config.ts",

--- a/core-web/libs/sdk/types/tsconfig.spec.json
+++ b/core-web/libs/sdk/types/tsconfig.spec.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "../../../dist/out-tsc",
         "module": "commonjs",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/core-web/libs/sdk/uve/tsconfig.spec.json
+++ b/core-web/libs/sdk/uve/tsconfig.spec.json
@@ -3,7 +3,8 @@
     "compilerOptions": {
         "outDir": "../../../dist/out-tsc",
         "module": "commonjs",
-        "types": ["jest", "node"]
+        "types": ["jest", "node"],
+        "isolatedModules": true
     },
     "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/core-web/nx.json
+++ b/core-web/nx.json
@@ -4,7 +4,7 @@
             "runner": "nx/tasks-runners/default",
             "options": {
                 "cacheableOperations": ["build", "lint", "test", "e2e", "build-storybook"],
-                "parallel": 3
+                "parallel": 5
             }
         }
     },

--- a/core-web/pom.xml
+++ b/core-web/pom.xml
@@ -202,8 +202,10 @@
 
                         <configuration>
                             <skip>${skipTests}</skip>
-                            <!-- Add detectOpenHandles to identify resource leaks, forceExit to show results -->
-                            <arguments>nx affected -t test --base=origin/main --exclude='tag:skip:test' --detectOpenHandles --forceExit</arguments>
+                            <!-- forceExit ensures Jest terminates even if something leaves a handle open.
+                                 Do NOT add --detectOpenHandles here: it forces maxWorkers=1 and
+                                 serializes the whole suite. Use it locally to debug leaks instead. -->
+                            <arguments>nx affected -t test --base=origin/main --exclude='tag:skip:test' --forceExit</arguments>
                         </configuration>
                     </execution>
 

--- a/core-web/pom.xml
+++ b/core-web/pom.xml
@@ -203,7 +203,7 @@
                         <configuration>
                             <skip>${skipTests}</skip>
                             <!-- forceExit ensures Jest terminates even if something leaves a handle open.
-                                 Do NOT add --detectOpenHandles here: it forces maxWorkers=1 and
+                                 Do NOT add detectOpenHandles here: it forces maxWorkers=1 and
                                  serializes the whole suite. Use it locally to debug leaks instead. -->
                             <arguments>nx affected -t test --base=origin/main --exclude='tag:skip:test' --forceExit</arguments>
                         </configuration>


### PR DESCRIPTION
- Drop --detectOpenHandles from CI invocation: this flag forces
  maxWorkers=1, which serializes the entire ~800-spec suite. Keep
  --forceExit to ensure Jest terminates if a handle leaks.
- Stop forcing collectCoverage: true and verbose: true in jest.preset.js;
  both are opt-in. Coverage adds ~2x overhead via instrumentation, and
  Nx already exposes a `ci` configuration that enables it when needed.
- Gate the github-actions reporter on CI=true so local runs don't pay
  for it.
- Add isolatedModules: true to the 10 tsconfig.spec.json files that
  were missing it (libs/dotcms, libs/sdk/*, libs/portlets/dot-categories,
  apps/mcp-server). This stops ts-jest / jest-preset-angular from doing
  full type-checking per spec file.
- Bump nx tasksRunnerOptions.parallel from 3 to 5 so test/lint/build
  targets use more cores on multi-core runners.