### PR TITLE
fix(cicd): remove hardcoded version from LTS workflow, add workflow_dispatch

### DIFF
--- a/.github/workflows/cicd_5-lts.yml
+++ b/.github/workflows/cicd_5-lts.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           if [ -n "$INPUT_VERSION" ]; then
             if [[ ! "$INPUT_VERSION" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]{2}(-[0-9]{1,2}|_lts_v[0-9]{1,2})$ ]]; then
-              echo "::error::Invalid version format: '$INPUT_VERSION'. Expected yy.mm.dd-## or yy.mm.dd_lts_v##"
+              echo "::error::Invalid version format: '$INPUT_VERSION'. Expected format: yy.mm.dd-## (e.g. 26.04.28-03)"
               exit 1
             fi
             echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cicd_5-lts.yml
+++ b/.github/workflows/cicd_5-lts.yml
@@ -15,6 +15,13 @@ on:
   push:
     branches:
       - release-*
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Build version for Docker image tagging (e.g. 26.04.28-03). Defaults to the revision in .mvn/maven.config when left empty.'
+        required: false
+        type: string
+        default: ''
 
 # Concurrency group to manage multiple runs
 concurrency:
@@ -30,16 +37,37 @@ jobs:
     with:
       change-detection: 'enabled'
 
+  # Resolve the build version: use the workflow_dispatch input when provided, otherwise
+  # read -Drevision and -Dchangelist from .mvn/maven.config on the current branch.
+  # This ensures the Docker image tag always matches what Maven computes for project.version.
+  setup:
+    name: Resolve Version
+    runs-on: ubuntu-${{ vars.UBUNTU_RUNNER_VERSION || '24.04' }}
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Resolve version from input or maven.config
+        id: resolve
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            revision=$(grep -oP '(?<=-Drevision=)\S+' .mvn/maven.config 2>/dev/null || true)
+            changelist=$(grep -oP '(?<=-Dchangelist=)\S+' .mvn/maven.config 2>/dev/null || true)
+            echo "version=${revision}${changelist}" >> "$GITHUB_OUTPUT"
+          fi
+
   # Build job - only runs if no artifacts were found during initialization
   build:
     name: PR Build
-    needs: [ initialize ]
+    needs: [ initialize, setup ]
     if: fromJSON(needs.initialize.outputs.filters).build == 'true' && needs.initialize.outputs.found_artifacts == 'false'
     uses: ./.github/workflows/cicd_comp_build-phase.yml
     with:
       core-build: true
       run-pr-checks: false
-      version: '24.12.27'
+      version: ${{ needs.setup.outputs.version }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/cicd_5-lts.yml
+++ b/.github/workflows/cicd_5-lts.yml
@@ -53,6 +53,10 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
           if [ -n "$INPUT_VERSION" ]; then
+            if [[ ! "$INPUT_VERSION" =~ ^[0-9]{2}\.[0-9]{2}\.[0-9]{2}(-[0-9]{1,2}|_lts_v[0-9]{1,2})$ ]]; then
+              echo "::error::Invalid version format: '$INPUT_VERSION'. Expected yy.mm.dd-## or yy.mm.dd_lts_v##"
+              exit 1
+            fi
             echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           else
             revision=$(grep -oP '(?<=-Drevision=)\S+' .mvn/maven.config 2>/dev/null || true)

--- a/.github/workflows/cicd_5-lts.yml
+++ b/.github/workflows/cicd_5-lts.yml
@@ -25,7 +25,7 @@ on:
 
 # Concurrency group to manage multiple runs
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   # Cancel any in-progress runs for the same branch/PR to prevent delays from changes during build
   cancel-in-progress: true
 
@@ -49,9 +49,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Resolve version from input or maven.config
         id: resolve
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [ -n "${{ inputs.version }}" ]; then
-            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          if [ -n "$INPUT_VERSION" ]; then
+            echo "version=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
           else
             revision=$(grep -oP '(?<=-Drevision=)\S+' .mvn/maven.config 2>/dev/null || true)
             changelist=$(grep -oP '(?<=-Dchangelist=)\S+' .mvn/maven.config 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- **Root cause**: `cicd_5-lts.yml` had a hardcoded `version: '24.12.27'` passed to the build phase. The Docker image was always saved as `dotcms/dotcms-test:24.12.27`, but Postman tests derive the image name from `.mvn/maven.config` at test time — so on any release branch with a different revision the versions diverge and the test fails with a 404 trying to pull the image from Docker Hub.
- **Fix**: Add a `setup` job that reads `-Drevision` and `-Dchangelist` from `.mvn/maven.config` on the current branch, so the Docker image tag always matches what Maven computes for `project.version`.
- **Bonus**: Add `workflow_dispatch` trigger with an optional `version` input so the workflow can be manually kicked off for hotfix branches where the test run needs to be triggered after the release build completes.

## How it works

For automatic `push` triggers: the `setup` job reads `.mvn/maven.config` and extracts the version dynamically (e.g. `26.04.28-03` on a hotfix branch, `1.0.0-SNAPSHOT` on a snapshot branch).

For manual `workflow_dispatch` triggers: if `version` is provided it takes precedence; otherwise falls back to the same `maven.config` logic.

## Test plan

- [ ] Merge and observe next push to a `release-*` branch — Postman tests should find the correct Docker image without a 404
- [ ] Manually trigger the workflow via Actions UI on a release branch and confirm the correct version is resolved in the `setup` job logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

=====================================
Closes: #35613 