### PR TITLE
feat(security): add Semgrep rules for SQL injection anti-patterns

### DIFF
--- a/.github/workflows/cicd_comp_semgrep-phase.yml
+++ b/.github/workflows/cicd_comp_semgrep-phase.yml
@@ -70,10 +70,13 @@ jobs:
         with:
           name: dependency-tree
       - name: Semgrep Scan
+        # `--config .semgrep/` adds dotCMS-local rules in addition to the rules
+        # configured in the Semgrep AppSec Platform. See .semgrep/dotcms-sqli.yml
+        # and dotCMS/core#35547 for the rule pack and rationale.
         run: |
           unzip -o dependency-tree.zip
           if [ "${NO_FAIL}" = "true" ]; then
-            semgrep ci || echo "Semgrep completed with errors, but continuing due to NO_FAIL=true"
+            semgrep ci --config .semgrep/ || echo "Semgrep completed with errors, but continuing due to NO_FAIL=true"
           else
-            semgrep ci
+            semgrep ci --config .semgrep/
           fi

--- a/.semgrep/dotcms-sqli.yml
+++ b/.semgrep/dotcms-sqli.yml
@@ -1,0 +1,144 @@
+# dotCMS SQL injection rules
+#
+# These rules complement the Semgrep AppSec Platform ruleset with checks
+# tailored to dotCMS's database APIs (DotConnect, HibernateUtil). They are
+# loaded by the PR Semgrep workflow via `semgrep ci --config .semgrep/`.
+#
+# Tracking issue: https://github.com/dotCMS/core/issues/35547
+#
+# Severity policy:
+#   - ERROR  : narrow patterns with very low FP rate (setSQL/setQuery/
+#              executeStatement concat, "'"+var+"'" literal-wrap)
+#   - WARNING: broader patterns that need a human review (regex-based
+#              quote-wrap detection, manual ":named" placeholder replace)
+#
+# Excluded paths cover legacy areas that legitimately concatenate
+# schema-derived names (startup migrations, integrity checkers, schema
+# introspection helpers).
+
+rules:
+  - id: dotcms-dotconnect-setsql-string-format
+    message: |
+      DotConnect.setSQL(String.format(...)) interpolates values directly into SQL.
+      Use '?' placeholders + DotConnect.addParam(...) instead. If the format
+      argument is a column or table name, route it through SQLUtil.sanitizeSortBy
+      or a static whitelist.
+    severity: ERROR
+    languages: [java]
+    pattern: $DC.setSQL(String.format(...))
+    paths:
+      exclude:
+        - "**/dotCMS/src/main/java/com/dotmarketing/startup/runonce/**"
+        - "**/dotCMS/src/main/java/com/dotcms/integritycheckers/**"
+        - "**/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java"
+        - "**/dotCMS/src/main/java/com/dotmarketing/util/starter/ImportStarterUtil.java"
+
+  - id: dotcms-dotconnect-setsql-concat
+    message: |
+      DotConnect.setSQL with string concatenation is a SQL injection risk.
+      Use '?' placeholders + DotConnect.addParam(...) for variables.
+      DB-dialect helpers (DbConnectionFactory.getDBTrue() etc.) are
+      excluded via pattern-not since they return constant strings.
+    severity: ERROR
+    languages: [java]
+    patterns:
+      - pattern: $DC.setSQL($X + $Y)
+      - pattern-not: $DC.setSQL("..." + "...")
+      - pattern-not: $DC.setSQL(... + DbConnectionFactory.$M(...) + ...)
+      - pattern-not: $DC.setSQL(... + DbConnectionFactory.$M() + ...)
+      - pattern-not: $DC.setSQL(... + $T.class.getName() + ...)
+    paths:
+      exclude:
+        - "**/dotCMS/src/main/java/com/dotmarketing/startup/runonce/**"
+        - "**/dotCMS/src/main/java/com/dotcms/integritycheckers/**"
+        - "**/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java"
+        - "**/dotCMS/src/main/java/com/dotmarketing/util/starter/ImportStarterUtil.java"
+
+  - id: dotcms-dotconnect-executestatement-tainted
+    message: |
+      DotConnect.executeStatement with concatenation or String.format —
+      use '?' placeholders + addParam(...) to bind values.
+    severity: ERROR
+    languages: [java]
+    pattern-either:
+      - patterns:
+          - pattern: $DC.executeStatement($X + $Y)
+          - pattern-not: $DC.executeStatement("..." + "...")
+          - pattern-not: $DC.executeStatement(... + DbConnectionFactory.$M(...) + ...)
+          - pattern-not: $DC.executeStatement(... + DbConnectionFactory.$M() + ...)
+      - pattern: $DC.executeStatement(String.format(...))
+    paths:
+      exclude:
+        - "**/dotCMS/src/main/java/com/dotmarketing/startup/runonce/**"
+        - "**/dotCMS/src/main/java/com/dotcms/integritycheckers/**"
+        - "**/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java"
+        - "**/dotCMS/src/main/java/com/dotmarketing/util/starter/ImportStarterUtil.java"
+
+  - id: dotcms-hibernate-setquery-concat
+    message: |
+      HibernateUtil.setQuery with concatenation/format — pass parameters via
+      setParam / setParamList. Public methods that accept a free-form WHERE
+      fragment as a parameter (e.g. getLinkByCondition, getContainerByCondition)
+      should be replaced with a typed query builder.
+    severity: ERROR
+    languages: [java]
+    pattern-either:
+      - patterns:
+          - pattern: $DH.setQuery($X + $Y)
+          - pattern-not: $DH.setQuery("..." + "...")
+          - pattern-not: $DH.setQuery(... + DbConnectionFactory.$M(...) + ...)
+          - pattern-not: $DH.setQuery(... + DbConnectionFactory.$M() + ...)
+          - pattern-not: $DH.setQuery(... + $T.class.getName() + ...)
+      - pattern: $DH.setQuery(String.format(...))
+    paths:
+      exclude:
+        - "**/dotCMS/src/main/java/com/dotmarketing/startup/runonce/**"
+        - "**/dotCMS/src/main/java/com/dotcms/integritycheckers/**"
+
+  - id: dotcms-sql-quoted-list-concat
+    message: |
+      Building a quoted SQL value with "'"+var+"'" is a SQL injection
+      anti-pattern — single-quote wrapping in Java does no escaping.
+      Use '?' placeholders + DotConnect.addParam(...) (or setParam() for HQL).
+    severity: ERROR
+    languages: [java]
+    pattern: |
+      "'" + $X + "'"
+    paths:
+      exclude:
+        - "**/dotCMS/src/main/java/com/dotmarketing/startup/runonce/**"
+        - "**/dotCMS/src/main/java/com/dotcms/integritycheckers/**"
+
+  - id: dotcms-sql-quote-wrap-concat
+    message: |
+      A variable is being concatenated between two strings with adjacent
+      single quotes (e.g. `"... col = '" + var + "'..."`). When this is part
+      of a SQL or HQL string, single-quote wrapping in Java does no escaping
+      and is a SQL injection vector. Review carefully — if it builds a SQL
+      query, use '?' placeholders + addParam(...) (or setParam() for HQL);
+      if it's a log message, it's safe.
+    severity: WARNING
+    languages: [java]
+    pattern-regex: '''"\s*\+\s*[A-Za-z_][\w.()]*\s*\+\s*"'''
+    paths:
+      exclude:
+        - "**/dotCMS/src/main/java/com/dotmarketing/startup/runonce/**"
+        - "**/dotCMS/src/main/java/com/dotcms/integritycheckers/**"
+        - "**/dotCMS/src/main/java/com/dotmarketing/common/db/DotDatabaseMetaData.java"
+        - "**/dotCMS/src/main/java/com/dotmarketing/util/starter/ImportStarterUtil.java"
+        - "**/dotCMS/src/test/**"
+        - "**/dotcms-integration/**"
+        - "**/dotcms-postman/**"
+
+  - id: dotcms-sql-manual-named-placeholder
+    message: |
+      Manual ":named" placeholder replacement on a SQL string is unsafe —
+      String.replace() does no escaping. Use '?' placeholders + addParam(...)
+      so the JDBC driver binds values.
+    severity: WARNING
+    languages: [java]
+    patterns:
+      - pattern: $SQL.replace($PLACEHOLDER, $VALUE)
+      - metavariable-regex:
+          metavariable: $PLACEHOLDER
+          regex: '^":[a-zA-Z_][a-zA-Z0-9_]*"$'


