### PR TITLE
fix(lang-var-migration): use JDBC savepoint to isolate unique_fields failures

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/languagevariable/business/LegacyLangVarMigrationHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/languagevariable/business/LegacyLangVarMigrationHelper.java
@@ -3,6 +3,7 @@ package com.dotcms.languagevariable.business;
 import com.dotcms.contenttype.model.type.KeyValueContentType;
 import com.dotcms.exception.ExceptionUtil;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.db.DbConnectionFactory;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.model.Contentlet;
@@ -24,6 +25,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.Savepoint;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -203,7 +206,7 @@ public class LegacyLangVarMigrationHelper {
                     if (existingVariable.isEmpty()) {
                         final Contentlet langVarAsContent = this.createLanguageVariableAsContent(key, value, language.getId());
                         try {
-                            final Contentlet checkedInContent = this.publish(langVarAsContent);
+                            final Contentlet checkedInContent = this.publishWithSavepoint(langVarAsContent);
                             Logger.debug(this, String.format("Saved Language Variable with Inode '%s' for language " +
                                     "'%s_%s'", checkedInContent.getInode(), language.getLanguageCode(), language.getCountryCode()));
                             success.add(checkedInContent.getInode());
@@ -337,6 +340,56 @@ public class LegacyLangVarMigrationHelper {
                         .workflowActionId(unpublishAction)
                         .modUser(APILocator.systemUser())
                         .build());
+    }
+
+    /**
+     * Wraps {@link #publish(Contentlet)} in a JDBC savepoint so that a duplicate-key failure in
+     * the {@code unique_fields} table does not poison the shared outer PostgreSQL transaction.
+     * <p>
+     * Without this guard, when {@code StartupTasksExecutor} wraps the entire migration task in a
+     * single transaction via {@code HibernateUtil.startTransaction()}, any {@code INSERT} that
+     * violates the {@code unique_fields_pkey} constraint puts the PostgreSQL connection into an
+     * aborted state. Every subsequent variable then fails with <em>"current transaction is
+     * aborted, commands ignored until end of transaction block"</em> even though only the first
+     * entry had a conflicting row.
+     * <p>
+     * Rolling back to the savepoint on failure resets the connection from aborted to active, so
+     * the remaining variables in the file can continue to be processed independently.
+     *
+     * @param contentlet The {@link Contentlet} representing the new Language Variable.
+     *
+     * @return The published Language Variable as a {@link Contentlet}.
+     *
+     * @throws DotSecurityException The user calling the API lacks the required permissions.
+     * @throws DotDataException     An error occurred when interacting with the database.
+     */
+    private Contentlet publishWithSavepoint(final Contentlet contentlet) throws DotSecurityException,
+            DotDataException {
+        final Connection conn = Try.of(DbConnectionFactory::getConnection).getOrNull();
+        final Savepoint sp = conn != null ? Try.of(() -> conn.setSavepoint()).getOrNull() : null;
+        try {
+            final Contentlet result = this.publish(contentlet);
+            if (sp != null) {
+                Try.run(() -> conn.releaseSavepoint(sp))
+                        .onFailure(ex -> Logger.warn(this,
+                                "Could not release savepoint after successful publish: " + ex.getMessage()));
+            }
+            return result;
+        } catch (final DotSecurityException | DotDataException e) {
+            if (sp != null) {
+                Try.run(() -> conn.rollback(sp))
+                        .onFailure(ex -> Logger.warn(this,
+                                "Could not rollback savepoint after failed publish: " + ex.getMessage()));
+            }
+            throw e;
+        } catch (final RuntimeException e) {
+            if (sp != null) {
+                Try.run(() -> conn.rollback(sp))
+                        .onFailure(ex -> Logger.warn(this,
+                                "Could not rollback savepoint after failed publish: " + ex.getMessage()));
+            }
+            throw e;
+        }
     }
 
 }

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task240306MigrateLegacyLanguageVariablesTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task240306MigrateLegacyLanguageVariablesTest.java
@@ -3,11 +3,14 @@ package com.dotmarketing.startup.runonce;
 import com.dotcms.contenttype.business.ContentTypeAPI;
 import com.dotcms.contenttype.business.ContentTypeAPIImpl;
 import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.KeyValueContentType;
 import com.dotcms.languagevariable.business.ImmutableMigrationSummary;
 import com.dotcms.languagevariable.business.LegacyLangVarMigrationHelper;
 import com.dotcms.languagevariable.business.LanguageVariableAPI;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.HibernateUtil;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
@@ -24,6 +27,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -321,6 +325,127 @@ public class Task240306MigrateLegacyLanguageVariablesTest {
             // Always restore the messages directory to its original state
             restoreMessagesDirectory(backupFiles);
         }
+    }
+
+    /**
+     * Reproduces the "transaction cascade" bug triggered in production by
+     * {@link com.dotmarketing.startup.StartupTasksExecutor#executeDataUpgrades()}.
+     *
+     * <p>{@code executeDataUpgrades()} wraps every upgrade task in a single shared PostgreSQL
+     * transaction via {@link HibernateUtil#startTransaction()}.  When one language variable fails
+     * with a duplicate-key violation in the {@code unique_fields} table, PostgreSQL marks the
+     * entire connection as <em>aborted</em>.  Every subsequent variable then fails with:
+     * <pre>
+     * ERROR: current transaction is aborted, commands ignored until end of transaction block
+     * </pre>
+     * even though only the first variable had a conflicting entry.</p>
+     *
+     * <p><b>Given scenario:</b>
+     * <ol>
+     *   <li>An outer transaction is started manually (reproducing {@code executeDataUpgrades()}).
+     *   </li>
+     *   <li>An orphaned row is pre-inserted in {@code unique_fields} for the key
+     *       {@code "key_conflict"} — simulating a previous failed migration that persisted the
+     *       unique-field entry without committing the actual contentlet.</li>
+     *   <li>A two-entry properties file is processed: {@code key_conflict} first, then
+     *       {@code key_valid}.</li>
+     * </ol>
+     * <b>Expected result (after the fix):</b> only {@code key_conflict} fails;
+     * {@code key_valid} is migrated successfully.<br>
+     * <b>Current result (before the fix):</b> both variables fail — {@code key_conflict} due
+     * to the duplicate key, and {@code key_valid} because the aborted transaction poisons the
+     * shared PostgreSQL connection.</p>
+     */
+    @Test
+    public void testMigrationVariableFailureDoesNotCascadeToSubsequentVariables()
+            throws Exception {
+
+        // ── setup ──────────────────────────────────────────────────────────────────────────────
+        final ContentTypeAPI ctAPI = APILocator.getContentTypeAPI(APILocator.systemUser());
+        final ContentType langVarCT = ctAPI.find(LanguageVariableAPI.LANGUAGEVARIABLE_VAR_NAME);
+        assertNotNull("Language Variable content type must exist", langVarCT);
+
+        // Use Arabic-SA as the test language (file name: cms_language_ar_SA.properties).
+        createLangVariantInNotExists("ar", "SA", "Arabic", "Saudi Arabia");
+        final Language testLanguage = APILocator.getLanguageAPI().getLanguage("ar", "SA");
+        assertNotNull("Arabic-SA test language must exist", testLanguage);
+
+        // Create a temp messages dir with exactly two entries:
+        //   key_conflict → will collide with the pre-inserted orphan unique_fields row
+        //   key_valid    → must succeed; currently also fails due to transaction cascade (bug)
+        final Path tempDir = Files.createTempDirectory("lang-var-cascade-test");
+        final Path propsFile = tempDir.resolve("cms_language_ar_SA.properties");
+        Files.write(propsFile,
+                "key_conflict=Conflict Value\nkey_valid=Valid Value\n"
+                        .getBytes(StandardCharsets.UTF_8));
+
+        // ── reproduce the production outer-transaction context ─────────────────────────────────
+        // StartupTasksExecutor calls HibernateUtil.startTransaction() before executeUpgrade(),
+        // causing all @WrapInTransaction CDI calls inside the migration to JOIN this transaction
+        // rather than managing their own. A single DB failure therefore aborts the shared
+        // PostgreSQL connection for all subsequent variables.
+        HibernateUtil.startTransaction();
+        ImmutableMigrationSummary summary = null;
+        try {
+            // Pre-insert an orphaned unique_fields row for "key_conflict" within the same
+            // transaction. The criteria string must match what UniqueFieldCriteria.criteria()
+            // would produce: contentTypeId + fieldVarName + languageId + fieldValue.
+            // (uniquePerSite = false for Language Variable, so no siteId is appended.)
+            final String criteria = langVarCT.id()
+                    + KeyValueContentType.KEY_VALUE_KEY_FIELD_VAR
+                    + testLanguage.getId()
+                    + "key_conflict";
+
+            new DotConnect()
+                    .setSQL("INSERT INTO unique_fields (unique_key_val, supporting_values) "
+                            + "VALUES (encode(sha256(convert_to(?::text, 'UTF8')), 'hex'), ?::jsonb)")
+                    .addParam(criteria)
+                    .addParam(String.format(
+                            "{\"contentTypeId\":\"%s\",\"fieldVariableName\":\"%s\","
+                                    + "\"languageId\":%d,\"fieldValue\":\"key_conflict\","
+                                    + "\"contentletIds\":[\"orphan-fake-id\"],\"live\":false,"
+                                    + "\"variant\":\"DEFAULT\",\"uniquePerSite\":false}",
+                            langVarCT.id(),
+                            KeyValueContentType.KEY_VALUE_KEY_FIELD_VAR,
+                            testLanguage.getId()))
+                    .loadResult();
+
+            final LegacyLangVarMigrationHelper helper =
+                    new LegacyLangVarMigrationHelper(langVarCT.id());
+            summary = helper.migrateLegacyLanguageVariables(tempDir);
+
+        } finally {
+            // Roll back everything (orphan row + any contentlets created during migration).
+            try {
+                HibernateUtil.rollbackTransaction();
+            } catch (final Exception rollbackEx) {
+                Logger.warn(Task240306MigrateLegacyLanguageVariablesTest.class,
+                        "Could not rollback test transaction: " + rollbackEx.getMessage());
+            }
+            Files.deleteIfExists(propsFile);
+            Files.deleteIfExists(tempDir);
+        }
+
+        // ── assertions ─────────────────────────────────────────────────────────────────────────
+        assertNotNull("Migration summary must be present", summary);
+
+        final List<String> fails  = summary.fails().getOrDefault(testLanguage, List.of());
+        final List<String> successes = summary.success().getOrDefault(testLanguage, List.of());
+
+        // key_conflict must fail — its unique_fields entry already exists (expected).
+        assertTrue("'key_conflict' must fail due to the pre-existing unique_fields entry",
+                fails.contains("key_conflict"));
+
+        // key_valid must NOT be collateral damage from key_conflict's failure.
+        // Before the fix this assertion fails: key_valid is also in fails because the shared
+        // PostgreSQL connection is poisoned by the aborted transaction.
+        assertFalse(
+                "REGRESSION: 'key_valid' must NOT fail. The failure of 'key_conflict' must not "
+                        + "cascade and abort the PostgreSQL connection for subsequent variables.",
+                fails.contains("key_valid"));
+
+        assertFalse("'key_valid' must have been successfully migrated",
+                successes.isEmpty());
     }
 
     /**


### PR DESCRIPTION
## Problem

Closes #35568
Related to support ticket: https://helpdesk.dotcms.com/a/tickets/35427

When `StartupTasksExecutor.executeDataUpgrades()` wraps the entire migration task in a single PostgreSQL transaction via `HibernateUtil.startTransaction()`, a duplicate-key violation in `unique_fields` aborts the **entire shared connection**. Every subsequent variable then fails with:

```
ERROR: current transaction is aborted, commands ignored until end of transaction block
```

even though only the first variable had a conflict. In production this caused hundreds of Language Variables to fail in cascade after a single collision.

## Root Cause of the Orphan

Orphaned `unique_fields` rows exist because `DBUniqueFieldValidationStrategy.innerValidate()` is annotated `@CloseDBIfOpened`, which forces the `INSERT INTO unique_fields` to commit on a separate connection independently of the outer contentlet transaction. If that outer transaction rolls back, the `unique_fields` row persists. Root cause fix is in PR #35567 (issue #35566).

## Fix

Added `publishWithSavepoint()` in `LegacyLangVarMigrationHelper`. Before each `publish()` call:

1. A JDBC savepoint is set on the current connection.
2. On failure: `conn.rollback(savepoint)` resets the PostgreSQL connection from **aborted** back to **active**, without touching the outer transaction.
3. On success: the savepoint is released.

Only the conflicting variable is skipped; all remaining variables in the file continue normally.

## Test

Added `testMigrationVariableFailureDoesNotCascadeToSubsequentVariables()` which:
1. Starts an outer transaction reproducing the `StartupTasksExecutor` context.
2. Pre-inserts an orphaned `unique_fields` row for `key_conflict`.
3. Runs the migration with a two-entry file (`key_conflict`, `key_valid`).
4. Asserts `key_conflict` fails (expected) and `key_valid` succeeds (was also failing before fix).

Verified: test **fails before** the fix, **passes after**.

## Scope

Only `LegacyLangVarMigrationHelper.java` and the integration test are modified. No changes to `unique_fields` infrastructure.

## Related

- Issue #35568 — this bug report
- Issue #35566 — root cause (`@CloseDBIfOpened` non-atomicity)
- PR #35567 — root cause fix

## Test plan
- [ ] `Task240306MigrateLegacyLanguageVariablesTest#testMigrationVariableFailureDoesNotCascadeToSubsequentVariables` — must pass
- [ ] Full `Task240306MigrateLegacyLanguageVariablesTest` suite — no regressions
- [ ] `testExecuteUpgrade`, `testDataTaskIdempotency`, `testDropThenRecreateLanguageVariableContentType` — must pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)