### PR TITLE
fix(folders): include source and target in COPY_FOLDER/MOVE_FOLDER payloads (#35225)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/browser/BrowserQuery.java
+++ b/dotCMS/src/main/java/com/dotcms/browser/BrowserQuery.java
@@ -203,7 +203,11 @@ public class BrowserQuery {
         if (null == folderObj || UtilMethods.isEmpty(folderObj.getIdentifier()) || null == siteObj || UtilMethods.isEmpty(siteObj.getIdentifier())) {
             final String errorMsg = String.format("Parent ID '%s' [ %s ] does not match any existing Folder or Site.",
                     parentId, siteId);
-            Logger.error(this, errorMsg + ". Maybe the Site/Folder was modified or deleted in the background. If " +
+            // Logged at warn rather than error because this is typically a transient
+            // race after a folder copy/move/delete: the client refreshes with a now-stale
+            // parent ID before the corresponding system event reaches it. The thrown
+            // DotRuntimeException still surfaces to the caller so the UI can recover.
+            Logger.warn(this, errorMsg + ". Maybe the Site/Folder was modified or deleted in the background. If " +
                                        "System Folder is specified, then set a value for hostIdSystemFolder as well.");
             throw new DotRuntimeException(errorMsg);
         }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -920,10 +920,9 @@ public class FolderAPIImpl implements FolderAPI  {
 		final Optional<Folder> newFolder = folderFactory.move(folderToMove, newParentFolder);
 
 		if (newFolder.isPresent()) {
-			this.systemEventsAPI.pushAsync(SystemEventType.MOVE_FOLDER, new Payload(
-					buildSourceTargetPayload(folderToMove, newFolder.get()),
-					Visibility.EXCLUDE_OWNER,
-					new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
+			final Folder targetFolder = newFolder.get();
+			HibernateUtil.addCommitListener(
+					Sneaky.sneaked(() -> sendMoveFolderSystemEvent(folderToMove, targetFolder, user)), 1000);
 		}
 
 		return newFolder.isPresent();
@@ -1058,7 +1057,13 @@ public class FolderAPIImpl implements FolderAPI  {
 	}
 
 	private static Map<String, Object> buildSourceTargetPayload(final Folder source, final Folder target) {
-		return Map.of("source", toEventFields(source), "target", toEventFields(target));
+		// Promote source fields to the top level so PermissionVerifier — which builds a
+		// Contentlet from payload.getData() and reads "identifier" — can still gate
+		// websocket delivery against the source folder.
+		final Map<String, Object> payload = new HashMap<>(toEventFields(source));
+		payload.put("source", toEventFields(source));
+		payload.put("target", toEventFields(target));
+		return payload;
 	}
 
 	private static Map<String, Object> toEventFields(final Folder folder) {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -379,7 +379,7 @@ public class FolderAPIImpl implements FolderAPI  {
 		final Folder newFolder = folderFactory.copy(folderToCopy, newParentFolder);
 
 		this.systemEventsAPI.pushAsync(SystemEventType.COPY_FOLDER, new Payload(
-				Map.of("source", folderToCopy.getMap(), "target", newFolder.getMap()),
+				buildSourceTargetPayload(folderToCopy, newFolder),
 				Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 	}
@@ -401,7 +401,7 @@ public class FolderAPIImpl implements FolderAPI  {
 		final Folder newFolder = folderFactory.copy(folderToCopy, newParentHost);
 
 		this.systemEventsAPI.pushAsync(SystemEventType.COPY_FOLDER, new Payload(
-				Map.of("source", folderToCopy.getMap(), "target", newFolder.getMap()),
+				buildSourceTargetPayload(folderToCopy, newFolder),
 				Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 	}
@@ -921,7 +921,7 @@ public class FolderAPIImpl implements FolderAPI  {
 
 		if (newFolder.isPresent()) {
 			this.systemEventsAPI.pushAsync(SystemEventType.MOVE_FOLDER, new Payload(
-					Map.of("source", folderToMove.getMap(), "target", newFolder.get().getMap()),
+					buildSourceTargetPayload(folderToMove, newFolder.get()),
 					Visibility.EXCLUDE_OWNER,
 					new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 		}
@@ -1052,9 +1052,23 @@ public class FolderAPIImpl implements FolderAPI  {
 			throws DotDataException, DotSecurityException {
 
 		this.systemEventsAPI.pushAsync(SystemEventType.MOVE_FOLDER, new Payload(
-				Map.of("source", folderToMove.getMap(), "target", newFolder.getMap()),
+				buildSourceTargetPayload(folderToMove, newFolder),
 				Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
+	}
+
+	private static Map<String, Object> buildSourceTargetPayload(final Folder source, final Folder target) {
+		return Map.of("source", toEventFields(source), "target", toEventFields(target));
+	}
+
+	private static Map<String, Object> toEventFields(final Folder folder) {
+		final Map<String, Object> fields = new HashMap<>();
+		fields.put("identifier", folder.getIdentifier());
+		fields.put("inode", folder.getInode());
+		fields.put("path", folder.getPath());
+		fields.put("name", folder.getName());
+		fields.put("hostId", folder.getHostId());
+		return fields;
 	}
 
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -48,6 +48,7 @@ import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.db.FlushCacheRunnable;
 import com.dotmarketing.db.HibernateUtil;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotHibernateException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
@@ -376,12 +377,9 @@ public class FolderAPIImpl implements FolderAPI  {
 			throw new DotSecurityException("User " + (user.getUserId() != null?user.getUserId():BLANK) + " does not have permission to add to Folder " + newParentFolder.getPath());
 		}
 
+		final Map<String, Object> sourceFields = toEventFields(folderToCopy);
 		final Folder newFolder = folderFactory.copy(folderToCopy, newParentFolder);
-
-		this.systemEventsAPI.pushAsync(SystemEventType.COPY_FOLDER, new Payload(
-				buildSourceTargetPayload(folderToCopy, newFolder),
-				Visibility.EXCLUDE_OWNER,
-				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
+		emitFolderEventOnCommit(SystemEventType.COPY_FOLDER, sourceFields, toEventFields(newFolder), user);
 	}
 
 	@WrapInTransaction
@@ -398,12 +396,9 @@ public class FolderAPIImpl implements FolderAPI  {
 		}
 
 		validateFolderName(folderToCopy);
+		final Map<String, Object> sourceFields = toEventFields(folderToCopy);
 		final Folder newFolder = folderFactory.copy(folderToCopy, newParentHost);
-
-		this.systemEventsAPI.pushAsync(SystemEventType.COPY_FOLDER, new Payload(
-				buildSourceTargetPayload(folderToCopy, newFolder),
-				Visibility.EXCLUDE_OWNER,
-				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
+		emitFolderEventOnCommit(SystemEventType.COPY_FOLDER, sourceFields, toEventFields(newFolder), user);
 	}
 
 	@CloseDBIfOpened
@@ -917,12 +912,16 @@ public class FolderAPIImpl implements FolderAPI  {
 		if (!permissionAPI.doesUserHavePermission(newParentFolder, PermissionAPI.PERMISSION_CAN_ADD_CHILDREN, user, respectFrontEndPermissions)) {
 			throw new DotSecurityException("User " + (user.getUserId() != null?user.getUserId():BLANK) + " does not have permission to add to Folder " + newParentFolder.getName());
 		}
+		// Snapshot source fields BEFORE folderFactory.move() — the source folder's
+		// DB row is deleted as part of the move, after which lazy lookups on the
+		// in-memory Folder (e.g. getPath() falling back to IdentifierAPI.find) would
+		// silently produce nulls in the event payload.
+		final Map<String, Object> sourceFields = toEventFields(folderToMove);
 		final Optional<Folder> newFolder = folderFactory.move(folderToMove, newParentFolder);
 
 		if (newFolder.isPresent()) {
-			final Folder targetFolder = newFolder.get();
-			HibernateUtil.addCommitListener(
-					Sneaky.sneaked(() -> sendMoveFolderSystemEvent(folderToMove, targetFolder, user)), 1000);
+			emitFolderEventOnCommit(SystemEventType.MOVE_FOLDER,
+					sourceFields, toEventFields(newFolder.get()), user);
 		}
 
 		return newFolder.isPresent();
@@ -944,11 +943,14 @@ public class FolderAPIImpl implements FolderAPI  {
 			throw new DotSecurityException("User " + (user.getUserId() != null?user.getUserId():BLANK) + " does not have permission to add to Folder " + newParentHost.getHostname());
 		}
 
+		// Snapshot source fields BEFORE folderFactory.move() — see comment in the
+		// Folder→Folder overload for why this matters.
+		final Map<String, Object> sourceFields = toEventFields(folderToMove);
 		final Optional<Folder> newFolder = folderFactory.move(folderToMove, newParentHost);
 
 		if (newFolder.isPresent()) {
-			HibernateUtil.addCommitListener(
-					Sneaky.sneaked(() -> sendMoveFolderSystemEvent(folderToMove, newFolder.get(), user)), 1000);
+			emitFolderEventOnCommit(SystemEventType.MOVE_FOLDER,
+					sourceFields, toEventFields(newFolder.get()), user);
 		}
 
 		return newFolder.isPresent();
@@ -1047,22 +1049,28 @@ public class FolderAPIImpl implements FolderAPI  {
 		});
 	}
 
-	private void sendMoveFolderSystemEvent(final Folder folderToMove, final Folder newFolder, final User user)
-			throws DotDataException, DotSecurityException {
-
-		this.systemEventsAPI.pushAsync(SystemEventType.MOVE_FOLDER, new Payload(
-				buildSourceTargetPayload(folderToMove, newFolder),
-				Visibility.EXCLUDE_OWNER,
-				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
+	private void emitFolderEventOnCommit(final SystemEventType type,
+										 final Map<String, Object> sourceFields,
+										 final Map<String, Object> targetFields,
+										 final User user) throws DotHibernateException {
+		final Map<String, Object> payload = buildSourceTargetPayload(sourceFields, targetFields);
+		HibernateUtil.addCommitListener(Sneaky.sneaked(() ->
+				this.systemEventsAPI.pushAsync(type, new Payload(payload, Visibility.EXCLUDE_OWNER,
+						new ExcludeOwnerVerifierBean(user.getUserId(),
+								PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)))), 1000);
 	}
 
-	private static Map<String, Object> buildSourceTargetPayload(final Folder source, final Folder target) {
-		// Promote source fields to the top level so PermissionVerifier — which builds a
-		// Contentlet from payload.getData() and reads "identifier" — can still gate
-		// websocket delivery against the source folder.
-		final Map<String, Object> payload = new HashMap<>(toEventFields(source));
-		payload.put("source", toEventFields(source));
-		payload.put("target", toEventFields(target));
+	private static Map<String, Object> buildSourceTargetPayload(final Map<String, Object> sourceFields,
+																final Map<String, Object> targetFields) {
+		// PermissionVerifier wraps payload.getData() in a Contentlet and reads
+		// "identifier" to resolve the Permissionable. Folder.getPermissionId() returns
+		// the inode, so we explicitly use the source folder's inode for the top-level
+		// "identifier" key. In modern dotCMS folder.identifier == folder.inode, but
+		// this guards the verifier path against any future divergence.
+		final Map<String, Object> payload = new HashMap<>(sourceFields);
+		payload.put("identifier", sourceFields.get("inode"));
+		payload.put("source", sourceFields);
+		payload.put("target", targetFields);
 		return payload;
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -1064,11 +1064,13 @@ public class FolderAPIImpl implements FolderAPI  {
 																final Map<String, Object> targetFields) {
 		// PermissionVerifier wraps payload.getData() in a Contentlet and reads
 		// "identifier" to resolve the Permissionable. Folder.getPermissionId() returns
-		// the inode, so we explicitly use the source folder's inode for the top-level
-		// "identifier" key. In modern dotCMS folder.identifier == folder.inode, but
-		// this guards the verifier path against any future divergence.
+		// the inode, so the top-level "identifier" must hold the inode value rather
+		// than the folder's actual identifier. We deliberately overwrite the entry
+		// copied from sourceFields here — in modern dotCMS folder.identifier ==
+		// folder.inode so the values match today, but this guards the verifier path
+		// against any future divergence.
 		final Map<String, Object> payload = new HashMap<>(sourceFields);
-		payload.put("identifier", sourceFields.get("inode"));
+		payload.put("identifier", sourceFields.get("inode")); // intentional overwrite
 		payload.put("source", sourceFields);
 		payload.put("target", targetFields);
 		return payload;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderAPIImpl.java
@@ -82,6 +82,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.TimeZone;
@@ -375,9 +376,11 @@ public class FolderAPIImpl implements FolderAPI  {
 			throw new DotSecurityException("User " + (user.getUserId() != null?user.getUserId():BLANK) + " does not have permission to add to Folder " + newParentFolder.getPath());
 		}
 
-		folderFactory.copy(folderToCopy, newParentFolder);
+		final Folder newFolder = folderFactory.copy(folderToCopy, newParentFolder);
 
-		this.systemEventsAPI.pushAsync(SystemEventType.COPY_FOLDER, new Payload(folderToCopy.getMap(), Visibility.EXCLUDE_OWNER,
+		this.systemEventsAPI.pushAsync(SystemEventType.COPY_FOLDER, new Payload(
+				Map.of("source", folderToCopy.getMap(), "target", newFolder.getMap()),
+				Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 	}
 
@@ -395,9 +398,11 @@ public class FolderAPIImpl implements FolderAPI  {
 		}
 
 		validateFolderName(folderToCopy);
-		folderFactory.copy(folderToCopy, newParentHost);
+		final Folder newFolder = folderFactory.copy(folderToCopy, newParentHost);
 
-		this.systemEventsAPI.pushAsync(SystemEventType.COPY_FOLDER, new Payload(folderToCopy.getMap(), Visibility.EXCLUDE_OWNER,
+		this.systemEventsAPI.pushAsync(SystemEventType.COPY_FOLDER, new Payload(
+				Map.of("source", folderToCopy.getMap(), "target", newFolder.getMap()),
+				Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 	}
 
@@ -912,12 +917,16 @@ public class FolderAPIImpl implements FolderAPI  {
 		if (!permissionAPI.doesUserHavePermission(newParentFolder, PermissionAPI.PERMISSION_CAN_ADD_CHILDREN, user, respectFrontEndPermissions)) {
 			throw new DotSecurityException("User " + (user.getUserId() != null?user.getUserId():BLANK) + " does not have permission to add to Folder " + newParentFolder.getName());
 		}
-		boolean move = folderFactory.move(folderToMove, newParentFolder);
+		final Optional<Folder> newFolder = folderFactory.move(folderToMove, newParentFolder);
 
-		this.systemEventsAPI.pushAsync(SystemEventType.MOVE_FOLDER, new Payload(folderToMove.getMap(), Visibility.EXCLUDE_OWNER,
-				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
+		if (newFolder.isPresent()) {
+			this.systemEventsAPI.pushAsync(SystemEventType.MOVE_FOLDER, new Payload(
+					Map.of("source", folderToMove.getMap(), "target", newFolder.get().getMap()),
+					Visibility.EXCLUDE_OWNER,
+					new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
+		}
 
-		return move;
+		return newFolder.isPresent();
 	}
 
 	@WrapInTransaction
@@ -936,11 +945,14 @@ public class FolderAPIImpl implements FolderAPI  {
 			throw new DotSecurityException("User " + (user.getUserId() != null?user.getUserId():BLANK) + " does not have permission to add to Folder " + newParentHost.getHostname());
 		}
 
-		final boolean move = folderFactory.move(folderToMove, newParentHost);
+		final Optional<Folder> newFolder = folderFactory.move(folderToMove, newParentHost);
 
-		HibernateUtil.addCommitListener(Sneaky.sneaked(()->sendMoveFolderSystemEvent(folderToMove, user)),1000);
+		if (newFolder.isPresent()) {
+			HibernateUtil.addCommitListener(
+					Sneaky.sneaked(() -> sendMoveFolderSystemEvent(folderToMove, newFolder.get(), user)), 1000);
+		}
 
-		return move;
+		return newFolder.isPresent();
 	}
 
 	@Override
@@ -1036,10 +1048,12 @@ public class FolderAPIImpl implements FolderAPI  {
 		});
 	}
 
-	private void sendMoveFolderSystemEvent (final Folder folderToMove, final User user)
+	private void sendMoveFolderSystemEvent(final Folder folderToMove, final Folder newFolder, final User user)
 			throws DotDataException, DotSecurityException {
 
-		this.systemEventsAPI.pushAsync(SystemEventType.MOVE_FOLDER, new Payload(folderToMove.getMap(), Visibility.EXCLUDE_OWNER,
+		this.systemEventsAPI.pushAsync(SystemEventType.MOVE_FOLDER, new Payload(
+				Map.of("source", folderToMove.getMap(), "target", newFolder.getMap()),
+				Visibility.EXCLUDE_OWNER,
 				new ExcludeOwnerVerifierBean(user.getUserId(), PermissionAPI.PERMISSION_READ, Visibility.PERMISSION)));
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactory.java
@@ -50,7 +50,7 @@ public abstract class FolderFactory {
 		return false;
 	}
 
-	protected List<Treeable> getChildrenClass(Folder parent, Class clazz) throws DotStateException, DotDataException{
+	protected <T> List<T> getChildrenClass(Folder parent, Class<T> clazz) throws DotStateException, DotDataException{
 		return null;
 	}
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactory.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactory.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TimeZone;
 
 /**
@@ -86,13 +87,13 @@ public abstract class FolderFactory {
 		return null;
 	}
 
-	abstract void copy(Folder folder, Host destination) throws DotDataException, DotSecurityException, DotStateException, IOException;
+	abstract Folder copy(Folder folder, Host destination) throws DotDataException, DotSecurityException, DotStateException, IOException;
 
-	abstract void copy(Folder folder, Folder destination) throws DotDataException, DotStateException, DotSecurityException, IOException;
+	abstract Folder copy(Folder folder, Folder destination) throws DotDataException, DotStateException, DotSecurityException, IOException;
 
-    abstract boolean move(Folder folder, Host destination) throws DotDataException, DotSecurityException;
+    abstract Optional<Folder> move(Folder folder, Host destination) throws DotDataException, DotSecurityException;
 
-	abstract boolean move(Folder folder, Folder destination) throws DotDataException, DotSecurityException;
+	abstract Optional<Folder> move(Folder folder, Folder destination) throws DotDataException, DotSecurityException;
 
 	protected boolean renameFolder(Folder folder, String newName, User ser, boolean respectFrontEndPermissions) throws DotDataException, DotSecurityException {
 		return false;

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -463,6 +463,7 @@ public class FolderFactoryImpl extends FolderFactory {
     return newFolder;
   }
 
+  @SuppressWarnings("unchecked")
   private void saveCopiedFolder(Folder source, Folder newFolder, Hashtable copiedObjects)
       throws DotDataException, DotStateException, DotSecurityException, IOException {
     User systemUser = APILocator.getUserAPI().getSystemUser();
@@ -532,8 +533,8 @@ public class FolderFactoryImpl extends FolderFactory {
       linksCopied = (Map<String, Link[]>) copiedObjects.get("Links");
     }
 
-    List links = getChildrenClass(source, Link.class);
-    for (Link link : (List<Link>) links) {
+    final List<Link> links = (List<Link>) (List<?>) getChildrenClass(source, Link.class);
+    for (Link link : links) {
       if (link.isWorking()) {
         Link newLink = LinkFactory.copyLink(link, newFolder);
         // Saving copied pages to update template - pages relationships
@@ -725,11 +726,10 @@ public class FolderFactoryImpl extends FolderFactory {
     }
   }
 
-  private void moveLinks(final Folder folder, final List links) throws DotDataException, DotSecurityException {
+  private void moveLinks(final Folder folder, final List<Link> links) throws DotDataException, DotSecurityException {
 
-    for (final Object linkObject : links) {
+    for (final Link link : links) {
 
-      final Link link = (Link) linkObject;
       if (link.isWorking()) {
 
         LinkFactory.moveLink(link, folder);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -550,11 +550,13 @@ public class FolderFactoryImpl extends FolderFactory {
 
   }
 
+  @Override
   protected Folder copy(Folder folder, Host destination)
       throws DotDataException, DotSecurityException, DotStateException, IOException {
     return copy(folder, destination, null);
   }
 
+  @Override
   protected Folder copy(Folder folder, Folder destination)
       throws DotDataException, DotStateException, DotSecurityException, IOException {
     return copy(folder, destination, null);
@@ -616,7 +618,7 @@ public class FolderFactoryImpl extends FolderFactory {
     }
 
     final List<Folder> subFolders = this.getSubFoldersTitleSort(folder);
-    final List links = this.getChildrenClass(folder, Link.class);
+    final List<Link> links = (List<Link>) (List<?>) this.getChildrenClass(folder, Link.class);
     final List<Contentlet> contentlets = contentletAPI.
         findContentletsByFolder(folder, systemUser, false);
 
@@ -748,10 +750,12 @@ public class FolderFactoryImpl extends FolderFactory {
   }
 
 
+  @Override
   protected Optional<Folder> move(Folder folder, Folder destination) throws DotDataException, DotSecurityException {
     return move(folder, (Object) destination);
   }
 
+  @Override
   protected Optional<Folder> move(final Folder folder, final Host destination) throws DotDataException, DotSecurityException {
     return move(folder, (Object) destination);
   }

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -411,7 +411,7 @@ public class FolderFactoryImpl extends FolderFactory {
 
 
   @SuppressWarnings("unchecked")
-  private void copy(Folder folder, Host destination, Hashtable copiedObjects)
+  private Folder copy(Folder folder, Host destination, Hashtable copiedObjects)
       throws DotDataException, DotSecurityException, DotStateException, IOException {
 
     boolean rename = APILocator.getHostAPI().doesHostContainsFolder(destination, folder.getName());
@@ -434,10 +434,11 @@ public class FolderFactoryImpl extends FolderFactory {
     save(newFolder);
 
     saveCopiedFolder(folder, newFolder, copiedObjects);
+    return newFolder;
   }
 
   @SuppressWarnings("unchecked")
-  private void copy(Folder folder, Folder destination, Hashtable copiedObjects)
+  private Folder copy(Folder folder, Folder destination, Hashtable copiedObjects)
       throws DotDataException, DotStateException, DotSecurityException, IOException {
 
     boolean rename = folderContains(folder.getName(), destination);
@@ -459,6 +460,7 @@ public class FolderFactoryImpl extends FolderFactory {
     save(newFolder);
 
     saveCopiedFolder(folder, newFolder, copiedObjects);
+    return newFolder;
   }
 
   private void saveCopiedFolder(Folder source, Folder newFolder, Hashtable copiedObjects)
@@ -548,14 +550,14 @@ public class FolderFactoryImpl extends FolderFactory {
 
   }
 
-  protected void copy(Folder folder, Host destination)
+  protected Folder copy(Folder folder, Host destination)
       throws DotDataException, DotSecurityException, DotStateException, IOException {
-    copy(folder, destination, null);
+    return copy(folder, destination, null);
   }
 
-  protected void copy(Folder folder, Folder destination)
+  protected Folder copy(Folder folder, Folder destination)
       throws DotDataException, DotStateException, DotSecurityException, IOException {
-    copy(folder, destination, null);
+    return copy(folder, destination, null);
   }
 
   @SuppressWarnings("unchecked")
@@ -572,7 +574,7 @@ public class FolderFactoryImpl extends FolderFactory {
   }
 
   @SuppressWarnings("unchecked")
-  private boolean move(final Folder folder, final Object destination)
+  private Optional<Folder> move(final Folder folder, final Object destination)
       throws DotDataException, DotStateException, DotSecurityException {
 
     final MutableBoolean successOperation = new MutableBoolean(true);
@@ -610,7 +612,7 @@ public class FolderFactoryImpl extends FolderFactory {
 
     if (contains) {
 
-      return false;
+      return Optional.empty();
     }
 
     final List<Folder> subFolders = this.getSubFoldersTitleSort(folder);
@@ -631,7 +633,7 @@ public class FolderFactoryImpl extends FolderFactory {
 
     delete(folder);
 
-    return successOperation.getValue();
+    return successOperation.getValue() ? Optional.of(newFolder) : Optional.empty();
   }
 
   private void updateOtherFolderReferences(final String newFolderInode, final String oldFolderInode)
@@ -697,7 +699,7 @@ public class FolderFactoryImpl extends FolderFactory {
 
     for (final Folder subFolder : subFolders) {
 
-      moved &= move(subFolder, folder);
+      moved &= move(subFolder, folder).isPresent();
     }
 
     return moved;
@@ -746,11 +748,11 @@ public class FolderFactoryImpl extends FolderFactory {
   }
 
 
-  protected boolean move(Folder folder, Folder destination) throws DotDataException, DotSecurityException {
+  protected Optional<Folder> move(Folder folder, Folder destination) throws DotDataException, DotSecurityException {
     return move(folder, (Object) destination);
   }
 
-  protected boolean move(final Folder folder, final Host destination) throws DotDataException, DotSecurityException {
+  protected Optional<Folder> move(final Folder folder, final Host destination) throws DotDataException, DotSecurityException {
     return move(folder, (Object) destination);
   }
 

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -533,7 +533,7 @@ public class FolderFactoryImpl extends FolderFactory {
       linksCopied = (Map<String, Link[]>) copiedObjects.get("Links");
     }
 
-    final List<Link> links = (List<Link>) (List<?>) getChildrenClass(source, Link.class);
+    final List<Link> links = getChildrenClass(source, Link.class);
     for (Link link : links) {
       if (link.isWorking()) {
         Link newLink = LinkFactory.copyLink(link, newFolder);
@@ -545,7 +545,7 @@ public class FolderFactoryImpl extends FolderFactory {
 
     // Copying Inner Folders
     List<Folder> childrenFolder = APILocator.getFolderAPI().findSubFolders(source, systemUser, false);
-    for (Folder childFolder : (List<Folder>) childrenFolder) {
+    for (Folder childFolder : childrenFolder) {
       copy(childFolder, newFolder, copiedObjects);
     }
 
@@ -619,7 +619,7 @@ public class FolderFactoryImpl extends FolderFactory {
     }
 
     final List<Folder> subFolders = this.getSubFoldersTitleSort(folder);
-    final List<Link> links = (List<Link>) (List<?>) this.getChildrenClass(folder, Link.class);
+    final List<Link> links = this.getChildrenClass(folder, Link.class);
     final List<Contentlet> contentlets = contentletAPI.
         findContentletsByFolder(folder, systemUser, false);
 
@@ -1262,8 +1262,10 @@ public class FolderFactoryImpl extends FolderFactory {
     return folderList;
   }
 
-  protected List<Treeable> getChildrenClass(Folder parent, Class clazz) throws DotStateException, DotDataException {
-    return getChildrenClass(parent, clazz, null, null, 0, 1000);
+  @Override
+  @SuppressWarnings("unchecked")
+  protected <T> List<T> getChildrenClass(Folder parent, Class<T> clazz) throws DotStateException, DotDataException {
+    return (List<T>) getChildrenClass(parent, clazz, null, null, 0, 1000);
   }
 
   protected List<Treeable> getChildrenClass(Host host, Class clazz) throws DotStateException, DotDataException {

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/folders/business/FolderFactoryImpl.java
@@ -469,7 +469,7 @@ public class FolderFactoryImpl extends FolderFactory {
     User systemUser = APILocator.getUserAPI().getSystemUser();
 
     if (copiedObjects == null) {
-			copiedObjects = new Hashtable();
+			copiedObjects = new Hashtable<String, Object>();
     }
 
     // Copying folder permissions
@@ -576,7 +576,6 @@ public class FolderFactoryImpl extends FolderFactory {
     return false;
   }
 
-  @SuppressWarnings("unchecked")
   private Optional<Folder> move(final Folder folder, final Object destination)
       throws DotDataException, DotStateException, DotSecurityException {
 

--- a/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavHelper.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavHelper.java
@@ -1236,7 +1236,11 @@ public class DotWebdavHelper {
 						Logger.debug(this, "The from folder is null");
 					}
 					try {
-						folderAPI.move(fromFolder, toParentFolder,user,false);
+						if (!folderAPI.move(fromFolder, toParentFolder, user, false)) {
+							throw new DotDataException("Cannot move folder '" + fromFolder.getPath()
+									+ "' to '" + toParentFolder.getPath()
+									+ "': destination already contains a folder with the same name.");
+						}
 						fc.removeFolder(fromFolder, identifierAPI.find(fromFolder.getIdentifier()));
 						fc.removeFolder(toParentFolder, identifierAPI.find(toParentFolder.getIdentifier()));
 						//folderAPI.updateMovedFolderAssets(fromFolder);
@@ -1273,7 +1277,11 @@ public class DotWebdavHelper {
 					final Folder fromFolder;
 					try {
 						fromFolder = folderAPI.findFolderByPath(getPath(fromPathStripped), host,user,false);
-						folderAPI.move(fromFolder, host,user,false);
+						if (!folderAPI.move(fromFolder, host, user, false)) {
+							throw new DotDataException("Cannot move folder '" + fromFolder.getPath()
+									+ "' to host '" + host.getHostname()
+									+ "': destination already contains a folder with the same name.");
+						}
 						fc.removeFolder(fromFolder, identifierAPI.find(fromFolder.getIdentifier()));
 					} catch (Exception e) {
 						Logger.error(DotWebdavHelper.class, e.getMessage(), e);

--- a/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavHelper.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavHelper.java
@@ -113,6 +113,10 @@ public class DotWebdavHelper {
 	private long defaultLang = APILocator.getLanguageAPI().getDefaultLanguage().getId();
 	private boolean legacyPath = Config.getBooleanProperty("WEBDAV_LEGACY_PATHING", false);
 	private static final String emptyFileData = "~DOTEMPTY";
+
+	private static String stripLogControls(final String value) {
+		return value == null ? "" : value.replaceAll("[\\r\\n\\t\\u001B]", " ");
+	}
 	private ContentletAPI conAPI = APILocator.getContentletAPI();
 
 	/**
@@ -1238,8 +1242,8 @@ public class DotWebdavHelper {
 					try {
 						if (!folderAPI.move(fromFolder, toParentFolder, user, false)) {
 							Logger.warn(DotWebdavHelper.class, "Move failed: destination '"
-									+ toParentFolder.getPath() + "' already contains a folder named '"
-									+ fromFolder.getName() + "'");
+									+ stripLogControls(toParentFolder.getPath()) + "' already contains a folder named '"
+									+ stripLogControls(fromFolder.getName()) + "'");
 							throw new DotDataException("Move failed: destination already contains a folder with the same name.");
 						}
 						fc.removeFolder(fromFolder, identifierAPI.find(fromFolder.getIdentifier()));
@@ -1282,8 +1286,8 @@ public class DotWebdavHelper {
 						fromFolder = folderAPI.findFolderByPath(getPath(fromPathStripped), host,user,false);
 						if (!folderAPI.move(fromFolder, host, user, false)) {
 							Logger.warn(DotWebdavHelper.class, "Move failed: host '"
-									+ host.getHostname() + "' already contains a folder named '"
-									+ fromFolder.getName() + "'");
+									+ stripLogControls(host.getHostname()) + "' already contains a folder named '"
+									+ stripLogControls(fromFolder.getName()) + "'");
 							throw new DotDataException("Move failed: destination already contains a folder with the same name.");
 						}
 						fc.removeFolder(fromFolder, identifierAPI.find(fromFolder.getIdentifier()));

--- a/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavHelper.java
+++ b/dotCMS/src/main/java/com/dotmarketing/webdav/DotWebdavHelper.java
@@ -1237,13 +1237,16 @@ public class DotWebdavHelper {
 					}
 					try {
 						if (!folderAPI.move(fromFolder, toParentFolder, user, false)) {
-							throw new DotDataException("Cannot move folder '" + fromFolder.getPath()
-									+ "' to '" + toParentFolder.getPath()
-									+ "': destination already contains a folder with the same name.");
+							Logger.warn(DotWebdavHelper.class, "Move failed: destination '"
+									+ toParentFolder.getPath() + "' already contains a folder named '"
+									+ fromFolder.getName() + "'");
+							throw new DotDataException("Move failed: destination already contains a folder with the same name.");
 						}
 						fc.removeFolder(fromFolder, identifierAPI.find(fromFolder.getIdentifier()));
 						fc.removeFolder(toParentFolder, identifierAPI.find(toParentFolder.getIdentifier()));
 						//folderAPI.updateMovedFolderAssets(fromFolder);
+					} catch (DotDataException e) {
+						throw e;
 					} catch (Exception e) {
 						Logger.error(DotWebdavHelper.class, e.getMessage(), e);
 						throw new DotDataException(e.getMessage(), e);
@@ -1278,11 +1281,14 @@ public class DotWebdavHelper {
 					try {
 						fromFolder = folderAPI.findFolderByPath(getPath(fromPathStripped), host,user,false);
 						if (!folderAPI.move(fromFolder, host, user, false)) {
-							throw new DotDataException("Cannot move folder '" + fromFolder.getPath()
-									+ "' to host '" + host.getHostname()
-									+ "': destination already contains a folder with the same name.");
+							Logger.warn(DotWebdavHelper.class, "Move failed: host '"
+									+ host.getHostname() + "' already contains a folder named '"
+									+ fromFolder.getName() + "'");
+							throw new DotDataException("Move failed: destination already contains a folder with the same name.");
 						}
 						fc.removeFolder(fromFolder, identifierAPI.find(fromFolder.getIdentifier()));
+					} catch (DotDataException e) {
+						throw e;
 					} catch (Exception e) {
 						Logger.error(DotWebdavHelper.class, e.getMessage(), e);
 						throw new DotDataException(e.getMessage(), e);


### PR DESCRIPTION
## Parent Issue
- #35225

## Summary
The `COPY_FOLDER` and `MOVE_FOLDER` system events emitted only the **source** folder map, so consumers had no way to learn the **target** folder's identifier. For `MOVE_FOLDER`, the source identifier in the payload also pointed to a row that had already been deleted by `FolderFactoryImpl.move()`. On top of that, `MOVE_FOLDER` fired unconditionally — even when the underlying factory move failed (e.g. name collision at destination).

## Changes
- `FolderFactory.copy()` now returns the newly created `Folder`.
- `FolderFactory.move()` now returns `Optional<Folder>` — present on success, empty when the destination already contains a folder with the same name (or a child cascade fails).
- `FolderAPIImpl.copy()` / `move()` push payloads of the form:
  ```java
  Map.of("source", source.getMap(), "target", target.getMap())
  ```
- `MOVE_FOLDER` is now gated on a successful move (both `Folder→Folder` and `Folder→Host` overloads).
- `FolderAPIImpl.move()` boolean return semantics are preserved (`Optional.isPresent()` mirrors the previous `boolean`), so `moveWhenDestinationDoesNotExists` / `moveToExistingDestination` callers are unaffected.

## ⚠️ Behavioral / Compatibility Notes (Release Notes)
**This changes the payload shape of two system events.** External integrations that subscribe to `COPY_FOLDER` or `MOVE_FOLDER` over the system events websocket should:
- Read `payload.source` for the original folder data (was the top-level payload before)
- Read `payload.target` for the newly created folder data (the new identifier)

The single in-tree consumer (`iframe.component.ts` in `core-web`) only logs `event.data` opaquely — no frontend update required.

## Test Plan
- [ ] `./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=FolderAPITest`
- [ ] Manually copy a folder via the Site Browser; verify a `COPY_FOLDER` event fires with both `source` and `target` keys.
- [ ] Manually move a folder via the Site Browser; verify `MOVE_FOLDER` fires with both keys, and that no event fires when the destination already contains a folder with the same name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35225