### PR TITLE
fix(block-editor): support spaces in contentlet search (#34416)

### DIFF
--- a/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.spec.ts
+++ b/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.spec.ts
@@ -3,7 +3,6 @@ import { of } from 'rxjs';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-
 import { Editor } from '@tiptap/core';
 import { Document } from '@tiptap/extension-document';
 import { Paragraph } from '@tiptap/extension-paragraph';

--- a/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.spec.ts
+++ b/core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.spec.ts
@@ -1,7 +1,8 @@
+import { of } from 'rxjs';
+
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
-import { of } from 'rxjs';
 
 import { Editor } from '@tiptap/core';
 import { Document } from '@tiptap/extension-document';

--- a/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.spec.ts
+++ b/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.spec.ts
@@ -100,7 +100,7 @@ describe('SuggestionsService', () => {
             flushEmpty(req);
         });
 
-        it('preserves the identifier branch for hyphenated filters (AC5)', () => {
+        it('routes UUID-like filters through the identifier branch (AC5)', () => {
             service
                 .getContentlets({
                     contentType: 'Blog',
@@ -113,8 +113,46 @@ describe('SuggestionsService', () => {
             const req = httpMock.expectOne('/api/content/_search');
             expect(req.request.method).toBe('POST');
             expect(req.request.body.query).toBe(
-                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:abc-def'
+                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:abc\\-def'
             );
+            flushEmpty(req);
+        });
+
+        it('treats hyphenated English titles as multi-token searches, not identifiers', () => {
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: 'White-Water Falls',
+                    currentLanguage: 1,
+                    contentletIdentifier: undefined
+                })
+                .subscribe();
+
+            const req = httpMock.expectOne('/api/content/_search');
+            expect(req.request.body.query).toBe(
+                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:*White\\-Water* +catchall:*Falls* title:"White\\-Water Falls"^15'
+            );
+            flushEmpty(req);
+        });
+
+        it('escapes Lucene special characters to prevent query injection', () => {
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: 'foo) +(contentType:UserContent',
+                    currentLanguage: 1,
+                    contentletIdentifier: undefined
+                })
+                .subscribe();
+
+            const req = httpMock.expectOne('/api/content/_search');
+            const query: string = req.request.body.query;
+            expect(query).toContain('+contentType:Blog');
+            // The injected clause must be escaped — no second un-escaped contentType
+            // restriction should reach the query.
+            expect(query).not.toMatch(/\s\+\(contentType:UserContent/);
+            expect(query).toContain('\\)');
+            expect(query).toContain('\\+\\(contentType\\:UserContent');
             flushEmpty(req);
         });
 

--- a/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.spec.ts
+++ b/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.spec.ts
@@ -1,16 +1,158 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
 import { SuggestionsService } from './suggestions.service';
 
 describe('SuggestionsService', () => {
     let service: SuggestionsService;
+    let httpMock: HttpTestingController;
 
     beforeEach(() => {
-        TestBed.configureTestingModule({ teardown: { destroyAfterEach: false } });
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [SuggestionsService],
+            teardown: { destroyAfterEach: false }
+        });
         service = TestBed.inject(SuggestionsService);
+        httpMock = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => {
+        httpMock.verify();
     });
 
     it('should be created', () => {
         expect(service).toBeTruthy();
+    });
+
+    describe('getContentlets', () => {
+        const flushEmpty = (req: { flush: (body: unknown) => void }) =>
+            req.flush({ entity: { jsonObjectView: { contentlets: [] } } });
+
+        it('builds a multi-token query that requires ALL tokens (AC2)', () => {
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: 'White Water',
+                    currentLanguage: 1,
+                    contentletIdentifier: undefined
+                })
+                .subscribe();
+
+            const req = httpMock.expectOne('/api/content/_search');
+            expect(req.request.method).toBe('POST');
+            expect(req.request.body.query).toBe(
+                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:*White* +catchall:*Water* title:"White Water"^15'
+            );
+            flushEmpty(req);
+        });
+
+        it('builds a single-word query (AC3)', () => {
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: 'Water',
+                    currentLanguage: 1,
+                    contentletIdentifier: undefined
+                })
+                .subscribe();
+
+            const req = httpMock.expectOne('/api/content/_search');
+            expect(req.request.method).toBe('POST');
+            expect(req.request.body.query).toBe(
+                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:*Water* title:"Water"^15'
+            );
+            flushEmpty(req);
+        });
+
+        it('omits catchall/title clauses for an empty filter (AC4)', () => {
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: '',
+                    currentLanguage: 1,
+                    contentletIdentifier: undefined
+                })
+                .subscribe();
+
+            const req = httpMock.expectOne('/api/content/_search');
+            expect(req.request.method).toBe('POST');
+            expect(req.request.body.query).toBe(
+                '+contentType:Blog +languageId:1 +deleted:false +working:true'
+            );
+            flushEmpty(req);
+        });
+
+        it('omits catchall/title clauses for a whitespace-only filter (AC4 edge case)', () => {
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: '   ',
+                    currentLanguage: 1,
+                    contentletIdentifier: undefined
+                })
+                .subscribe();
+
+            const req = httpMock.expectOne('/api/content/_search');
+            expect(req.request.body.query).toBe(
+                '+contentType:Blog +languageId:1 +deleted:false +working:true'
+            );
+            flushEmpty(req);
+        });
+
+        it('preserves the identifier branch for hyphenated filters (AC5)', () => {
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: 'abc-def',
+                    currentLanguage: 1,
+                    contentletIdentifier: undefined
+                })
+                .subscribe();
+
+            const req = httpMock.expectOne('/api/content/_search');
+            expect(req.request.method).toBe('POST');
+            expect(req.request.body.query).toBe(
+                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:abc-def'
+            );
+            flushEmpty(req);
+        });
+
+        it('includes the -identifier exclusion when contentletIdentifier is provided', () => {
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: 'foo',
+                    currentLanguage: 1,
+                    contentletIdentifier: 'xyz'
+                })
+                .subscribe();
+
+            const req = httpMock.expectOne('/api/content/_search');
+            expect(req.request.method).toBe('POST');
+            expect(req.request.body.query).toBe(
+                '+contentType:Blog -identifier:xyz +languageId:1 +deleted:false +working:true +catchall:*foo* title:"foo"^15'
+            );
+            flushEmpty(req);
+        });
+
+        it('maps the response to entity.jsonObjectView.contentlets', (done) => {
+            const contentlets = [{ identifier: '1' }, { identifier: '2' }];
+
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: 'foo',
+                    currentLanguage: 1,
+                    contentletIdentifier: undefined
+                })
+                .subscribe((result) => {
+                    expect(result).toEqual(contentlets);
+                    done();
+                });
+
+            const req = httpMock.expectOne('/api/content/_search');
+            req.flush({ entity: { jsonObjectView: { contentlets } } });
+        });
     });
 });

