### PR TITLE
fix(menu): recover Plugins portlet on broken-window installs (#35428)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260505AddPluginsPortletToMenu.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260505AddPluginsPortletToMenu.java
@@ -1,0 +1,154 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotcms.exception.ExceptionUtil;
+import com.dotmarketing.business.CacheLocator;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.startup.StartupTask;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UUIDUtil;
+import com.dotmarketing.util.UtilMethods;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.dotmarketing.util.PortletID.DYNAMIC_PLUGINS;
+import static com.dotmarketing.util.PortletID.MAINTENANCE;
+import static com.dotmarketing.util.PortletID.PLUGINS;
+import static com.dotmarketing.util.PortletID.PLUGINS_LEGACY;
+
+/**
+ * Recovery task for issue #35428. Ensures the new Angular {@code plugins} portlet is present
+ * in a sensible default layout on instances that were left in a broken state by the
+ * pre-{@code empty_20260331} starter. Those instances have a {@code dynamic-plugins} row in
+ * {@code cms_layouts_portlets} (seeded by the old starter) but no {@code plugins} row, because
+ * {@link Task260320AddPluginsPortletToMenu} was marked complete on first install without ever
+ * executing its body (the {@code firstTimeStart} skip in
+ * {@link com.dotmarketing.startup.StartupTasksExecutor#executeSchemaUpgrades}).
+ *
+ * <p>The layout is resolved through a fallback chain so the task is robust to whatever combination
+ * of legacy rows and renamed layouts the customer's database is in:
+ *
+ * <ol>
+ *   <li>Layout containing {@code dynamic-plugins} (legacy seed).</li>
+ *   <li>Layout containing {@code plugins-legacy} (post-rename intermediate state).</li>
+ *   <li>Layout named {@code system} (case-insensitive) — stable anchor by name.</li>
+ *   <li>Layout containing the {@code maintenance} portlet — last-resort System anchor by content.</li>
+ * </ol>
+ *
+ * <p>Inserts only the new {@code plugins} portlet. Leaves any existing {@code dynamic-plugins} and
+ * {@code plugins-legacy} rows untouched, preserving the rollback-safety convention asserted by
+ * {@code Task260320AddPluginsPortletToMenuTest#dynamicPluginsIsPreservedForRollbackSafety}.
+ *
+ * @author hassandotcms
+ * @since May 5th, 2026
+ */
+public class Task260505AddPluginsPortletToMenu implements StartupTask {
+
+    @Override
+    public boolean forceRun() {
+        try {
+            final int pluginsCount = new DotConnect()
+                    .setSQL("SELECT COUNT(portlet_id) AS count FROM cms_layouts_portlets WHERE portlet_id = ?")
+                    .addParam(PLUGINS.toString())
+                    .getInt("count");
+            return pluginsCount == 0;
+        } catch (final Exception e) {
+            Logger.error(this, String.format("An error occurred when checking the 'Plugins' portlet. " +
+                    "Please verify manually: %s", ExceptionUtil.getErrorMessage(e)), e);
+        }
+        return false;
+    }
+
+    @Override
+    public void executeUpgrade() throws DotDataException {
+        Logger.info(this, "Ensuring the Angular 'plugins' portlet is present in the admin menu");
+
+        final String layoutId = resolveTargetLayout();
+        if (UtilMethods.isNotSet(layoutId)) {
+            Logger.error(this, "No suitable layout found to host the 'plugins' portlet. " +
+                    "Please add it manually via Roles & Tools.");
+            return;
+        }
+
+        final boolean alreadyInLayout = new DotConnect()
+                .setSQL("SELECT COUNT(portlet_id) AS count FROM cms_layouts_portlets WHERE layout_id = ? AND portlet_id = ?")
+                .addParam(layoutId)
+                .addParam(PLUGINS.toString())
+                .getInt("count") > 0;
+        if (alreadyInLayout) {
+            Logger.info(this, "The 'plugins' portlet is already present in layout " + layoutId + "; nothing to do.");
+            return;
+        }
+
+        final int nextOrder = new DotConnect()
+                .setSQL("SELECT MAX(portlet_order) AS portlet_order FROM cms_layouts_portlets WHERE layout_id = ?")
+                .addParam(layoutId)
+                .getInt("portlet_order") + 1;
+
+        new DotConnect()
+                .setSQL("INSERT INTO cms_layouts_portlets(id, layout_id, portlet_id, portlet_order) VALUES (?, ?, ?, ?)")
+                .addParam(UUIDUtil.uuid())
+                .addParam(layoutId)
+                .addParam(PLUGINS.toString())
+                .addParam(nextOrder)
+                .loadResult();
+        Logger.info(this, "Added 'plugins' portlet at position " + nextOrder + " in layout: " + layoutId);
+
+        CacheLocator.getLayoutCache().clearCache();
+    }
+
+    /**
+     * Picks the layout that should host the new {@code plugins} portlet, walking the fallback chain
+     * documented on the class. Returns {@code null} when no anchor can be found, which signals the
+     * caller to log and exit cleanly without inserting anything.
+     */
+    private String resolveTargetLayout() throws DotDataException {
+        // 1. Layout containing 'dynamic-plugins' (legacy seed).
+        String layoutId = findLayoutContainingPortlet(DYNAMIC_PLUGINS.toString());
+        if (UtilMethods.isSet(layoutId)) {
+            return layoutId;
+        }
+
+        // 2. Layout containing 'plugins-legacy' (post-rename intermediate state).
+        layoutId = findLayoutContainingPortlet(PLUGINS_LEGACY.toString());
+        if (UtilMethods.isSet(layoutId)) {
+            return layoutId;
+        }
+
+        // 3. Layout named 'system' (case-insensitive).
+        final List<Map<String, Object>> systemByName = new DotConnect()
+                .setSQL("SELECT id FROM cms_layout WHERE LOWER(layout_name) = 'system'")
+                .loadObjectResults();
+        if (!systemByName.isEmpty()) {
+            final String id = systemByName.get(0).getOrDefault("id", "").toString();
+            if (UtilMethods.isSet(id)) {
+                return id;
+            }
+        }
+
+        // 4. Layout containing the 'maintenance' portlet.
+        layoutId = findLayoutContainingPortlet(MAINTENANCE.toString());
+        if (UtilMethods.isSet(layoutId)) {
+            return layoutId;
+        }
+
+        return null;
+    }
+
+    private String findLayoutContainingPortlet(final String portletId) throws DotDataException {
+        // ORDER BY layout_id keeps the choice deterministic in the rare case the same portlet ID
+        // appears in more than one layout (cms_layouts_portlets UNIQUE is on (layout_id, portlet_id),
+        // not portlet_id alone).
+        final List<Map<String, Object>> results = new DotConnect()
+                .setSQL("SELECT layout_id FROM cms_layouts_portlets WHERE portlet_id = ? ORDER BY layout_id")
+                .setMaxRows(1)
+                .addParam(portletId)
+                .loadObjectResults();
+        if (results.isEmpty()) {
+            return null;
+        }
+        return results.get(0).getOrDefault("layout_id", "").toString();
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -266,6 +266,7 @@ import com.dotmarketing.startup.runonce.Task260324AddIdentifierPathTriggerIndex;
 import com.dotmarketing.startup.runonce.Task260403SetLz4CompressionOnTextColumns;
 import com.dotmarketing.startup.runonce.Task260403SetPermissionReferenceUnlogged;
 import com.dotmarketing.startup.runonce.Task260407AddBaseTypeColumnToIdentifier;
+import com.dotmarketing.startup.runonce.Task260505AddPluginsPortletToMenu;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -606,6 +607,7 @@ public class TaskLocatorUtil {
         .add(Task260403SetLz4CompressionOnTextColumns.class)
         .add(Task260403SetPermissionReferenceUnlogged.class)
         .add(Task260407AddBaseTypeColumnToIdentifier.class)
+        .add(Task260505AddPluginsPortletToMenu.class)
         .build();
 
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -34,6 +34,7 @@ import com.dotmarketing.startup.runonce.Task251212AddVersionColumnIndicesTableTe
 import com.dotmarketing.startup.runonce.Task260206AddUsagePortletToMenuTest;
 import com.dotmarketing.startup.runonce.Task260320AddPluginsPortletToMenuTest;
 import com.dotmarketing.startup.runonce.Task260407AddBaseTypeColumnToIdentifierTest;
+import com.dotmarketing.startup.runonce.Task260505AddPluginsPortletToMenuTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -77,6 +78,7 @@ import org.junit.runners.Suite;
         Task251212AddVersionColumnIndicesTableTest.class,
         Task260206AddUsagePortletToMenuTest.class,
         Task260320AddPluginsPortletToMenuTest.class,
+        Task260505AddPluginsPortletToMenuTest.class,
         Task260407AddBaseTypeColumnToIdentifierTest.class,
         ImportContentletsActionSmokeTest.class,
 })

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260505AddPluginsPortletToMenuTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260505AddPluginsPortletToMenuTest.java
@@ -1,0 +1,166 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UUIDUtil;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that the {@link Task260505AddPluginsPortletToMenu} recovery task runs as expected.
+ *
+ * <p>Unlike its companion {@link Task260320AddPluginsPortletToMenuTest}, this class cannot rely on
+ * the integration starter seeding the legacy {@code dynamic-plugins} row — current starters
+ * ({@code empty_20260331} and later) ship the corrected state with {@code plugins} already in the
+ * layout. To reproduce the broken-window scenario the recovery task is built for, each test sets
+ * up a {@code dynamic-plugins} anchor in the {@code system} layout and then deletes any
+ * {@code plugins} row, putting the DB in the same shape an affected customer's instance is in.
+ *
+ * @author hassandotcms
+ * @since May 5th, 2026
+ */
+public class Task260505AddPluginsPortletToMenuTest {
+
+    /** Matches {@link com.dotmarketing.util.PortletID#PLUGINS} */
+    private static final String PLUGINS_PORTLET_ID = "plugins";
+    /** Matches {@link com.dotmarketing.util.PortletID#DYNAMIC_PLUGINS} */
+    private static final String DYNAMIC_PLUGINS_PORTLET_ID = "dynamic-plugins";
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Reproduces the broken-window install state: a {@code dynamic-plugins} row in the {@code system}
+     * layout, no {@code plugins} row. Idempotent — if {@code dynamic-plugins} is already there
+     * (e.g. from a previous test or an older starter) we leave it alone.
+     */
+    @Before
+    public void setUpBrokenWindowState() throws DotDataException {
+        deletePluginsPortlet();
+
+        final int existingDynamic = new DotConnect()
+                .setSQL("SELECT COUNT(*) AS count FROM cms_layouts_portlets WHERE portlet_id = ?")
+                .addParam(DYNAMIC_PLUGINS_PORTLET_ID)
+                .getInt("count");
+        if (existingDynamic > 0) {
+            return;
+        }
+
+        final String systemLayoutId = new DotConnect()
+                .setSQL("SELECT id FROM cms_layout WHERE LOWER(layout_name) = 'system'")
+                .getString("id");
+        Assume.assumeTrue(
+                "Integration DB must have a 'system' layout to host the dynamic-plugins anchor",
+                systemLayoutId != null && !systemLayoutId.isEmpty());
+
+        new DotConnect()
+                .setSQL("INSERT INTO cms_layouts_portlets(id, layout_id, portlet_id, portlet_order) " +
+                        "VALUES (?, ?, ?, ?)")
+                .addParam(UUIDUtil.uuid())
+                .addParam(systemLayoutId)
+                .addParam(DYNAMIC_PLUGINS_PORTLET_ID)
+                .addParam(99)
+                .loadResult();
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link Task260505AddPluginsPortletToMenu#executeUpgrade()}</li>
+     *     <li><b>Given scenario:</b> The {@code plugins} portlet is missing while
+     *     {@code dynamic-plugins} remains as the legacy anchor (the broken-window state).</li>
+     *     <li><b>Expected result:</b> {@code forceRun()} is true, the task adds the portlet, then
+     *     {@code forceRun()} is false.</li>
+     * </ul>
+     */
+    @Test
+    public void upgradeTaskExecution() throws Exception {
+        final Task260505AddPluginsPortletToMenu upgradeTask = new Task260505AddPluginsPortletToMenu();
+
+        assertTrue(
+                "The 'plugins' portlet was explicitly deleted before, so the UT must run",
+                upgradeTask.forceRun());
+        upgradeTask.executeUpgrade();
+        assertFalse(
+                "The 'plugins' portlet has already been added, so the UT must NOT run again",
+                upgradeTask.forceRun());
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link Task260505AddPluginsPortletToMenu#executeUpgrade()}</li>
+     *     <li><b>Given scenario:</b> The task runs successfully.</li>
+     *     <li><b>Expected result:</b> {@code dynamic-plugins} remains untouched in
+     *     {@code cms_layouts_portlets} so that a version rollback finds it and the old
+     *     {@code portlet.xml} renders the JSP portlet without any DB repair.</li>
+     * </ul>
+     */
+    @Test
+    public void dynamicPluginsIsPreservedForRollbackSafety() throws DotDataException {
+        new Task260505AddPluginsPortletToMenu().executeUpgrade();
+
+        final int count = new DotConnect()
+                .setSQL("SELECT COUNT(*) AS count FROM cms_layouts_portlets WHERE portlet_id = ?")
+                .addParam(DYNAMIC_PLUGINS_PORTLET_ID)
+                .getInt("count");
+        assertTrue(
+                "'dynamic-plugins' must remain in the layout after the upgrade so a rollback restores the JSP portlet",
+                count > 0);
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link Task260505AddPluginsPortletToMenu#forceRun()}</li>
+     *     <li><b>Given scenario:</b> Both {@code dynamic-plugins} and {@code plugins} are present
+     *     in the layout (the steady state after a successful upgrade).</li>
+     *     <li><b>Expected result:</b> {@code forceRun()} returns {@code false} — the presence of
+     *     {@code dynamic-plugins} alone must not trigger a re-run.</li>
+     * </ul>
+     */
+    @Test
+    public void forceRunReturnsFalseWhenBothPortletsCoexist() throws DotDataException {
+        new Task260505AddPluginsPortletToMenu().executeUpgrade();
+
+        assertFalse(
+                "forceRun() must return false when both portlets are present — " +
+                        "dynamic-plugins presence alone must not trigger a re-run",
+                new Task260505AddPluginsPortletToMenu().forceRun());
+    }
+
+    /**
+     * <ul>
+     *     <li><b>Method to test:</b> {@link Task260505AddPluginsPortletToMenu#executeUpgrade()}</li>
+     *     <li><b>Given scenario:</b> The task runs twice in a row.</li>
+     *     <li><b>Expected result:</b> No exception; second run is a no-op for inserts.</li>
+     * </ul>
+     */
+    @Test
+    public void checkUpgradeTaskIdempotency() throws DotDataException {
+        final Task260505AddPluginsPortletToMenu task = new Task260505AddPluginsPortletToMenu();
+
+        task.executeUpgrade();
+        task.executeUpgrade();
+
+        assertFalse("After running twice, forceRun() should return false", task.forceRun());
+    }
+
+    private void deletePluginsPortlet() {
+        try {
+            new DotConnect()
+                    .setSQL("DELETE FROM cms_layouts_portlets WHERE portlet_id = ?")
+                    .addParam(PLUGINS_PORTLET_ID)
+                    .loadResult();
+        } catch (final Exception e) {
+            Logger.info(this, "Failed deleting the portlet_id " + PLUGINS_PORTLET_ID);
+        }
+    }
+
+}


### PR DESCRIPTION
Adds Task260505AddPluginsPortletToMenu, a runonce upgrade task with a higher task ID than Task260320 so it reaches instances poisoned during the Mar 31 - Apr 16 starter/code mismatch. On those installs Task260320 was recorded in db_version on first startup but its body never ran (the firstTimeStart skip in StartupTasksExecutor#executeSchemaUpgrades), leaving cms_layouts_portlets with a 'dynamic-plugins' row, no 'plugins' row, and Task260320 permanently locked out by the version gate.

### Proposed Changes
* change 1
* change 2

### Checklist
- [ ] Tests
- [ ] Translations
- [ ] Security Implications Contemplated (add notes if applicable)

### Additional Info
** any additional useful context or info **

### Screenshots
Original             |  Updated
:-------------------------:|:-------------------------:
** original screenshot **  |  ** updated screenshot **

This PR fixes: #35428

This PR fixes: #35428