### PR TITLE
feat(analytics): enhance DotAnalyticsService

### DIFF
--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.spec.ts
@@ -9,6 +9,10 @@ import { CubeJSQuery, Granularity } from '../types';
 
 const ANALYTICS_API_ENDPOINT = '/api/v1/analytics/content/_query/cube';
 const ANALYTICS_EVENT_TOTAL_EVENTS = '/api/v1/analytics/event/total-events';
+const ANALYTICS_EVENT_UNIQUE_VISITORS = '/api/v1/analytics/event/unique-visitors';
+const ANALYTICS_EVENT_TOP_CONTENT = '/api/v1/analytics/event/top-content';
+const ANALYTICS_EVENT_PAGE_VIEWS_BY_DEVICE_BROWSER =
+    '/api/v1/analytics/event/pageviews-by-device-browser';
 
 /** SpectatorHttp.expectOne always wraps URL in an object, so function matchers break; use the real backend matcher. */
 function expectTotalEventsReq(httpMock: HttpTestingController) {
@@ -18,6 +22,44 @@ function expectTotalEventsReq(httpMock: HttpTestingController) {
             (req.urlWithParams === ANALYTICS_EVENT_TOTAL_EVENTS ||
                 req.urlWithParams.startsWith(`${ANALYTICS_EVENT_TOTAL_EVENTS}?`))
     );
+}
+
+function expectUniqueVisitorsReq(httpMock: HttpTestingController) {
+    return httpMock.expectOne(
+        (req) =>
+            req.method === 'GET' &&
+            (req.urlWithParams === ANALYTICS_EVENT_UNIQUE_VISITORS ||
+                req.urlWithParams.startsWith(`${ANALYTICS_EVENT_UNIQUE_VISITORS}?`))
+    );
+}
+
+function expectTopContentReq(httpMock: HttpTestingController) {
+    return httpMock.expectOne(
+        (req) =>
+            req.method === 'GET' &&
+            (req.urlWithParams === ANALYTICS_EVENT_TOP_CONTENT ||
+                req.urlWithParams.startsWith(`${ANALYTICS_EVENT_TOP_CONTENT}?`))
+    );
+}
+
+function expectPageviewsByDeviceBrowserReq(httpMock: HttpTestingController) {
+    return httpMock.expectOne(
+        (req) =>
+            req.method === 'GET' &&
+            (req.urlWithParams === ANALYTICS_EVENT_PAGE_VIEWS_BY_DEVICE_BROWSER ||
+                req.urlWithParams.startsWith(`${ANALYTICS_EVENT_PAGE_VIEWS_BY_DEVICE_BROWSER}?`))
+    );
+}
+
+function dotCMSWrap<T>(data: T) {
+    return {
+        entity: { data },
+        errors: [],
+        i18nMessagesMap: {},
+        messages: [],
+        pagination: null,
+        permissions: []
+    };
 }
 
 describe('DotAnalyticsService', () => {
@@ -227,6 +269,138 @@ describe('DotAnalyticsService', () => {
                 pagination: null,
                 permissions: []
             });
+        });
+    });
+
+    describe('getUniqueVisitors', () => {
+        it('should GET unique-visitors with range only and omit optional query keys', () => {
+            spectator.service.getUniqueVisitors({ range: 'last_7_days' }).subscribe();
+
+            const req = expectUniqueVisitorsReq(TestBed.inject(HttpTestingController));
+            expect(req.request.params.get('range')).toBe('last_7_days');
+            expect(req.request.params.get('granularity')).toBeNull();
+            expect(req.request.params.get('siteId')).toBeNull();
+
+            req.flush(dotCMSWrap({ uniqueVisitors: 100 }));
+        });
+
+        it('should GET unique-visitors with from, to, granularity, and siteId', () => {
+            let result!: unknown;
+            spectator.service
+                .getUniqueVisitors({
+                    from: '2026-01-01',
+                    to: '2026-01-31',
+                    granularity: 'day',
+                    siteId: 'site-x'
+                })
+                .subscribe((data) => {
+                    result = data;
+                });
+
+            const req = expectUniqueVisitorsReq(TestBed.inject(HttpTestingController));
+            expect(req.request.params.get('from')).toBe('2026-01-01');
+            expect(req.request.params.get('to')).toBe('2026-01-31');
+            expect(req.request.params.get('granularity')).toBe('day');
+            expect(req.request.params.get('siteId')).toBe('site-x');
+
+            req.flush(
+                dotCMSWrap([
+                    { day: '2026-01-01', uniqueVisitors: 1 },
+                    { day: '2026-01-02', uniqueVisitors: 2 }
+                ])
+            );
+
+            expect(result).toEqual([
+                { day: '2026-01-01', uniqueVisitors: 1 },
+                { day: '2026-01-02', uniqueVisitors: 2 }
+            ]);
+        });
+
+        it('should propagate HTTP errors for unique-visitors', (done) => {
+            spectator.service.getUniqueVisitors({ range: 'last_7_days' }).subscribe({
+                error: (e) => {
+                    expect(e.status).toBe(500);
+                    done();
+                }
+            });
+
+            const req = expectUniqueVisitorsReq(TestBed.inject(HttpTestingController));
+            req.flush('Server error', { status: 500, statusText: 'Internal Server Error' });
+        });
+    });
+
+    describe('getTopContent', () => {
+        it('should GET top-content with range and optional filters', () => {
+            let result!: unknown;
+            spectator.service
+                .getTopContent({
+                    range: 'last_7_days',
+                    eventType: 'pageview',
+                    siteId: 's1'
+                })
+                .subscribe((data) => {
+                    result = data;
+                });
+
+            const req = expectTopContentReq(TestBed.inject(HttpTestingController));
+            expect(req.request.params.get('range')).toBe('last_7_days');
+            expect(req.request.params.get('eventType')).toBe('pageview');
+            expect(req.request.params.get('siteId')).toBe('s1');
+
+            req.flush(
+                dotCMSWrap([
+                    { identifier: '1', title: 'A', totalEvents: 5 },
+                    { identifier: '2', title: 'B', totalEvents: 3 }
+                ])
+            );
+
+            expect(result).toEqual([
+                { identifier: '1', title: 'A', totalEvents: 5 },
+                { identifier: '2', title: 'B', totalEvents: 3 }
+            ]);
+        });
+
+        it('should GET top-content with from and to omitting optional keys', () => {
+            spectator.service.getTopContent({ from: '2026-05-01', to: '2026-05-07' }).subscribe();
+
+            const req = expectTopContentReq(TestBed.inject(HttpTestingController));
+            expect(req.request.params.get('from')).toBe('2026-05-01');
+            expect(req.request.params.get('to')).toBe('2026-05-07');
+            expect(req.request.params.get('eventType')).toBeNull();
+
+            req.flush(dotCMSWrap([]));
+        });
+    });
+
+    describe('getPageviewsByDeviceBrowser', () => {
+        it('should GET pageviews-by-device-browser with params', () => {
+            let result!: unknown;
+            spectator.service
+                .getPageviewsByDeviceBrowser({
+                    range: 'last_30_days',
+                    eventType: 'pageview',
+                    siteId: 'host1'
+                })
+                .subscribe((data) => {
+                    result = data;
+                });
+
+            const req = expectPageviewsByDeviceBrowserReq(TestBed.inject(HttpTestingController));
+            expect(req.request.params.get('range')).toBe('last_30_days');
+            expect(req.request.params.get('eventType')).toBe('pageview');
+            expect(req.request.params.get('siteId')).toBe('host1');
+
+            req.flush(
+                dotCMSWrap([
+                    { browser: 'Chrome', device: 'desktop', total: 10 },
+                    { browser: 'Safari', device: 'mobile', total: 4 }
+                ])
+            );
+
+            expect(result).toEqual([
+                { browser: 'Chrome', device: 'desktop', total: 10 },
+                { browser: 'Safari', device: 'mobile', total: 4 }
+            ]);
         });
     });
 

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.spec.ts
@@ -1,10 +1,24 @@
 import { createHttpFactory, HttpMethod, SpectatorHttp } from '@ngneat/spectator/jest';
 