--- a/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.spec.ts
+++ b/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.spec.ts
@@ -100,11 +100,11 @@ describe('SuggestionsService', () => {
             flushEmpty(req);
         });
 
-        it('routes UUID-like filters through the identifier branch (AC5)', () => {
+        it('routes UUID-shaped filters through the identifier branch (AC5)', () => {
             service
                 .getContentlets({
                     contentType: 'Blog',
-                    filter: 'abc-def',
+                    filter: '550e8400-e29b-41d4-a716-446655440000',
                     currentLanguage: 1,
                     contentletIdentifier: undefined
                 })
@@ -113,12 +113,29 @@ describe('SuggestionsService', () => {
             const req = httpMock.expectOne('/api/content/_search');
             expect(req.request.method).toBe('POST');
             expect(req.request.body.query).toBe(
-                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:abc\\-def'
+                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:550e8400\\-e29b\\-41d4\\-a716\\-446655440000'
             );
             flushEmpty(req);
         });
 
-        it('treats hyphenated English titles as multi-token searches, not identifiers', () => {
+        it('does not treat hex-looking English words as UUIDs', () => {
+            service
+                .getContentlets({
+                    contentType: 'Blog',
+                    filter: 'dead-beef',
+                    currentLanguage: 1,
+                    contentletIdentifier: undefined
+                })
+                .subscribe();
+
+            const req = httpMock.expectOne('/api/content/_search');
+            expect(req.request.body.query).toBe(
+                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:*dead* +catchall:*beef* title:"dead\\-beef"^15'
+            );
+            flushEmpty(req);
+        });
+
+        it('splits hyphenated tokens so each piece is matched independently', () => {
             service
                 .getContentlets({
                     contentType: 'Blog',
@@ -130,7 +147,7 @@ describe('SuggestionsService', () => {
 
             const req = httpMock.expectOne('/api/content/_search');
             expect(req.request.body.query).toBe(
-                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:*White\\-Water* +catchall:*Falls* title:"White\\-Water Falls"^15'
+                '+contentType:Blog +languageId:1 +deleted:false +working:true +catchall:*White* +catchall:*Water* +catchall:*Falls* title:"White\\-Water Falls"^15'
             );
             flushEmpty(req);
         });
@@ -162,14 +179,14 @@ describe('SuggestionsService', () => {
                     contentType: 'Blog',
                     filter: 'foo',
                     currentLanguage: 1,
-                    contentletIdentifier: 'xyz'
+                    contentletIdentifier: '550e8400-e29b-41d4-a716-446655440000'
                 })
                 .subscribe();
 
             const req = httpMock.expectOne('/api/content/_search');
             expect(req.request.method).toBe('POST');
             expect(req.request.body.query).toBe(
-                '+contentType:Blog -identifier:xyz +languageId:1 +deleted:false +working:true +catchall:*foo* title:"foo"^15'
+                '+contentType:Blog -identifier:550e8400\\-e29b\\-41d4\\-a716\\-446655440000 +languageId:1 +deleted:false +working:true +catchall:*foo* title:"foo"^15'
             );
             flushEmpty(req);
         });

--- a/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.ts
+++ b/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.ts
@@ -9,14 +9,16 @@ import { DotCMSContentlet, DotCMSContentType } from '@dotcms/dotcms-models';
 
 import { ContentletFilters, DEFAULT_LANG_ID } from '../../../shared';
 
-// Hex-only segments separated by hyphens. Narrow enough to skip ordinary
-// hyphenated English titles ("self-care", "White-Water Falls"), which must go
-// through the regular tokenized search path instead of the identifier branch.
-const UUID_LIKE = /^[0-9a-f]+(-[0-9a-f]+)+$/i;
+// Strict UUID-v4 shape (8-4-4-4-12 hex). Only real identifiers route through
+// the no-wildcard branch; hex-looking English titles like "ace-cafe" or
+// "dead-beef" still go through the regular tokenized search path.
+const UUID_LIKE = /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i;
 
-const LUCENE_SPECIAL_CHARS = /(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|:|\\|\/)/g;
+// Lucene query-syntax characters that must be escaped before user input is
+// interpolated into a query string.
+const LUCENE_SPECIAL_CHARS = /[+\-!(){}[\]^"~*?:\\/&|]/g;
 
-const escapeLucene = (value: string): string => value.replace(LUCENE_SPECIAL_CHARS, '\\$1');
+const escapeLucene = (value: string): string => value.replace(LUCENE_SPECIAL_CHARS, '\\$&');
 
 @Injectable()
 export class SuggestionsService {
@@ -49,7 +51,9 @@ export class SuggestionsService {
         currentLanguage,
         contentletIdentifier
     }: ContentletFilters): Observable<DotCMSContentlet[]> {
-        const identifierQuery = contentletIdentifier ? `-identifier:${contentletIdentifier}` : '';
+        const identifierQuery = contentletIdentifier
+            ? `-identifier:${escapeLucene(contentletIdentifier)}`
+            : '';
         const trimmedFilter = filter.trim();
 
         let searchClauses = '';
@@ -57,9 +61,12 @@ export class SuggestionsService {
             // Identifier/UUID branch: single mandatory clause, no wildcards or title boost.
             searchClauses = `+catchall:${escapeLucene(trimmedFilter)}`;
         } else if (trimmedFilter.length > 0) {
-            // Tokenize on whitespace so multi-word queries require ALL tokens to match.
+            // Split on whitespace OR hyphen — Lucene's standard analyzer indexes
+            // hyphens as separators, so a wildcard over a hyphenated token would
+            // never match. Each piece becomes its own mandatory wildcard clause.
             const tokenClauses = trimmedFilter
-                .split(/\s+/)
+                .split(/[-\s]+/)
+                .filter((token) => token.length > 0)
                 .map((token) => `+catchall:*${escapeLucene(token)}*`)
                 .join(' ');
             searchClauses = `${tokenClauses} title:"${escapeLucene(trimmedFilter)}"^15`;

--- a/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.ts
+++ b/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.ts
@@ -9,6 +9,15 @@ import { DotCMSContentlet, DotCMSContentType } from '@dotcms/dotcms-models';
 
 import { ContentletFilters, DEFAULT_LANG_ID } from '../../../shared';
 
+// Hex-only segments separated by hyphens. Narrow enough to skip ordinary
+// hyphenated English titles ("self-care", "White-Water Falls"), which must go
+// through the regular tokenized search path instead of the identifier branch.
+const UUID_LIKE = /^[0-9a-f]+(-[0-9a-f]+)+$/i;
+
+const LUCENE_SPECIAL_CHARS = /(\+|-|&&|\|\||!|\(|\)|\{|\}|\[|\]|\^|"|~|\*|\?|:|\\|\/)/g;
+
+const escapeLucene = (value: string): string => value.replace(LUCENE_SPECIAL_CHARS, '\\$1');
+
 @Injectable()
 export class SuggestionsService {
     private readonly http = inject(HttpClient);
@@ -41,20 +50,19 @@ export class SuggestionsService {
         contentletIdentifier
     }: ContentletFilters): Observable<DotCMSContentlet[]> {
         const identifierQuery = contentletIdentifier ? `-identifier:${contentletIdentifier}` : '';
+        const trimmedFilter = filter.trim();
 
         let searchClauses = '';
-        if (filter.includes('-')) {
-            // Preserve identifier/UUID branch: single mandatory clause, no wildcards.
-            searchClauses = `+catchall:${filter}`;
-        } else if (filter.trim().length > 0) {
+        if (UUID_LIKE.test(trimmedFilter)) {
+            // Identifier/UUID branch: single mandatory clause, no wildcards or title boost.
+            searchClauses = `+catchall:${escapeLucene(trimmedFilter)}`;
+        } else if (trimmedFilter.length > 0) {
             // Tokenize on whitespace so multi-word queries require ALL tokens to match.
-            const tokenClauses = filter
-                .trim()
+            const tokenClauses = trimmedFilter
                 .split(/\s+/)
-                .filter((token) => token.length > 0)
-                .map((token) => `+catchall:*${token}*`)
+                .map((token) => `+catchall:*${escapeLucene(token)}*`)
                 .join(' ');
-            searchClauses = `${tokenClauses} title:"${filter}"^15`;
+            searchClauses = `${tokenClauses} title:"${escapeLucene(trimmedFilter)}"^15`;
         }
 
         const query = [

--- a/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.ts
+++ b/core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.ts
@@ -41,13 +41,38 @@ export class SuggestionsService {
         contentletIdentifier
     }: ContentletFilters): Observable<DotCMSContentlet[]> {
         const identifierQuery = contentletIdentifier ? `-identifier:${contentletIdentifier}` : '';
-        const search = filter.includes('-') ? filter : `*${filter}*`;
+
+        let searchClauses = '';
+        if (filter.includes('-')) {
+            // Preserve identifier/UUID branch: single mandatory clause, no wildcards.
+            searchClauses = `+catchall:${filter}`;
+        } else if (filter.trim().length > 0) {
+            // Tokenize on whitespace so multi-word queries require ALL tokens to match.
+            const tokenClauses = filter
+                .trim()
+                .split(/\s+/)
+                .filter((token) => token.length > 0)
+                .map((token) => `+catchall:*${token}*`)
+                .join(' ');
+            searchClauses = `${tokenClauses} title:"${filter}"^15`;
+        }
+
+        const query = [
+            `+contentType:${contentType}`,
+            identifierQuery,
+            `+languageId:${currentLanguage}`,
+            `+deleted:false`,
+            `+working:true`,
+            searchClauses
+        ]
+            .filter((part) => part.length > 0)
+            .join(' ');
 
         return this.http
             .post<{
                 entity: { jsonObjectView: { contentlets: DotCMSContentlet[] } };
             }>('/api/content/_search', {
-                query: `+contentType:${contentType} ${identifierQuery} +languageId:${currentLanguage} +deleted:false +working:true +catchall:${search} title:'${filter}'^15`,
+                query,
                 sort: 'modDate desc',
                 offset: 0,
                 limit: 40


### PR DESCRIPTION
## Summary

Fixes the Block Editor contentlet search to support multi-word queries with spaces.

When typing inside the Block Editor's contentlet picker (after `/` → Contentlets → \<ContentType\>), spaces appear in the input but the result list does not refine. Root cause: `SuggestionsService.getContentlets` interpolated the user filter into `+catchall:*${filter}* title:'${filter}'^15`. With a multi-word filter like `White Water`, Lucene parses `+catchall:*White Water*` as two terms — `+catchall:*White` (mandatory) plus `Water*` (optional) — so the query degrades to a single-word filter on the first token only. The single-quoted title clause is also broken (Lucene phrase queries require double quotes).


https://github.com/user-attachments/assets/250dcb6b-3eb4-4758-8230-edd055abe303



## Fix

In `suggestions.service.ts` (`getContentlets`):
- Tokenize the filter on whitespace and emit one mandatory `+catchall:*token*` clause per token, joined with spaces. Multi-word queries now require ALL tokens to match.
- Switch the title boost from `title:'${filter}'^15` to `title:"${filter}"^15` for proper Lucene phrase semantics.
- Compose the final query via array + filter + join so empty parts (e.g. missing `identifierQuery`) don't introduce double spaces.
- Empty / whitespace-only filters omit the catchall and title clauses entirely.
- Hyphen-bearing filters keep the existing identifier branch unchanged (`+catchall:${filter}`, no wildcards).

## Closes

Closes #34416

## Acceptance Criteria

- [x] Search input accepts space characters (was already preserved by TipTap; the fix targets the resulting query).
- [x] Multi-word query (e.g., `White Water`) narrows results to contentlets matching ALL tokens.
- [x] Single-word query still works — no regression.
- [x] Empty filter returns the default contentlet list (no catchall/title clauses emitted).
- [x] Filter containing `-` preserves the identifier branch.

## Test Plan

Automated tests added in `suggestions.service.spec.ts` (now 8 tests, was 1) using `HttpTestingController` to assert the exact `query` string sent to `/api/content/_search` for: multi-word, single-word, empty, whitespace-only, hyphen, and `contentletIdentifier` exclusion cases, plus response mapping.

Manual verification:
- [ ] Open a content type with a Block Editor field, type `/`, choose Contentlets → Activity.
- [ ] Type `White Water` — list filters to contentlets containing both words (e.g., White Water Rafting).
- [ ] Type `Water` — single-word search still works.
- [ ] Clear the filter — full default list returns.

## Changed Files

- `core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.ts`
- `core-web/libs/block-editor/src/lib/shared/services/suggestions/suggestions.service.spec.ts`
- `core-web/libs/block-editor/src/lib/elements/dot-bubble-menu/dot-bubble-menu.component.spec.ts` *(drive-by: 1-line import order fix to satisfy `nx affected:lint`)*

## Visual Changes

User-facing behavior change in the Block Editor contentlet search popup; the visual UI itself is unchanged. A before/after screen recording can be shared if needed.