### PR DESCRIPTION
## Summary

Adds dotCMS-specific Semgrep rules so PR scans catch SQL injection anti-patterns in our `DotConnect` and `HibernateUtil` SQL APIs — patterns the current Semgrep AppSec Platform ruleset does not cover.

Closes #35547.

## Changes

- **New: `.semgrep/dotcms-sqli.yml`** — 7 rules:
  - `dotcms-dotconnect-setsql-string-format` (ERROR) — flags `dc.setSQL(String.format(...))`.
  - `dotcms-dotconnect-setsql-concat` (ERROR) — flags `dc.setSQL(... + var + ...)`, with `pattern-not` exclusions for `DbConnectionFactory.getDB*()` and `Class.getName()` (constants).
  - `dotcms-dotconnect-executestatement-tainted` (ERROR) — same for `executeStatement(...)`.
  - `dotcms-hibernate-setquery-concat` (ERROR) — same for `HibernateUtil.setQuery(...)`.
  - `dotcms-sql-quoted-list-concat` (ERROR) — narrow AST pattern for the `"'" + var + "'"` literal-wrap (the `PublishAuditAPIImpl.java:231` shape).
  - `dotcms-sql-quote-wrap-concat` (WARNING) — broader regex match for `"... = '" + var + "'..."` shape that hides inside multi-character string literals.
  - `dotcms-sql-manual-named-placeholder` (WARNING) — flags `sql.replace(":named", value)`.

  Path excludes cover legacy areas where SQL is concatenated from internal schema constants only: `startup/runonce/Task*`, `integritycheckers/`, `DotDatabaseMetaData.java`, `ImportStarterUtil.java`. The broad WARNING rule additionally excludes test trees and integration/postman modules.

