### PR TITLE
feat(uve): navigate to new edit content editor from Go to Full Editor when the new edit content is active

### DIFF
--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.spec.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.spec.ts
@@ -310,7 +310,7 @@ describe('withBreadcrumbs Feature', () => {
             expect(store.selectLastBreadcrumbLabel()).toBe('Edit');
         });
 
-        it('should do nothing when new item has same id as last breadcrumb', () => {
+        it('should update URL in place when new item has same id as last breadcrumb but different URL', () => {
             store.setBreadcrumbs([
                 { label: 'Content', url: '/dotAdmin/#/c/content' },
                 { label: 'Edit', id: 'content-abc', url: '/dotAdmin/#/content/456' }
@@ -325,7 +325,8 @@ describe('withBreadcrumbs Feature', () => {
             });
 
             expect(store.breadcrumbs().length).toBe(before);
-            expect(store.selectLastBreadcrumbLabel()).toBe('Edit');
+            expect(store.selectLastBreadcrumbLabel()).toBe('Edit Same Id');
+            expect(store.lastBreadcrumb()?.url).toBe('/dotAdmin/#/content/789');
         });
 
         it('should replace last breadcrumb when both new and last URL match content-edit pattern', () => {
@@ -348,7 +349,7 @@ describe('withBreadcrumbs Feature', () => {
             expect(store.lastBreadcrumb()?.url).toBe('/dotAdmin/#/content/new-id');
         });
 
-        it('should append breadcrumb when both URLs match edit-page/content pattern', () => {
+        it('should replace last breadcrumb when both URLs match edit-page/content pattern', () => {
             store.setBreadcrumbs([
                 { label: 'Content', disabled: true },
                 {
@@ -367,9 +368,8 @@ describe('withBreadcrumbs Feature', () => {
                 target: '_self'
             });
 
-            expect(store.breadcrumbs().length).toBe(before + 1);
+            expect(store.breadcrumbs().length).toBe(before);
             expect(store.selectLastBreadcrumbLabel()).toBe('Edit Other');
-            expect(store.breadcrumbs().at(-2)?.label).toBe('Edit');
         });
 
         it('should append when new URL matches content-edit but last does not', () => {

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.spec.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.spec.ts
@@ -348,7 +348,7 @@ describe('withBreadcrumbs Feature', () => {
             expect(store.lastBreadcrumb()?.url).toBe('/dotAdmin/#/content/new-id');
         });
 
-        it('should replace last breadcrumb when both URLs match edit-page/content pattern', () => {
+        it('should append breadcrumb when both URLs match edit-page/content pattern', () => {
             store.setBreadcrumbs([
                 { label: 'Content', disabled: true },
                 {
@@ -367,8 +367,9 @@ describe('withBreadcrumbs Feature', () => {
                 target: '_self'
             });
 
-            expect(store.breadcrumbs().length).toBe(before);
+            expect(store.breadcrumbs().length).toBe(before + 1);
             expect(store.selectLastBreadcrumbLabel()).toBe('Edit Other');
+            expect(store.breadcrumbs().at(-2)?.label).toBe('Edit');
         });
 
         it('should append when new URL matches content-edit but last does not', () => {
@@ -436,6 +437,37 @@ describe('withBreadcrumbs Feature', () => {
 
             expect(store.breadcrumbs().length).toBe(1);
             expect(store.selectLastBreadcrumbLabel()).toBe('First');
+        });
+
+        it('should truncate to existing breadcrumb when same URL exists before last item', () => {
+            store.setBreadcrumbs([
+                { label: 'Site', disabled: true },
+                {
+                    label: 'Blog Detail',
+                    id: 'page-1',
+                    url: '/dotAdmin/#/edit-page/content?url=%2Fblog%2Fpost%2Fa',
+                    target: '_self'
+                },
+                {
+                    label: 'Contentlet',
+                    id: 'contentlet-1',
+                    url: '/dotAdmin/#/content/abc',
+                    target: '_self'
+                }
+            ]);
+
+            store.addNewBreadcrumb({
+                label: 'Blog Detail',
+                id: 'page-1',
+                url: '/dotAdmin/#/edit-page/content?url=%2Fblog%2Fpost%2Fa',
+                target: '_self'
+            });
+
+            expect(store.breadcrumbs().map((crumb) => crumb.label)).toEqual([
+                'Home',
+                'Site',
+                'Blog Detail'
+            ]);
         });
 
         it('should normalize URL by stripping /dotAdmin/# prefix for comparison', () => {

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
@@ -159,6 +159,10 @@ export function withBreadcrumbs(menuItems: Signal<MenuItemEntity[]>) {
 
                 if (existingIndex > -1) {
                     if (existingIndex === currentBreadcrumbs.length - 1) {
+                        // Same id but URL changed (e.g. language or variant switch) — update in place.
+                        if (normalizeUrl(currentBreadcrumbs[existingIndex].url) !== url) {
+                            setLastBreadcrumb(item);
+                        }
                         return;
                     }
                     truncateBreadcrumbs(existingIndex);

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts
@@ -8,7 +8,7 @@ import {
     withState
 } from '@ngrx/signals';
 
-import { computed, effect, inject, Signal } from '@angular/core';
+import { computed, effect, inject, Signal, untracked } from '@angular/core';
 import { Event, NavigationEnd, Router } from '@angular/router';
 
 import { MenuItem } from 'primeng/api';
@@ -147,19 +147,25 @@ export function withBreadcrumbs(menuItems: Signal<MenuItemEntity[]>) {
 
             const addNewBreadcrumb = (item: MenuItem) => {
                 const url = normalizeUrl(item?.url);
+                const currentBreadcrumbs = store.breadcrumbs();
 
-                const lastBreadcrumb = store.lastBreadcrumb();
-                const lastBreadcrumbUrl = normalizeUrl(lastBreadcrumb?.url);
+                const existingIndex = currentBreadcrumbs.findIndex((crumb) => {
+                    const crumbUrl = normalizeUrl(crumb?.url);
+                    const sameUrl = !!url && !!crumbUrl && url === crumbUrl;
+                    const sameId = !!item?.id && !!crumb?.id && item.id === crumb.id;
 
-                // Before checking if the url is the same, we need to check if the url exists in the breadcrumbs
-                const isSameUrl = url && lastBreadcrumbUrl && url === lastBreadcrumbUrl;
+                    return sameUrl || sameId;
+                });
 
-                // Before checking if the id is the same, we need to check if the id exists in the breadcrumbs
-                const isSameId = item?.id && lastBreadcrumb?.id && item.id === lastBreadcrumb.id;
-
-                if (isSameUrl || isSameId) {
+                if (existingIndex > -1) {
+                    if (existingIndex === currentBreadcrumbs.length - 1) {
+                        return;
+                    }
+                    truncateBreadcrumbs(existingIndex);
                     return;
                 }
+
+                const lastBreadcrumb = store.lastBreadcrumb();
 
                 if (lastBreadcrumb && shouldReplaceLastCrumb(item, lastBreadcrumb)) {
                     setLastBreadcrumb(item);
@@ -305,7 +311,10 @@ export function withBreadcrumbs(menuItems: Signal<MenuItemEntity[]>) {
 
                     // When `menuItems` is loaded and we have a current URL, process the route
                     if (menu.length > 0 && currentUrl) {
-                        const breadcrumbs = store.breadcrumbs();
+                        // Do not depend on `breadcrumbs`: every add/truncate would re-run this effect.
+                        // If the URL does not match any crumb, `_processUrl` can mutate breadcrumbs and
+                        // loop forever (especially when query-param ordering differs from the router).
+                        const breadcrumbs = untracked(() => store.breadcrumbs());
                         const newUrl = `/dotAdmin/#${currentUrl}`;
 
                         // Check if any breadcrumb matches the current URL

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.spec.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.spec.ts
@@ -243,7 +243,7 @@ describe('shouldReplaceLastCrumb', () => {
             ).toBe(true);
         });
 
-        it('should return false when both items match /edit-page/content?{params}', () => {
+        it('should return true when both items match /edit-page/content?{params} (via uvePage rule)', () => {
             expect(
                 shouldReplaceLastCrumb(
                     { label: 'New', url: '/dotAdmin/#/edit-page/content?url=page2' },

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.spec.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.spec.ts
@@ -243,13 +243,13 @@ describe('shouldReplaceLastCrumb', () => {
             ).toBe(true);
         });
 
-        it('should return true when both items match /edit-page/content?{params}', () => {
+        it('should return false when both items match /edit-page/content?{params}', () => {
             expect(
                 shouldReplaceLastCrumb(
                     { label: 'New', url: '/dotAdmin/#/edit-page/content?url=page2' },
                     { label: 'Old', url: '/dotAdmin/#/edit-page/content?url=page1' }
                 )
-            ).toBe(true);
+            ).toBe(false);
         });
 
         it('should return false when only new item matches content-edit', () => {

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.spec.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.spec.ts
@@ -249,7 +249,7 @@ describe('shouldReplaceLastCrumb', () => {
                     { label: 'New', url: '/dotAdmin/#/edit-page/content?url=page2' },
                     { label: 'Old', url: '/dotAdmin/#/edit-page/content?url=page1' }
                 )
-            ).toBe(false);
+            ).toBe(true);
         });
 
         it('should return false when only new item matches content-edit', () => {

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.ts
@@ -163,10 +163,19 @@ interface ReplaceLastCrumbRule {
  */
 const REPLACE_LAST_CRUMB_RULES: Record<string, ReplaceLastCrumbRule> = {
     contentEdit: {
+        // Match only root content routes (e.g. /content/{inode}, /content?filter=...),
+        // but not nested routes like /edit-page/content used by UVE breadcrumbs.
         test: (item, last) => {
-            // Match only root content routes (e.g. /content/{inode}, /content?filter=...),
-            // but not nested routes like /edit-page/content used by UVE breadcrumbs.
             const regex = /^\/content(?:[/?].+)?$/;
+            const normalize = (url: string | undefined) => (url ?? '').replace(/^.*#/, '');
+            return regex.test(normalize(item.url)) && regex.test(normalize(last.url));
+        }
+    },
+    uvePage: {
+        // When navigating between different pages in UVE, replace the last crumb
+        // so the trail stays as Pages > [Current Page] instead of accumulating every visited page.
+        test: (item, last) => {
+            const regex = /\/edit-page\/content/;
             const normalize = (url: string | undefined) => (url ?? '').replace(/^.*#/, '');
             return regex.test(normalize(item.url)) && regex.test(normalize(last.url));
         }

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.ts
@@ -164,7 +164,9 @@ interface ReplaceLastCrumbRule {
 const REPLACE_LAST_CRUMB_RULES: Record<string, ReplaceLastCrumbRule> = {
     contentEdit: {
         test: (item, last) => {
-            const regex = /\/content[/?].+/;
+            // Match only root content routes (e.g. /content/{inode}, /content?filter=...),
+            // but not nested routes like /edit-page/content used by UVE breadcrumbs.
+            const regex = /^\/content(?:[/?].+)?$/;
             const normalize = (url: string | undefined) => (url ?? '').replace(/^.*#/, '');
             return regex.test(normalize(item.url)) && regex.test(normalize(last.url));
         }

--- a/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.ts
+++ b/core-web/libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.ts
@@ -163,7 +163,7 @@ interface ReplaceLastCrumbRule {
  */
 const REPLACE_LAST_CRUMB_RULES: Record<string, ReplaceLastCrumbRule> = {
     contentEdit: {
-        // Match only root content routes (e.g. /content/{inode}, /content?filter=...),
+        // Match content edit routes (e.g. /content/{inode}, /content/{inode}?tab=...),
         // but not nested routes like /edit-page/content used by UVE breadcrumbs.
         test: (item, last) => {
             const regex = /^\/content(?:[/?].+)?$/;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -226,11 +226,19 @@ describe('DotEmaShellComponent', () => {
                     const queryParams = extras?.queryParams ?? {};
                     const queryString = new URLSearchParams(
                         Object.fromEntries(
-                            Object.entries(queryParams).map(([k, v]) => [k, String(v ?? '')])
+                            Object.entries(queryParams)
+                                .filter(([, v]) => v !== undefined && v !== null && v !== '')
+                                .map(([k, v]) => [k, String(v)])
                         )
                     ).toString();
-                    return { toString: () => (queryString ? `/?${queryString}` : '/') };
-                })
+                    const segments = Array.isArray(commands)
+                        ? commands.map((c) => String(c).replace(/^\/+/, '')).filter(Boolean)
+                        : [];
+                    const path = segments.length ? `/${segments.join('/')}` : '/';
+                    const withQuery = queryString ? `${path}?${queryString}` : path;
+                    return { toString: () => withQuery };
+                }),
+                serializeUrl: jest.fn((tree: { toString: () => string }) => tree.toString())
             }),
             mockProvider(DotSiteService, {
                 getCurrentSite: () => of(null)
@@ -1074,6 +1082,31 @@ describe('DotEmaShellComponent', () => {
         });
 
         describe('Breadcrumb', () => {
+            const routerUrlForIndexPage =
+                '/edit-page/content?language_id=1&url=index&variantName=DEFAULT&mode=EDIT_MODE';
+            const routerUrlForOtherPage =
+                '/edit-page/content?language_id=1&url=%2Fother-page&variantName=DEFAULT&mode=EDIT_MODE';
+
+            const routerUrlHolder: { current: string } = { current: routerUrlForIndexPage };
+            let routerUrlOriginal: PropertyDescriptor | undefined;
+
+            beforeEach(() => {
+                routerUrlHolder.current = routerUrlForIndexPage;
+                routerUrlOriginal = Object.getOwnPropertyDescriptor(router, 'url');
+                Object.defineProperty(router, 'url', {
+                    configurable: true,
+                    get: () => routerUrlHolder.current
+                });
+            });
+
+            afterEach(() => {
+                if (routerUrlOriginal) {
+                    Object.defineProperty(router, 'url', routerUrlOriginal);
+                } else {
+                    Reflect.deleteProperty(router, 'url');
+                }
+            });
+
             it('should call GlobalStore.addNewBreadcrumb when page loads with page title, edit-page URL and identifier', async () => {
                 mockGlobalStore.addNewBreadcrumb.mockClear();
                 spectator.detectChanges();
@@ -1084,7 +1117,8 @@ describe('DotEmaShellComponent', () => {
                     expect.objectContaining({
                         label: expect.any(String),
                         id: '123',
-                        url: 'index'
+                        target: '_self',
+                        url: `/dotAdmin/#${routerUrlForIndexPage}`
                     })
                 );
             });
@@ -1112,6 +1146,7 @@ describe('DotEmaShellComponent', () => {
                 };
                 jest.spyOn(dotPageApiService, 'get').mockReturnValue(of(differentPageResponse));
                 mockGlobalStore.addNewBreadcrumb.mockClear();
+                routerUrlHolder.current = routerUrlForOtherPage;
 
                 store.pageLoad({
                     ...INITIAL_PAGE_PARAMS,
@@ -1125,7 +1160,8 @@ describe('DotEmaShellComponent', () => {
                     expect.objectContaining({
                         label: 'Other Page',
                         id: '456',
-                        url: '/other-page'
+                        target: '_self',
+                        url: `/dotAdmin/#${routerUrlForOtherPage}`
                     })
                 );
             });
@@ -1138,7 +1174,7 @@ describe('DotEmaShellComponent', () => {
 
                 expect(mockGlobalStore.addNewBreadcrumb).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        url: INITIAL_PAGE_PARAMS.url
+                        url: `/dotAdmin/#${routerUrlForIndexPage}`
                     })
                 );
             });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -208,14 +208,25 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
 
     readonly $updateBreadcrumbEffect = effect(() => {
         const page = this.uveStore.pageAsset()?.page;
-
-        if (page) {
-            this.#globalStore.addNewBreadcrumb({
-                label: page?.title,
-                url: this.uveStore.pageParams().url,
-                id: `${page?.identifier}`
-            });
+        if (!page) {
+            return;
         }
+
+        const baseClientHost = this.#activatedRoute.snapshot.data?.uveConfig?.url;
+        const cleaned = normalizeQueryParams(this.uveStore.pageFriendlyParams(), baseClientHost);
+
+        const pathWithQuery = this.#router.serializeUrl(
+            this.#router.createUrlTree(['/edit-page', 'content'], { queryParams: cleaned })
+        );
+
+        const breadcrumbUrl = `/dotAdmin/#${pathWithQuery}`;
+
+        this.#globalStore.addNewBreadcrumb({
+            label: page.title,
+            target: '_self',
+            url: breadcrumbUrl,
+            id: `${page.identifier}`
+        });
     });
 
     ngOnInit(): void {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2471,7 +2471,7 @@ describe('EditEmaEditorComponent', () => {
 
                 spectator.component['handleOpenFullEditor']();
 
-                expect(router.navigate).toHaveBeenCalledWith(['content', 'contentlet-inode-123']);
+                expect(router.navigate).toHaveBeenCalledWith(['/content', 'contentlet-inode-123']);
             });
 
             it('should open dialog when CONTENT_EDITOR2_ENABLED is false', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2449,6 +2449,83 @@ describe('EditEmaEditorComponent', () => {
                 });
             });
         });
+
+        describe('handleOpenFullEditor', () => {
+            beforeEach(() => {
+                store.setActiveContentlet(EDIT_ACTION_PAYLOAD_MOCK);
+                spectator.detectChanges();
+            });
+
+            it('should navigate to the new edit content when CONTENT_EDITOR2_ENABLED is true', () => {
+                const router = spectator.inject(Router);
+                jest.spyOn(router, 'navigate');
+                patchState(store, {
+                    contentTypeCache: {
+                        test: {
+                            metadata: {
+                                [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: true
+                            }
+                        } as never
+                    }
+                });
+
+                spectator.component['handleOpenFullEditor']();
+
+                expect(router.navigate).toHaveBeenCalledWith(['content', 'contentlet-inode-123']);
+            });
+
+            it('should open dialog when CONTENT_EDITOR2_ENABLED is false', () => {
+                const router = spectator.inject(Router);
+                jest.spyOn(router, 'navigate');
+                const dialogSpy = jest.spyOn(spectator.component['dialog'], 'editContentlet');
+                patchState(store, {
+                    contentTypeCache: {
+                        test: {
+                            metadata: {
+                                [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: false
+                            }
+                        } as never
+                    }
+                });
+
+                spectator.component['handleOpenFullEditor']();
+
+                expect(dialogSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({ inode: 'contentlet-inode-123' })
+                );
+                expect(router.navigate).not.toHaveBeenCalled();
+            });
+
+            it('should open dialog when content type is not in cache', () => {
+                const router = spectator.inject(Router);
+                jest.spyOn(router, 'navigate');
+                const dialogSpy = jest.spyOn(spectator.component['dialog'], 'editContentlet');
+                patchState(store, { contentTypeCache: {} });
+
+                spectator.component['handleOpenFullEditor']();
+
+                expect(dialogSpy).toHaveBeenCalledWith(
+                    expect.objectContaining({ inode: 'contentlet-inode-123' })
+                );
+                expect(router.navigate).not.toHaveBeenCalled();
+            });
+
+            it('should do nothing when contentlet has no inode', () => {
+                const router = spectator.inject(Router);
+                jest.spyOn(router, 'navigate');
+                store.setActiveContentlet({
+                    ...EDIT_ACTION_PAYLOAD_MOCK,
+                    contentlet: { ...EDIT_ACTION_PAYLOAD_MOCK.contentlet, inode: '' }
+                });
+                const dialogSpy = jest.spyOn(spectator.component['dialog'], 'editContentlet');
+                spectator.detectChanges();
+
+                spectator.component['handleOpenFullEditor']();
+
+                expect(router.navigate).not.toHaveBeenCalled();
+                expect(dialogSpy).not.toHaveBeenCalled();
+            });
+        });
     });
 
     afterEach(() => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -23,6 +23,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
@@ -51,6 +52,7 @@ import {
     DotCMSTempFile,
     DotLanguage,
     DotTreeNode,
+    FeaturedFlags,
     SeoMetaTags,
     SeoMetaTagsResult
 } from '@dotcms/dotcms-models';
@@ -252,6 +254,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
     private readonly actionsHandler = inject(DotUveActionsHandlerService);
     private readonly dragDropService = inject(DotUveDragDropService);
     private readonly iframeMessenger = inject(UveIframeMessengerService);
+    readonly #router = inject(Router);
     #iframeResizeObserver: ResizeObserver | null = null;
 
     readonly host = '*';
@@ -1112,7 +1115,17 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
         // updated page asset, so it reflects the post-save version.
         const { contentlet } = this.$contentletEditData();
 
-        if (contentlet?.inode) {
+        if (!contentlet?.inode) {
+            return;
+        }
+
+        const contentType = this.uveStore.contentTypeCache()[contentlet.contentType];
+        const isNewEditor =
+            contentType?.metadata?.[FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED];
+
+        if (isNewEditor) {
+            this.#router.navigate(['content', contentlet.inode]);
+        } else {
             this.dialog?.editContentlet(contentlet);
         }
     }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1121,10 +1121,10 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
 
         const contentType = this.uveStore.contentTypeCache()[contentlet.contentType];
         const isNewEditor =
-            contentType?.metadata?.[FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED];
+            contentType?.metadata?.[FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED] === true;
 
         if (isNewEditor) {
-            this.#router.navigate(['content', contentlet.inode]);
+            this.#router.navigate(['/content', contentlet.inode]);
         } else {
             this.dialog?.editContentlet(contentlet);
         }


### PR DESCRIPTION
## Summary

- When the user clicks **Go to Full Editor** in UVE, navigate to `/content/:inode` if the content type has `FEATURE_FLAG_CONTENT_EDITOR2_ENABLED` in its metadata; otherwise fall back to the existing dialog behavior
- Update the UVE breadcrumb to use the full `/dotAdmin/#/edit-page/content?...` URL so users can navigate back to the exact editor page from the breadcrumb trail
- Fix breadcrumb deduplication to search the entire trail (not just the last crumb), enabling correct truncation when navigating back to a previous UVE page
- Fix `contentEdit` regex in breadcrumb utils to prevent `/edit-page/content?...` UVE routes from incorrectly triggering the replace-last-crumb rule
- Add `untracked()` around `breadcrumbs` read inside the navigation effect to prevent infinite reactive loops

https://github.com/user-attachments/assets/c4f0269e-aeda-4535-a765-115896479c69


## Changed Files

- `libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts` — core "Go to Full Editor" routing logic
- `libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts` — UVE breadcrumb now uses full navigable URL
- `libs/global-store/src/lib/features/breadcrumb/breadcrumb.feature.ts` — full-trail deduplication + `untracked()` fix
- `libs/global-store/src/lib/features/breadcrumb/breadcrumb.utils.ts` — regex fix for UVE routes

## Acceptance Criteria

- [x] Clicking "Go to Full Editor" navigates to `/content/:inode` when `FEATURE_FLAG_CONTENT_EDITOR2_ENABLED` is `true` in the content type metadata
- [x] Falls back to the existing dialog when the flag is absent or `false`
- [x] Falls back to dialog when the content type is not in the cache
- [x] Does nothing when the contentlet has no inode
- [x] UVE breadcrumb is clickable and navigates back to the correct editor page
- [x] Navigating back to a previously visited UVE page truncates the breadcrumb trail correctly

## Test Plan

- [x] Unit tests added for all `handleOpenFullEditor` branches (new editor, dialog fallback, cache miss, no inode)
- [x] Breadcrumb tests updated and new truncation test added
- [x] All affected tests pass locally

Closes #33235

🤖 Generated with [Claude Code](https://claude.com/claude-code)