### PR TITLE
fix(content): enforce anonymous access restrictions for content references endpoints

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/content/ContentResource.java
@@ -459,7 +459,7 @@ public class ContentResource {
 
         new WebResource.InitBuilder(this.webResource)
                         .requestAndResponse(request, response)
-                        .requiredAnonAccess(AnonymousAccess.READ)
+                        .requiredAnonAccess(AnonymousAccess.NONE)
                         .init();
 
         Logger.debug(this, () -> "Finding the counts for contentlet id: " + identifier);
@@ -494,6 +494,9 @@ public class ContentResource {
         @ApiResponse(responseCode = "401",
                     description = "Unauthorized - authentication required",
                     content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "403",
+                    description = "Forbidden - user lacks read permission on the contentlet",
+                    content = @Content(mediaType = "application/json")),
         @ApiResponse(responseCode = "404",
                     description = "Not found - contentlet not found",
                     content = @Content(mediaType = "application/json"))
@@ -512,7 +515,7 @@ public class ContentResource {
 
         final User user = new WebResource.InitBuilder(this.webResource)
                 .requestAndResponse(request, response)
-                .requiredAnonAccess(AnonymousAccess.READ)
+                .requiredAnonAccess(AnonymousAccess.NONE)
                 .init().getUser();
 
         Logger.debug(this, () -> "Finding the references for contentlet id: " + inodeOrIdentifier);

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -7374,6 +7374,10 @@ paths:
           content:
             application/json: {}
           description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: Forbidden - user lacks read permission on the contentlet
         "404":
           content:
             application/json: {}

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/ContentResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/content/ContentResourceIntegrationTest.java
@@ -982,6 +982,61 @@ public class ContentResourceIntegrationTest {
     }
 
     /**
+     * Method to test: {@link ContentResource#getContentletReferences}
+     * <p>
+     * Given scenario: An unauthenticated (anonymous) HTTP request hits the endpoint,
+     * which requires {@code AnonymousAccess.NONE}.
+     * <p>
+     * Expected result: {@link com.dotcms.rest.exception.SecurityException} is thrown,
+     * mapping to HTTP 401 — anonymous callers are rejected before any content lookup.
+     */
+    @Test(expected = com.dotcms.rest.exception.SecurityException.class)
+    public void test_getContentletReferences_anonymousRequest_throwsUnauthorized()
+            throws Exception {
+        final Language english = APILocator.getLanguageAPI().getDefaultLanguage();
+        final Structure structure = new StructureDataGen().nextPersisted();
+        final Contentlet content = new ContentletDataGen(structure.getInode())
+                .languageId(english.getId()).nextPersisted();
+
+        new ContentResource().getContentletReferences(
+                createAnonymousRequest(), mock(HttpServletResponse.class),
+                content.getIdentifier(), "");
+    }
+
+    /**
+     * Method to test: {@link ContentResource#getAllContentletReferencesCount}
+     * <p>
+     * Given scenario: An unauthenticated (anonymous) HTTP request hits the endpoint,
+     * which requires {@code AnonymousAccess.NONE}.
+     * <p>
+     * Expected result: {@link com.dotcms.rest.exception.SecurityException} is thrown,
+     * mapping to HTTP 401 — anonymous callers are rejected before any count lookup.
+     */
+    @Test(expected = com.dotcms.rest.exception.SecurityException.class)
+    public void test_getAllContentletReferencesCount_anonymousRequest_throwsUnauthorized()
+            throws Exception {
+        final Language english = APILocator.getLanguageAPI().getDefaultLanguage();
+        final Structure structure = new StructureDataGen().nextPersisted();
+        final Contentlet content = new ContentletDataGen(structure.getInode())
+                .languageId(english.getId()).nextPersisted();
+
+        new ContentResource().getAllContentletReferencesCount(
+                createAnonymousRequest(), mock(HttpServletResponse.class),
+                content.getIdentifier());
+    }
+
+    /**
+     * Creates an unauthenticated (anonymous) HttpServletRequest with no user or auth header.
+     */
+    private static HttpServletRequest createAnonymousRequest() {
+        return new MockAttributeRequest(
+                new MockSessionRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()
+                ).request()
+        ).request();
+    }
+
+    /**
      * Creates an authenticated HttpServletRequest with admin credentials.
      */
     private static HttpServletRequest createAuthenticatedRequest() {


### PR DESCRIPTION

- Updated `getContentletReferences` and `getAllContentletReferencesCount` to require `AnonymousAccess.NONE`, ensuring unauthenticated callers are blocked.
- Added tests to verify that unauthorized (anonymous) requests throw `SecurityException` as expected, mapping to HTTP 401 responses.
- Enhanced OpenAPI documentation, adding `403 Forbidden` responses to describe cases where users lack contentlet read permissions.
- Refactored `createAnonymousRequest` utility for better test coverage.

ref: #30584

This PR fixes: #30584