### PR TITLE
feat(ci): block PR merge on Critical/High backend review findings

### DIFF
--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -256,6 +256,23 @@ jobs:
           ✅ **dotCMS Backend Review**: no issues found.
         Then follow the same find-and-update-or-create logic above.
 
+        ## STEP 6 — Submit a formal GitHub review
+
+        After posting the comment, submit a formal PR review so that merging is
+        blocked until Critical or High findings are resolved.
+
+        Check whether the review body contains any Critical or High findings:
+
+          if grep -qE '🔴 Critical|🟠 High' /tmp/dotcms_review_body.md; then
+            gh pr review ${{ github.event.pull_request.number }} \
+              --request-changes \
+              --body "🚫 Critical or High severity findings must be resolved before merging. See the review comment above for details."
+          else
+            gh pr review ${{ github.event.pull_request.number }} \
+              --approve \
+              --body "✅ No Critical or High severity issues found."
+          fi
+
         Rules:
         - One block per issue — do not combine multiple issues
         - Be specific: quote actual file names and line numbers


### PR DESCRIPTION
## Summary

- Adds **STEP 6** to the AI backend reviewer workflow (`ai_claude-backend-reviewer.yml`)
- After posting the review comment, the orchestrator now submits a formal GitHub PR review:
  - **Critical or High findings** → `REQUEST_CHANGES` (merge blocked until resolved)
  - **Clean review** → `APPROVE` (automatically lifts a previous block on the next clean push)

## Motivation

PR [#35345](https://github.com/dotCMS/core/pull/35345) had a 🔴 Critical cross-site content-bleed finding flagged by the automated reviewer — twice. It was ignored and the PR was approved and merged, leading to a production incident (Lennox ticket #36966: wrong brand content rendering on product pages after release 26.04.28-02).

The previous workflow only posted a comment. Comments are easy to ignore. A formal `REQUEST_CHANGES` review cannot be bypassed with a simple Approve click — it must be explicitly dismissed or resolved.

## Setup required

To fully enforce the block, enable the following in **Settings → Branches → Branch protection rules** on `main`:
- ✅ Require a pull request before merging
- ✅ Dismiss stale pull request approvals when new commits are pushed

## Test plan
- [ ] Open a PR with a Java change that triggers a Critical/High finding — verify the bot submits `REQUEST_CHANGES` and the merge button is blocked
- [ ] Push a fix — verify the bot submits `APPROVE` on the clean re-run and the block is lifted

Closes #35614

🤖 Generated with [Claude Code](https://claude.com/claude-code)