### PR TITLE
fix(uve-toolbar): truncate long URLs and prevent device/zoom controls overlap

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-device-controls/dot-uve-device-controls.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-device-controls/dot-uve-device-controls.component.ts
@@ -18,7 +18,9 @@ import {
     imports: [ButtonModule, TooltipModule, DotMessagePipe],
     templateUrl: './dot-uve-device-controls.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
-    host: { class: 'flex items-center bg-gray-100 rounded-full px-3 py-1 gap-1 overflow-hidden' }
+    host: {
+        class: 'flex shrink-0 items-center bg-gray-100 rounded-full px-3 py-1 gap-1 overflow-hidden'
+    }
 })
 export class DotUveDeviceControlsComponent {
     $state = input.required<DeviceSelectorState>({ alias: 'state' });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-zoom-controls/dot-uve-zoom-controls.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-zoom-controls/dot-uve-zoom-controls.component.ts
@@ -10,7 +10,7 @@ import { UVEStore } from '../../../store/dot-uve.store';
     templateUrl: './dot-uve-zoom-controls.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     imports: [ButtonModule],
-    host: { class: 'flex items-center bg-gray-100 rounded-full px-3 py-1 gap-1' }
+    host: { class: 'flex shrink-0 items-center bg-gray-100 rounded-full px-3 py-1 gap-1' }
 })
 export class DotUveZoomControlsComponent {
     protected readonly store = inject(UVEStore);

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.scss
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.scss
@@ -211,6 +211,7 @@ a:active {
 
 .browser-url-pill {
     flex: 1;
+    min-width: 0;
     display: flex;
     align-items: center;
     gap: $spacing-1;
@@ -219,9 +220,13 @@ a:active {
 }
 
 .browser-url-bar {
+    flex: 1;
+    min-width: 0;
     color: $black;
     font-size: 0.875rem;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .flip-horizontal {


### PR DESCRIPTION
## Summary

- Long page URLs in the UVE toolbar were pushing the URL pill past its allotted space, shrinking the device controls and overlapping the zoom controls onto the toolbar's right-side button.
- The pill (`flex: 1`) had no `min-width: 0`, and the inner `.browser-url-bar` had `white-space: nowrap` without ellipsis, so flex couldn't shrink the pill below the URL's content width.
- Added `min-width: 0` to `.browser-url-pill`, plus `flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis` to `.browser-url-bar` so long URLs ellipsis cleanly within the pill.
- Added `shrink-0` to the `dot-uve-device-controls` and `dot-uve-zoom-controls` host classes so they keep their natural width regardless of URL length.

The full URL remains accessible via the existing copy-URL popover (link icon button).

Fixes #35542

## Test plan

- [ ] Open a page with a long URL (deep nested path or long slug) in UVE
- [ ] Confirm the URL pill truncates with an ellipsis
- [ ] Confirm device controls retain their full width and remain usable
- [ ] Confirm zoom controls do not overlap the right-side toolbar button
- [ ] Open a page with a short URL — confirm the pill, device controls, and zoom controls remain centered as before
- [ ] Click the link icon — confirm the popover still shows the full URL list
- [ ] `yarn nx test portlets-edit-ema-portlet` — passes locally (1341 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)