### PR TITLE
fix(security): backport SQL injection + auth fixes to 26.04.28 (hotfix)

### DIFF
--- a/.github/workflows/cicd_5-lts.yml
+++ b/.github/workflows/cicd_5-lts.yml
@@ -15,10 +15,17 @@ on:
   push:
     branches:
       - release-*
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Build version for Docker image tagging (e.g. 26.04.28-03). Defaults to the revision in .mvn/maven.config when left empty.'
+        required: false
+        type: string
+        default: ''
 
 # Concurrency group to manage multiple runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   # Cancel any in-progress runs for the same branch/PR to prevent delays from changes during build
   cancel-in-progress: true
 
@@ -30,16 +37,43 @@ jobs:
     with:
       change-detection: 'enabled'
 
+  # Resolve the build version: use the workflow_dispatch input when provided, otherwise
+  # read -Drevision and -Dchangelist from .mvn/maven.config on the current branch.
+  # This ensures the Docker image tag always matches what Maven computes for project.version.
+  setup:
+    name: Resolve Version
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve version from input or maven.config
+        id: resolve
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$INPUT_VERSION" ]; then
+            if [[ ! "$INPUT_VERSION" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]{2}(-[0-9]{1,2}|_lts_v[0-9]{1,2})$ ]]; then
+              echo "::error::Invalid version format: '$INPUT_VERSION'. Expected format: yy.mm.dd-## (e.g. 26.04.28-03)"
+              exit 1
+            fi
+            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+          else
+            revision=$(grep -oP '(?<=-Drevision=)\S+' .mvn/maven.config 2>/dev/null || true)
+            changelist=$(grep -oP '(?<=-Dchangelist=)\S+' .mvn/maven.config 2>/dev/null || true)
+            echo "version=${revision}${changelist}" >> "$GITHUB_OUTPUT"
+          fi
+
   # Build job - only runs if no artifacts were found during initialization
   build:
     name: PR Build
-    needs: [ initialize ]
+    needs: [ initialize, setup ]
     if: fromJSON(needs.initialize.outputs.filters).build == 'true' && needs.initialize.outputs.found_artifacts == 'false'
     uses: ./.github/workflows/cicd_comp_build-phase.yml
     with:
       core-build: true
       run-pr-checks: false
-      version: '24.12.27'
+      version: ${{ needs.setup.outputs.version }}
     permissions:
       contents: read
       packages: write

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,3 @@
 -Dprod=true
--Drevision=26.04.28-02
+-Drevision=26.04.28-03
 -Dchangelist=

--- a/LICENSE
+++ b/LICENSE
@@ -41,7 +41,7 @@ For example:
    Development: an instance that is set up for an internal evaluation.
    Development: A local instance used to develop a new plugin or website.
 
-Change Date:     Four years from April 28, 2026
+Change Date:     Four years from May 07, 2026
 
 Change License:  GNU General Public License (GPL) v3
 