+import { HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
 import { DotAnalyticsService } from './dot-analytics.service';
 
 import { CubeJSQuery, Granularity } from '../types';
 
 const ANALYTICS_API_ENDPOINT = '/api/v1/analytics/content/_query/cube';
+const ANALYTICS_EVENT_TOTAL_EVENTS = '/api/v1/analytics/event/total-events';
+
+/** SpectatorHttp.expectOne always wraps URL in an object, so function matchers break; use the real backend matcher. */
+function expectTotalEventsReq(httpMock: HttpTestingController) {
+    return httpMock.expectOne(
+        (req) =>
+            req.method === 'GET' &&
+            (req.urlWithParams === ANALYTICS_EVENT_TOTAL_EVENTS ||
+                req.urlWithParams.startsWith(`${ANALYTICS_EVENT_TOTAL_EVENTS}?`))
+    );
+}
 
 describe('DotAnalyticsService', () => {
     let spectator: SpectatorHttp<DotAnalyticsService>;
@@ -50,7 +64,7 @@ describe('DotAnalyticsService', () => {
                 permissions: []
             };
 
-            let result: unknown[];
+            let result!: unknown[];
             spectator.service.cubeQuery(testQuery).subscribe((data) => {
                 result = data;
             });
@@ -74,7 +88,7 @@ describe('DotAnalyticsService', () => {
                 permissions: []
             };
 
-            let result: unknown[];
+            let result!: unknown[];
             spectator.service.cubeQuery(testQuery).subscribe((data) => {
                 result = data;
             });
@@ -116,6 +130,103 @@ describe('DotAnalyticsService', () => {
 
             const req = spectator.expectOne(ANALYTICS_API_ENDPOINT, HttpMethod.POST);
             expect(req.request.body).toEqual(complexQuery);
+        });
+    });
+
+    describe('getTotalEvents', () => {
+        it('should GET total-events with range only and omit optional query keys', () => {
+            spectator.service.getTotalEvents({ range: 'last_7_days' }).subscribe();
+
+            const req = expectTotalEventsReq(TestBed.inject(HttpTestingController));
+            expect(req.request.params.get('range')).toBe('last_7_days');
+            expect(req.request.params.get('granularity')).toBeNull();
+            expect(req.request.params.get('eventType')).toBeNull();
+            expect(req.request.params.get('siteId')).toBeNull();
+
+            req.flush({
+                entity: { data: { totalEvents: 42 } },
+                errors: [],
+                i18nMessagesMap: {},
+                messages: [],
+                pagination: null,
+                permissions: []
+            });
+        });
+
+        it('should GET total-events with from and to', () => {
+            spectator.service.getTotalEvents({ from: '2026-01-01', to: '2026-01-31' }).subscribe();
+
+            const req = expectTotalEventsReq(TestBed.inject(HttpTestingController));
+            expect(req.request.params.get('from')).toBe('2026-01-01');
+            expect(req.request.params.get('to')).toBe('2026-01-31');
+
+            req.flush({
+                entity: { data: { totalEvents: 10 } },
+                errors: [],
+                i18nMessagesMap: {},
+                messages: [],
+                pagination: null,
+                permissions: []
+            });
+        });
+
+        it('should append eventType, siteId, and granularity when provided in options', () => {
+            let result!: unknown;
+            spectator.service
+                .getTotalEvents({
+                    range: 'last_7_days',
+                    granularity: 'day',
+                    eventType: 'pageview',
+                    siteId: 'site-abc'
+                })
+                .subscribe((data) => {
+                    result = data;
+                });
+
+            const req = expectTotalEventsReq(TestBed.inject(HttpTestingController));
+            expect(req.request.params.get('range')).toBe('last_7_days');
+            expect(req.request.params.get('granularity')).toBe('day');
+            expect(req.request.params.get('eventType')).toBe('pageview');
+            expect(req.request.params.get('siteId')).toBe('site-abc');
+
+            req.flush({
+                entity: {
+                    data: [
+                        { day: '2026-05-01', totalEvents: 3 },
+                        { day: '2026-05-02', totalEvents: 5 }
+                    ]
+                },
+                errors: [],
+                i18nMessagesMap: {},
+                messages: [],
+                pagination: null,
+                permissions: []
+            });
+
+            expect(result).toEqual([
+                { day: '2026-05-01', totalEvents: 3 },
+                { day: '2026-05-02', totalEvents: 5 }
+            ]);
+        });
+
+        it('should append impression eventType without granularity', () => {
+            spectator.service
+                .getTotalEvents({ range: 'last_30_days', eventType: 'impressions' })
+                .subscribe();
+
+            const req = expectTotalEventsReq(TestBed.inject(HttpTestingController));
+            expect(req.request.params.get('range')).toBe('last_30_days');
+            expect(req.request.params.get('eventType')).toBe('impressions');
+            expect(req.request.params.get('granularity')).toBeNull();
+
+            req.flush({
+                entity: { data: { totalEvents: 99 } },
+                errors: [],
+                i18nMessagesMap: {},
+                messages: [],
+                pagination: null,
+                permissions: []
+            });
         });
     });
 

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.spec.ts
@@ -261,14 +261,19 @@ describe('DotAnalyticsService', () => {
             expect(req.request.params.get('eventType')).toBe('impressions');
             expect(req.request.params.get('granularity')).toBeNull();
 
-            req.flush({
-                entity: { data: { totalEvents: 99 } },
-                errors: [],
-                i18nMessagesMap: {},
-                messages: [],
-                pagination: null,
-                permissions: []
+            req.flush(dotCMSWrap({ totalEvents: 99 }));
+        });
+
+        it('should propagate HTTP errors for total-events', (done) => {
+            spectator.service.getTotalEvents({ range: 'last_7_days' }).subscribe({
+                error: (e) => {
+                    expect(e.status).toBe(500);
+                    done();
+                }
             });
+
+            const req = expectTotalEventsReq(TestBed.inject(HttpTestingController));
+            req.flush('Server error', { status: 500, statusText: 'Internal Server Error' });
         });
     });
 
@@ -370,6 +375,18 @@ describe('DotAnalyticsService', () => {
 
             req.flush(dotCMSWrap([]));
         });
+
+        it('should propagate HTTP errors for top-content', (done) => {
+            spectator.service.getTopContent({ range: 'last_7_days' }).subscribe({
+                error: (e) => {
+                    expect(e.status).toBe(500);
+                    done();
+                }
+            });
+
+            const req = expectTopContentReq(TestBed.inject(HttpTestingController));
+            req.flush('Server error', { status: 500, statusText: 'Internal Server Error' });
+        });
     });
 
     describe('getPageviewsByDeviceBrowser', () => {
@@ -401,6 +418,18 @@ describe('DotAnalyticsService', () => {
                 { browser: 'Chrome', device: 'desktop', total: 10 },
                 { browser: 'Safari', device: 'mobile', total: 4 }
             ]);
+        });
+
+        it('should propagate HTTP errors for pageviews-by-device-browser', (done) => {
+            spectator.service.getPageviewsByDeviceBrowser({ range: 'last_30_days' }).subscribe({
+                error: (e) => {
+                    expect(e.status).toBe(500);
+                    done();
+                }
+            });
+
+            const req = expectPageviewsByDeviceBrowserReq(TestBed.inject(HttpTestingController));
+            req.flush('Server error', { status: 500, statusText: 'Internal Server Error' });
         });
     });
 

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
@@ -14,6 +14,7 @@ import {
     CubeJSQuery,
     DeviceBrowserData,
     GetPageviewsByDeviceBrowserParams,
+    GetRangeSiteEventParams,
     GetTopContentParams,
     GetTotalEventsParams,
     GetUniqueVisitorsParams,
@@ -204,7 +205,7 @@ export class DotAnalyticsService {
         return httpParams;
     }
 
-    #buildRangeSiteEventParams(params: GetTopContentParams): HttpParams {
+    #buildRangeSiteEventParams(params: GetRangeSiteEventParams): HttpParams {
         let httpParams = this.#buildRangeParams(
             'range' in params ? { range: params.range } : { from: params.from, to: params.to }
         );

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
@@ -10,19 +10,26 @@ import { DotCMSResponse, HealthStatusTypes } from '@dotcms/dotcms-models';
 import {
     AnalyticsApiResponse,
     AnalyticsEventResponse,
-    ApiRangeParams,
     CubeJSQuery,
     DeviceBrowserData,
-    GetPageviewsByDeviceBrowserParams,
     GetRangeSiteEventParams,
-    GetTopContentParams,
+    GetTotalEventsDayGranularityParams,
+    GetTotalEventsNonDayGranularityParams,
     GetTotalEventsParams,
+    GetTotalEventsWithoutGranularity,
+    GetUniqueVisitorsDayGranularityParams,
+    GetUniqueVisitorsNonDayGranularityParams,
     GetUniqueVisitorsParams,
+    GetUniqueVisitorsWithoutGranularity,
     TopContentData,
+    TotalEventsByBucketRow,
     TotalEventsByDayData,
     TotalEventsData,
+    TotalEventsNonDayBucketRow,
+    UniqueVisitorsByBucketRow,
     UniqueVisitorsByDayData,
-    UniqueVisitorsData
+    UniqueVisitorsData,
+    UniqueVisitorsNonDayBucketRow
 } from '../../index';
 
 /**
@@ -92,38 +99,45 @@ export class DotAnalyticsService {
     }
 
     /**
-     * Fetches total events from the new analytics event endpoint.
-     *
-     * @param params - Date range (`range` or `from`+`to`) plus optional `granularity`, `eventType`, `siteId`
-     * @returns Aggregate `{ totalEvents }` or per-bucket rows when `granularity` is sent (runtime shape; typed as union)
+     * Fetches total events — aggregate when `granularity` is omitted.
      */
+    getTotalEvents(params: GetTotalEventsWithoutGranularity): Observable<TotalEventsData>;
+    /** Per-day buckets. */
+    getTotalEvents(params: GetTotalEventsDayGranularityParams): Observable<TotalEventsByDayData[]>;
+    getTotalEvents(
+        params: GetTotalEventsNonDayGranularityParams
+    ): Observable<TotalEventsNonDayBucketRow[]>;
     getTotalEvents(
         params: GetTotalEventsParams
-    ): Observable<TotalEventsData | TotalEventsByDayData[]> {
+    ): Observable<TotalEventsData | TotalEventsByBucketRow[]> {
         const httpParams = this.#buildTotalEventsParams(params);
 
         return this.#http
             .get<
-                DotCMSResponse<AnalyticsEventResponse<TotalEventsData | TotalEventsByDayData[]>>
+                DotCMSResponse<AnalyticsEventResponse<TotalEventsData | TotalEventsByBucketRow[]>>
             >(`${this.#EVENT_URL}/total-events`, { params: httpParams })
             .pipe(map((response) => response.entity.data));
     }
 
     /**
-     * Fetches unique visitors from the new analytics event endpoint.
-     *
-     * @param params - Date range plus optional `granularity` and `siteId` (no `eventType`)
-     * @returns Aggregate `{ uniqueVisitors }` or per-bucket rows when `granularity` is sent (typed as union)
+     * Fetches unique visitors — aggregate when `granularity` is omitted.
      */
