### PR TITLE
fix(content-import): prevent duplicate tags on CSV import (#35124)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -4028,8 +4028,15 @@ public class ImportUtil {
             final Field field = entry.getValue();
             final Object value = values.get(entry.getKey());
 
-            if (!field.getFieldType().equals(Field.FieldType.TAG.toString())
-                    || !(value instanceof String)) {
+            if (!field.getFieldType().equals(Field.FieldType.TAG.toString())) {
+                continue;
+            }
+            if (!(value instanceof String)) {
+                if (value != null) {
+                    Logger.warn(ImportUtil.class, String.format(
+                            "Tag field '%s' has unexpected value type '%s'; skipping",
+                            field.getVelocityVarName(), value.getClass().getName()));
+                }
                 continue;
             }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -4032,11 +4032,14 @@ public class ImportUtil {
                 continue;
             }
             if (!(value instanceof String)) {
-                if (value != null) {
-                    Logger.warn(ImportUtil.class, String.format(
-                            "Tag field '%s' has unexpected value type '%s'; skipping",
-                            field.getVelocityVarName(), value.getClass().getName()));
-                }
+                Logger.warn(
+                        ImportUtil.class,
+                        String.format(
+                                "Tag field '%s' has unexpected value type '%s'; skipping",
+                                field.getVelocityVarName(),
+                                value == null ? "null" : value.getClass().getName()
+                        )
+                );
                 continue;
             }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/ImportUtil.java
@@ -59,6 +59,8 @@ import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
 import com.dotmarketing.portlets.workflows.model.WorkflowAction;
+import com.dotmarketing.tag.business.TagAPI;
+import com.dotmarketing.tag.model.Tag;
 import com.dotmarketing.util.importer.HeaderValidationCodes;
 import com.dotmarketing.util.importer.ImportLineValidationCodes;
 import com.dotmarketing.util.importer.ImportResultConverter;
@@ -4019,28 +4021,29 @@ public class ImportUtil {
             final Map<Integer, Object> values,
             final Pair<Host, Folder> siteAndFolder) {
 
+        final TagAPI tagAPI = APILocator.getTagAPI();
+        final String hostId = getHostId(siteAndFolder);
+
         for (Map.Entry<Integer, Field> entry : headers.entrySet()) {
-            Field field = entry.getValue();
-            Object value = values.get(entry.getKey());
+            final Field field = entry.getValue();
+            final Object value = values.get(entry.getKey());
 
-            if (field.getFieldType().equals(Field.FieldType.TAG.toString())
-                    && value instanceof String) {
-                String[] tags = ((String) value).split(",");
-                String hostId = getHostId(siteAndFolder);
+            if (!field.getFieldType().equals(Field.FieldType.TAG.toString())
+                    || !(value instanceof String)) {
+                continue;
+            }
 
-                for (String tagName : tags) {
-                    try {
-                        if (tagName != null && !tagName.trim().isEmpty()) {
-                            APILocator.getTagAPI().addContentletTagInode(
-                                    tagName.trim(),
-                                    cont.getInode(),
-                                    hostId,
-                                    field.getVelocityVarName());
-                        }
-                    } catch (Exception e) {
-                        Logger.error(ImportUtil.class, "Unable to import tags: " + e.getMessage());
-                    }
+            try {
+                tagAPI.deleteTagInodesByInodeAndFieldVarName(
+                        cont.getInode(), field.getVelocityVarName());
+
+                final List<Tag> tags = tagAPI.getTagsInText((String) value, hostId);
+                for (final Tag tag : tags) {
+                    tagAPI.addContentletTagInode(tag, cont.getInode(),
+                            field.getVelocityVarName());
                 }
+            } catch (Exception e) {
+                Logger.error(ImportUtil.class, "Unable to import tags: " + e.getMessage());
             }
         }
     }

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -5596,7 +5596,7 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
      */
     @Test
     public void importFile_tagFieldUpdate_replacesExistingTags()
-            throws DotSecurityException, DotDataException, IOException {
+            throws DotSecurityException, DotDataException, IOException, InterruptedException {
 
         final TagAPI tagAPI = APILocator.getTagAPI();
         final String suffix = String.valueOf(System.currentTimeMillis());
@@ -5655,6 +5655,12 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
                     new HashSet<>(Arrays.asList(oldTagA.toLowerCase(), oldTagB.toLowerCase())),
                     firstTags);
 
+            for (final Contentlet c : afterFirst) {
+                c.setIndexPolicy(IndexPolicy.FORCE);
+            }
+            APILocator.getContentletIndexAPI().addContentToIndex(afterFirst);
+            Thread.sleep(1000);
+
             final String secondCsv = "title,hostFolder,tags\r\n" +
                     contentTitle + "," + defaultSite.getIdentifier() + ",\""
                     + newTagC + "," + newTagD + "\"\r\n";
@@ -5663,10 +5669,9 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
 
             final List<Contentlet> afterSecond = contentletAPI.findByStructure(
                     contentType.inode(), user, false, 0, 0);
-            final Contentlet updated = afterSecond.stream()
-                    .filter(c -> contentTitle.equals(c.getStringProperty("title")))
-                    .findFirst()
-                    .orElseThrow(() -> new AssertionError("Updated contentlet not found"));
+            assertEquals("Update should not create a parallel contentlet",
+                    1, afterSecond.size());
+            final Contentlet updated = afterSecond.get(0);
 
             final Set<String> updatedTags = tagAPI.getTagsByInodeAndFieldVarName(
                             updated.getInode(), tagsField.variable())

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -5609,13 +5609,11 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
         ContentType contentType = null;
 
         try {
-            com.dotcms.contenttype.model.field.Field titleField =
-                    FieldBuilder.builder(TextField.class)
-                            .name("title")
-                            .variable("title")
-                            .unique(true)
-                            .dataType(DataTypes.TEXT)
-                            .build();
+            com.dotcms.contenttype.model.field.Field titleField = new FieldDataGen()
+                    .name("title")
+                    .velocityVarName("title")
+                    .type(TextField.class)
+                    .next();
             com.dotcms.contenttype.model.field.Field hostField = new FieldDataGen()
                     .name("hostFolder")
                     .velocityVarName("hostFolder")
@@ -5628,12 +5626,11 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
                     .next();
 
             contentType = new ContentTypeDataGen()
+                    .field(titleField)
                     .field(hostField)
                     .field(tagsField)
                     .nextPersisted();
-            titleField = fieldAPI.save(
-                    FieldBuilder.builder(titleField).contentTypeId(contentType.id()).build(),
-                    user);
+            titleField = fieldAPI.byContentTypeAndVar(contentType, titleField.variable());
             tagsField = fieldAPI.byContentTypeAndVar(contentType, tagsField.variable());
 
             workflowAPI.saveSchemesForStruct(new StructureTransformer(contentType).asStructure(),

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -18,6 +18,7 @@ import com.dotcms.contenttype.model.field.KeyValueField;
 import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.SelectField;
 import com.dotcms.contenttype.model.field.StoryBlockField;
+import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.field.TextAreaField;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.field.TimeField;
@@ -69,6 +70,8 @@ import com.dotmarketing.portlets.structure.model.Field;
 import com.dotmarketing.portlets.structure.model.Relationship;
 import com.dotmarketing.portlets.structure.model.Structure;
 import com.dotmarketing.portlets.templates.model.Template;
+import com.dotmarketing.tag.business.TagAPI;
+import com.dotmarketing.tag.model.Tag;
 import com.dotmarketing.portlets.workflows.actionlet.PublishContentActionlet;
 import com.dotmarketing.portlets.workflows.actionlet.SaveContentActionlet;
 import com.dotmarketing.portlets.workflows.actionlet.SaveContentAsDraftActionlet;
@@ -5331,6 +5334,167 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
                     }
                 } catch (Exception e) {
                     Logger.warn(ImportUtilTest.class, "Error cleaning up language 2", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Method to test: {@link ImportUtil#importFile(Long, String, String, String[], boolean, boolean, User, long, String[], CsvReader, int, int, Reader, String, HttpServletRequest)}
+     * Test Case: CSV import on a site whose tagStorage differs from where an existing tag lives (tag in SYSTEM_HOST, site tagStorage points to itself).
+     * Expected Results: The imported content has exactly one tag relation for the name and no parallel Tag record is created (#35124).
+     */
+    @Test
+    public void importFile_tagFieldUnderSiteWithDifferingTagStorage_doesNotCreateDuplicateTagInodes()
+            throws DotSecurityException, DotDataException, IOException {
+
+        final TagAPI tagAPI = APILocator.getTagAPI();
+        final String suffix = String.valueOf(System.currentTimeMillis());
+        final String tagName = "susa-" + suffix;
+
+        Host testSite = null;
+        ContentType contentType = null;
+        Tag preExistingSystemHostTag = null;
+
+        try {
+            // Site with tagStorage pointing to itself, so it differs from SYSTEM_HOST.
+            testSite = new SiteDataGen()
+                    .name("import-tag-" + suffix + ".dotcms.com")
+                    .nextPersisted();
+            testSite.setTagStorage(testSite.getIdentifier());
+            testSite.setIndexPolicy(IndexPolicy.WAIT_FOR);
+            testSite.setBoolProperty(Contentlet.IS_TEST_MODE, true);
+            testSite.setBoolProperty(Contentlet.DISABLE_WORKFLOW, true);
+            testSite = APILocator.getHostAPI().save(testSite, user, false);
+
+            preExistingSystemHostTag = tagAPI.saveTag(tagName, "", Host.SYSTEM_HOST);
+            assertNotNull("Pre-existing tag should be created", preExistingSystemHostTag);
+            assertEquals("Pre-existing tag should live under SYSTEM_HOST",
+                    Host.SYSTEM_HOST, preExistingSystemHostTag.getHostId());
+            assertEquals("Only the SYSTEM_HOST tag should exist before import",
+                    1, tagAPI.getTagsByName(tagName).size());
+
+            com.dotcms.contenttype.model.field.Field titleField = new FieldDataGen()
+                    .name("title")
+                    .velocityVarName("title")
+                    .type(TextField.class)
+                    .next();
+            com.dotcms.contenttype.model.field.Field hostField = new FieldDataGen()
+                    .name("hostFolder")
+                    .velocityVarName("hostFolder")
+                    .type(HostFolderField.class)
+                    .next();
+            com.dotcms.contenttype.model.field.Field tagsField = new FieldDataGen()
+                    .name("tags")
+                    .velocityVarName("tags")
+                    .type(TagField.class)
+                    .next();
+
+            contentType = new ContentTypeDataGen()
+                    .field(titleField)
+                    .field(hostField)
+                    .field(tagsField)
+                    .nextPersisted();
+
+            titleField = fieldAPI.byContentTypeAndVar(contentType, titleField.variable());
+            hostField = fieldAPI.byContentTypeAndVar(contentType, hostField.variable());
+            tagsField = fieldAPI.byContentTypeAndVar(contentType, tagsField.variable());
+
+            workflowAPI.saveSchemesForStruct(new StructureTransformer(contentType).asStructure(),
+                    Arrays.asList(schemeStepActionResult1.getScheme()));
+
+            final String contentTitle = "tag-dup-repro-" + suffix;
+            final String csv = "title,hostFolder,tags\r\n" +
+                    contentTitle + "," + testSite.getIdentifier() + "," + tagName + "\r\n";
+
+            final Reader reader = createTempFile(csv);
+            final CsvReader csvreader = new CsvReader(reader);
+            csvreader.setSafetySwitch(false);
+            final String[] csvHeaders = csvreader.getHeaders();
+
+            final HashMap<String, List<String>> results = ImportUtil.importFile(
+                    0L,
+                    testSite.getInode(),
+                    contentType.inode(),
+                    new String[]{},
+                    false,
+                    false,
+                    user,
+                    defaultLanguage.getId(),
+                    csvHeaders,
+                    csvreader,
+                    -1,
+                    -1,
+                    reader,
+                    schemeStepActionResult1.getAction().getId(),
+                    getHttpRequest()
+            );
+
+            final List<String> errors = results.get("errors");
+            assertTrue("Import should not produce errors: " + errors,
+                    errors == null || errors.isEmpty());
+
+            final List<Contentlet> savedData = contentletAPI.findByStructure(
+                    contentType.inode(), user, false, 0, 0);
+            assertEquals("Exactly one contentlet should have been imported", 1, savedData.size());
+            final Contentlet imported = savedData.get(0);
+
+            final List<Tag> tagsOnContent = tagAPI.getTagsByInodeAndFieldVarName(
+                    imported.getInode(), tagsField.variable());
+            final long matchingByName = tagsOnContent.stream()
+                    .filter(t -> tagName.equalsIgnoreCase(t.getTagName()))
+                    .count();
+            assertEquals(
+                    "Imported content should have exactly one tag relation for '" + tagName
+                            + "' (got " + tagsOnContent.size() + " tag(s): " + tagsOnContent + ")",
+                    1L, matchingByName);
+
+            final List<Tag> tagsByName = tagAPI.getTagsByName(tagName);
+            assertEquals(
+                    "Only the original SYSTEM_HOST tag should exist after import (got: "
+                            + tagsByName + ")",
+                    1, tagsByName.size());
+            assertEquals("Surviving tag should still be the SYSTEM_HOST one",
+                    Host.SYSTEM_HOST, tagsByName.get(0).getHostId());
+
+        } finally {
+            if (contentType != null) {
+                try {
+                    final List<Contentlet> contentlets = contentletAPI.findByStructure(
+                            contentType.inode(), user, false, 0, -1);
+                    for (final Contentlet c : contentlets) {
+                        try {
+                            contentletAPI.archive(c, user, false);
+                            contentletAPI.delete(c, user, false);
+                        } catch (Exception e) {
+                            Logger.warn(ImportUtilTest.class,
+                                    "Error cleaning up imported contentlet", e);
+                        }
+                    }
+                    contentTypeApi.delete(contentType);
+                } catch (Exception e) {
+                    Logger.warn(ImportUtilTest.class, "Error cleaning up content type", e);
+                }
+            }
+
+            try {
+                for (final Tag t : tagAPI.getTagsByName(tagName)) {
+                    try {
+                        tagAPI.deleteTag(t);
+                    } catch (Exception e) {
+                        Logger.warn(ImportUtilTest.class, "Error cleaning up tag " + t, e);
+                    }
+                }
+            } catch (Exception e) {
+                Logger.warn(ImportUtilTest.class, "Error listing tags for cleanup", e);
+            }
+
+            if (testSite != null) {
+                try {
+                    APILocator.getHostAPI().archive(testSite, user, false);
+                    APILocator.getHostAPI().delete(testSite, user, false);
+                } catch (Exception e) {
+                    Logger.warn(ImportUtilTest.class, "Error cleaning up test site", e);
                 }
             }
         }

--- a/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/util/ImportUtilTest.java
@@ -117,9 +117,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -5497,6 +5499,246 @@ public class ImportUtilTest extends BaseWorkflowIntegrationTest {
                     Logger.warn(ImportUtilTest.class, "Error cleaning up test site", e);
                 }
             }
+        }
+    }
+
+    /**
+     * Method to test: {@link ImportUtil#importFile(Long, String, String, String[], boolean, boolean, User, long, String[], CsvReader, int, int, Reader, String, HttpServletRequest)}
+     * Test Case: A single CSV row contains multiple comma-separated tag names in the tag field.
+     * Expected Results: All listed tags are linked to the imported content, none are dropped.
+     */
+    @Test
+    public void importFile_tagFieldWithMultipleCommaSeparatedTags_linksAllTags()
+            throws DotSecurityException, DotDataException, IOException {
+
+        final TagAPI tagAPI = APILocator.getTagAPI();
+        final String suffix = String.valueOf(System.currentTimeMillis());
+        final List<String> tagNames = Arrays.asList(
+                "multi-a-" + suffix, "multi-b-" + suffix, "multi-c-" + suffix);
+
+        ContentType contentType = null;
+
+        try {
+            com.dotcms.contenttype.model.field.Field titleField = new FieldDataGen()
+                    .name("title")
+                    .velocityVarName("title")
+                    .type(TextField.class)
+                    .next();
+            com.dotcms.contenttype.model.field.Field hostField = new FieldDataGen()
+                    .name("hostFolder")
+                    .velocityVarName("hostFolder")
+                    .type(HostFolderField.class)
+                    .next();
+            com.dotcms.contenttype.model.field.Field tagsField = new FieldDataGen()
+                    .name("tags")
+                    .velocityVarName("tags")
+                    .type(TagField.class)
+                    .next();
+
+            contentType = new ContentTypeDataGen()
+                    .field(titleField)
+                    .field(hostField)
+                    .field(tagsField)
+                    .nextPersisted();
+
+            tagsField = fieldAPI.byContentTypeAndVar(contentType, tagsField.variable());
+
+            workflowAPI.saveSchemesForStruct(new StructureTransformer(contentType).asStructure(),
+                    Arrays.asList(schemeStepActionResult1.getScheme()));
+
+            final String contentTitle = "multi-tag-" + suffix;
+            final String csv = "title,hostFolder,tags\r\n" +
+                    contentTitle + "," + defaultSite.getIdentifier() + ",\""
+                    + String.join(",", tagNames) + "\"\r\n";
+
+            final Reader reader = createTempFile(csv);
+            final CsvReader csvreader = new CsvReader(reader);
+            csvreader.setSafetySwitch(false);
+            final String[] csvHeaders = csvreader.getHeaders();
+
+            final HashMap<String, List<String>> results = ImportUtil.importFile(
+                    0L, defaultSite.getInode(), contentType.inode(), new String[]{},
+                    false, false, user, defaultLanguage.getId(),
+                    csvHeaders, csvreader, -1, -1, reader,
+                    schemeStepActionResult1.getAction().getId(), getHttpRequest());
+
+            final List<String> errors = results.get("errors");
+            assertTrue("Import should not produce errors: " + errors,
+                    errors == null || errors.isEmpty());
+
+            final List<Contentlet> savedData = contentletAPI.findByStructure(
+                    contentType.inode(), user, false, 0, 0);
+            assertEquals("Exactly one contentlet should have been imported", 1, savedData.size());
+            final Contentlet imported = savedData.get(0);
+
+            final List<Tag> linkedTags = tagAPI.getTagsByInodeAndFieldVarName(
+                    imported.getInode(), tagsField.variable());
+            final Set<String> linkedNames = linkedTags.stream()
+                    .map(Tag::getTagName)
+                    .map(String::toLowerCase)
+                    .collect(Collectors.toSet());
+
+            assertEquals("All comma-separated tags should be linked (got: " + linkedTags + ")",
+                    tagNames.stream().map(String::toLowerCase).collect(Collectors.toSet()),
+                    linkedNames);
+        } finally {
+            cleanUpContentType(contentType);
+            for (final String name : tagNames) {
+                cleanUpTagsByName(tagAPI, name);
+            }
+        }
+    }
+
+    /**
+     * Method to test: {@link ImportUtil#importFile(Long, String, String, String[], boolean, boolean, User, long, String[], CsvReader, int, int, Reader, String, HttpServletRequest)}
+     * Test Case: Existing content with tags is updated via CSV import (matched by unique key field) with a different set of tag names.
+     * Expected Results: After the second import the contentlet has only the new tag set; the original tags are no longer linked (strict-replace).
+     */
+    @Test
+    public void importFile_tagFieldUpdate_replacesExistingTags()
+            throws DotSecurityException, DotDataException, IOException {
+
+        final TagAPI tagAPI = APILocator.getTagAPI();
+        final String suffix = String.valueOf(System.currentTimeMillis());
+        final String oldTagA = "old-a-" + suffix;
+        final String oldTagB = "old-b-" + suffix;
+        final String newTagC = "new-c-" + suffix;
+        final String newTagD = "new-d-" + suffix;
+        final List<String> allTagNames = Arrays.asList(oldTagA, oldTagB, newTagC, newTagD);
+
+        ContentType contentType = null;
+
+        try {
+            com.dotcms.contenttype.model.field.Field titleField =
+                    FieldBuilder.builder(TextField.class)
+                            .name("title")
+                            .variable("title")
+                            .unique(true)
+                            .dataType(DataTypes.TEXT)
+                            .build();
+            com.dotcms.contenttype.model.field.Field hostField = new FieldDataGen()
+                    .name("hostFolder")
+                    .velocityVarName("hostFolder")
+                    .type(HostFolderField.class)
+                    .next();
+            com.dotcms.contenttype.model.field.Field tagsField = new FieldDataGen()
+                    .name("tags")
+                    .velocityVarName("tags")
+                    .type(TagField.class)
+                    .next();
+
+            contentType = new ContentTypeDataGen()
+                    .field(hostField)
+                    .field(tagsField)
+                    .nextPersisted();
+            titleField = fieldAPI.save(
+                    FieldBuilder.builder(titleField).contentTypeId(contentType.id()).build(),
+                    user);
+            tagsField = fieldAPI.byContentTypeAndVar(contentType, tagsField.variable());
+
+            workflowAPI.saveSchemesForStruct(new StructureTransformer(contentType).asStructure(),
+                    Arrays.asList(schemeStepActionResult1.getScheme()));
+
+            final String contentTitle = "replace-tags-" + suffix;
+            final String firstCsv = "title,hostFolder,tags\r\n" +
+                    contentTitle + "," + defaultSite.getIdentifier() + ",\""
+                    + oldTagA + "," + oldTagB + "\"\r\n";
+
+            runImport(firstCsv, contentType, new String[]{titleField.id()});
+
+            final List<Contentlet> afterFirst = contentletAPI.findByStructure(
+                    contentType.inode(), user, false, 0, 0);
+            assertEquals("First import should produce one contentlet", 1, afterFirst.size());
+
+            final Set<String> firstTags = tagAPI.getTagsByInodeAndFieldVarName(
+                            afterFirst.get(0).getInode(), tagsField.variable())
+                    .stream().map(Tag::getTagName).map(String::toLowerCase)
+                    .collect(Collectors.toSet());
+            assertEquals("First import should link only the original tags",
+                    new HashSet<>(Arrays.asList(oldTagA.toLowerCase(), oldTagB.toLowerCase())),
+                    firstTags);
+
+            final String secondCsv = "title,hostFolder,tags\r\n" +
+                    contentTitle + "," + defaultSite.getIdentifier() + ",\""
+                    + newTagC + "," + newTagD + "\"\r\n";
+
+            runImport(secondCsv, contentType, new String[]{titleField.id()});
+
+            final List<Contentlet> afterSecond = contentletAPI.findByStructure(
+                    contentType.inode(), user, false, 0, 0);
+            final Contentlet updated = afterSecond.stream()
+                    .filter(c -> contentTitle.equals(c.getStringProperty("title")))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Updated contentlet not found"));
+
+            final Set<String> updatedTags = tagAPI.getTagsByInodeAndFieldVarName(
+                            updated.getInode(), tagsField.variable())
+                    .stream().map(Tag::getTagName).map(String::toLowerCase)
+                    .collect(Collectors.toSet());
+
+            assertEquals("Update should strict-replace tags: only new ones should remain (got: "
+                            + updatedTags + ")",
+                    new HashSet<>(Arrays.asList(newTagC.toLowerCase(), newTagD.toLowerCase())),
+                    updatedTags);
+        } finally {
+            cleanUpContentType(contentType);
+            for (final String name : allTagNames) {
+                cleanUpTagsByName(tagAPI, name);
+            }
+        }
+    }
+
+    private void runImport(final String csv, final ContentType contentType, final String[] keyFields)
+            throws DotDataException, DotSecurityException, IOException {
+        final Reader reader = createTempFile(csv);
+        final CsvReader csvreader = new CsvReader(reader);
+        csvreader.setSafetySwitch(false);
+        final String[] csvHeaders = csvreader.getHeaders();
+
+        final HashMap<String, List<String>> results = ImportUtil.importFile(
+                0L, defaultSite.getInode(), contentType.inode(), keyFields,
+                false, false, user, defaultLanguage.getId(),
+                csvHeaders, csvreader, -1, -1, reader,
+                schemeStepActionResult1.getAction().getId(), getHttpRequest());
+
+        final List<String> errors = results.get("errors");
+        assertTrue("Import should not produce errors: " + errors,
+                errors == null || errors.isEmpty());
+    }
+
+    private void cleanUpContentType(final ContentType contentType) {
+        if (contentType == null) {
+            return;
+        }
+        try {
+            final List<Contentlet> contentlets = contentletAPI.findByStructure(
+                    contentType.inode(), user, false, 0, -1);
+            for (final Contentlet c : contentlets) {
+                try {
+                    contentletAPI.archive(c, user, false);
+                    contentletAPI.delete(c, user, false);
+                } catch (Exception e) {
+                    Logger.warn(ImportUtilTest.class,
+                            "Error cleaning up imported contentlet", e);
+                }
+            }
+            contentTypeApi.delete(contentType);
+        } catch (Exception e) {
+            Logger.warn(ImportUtilTest.class, "Error cleaning up content type", e);
+        }
+    }
+
+    private void cleanUpTagsByName(final TagAPI tagAPI, final String tagName) {
+        try {
+            for (final Tag t : tagAPI.getTagsByName(tagName)) {
+                try {
+                    tagAPI.deleteTag(t);
+                } catch (Exception e) {
+                    Logger.warn(ImportUtilTest.class, "Error cleaning up tag " + t, e);
+                }
+            }
+        } catch (Exception e) {
+            Logger.warn(ImportUtilTest.class, "Error listing tags for cleanup", e);
         }
     }
 


### PR DESCRIPTION
Align ImportUtil#processTagFields with ESContentletAPIImpl#relateTags so both paths resolve to the same Tag record. Previously the post-checkin path used a strict (name, siteId) lookup with searchInSystemHost=false and no tagStorage resolution, which on sites whose tagStorage differed from where the tag actually lived (e.g. tag at SYSTEM_HOST, site tagStorage = self) caused saveTag to create a parallel Tag and a second TagInode pointing at it; rendering as duplicate chips on the content.

Switch processTagFields to TagAPI#getTagsInText (smart lookup, prefers persona > site > global) and wipe TagInodes for (inode, fieldVar) before re-adding for strict-replace, idempotent semantics. 

Adds an integration test reproducing the duplicate-tag scenario.



### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #35124

This PR fixes: #35124