### PR TITLE
fix(categories): default CategoryForm.active to true on omitted JSON (#35501)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/categories/CategoryForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/categories/CategoryForm.java
@@ -21,7 +21,7 @@ public class CategoryForm extends Validated {
     private String key;
     @NotNull
     private String categoryName;
-    private boolean active = true;
+    private boolean active;
     private int sortOrder;
     private String categoryVelocityVarName;
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/categories/CategoryForm.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/categories/CategoryForm.java
@@ -21,7 +21,7 @@ public class CategoryForm extends Validated {
     private String key;
     @NotNull
     private String categoryName;
-    private boolean active;
+    private boolean active = true;
     private int sortOrder;
     private String categoryVelocityVarName;
 
@@ -96,7 +96,7 @@ public class CategoryForm extends Validated {
         @JsonProperty
         private String categoryName;
         @JsonProperty
-        private boolean active;
+        private boolean active = true;
         @JsonProperty
         private int sortOrder;
         @JsonProperty

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/categories/CategoryFormTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/categories/CategoryFormTest.java
@@ -1,0 +1,68 @@
+package com.dotcms.rest.api.v1.categories;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link CategoryForm} Jackson deserialization, focused on the
+ * {@code active} field default behavior (issue #35501).
+ */
+public class CategoryFormTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * AC1: A create payload that omits {@code active} must default to {@code true},
+     * matching the {@code Category} model default and avoiding silently inactive categories.
+     */
+    @Test
+    public void deserialize_omittedActive_defaultsToTrue() throws IOException {
+        final String json = "{\"categoryName\":\"adds\",\"categoryVelocityVarName\":\"adds\","
+                + "\"key\":\"asd\",\"keywords\":\"asd\"}";
+
+        final CategoryForm form = mapper.readValue(json, CategoryForm.class);
+
+        assertTrue("active must default to true when omitted from JSON", form.isActive());
+    }
+
+    /**
+     * AC2: An explicit {@code "active": false} in the payload must be honored.
+     */
+    @Test
+    public void deserialize_explicitActiveFalse_isPreserved() throws IOException {
+        final String json = "{\"categoryName\":\"x\",\"active\":false}";
+
+        final CategoryForm form = mapper.readValue(json, CategoryForm.class);
+
+        assertFalse("explicit active=false must be preserved", form.isActive());
+    }
+
+    /**
+     * AC3: An explicit {@code "active": true} in the payload must be honored.
+     */
+    @Test
+    public void deserialize_explicitActiveTrue_isPreserved() throws IOException {
+        final String json = "{\"categoryName\":\"x\",\"active\":true}";
+
+        final CategoryForm form = mapper.readValue(json, CategoryForm.class);
+
+        assertTrue("explicit active=true must be preserved", form.isActive());
+    }
+
+    /**
+     * Builder default mirrors the deserialization default — guards against the
+     * field being reset to the primitive default in either side of the form.
+     */
+    @Test
+    public void builder_defaultActive_isTrue() {
+        final CategoryForm form = new CategoryForm.Builder()
+                .setCategoryName("x")
+                .build();
+
+        assertTrue("Builder default for active must be true", form.isActive());
+    }
+}


### PR DESCRIPTION
## Summary

`CategoryForm` declared `private boolean active;` (a Java primitive that defaults to `false`). Because `CategoriesResource.fillAndSave()` runs `BeanUtils.copyProperties(category, categoryForm)` on POST, an omitted `active` field on the request silently overwrote the `Category` model's `true` default — every category created from the new Angular categories portlet (which doesn't send `active`) was created inactive.

Defaulting both the form field and the inner `Builder` field to `true` makes omitted JSON behave like the model: omitted ⇒ active, explicit `true`/`false` ⇒ honored.

<img width="1602" height="874" alt="CleanShot 2026-04-29 at 16 08 38@2x" src="https://github.com/user-attachments/assets/c116526b-6cf8-4198-b86a-38000402ca50" />


Closes #35501

## Acceptance Criteria

- [x] **AC1** — POST without `active` ⇒ category active (verified by `deserialize_omittedActive_defaultsToTrue`)
- [x] **AC2** — POST with `"active": false` ⇒ category inactive (verified by `deserialize_explicitActiveFalse_isPreserved`)
- [x] **AC3** — POST with `"active": true` ⇒ category active (verified by `deserialize_explicitActiveTrue_isPreserved`)
- [x] **AC4/AC5** — PUT semantics unchanged: `fillAndSave` (PUT overload) seeds the update from the existing entity and only re-applies `categoryName`, `key`, `keywords` from the form, so the form's `active` was never read on PUT before this fix and is still not read after — existing values are preserved when omitted.
- [x] **AC6** — New Angular categories portlet creates active categories by default (it omits `active`, which now defaults to `true` server-side)
- [x] **AC7** — No retroactive change: only the default for new POSTs changes; existing rows are untouched.
- [x] **AC8** — Unit test added: `CategoryFormTest` covers all three create scenarios + Builder default.

## Test plan

- [x] `./mvnw test -pl :dotcms-core -Dtest=CategoryFormTest` — 4/4 passing locally
- [ ] Manual: create a category through the new Angular categories portlet and verify it appears as active
- [ ] CI: full test suite

## Changed files

- `dotCMS/src/main/java/com/dotcms/rest/api/v1/categories/CategoryForm.java` — default `active = true` on class field and Builder field
- `dotCMS/src/test/java/com/dotcms/rest/api/v1/categories/CategoryFormTest.java` — new unit test

This PR fixes: #35501