+    getUniqueVisitors(params: GetUniqueVisitorsWithoutGranularity): Observable<UniqueVisitorsData>;
+    getUniqueVisitors(
+        params: GetUniqueVisitorsDayGranularityParams
+    ): Observable<UniqueVisitorsByDayData[]>;
+    getUniqueVisitors(
+        params: GetUniqueVisitorsNonDayGranularityParams
+    ): Observable<UniqueVisitorsNonDayBucketRow[]>;
     getUniqueVisitors(
         params: GetUniqueVisitorsParams
-    ): Observable<UniqueVisitorsData | UniqueVisitorsByDayData[]> {
+    ): Observable<UniqueVisitorsData | UniqueVisitorsByBucketRow[]> {
         const httpParams = this.#buildUniqueVisitorsParams(params);
 
         return this.#http
             .get<
                 DotCMSResponse<
-                    AnalyticsEventResponse<UniqueVisitorsData | UniqueVisitorsByDayData[]>
+                    AnalyticsEventResponse<UniqueVisitorsData | UniqueVisitorsByBucketRow[]>
                 >
             >(`${this.#EVENT_URL}/unique-visitors`, { params: httpParams })
             .pipe(map((response) => response.entity.data));
@@ -135,7 +149,7 @@ export class DotAnalyticsService {
      *
      * @param params - Date range plus optional `siteId` and `eventType` query params
      */
-    getTopContent(params: GetTopContentParams): Observable<TopContentData[]> {
+    getTopContent(params: GetRangeSiteEventParams): Observable<TopContentData[]> {
         const httpParams = this.#buildRangeSiteEventParams(params);
 
         return this.#http
@@ -150,9 +164,7 @@ export class DotAnalyticsService {
      *
      * @param params - Date range plus optional `siteId` and `eventType`
      */
-    getPageviewsByDeviceBrowser(
-        params: GetPageviewsByDeviceBrowserParams
-    ): Observable<DeviceBrowserData[]> {
+    getPageviewsByDeviceBrowser(params: GetRangeSiteEventParams): Observable<DeviceBrowserData[]> {
         const httpParams = this.#buildRangeSiteEventParams(params);
 
         return this.#http
@@ -162,7 +174,9 @@ export class DotAnalyticsService {
             .pipe(map((response) => response.entity.data));
     }
 
-    #buildRangeParams(rangeParams: ApiRangeParams): HttpParams {
+    #buildRangeParams(
+        rangeParams: GetTotalEventsParams | GetUniqueVisitorsParams | GetRangeSiteEventParams
+    ): HttpParams {
         let params = new HttpParams();
         if ('range' in rangeParams) {
             params = params.set('range', rangeParams.range);
@@ -175,9 +189,7 @@ export class DotAnalyticsService {
     }
 
     #buildTotalEventsParams(params: GetTotalEventsParams): HttpParams {
-        let httpParams = this.#buildRangeParams(
-            'range' in params ? { range: params.range } : { from: params.from, to: params.to }
-        );
+        let httpParams = this.#buildRangeParams(params);
         if (params.granularity) {
             httpParams = httpParams.set('granularity', params.granularity);
         }
@@ -192,9 +204,7 @@ export class DotAnalyticsService {
     }
 
     #buildUniqueVisitorsParams(params: GetUniqueVisitorsParams): HttpParams {
-        let httpParams = this.#buildRangeParams(
-            'range' in params ? { range: params.range } : { from: params.from, to: params.to }
-        );
+        let httpParams = this.#buildRangeParams(params);
         if (params.granularity) {
             httpParams = httpParams.set('granularity', params.granularity);
         }
@@ -206,9 +216,7 @@ export class DotAnalyticsService {
     }
 
     #buildRangeSiteEventParams(params: GetRangeSiteEventParams): HttpParams {
-        let httpParams = this.#buildRangeParams(
-            'range' in params ? { range: params.range } : { from: params.from, to: params.to }
-        );
+        let httpParams = this.#buildRangeParams(params);
         if (params.eventType) {
             httpParams = httpParams.set('eventType', params.eventType);
         }

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
@@ -10,10 +10,13 @@ import { DotCMSResponse, HealthStatusTypes } from '@dotcms/dotcms-models';
 import {
     AnalyticsApiResponse,
     AnalyticsEventResponse,
-    ApiGranularity,
     ApiRangeParams,
     CubeJSQuery,
     DeviceBrowserData,
+    GetPageviewsByDeviceBrowserParams,
+    GetTopContentParams,
+    GetTotalEventsParams,
+    GetUniqueVisitorsParams,
     TopContentData,
     TotalEventsByDayData,
     TotalEventsData,
@@ -89,95 +92,72 @@ export class DotAnalyticsService {
 
     /**
      * Fetches total events from the new analytics event endpoint.
-     * Supports predefined ranges (`?range=last_7_days`) or custom dates (`?from=...&to=...`).
      *
-     * @param rangeParams - Object with either `range` or `from`+`to` query params
-     * @param granularity - Optional granularity (e.g. 'day', 'hour')
-     * @returns Observable of TotalEventsData (single object) or TotalEventsByDayData[] (array with granularity)
+     * @param params - Date range (`range` or `from`+`to`) plus optional `granularity`, `eventType`, `siteId`
+     * @returns Aggregate `{ totalEvents }` or per-bucket rows when `granularity` is sent (runtime shape; typed as union)
      */
-    getTotalEvents(rangeParams: ApiRangeParams): Observable<TotalEventsData>;
     getTotalEvents(
-        rangeParams: ApiRangeParams,
-        granularity: ApiGranularity
-    ): Observable<TotalEventsByDayData[]>;
-    getTotalEvents(
-        rangeParams: ApiRangeParams,
-        granularity?: ApiGranularity
+        params: GetTotalEventsParams
     ): Observable<TotalEventsData | TotalEventsByDayData[]> {
-        let params = this.#buildRangeParams(rangeParams);
-        if (granularity) {
-            params = params.set('granularity', granularity);
-        }
+        const httpParams = this.#buildTotalEventsParams(params);
 
         return this.#http
             .get<
                 DotCMSResponse<AnalyticsEventResponse<TotalEventsData | TotalEventsByDayData[]>>
-            >(`${this.#EVENT_URL}/total-events`, { params })
+            >(`${this.#EVENT_URL}/total-events`, { params: httpParams })
             .pipe(map((response) => response.entity.data));
     }
 
     /**
      * Fetches unique visitors from the new analytics event endpoint.
-     * Supports predefined ranges (`?range=last_7_days`) or custom dates (`?from=...&to=...`).
      *
-     * @param rangeParams - Object with either `range` or `from`+`to` query params
-     * @param granularity - Optional granularity (e.g. 'day', 'hour')
-     * @returns Observable of UniqueVisitorsData (single object) or UniqueVisitorsByDayData[] (array with granularity)
+     * @param params - Date range plus optional `granularity` and `siteId` (no `eventType`)
+     * @returns Aggregate `{ uniqueVisitors }` or per-bucket rows when `granularity` is sent (typed as union)
      */
-    getUniqueVisitors(rangeParams: ApiRangeParams): Observable<UniqueVisitorsData>;
     getUniqueVisitors(
-        rangeParams: ApiRangeParams,
-        granularity: ApiGranularity
-    ): Observable<UniqueVisitorsByDayData[]>;
-    getUniqueVisitors(
-        rangeParams: ApiRangeParams,
-        granularity?: ApiGranularity
+        params: GetUniqueVisitorsParams
     ): Observable<UniqueVisitorsData | UniqueVisitorsByDayData[]> {
-        let params = this.#buildRangeParams(rangeParams);
-        if (granularity) {
-            params = params.set('granularity', granularity);
-        }
+        const httpParams = this.#buildUniqueVisitorsParams(params);
 
         return this.#http
             .get<
                 DotCMSResponse<
                     AnalyticsEventResponse<UniqueVisitorsData | UniqueVisitorsByDayData[]>
                 >
-            >(`${this.#EVENT_URL}/unique-visitors`, { params })
+            >(`${this.#EVENT_URL}/unique-visitors`, { params: httpParams })
             .pipe(map((response) => response.entity.data));
     }
 
     /**
      * Fetches top content from the new analytics event endpoint.
-     * Returns an array of content items ordered by total events descending.
+     * Returns content ordered by total events descending.
      *
-     * @param rangeParams - Object with either `range` or `from`+`to` query params
-     * @returns Observable of TopContentData[]
+     * @param params - Date range plus optional `siteId` and `eventType` query params
      */
-    getTopContent(rangeParams: ApiRangeParams): Observable<TopContentData[]> {
-        const params = this.#buildRangeParams(rangeParams);
+    getTopContent(params: GetTopContentParams): Observable<TopContentData[]> {
+        const httpParams = this.#buildRangeSiteEventParams(params);
 
         return this.#http
             .get<
                 DotCMSResponse<AnalyticsEventResponse<TopContentData[]>>
-            >(`${this.#EVENT_URL}/top-content`, { params })
+            >(`${this.#EVENT_URL}/top-content`, { params: httpParams })
             .pipe(map((response) => response.entity.data));
     }
 
     /**
      * Fetches pageviews by device and browser from the new analytics event endpoint.
-     * Returns an array of items with browser, device, and total count.
      *
-     * @param rangeParams - Object with either `range` or `from`+`to` query params
-     * @returns Observable of DeviceBrowserData[]
+     * @param params - Date range plus optional `siteId` and `eventType`
      */
-    getPageviewsByDeviceBrowser(rangeParams: ApiRangeParams): Observable<DeviceBrowserData[]> {
-        const params = this.#buildRangeParams(rangeParams);
+    getPageviewsByDeviceBrowser(
+        params: GetPageviewsByDeviceBrowserParams
+    ): Observable<DeviceBrowserData[]> {
+        const httpParams = this.#buildRangeSiteEventParams(params);
 
         return this.#http
             .get<
                 DotCMSResponse<AnalyticsEventResponse<DeviceBrowserData[]>>
-            >(`${this.#EVENT_URL}/pageviews-by-device-browser`, { params })
+            >(`${this.#EVENT_URL}/pageviews-by-device-browser`, { params: httpParams })
             .pipe(map((response) => response.entity.data));
     }
 
@@ -191,6 +171,51 @@ export class DotAnalyticsService {
         }
 
         return params;
+    }
+
+    #buildTotalEventsParams(params: GetTotalEventsParams): HttpParams {
+        let httpParams = this.#buildRangeParams(
+            'range' in params ? { range: params.range } : { from: params.from, to: params.to }
+        );
+        if (params.granularity) {
+            httpParams = httpParams.set('granularity', params.granularity);
+        }
+        if (params.eventType) {
+            httpParams = httpParams.set('eventType', params.eventType);
+        }
+        if (params.siteId) {
+            httpParams = httpParams.set('siteId', params.siteId);
+        }
+
+        return httpParams;
+    }
+
+    #buildUniqueVisitorsParams(params: GetUniqueVisitorsParams): HttpParams {
+        let httpParams = this.#buildRangeParams(
+            'range' in params ? { range: params.range } : { from: params.from, to: params.to }
+        );
+        if (params.granularity) {
+            httpParams = httpParams.set('granularity', params.granularity);
+        }
+        if (params.siteId) {
+            httpParams = httpParams.set('siteId', params.siteId);
+        }
+
+        return httpParams;
+    }
+
+    #buildRangeSiteEventParams(params: GetTopContentParams): HttpParams {
+        let httpParams = this.#buildRangeParams(
+            'range' in params ? { range: params.range } : { from: params.from, to: params.to }
+        );
+        if (params.eventType) {
+            httpParams = httpParams.set('eventType', params.eventType);
+        }
+        if (params.siteId) {
+            httpParams = httpParams.set('siteId', params.siteId);
+        }
+
+        return httpParams;
     }
 
     /**

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/services/dot-analytics.service.ts
@@ -13,23 +13,17 @@ import {
     CubeJSQuery,
     DeviceBrowserData,
     GetRangeSiteEventParams,
-    GetTotalEventsDayGranularityParams,
-    GetTotalEventsNonDayGranularityParams,
     GetTotalEventsParams,
     GetTotalEventsWithoutGranularity,
-    GetUniqueVisitorsDayGranularityParams,
-    GetUniqueVisitorsNonDayGranularityParams,
+    GetTotalEventsWithGranularity,
     GetUniqueVisitorsParams,
     GetUniqueVisitorsWithoutGranularity,
+    GetUniqueVisitorsWithGranularity,
     TopContentData,
-    TotalEventsByBucketRow,
     TotalEventsByDayData,
     TotalEventsData,
-    TotalEventsNonDayBucketRow,
-    UniqueVisitorsByBucketRow,
     UniqueVisitorsByDayData,
-    UniqueVisitorsData,
-    UniqueVisitorsNonDayBucketRow
+    UniqueVisitorsData
 } from '../../index';
 
 /**
@@ -102,19 +96,16 @@ export class DotAnalyticsService {
      * Fetches total events — aggregate when `granularity` is omitted.
      */
     getTotalEvents(params: GetTotalEventsWithoutGranularity): Observable<TotalEventsData>;
-    /** Per-day buckets. */
-    getTotalEvents(params: GetTotalEventsDayGranularityParams): Observable<TotalEventsByDayData[]>;
-    getTotalEvents(
-        params: GetTotalEventsNonDayGranularityParams
-    ): Observable<TotalEventsNonDayBucketRow[]>;
+    /** Time series: each row uses `day` as bucket label (see {@link TotalEventsByDayData}). */
+    getTotalEvents(params: GetTotalEventsWithGranularity): Observable<TotalEventsByDayData[]>;
     getTotalEvents(
         params: GetTotalEventsParams
-    ): Observable<TotalEventsData | TotalEventsByBucketRow[]> {
+    ): Observable<TotalEventsData | TotalEventsByDayData[]> {
         const httpParams = this.#buildTotalEventsParams(params);
 
         return this.#http
             .get<
-                DotCMSResponse<AnalyticsEventResponse<TotalEventsData | TotalEventsByBucketRow[]>>
+                DotCMSResponse<AnalyticsEventResponse<TotalEventsData | TotalEventsByDayData[]>>
             >(`${this.#EVENT_URL}/total-events`, { params: httpParams })
             .pipe(map((response) => response.entity.data));
     }
@@ -123,21 +114,19 @@ export class DotAnalyticsService {
      * Fetches unique visitors — aggregate when `granularity` is omitted.
      */
     getUniqueVisitors(params: GetUniqueVisitorsWithoutGranularity): Observable<UniqueVisitorsData>;
+    /** Time series: each row uses `day` as bucket label (see {@link UniqueVisitorsByDayData}). */
     getUniqueVisitors(
-        params: GetUniqueVisitorsDayGranularityParams
+        params: GetUniqueVisitorsWithGranularity
     ): Observable<UniqueVisitorsByDayData[]>;
     getUniqueVisitors(
-        params: GetUniqueVisitorsNonDayGranularityParams
-    ): Observable<UniqueVisitorsNonDayBucketRow[]>;
-    getUniqueVisitors(
         params: GetUniqueVisitorsParams
-    ): Observable<UniqueVisitorsData | UniqueVisitorsByBucketRow[]> {
+    ): Observable<UniqueVisitorsData | UniqueVisitorsByDayData[]> {
         const httpParams = this.#buildUniqueVisitorsParams(params);
 
         return this.#http
             .get<
                 DotCMSResponse<
-                    AnalyticsEventResponse<UniqueVisitorsData | UniqueVisitorsByBucketRow[]>
+                    AnalyticsEventResponse<UniqueVisitorsData | UniqueVisitorsByDayData[]>
                 >
             >(`${this.#EVENT_URL}/unique-visitors`, { params: httpParams })
             .pipe(map((response) => response.entity.data));

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
@@ -2,7 +2,7 @@ import { tapResponse } from '@ngrx/operators';
 import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { format } from 'date-fns';
-import { of, pipe, throwError } from 'rxjs';
+import { pipe } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
@@ -129,18 +129,6 @@ export function withPageview() {
                                     siteId: currentSiteId
                                 })
                                 .pipe(
-                                    switchMap((data) =>
-                                        Array.isArray(data)
-                                            ? throwError(
-                                                  () =>
-                                                      new Error(
-                                                          dotMessageService.get(
-                                                              'analytics.error.loading.total-pageviews'
-                                                          )
-                                                      )
-                                              )
-                                            : of(data)
-                                    ),
                                     tapResponse({
                                         next: (data) => {
                                             patchState(store, {
@@ -186,24 +174,13 @@ export function withPageview() {
                         switchMap(({ timeRange, currentSiteId }) => {
                             const rangeParams = toApiRangeParams(timeRange);
 
+                            // Unique-visitors endpoint has no eventType filter; totals reflect whatever the backend aggregates.
                             return analyticsService
                                 .getUniqueVisitors({
                                     ...rangeParams,
                                     siteId: currentSiteId
                                 })
                                 .pipe(
-                                    switchMap((data) =>
-                                        Array.isArray(data)
-                                            ? throwError(
-                                                  () =>
-                                                      new Error(
-                                                          dotMessageService.get(
-                                                              'analytics.error.loading.unique-visitors'
-                                                          )
-                                                      )
-                                              )
-                                            : of(data)
-                                    ),
                                     tapResponse({
                                         next: (data) => {
                                             patchState(store, {
@@ -332,18 +309,6 @@ export function withPageview() {
                                     siteId: currentSiteId
                                 })
                                 .pipe(
-                                    switchMap((data) =>
-                                        Array.isArray(data)
-                                            ? of(data)
-                                            : throwError(
-                                                  () =>
-                                                      new Error(
-                                                          dotMessageService.get(
-                                                              'analytics.error.loading.pageviews-timeline'
-                                                          )
-                                                      )
-                                              )
-                                    ),
                                     map((items) =>
                                         fillMissingApiDates(items, timeRange, 'day', (date) => ({
                                             day: format(date, 'yyyy-MM-dd'),

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
@@ -2,12 +2,12 @@ import { tapResponse } from '@ngrx/operators';
 import { patchState, signalStoreFeature, type, withMethods, withState } from '@ngrx/signals';
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { format } from 'date-fns';
-import { pipe } from 'rxjs';
+import { of, pipe, throwError } from 'rxjs';
 
 import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 
-import { filter, map, switchMap, tap } from 'rxjs/operators';
+import { map, switchMap, tap } from 'rxjs/operators';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { ComponentStatus } from '@dotcms/dotcms-models';
@@ -23,10 +23,8 @@ import {
     TimeRangeInput,
     TopContentData,
     TotalEventsByDayData,
-    TotalEventsData,
     TopPagePerformanceEntity,
     TotalPageViewsEntity,
-    UniqueVisitorsData,
     UniqueVisitorsEntity
 } from '../../types';
 import {
@@ -59,6 +57,35 @@ const initialPageviewState: PageviewState = {
     pageViewDeviceBrowsers: createInitialRequestState(),
     topPagesTable: createInitialRequestState()
 };
+
+function analyticsResponseBodyMessage(error: HttpErrorResponse): string | null {
+    const body = error.error;
+    if (typeof body === 'string' && body.trim()) {
+        return body.trim();
+    }
+    if (body && typeof body === 'object' && 'message' in body) {
+        const m = (body as { message: unknown }).message;
+        if (typeof m === 'string' && m.trim()) {
+            return m.trim();
+        }
+    }
+    return null;
+}
+
+/** User-facing message: prefer API body `message`, then `Error.message`, else i18n (never Angular's generic `HttpErrorResponse.message` alone). */
+function pageviewFeatureErrorMessage(
+    error: unknown,
+    dotMessageService: DotMessageService,
+    i18nKey: string
+): string {
+    if (error instanceof HttpErrorResponse) {
+        return analyticsResponseBodyMessage(error) ?? dotMessageService.get(i18nKey);
+    }
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+    return dotMessageService.get(i18nKey);
+}
 
 /**
  * Signal Store Feature for managing pageview analytics data.
@@ -102,7 +129,18 @@ export function withPageview() {
                                     siteId: currentSiteId
                                 })
                                 .pipe(
-                                    filter((data): data is TotalEventsData => !Array.isArray(data)),
+                                    switchMap((data) =>
+                                        Array.isArray(data)
+                                            ? throwError(
+                                                  () =>
+                                                      new Error(
+                                                          dotMessageService.get(
+                                                              'analytics.error.loading.total-pageviews'
+                                                          )
+                                                      )
+                                              )
+                                            : of(data)
+                                    ),
                                     tapResponse({
                                         next: (data) => {
                                             patchState(store, {
@@ -113,12 +151,12 @@ export function withPageview() {
                                                 }
                                             });
                                         },
-                                        error: (error: HttpErrorResponse) => {
-                                            const errorMessage =
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.total-pageviews'
-                                                );
+                                        error: (error: unknown) => {
+                                            const errorMessage = pageviewFeatureErrorMessage(
+                                                error,
+                                                dotMessageService,
+                                                'analytics.error.loading.total-pageviews'
+                                            );
                                             patchState(store, {
                                                 totalPageViews: {
                                                     status: ComponentStatus.ERROR,
@@ -154,8 +192,17 @@ export function withPageview() {
                                     siteId: currentSiteId
                                 })
                                 .pipe(
-                                    filter(
-                                        (data): data is UniqueVisitorsData => !Array.isArray(data)
+                                    switchMap((data) =>
+                                        Array.isArray(data)
+                                            ? throwError(
+                                                  () =>
+                                                      new Error(
+                                                          dotMessageService.get(
+                                                              'analytics.error.loading.unique-visitors'
+                                                          )
+                                                      )
+                                              )
+                                            : of(data)
                                     ),
                                     tapResponse({
                                         next: (data) => {
@@ -167,12 +214,12 @@ export function withPageview() {
                                                 }
                                             });
                                         },
-                                        error: (error: HttpErrorResponse) => {
-                                            const errorMessage =
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.unique-visitors'
-                                                );
+                                        error: (error: unknown) => {
+                                            const errorMessage = pageviewFeatureErrorMessage(
+                                                error,
+                                                dotMessageService,
+                                                'analytics.error.loading.unique-visitors'
+                                            );
                                             patchState(store, {
                                                 uniqueVisitors: {
                                                     status: ComponentStatus.ERROR,
@@ -239,12 +286,12 @@ export function withPageview() {
                                                 }
                                             });
                                         },
-                                        error: (error: HttpErrorResponse) => {
-                                            const errorMessage =
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.top-page-performance'
-                                                );
+                                        error: (error: unknown) => {
+                                            const errorMessage = pageviewFeatureErrorMessage(
+                                                error,
+                                                dotMessageService,
+                                                'analytics.error.loading.top-page-performance'
+                                            );
                                             patchState(store, {
                                                 topPagePerformance: {
                                                     status: ComponentStatus.ERROR,
@@ -285,8 +332,17 @@ export function withPageview() {
                                     siteId: currentSiteId
                                 })
                                 .pipe(
-                                    filter((data): data is TotalEventsByDayData[] =>
+                                    switchMap((data) =>
                                         Array.isArray(data)
+                                            ? of(data)
+                                            : throwError(
+                                                  () =>
+                                                      new Error(
+                                                          dotMessageService.get(
+                                                              'analytics.error.loading.pageviews-timeline'
+                                                          )
+                                                      )
+                                              )
                                     ),
                                     map((items) =>
                                         fillMissingApiDates(items, timeRange, 'day', (date) => ({
@@ -304,16 +360,16 @@ export function withPageview() {
                                                 }
                                             });
                                         },
-                                        error: (error: HttpErrorResponse) => {
+                                        error: (error: unknown) => {
                                             patchState(store, {
                                                 pageViewTimeLine: {
                                                     status: ComponentStatus.ERROR,
                                                     data: null,
-                                                    error:
-                                                        error.message ||
-                                                        dotMessageService.get(
-                                                            'analytics.error.loading.pageviews-timeline'
-                                                        )
+                                                    error: pageviewFeatureErrorMessage(
+                                                        error,
+                                                        dotMessageService,
+                                                        'analytics.error.loading.pageviews-timeline'
+                                                    )
                                                 }
                                             });
                                         }
@@ -368,12 +424,12 @@ export function withPageview() {
                                                 }
                                             });
                                         },
-                                        error: (error: HttpErrorResponse) => {
-                                            const errorMessage =
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.device-breakdown'
-                                                );
+                                        error: (error: unknown) => {
+                                            const errorMessage = pageviewFeatureErrorMessage(
+                                                error,
+                                                dotMessageService,
+                                                'analytics.error.loading.device-breakdown'
+                                            );
                                             patchState(store, {
                                                 pageViewDeviceBrowsers: {
                                                     status: ComponentStatus.ERROR,
@@ -420,12 +476,12 @@ export function withPageview() {
                                                 }
                                             });
                                         },
-                                        error: (error: HttpErrorResponse) => {
-                                            const errorMessage =
-                                                error.message ||
-                                                dotMessageService.get(
-                                                    'analytics.error.loading.top-pages-table'
-                                                );
+                                        error: (error: unknown) => {
+                                            const errorMessage = pageviewFeatureErrorMessage(
+                                                error,
+                                                dotMessageService,
+                                                'analytics.error.loading.top-pages-table'
+                                            );
                                             patchState(store, {
                                                 topPagesTable: {
                                                     status: ComponentStatus.ERROR,
@@ -445,19 +501,32 @@ export function withPageview() {
             /**
              * Coordinated method to load all pageview data.
              * Calls all individual load methods while maintaining their independent states.
+             *
+             * When `GlobalStore.currentSiteId()` is empty, loads are skipped and all pageview
+             * slices are reset to initial `INIT` status so the UI does not stay stale or loading.
              */
             loadAllPageviewData(): void {
                 const timeRange = store.timeRange();
                 const currentSiteId = globalStore.currentSiteId();
 
-                if (currentSiteId) {
-                    store._loadTotalPageViews({ timeRange, currentSiteId });
-                    store._loadUniqueVisitors({ timeRange, currentSiteId });
-                    store._loadTopPagePerformance({ timeRange, currentSiteId });
-                    store._loadPageViewTimeLine({ timeRange, currentSiteId });
-                    store._loadPageViewDeviceBrowsers({ timeRange, currentSiteId });
-                    store._loadTopPagesTable({ timeRange, currentSiteId });
+                if (!currentSiteId) {
+                    patchState(store, {
+                        totalPageViews: createInitialRequestState(),
+                        uniqueVisitors: createInitialRequestState(),
+                        topPagePerformance: createInitialRequestState(),
+                        pageViewTimeLine: createInitialRequestState(),
+                        pageViewDeviceBrowsers: createInitialRequestState(),
+                        topPagesTable: createInitialRequestState()
+                    });
+                    return;
                 }
+
+                store._loadTotalPageViews({ timeRange, currentSiteId });
+                store._loadUniqueVisitors({ timeRange, currentSiteId });
+                store._loadTopPagePerformance({ timeRange, currentSiteId });
+                store._loadPageViewTimeLine({ timeRange, currentSiteId });
+                store._loadPageViewDeviceBrowsers({ timeRange, currentSiteId });
+                store._loadTopPagesTable({ timeRange, currentSiteId });
             }
         }))
     );

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/store/features/with-pageview.feature.ts
@@ -7,7 +7,7 @@ import { pipe } from 'rxjs';
 import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 
-import { map, switchMap, tap } from 'rxjs/operators';
+import { filter, map, switchMap, tap } from 'rxjs/operators';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { ComponentStatus } from '@dotcms/dotcms-models';
@@ -92,41 +92,43 @@ export function withPageview() {
                                 }
                             })
                         ),
-                        switchMap(({ timeRange }) => {
+                        switchMap(({ timeRange, currentSiteId }) => {
                             const rangeParams = toApiRangeParams(timeRange);
 
-                            return analyticsService.getTotalEvents(rangeParams).pipe(
-                                map(
-                                    (data: TotalEventsData): TotalPageViewsEntity => ({
-                                        totalEvents: data.totalEvents
-                                    })
-                                ),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            totalPageViews: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.total-pageviews'
-                                            );
-                                        patchState(store, {
-                                            totalPageViews: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
+                            return analyticsService
+                                .getTotalEvents({
+                                    ...rangeParams,
+                                    eventType: 'pageview',
+                                    siteId: currentSiteId
                                 })
-                            );
+                                .pipe(
+                                    filter((data): data is TotalEventsData => !Array.isArray(data)),
+                                    tapResponse({
+                                        next: (data) => {
+                                            patchState(store, {
+                                                totalPageViews: {
+                                                    status: ComponentStatus.LOADED,
+                                                    data,
+                                                    error: null
+                                                }
+                                            });
+                                        },
+                                        error: (error: HttpErrorResponse) => {
+                                            const errorMessage =
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.total-pageviews'
+                                                );
+                                            patchState(store, {
+                                                totalPageViews: {
+                                                    status: ComponentStatus.ERROR,
+                                                    data: null,
+                                                    error: errorMessage
+                                                }
+                                            });
+                                        }
+                                    })
+                                );
                         })
                     )
                 ),
@@ -143,41 +145,44 @@ export function withPageview() {
                                 }
                             })
                         ),
-                        switchMap(({ timeRange }) => {
+                        switchMap(({ timeRange, currentSiteId }) => {
                             const rangeParams = toApiRangeParams(timeRange);
 
-                            return analyticsService.getUniqueVisitors(rangeParams).pipe(
-                                map(
-                                    (data: UniqueVisitorsData): UniqueVisitorsEntity => ({
-                                        uniqueVisitors: data.uniqueVisitors
-                                    })
-                                ),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            uniqueVisitors: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.unique-visitors'
-                                            );
-                                        patchState(store, {
-                                            uniqueVisitors: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
+                            return analyticsService
+                                .getUniqueVisitors({
+                                    ...rangeParams,
+                                    siteId: currentSiteId
                                 })
-                            );
+                                .pipe(
+                                    filter(
+                                        (data): data is UniqueVisitorsData => !Array.isArray(data)
+                                    ),
+                                    tapResponse({
+                                        next: (data) => {
+                                            patchState(store, {
+                                                uniqueVisitors: {
+                                                    status: ComponentStatus.LOADED,
+                                                    data,
+                                                    error: null
+                                                }
+                                            });
+                                        },
+                                        error: (error: HttpErrorResponse) => {
+                                            const errorMessage =
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.unique-visitors'
+                                                );
+                                            patchState(store, {
+                                                uniqueVisitors: {
+                                                    status: ComponentStatus.ERROR,
+                                                    data: null,
+                                                    error: errorMessage
+                                                }
+                                            });
+                                        }
+                                    })
+                                );
                         })
                     )
                 ),
@@ -197,49 +202,59 @@ export function withPageview() {
                                 }
                             })
                         ),
-                        switchMap(({ timeRange }) => {
+                        switchMap(({ timeRange, currentSiteId }) => {
                             const rangeParams = toApiRangeParams(timeRange);
 
-                            return analyticsService.getTopContent(rangeParams).pipe(
-                                map((items: TopContentData[]): TopPagePerformanceEntity | null => {
-                                    if (!items?.length) {
-                                        return null;
-                                    }
-
-                                    const top = items[0];
-
-                                    return {
-                                        identifier: top.identifier,
-                                        title: top.title,
-                                        totalEvents: top.totalEvents
-                                    };
-                                }),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            topPagePerformance: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.top-page-performance'
-                                            );
-                                        patchState(store, {
-                                            topPagePerformance: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
+                            return analyticsService
+                                .getTopContent({
+                                    ...rangeParams,
+                                    eventType: 'pageview',
+                                    siteId: currentSiteId
                                 })
-                            );
+                                .pipe(
+                                    map(
+                                        (
+                                            items: TopContentData[]
+                                        ): TopPagePerformanceEntity | null => {
+                                            if (!items?.length) {
+                                                return null;
+                                            }
+
+                                            const top = items[0];
+
+                                            return {
+                                                identifier: top.identifier,
+                                                title: top.title,
+                                                totalEvents: top.totalEvents
+                                            };
+                                        }
+                                    ),
+                                    tapResponse({
+                                        next: (data) => {
+                                            patchState(store, {
+                                                topPagePerformance: {
+                                                    status: ComponentStatus.LOADED,
+                                                    data,
+                                                    error: null
+                                                }
+                                            });
+                                        },
+                                        error: (error: HttpErrorResponse) => {
+                                            const errorMessage =
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.top-page-performance'
+                                                );
+                                            patchState(store, {
+                                                topPagePerformance: {
+                                                    status: ComponentStatus.ERROR,
+                                                    data: null,
+                                                    error: errorMessage
+                                                }
+                                            });
+                                        }
+                                    })
+                                );
                         })
                     )
                 ),
@@ -259,41 +274,51 @@ export function withPageview() {
                                 }
                             })
                         ),
-                        switchMap(({ timeRange }) => {
+                        switchMap(({ timeRange, currentSiteId }) => {
                             const rangeParams = toApiRangeParams(timeRange);
 
-                            return analyticsService.getTotalEvents(rangeParams, 'day').pipe(
-                                map((items) =>
-                                    fillMissingApiDates(items, timeRange, 'day', (date) => ({
-                                        day: format(date, 'yyyy-MM-dd'),
-                                        totalEvents: 0
-                                    }))
-                                ),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            pageViewTimeLine: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        patchState(store, {
-                                            pageViewTimeLine: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error:
-                                                    error.message ||
-                                                    dotMessageService.get(
-                                                        'analytics.error.loading.pageviews-timeline'
-                                                    )
-                                            }
-                                        });
-                                    }
+                            return analyticsService
+                                .getTotalEvents({
+                                    ...rangeParams,
+                                    granularity: 'day',
+                                    eventType: 'pageview',
+                                    siteId: currentSiteId
                                 })
-                            );
+                                .pipe(
+                                    filter((data): data is TotalEventsByDayData[] =>
+                                        Array.isArray(data)
+                                    ),
+                                    map((items) =>
+                                        fillMissingApiDates(items, timeRange, 'day', (date) => ({
+                                            day: format(date, 'yyyy-MM-dd'),
+                                            totalEvents: 0
+                                        }))
+                                    ),
+                                    tapResponse({
+                                        next: (data) => {
+                                            patchState(store, {
+                                                pageViewTimeLine: {
+                                                    status: ComponentStatus.LOADED,
+                                                    data,
+                                                    error: null
+                                                }
+                                            });
+                                        },
+                                        error: (error: HttpErrorResponse) => {
+                                            patchState(store, {
+                                                pageViewTimeLine: {
+                                                    status: ComponentStatus.ERROR,
+                                                    data: null,
+                                                    error:
+                                                        error.message ||
+                                                        dotMessageService.get(
+                                                            'analytics.error.loading.pageviews-timeline'
+                                                        )
+                                                }
+                                            });
+                                        }
+                                    })
+                                );
                         })
                     )
                 ),
@@ -313,43 +338,52 @@ export function withPageview() {
                                 }
                             })
                         ),
-                        switchMap(({ timeRange }) => {
+                        switchMap(({ timeRange, currentSiteId }) => {
                             const rangeParams = toApiRangeParams(timeRange);
 
-                            return analyticsService.getPageviewsByDeviceBrowser(rangeParams).pipe(
-                                map((items: DeviceBrowserData[]): PageViewDeviceBrowsersEntity[] =>
-                                    items.map((item) => ({
-                                        browser: item.browser,
-                                        device: item.device,
-                                        total: item.total
-                                    }))
-                                ),
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            pageViewDeviceBrowsers: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.device-breakdown'
-                                            );
-                                        patchState(store, {
-                                            pageViewDeviceBrowsers: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
+                            return analyticsService
+                                .getPageviewsByDeviceBrowser({
+                                    ...rangeParams,
+                                    eventType: 'pageview',
+                                    siteId: currentSiteId
                                 })
-                            );
+                                .pipe(
+                                    map(
+                                        (
+                                            items: DeviceBrowserData[]
+                                        ): PageViewDeviceBrowsersEntity[] =>
+                                            items.map((item) => ({
+                                                browser: item.browser,
+                                                device: item.device,
+                                                total: item.total
+                                            }))
+                                    ),
+                                    tapResponse({
+                                        next: (data) => {
+                                            patchState(store, {
+                                                pageViewDeviceBrowsers: {
+                                                    status: ComponentStatus.LOADED,
+                                                    data,
+                                                    error: null
+                                                }
+                                            });
+                                        },
+                                        error: (error: HttpErrorResponse) => {
+                                            const errorMessage =
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.device-breakdown'
+                                                );
+                                            patchState(store, {
+                                                pageViewDeviceBrowsers: {
+                                                    status: ComponentStatus.ERROR,
+                                                    data: null,
+                                                    error: errorMessage
+                                                }
+                                            });
+                                        }
+                                    })
+                                );
                         })
                     )
                 ),
@@ -366,36 +400,42 @@ export function withPageview() {
                                 }
                             })
                         ),
