### PR TITLE
feat(style-editor): Improved empty message

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-tab/content-type-fields-tab.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/fields/content-type-fields-tab/content-type-fields-tab.component.spec.ts
@@ -17,6 +17,7 @@ import { dotcmsContentTypeFieldBasicMock, MockDotMessageService } from '@dotcms/
 import { ContentTypeFieldsTabComponent } from '.';
 
 import { DOTTestBed } from '../../../../../../test/dot-test-bed';
+import { DotMaxlengthDirective } from '../../../../../../view/directives/dot-maxlength/dot-maxlength.directive';
 
 const tabField: DotCMSContentTypeField = {
     ...dotcmsContentTypeFieldBasicMock,
@@ -59,7 +60,7 @@ describe('ContentTypeFieldsTabComponent', () => {
     beforeEach(waitForAsync(() => {
         DOTTestBed.configureTestingModule({
             declarations: [ContentTypeFieldsTabComponent, DotTestHostComponent],
-            imports: [TooltipModule, ButtonModule, DotMessagePipe],
+            imports: [TooltipModule, ButtonModule, DotMessagePipe, DotMaxlengthDirective],
             providers: [
                 DotAlertConfirmService,
                 {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.html
@@ -1,23 +1,26 @@
 <div class="h-full min-h-0 flex flex-col">
-    <p-tabs [value]="0" class="flex flex-col grow min-h-0">
+    <p-tabs
+        [value]="$activeTab()"
+        (valueChange)="onTabChange($event)"
+        class="flex flex-col grow min-h-0">
         <p-tablist
             class="shrink-0"
             [pt]="{ root: { class: '!bg-surface-50 border-b border-gray-200' } }">
-            <p-tab [value]="0">
+            <p-tab value="fields">
                 {{ 'contenttypes.tab.fields.header' | dm }}
             </p-tab>
             @if ($contentType() && $showStyleEditorTab()) {
-                <p-tab [value]="1" data-testid="style-editor-tab">
+                <p-tab value="style-editor" data-testid="style-editor-tab">
                     {{ 'contenttypes.tab.style.editor.header' | dm }}
                 </p-tab>
             }
-            @if ($contentType() && showPermissionsTab | async) {
-                <p-tab [value]="2">
+            @if ($contentType() && $showPermissionsTab()) {
+                <p-tab value="permissions">
                     {{ 'contenttypes.tab.permissions.header' | dm }}
                 </p-tab>
             }
             @if ($contentType()) {
-                <p-tab [value]="$contentType() && (showPermissionsTab | async) ? 3 : 2">
+                <p-tab value="push-history">
                     {{ 'contenttypes.tab.publisher.push.history.header' | dm }}
                 </p-tab>
             }
@@ -42,7 +45,7 @@
             </div>
         </p-tablist>
         <p-tabpanels class="grow basis-0 min-h-0 p-0!">
-            <p-tabpanel [value]="0" class="h-full min-h-0">
+            <p-tabpanel value="fields" class="h-full min-h-0">
                 <div class="flex h-full min-h-0" id="content-type-form-layout">
                     <div
                         class="flex flex-col grow min-h-0 overflow-x-hidden overflow-y-auto bg-gray-200 p-6"
@@ -61,12 +64,15 @@
                 </div>
             </p-tabpanel>
             @if ($contentType() && $showStyleEditorTab()) {
-                <p-tabpanel [value]="1" class="h-full min-h-0" data-testid="style-editor-panel">
+                <p-tabpanel
+                    value="style-editor"
+                    class="h-full min-h-0"
+                    data-testid="style-editor-panel">
                     <dot-style-editor-builder [contentType]="$contentType()" />
                 </p-tabpanel>
             }
-            @if ($contentType() && showPermissionsTab | async) {
-                <p-tabpanel [value]="2" class="h-full">
+            @if ($contentType() && $showPermissionsTab()) {
+                <p-tabpanel value="permissions" class="h-full">
                     <div class="h-full">
                         <dot-portlet-box class="h-full">
                             <dot-iframe class="h-full" [src]="permissionURL" />
@@ -75,9 +81,7 @@
                 </p-tabpanel>
             }
             @if ($contentType()) {
-                <p-tabpanel
-                    [value]="$contentType() && (showPermissionsTab | async) ? 3 : 2"
-                    class="h-full">
+                <p-tabpanel value="push-history" class="h-full">
                     <div class="h-full">
                         <dot-portlet-box class="h-full">
                             <dot-iframe class="h-full" [src]="pushHistoryURL" />

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.spec.ts
@@ -15,13 +15,14 @@ Object.defineProperty(window, 'matchMedia', {
     }))
 });
 
-import { BehaviorSubject, of } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { Component, DebugElement, EventEmitter, Input, Output } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { MenuItem } from 'primeng/api';
@@ -35,12 +36,11 @@ import {
     DotHttpErrorManagerService,
     DotIframeService,
     DotMessageService,
-    DotPropertiesService,
     DotRouterService,
     DotUiColorsService
 } from '@dotcms/data-access';
 import { DotcmsEventsService, LoggerService, LoginService } from '@dotcms/dotcms-js';
-import { DotCMSContentType } from '@dotcms/dotcms-models';
+import { DotCMSContentType, FeaturedFlags } from '@dotcms/dotcms-models';
 import {
     DotApiLinkComponent,
     DotCopyButtonComponent,
@@ -136,12 +136,8 @@ const fakeContentType: DotCMSContentType = {
 describe('ContentTypesLayoutComponent', () => {
     let fixture: ComponentFixture<TestHostComponent>;
     let de: DebugElement;
-    let featureFlagSubject: BehaviorSubject<boolean>;
 
     beforeEach(() => {
-        // Default: feature enabled. Tests that need it disabled can emit false.
-        featureFlagSubject = new BehaviorSubject<boolean>(true);
-
         const messageServiceMock = new MockDotMessageService({
             'contenttypes.sidebar.components.title': 'Field Title',
             'contenttypes.tab.fields.header': 'Fields Header Tab',
@@ -234,9 +230,18 @@ describe('ContentTypesLayoutComponent', () => {
                     useValue: { confirm: jest.fn(), alert: jest.fn() }
                 },
                 {
-                    provide: DotPropertiesService,
+                    provide: ActivatedRoute,
                     useValue: {
-                        getFeatureFlag: jest.fn().mockReturnValue(featureFlagSubject.asObservable())
+                        snapshot: {
+                            data: {
+                                featuredFlags: {
+                                    [FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR]: true
+                                },
+                                tabPermissions: { showPermissionsTab: true }
+                            }
+                        },
+                        firstChild: null,
+                        events: EMPTY
                     }
                 }
             ]
@@ -274,7 +279,7 @@ describe('ContentTypesLayoutComponent', () => {
     });
 
     it('should not have a Permissions tab', () => {
-        const pTabPanel = de.query(By.css('p-tabpanel[value="2"]'));
+        const pTabPanel = de.query(By.css('p-tabpanel[value="permissions"]'));
         expect(pTabPanel).toBeFalsy();
     });
 
@@ -287,21 +292,21 @@ describe('ContentTypesLayoutComponent', () => {
         expect(fieldDragDropService.setBagOptions).toHaveBeenCalledTimes(1);
     });
 
-    it('should have dot-portlet-box in the Permissions tab after it has been clicked', fakeAsync(() => {
+    it('should navigate to the route and immediately update $activeTab when clicking a tab', () => {
         fixture.componentRef.setInput('contentType', fakeContentType);
         fixture.detectChanges();
 
-        const tabs = de.queryAll(By.css('p-tab'));
-        // tabs[0]=Fields, [1]=StyleEditor, [2]=Permissions
-        tabs[2].nativeElement.click();
-        fixture.detectChanges();
+        const router = fixture.debugElement.injector.get(Router);
+        jest.spyOn(router, 'navigate');
 
-        fixture.whenStable().then(() => {
-            const panels = de.queryAll(By.css('p-tabpanel'));
-            const contentTypePushHistoryPortletBox = panels[2].query(By.css('dot-portlet-box'));
-            expect(contentTypePushHistoryPortletBox).not.toBeNull();
-        });
-    }));
+        de.componentInstance.onTabChange('permissions');
+
+        expect(de.componentInstance.$activeTab()).toBe('permissions');
+        expect(router.navigate).toHaveBeenCalledWith(
+            ['permissions'],
+            expect.objectContaining({ relativeTo: expect.anything() })
+        );
+    });
 
     describe('Edit toolBar', () => {
         beforeEach(() => {
@@ -335,13 +340,9 @@ describe('ContentTypesLayoutComponent', () => {
 
     describe('Tabs', () => {
         let iframe: DebugElement;
-        let dotCurrentUserService: DotCurrentUserService;
 
         beforeEach(() => {
             fixture.componentRef.setInput('contentType', fakeContentType);
-            dotCurrentUserService = fixture.debugElement.injector.get(DotCurrentUserService);
-            jest.spyOn(dotCurrentUserService, 'hasAccessToPortlet').mockReturnValue(of(true));
-
             fixture.detectChanges();
         });
 
@@ -498,7 +499,7 @@ describe('ContentTypesLayoutComponent', () => {
             });
 
             it('should hide the style editor tab when feature flag is disabled', () => {
-                featureFlagSubject.next(false);
+                de.componentInstance.$showStyleEditorTab.set(false);
                 fixture.detectChanges();
 
                 const styleEditorPanel = de.query(By.css('[data-testid="style-editor-panel"]'));

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/components/layout/content-types-layout.component.ts
@@ -1,6 +1,3 @@
-import { Observable } from 'rxjs';
-
-import { AsyncPipe } from '@angular/common';
 import {
     Component,
     ElementRef,
@@ -10,9 +7,11 @@ import {
     inject,
     input,
     output,
+    signal,
     viewChild
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 
 import { MenuItem } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
@@ -21,12 +20,9 @@ import { MenuModule } from 'primeng/menu';
 import { SplitButtonModule } from 'primeng/splitbutton';
 import { TabsModule } from 'primeng/tabs';
 
-import {
-    DotCurrentUserService,
-    DotEventsService,
-    DotMessageService,
-    DotPropertiesService
-} from '@dotcms/data-access';
+import { filter, map } from 'rxjs/operators';
+
+import { DotEventsService, DotMessageService } from '@dotcms/data-access';
 import { DotCMSContentType, FeaturedFlags } from '@dotcms/dotcms-models';
 import { DotClipboardUtil, DotMessagePipe } from '@dotcms/ui';
 
@@ -43,7 +39,6 @@ import { DotStyleEditorBuilderComponent } from '../style-editor/dot-style-editor
     templateUrl: 'content-types-layout.component.html',
     providers: [DotClipboardUtil],
     imports: [
-        AsyncPipe,
         TabsModule,
         SplitButtonModule,
         ButtonModule,
@@ -61,9 +56,9 @@ export class ContentTypesLayoutComponent implements OnInit {
     #dotMessageService = inject(DotMessageService);
     #fieldDragDropService = inject(FieldDragDropService);
     #dotEventsService = inject(DotEventsService);
-    #dotCurrentUserService = inject(DotCurrentUserService);
-    #dotPropertiesService = inject(DotPropertiesService);
     #dotClipboardUtil = inject(DotClipboardUtil);
+    #router = inject(Router);
+    #route = inject(ActivatedRoute);
 
     $contentType = input.required<DotCMSContentType>({ alias: 'contentType' });
     openEditDialog = output<unknown>();
@@ -74,11 +69,14 @@ export class ContentTypesLayoutComponent implements OnInit {
     permissionURL: string;
     pushHistoryURL: string;
     contentTypeNameInputSize: number;
-    showPermissionsTab: Observable<boolean>;
-    readonly $showStyleEditorTab = toSignal(
-        this.#dotPropertiesService.getFeatureFlag(FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR),
-        { initialValue: false }
+    readonly $showStyleEditorTab = signal<boolean>(
+        this.#route.snapshot.data['featuredFlags']?.[FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR] ??
+            false
     );
+    readonly $showPermissionsTab = signal<boolean>(
+        this.#route.snapshot.data['tabPermissions']?.showPermissionsTab ?? false
+    );
+    readonly $activeTab = signal(this.#route.firstChild?.snapshot.url[0]?.path ?? 'fields');
     addToMenuContentType = false;
 
     actions: MenuItem[];
@@ -115,7 +113,6 @@ export class ContentTypesLayoutComponent implements OnInit {
     });
 
     ngOnInit(): void {
-        this.showPermissionsTab = this.#dotCurrentUserService.hasAccessToPortlet('permissions');
         this.#fieldDragDropService.setBagOptions();
         this.loadActions();
     }
@@ -128,6 +125,15 @@ export class ContentTypesLayoutComponent implements OnInit {
                 this.pushHistoryURL = `/html/content_types/push_history.jsp?contentTypeId=${ct.id}&popup=true`;
             }
         });
+
+        // Keep $activeTab in sync with browser back/forward navigation.
+        this.#router.events
+            .pipe(
+                filter((e) => e instanceof NavigationEnd),
+                map(() => this.#route.firstChild?.snapshot.url[0]?.path ?? 'fields'),
+                takeUntilDestroyed()
+            )
+            .subscribe((tab) => this.$activeTab.set(tab));
     }
 
     /**
@@ -176,6 +182,11 @@ export class ContentTypesLayoutComponent implements OnInit {
             const newInputSize = event.target['value'].length * 8 + 22;
             this.contentTypeNameInputSize = newInputSize > 485 ? 485 : newInputSize;
         }
+    }
+
+    onTabChange(tab: unknown): void {
+        this.$activeTab.set(tab as string);
+        this.#router.navigate([tab as string], { relativeTo: this.#route });
     }
 
     private loadActions(): void {

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.guard.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.guard.spec.ts
@@ -1,0 +1,152 @@
+import { of } from 'rxjs';
+
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+
+import { DotCurrentUserService, DotPropertiesService } from '@dotcms/data-access';
+import { FeaturedFlags } from '@dotcms/dotcms-models';
+
+import { permissionsTabGuard, styleEditorTabGuard } from './dot-content-type-tabs.guard';
+
+const BASE_URL = '/content-types-angular/edit/123';
+const STYLE_EDITOR_URL = `${BASE_URL}/style-editor`;
+const PERMISSIONS_URL = `${BASE_URL}/permissions`;
+const FIELDS_URL = `${BASE_URL}/fields`;
+
+const mockRoute = {} as ActivatedRouteSnapshot;
+
+function mockState(url: string): RouterStateSnapshot {
+    return { url } as RouterStateSnapshot;
+}
+
+describe('styleEditorTabGuard', () => {
+    let dotPropertiesService: DotPropertiesService;
+    let router: Router;
+
+    const setup = (featureFlagEnabled: boolean) => {
+        TestBed.configureTestingModule({
+            providers: [
+                HttpClient,
+                {
+                    provide: DotPropertiesService,
+                    useValue: { getFeatureFlag: jest.fn().mockReturnValue(of(featureFlagEnabled)) }
+                },
+                {
+                    provide: Router,
+                    useValue: {
+                        parseUrl: jest.fn((url: string) => ({ url }) as unknown as UrlTree)
+                    }
+                }
+            ],
+            imports: [HttpClientTestingModule]
+        });
+
+        dotPropertiesService = TestBed.inject(DotPropertiesService);
+        router = TestBed.inject(Router);
+    };
+
+    it('should allow access when feature flag is enabled', (done) => {
+        setup(true);
+
+        TestBed.runInInjectionContext(() =>
+            styleEditorTabGuard(mockRoute, mockState(STYLE_EDITOR_URL))
+        ).subscribe((result) => {
+            expect(result).toBe(true);
+            expect(dotPropertiesService.getFeatureFlag).toHaveBeenCalledWith(
+                FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR
+            );
+            done();
+        });
+    });
+
+    it('should redirect to fields when feature flag is disabled', (done) => {
+        setup(false);
+
+        TestBed.runInInjectionContext(() =>
+            styleEditorTabGuard(mockRoute, mockState(STYLE_EDITOR_URL))
+        ).subscribe((result) => {
+            expect(router.parseUrl).toHaveBeenCalledWith(FIELDS_URL);
+            expect(result).not.toBe(false);
+            done();
+        });
+    });
+
+    it('should preserve query params in the redirect url', (done) => {
+        setup(false);
+        const urlWithQuery = `${STYLE_EDITOR_URL}?foo=bar`;
+
+        TestBed.runInInjectionContext(() =>
+            styleEditorTabGuard(mockRoute, mockState(urlWithQuery))
+        ).subscribe(() => {
+            expect(router.parseUrl).toHaveBeenCalledWith(`${FIELDS_URL}?foo=bar`);
+            done();
+        });
+    });
+});
+
+describe('permissionsTabGuard', () => {
+    let dotCurrentUserService: DotCurrentUserService;
+    let router: Router;
+
+    const setup = (hasAccess: boolean) => {
+        TestBed.configureTestingModule({
+            providers: [
+                HttpClient,
+                {
+                    provide: DotCurrentUserService,
+                    useValue: {
+                        hasAccessToPortlet: jest.fn().mockReturnValue(of(hasAccess))
+                    }
+                },
+                {
+                    provide: Router,
+                    useValue: {
+                        parseUrl: jest.fn((url: string) => ({ url }) as unknown as UrlTree)
+                    }
+                }
+            ],
+            imports: [HttpClientTestingModule]
+        });
+
+        dotCurrentUserService = TestBed.inject(DotCurrentUserService);
+        router = TestBed.inject(Router);
+    };
+
+    it('should allow access when user has permissions portlet access', (done) => {
+        setup(true);
+
+        TestBed.runInInjectionContext(() =>
+            permissionsTabGuard(mockRoute, mockState(PERMISSIONS_URL))
+        ).subscribe((result) => {
+            expect(result).toBe(true);
+            expect(dotCurrentUserService.hasAccessToPortlet).toHaveBeenCalledWith('permissions');
+            done();
+        });
+    });
+
+    it('should redirect to fields when user lacks permissions portlet access', (done) => {
+        setup(false);
+
+        TestBed.runInInjectionContext(() =>
+            permissionsTabGuard(mockRoute, mockState(PERMISSIONS_URL))
+        ).subscribe((result) => {
+            expect(router.parseUrl).toHaveBeenCalledWith(FIELDS_URL);
+            expect(result).not.toBe(false);
+            done();
+        });
+    });
+
+    it('should preserve query params in the redirect url', (done) => {
+        setup(false);
+        const urlWithQuery = `${PERMISSIONS_URL}?foo=bar`;
+
+        TestBed.runInInjectionContext(() =>
+            permissionsTabGuard(mockRoute, mockState(urlWithQuery))
+        ).subscribe(() => {
+            expect(router.parseUrl).toHaveBeenCalledWith(`${FIELDS_URL}?foo=bar`);
+            done();
+        });
+    });
+});

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.guard.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.guard.ts
@@ -1,0 +1,26 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+
+import { map } from 'rxjs/operators';
+
+import { DotCurrentUserService, DotPropertiesService } from '@dotcms/data-access';
+import { FeaturedFlags } from '@dotcms/dotcms-models';
+
+const redirectToFields = (router: Router, url: string) =>
+    router.parseUrl(url.replace(/\/[^/?]+(\?.*)?$/, '/fields$1'));
+
+export const styleEditorTabGuard: CanActivateFn = (_route, state) => {
+    const router = inject(Router);
+
+    return inject(DotPropertiesService)
+        .getFeatureFlag(FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR)
+        .pipe(map((enabled) => enabled || redirectToFields(router, state.url)));
+};
+
+export const permissionsTabGuard: CanActivateFn = (_route, state) => {
+    const router = inject(Router);
+
+    return inject(DotCurrentUserService)
+        .hasAccessToPortlet('permissions')
+        .pipe(map((hasAccess) => hasAccess || redirectToFields(router, state.url)));
+};

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.resolver.spec.ts
@@ -1,0 +1,54 @@
+import { of } from 'rxjs';
+
+import { HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { DotCurrentUserService } from '@dotcms/data-access';
+
+import {
+    DotContentTypeTabsResolver,
+    DotContentTypeTabsResolvedData
+} from './dot-content-type-tabs.resolver';
+
+describe('DotContentTypeTabsResolver', () => {
+    let resolver: DotContentTypeTabsResolver;
+    let dotCurrentUserService: DotCurrentUserService;
+
+    const setup = (hasAccess: boolean) => {
+        TestBed.configureTestingModule({
+            providers: [
+                DotContentTypeTabsResolver,
+                HttpClient,
+                {
+                    provide: DotCurrentUserService,
+                    useValue: { hasAccessToPortlet: jest.fn().mockReturnValue(of(hasAccess)) }
+                }
+            ],
+            imports: [HttpClientTestingModule]
+        });
+
+        resolver = TestBed.inject(DotContentTypeTabsResolver);
+        dotCurrentUserService = TestBed.inject(DotCurrentUserService);
+    };
+
+    it('should resolve showPermissionsTab as true when user has access', (done) => {
+        setup(true);
+
+        resolver.resolve().subscribe((result: DotContentTypeTabsResolvedData) => {
+            expect(dotCurrentUserService.hasAccessToPortlet).toHaveBeenCalledWith('permissions');
+            expect(result).toEqual({ showPermissionsTab: true });
+            done();
+        });
+    });
+
+    it('should resolve showPermissionsTab as false when user lacks access', (done) => {
+        setup(false);
+
+        resolver.resolve().subscribe((result: DotContentTypeTabsResolvedData) => {
+            expect(dotCurrentUserService.hasAccessToPortlet).toHaveBeenCalledWith('permissions');
+            expect(result).toEqual({ showPermissionsTab: false });
+            done();
+        });
+    });
+});

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.resolver.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.resolver.spec.ts
@@ -3,22 +3,24 @@ import { of } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 
 import { DotCurrentUserService } from '@dotcms/data-access';
 
 import {
-    DotContentTypeTabsResolver,
-    DotContentTypeTabsResolvedData
+    DotContentTypeTabsResolvedData,
+    dotContentTypeTabsResolver
 } from './dot-content-type-tabs.resolver';
 
-describe('DotContentTypeTabsResolver', () => {
-    let resolver: DotContentTypeTabsResolver;
+const mockRoute = {} as ActivatedRouteSnapshot;
+const mockState = {} as RouterStateSnapshot;
+
+describe('dotContentTypeTabsResolver', () => {
     let dotCurrentUserService: DotCurrentUserService;
 
     const setup = (hasAccess: boolean) => {
         TestBed.configureTestingModule({
             providers: [
-                DotContentTypeTabsResolver,
                 HttpClient,
                 {
                     provide: DotCurrentUserService,
@@ -28,14 +30,15 @@ describe('DotContentTypeTabsResolver', () => {
             imports: [HttpClientTestingModule]
         });
 
-        resolver = TestBed.inject(DotContentTypeTabsResolver);
         dotCurrentUserService = TestBed.inject(DotCurrentUserService);
     };
 
     it('should resolve showPermissionsTab as true when user has access', (done) => {
         setup(true);
 
-        resolver.resolve().subscribe((result: DotContentTypeTabsResolvedData) => {
+        TestBed.runInInjectionContext(() =>
+            dotContentTypeTabsResolver(mockRoute, mockState)
+        ).subscribe((result: DotContentTypeTabsResolvedData) => {
             expect(dotCurrentUserService.hasAccessToPortlet).toHaveBeenCalledWith('permissions');
             expect(result).toEqual({ showPermissionsTab: true });
             done();
@@ -45,7 +48,9 @@ describe('DotContentTypeTabsResolver', () => {
     it('should resolve showPermissionsTab as false when user lacks access', (done) => {
         setup(false);
 
-        resolver.resolve().subscribe((result: DotContentTypeTabsResolvedData) => {
+        TestBed.runInInjectionContext(() =>
+            dotContentTypeTabsResolver(mockRoute, mockState)
+        ).subscribe((result: DotContentTypeTabsResolvedData) => {
             expect(dotCurrentUserService.hasAccessToPortlet).toHaveBeenCalledWith('permissions');
             expect(result).toEqual({ showPermissionsTab: false });
             done();

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.resolver.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.resolver.ts
@@ -1,7 +1,5 @@
-import { Observable } from 'rxjs';
-
-import { Injectable, inject } from '@angular/core';
-import { Resolve } from '@angular/router';
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
 
 import { map } from 'rxjs/operators';
 
@@ -11,13 +9,7 @@ export interface DotContentTypeTabsResolvedData {
     showPermissionsTab: boolean;
 }
 
-@Injectable()
-export class DotContentTypeTabsResolver implements Resolve<DotContentTypeTabsResolvedData> {
-    private dotCurrentUserService = inject(DotCurrentUserService);
-
-    resolve(): Observable<DotContentTypeTabsResolvedData> {
-        return this.dotCurrentUserService
-            .hasAccessToPortlet('permissions')
-            .pipe(map((showPermissionsTab) => ({ showPermissionsTab })));
-    }
-}
+export const dotContentTypeTabsResolver: ResolveFn<DotContentTypeTabsResolvedData> = () =>
+    inject(DotCurrentUserService)
+        .hasAccessToPortlet('permissions')
+        .pipe(map((showPermissionsTab) => ({ showPermissionsTab })));

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.resolver.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-type-tabs.resolver.ts
@@ -1,0 +1,23 @@
+import { Observable } from 'rxjs';
+
+import { Injectable, inject } from '@angular/core';
+import { Resolve } from '@angular/router';
+
+import { map } from 'rxjs/operators';
+
+import { DotCurrentUserService } from '@dotcms/data-access';
+
+export interface DotContentTypeTabsResolvedData {
+    showPermissionsTab: boolean;
+}
+
+@Injectable()
+export class DotContentTypeTabsResolver implements Resolve<DotContentTypeTabsResolvedData> {
+    private dotCurrentUserService = inject(DotCurrentUserService);
+
+    resolve(): Observable<DotContentTypeTabsResolvedData> {
+        return this.dotCurrentUserService
+            .hasAccessToPortlet('permissions')
+            .pipe(map((showPermissionsTab) => ({ showPermissionsTab })));
+    }
+}

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit-resolver.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit-resolver.service.ts
@@ -4,7 +4,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 
-import { catchError, map, take, tap } from 'rxjs/operators';
+import { catchError, map, take } from 'rxjs/operators';
 
 import {
     DotContentTypesInfoService,
@@ -15,7 +15,6 @@ import {
 } from '@dotcms/data-access';
 import { LoginService } from '@dotcms/dotcms-js';
 import { DotCMSContentType } from '@dotcms/dotcms-models';
-import { GlobalStore } from '@dotcms/store';
 
 /**
  * With the url return a content type by id or a default content type
@@ -31,31 +30,14 @@ export class DotContentTypeEditResolver implements Resolve<DotCMSContentType> {
     private dotHttpErrorManagerService = inject(DotHttpErrorManagerService);
     private dotRouterService = inject(DotRouterService);
     private loginService = inject(LoginService);
-    readonly #globalStore = inject(GlobalStore);
 
     resolve(route: ActivatedRouteSnapshot): Observable<DotCMSContentType> {
         if (route.paramMap.get('id')) {
-            return this.getContentType(route.paramMap.get('id')).pipe(
-                tap((contentType) => {
-                    this.#globalStore.addNewBreadcrumb({
-                        label: contentType.name,
-                        target: '_self',
-                        url: `/dotAdmin/#/content-types-angular/edit/${contentType.id}`
-                    });
-                })
-            );
+            return this.getContentType(route.paramMap.get('id'));
         } else {
             const contentType = this.getFilterByParam(route) || route.paramMap.get('type');
 
-            return this.getDefaultContentType(contentType).pipe(
-                tap((contentType) => {
-                    this.#globalStore.addNewBreadcrumb({
-                        label: contentType.name,
-                        target: '_self',
-                        url: `/dotAdmin/#/content-types-angular/create/${contentType.variable}`
-                    });
-                })
-            );
+            return this.getDefaultContentType(contentType);
         }
     }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.html
@@ -1,3 +1,4 @@
+<router-outlet />
 @if (isEditMode()) {
     <dot-content-type-layout
         (openEditDialog)="startFormDialog()"

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
@@ -51,6 +51,7 @@ import { DotEditContentTypeCacheService } from './components/fields/content-type
 import { FieldService } from './components/fields/service';
 import { DotContentTypesEditComponent } from './dot-content-types-edit.component';
 
+import { GlobalStore } from '@dotcms/store';
 import { DotMenuService } from '../../../api/services/dot-menu.service';
 
 // eslint-disable-next-line max-len
@@ -187,7 +188,8 @@ describe('DotContentTypesEditComponent', () => {
                 DotMenuService,
                 DotEventsService,
                 FieldService,
-                Location
+                Location,
+                { provide: GlobalStore, useValue: { addNewBreadcrumb: jest.fn() } }
             ]
         };
     };
@@ -521,6 +523,7 @@ describe('DotContentTypesEditComponent', () => {
                     { provide: DotMessageService, useValue: messageServiceMock },
                     { provide: DotRouterService, useClass: MockDotRouterService },
                     { provide: DotMessageDisplayService, useClass: DotMessageDisplayServiceMock },
+                    { provide: GlobalStore, useValue: { addNewBreadcrumb: jest.fn() } },
                     ConfirmationService,
                     DotAlertConfirmService,
                     DotContentTypesInfoService,

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.spec.ts
@@ -33,6 +33,7 @@ import {
     DotCMSContentTypeField,
     DotCMSContentTypeLayoutRow
 } from '@dotcms/dotcms-models';
+import { GlobalStore } from '@dotcms/store';
 import { DotIconComponent } from '@dotcms/ui';
 import {
     cleanUpDialog,
@@ -51,7 +52,6 @@ import { DotEditContentTypeCacheService } from './components/fields/content-type
 import { FieldService } from './components/fields/service';
 import { DotContentTypesEditComponent } from './dot-content-types-edit.component';
 
-import { GlobalStore } from '@dotcms/store';
 import { DotMenuService } from '../../../api/services/dot-menu.service';
 
 // eslint-disable-next-line max-len

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.component.ts
@@ -24,6 +24,7 @@ import {
     DotCMSWorkflow,
     DotDialogActions
 } from '@dotcms/dotcms-models';
+import { GlobalStore } from '@dotcms/store';
 
 import { DotEditContentTypeCacheService } from './components/fields/content-type-fields-properties-form/field-properties/dot-relationships-property/services/dot-edit-content-type-cache.service';
 import { ContentTypeFieldsDropZoneComponent } from './components/fields/index';
@@ -53,6 +54,7 @@ export class DotContentTypesEditComponent implements OnInit, OnDestroy {
     private dotMessageService = inject(DotMessageService);
     router = inject(Router);
     private dotEditContentTypeCacheService = inject(DotEditContentTypeCacheService);
+    readonly #globalStore = inject(GlobalStore);
 
     readonly $contentTypesForm = viewChild<ContentTypesFormComponent>('form');
     readonly $fieldsDropZone = viewChild<ContentTypeFieldsDropZoneComponent>('fieldsDropZone');
@@ -87,6 +89,12 @@ export class DotContentTypesEditComponent implements OnInit, OnDestroy {
                 if (isFirstLoad) {
                     this.checkAndOpenFormDialog();
                 }
+
+                this.#globalStore.addNewBreadcrumb({
+                    label: contentType.name,
+                    target: '_self',
+                    url: `/dotAdmin/#/content-types-angular/edit/${contentType.id}`
+                });
             });
 
         this.contentTypeActions = [

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
@@ -68,6 +68,7 @@ import { FieldPropertyService } from './components/fields/service/field-properti
 import { FieldService } from './components/fields/service/field.service';
 import { ContentTypesFormComponent } from './components/form/content-types-form.component';
 import { ContentTypesLayoutComponent } from './components/layout/content-types-layout.component';
+import { DotContentTypeTabsResolver } from './dot-content-type-tabs.resolver';
 import { DotContentTypesEditComponent } from './dot-content-types-edit.component';
 import { dotContentTypesEditRoutes } from './dot-content-types-edit.routes';
 
@@ -186,6 +187,7 @@ import { DotFeatureFlagResolver } from '../resolvers/dot-feature-flag-resolver.s
         DotWorkflowsActionsService,
         DotWorkflowsActionsSelectorFieldService,
         DotFeatureFlagResolver,
+        DotContentTypeTabsResolver,
         DotEditContentTypeCacheService,
         DotFieldVariablesService
     ],

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.module.ts
@@ -68,7 +68,6 @@ import { FieldPropertyService } from './components/fields/service/field-properti
 import { FieldService } from './components/fields/service/field.service';
 import { ContentTypesFormComponent } from './components/form/content-types-form.component';
 import { ContentTypesLayoutComponent } from './components/layout/content-types-layout.component';
-import { DotContentTypeTabsResolver } from './dot-content-type-tabs.resolver';
 import { DotContentTypesEditComponent } from './dot-content-types-edit.component';
 import { dotContentTypesEditRoutes } from './dot-content-types-edit.routes';
 
@@ -187,7 +186,6 @@ import { DotFeatureFlagResolver } from '../resolvers/dot-feature-flag-resolver.s
         DotWorkflowsActionsService,
         DotWorkflowsActionsSelectorFieldService,
         DotFeatureFlagResolver,
-        DotContentTypeTabsResolver,
         DotEditContentTypeCacheService,
         DotFieldVariablesService
     ],

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.routes.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.routes.ts
@@ -4,6 +4,9 @@ import { FeaturedFlags } from '@dotcms/dotcms-models';
 
 import { DotContentTypesEditComponent } from '.';
 
+import { permissionsTabGuard, styleEditorTabGuard } from './dot-content-type-tabs.guard';
+import { DotContentTypeTabsResolver } from './dot-content-type-tabs.resolver';
+
 import { DotFeatureFlagResolver } from '../resolvers/dot-feature-flag-resolver.service';
 
 export const dotContentTypesEditRoutes: Routes = [
@@ -11,10 +14,21 @@ export const dotContentTypesEditRoutes: Routes = [
         component: DotContentTypesEditComponent,
         path: '',
         resolve: {
-            featuredFlags: DotFeatureFlagResolver
+            featuredFlags: DotFeatureFlagResolver,
+            tabPermissions: DotContentTypeTabsResolver
         },
         data: {
-            featuredFlagsToCheck: [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]
-        }
+            featuredFlagsToCheck: [
+                FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED,
+                FeaturedFlags.FEATURE_FLAG_UVE_STYLE_EDITOR
+            ]
+        },
+        children: [
+            { path: '', redirectTo: 'fields', pathMatch: 'full' },
+            { path: 'fields', children: [] },
+            { path: 'style-editor', canActivate: [styleEditorTabGuard], children: [] },
+            { path: 'permissions', canActivate: [permissionsTabGuard], children: [] },
+            { path: 'push-history', children: [] }
+        ]
     }
 ];

--- a/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.routes.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/shared/dot-content-types-edit/dot-content-types-edit.routes.ts
@@ -5,7 +5,7 @@ import { FeaturedFlags } from '@dotcms/dotcms-models';
 import { DotContentTypesEditComponent } from '.';
 
 import { permissionsTabGuard, styleEditorTabGuard } from './dot-content-type-tabs.guard';
-import { DotContentTypeTabsResolver } from './dot-content-type-tabs.resolver';
+import { dotContentTypeTabsResolver } from './dot-content-type-tabs.resolver';
 
 import { DotFeatureFlagResolver } from '../resolvers/dot-feature-flag-resolver.service';
 
@@ -15,7 +15,7 @@ export const dotContentTypesEditRoutes: Routes = [
         path: '',
         resolve: {
             featuredFlags: DotFeatureFlagResolver,
-            tabPermissions: DotContentTypeTabsResolver
+            tabPermissions: dotContentTypeTabsResolver
         },
         data: {
             featuredFlagsToCheck: [

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.html
@@ -1,18 +1,20 @@
-<div class="rounded-full p-6">
+<div class="rounded-full p-6" data-testid="uve-style-editor-empty-state-icon">
     <i class="pi pi-sliders-h text-[5rem]! text-gray-500"></i>
 </div>
 <div class="space-y-2">
-    <div class="font-bold text-gray-900">
+    <div class="font-bold text-gray-900" data-testid="uve-style-editor-empty-state-title">
         {{ 'uve.palette.style-editor.empty-state.title' | dm }}
     </div>
     <p
         class="m-0 text-sm text-gray-800 [&_a]:cursor-pointer [&_a]:font-semibold [&_a]:text-[var(--color-palette-primary-500)] [&_a]:underline hover:[&_a]:text-[var(--color-palette-primary-600)]"
+        data-testid="uve-style-editor-empty-state-message"
         [innerHTML]="'uve.palette.style-editor.empty-state.message' | dm"></p>
 </div>
 @if ($contentTypeVar()) {
-    <a
-        [routerLink]="['/content-types-angular/edit', $contentTypeVar(), 'style-editor']"
-        class="cursor-pointer text-sm font-semibold text-[var(--color-palette-primary-500)] underline hover:text-[var(--color-palette-primary-600)]">
-        {{ 'uve.palette.style-editor.empty-state.cta' | dm }}
-    </a>
+    <p-button
+        [attr.data-testid]="'uve-style-editor-empty-state-cta'"
+        [label]="'uve.palette.style-editor.empty-state.cta' | dm"
+        variant="outlined"
+        [rounded]="true"
+        (onClick)="navigateToStyleEditor()" />
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.html
@@ -9,3 +9,10 @@
         class="m-0 text-sm text-gray-800 [&_a]:cursor-pointer [&_a]:font-semibold [&_a]:text-[var(--color-palette-primary-500)] [&_a]:underline hover:[&_a]:text-[var(--color-palette-primary-600)]"
         [innerHTML]="'uve.palette.style-editor.empty-state.message' | dm"></p>
 </div>
+@if ($contentTypeVar()) {
+    <a
+        [routerLink]="['/content-types-angular/edit', $contentTypeVar(), 'style-editor']"
+        class="cursor-pointer text-sm font-semibold text-[var(--color-palette-primary-500)] underline hover:text-[var(--color-palette-primary-600)]">
+        {{ 'uve.palette.style-editor.empty-state.cta' | dm }}
+    </a>
+}

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.spec.ts
@@ -1,0 +1,125 @@
+import { Spectator, byTestId, createComponentFactory, mockProvider } from '@ngneat/spectator/jest';
+
+import { Router } from '@angular/router';
+
+import { DotMessageService } from '@dotcms/data-access';
+import { DotMessagePipe } from '@dotcms/ui';
+import { MockDotMessageService } from '@dotcms/utils-testing';
+
+import { DotUveStyleEditorEmptyStateComponent } from './dot-uve-style-editor-empty-state.component';
+
+const messagesMock = {
+    'uve.palette.style-editor.empty-state.title': 'Style editor',
+    'uve.palette.style-editor.empty-state.message':
+        'Customize your components. <a href="#">Learn more</a>',
+    'uve.palette.style-editor.empty-state.cta': 'Define styles'
+};
+
+describe('DotUveStyleEditorEmptyStateComponent', () => {
+    let spectator: Spectator<DotUveStyleEditorEmptyStateComponent>;
+    let router: Router;
+
+    const createComponent = createComponentFactory({
+        component: DotUveStyleEditorEmptyStateComponent,
+        imports: [DotMessagePipe],
+        providers: [
+            {
+                provide: DotMessageService,
+                useValue: new MockDotMessageService(messagesMock)
+            },
+            mockProvider(Router, {
+                navigate: jest.fn().mockResolvedValue(true)
+            })
+        ]
+    });
+
+    beforeEach(() => {
+        spectator = createComponent();
+        router = spectator.inject(Router);
+        spectator.detectChanges();
+    });
+
+    it('should create', () => {
+        expect(spectator.component).toBeTruthy();
+    });
+
+    it('should expose the content type variable input via setInput', () => {
+        spectator.setInput('contentTypeVar', 'Blog');
+        spectator.detectChanges();
+
+        expect(spectator.component.$contentTypeVar()).toBe('Blog');
+    });
+
+    describe('layout and copy', () => {
+        it('should set the root host data-testid for the empty state', () => {
+            expect(spectator.element.getAttribute('data-testid')).toBe(
+                'uve-style-editor-empty-state'
+            );
+        });
+
+        it('should render the sliders icon', () => {
+            const iconHost = spectator.query(byTestId('uve-style-editor-empty-state-icon'));
+            expect(iconHost).toBeTruthy();
+            expect(iconHost?.querySelector('i.pi-sliders-h')).toBeTruthy();
+        });
+
+        it('should render the title from DotMessageService', () => {
+            const title = spectator.query(byTestId('uve-style-editor-empty-state-title'));
+            expect(title?.textContent?.trim()).toBe('Style editor');
+        });
+
+        it('should render the message HTML from DotMessageService', () => {
+            const message = spectator.query(byTestId('uve-style-editor-empty-state-message'));
+            expect(message?.innerHTML).toContain('Customize your components');
+            expect(message?.querySelector('a')).toBeTruthy();
+        });
+    });
+
+    describe('CTA button', () => {
+        it('should not render the CTA when contentTypeVar is empty', () => {
+            spectator.setInput('contentTypeVar', '');
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('uve-style-editor-empty-state-cta'))).toBeFalsy();
+        });
+
+        it('should render the CTA when contentTypeVar is set', () => {
+            spectator.setInput('contentTypeVar', 'Blog');
+            spectator.detectChanges();
+
+            const cta = spectator.query(byTestId('uve-style-editor-empty-state-cta'));
+            expect(cta).toBeTruthy();
+            expect(cta?.textContent?.trim()).toContain('Define styles');
+        });
+
+        it('should navigate to the style editor route when the CTA is clicked', () => {
+            spectator.setInput('contentTypeVar', 'Blog');
+            spectator.detectChanges();
+
+            const cta = spectator.query(byTestId('uve-style-editor-empty-state-cta'));
+            const nativeButton = cta?.querySelector('button');
+            expect(nativeButton).toBeTruthy();
+            spectator.click(nativeButton as HTMLElement);
+
+            expect(router.navigate).toHaveBeenCalledTimes(1);
+            expect(router.navigate).toHaveBeenCalledWith([
+                '/content-types-angular/edit',
+                'Blog',
+                'style-editor'
+            ]);
+        });
+
+        it('should navigate using the current content type variable when navigateToStyleEditor runs', () => {
+            spectator.setInput('contentTypeVar', 'Product');
+            spectator.detectChanges();
+
+            spectator.component.navigateToStyleEditor();
+
+            expect(router.navigate).toHaveBeenCalledWith([
+                '/content-types-angular/edit',
+                'Product',
+                'style-editor'
+            ]);
+        });
+    });
+});

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.ts
@@ -1,17 +1,30 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
+
+import { ButtonModule } from 'primeng/button';
 
 import { DotMessagePipe } from '@dotcms/ui';
 
 @Component({
     selector: 'dot-uve-style-editor-empty-state',
-    imports: [DotMessagePipe, RouterLink],
+    imports: [DotMessagePipe, RouterLink, ButtonModule],
     templateUrl: './dot-uve-style-editor-empty-state.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
-        class: 'flex h-full w-full flex-col items-center justify-center gap-4 px-6 py-10 text-center'
+        class: 'flex h-full w-full flex-col items-center justify-center gap-4 px-6 py-10 text-center',
+        '[attr.data-testid]': "'uve-style-editor-empty-state'"
     }
 })
 export class DotUveStyleEditorEmptyStateComponent {
     readonly $contentTypeVar = input<string>('', { alias: 'contentTypeVar' });
+
+    readonly #router = inject(Router);
+
+    navigateToStyleEditor() {
+        this.#router.navigate([
+            '/content-types-angular/edit',
+            this.$contentTypeVar(),
+            'style-editor'
+        ]);
+    }
 }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.ts
@@ -1,14 +1,17 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 import { DotMessagePipe } from '@dotcms/ui';
 
 @Component({
     selector: 'dot-uve-style-editor-empty-state',
-    imports: [DotMessagePipe],
+    imports: [DotMessagePipe, RouterLink],
     templateUrl: './dot-uve-style-editor-empty-state.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     host: {
         class: 'flex h-full w-full flex-col items-center justify-center gap-4 px-6 py-10 text-center'
     }
 })
-export class DotUveStyleEditorEmptyStateComponent {}
+export class DotUveStyleEditorEmptyStateComponent {
+    readonly $contentTypeVar = input<string>('', { alias: 'contentTypeVar' });
+}

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.html
@@ -257,7 +257,8 @@
                                 @if ($styleSchema()) {
                                     <dot-uve-style-editor-form [schema]="$styleSchema()!" />
                                 } @else {
-                                    <dot-uve-style-editor-empty-state />
+                                    <dot-uve-style-editor-empty-state
+                                        [contentTypeVar]="$styleSchemaContentTypeVar()" />
                                 }
                             </div>
                         }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -204,6 +204,9 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
     readonly $styleSchema = computed<StyleEditorFormSchema | undefined>(() => {
         return this.uveStore.$styleSchema();
     });
+    readonly $styleSchemaContentTypeVar = computed(
+        () => this.uveStore.editorActiveContentlet()?.contentlet?.contentType ?? ''
+    );
 
     protected readonly $contentletEditData = computed(() => {
         const { container, contentlet: contentletPayload } =

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6173,6 +6173,9 @@ uve.palette.favorite.search.state.label=Searching for more results…
 uve.palette.style-editor.empty-state.title=Style editor
 uve.palette.style-editor.empty-state.message=allows you to change<br /> the look and feel of your<br /> components. <a href="https://dev.dotcms.com/docs/sdk-uve-library#style-editor" class="empty-state__link" target="_blank" rel="noopener noreferrer">Learn more</a>
 style.editor.text.field.default.placeholder=Enter value
+uve.palette.style-editor.empty-state.cta=Define styles for this content type
+uve.palette.style-editor.empty-state.no-schema.title=No schema configured
+uve.palette.style-editor.empty-state.no-schema.description=Add a style schema to control how your components look and feel.
 
 # Page Scanner
 page.scanner.a11y.dialog.title=Accessibility Report

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6173,7 +6173,7 @@ uve.palette.favorite.search.state.label=Searching for more results…
 uve.palette.style-editor.empty-state.title=Style editor
 uve.palette.style-editor.empty-state.message=allows you to change<br /> the look and feel of your<br /> components. <a href="https://dev.dotcms.com/docs/sdk-uve-library#style-editor" class="empty-state__link" target="_blank" rel="noopener noreferrer">Learn more</a>
 style.editor.text.field.default.placeholder=Enter value
-uve.palette.style-editor.empty-state.cta=Define styles for this content type
+uve.palette.style-editor.empty-state.cta=Define styles
 
 # Page Scanner
 page.scanner.a11y.dialog.title=Accessibility Report

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6174,8 +6174,6 @@ uve.palette.style-editor.empty-state.title=Style editor
 uve.palette.style-editor.empty-state.message=allows you to change<br /> the look and feel of your<br /> components. <a href="https://dev.dotcms.com/docs/sdk-uve-library#style-editor" class="empty-state__link" target="_blank" rel="noopener noreferrer">Learn more</a>
 style.editor.text.field.default.placeholder=Enter value
 uve.palette.style-editor.empty-state.cta=Define styles for this content type
-uve.palette.style-editor.empty-state.no-schema.title=No schema configured
-uve.palette.style-editor.empty-state.no-schema.description=Add a style schema to control how your components look and feel.
 
 # Page Scanner
 page.scanner.a11y.dialog.title=Accessibility Report


### PR DESCRIPTION

- Added  and  to manage access to the style editor and permissions tabs based on feature flags and user permissions.
- Introduced  to resolve permissions for displaying the permissions tab.
- Updated routing to include guards and resolvers for the new tabs.
- Enhanced component templates to reflect the new tab structure and logic.
- Added unit tests for guards and resolver to ensure correct functionality.

This implementation improves user experience by conditionally displaying tabs based on user permissions and feature availability.

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #35466

This PR fixes: #35466