### PR TITLE
fix(browser): pass folderPath when creating file asset from Site Browser

### DIFF
--- a/core-web/apps/dotcms-ui-e2e/src/pages/newEditContentForm.page.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/pages/newEditContentForm.page.ts
@@ -117,4 +117,17 @@ export class NewEditContentFormPage {
         await this.page.waitForLoadState('domcontentloaded');
         await this.page.getByTestId('title').waitFor({ state: 'visible', timeout: 15000 });
     }
+
+    /**
+     * Navigates to create a new file-asset content with a folderPath query param.
+     * File asset types don't expose data-testid="title", so this waits for the
+     * built-in hostFolder field instead.
+     */
+    async goToNewFileAssetWithFolderPath(contentType: string, folderPath: string) {
+        await this.page.goto(`/dotAdmin/#/content/new/${contentType}?folderPath=${folderPath}`);
+        await this.page.waitForLoadState('domcontentloaded');
+        await this.page
+            .getByTestId('field-hostFolder')
+            .waitFor({ state: 'visible', timeout: 15000 });
+    }
 }

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/host-folder-field/host-folder-field-file-asset.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/host-folder-field/host-folder-field-file-asset.spec.ts
@@ -1,3 +1,5 @@
+import { NewEditContentFormPage } from '@pages';
+
 import { HostFolderField } from './helpers/host-folder-field';
 
 import { test } from '../../../../fixtures/host-folder.fixture';