-                        switchMap(({ timeRange }) => {
+                        switchMap(({ timeRange, currentSiteId }) => {
                             const rangeParams = toApiRangeParams(timeRange);
 
-                            return analyticsService.getTopContent(rangeParams).pipe(
-                                tapResponse({
-                                    next: (data) => {
-                                        patchState(store, {
-                                            topPagesTable: {
-                                                status: ComponentStatus.LOADED,
-                                                data,
-                                                error: null
-                                            }
-                                        });
-                                    },
-                                    error: (error: HttpErrorResponse) => {
-                                        const errorMessage =
-                                            error.message ||
-                                            dotMessageService.get(
-                                                'analytics.error.loading.top-pages-table'
-                                            );
-                                        patchState(store, {
-                                            topPagesTable: {
-                                                status: ComponentStatus.ERROR,
-                                                data: null,
-                                                error: errorMessage
-                                            }
-                                        });
-                                    }
+                            return analyticsService
+                                .getTopContent({
+                                    ...rangeParams,
+                                    eventType: 'pageview',
+                                    siteId: currentSiteId
                                 })
-                            );
+                                .pipe(
+                                    tapResponse({
+                                        next: (data) => {
+                                            patchState(store, {
+                                                topPagesTable: {
+                                                    status: ComponentStatus.LOADED,
+                                                    data,
+                                                    error: null
+                                                }
+                                            });
+                                        },
+                                        error: (error: HttpErrorResponse) => {
+                                            const errorMessage =
+                                                error.message ||
+                                                dotMessageService.get(
+                                                    'analytics.error.loading.top-pages-table'
+                                                );
+                                            patchState(store, {
+                                                topPagesTable: {
+                                                    status: ComponentStatus.ERROR,
+                                                    data: null,
+                                                    error: errorMessage
+                                                }
+                                            });
+                                        }
+                                    })
+                                );
                         })
                     )
                 )

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/types/analytics-api.types.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/types/analytics-api.types.ts
@@ -7,11 +7,48 @@
 export type ApiGranularity = 'hour' | 'day' | 'week' | 'month';
 
 /**
+ * Event kinds accepted by the analytics event API (`eventType` query param).
+ * Extend this union when the upstream API adds more values.
+ */
+export type AnalyticsEventType = 'pageview' | 'impressions';
+
+/**
  * Query params for the analytics event API.
  * Either a predefined `range` OR both `from` + `to` (never partial).
  * The API returns 400 if only one of from/to is provided.
  */
 export type ApiRangeParams = { range: string } | { from: string; to: string };
+
+/** Optional filters for GET `total-events` (merged with {@link ApiRangeParams}). */
+export interface GetTotalEventsFilters {
+    granularity?: ApiGranularity;
+    eventType?: AnalyticsEventType;
+    siteId?: string;
+}
+
+/** Single parameter object for total-events: {@link ApiRangeParams} plus optional filters. */
+export type GetTotalEventsParams = ApiRangeParams & GetTotalEventsFilters;
+
+/** Optional filters for GET `unique-visitors` (`granularity`, `siteId` only — no `eventType`). */
+export interface GetUniqueVisitorsFilters {
+    granularity?: ApiGranularity;
+    siteId?: string;
+}
+
+/** Single parameter object for unique-visitors: {@link ApiRangeParams} plus optional filters. */
+export type GetUniqueVisitorsParams = ApiRangeParams & GetUniqueVisitorsFilters;
+
+/** Optional filters for GET `top-content`. */
+export interface GetTopContentFilters {
+    siteId?: string;
+    eventType?: AnalyticsEventType;
+}
+
+/** Single parameter object for top-content: {@link ApiRangeParams} plus optional filters. */
+export type GetTopContentParams = ApiRangeParams & GetTopContentFilters;
+
+/** Params for GET `pageviews-by-device-browser` (same optional `siteId` / `eventType` as top-content). */
+export type GetPageviewsByDeviceBrowserParams = GetTopContentParams;
 
 /** Response wrapper from analytics event endpoints (entity.data field) */
 export interface AnalyticsEventResponse<T> {

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/types/analytics-api.types.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/types/analytics-api.types.ts
@@ -44,11 +44,16 @@ export interface GetTopContentFilters {
     eventType?: AnalyticsEventType;
 }
 
+/**
+ * Shared query shape for `top-content` and `pageviews-by-device-browser` (range + optional `siteId` / `eventType`).
+ */
+export type GetRangeSiteEventParams = ApiRangeParams & GetTopContentFilters;
+
 /** Single parameter object for top-content: {@link ApiRangeParams} plus optional filters. */
-export type GetTopContentParams = ApiRangeParams & GetTopContentFilters;
+export type GetTopContentParams = GetRangeSiteEventParams;
 
 /** Params for GET `pageviews-by-device-browser` (same optional `siteId` / `eventType` as top-content). */
-export type GetPageviewsByDeviceBrowserParams = GetTopContentParams;
+export type GetPageviewsByDeviceBrowserParams = GetRangeSiteEventParams;
 
 /** Response wrapper from analytics event endpoints (entity.data field) */
 export interface AnalyticsEventResponse<T> {
@@ -62,7 +67,11 @@ export interface TotalEventsData {
     totalEvents: number;
 }
 
-/** Total events by day (with granularity) */
+/**
+ * One time-bucket row when the event API is called with `granularity`.
+ * The store and current dotCMS usage only request **`granularity: 'day'`**, for which the API returns `{ day, totalEvents }`.
+ * Other granularities (`hour`, `week`, `month`) may use different bucket field names upstream; extend this type if those are supported in the UI.
+ */
 export interface TotalEventsByDayData {
     day: string;
     totalEvents: number;

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/types/analytics-api.types.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/types/analytics-api.types.ts
@@ -26,17 +26,62 @@ export interface GetTotalEventsFilters {
     siteId?: string;
 }
 
-/** Single parameter object for total-events: {@link ApiRangeParams} plus optional filters. */
-export type GetTotalEventsParams = ApiRangeParams & GetTotalEventsFilters;
+/** {@link ApiRangeParams} plus optional filters, without a time bucket (no `granularity`). */
+export type GetTotalEventsWithoutGranularity = ApiRangeParams &
+    Omit<GetTotalEventsFilters, 'granularity'> & { granularity?: never };
 
-/** Optional filters for GET `unique-visitors` (`granularity`, `siteId` only — no `eventType`). */
+/** {@link ApiRangeParams} plus optional filters including a required bucket `granularity`. */
+export type GetTotalEventsWithGranularity = ApiRangeParams &
+    Omit<GetTotalEventsFilters, 'granularity'> & {
+        granularity: ApiGranularity;
+    };
+
+/** When `granularity` is `'day'`, responses use `{ day, totalEvents }` rows. */
+export type GetTotalEventsDayGranularityParams = ApiRangeParams &
+    Omit<GetTotalEventsFilters, 'granularity'> & { granularity: 'day' };
+
+/** Non-`day` granularities yield bucket fields `hour`, `week`, or `month` respectively. */
+export type GetTotalEventsNonDayGranularityParams = ApiRangeParams &
+    Omit<GetTotalEventsFilters, 'granularity'> & {
+        granularity: Exclude<ApiGranularity, 'day'>;
+    };
+
+/** Arguments for GET `total-events`. */
+export type GetTotalEventsParams = GetTotalEventsWithoutGranularity | GetTotalEventsWithGranularity;
+
+/**
+ * Optional filters for GET `unique-visitors` (`granularity`, `siteId` only).
+ * The analytics event API does not support `eventType` on this route; counts include all event
+ * kinds the backend aggregates (e.g. not limited to pageviews). See product/API docs before
+ * interpreting trends if new event kinds are tracked.
+ */
 export interface GetUniqueVisitorsFilters {
     granularity?: ApiGranularity;
     siteId?: string;
 }
 
-/** Single parameter object for unique-visitors: {@link ApiRangeParams} plus optional filters. */
-export type GetUniqueVisitorsParams = ApiRangeParams & GetUniqueVisitorsFilters;
+/** Unique visitors aggregate (no buckets). */
+export type GetUniqueVisitorsWithoutGranularity = ApiRangeParams &
+    Omit<GetUniqueVisitorsFilters, 'granularity'> & { granularity?: never };
+
+/** Bucketed unique visitors. */
+export type GetUniqueVisitorsWithGranularity = ApiRangeParams &
+    Omit<GetUniqueVisitorsFilters, 'granularity'> & {
+        granularity: ApiGranularity;
+    };
+
+export type GetUniqueVisitorsDayGranularityParams = ApiRangeParams &
+    Omit<GetUniqueVisitorsFilters, 'granularity'> & { granularity: 'day' };
+
+export type GetUniqueVisitorsNonDayGranularityParams = ApiRangeParams &
+    Omit<GetUniqueVisitorsFilters, 'granularity'> & {
+        granularity: Exclude<ApiGranularity, 'day'>;
+    };
+
+/** Arguments for GET `unique-visitors`. */
+export type GetUniqueVisitorsParams =
+    | GetUniqueVisitorsWithoutGranularity
+    | GetUniqueVisitorsWithGranularity;
 
 /** Optional filters for GET `top-content`. */
 export interface GetTopContentFilters {
@@ -48,12 +93,6 @@ export interface GetTopContentFilters {
  * Shared query shape for `top-content` and `pageviews-by-device-browser` (range + optional `siteId` / `eventType`).
  */
 export type GetRangeSiteEventParams = ApiRangeParams & GetTopContentFilters;
-
-/** Single parameter object for top-content: {@link ApiRangeParams} plus optional filters. */
-export type GetTopContentParams = GetRangeSiteEventParams;
-
-/** Params for GET `pageviews-by-device-browser` (same optional `siteId` / `eventType` as top-content). */
-export type GetPageviewsByDeviceBrowserParams = GetRangeSiteEventParams;
 
 /** Response wrapper from analytics event endpoints (entity.data field) */
 export interface AnalyticsEventResponse<T> {
@@ -68,25 +107,37 @@ export interface TotalEventsData {
 }
 
 /**
- * One time-bucket row when the event API is called with `granularity`.
- * The store and current dotCMS usage only request **`granularity: 'day'`**, for which the API returns `{ day, totalEvents }`.
- * Other granularities (`hour`, `week`, `month`) may use different bucket field names upstream; extend this type if those are supported in the UI.
+ * One time-bucket row per `granularity` when the event API returns a series (not an aggregate).
+ * Field names match the requested granularity.
  */
-export interface TotalEventsByDayData {
-    day: string;
-    totalEvents: number;
-}
+export type TotalEventsByBucketRow =
+    | { hour: string; totalEvents: number }
+    | { day: string; totalEvents: number }
+    | { week: string; totalEvents: number }
+    | { month: string; totalEvents: number };
+
+/** Convenience alias for the common `granularity: 'day'` case. */
+export type TotalEventsByDayData = Extract<TotalEventsByBucketRow, { day: string }>;
+
+export type TotalEventsNonDayBucketRow = Exclude<TotalEventsByBucketRow, TotalEventsByDayData>;
 
 /** Unique visitors (no granularity) */
 export interface UniqueVisitorsData {
     uniqueVisitors: number;
 }
 
-/** Unique visitors by day (with granularity) */
-export interface UniqueVisitorsByDayData {
-    day: string;
-    uniqueVisitors: number;
-}
+export type UniqueVisitorsByBucketRow =
+    | { hour: string; uniqueVisitors: number }
+    | { day: string; uniqueVisitors: number }
+    | { week: string; uniqueVisitors: number }
+    | { month: string; uniqueVisitors: number };
+
+export type UniqueVisitorsByDayData = Extract<UniqueVisitorsByBucketRow, { day: string }>;
+
+export type UniqueVisitorsNonDayBucketRow = Exclude<
+    UniqueVisitorsByBucketRow,
+    UniqueVisitorsByDayData
+>;
 
 /** Top content item from /api/v1/analytics/event/top-content */
 export interface TopContentData {

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/types/analytics-api.types.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/types/analytics-api.types.ts
@@ -3,8 +3,8 @@
  * Separate from CubeJS types which will be removed in the future.
  */
 
-/** Granularity options for the new analytics event API */
-export type ApiGranularity = 'hour' | 'day' | 'week' | 'month';
+/** Granularity values accepted by `granularity=` on Analytics Event endpoints (proxy → upstream). */
+export type ApiGranularity = 'day' | 'month';
 
 /**
  * Event kinds accepted by the analytics event API (`eventType` query param).
@@ -36,16 +36,6 @@ export type GetTotalEventsWithGranularity = ApiRangeParams &
         granularity: ApiGranularity;
     };
 
-/** When `granularity` is `'day'`, responses use `{ day, totalEvents }` rows. */
-export type GetTotalEventsDayGranularityParams = ApiRangeParams &
-    Omit<GetTotalEventsFilters, 'granularity'> & { granularity: 'day' };
-
-/** Non-`day` granularities yield bucket fields `hour`, `week`, or `month` respectively. */
-export type GetTotalEventsNonDayGranularityParams = ApiRangeParams &
-    Omit<GetTotalEventsFilters, 'granularity'> & {
-        granularity: Exclude<ApiGranularity, 'day'>;
-    };
-
 /** Arguments for GET `total-events`. */
 export type GetTotalEventsParams = GetTotalEventsWithoutGranularity | GetTotalEventsWithGranularity;
 
@@ -68,14 +58,6 @@ export type GetUniqueVisitorsWithoutGranularity = ApiRangeParams &
 export type GetUniqueVisitorsWithGranularity = ApiRangeParams &
     Omit<GetUniqueVisitorsFilters, 'granularity'> & {
         granularity: ApiGranularity;
-    };
-
-export type GetUniqueVisitorsDayGranularityParams = ApiRangeParams &
-    Omit<GetUniqueVisitorsFilters, 'granularity'> & { granularity: 'day' };
-
-export type GetUniqueVisitorsNonDayGranularityParams = ApiRangeParams &
-    Omit<GetUniqueVisitorsFilters, 'granularity'> & {
-        granularity: Exclude<ApiGranularity, 'day'>;
     };
 
 /** Arguments for GET `unique-visitors`. */
@@ -107,37 +89,25 @@ export interface TotalEventsData {
 }
 
 /**
- * One time-bucket row per `granularity` when the event API returns a series (not an aggregate).
- * Field names match the requested granularity.
+ * One time-bucket row when the Event API returns a series (`granularity` set).
+ * The JSON field is always **`day`** (yyyy-MM-dd); for `granularity: 'month'`, values are bucket
+ * starts (typically the first day of each month), not necessarily every calendar day in the range.
  */
-export type TotalEventsByBucketRow =
-    | { hour: string; totalEvents: number }
-    | { day: string; totalEvents: number }
-    | { week: string; totalEvents: number }
-    | { month: string; totalEvents: number };
-
-/** Convenience alias for the common `granularity: 'day'` case. */
-export type TotalEventsByDayData = Extract<TotalEventsByBucketRow, { day: string }>;
-
-export type TotalEventsNonDayBucketRow = Exclude<TotalEventsByBucketRow, TotalEventsByDayData>;
+export interface TotalEventsByDayData {
+    day: string;
+    totalEvents: number;
+}
 
 /** Unique visitors (no granularity) */
 export interface UniqueVisitorsData {
     uniqueVisitors: number;
 }
 
-export type UniqueVisitorsByBucketRow =
-    | { hour: string; uniqueVisitors: number }
-    | { day: string; uniqueVisitors: number }
-    | { week: string; uniqueVisitors: number }
-    | { month: string; uniqueVisitors: number };
-
-export type UniqueVisitorsByDayData = Extract<UniqueVisitorsByBucketRow, { day: string }>;
-
-export type UniqueVisitorsNonDayBucketRow = Exclude<
-    UniqueVisitorsByBucketRow,
-    UniqueVisitorsByDayData
->;
+/** One bucket row for unique-visitors series; **`day`** is the bucket label (same semantics as {@link TotalEventsByDayData}). */
+export interface UniqueVisitorsByDayData {
+    day: string;
+    uniqueVisitors: number;
+}
 
 /** Top content item from /api/v1/analytics/event/top-content */
 export interface TopContentData {

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.ts
@@ -1,6 +1,7 @@
 import {
     addDays,
     addHours,
+    addMonths,
     differenceInDays,
     endOfDay,
     format,
@@ -604,6 +605,9 @@ type ApiTimelineEntity = { day: string };
 /**
  * Fills missing dates for new API timeline data (shape: { day: string, ... }).
  * The API returns sparse data (only days with events), this fills gaps with zeros.
+ *
+ * Stepping follows {@link ApiGranularity}: **`day`** advances one calendar day per bucket;
+ * **`month`** advances one calendar month per bucket (`day` keys are typically month starts).
  */
 export const fillMissingApiDates = <T extends ApiTimelineEntity>(
     data: T[],
@@ -633,7 +637,7 @@ export const fillMissingApiDates = <T extends ApiTimelineEntity>(
         } else {
             filledData.push(createEmptyEntity(currentDate));
         }
-        currentDate = granularity === 'hour' ? addHours(currentDate, 1) : addDays(currentDate, 1);
+        currentDate = granularity === 'month' ? addMonths(currentDate, 1) : addDays(currentDate, 1);
     }
 
     return filledData;


### PR DESCRIPTION
This pull request refactors the DotAnalyticsService API and its consumers to use unified parameter objects for analytics queries, improving flexibility and maintainability. The service methods now accept a single options object (including optional fields like `granularity`, `eventType`, and `siteId`), and the store feature is updated accordingly. Additional tests are added for new query combinations, and utility functions are introduced to build query parameters consistently.

**DotAnalyticsService API refactor and enhancements:**

* Refactored all analytics service methods (`getTotalEvents`, `getUniqueVisitors`, `getTopContent`, `getPageviewsByDeviceBrowser`) to accept a single parameter object with optional fields (`granularity`, `eventType`, `siteId`), replacing multiple parameters and overloads. Added private utility methods to build HTTP query parameters for each API call. [[1]](diffhunk://#diff-c0a594cb6bf35693b60035c742263700865b55e180715509ac6b9377ddaeb95bL13-R19) [[2]](diffhunk://#diff-c0a594cb6bf35693b60035c742263700865b55e180715509ac6b9377ddaeb95bL92-R160) [[3]](diffhunk://#diff-c0a594cb6bf35693b60035c742263700865b55e180715509ac6b9377ddaeb95bR176-R220)

* Updated the store feature (`withPageview`) to use the new parameter object format for all analytics queries, ensuring correct passing of `eventType` and `siteId`, and added type guards for array vs. object responses. [[1]](diffhunk://#diff-989f33d2983ed4588112a6b12fa172e230e6e75dcc308948fcc4bc7e73161d59L10-R10) [[2]](diffhunk://#diff-989f33d2983ed4588112a6b12fa172e230e6e75dcc308948fcc4bc7e73161d59L95-R105) [[3]](diffhunk://#diff-989f33d2983ed4588112a6b12fa172e230e6e75dcc308948fcc4bc7e73161d59L146-R158) [[4]](diffhunk://#diff-989f33d2983ed4588112a6b12fa172e230e6e75dcc308948fcc4bc7e73161d59L200-R218) [[5]](diffhunk://#diff-989f33d2983ed4588112a6b12fa172e230e6e75dcc308948fcc4bc7e73161d59L216-R231) [[6]](diffhunk://#diff-989f33d2983ed4588112a6b12fa172e230e6e75dcc308948fcc4bc7e73161d59L262-R290) [[7]](diffhunk://#diff-989f33d2983ed4588112a6b12fa172e230e6e75dcc308948fcc4bc7e73161d59L316-R354)

**Testing improvements:**

* Added comprehensive tests for `getTotalEvents` in `dot-analytics.service.spec.ts`, covering various combinations of query parameters and validating request construction. Introduced a helper function to match requests by URL and method. [[1]](diffhunk://#diff-99331c74e1a5318c227da2286205a09c838813f9e2e732e45c6734cdde4b1793R3-R21) [[2]](diffhunk://#diff-99331c74e1a5318c227da2286205a09c838813f9e2e732e45c6734cdde4b1793R136-R232)

**Minor improvements:**

* Fixed strict typing for test variables in the service spec file. [[1]](diffhunk://#diff-99331c74e1a5318c227da2286205a09c838813f9e2e732e45c6734cdde4b1793L53-R67) [[2]](diffhunk://#diff-99331c74e1a5318c227da2286205a09c838813f9e2e732e45c6734cdde4b1793L77-R91)

This PR fixes: #34849

This PR fixes: #34849