### PR TITLE
fix(block-editor): render subscript and superscript marks as <sub>/<sup> in Story Block HTML output

### DIFF
--- a/dotCMS/src/main/webapp/WEB-INF/velocity/VM_global_library.vm
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/VM_global_library.vm
@@ -26,6 +26,12 @@
             *##if ($mark.type == "underline")#*
                 *#<u>#*
             *##end#*
+            *##if ($mark.type == "subscript")#*
+                *#<sub>#*
+            *##end#*
+            *##if ($mark.type == "superscript")#*
+                *#<sup>#*
+            *##end#*
             *##if ($mark.type == "link")#*
                 *#<a href="${esc.html($mark.attrs.href)}" target="${esc.html($mark.attrs.target)}"#*
                 *##if($mark.attrs.title) title="${esc.html($mark.attrs.title)}"#end#*
@@ -53,6 +59,12 @@
             *##end#*
             *##if ($mark.type == "underline")#*
                 *#</u>#*
+            *##end#*
+            *##if ($mark.type == "subscript")#*
+                *#</sub>#*
+            *##end#*
+            *##if ($mark.type == "superscript")#*
+                *#</sup>#*
             *##end#*
             *##if($mark.type == "link")#*
                 *#</a>#*

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
@@ -88,6 +88,12 @@ public class StoryBlockMapTest extends IntegrationTestBase {
             "            #if ($mark.type == \"underline\")\n" +
             "            <u>\n" +
             "            #end\n" +
+            "            #if ($mark.type == \"subscript\")\n" +
+            "            <sub>\n" +
+            "            #end\n" +
+            "            #if ($mark.type == \"superscript\")\n" +
+            "            <sup>\n" +
+            "            #end\n" +
             "            #if ($mark.type == \"link\")\n" +
             "            <a href=\"$mark.attrs.href\" target=\"$mark.attrs.target\">\n" +
             "            #end\n" +
@@ -111,6 +117,12 @@ public class StoryBlockMapTest extends IntegrationTestBase {
             "            #end\n" +
             "            #if ($mark.type == \"underline\")\n" +
             "            </u>\n" +
+            "            #end\n" +
+            "            #if ($mark.type == \"subscript\")\n" +
+            "            </sub>\n" +
+            "            #end\n" +
+            "            #if ($mark.type == \"superscript\")\n" +
+            "            </sup>\n" +
             "            #end\n" +
             "            #if($mark.type == \"link\")\n" +
             "            </a>\n" +

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
@@ -57,6 +57,15 @@ public class StoryBlockMapTest extends IntegrationTestBase {
     private static final String JSON_ULIST =
             "{\"type\":\"doc\",\"content\":[{\"type\":\"bulletList\",\"content\":[{\"type\":\"listItem\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"text\",\"text\":\"1\"}]}]},{\"type\":\"listItem\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"text\",\"text\":\"2\"}]}]},{\"type\":\"listItem\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":[{\"type\":\"text\",\"text\":\"3\"}]}]}]}]}";
 
+    private static final String JSON_SUB_SUP =
+            "{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\",\"attrs\":{\"textAlign\":\"left\"},\"content\":["
+                    + "{\"type\":\"text\",\"marks\":[{\"type\":\"superscript\"}],\"text\":\"sup\"},"
+                    + "{\"type\":\"text\",\"text\":\" and \"},"
+                    + "{\"type\":\"text\",\"marks\":[{\"type\":\"subscript\"}],\"text\":\"sub\"},"
+                    + "{\"type\":\"text\",\"text\":\" and \"},"
+                    + "{\"type\":\"text\",\"marks\":[{\"type\":\"bold\"},{\"type\":\"superscript\"}],\"text\":\"bold-sup\"}"
+                    + "]}]}";
+
     private static final String MACRO = "#macro(renderMarks $content)\n" +
             "\n" +
             "    #if($content.marks)\n" +
@@ -254,6 +263,24 @@ public class StoryBlockMapTest extends IntegrationTestBase {
         Assert.assertTrue(html.contains("heading 2"));
         Assert.assertTrue(html.contains("</h2>"));
 
+    }
+
+    /**
+     * Method to test: {@link StoryBlockMap#toHtml()}
+     * Given Scenario: A paragraph contains text with subscript, superscript, and a combined bold+superscript mark.
+     * ExpectedResult: The rendered HTML wraps each text run in {@code <sub>} / {@code <sup>} tags, and combined
+     *   marks nest with the correct closing order (e.g. {@code <strong><sup>bold-sup</sup></strong>}).
+     */
+    @Test
+    public void test_subscript_and_superscript_marks_render_to_html() throws JSONException {
+
+        final StoryBlockMap storyBlockMap = new StoryBlockMap(JSON_SUB_SUP);
+        final String html = storyBlockMap.toHtml();
+
+        Assert.assertTrue(html + ": missing <sup>sup</sup>", html.contains("<sup>sup</sup>"));
+        Assert.assertTrue(html + ": missing <sub>sub</sub>", html.contains("<sub>sub</sub>"));
+        Assert.assertTrue(html + ": missing <strong><sup>bold-sup</sup></strong>",
+                html.contains("<strong><sup>bold-sup</sup></strong>"));
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/viewtools/content/StoryBlockMapTest.java
@@ -288,11 +288,16 @@ public class StoryBlockMapTest extends IntegrationTestBase {
 
         final StoryBlockMap storyBlockMap = new StoryBlockMap(JSON_SUB_SUP);
         final String html = storyBlockMap.toHtml();
+        // The inline MACRO registered in @Before pads tags with newlines/indent, so
+        // strip whitespace before asserting on contiguous mark wrappings.
+        final String normalized = html.replaceAll("\\s+", "");
 
-        Assert.assertTrue(html + ": missing <sup>sup</sup>", html.contains("<sup>sup</sup>"));
-        Assert.assertTrue(html + ": missing <sub>sub</sub>", html.contains("<sub>sub</sub>"));
+        Assert.assertTrue(html + ": missing <sup>sup</sup>",
+                normalized.contains("<sup>sup</sup>"));
+        Assert.assertTrue(html + ": missing <sub>sub</sub>",
+                normalized.contains("<sub>sub</sub>"));
         Assert.assertTrue(html + ": missing <strong><sup>bold-sup</sup></strong>",
-                html.contains("<strong><sup>bold-sup</sup></strong>"));
+                normalized.contains("<strong><sup>bold-sup</sup></strong>"));
     }
 
     /**


### PR DESCRIPTION
## Summary

- Adds `subscript` and `superscript` mark handling to the `renderMarks` macro in `dotCMS/src/main/webapp/WEB-INF/velocity/VM_global_library.vm` — previously these marks were silently dropped during Story Block HTML rendering even though the Block Editor (TipTap) registers both extensions.
- Branches are added to both the opening loop and the closing reverse-range loop so nested combinations (e.g. `bold` + `superscript`) close in the correct order.
- Adds integration coverage in `StoryBlockMapTest` (`test_subscript_and_superscript_marks_render_to_html`) covering each mark individually plus a combined nesting case (`<strong><sup>bold-sup</sup></strong>`).

Closes #35460

## Before / After

**Input JSON:**
```json
{ "type": "text", "marks": [{ "type": "superscript" }], "text": "2" }
```

| | Output |
|---|---|
| Before | `2` |
| After | `<sup>2</sup>` |

## Test plan

- [ ] `./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=StoryBlockMapTest` passes (new test + existing tests).
- [ ] Manual: create a contentlet with a Block Editor field, apply Subscript and Superscript via the toolbar, save/publish, render via `$contentlet.myField.toHtml` in a VTL/page, confirm `<sub>` / `<sup>` wrap the affected text.
- [ ] Manual regression: confirm `bold`, `italic`, `strike`, `underline`, and `link` still render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35460