### PR TITLE
fix(edit-content): keep CATEGORY form value as array across workflow rebuilds

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.ts
@@ -92,15 +92,6 @@ export class DotCategoryFieldComponent
      * @memberof DotEditContentCategoryFieldComponent
      */
     ngOnInit(): void {
-        // `store.load()` reads selected categories directly from the contentlet
-        // — that is the single source of truth on mount. We intentionally do NOT
-        // wire `handleChangeValue` (writeValue → store) anymore: when the parent
-        // form is rebuilt (e.g. after a reset-workflow subaction changes the
-        // contentlet's modDate), writeValue and load() ran in parallel and both
-        // hit `setSelectedFromInodes`. A racing empty/early-exit branch could
-        // set `selected: []` and `state: LOADED`, causing the effect below to
-        // emit `onChange([])` and blank the form control — even though chips
-        // were still rendered from the in-flight load result.
         this.store.load({
             field: this.$field(),
             contentlet: this.$contentlet()
@@ -144,26 +135,6 @@ export class DotCategoryFieldComponent
         this.onTouched();
     }
 
-    /**
-     * When the parent form is rebuilt (e.g. after a reset-workflow subaction
-     * patches the contentlet with a new modDate), this component instance is
-     * reused but the new form control writes its raw initial value — a CSV
-     * string produced by `castSingleSelectableValue`, not the inode array the
-     * LOADED effect last emitted. Because `store.state()` doesn't change on
-     * reuse (it's already LOADED), the effect won't refire and the form keeps
-     * the stale string, which `processFormValue` later turns into `[]`,
-     * blanking required category fields on save.
-     *
-     * On every writeValue, if the store already has selected categories from
-     * a prior load, push their inodes back into the form control to keep it
-     * in sync with the visible chips. The onChange call is deferred to a
-     * microtask because writeValue is invoked synchronously inside
-     * `FormGroupDirective._updateDomValue` -> `setUpControl(...)`, BEFORE
-     * Angular assigns `dir.control = newCtrl`. Calling onChange synchronously
-     * inside setUpControl walks through `viewToModelUpdate` and dereferences
-     * the not-yet-assigned `dir.control`, throwing
-     * "no FormControl instance attached".
-     */
     override writeValue(value: string[]): void {
         super.writeValue(value);
 
@@ -180,6 +151,8 @@ export class DotCategoryFieldComponent
             return;
         }
 
+        // Defer to microtask: Angular calls writeValue from setUpControl
+        // BEFORE assigning dir.control, so a sync onChange throws.
         queueMicrotask(() => this.onChange(inodes));
     }
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.ts
@@ -22,6 +22,7 @@ import { DotCategoryFieldDialogComponent } from './../dot-category-field-dialog/
 import { BaseControlValueAccessor } from '../../../shared/base-control-value-accesor';
 import { CategoriesService } from '../../services/categories.service';
 import { CategoryFieldStore } from '../../store/content-category-field.store';
+import { sameInodes } from '../../utils/category-field.utils';
 
 /**
  * @class
@@ -155,18 +156,4 @@ export class DotCategoryFieldComponent
         // BEFORE assigning dir.control, so a sync onChange throws.
         queueMicrotask(() => this.onChange(inodes));
     }
-}
-
-function sameInodes(value: string[], inodes: string[]): boolean {
-    if (value.length !== inodes.length) {
-        return false;
-    }
-
-    for (let i = 0; i < inodes.length; i++) {
-        if (value[i] !== inodes[i]) {
-            return false;
-        }
-    }
-
-    return true;
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.ts
@@ -1,5 +1,3 @@
-import { signalMethod } from '@ngrx/signals';
-
 import {
     ChangeDetectionStrategy,
     Component,
@@ -88,19 +86,21 @@ export class DotCategoryFieldComponent
      */
     $hasSelectedCategories = computed(() => this.store.selected().length > 0);
 
-    constructor() {
-        super();
-        this.handleChangeValue(this.$value);
-    }
-
     /**
      * Initialize the component.
      *
      * @memberof DotEditContentCategoryFieldComponent
      */
     ngOnInit(): void {
-        // Initialize the store with field information only
-        // The contentlet data will come through ControlValueAccessor's writeValue
+        // `store.load()` reads selected categories directly from the contentlet
+        // — that is the single source of truth on mount. We intentionally do NOT
+        // wire `handleChangeValue` (writeValue → store) anymore: when the parent
+        // form is rebuilt (e.g. after a reset-workflow subaction changes the
+        // contentlet's modDate), writeValue and load() ran in parallel and both
+        // hit `setSelectedFromInodes`. A racing empty/early-exit branch could
+        // set `selected: []` and `state: LOADED`, causing the effect below to
+        // emit `onChange([])` and blank the form control — even though chips
+        // were still rendered from the in-flight load result.
         this.store.load({
             field: this.$field(),
             contentlet: this.$contentlet()
@@ -144,18 +144,56 @@ export class DotCategoryFieldComponent
         this.onTouched();
     }
 
-    readonly handleChangeValue = signalMethod<string[]>((value) => {
-        if (!value) {
-            this.store.setSelectedFromInodes([]);
+    /**
+     * When the parent form is rebuilt (e.g. after a reset-workflow subaction
+     * patches the contentlet with a new modDate), this component instance is
+     * reused but the new form control writes its raw initial value — a CSV
+     * string produced by `castSingleSelectableValue`, not the inode array the
+     * LOADED effect last emitted. Because `store.state()` doesn't change on
+     * reuse (it's already LOADED), the effect won't refire and the form keeps
+     * the stale string, which `processFormValue` later turns into `[]`,
+     * blanking required category fields on save.
+     *
+     * On every writeValue, if the store already has selected categories from
+     * a prior load, push their inodes back into the form control to keep it
+     * in sync with the visible chips. The onChange call is deferred to a
+     * microtask because writeValue is invoked synchronously inside
+     * `FormGroupDirective._updateDomValue` -> `setUpControl(...)`, BEFORE
+     * Angular assigns `dir.control = newCtrl`. Calling onChange synchronously
+     * inside setUpControl walks through `viewToModelUpdate` and dereferences
+     * the not-yet-assigned `dir.control`, throwing
+     * "no FormControl instance attached".
+     */
+    override writeValue(value: string[]): void {
+        super.writeValue(value);
 
+        if (this.store.state() !== ComponentStatus.LOADED) {
             return;
         }
 
-        if (!Array.isArray(value)) {
+        const inodes = this.store.selected().map((category) => category.inode);
+        if (inodes.length === 0) {
             return;
         }
 
-        // Update store with the new value
-        this.store.setSelectedFromInodes(value);
-    });
+        if (Array.isArray(value) && sameInodes(value, inodes)) {
+            return;
+        }
+
+        queueMicrotask(() => this.onChange(inodes));
+    }
+}
+
+function sameInodes(value: string[], inodes: string[]): boolean {
+    if (value.length !== inodes.length) {
+        return false;
+    }
+
+    for (let i = 0; i < inodes.length; i++) {
+        if (value[i] !== inodes[i]) {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.spec.ts
@@ -8,6 +8,7 @@ import {
     getSelectedFromContentlet,
     removeEmptyArrays,
     removeItemByKey,
+    sameInodes,
     transformCategories,
     updateChecked,
     getMenuItemsFromKeyParentPath
@@ -646,6 +647,28 @@ describe('CategoryFieldUtils', () => {
             const array: DotCategory[][] = [[], [], []];
             const result = removeEmptyArrays(array);
             expect(result).toEqual([]);
+        });
+    });
+
+    describe('sameInodes', () => {
+        it('should return true for equal arrays in the same order', () => {
+            expect(sameInodes(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(true);
+        });
+
+        it('should return true for equal arrays in different order', () => {
+            expect(sameInodes(['a', 'b', 'c'], ['c', 'a', 'b'])).toBe(true);
+        });
+
+        it('should return false when arrays differ in length', () => {
+            expect(sameInodes(['a', 'b'], ['a', 'b', 'c'])).toBe(false);
+        });
+
+        it('should return false when arrays have the same length but different members', () => {
+            expect(sameInodes(['a', 'b', 'c'], ['a', 'b', 'd'])).toBe(false);
+        });
+
+        it('should return true for two empty arrays', () => {
+            expect(sameInodes([], [])).toBe(true);
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/utils/category-field.utils.ts
@@ -293,3 +293,25 @@ export const getMenuItemsFromKeyParentPath = (
 export const removeEmptyArrays = (array: DotCategory[][]): DotCategory[][] => {
     return array.filter((item) => item.length > 0);
 };
+
+/**
+ * Shallowly compares two arrays of inode strings, ignoring order.
+ *
+ * Used by the category field's `ControlValueAccessor` to short-circuit
+ * `writeValue` when the value the form is writing already matches the
+ * inodes the store has selected, avoiding spurious `onChange` emissions
+ * after a form rebuild (e.g. workflow action).
+ *
+ * @param value - Inodes coming from the form (`writeValue` argument).
+ * @param inodes - Inodes currently selected in the store.
+ * @returns `true` when both arrays contain the same inodes, regardless of order.
+ */
+export const sameInodes = (value: string[], inodes: string[]): boolean => {
+    if (value.length !== inodes.length) {
+        return false;
+    }
+
+    const set = new Set(value);
+
+    return inodes.every((inode) => set.has(inode));
+};

--- a/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.constant.ts
+++ b/core-web/libs/edit-content/src/lib/models/dot-edit-content-field.constant.ts
@@ -18,7 +18,11 @@ export const FLATTENED_FIELD_TYPES = [
     FIELD_TYPES.TAG
 ];
 
-export const UNCASTED_FIELD_TYPES = [FIELD_TYPES.BLOCK_EDITOR, FIELD_TYPES.KEY_VALUE];
+export const UNCASTED_FIELD_TYPES = [
+    FIELD_TYPES.BLOCK_EDITOR,
+    FIELD_TYPES.KEY_VALUE,
+    FIELD_TYPES.CATEGORY
+];
 
 export const TAB_FIELD_CLAZZ = 'com.dotcms.contenttype.model.field.ImmutableTabDividerField';
 


### PR DESCRIPTION
## Parent Issue
Fixes #35529

## Proposed Changes

In the **new Edit Content experience**, after firing any workflow action that re-fetches the contentlet (Reset Workflow, or any subaction that updates the contentlet's `modDate`), required CATEGORY fields visually retained their selected chips but the form control's value silently reverted to a CSV string. The next save coerced that string to `[]` and the backend rejected with `"field required"` for required category fields. A secondary symptom — an Angular `"There is no FormControl instance attached"` error during form rebind — left some sibling inputs visually stuck in a disabled / loading state.

Two related fixes in `libs/edit-content`:

1. **`dot-edit-content-field.constant.ts`** — Add `FIELD_TYPES.CATEGORY` to `UNCASTED_FIELD_TYPES`. `categoryResolutionFn` returns an array of category keys, but it was being routed through `castSingleSelectableValue` (intended for radio/select/checkbox single-value fields), which falls into `String(value)` and produces a CSV string. The CSV intermediate had no consumer — the store ignores the form's initial value and reads the contentlet directly — but `processFormValue` was silently turning the unrecovered string into `[]`. Keeping the array shape end-to-end is also defense in depth: if the LOADED-state effect ever fails to upgrade keys to inodes, the form sends keys instead of an empty array.

2. **`dot-category-field.component.ts`** — Override `writeValue` to re-emit inodes after a form rebuild. Angular's `formGroup` directive does not destroy the `dot-category-field` on rebind — the same component instance is reused with a new `FormControl`. The store stays in `LOADED` state from the first mount, so the LOADED effect doesn't refire and never pushes the inodes back into the new control. The `onChange` call is deferred to a microtask because `writeValue` is invoked synchronously inside `FormGroupDirective._updateDomValue → setUpControl(...)`, **before** Angular assigns `dir.control = newCtrl`; calling `onChange` synchronously dereferences the not-yet-assigned `dir.control` and throws `"no FormControl instance attached"`, which aborted the rebind loop and left sibling controls in their stale `form.disable()` state.

The constructor's `handleChangeValue($value)` was also removed — it wired a `signalMethod` that fed `writeValue` back into the store, duplicating what `store.load()` already does from the contentlet, and was misnamed (`setSelectedFromInodes` was actually being called with keys, not inodes).

## Why is this important

- Restores save functionality for any user editing content with required CATEGORY fields after running a workflow action — currently a hard block.
- Removes a silent "form looks fine, save fails" failure mode that's confusing to debug.
- Eliminates a console-level Angular error that was masking the secondary "stuck disabled inputs" issue.

## Quality Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation. (No docs needed)
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective. (See verification below)
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published.

## Additional Information

**Verified end-to-end in the new edit-content UI**, with `dot-category-field` instances on a Job Aid Article contentlet (required `audience` and `navigationLocation`):

| Step | Action | Result |
|---|---|---|
| 1 | Modify title + Publish | 200 OK, new inode |
| 2 | Click Reset Workflow | Form values stay as arrays of inodes; no inputs stuck disabled |
| 3 | Modify title | OK |
| 4 | Click Publish | 200 OK, no `"field required"` error, no console errors |

Form-control inspection after Reset Workflow:
```js
{ audience: ["ae4f244a...", "e046cc15..."],
  navigationLocation: ["98114998...", "27d24583..."],
  formValid: true,
  cats: [{ fld: "navigationLocation", isDis: false, sigVal: ["jobAidsA","jobAidsB"] },
         { fld: "audience", isDis: false, sigVal: ["audienceA","audienceB"] }] }
```

`sigVal` is now an array of keys instead of the previous CSV string `"jobAidsA,jobAidsB"` — confirming the cast is gone.

**Tests:** All `category` test suites pass (`yarn nx test edit-content --testPathPattern=category` → 1809 passed). The single failing test in the broader edit-content run (`calendar-field.util.spec.ts` — "now" handling) is a pre-existing flake unrelated to this change.

This PR fixes: #35529