@@ -5,6 +7,7 @@ import { test } from '../../../../fixtures/host-folder.fixture';
 test.describe('Folder Context Pre-fill — File Asset Content Type', () => {
     test.describe.configure({ mode: 'serial' });
 
+    let contentTypeId: string;
     let contentTypeVariable: string;
     let siteName: string;
     let folder1Name: string;
@@ -15,6 +18,7 @@ test.describe('Folder Context Pre-fill — File Asset Content Type', () => {
             clazz: 'com.dotcms.contenttype.model.type.ImmutableFileAssetContentType',
             name: `FileAssetTest${testSuffix}`
         });
+        contentTypeId = contentType.id;
         contentTypeVariable = contentType.variable;
 
         const defaultSite = await apiHelpers.getDefaultSite();
@@ -25,23 +29,15 @@ test.describe('Folder Context Pre-fill — File Asset Content Type', () => {
         await apiHelpers.createFolders(siteName, [`/${folder1Name}/${folder2Name}`]);
     });
 
-    async function navigateToNewFileAsset(
-        adminPage: import('@playwright/test').Page,
-        contentType: string,
-        folderPath: string
-    ) {
-        await adminPage.goto(`/dotAdmin/#/content/new/${contentType}?folderPath=${folderPath}`);
-        await adminPage.waitForLoadState('domcontentloaded');
-        await adminPage
-            .getByTestId('field-hostFolder')
-            .waitFor({ state: 'visible', timeout: 15000 });
-    }
+    test.afterEach(async ({ apiHelpers }) => {
+        await apiHelpers.deleteContentType(contentTypeId);
+    });
 
     test('folderPath query param pre-fills Host/Folder field for file asset type @critical', async ({
         adminPage
     }) => {
-        await navigateToNewFileAsset(
-            adminPage,
+        const formPage = new NewEditContentFormPage(adminPage);
+        await formPage.goToNewFileAssetWithFolderPath(
             contentTypeVariable,
             `${siteName}/${folder1Name}/${folder2Name}/`
         );
@@ -53,7 +49,11 @@ test.describe('Folder Context Pre-fill — File Asset Content Type', () => {
     test('shallow folderPath pre-fills single-level folder for file asset type @critical', async ({
         adminPage
     }) => {
-        await navigateToNewFileAsset(adminPage, contentTypeVariable, `${siteName}/${folder1Name}/`);
+        const formPage = new NewEditContentFormPage(adminPage);
+        await formPage.goToNewFileAssetWithFolderPath(
+            contentTypeVariable,
+            `${siteName}/${folder1Name}/`
+        );
 
         const field = new HostFolderField(adminPage, 'hostFolder');
         await field.expectLabelContains(`${siteName}/${folder1Name}`);
@@ -62,7 +62,8 @@ test.describe('Folder Context Pre-fill — File Asset Content Type', () => {
     test('empty folderPath falls back to default site for file asset type', async ({
         adminPage
     }) => {
-        await navigateToNewFileAsset(adminPage, contentTypeVariable, '');
+        const formPage = new NewEditContentFormPage(adminPage);
+        await formPage.goToNewFileAssetWithFolderPath(contentTypeVariable, '');
 
         const field = new HostFolderField(adminPage, 'hostFolder');
         await field.expectLabelMatchesPattern(/^\/\/.+/);

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/host-folder-field/host-folder-field-file-asset.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/fields/host-folder-field/host-folder-field-file-asset.spec.ts
@@ -1,0 +1,71 @@
+import { HostFolderField } from './helpers/host-folder-field';
+
+import { test } from '../../../../fixtures/host-folder.fixture';
+
+test.describe('Folder Context Pre-fill — File Asset Content Type', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    let contentTypeVariable: string;
+    let siteName: string;
+    let folder1Name: string;
+    let folder2Name: string;
+
+    test.beforeEach(async ({ apiHelpers, testSuffix }) => {
+        const contentType = await apiHelpers.createContentType({
+            clazz: 'com.dotcms.contenttype.model.type.ImmutableFileAssetContentType',
+            name: `FileAssetTest${testSuffix}`
+        });
+        contentTypeVariable = contentType.variable;
+
+        const defaultSite = await apiHelpers.getDefaultSite();
+        siteName = defaultSite.hostname;
+        folder1Name = `folder-1-${testSuffix}`;
+        folder2Name = `folder-2-${testSuffix}`;
+
+        await apiHelpers.createFolders(siteName, [`/${folder1Name}/${folder2Name}`]);
+    });
+
+    async function navigateToNewFileAsset(
+        adminPage: import('@playwright/test').Page,
+        contentType: string,
+        folderPath: string
+    ) {
+        await adminPage.goto(`/dotAdmin/#/content/new/${contentType}?folderPath=${folderPath}`);
+        await adminPage.waitForLoadState('domcontentloaded');
+        await adminPage
+            .getByTestId('field-hostFolder')
+            .waitFor({ state: 'visible', timeout: 15000 });
+    }
+
+    test('folderPath query param pre-fills Host/Folder field for file asset type @critical', async ({
+        adminPage
+    }) => {
+        await navigateToNewFileAsset(
+            adminPage,
+            contentTypeVariable,
+            `${siteName}/${folder1Name}/${folder2Name}/`
+        );
+
+        const field = new HostFolderField(adminPage, 'hostFolder');
+        await field.expectLabelContains(`${siteName}/${folder1Name}/${folder2Name}`);
+    });
+
+    test('shallow folderPath pre-fills single-level folder for file asset type @critical', async ({
+        adminPage
+    }) => {
+        await navigateToNewFileAsset(adminPage, contentTypeVariable, `${siteName}/${folder1Name}/`);
+
+        const field = new HostFolderField(adminPage, 'hostFolder');
+        await field.expectLabelContains(`${siteName}/${folder1Name}`);
+    });
+
+    test('empty folderPath falls back to default site for file asset type', async ({
+        adminPage
+    }) => {
+        await navigateToNewFileAsset(adminPage, contentTypeVariable, '');
+
+        const field = new HostFolderField(adminPage, 'hostFolder');
+        await field.expectLabelMatchesPattern(/^\/\/.+/);
+        await field.expectFormFunctional();
+    });
+});

--- a/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/browser/view_browser_js_inc.jsp
@@ -1531,6 +1531,7 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
     }
 
     function showFileAssetPopUp(folderMap, fileAssetTypeMap, isMultiple){
+        currentFileAssetFolderMap = folderMap;
         hidePopUp('context_menu_popup_'+folderMap.inode);
         var faDialog = dijit.byId("addFileAssetDialog");
         if (faDialog) {
@@ -1563,6 +1564,7 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
     }
 
     var currentPageAssetFolderMap = null;
+    var currentFileAssetFolderMap = null;
 
     function showPageAssetPopUp(folderMap){
         currentPageAssetFolderMap = folderMap;
@@ -1656,7 +1658,13 @@ Structure defaultFileAssetStructure = CacheLocator.getContentTypeCache().getStru
 
         if(!isMultiple){
             var loc='<portlet:actionURL windowState="<%= WindowState.MAXIMIZED.toString() %>"><portlet:param name="struts_action" value="/ext/contentlet/edit_contentlet" /><portlet:param name="cmd" value="new" /></portlet:actionURL>&selectedStructure=' + selected +'&folder='+folderInode+'&referer=' + escape(refererVar);
-            createContentlet(loc, selected.item.velocityVarName);
+            var folderPath = '';
+            if (currentFileAssetFolderMap && currentFileAssetFolderMap.fullPath) {
+                var hostName = currentFileAssetFolderMap.fullPath.split(':')[0];
+                var cmsFolderPath = currentFileAssetFolderMap.folderPath || '/';
+                folderPath = cmsFolderPath === '/' ? hostName : hostName + cmsFolderPath;
+            }
+            createContentlet(loc, selected.item.velocityVarName, folderPath);
         } else {
             addMultipleFile(folderInode, selected, escape(refererVar));
         }


### PR DESCRIPTION
## Summary

- Fixes TC-004 QA failure from PR #35322: when a user navigated into a nested folder in Site Browser and opened **Add Asset → File**, the `folderPath` was not passed to `createContentlet()`, so the new Angular edit-content form always defaulted the Host/Folder field to site root instead of the current folder
- Stores the active `folderMap` in `currentFileAssetFolderMap` inside `showFileAssetPopUp` — mirroring the existing `currentPageAssetFolderMap` pattern already in place for HTML pages
- Passes the resolved `folderPath` to `createContentlet()` in the single-file branch of `getSelectedfileAsset`
- Adds E2E coverage for `FileAssetContentType` `folderPath` pre-fill (field variable `hostFolder`), complementing the `SimpleContentType` specs added in PR #35322

## VIDEO

https://github.com/user-attachments/assets/5f0a3de9-5fa9-4e6d-8371-845a85f3d19b


## Related

Closes #34588

## Test plan

- [ ] Navigate into a nested folder in Site Browser (e.g. `folder-1/folder-2`)
- [ ] Click **+** → **Add Asset** → **File**, select a file-asset content type with the new editor enabled
- [ ] Verify the Angular form opens with `?folderPath=<site>/folder-1/folder-2/` in the URL and Host/Folder field pre-filled correctly
- [ ] Upload a file, save, return to Site Browser → confirm file is inside `folder-2`, not at site root
- [ ] Verify HTML page creation (TC-003) still works as before — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #34588