- **Modified: `.github/workflows/cicd_comp_semgrep-phase.yml`** — pass `--config .semgrep/` to `semgrep ci` so local rules run alongside cloud rules.

## How it behaves

- `semgrep ci` runs in **diff-aware mode**: only findings *introduced* by a PR fail it. The existing baseline of findings on `main` does not block unrelated PRs.
- Cloud-platform rules continue to run as before — these rules are additive, not a replacement.

## Validation

Tested locally with `semgrep 1.135.0`:

```
$ semgrep --validate --config .semgrep/dotcms-sqli.yml
Configuration is valid - found 0 configuration error(s), and 7 rule(s).

$ semgrep --config .semgrep/dotcms-sqli.yml dotCMS/src/main/java
Total findings: 717
  setsql-string-format: 14
  setsql-concat: 37
  executestatement-tainted: 3
  hibernate-setquery-concat: 22
  quoted-list-concat: 19
  quote-wrap-concat: 620 (WARNING — broad regex; tightened by future taint rules)
  manual-named-placeholder: 2
```

Confirmed every dotCMS-specific anti-pattern surfaced by recent code review is caught by at least one rule (regression-tested against 7 representative locations across the DB and portlet layers).

## Test plan

- [ ] `PR Semgrep` job runs successfully on this PR (validates the workflow change).
- [ ] No *new* Semgrep findings are introduced by this PR itself.
- [ ] Manually open a throwaway PR introducing `dc.setSQL("SELECT x FROM y WHERE z = '" + userInput + "'")` and confirm `PR Semgrep` blocks it.
- [ ] Verify cloud-platform Semgrep scan still runs (separate check, should be unaffected).

## Follow-ups (out of scope)

- Convert the broad `quote-wrap-concat` regex rule into a Semgrep taint-mode rule once the source/sink/sanitizer model for `DotConnect` is defined — should let us drop the WARNING noise and bump back to ERROR.
- Investigate why `vars.DISABLE_SEMGREP` may be set to `'true'` (PR Semgrep job currently shows `skipping` on some PRs — separate from this rule pack).
- Replicate equivalent rules in the Semgrep AppSec Platform UI for `dotcms1` org so the cloud-platform check enforces them too (see issue body for dashboard guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)