--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditAPIImpl.java
@@ -16,6 +16,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -224,23 +225,29 @@ public class PublishAuditAPIImpl extends PublishAuditAPI {
 	@CloseDBIfOpened
 	public List<PublishAuditStatus> getPublishAuditStatuses(List<String> bundleIds)
             throws DotPublisherException {
+		if (bundleIds == null || bundleIds.isEmpty()) {
+			return Collections.emptyList();
+		}
 		try {
 			final List<PublishAuditStatus> result = new ArrayList<>();
 
-			DotConnect dc = new DotConnect();
-			final List<String> parameter = bundleIds.stream().map(id -> "'" + id + "'").collect(Collectors.toList());
+			final DotConnect dc = new DotConnect();
+			final String placeholders = bundleIds.stream()
+					.map(id -> "?")
+					.collect(Collectors.joining(","));
 
-			dc.setSQL(String.format(SELECT_ALL_BY_BUNDLES_IDS,  String.join(",", parameter)));
-			List<Map<String, Object>> items = dc.loadObjectResults();
+			dc.setSQL(String.format(SELECT_ALL_BY_BUNDLES_IDS, placeholders));
+			bundleIds.forEach(dc::addParam);
+			final List<Map<String, Object>> items = dc.loadObjectResults();
 
-			for(Map<String, Object> item: items) {
-				result.add(turnIntoPublishAuditStatus(NO_LIMIT_ASSETS,  item));
+			for (final Map<String, Object> item : items) {
+				result.add(turnIntoPublishAuditStatus(NO_LIMIT_ASSETS, item));
 			}
 
 			return result;
-		}catch(Exception e){
-			Logger.debug(PublisherUtil.class,e.getMessage(),e);
-			throw new DotPublisherException("Unable to get list of elements with error:"+e.getMessage(), e);
+		} catch (Exception e) {
+			Logger.error(PublishAuditAPIImpl.class, e.getMessage(), e);
+			throw new DotPublisherException("Unable to get list of elements with error:" + e.getMessage(), e);
 		}
 
 	}

--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditAPIImpl.java
@@ -236,15 +236,7 @@ public class PublishAuditAPIImpl extends PublishAuditAPI {
 					.map(id -> "?")
 					.collect(Collectors.joining(","));
 
-   // Build placeholders for the IN clause, e.g., "?, ?, ?"
-   String placeholders = bundleIds.stream().map(id -> "?").collect(Collectors.joining(","));
-   String newQueryString = String.format(SELECT_ALL_BY_BUNDLES_IDS, placeholders);
-   dc.setSQL(newQueryString);
-
-   // Add each bundleId as a parameter to safely bind it (prevents SQL injection)
-   for (String id : bundleIds) {
-   	dc.addParam(id);
-   }
+			dc.setSQL(String.format(SELECT_ALL_BY_BUNDLES_IDS, placeholders));
 			bundleIds.forEach(dc::addParam);
 			final List<Map<String, Object>> items = dc.loadObjectResults();
 

--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublishAuditAPIImpl.java
@@ -236,7 +236,15 @@ public class PublishAuditAPIImpl extends PublishAuditAPI {
 					.map(id -> "?")
 					.collect(Collectors.joining(","));
 
-			dc.setSQL(String.format(SELECT_ALL_BY_BUNDLES_IDS, placeholders));
+   // Build placeholders for the IN clause, e.g., "?, ?, ?"
+   String placeholders = bundleIds.stream().map(id -> "?").collect(Collectors.joining(","));
+   String newQueryString = String.format(SELECT_ALL_BY_BUNDLES_IDS, placeholders);
+   dc.setSQL(newQueryString);
+
+   // Add each bundleId as a parameter to safely bind it (prevents SQL injection)
+   for (String id : bundleIds) {
+   	dc.addParam(id);
+   }
 			bundleIds.forEach(dc::addParam);
 			final List<Map<String, Object>> items = dc.loadObjectResults();
 

--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublisherQueueJob.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublisherQueueJob.java
@@ -15,6 +15,7 @@ import com.dotcms.publisher.endpoint.bean.PublishingEndPoint;
 import com.dotcms.publisher.endpoint.business.PublishingEndPointAPI;
 import com.dotcms.publisher.environment.bean.Environment;
 import com.dotcms.publisher.environment.business.EnvironmentAPI;
+import com.dotcms.publisher.pusher.AuthCredentialPushPublishUtil;
 import com.dotcms.publisher.pusher.PushPublisher;
 import com.dotcms.publisher.pusher.PushPublisherConfig;
 import com.dotcms.publisher.util.PublisherUtil;
@@ -653,6 +654,7 @@ public class PublisherQueueJob implements StatefulJob {
 
 		final String responseBody = webTarget
 				.request(MediaType.APPLICATION_JSON)
+				.header("Authorization", AuthCredentialPushPublishUtil.INSTANCE.getRequestToken(targetEndpoint).orElse(""))
 				.post(Entity.entity(bundleIds, MediaType.APPLICATION_JSON))
 				.readEntity(String.class);
 

--- a/dotCMS/src/main/java/com/dotcms/publisher/pusher/AuthCredentialPushPublishUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/pusher/AuthCredentialPushPublishUtil.java
@@ -154,9 +154,9 @@ public enum AuthCredentialPushPublishUtil {
                 .startsWith(BEARER)) {
 
             return authorizationHeader.substring(BEARER.length());
-        } else {
-            throw new IllegalArgumentException("Bearer Authorization header expected");
         }
+
+        return StringUtils.EMPTY;
     }
 
     public static class PushPublishAuthenticationToken {

--- a/dotCMS/src/main/java/com/dotcms/rest/AuditPublishingResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/AuditPublishingResource.java
@@ -4,7 +4,10 @@ import com.dotcms.publisher.business.DotPublisherException;
 import com.dotcms.publisher.business.PublishAuditAPI;
 import com.dotcms.publisher.business.PublishAuditStatus;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.*;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -24,7 +27,18 @@ public class AuditPublishingResource {
     @GET
     @Path("/get/{bundleId:.*}")
     @Produces(MediaType.TEXT_XML)
-    public Response get(@PathParam("bundleId") String bundleId) {
+    public Response get(@PathParam("bundleId") final String bundleId,
+                        @Context final HttpServletRequest request,
+                        @Context final HttpServletResponse response) {
+
+        new WebResource.InitBuilder()
+                .requiredBackendUser(true)
+                .requiredFrontendUser(false)
+                .requestAndResponse(request, response)
+                .rejectWhenNoUser(true)
+                .requiredPortlet("publishing-queue")
+                .init();
+
         PublishAuditStatus status = null;
 
         try {
@@ -42,7 +56,18 @@ public class AuditPublishingResource {
     @POST
     @Path("/getAll")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getAll( List<String> bundleIds) {
+    public Response getAll(final List<String> bundleIds,
+                           @Context final HttpServletRequest request,
+                           @Context final HttpServletResponse response) {
+
+        new WebResource.InitBuilder()
+                .requiredBackendUser(true)
+                .requiredFrontendUser(false)
+                .requestAndResponse(request, response)
+                .rejectWhenNoUser(true)
+                .requiredPortlet("publishing-queue")
+                .init();
+
         try {
             final List<PublishAuditStatus> statuses = auditAPI.getPublishAuditStatuses(bundleIds);
 

--- a/dotCMS/src/main/java/com/dotcms/rest/AuditPublishingResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/AuditPublishingResource.java
@@ -3,21 +3,19 @@ package com.dotcms.rest;
 import com.dotcms.publisher.business.DotPublisherException;
 import com.dotcms.publisher.business.PublishAuditAPI;
 import com.dotcms.publisher.business.PublishAuditStatus;
+import com.dotcms.publisher.pusher.AuthCredentialPushPublishUtil;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
-import com.google.common.collect.Lists;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
+import java.util.Optional;
 
 @Path("/auditPublishing")
 @Tag(name = "Publishing")
@@ -28,16 +26,16 @@ public class AuditPublishingResource {
     @Path("/get/{bundleId:.*}")
     @Produces(MediaType.TEXT_XML)
     public Response get(@PathParam("bundleId") final String bundleId,
-                        @Context final HttpServletRequest request,
-                        @Context final HttpServletResponse response) {
+                        @Context final HttpServletRequest request) {
 
-        new WebResource.InitBuilder()
-                .requiredBackendUser(true)
-                .requiredFrontendUser(false)
-                .requestAndResponse(request, response)
-                .rejectWhenNoUser(true)
-                .requiredPortlet("publishing-queue")
-                .init();
+        final AuthCredentialPushPublishUtil.PushPublishAuthenticationToken ppAuthToken =
+                AuthCredentialPushPublishUtil.INSTANCE.processAuthHeader(request);
+
+        final Optional<Response> failResponse = PushPublishResourceUtil.getFailResponse(request, ppAuthToken);
+
+        if (failResponse.isPresent()) {
+            return failResponse.get();
+        }
 
         PublishAuditStatus status = null;
 
@@ -57,16 +55,16 @@ public class AuditPublishingResource {
     @Path("/getAll")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getAll(final List<String> bundleIds,
-                           @Context final HttpServletRequest request,
-                           @Context final HttpServletResponse response) {
+                           @Context final HttpServletRequest request) {
 
-        new WebResource.InitBuilder()
-                .requiredBackendUser(true)
-                .requiredFrontendUser(false)
-                .requestAndResponse(request, response)
-                .rejectWhenNoUser(true)
-                .requiredPortlet("publishing-queue")
-                .init();
+        final AuthCredentialPushPublishUtil.PushPublishAuthenticationToken ppAuthToken =
+                AuthCredentialPushPublishUtil.INSTANCE.processAuthHeader(request);
+
+        final Optional<Response> failResponse = PushPublishResourceUtil.getFailResponse(request, ppAuthToken);
+
+        if (failResponse.isPresent()) {
+            return failResponse.get();
+        }
 
         try {
             final List<PublishAuditStatus> statuses = auditAPI.getPublishAuditStatuses(bundleIds);

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite2a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite2a.java
@@ -105,7 +105,8 @@ import org.junit.runners.Suite.SuiteClasses;
         com.dotmarketing.portlets.categories.business.CategoryAPITest.class,
         com.dotmarketing.filters.FiltersTest.class,
         InterceptorHandlerTest.class,
-        com.dotcms.graphql.datafetcher.page.NumberContentsDataFetcherTest.class
+        com.dotcms.graphql.datafetcher.page.NumberContentsDataFetcherTest.class,
+        com.dotcms.rest.AuditPublishingResourceTest.class,
 })
 public class MainSuite2a {
 

--- a/dotcms-integration/src/test/java/com/dotcms/publisher/business/PublishAuditAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/publisher/business/PublishAuditAPITest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -384,6 +385,101 @@ public class PublishAuditAPITest {
                         assertEquals(2, publishAuditStatus.getStatusPojo().getAssets().size());
                     }
                 });
+    }
+
+    /**
+     * Method to test: {@link PublishAuditAPI#getPublishAuditStatuses(List)}
+     * When: three audit statuses are inserted and two of them are requested by id
+     * Should: return exactly the two requested rows.
+     */
+    @Test
+    public void test_getPublishAuditStatuses_returnsRequestedRows() throws DotPublisherException {
+        final String bundleId1 = UUIDGenerator.generateUuid();
+        final String bundleId2 = UUIDGenerator.generateUuid();
+        final String bundleId3 = UUIDGenerator.generateUuid();
+        insertPublishAuditStatus(Status.SUCCESS, bundleId1);
+        insertPublishAuditStatus(Status.FAILED_TO_PUBLISH, bundleId2);
+        insertPublishAuditStatus(Status.SUCCESS, bundleId3);
+
+        try {
+            final List<PublishAuditStatus> result = publishAuditAPI.getPublishAuditStatuses(
+                    Arrays.asList(bundleId1, bundleId2));
+
+            assertNotNull(result);
+            assertEquals(2, result.size());
+            final Set<String> ids = result.stream()
+                    .map(PublishAuditStatus::getBundleId)
+                    .collect(Collectors.toSet());
+            assertTrue(ids.contains(bundleId1));
+            assertTrue(ids.contains(bundleId2));
+            assertFalse(ids.contains(bundleId3));
+        } finally {
+            publishAuditAPI.deletePublishAuditStatus(bundleId1);
+            publishAuditAPI.deletePublishAuditStatus(bundleId2);
+            publishAuditAPI.deletePublishAuditStatus(bundleId3);
+        }
+    }
+
+    /**
+     * Method to test: {@link PublishAuditAPI#getPublishAuditStatuses(List)}
+     * When: an empty list is passed
+     * Should: return an empty result, not throw or produce invalid SQL.
+     */
+    @Test
+    public void test_getPublishAuditStatuses_emptyList_returnsEmpty() throws DotPublisherException {
+        final List<PublishAuditStatus> result = publishAuditAPI.getPublishAuditStatuses(Collections.emptyList());
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    /**
+     * Method to test: {@link PublishAuditAPI#getPublishAuditStatuses(List)}
+     * When: null is passed
+     * Should: return an empty result, not throw NPE.
+     */
+    @Test
+    public void test_getPublishAuditStatuses_nullList_returnsEmpty() throws DotPublisherException {
+        final List<PublishAuditStatus> result = publishAuditAPI.getPublishAuditStatuses(null);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    /**
+     * Method to test: {@link PublishAuditAPI#getPublishAuditStatuses(List)}
+     * When: bundle ids contain SQL meta-characters (single quotes, OR 1=1, ; DROP TABLE)
+     * Should: bind the values as parameters, return an empty result, leave the
+     *         publishing_queue_audit table intact.
+     *
+     * Regression test for the previous String.format-based IN-clause that
+     * concatenated quote-wrapped ids directly into the SQL.
+     */
+    @Test
+    public void test_getPublishAuditStatuses_neutralizesSqlInjectionAttempts() throws DotPublisherException {
+        final String realBundleId = UUIDGenerator.generateUuid();
+        insertPublishAuditStatus(Status.SUCCESS, realBundleId);
+
+        try {
+            final List<String> maliciousIds = Arrays.asList(
+                    "x' OR '1'='1",
+                    "x'; DROP TABLE publishing_queue_audit; --",
+                    "x' UNION SELECT '" + realBundleId + "' --",
+                    "x'/*",
+                    "x\\' OR \\'1\\'=\\'1"
+            );
+
+            final List<PublishAuditStatus> result = publishAuditAPI.getPublishAuditStatuses(maliciousIds);
+
+            assertNotNull(result);
+            assertTrue("Malicious bundle ids should not match any rows; got "
+                    + result.size() + " rows back, indicating values were not bound as parameters",
+                    result.isEmpty());
+
+            final PublishAuditStatus stillThere = publishAuditAPI.getPublishAuditStatus(realBundleId);
+            assertNotNull("publishing_queue_audit row was lost after SQL injection attempt — "
+                    + "DROP TABLE payload may have executed", stillThere);
+        } finally {
+            publishAuditAPI.deletePublishAuditStatus(realBundleId);
+        }
     }
 
     @Test

--- a/dotcms-integration/src/test/java/com/dotcms/rest/AuditPublishingResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/AuditPublishingResourceTest.java
@@ -1,0 +1,52 @@
+package com.dotcms.rest;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.rest.exception.SecurityException;
+import com.dotcms.util.IntegrationTestInitService;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collections;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Verifies that {@link AuditPublishingResource} enforces backend-user
+ * authentication on its endpoints. Both methods previously skipped
+ * {@link WebResource#init} entirely and were reachable anonymously.
+ */
+public class AuditPublishingResourceTest extends IntegrationTestBase {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Method to test: {@link AuditPublishingResource#get(String, HttpServletRequest, HttpServletResponse)}
+     * When: called with a request that carries no authenticated user
+     * Should: reject the call with a SecurityException. The resource is now
+     *         backend-only and `rejectWhenNoUser(true)` is configured.
+     */
+    @Test(expected = SecurityException.class)
+    public void test_get_rejectsAnonymousRequest() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        new AuditPublishingResource().get("any-bundle-id", request, response);
+    }
+
+    /**
+     * Method to test: {@link AuditPublishingResource#getAll(java.util.List, HttpServletRequest, HttpServletResponse)}
+     * When: called with a request that carries no authenticated user
+     * Should: reject the call with a SecurityException.
+     */
+    @Test(expected = SecurityException.class)
+    public void test_getAll_rejectsAnonymousRequest() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        new AuditPublishingResource().getAll(Collections.singletonList("any-bundle-id"),
+                request, response);
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/rest/AuditPublishingResourceTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/AuditPublishingResourceTest.java
@@ -1,21 +1,21 @@
 package com.dotcms.rest;
 
 import com.dotcms.IntegrationTestBase;
-import com.dotcms.rest.exception.SecurityException;
 import com.dotcms.util.IntegrationTestInitService;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
 import java.util.Collections;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 /**
- * Verifies that {@link AuditPublishingResource} enforces backend-user
- * authentication on its endpoints. Both methods previously skipped
- * {@link WebResource#init} entirely and were reachable anonymously.
+ * Verifies that {@link AuditPublishingResource} enforces push-publish token
+ * authentication on its endpoints. Both methods were previously reachable
+ * anonymously; they now require a valid PP auth token.
  */
 public class AuditPublishingResourceTest extends IntegrationTestBase {
 
@@ -25,28 +25,27 @@ public class AuditPublishingResourceTest extends IntegrationTestBase {
     }
 
     /**
-     * Method to test: {@link AuditPublishingResource#get(String, HttpServletRequest, HttpServletResponse)}
-     * When: called with a request that carries no authenticated user
-     * Should: reject the call with a SecurityException. The resource is now
-     *         backend-only and `rejectWhenNoUser(true)` is configured.
+     * Method to test: {@link AuditPublishingResource#get(String, HttpServletRequest)}
+     * When: called with a request that carries no push-publish auth token
+     * Should: return 401 Unauthorized.
      */
-    @Test(expected = SecurityException.class)
+    @Test
     public void test_get_rejectsAnonymousRequest() {
         final HttpServletRequest request = mock(HttpServletRequest.class);
-        final HttpServletResponse response = mock(HttpServletResponse.class);
-        new AuditPublishingResource().get("any-bundle-id", request, response);
+        final Response response = new AuditPublishingResource().get("any-bundle-id", request);
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
     }
 
     /**
-     * Method to test: {@link AuditPublishingResource#getAll(java.util.List, HttpServletRequest, HttpServletResponse)}
-     * When: called with a request that carries no authenticated user
-     * Should: reject the call with a SecurityException.
+     * Method to test: {@link AuditPublishingResource#getAll(java.util.List, HttpServletRequest)}
+     * When: called with a request that carries no push-publish auth token
+     * Should: return 401 Unauthorized.
      */
-    @Test(expected = SecurityException.class)
+    @Test
     public void test_getAll_rejectsAnonymousRequest() {
         final HttpServletRequest request = mock(HttpServletRequest.class);
-        final HttpServletResponse response = mock(HttpServletResponse.class);
-        new AuditPublishingResource().getAll(Collections.singletonList("any-bundle-id"),
-                request, response);
+        final Response response = new AuditPublishingResource()
+                .getAll(Collections.singletonList("any-bundle-id"), request);
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
     }
 }

--- a/dotcms-postman/src/main/resources/postman/Push_Publish_JWT_Token_Test.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Push_Publish_JWT_Token_Test.postman_collection.json
@@ -284,6 +284,16 @@
 						}
 					],
 					"request": {
+						"auth": {
+                        	"type": "bearer",
+                        	"bearer": [
+								{
+									"key": "token",
+                                  	"value": "{{token}}",
+                            		"type": "string"
+								}
+							]
+						},
 						"method": "GET",
 						"header": [],
 						"url": {


### PR DESCRIPTION
## Summary

Security hotfix for customers running `v26.04.28-02`. Cherry-picks 9 commits from PR #35553 onto the `26.04.28` release line — no other changes from `main` are included.

**Do not merge this PR.** It exists to run CI and collect reviews. The release (`26.04.28-03`) is being cut directly from this branch.

## What's included

- **SQL injection fix** — `PublishAuditAPIImpl.getPublishAuditStatuses()` now uses bound parameters instead of string-concatenated `IN (...)` clause (Refs: dotCMS/private-issues#581)
- **Auth gate** — `/api/auditPublishing/get` and `/getAll` now require an authenticated backend user with `publishing-queue` portlet permission (previously unauthenticated)
- **PP authorization** — switched from `WebResource.InitBuilder` to PP auth in `AuditPublishingResource`
- **Auth header** — adds PP auth header to audit poll; prevents 500 on missing token
- Regression tests and Postman collection updates

## Cherry-picked from

PR #35553 (merged to `main` on 2026-05-06)

Commits cherry-picked (merge-from-main commits excluded):
- `dc515d99` fix(publisher): parameterize getPublishAuditStatuses bundle-id query
- `f783f9dd` test(publisher): regression tests for parameterization
- `f68ff49f` Apply suggestions from code review
- `947fda39` fix: remove duplicate placeholders block
- `10dcb623` fix(rest): require backend user + publishing-queue portlet on AuditPublishingResource
- `15b6b8c3` test: use dotCMS-specific SecurityException
- `381d83df` add AuditPublishingResourceTest to MainSuite2a
- `13f70a5e` use PP authorization in AuditPublishingResource
- `071f4da8` fix(publisher): add PP auth header to audit poll and prevent 500 on missing token