### PR TITLE
fix(uve): add site URL option to copy URL popover in page editor

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -876,6 +876,35 @@ describe('EditEmaEditorComponent', () => {
                     expect(siteUrl).toBeUndefined();
                 });
 
+                it('should include site URL using origin scheme when clientHost is absent and hostname differs', () => {
+                    patchState(store, {
+                        pageParams: {
+                            url: '/my-page',
+                            clientHost: undefined,
+                            language_id: '1',
+                            [PERSONA_KEY]: 'dot:persona'
+                        },
+                        pageAssetResponse: {
+                            pageAsset: {
+                                ...MOCK_RESPONSE_HEADLESS,
+                                site: {
+                                    identifier: '123',
+                                    hostname: 'demo.dotcms.com',
+                                    aliases: null
+                                }
+                            }
+                        }
+                    });
+
+                    const siteUrl = spectator.component
+                        .$pageURLS()
+                        .find((u) => u.label === 'uve.toolbar.page.site.url');
+
+                    const { protocol } = new URL(window.location.origin);
+
+                    expect(siteUrl?.value).toBe(`${protocol}//demo.dotcms.com/my-page`);
+                });
+
                 it('should not include site URL when site has no hostname', () => {
                     patchState(store, {
                         pageParams: {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -836,6 +836,7 @@ describe('EditEmaEditorComponent', () => {
                                 site: {
                                     identifier: '123',
                                     hostname: 'demo.dotcms.com',
+                                    systemHost: false,
                                     aliases: null
                                 }
                             }
@@ -863,6 +864,7 @@ describe('EditEmaEditorComponent', () => {
                                 site: {
                                     identifier: '123',
                                     hostname: 'demo.dotcms.com',
+                                    systemHost: false,
                                     aliases: null
                                 }
                             }
@@ -890,6 +892,7 @@ describe('EditEmaEditorComponent', () => {
                                 site: {
                                     identifier: '123',
                                     hostname: 'demo.dotcms.com',
+                                    systemHost: false,
                                     aliases: null
                                 }
                             }
@@ -903,7 +906,7 @@ describe('EditEmaEditorComponent', () => {
                     expect(siteUrl?.value).toBe('https://demo.dotcms.com/my-page');
                 });
 
-                it('should include site URL when clientHost has a non-standard port and hostname matches', () => {
+                it('should include site URL when clientHost has a port and site hostname is portless', () => {
                     patchState(store, {
                         pageParams: {
                             url: '/my-page',
@@ -917,6 +920,7 @@ describe('EditEmaEditorComponent', () => {
                                 site: {
                                     identifier: '123',
                                     hostname: 'demo.dotcms.com',
+                                    systemHost: false,
                                     aliases: null
                                 }
                             }
@@ -930,7 +934,7 @@ describe('EditEmaEditorComponent', () => {
                     expect(siteUrl?.value).toBe('https://demo.dotcms.com/my-page');
                 });
 
-                it('should suppress site URL when site hostname contains spaces (non-addressable host)', () => {
+                it('should suppress site URL for the System Host pseudo-site', () => {
                     patchState(store, {
                         pageParams: {
                             url: '/my-page',
@@ -944,6 +948,35 @@ describe('EditEmaEditorComponent', () => {
                                 site: {
                                     identifier: '123',
                                     hostname: 'System Host',
+                                    systemHost: true,
+                                    aliases: null
+                                }
+                            }
+                        }
+                    });
+
+                    const siteUrl = spectator.component
+                        .$pageURLS()
+                        .find((u) => u.label === 'uve.toolbar.page.site.url');
+
+                    expect(siteUrl).toBeUndefined();
+                });
+
+                it('should suppress site URL when hostname is malformed and URL construction throws', () => {
+                    patchState(store, {
+                        pageParams: {
+                            url: '/my-page',
+                            clientHost: 'https://example.com',
+                            language_id: '1',
+                            [PERSONA_KEY]: 'dot:persona'
+                        },
+                        pageAssetResponse: {
+                            pageAsset: {
+                                ...MOCK_RESPONSE_HEADLESS,
+                                site: {
+                                    identifier: '123',
+                                    hostname: 'invalid host name',
+                                    systemHost: false,
                                     aliases: null
                                 }
                             }
@@ -971,6 +1004,7 @@ describe('EditEmaEditorComponent', () => {
                                 site: {
                                     identifier: '123',
                                     hostname: 'Demo.DotCMS.com',
+                                    systemHost: false,
                                     aliases: null
                                 }
                             }
@@ -995,7 +1029,12 @@ describe('EditEmaEditorComponent', () => {
                         pageAssetResponse: {
                             pageAsset: {
                                 ...MOCK_RESPONSE_HEADLESS,
-                                site: { identifier: '123', hostname: '', aliases: null }
+                                site: {
+                                    identifier: '123',
+                                    hostname: '',
+                                    systemHost: false,
+                                    aliases: null
+                                }
                             }
                         }
                     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -833,7 +833,11 @@ describe('EditEmaEditorComponent', () => {
                         pageAssetResponse: {
                             pageAsset: {
                                 ...MOCK_RESPONSE_HEADLESS,
-                                site: { identifier: '123', hostname: 'demo.dotcms.com', aliases: null }
+                                site: {
+                                    identifier: '123',
+                                    hostname: 'demo.dotcms.com',
+                                    aliases: null
+                                }
                             }
                         }
                     });
@@ -856,7 +860,11 @@ describe('EditEmaEditorComponent', () => {
                         pageAssetResponse: {
                             pageAsset: {
                                 ...MOCK_RESPONSE_HEADLESS,
-                                site: { identifier: '123', hostname: 'demo.dotcms.com', aliases: null }
+                                site: {
+                                    identifier: '123',
+                                    hostname: 'demo.dotcms.com',
+                                    aliases: null
+                                }
                             }
                         }
                     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -905,6 +905,33 @@ describe('EditEmaEditorComponent', () => {
                     expect(siteUrl?.value).toBe(`${protocol}//demo.dotcms.com/my-page`);
                 });
 
+                it('should not include site URL when site hostname matches clientHost with different casing', () => {
+                    patchState(store, {
+                        pageParams: {
+                            url: '/my-page',
+                            clientHost: 'https://demo.dotcms.com',
+                            language_id: '1',
+                            [PERSONA_KEY]: 'dot:persona'
+                        },
+                        pageAssetResponse: {
+                            pageAsset: {
+                                ...MOCK_RESPONSE_HEADLESS,
+                                site: {
+                                    identifier: '123',
+                                    hostname: 'Demo.DotCMS.com',
+                                    aliases: null
+                                }
+                            }
+                        }
+                    });
+
+                    const siteUrl = spectator.component
+                        .$pageURLS()
+                        .find((u) => u.label === 'uve.toolbar.page.site.url');
+
+                    expect(siteUrl).toBeUndefined();
+                });
+
                 it('should not include site URL when site has no hostname', () => {
                     patchState(store, {
                         pageParams: {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -876,7 +876,7 @@ describe('EditEmaEditorComponent', () => {
                     expect(siteUrl).toBeUndefined();
                 });
 
-                it('should include site URL using origin scheme when clientHost is absent and hostname differs', () => {
+                it('should include site URL with https when clientHost is absent and hostname differs', () => {
                     patchState(store, {
                         pageParams: {
                             url: '/my-page',
@@ -900,9 +900,61 @@ describe('EditEmaEditorComponent', () => {
                         .$pageURLS()
                         .find((u) => u.label === 'uve.toolbar.page.site.url');
 
-                    const { protocol } = new URL(window.location.origin);
+                    expect(siteUrl?.value).toBe('https://demo.dotcms.com/my-page');
+                });
 
-                    expect(siteUrl?.value).toBe(`${protocol}//demo.dotcms.com/my-page`);
+                it('should include site URL when clientHost has a non-standard port and hostname matches', () => {
+                    patchState(store, {
+                        pageParams: {
+                            url: '/my-page',
+                            clientHost: 'https://demo.dotcms.com:8080',
+                            language_id: '1',
+                            [PERSONA_KEY]: 'dot:persona'
+                        },
+                        pageAssetResponse: {
+                            pageAsset: {
+                                ...MOCK_RESPONSE_HEADLESS,
+                                site: {
+                                    identifier: '123',
+                                    hostname: 'demo.dotcms.com',
+                                    aliases: null
+                                }
+                            }
+                        }
+                    });
+
+                    const siteUrl = spectator.component
+                        .$pageURLS()
+                        .find((u) => u.label === 'uve.toolbar.page.site.url');
+
+                    expect(siteUrl?.value).toBe('https://demo.dotcms.com/my-page');
+                });
+
+                it('should suppress site URL when site hostname contains spaces (non-addressable host)', () => {
+                    patchState(store, {
+                        pageParams: {
+                            url: '/my-page',
+                            clientHost: 'https://example.com',
+                            language_id: '1',
+                            [PERSONA_KEY]: 'dot:persona'
+                        },
+                        pageAssetResponse: {
+                            pageAsset: {
+                                ...MOCK_RESPONSE_HEADLESS,
+                                site: {
+                                    identifier: '123',
+                                    hostname: 'System Host',
+                                    aliases: null
+                                }
+                            }
+                        }
+                    });
+
+                    const siteUrl = spectator.component
+                        .$pageURLS()
+                        .find((u) => u.label === 'uve.toolbar.page.site.url');
+
+                    expect(siteUrl).toBeUndefined();
                 });
 
                 it('should not include site URL when site hostname matches clientHost with different casing', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -821,6 +821,75 @@ describe('EditEmaEditorComponent', () => {
                     expect(viewUrl).toBeTruthy();
                     expect(typeof viewUrl?.value).toBe('string');
                 });
+
+                it('should include site URL when site hostname differs from clientHost', () => {
+                    patchState(store, {
+                        pageParams: {
+                            url: '/my-page',
+                            clientHost: 'https://example.com',
+                            language_id: '1',
+                            [PERSONA_KEY]: 'dot:persona'
+                        },
+                        pageAssetResponse: {
+                            pageAsset: {
+                                ...MOCK_RESPONSE_HEADLESS,
+                                site: { identifier: '123', hostname: 'demo.dotcms.com', aliases: null }
+                            }
+                        }
+                    });
+
+                    const siteUrl = spectator.component
+                        .$pageURLS()
+                        .find((u) => u.label === 'uve.toolbar.page.site.url');
+
+                    expect(siteUrl?.value).toBe('https://demo.dotcms.com/my-page');
+                });
+
+                it('should not include site URL when site hostname matches the clientHost', () => {
+                    patchState(store, {
+                        pageParams: {
+                            url: '/my-page',
+                            clientHost: 'https://demo.dotcms.com',
+                            language_id: '1',
+                            [PERSONA_KEY]: 'dot:persona'
+                        },
+                        pageAssetResponse: {
+                            pageAsset: {
+                                ...MOCK_RESPONSE_HEADLESS,
+                                site: { identifier: '123', hostname: 'demo.dotcms.com', aliases: null }
+                            }
+                        }
+                    });
+
+                    const siteUrl = spectator.component
+                        .$pageURLS()
+                        .find((u) => u.label === 'uve.toolbar.page.site.url');
+
+                    expect(siteUrl).toBeUndefined();
+                });
+
+                it('should not include site URL when site has no hostname', () => {
+                    patchState(store, {
+                        pageParams: {
+                            url: '/my-page',
+                            clientHost: 'https://example.com',
+                            language_id: '1',
+                            [PERSONA_KEY]: 'dot:persona'
+                        },
+                        pageAssetResponse: {
+                            pageAsset: {
+                                ...MOCK_RESPONSE_HEADLESS,
+                                site: { identifier: '123', hostname: '', aliases: null }
+                            }
+                        }
+                    });
+
+                    const siteUrl = spectator.component
+                        .$pageURLS()
+                        .find((u) => u.label === 'uve.toolbar.page.site.url');
+
+                    expect(siteUrl).toBeUndefined();
+                });
             });
 
             describe('$pageURL', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1456,11 +1456,12 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
         const siteId = site?.identifier;
         const host = params?.clientHost || this.window.location.origin;
         const path = params?.url?.replace(/\/index(\.html)?$/, '') || '/';
+        const liveUrl = new URL(path, host).toString();
 
         const urls: { label: string; value: string }[] = [
             {
                 label: 'uve.toolbar.page.live.url',
-                value: new URL(path, host).toString()
+                value: liveUrl
             },
             {
                 label: 'uve.toolbar.page.current.view.url',
@@ -1469,13 +1470,18 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
         ];
 
         if (site?.hostname) {
-            const siteHostUrl = new URL(path, `https://${site.hostname}`).toString();
+            try {
+                const { protocol, hostname: hostHostname } = new URL(host);
+                const siteHostUrl = new URL(path, `${protocol}//${site.hostname}`).toString();
 
-            if (siteHostUrl !== new URL(path, host).toString()) {
-                urls.push({
-                    label: 'uve.toolbar.page.site.url',
-                    value: siteHostUrl
-                });
+                if (hostHostname !== site.hostname) {
+                    urls.push({
+                        label: 'uve.toolbar.page.site.url',
+                        value: siteHostUrl
+                    });
+                }
+            } catch {
+                // Ignore malformed hostname — silently skip Site URL entry
             }
         }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1468,19 +1468,28 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
         ];
 
         // Site URL uses https:// — DotSite exposes no protocol field so https is assumed for
-        // public-facing links. Spaces in the hostname (e.g. "System Host") indicate a
-        // non-addressable pseudo-host; those are skipped via the guard below.
-        // Dedup compares the full computed URL so port-only differences are not suppressed.
+        // public-facing links. The WHATWG URL parser normalises the host to lowercase, so no
+        // manual .toLowerCase() is needed. Dedup compares full computed URLs so port-only
+        // differences are not suppressed. Note: on http-only dev setups the Live URL may share
+        // the same hostname as the Site URL but with a different scheme; the dedup check will
+        // treat them as distinct and show both, which is acceptable since prod is always HTTPS.
+        // Spaces in the hostname (e.g. "System Host") indicate a non-addressable pseudo-host
+        // and are skipped. Other malformed values (e.g. accidental scheme prefix) are caught
+        // below rather than silently corrupting the URL.
         // TODO: also check site.aliases so an admin reached via an alias does not show a
         //       redundant Site URL entry pointing to the same host.
         if (site?.hostname && !site.hostname.includes(' ')) {
-            const siteHostUrl = new URL(path, `https://${site.hostname.toLowerCase()}`).toString();
+            try {
+                const siteHostUrl = new URL(path, `https://${site.hostname}`).toString();
 
-            if (siteHostUrl !== liveUrl) {
-                urls.push({
-                    label: 'uve.toolbar.page.site.url',
-                    value: siteHostUrl
-                });
+                if (siteHostUrl !== liveUrl) {
+                    urls.push({
+                        label: 'uve.toolbar.page.site.url',
+                        value: siteHostUrl
+                    });
+                }
+            } catch {
+                // Malformed hostname (e.g. accidental scheme prefix) — skip Site URL entry
             }
         }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1471,17 +1471,18 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
 
         if (site?.hostname) {
             try {
+                const siteHostname = site.hostname.toLowerCase();
                 const { protocol, hostname: hostHostname } = new URL(host);
-                const siteHostUrl = new URL(path, `${protocol}//${site.hostname}`).toString();
+                const siteHostUrl = new URL(path, `${protocol}//${siteHostname}`).toString();
 
-                if (hostHostname !== site.hostname) {
+                if (hostHostname !== siteHostname) {
                     urls.push({
                         label: 'uve.toolbar.page.site.url',
                         value: siteHostUrl
                     });
                 }
-            } catch {
-                // Ignore malformed hostname — silently skip Site URL entry
+            } catch (e) {
+                console.warn('[UVE] Could not build Site URL from hostname:', site.hostname, e);
             }
         }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -116,6 +116,8 @@ import {
     shouldNavigate
 } from '../utils';
 
+type PageURL = { label: string; value: string };
+
 // Message keys constants
 const MESSAGE_KEY = {
     DUPLICATE_CONTENT: {
@@ -1450,7 +1452,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
         }
     }
 
-    readonly $pageURLS = computed<{ label: string; value: string }[]>(() => {
+    readonly $pageURLS = computed<PageURL[]>(() => {
         const params = this.uveStore.pageParams();
         const site = this.uveStore.pageAsset()?.site;
         const siteId = site?.identifier;
@@ -1458,33 +1460,34 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
         const path = params?.url?.replace(/\/index(\.html)?$/, '') || '/';
         const liveUrl = new URL(path, host).toString();
 
-        const urls: { label: string; value: string }[] = [
+        const urls: PageURL[] = [
             {
                 label: 'uve.toolbar.page.live.url',
                 value: liveUrl
-            },
-            {
-                label: 'uve.toolbar.page.current.view.url',
-                value: createFullURL(params, siteId)
             }
         ];
 
-        if (site?.hostname) {
-            try {
-                const siteHostname = site.hostname.toLowerCase();
-                const { protocol, hostname: hostHostname } = new URL(host);
-                const siteHostUrl = new URL(path, `${protocol}//${siteHostname}`).toString();
+        // Site URL uses https:// — DotSite exposes no protocol field so https is assumed for
+        // public-facing links. Spaces in the hostname (e.g. "System Host") indicate a
+        // non-addressable pseudo-host; those are skipped via the guard below.
+        // Dedup compares the full computed URL so port-only differences are not suppressed.
+        // TODO: also check site.aliases so an admin reached via an alias does not show a
+        //       redundant Site URL entry pointing to the same host.
+        if (site?.hostname && !site.hostname.includes(' ')) {
+            const siteHostUrl = new URL(path, `https://${site.hostname.toLowerCase()}`).toString();
 
-                if (hostHostname !== siteHostname) {
-                    urls.push({
-                        label: 'uve.toolbar.page.site.url',
-                        value: siteHostUrl
-                    });
-                }
-            } catch (e) {
-                console.warn('[UVE] Could not build Site URL from hostname:', site.hostname, e);
+            if (siteHostUrl !== liveUrl) {
+                urls.push({
+                    label: 'uve.toolbar.page.site.url',
+                    value: siteHostUrl
+                });
             }
         }
+
+        urls.push({
+            label: 'uve.toolbar.page.current.view.url',
+            value: createFullURL(params, siteId)
+        });
 
         return urls;
     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1464,21 +1464,20 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
             {
                 label: 'uve.toolbar.page.live.url',
                 value: liveUrl
+            },
+            {
+                label: 'uve.toolbar.page.current.view.url',
+                value: createFullURL(params, siteId)
             }
         ];
 
-        // Site URL uses https:// — DotSite exposes no protocol field so https is assumed for
-        // public-facing links. The WHATWG URL parser normalises the host to lowercase, so no
-        // manual .toLowerCase() is needed. Dedup compares full computed URLs so port-only
-        // differences are not suppressed. Note: on http-only dev setups the Live URL may share
-        // the same hostname as the Site URL but with a different scheme; the dedup check will
-        // treat them as distinct and show both, which is acceptable since prod is always HTTPS.
-        // Spaces in the hostname (e.g. "System Host") indicate a non-addressable pseudo-host
-        // and are skipped. Other malformed values (e.g. accidental scheme prefix) are caught
-        // below rather than silently corrupting the URL.
-        // TODO: also check site.aliases so an admin reached via an alias does not show a
-        //       redundant Site URL entry pointing to the same host.
-        if (site?.hostname && !site.hostname.includes(' ')) {
+        // Site URL: https:// assumed since DotSite has no protocol field (prod is always HTTPS).
+        // WHATWG normalises the host to lowercase so no manual toLowerCase() needed.
+        // Dedup compares full URLs so port-only differences are not suppressed.
+        // systemHost excludes the non-addressable System Host pseudo-site.
+        // try/catch covers any remaining malformed hostname values.
+        // TODO: also check site.aliases to avoid duplicates when admin is reached via an alias.
+        if (site?.hostname && !site.systemHost) {
             try {
                 const siteHostUrl = new URL(path, `https://${site.hostname}`).toString();
 
@@ -1489,14 +1488,9 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
                     });
                 }
             } catch {
-                // Malformed hostname (e.g. accidental scheme prefix) — skip Site URL entry
+                // Malformed hostname — skip Site URL entry
             }
         }
-
-        urls.push({
-            label: 'uve.toolbar.page.current.view.url',
-            value: createFullURL(params, siteId)
-        });
 
         return urls;
     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1452,11 +1452,12 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
 
     readonly $pageURLS = computed<{ label: string; value: string }[]>(() => {
         const params = this.uveStore.pageParams();
-        const siteId = this.uveStore.pageAsset()?.site?.identifier;
+        const site = this.uveStore.pageAsset()?.site;
+        const siteId = site?.identifier;
         const host = params?.clientHost || this.window.location.origin;
         const path = params?.url?.replace(/\/index(\.html)?$/, '') || '/';
 
-        return [
+        const urls: { label: string; value: string }[] = [
             {
                 label: 'uve.toolbar.page.live.url',
                 value: new URL(path, host).toString()
@@ -1466,6 +1467,19 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
                 value: createFullURL(params, siteId)
             }
         ];
+
+        if (site?.hostname) {
+            const siteHostUrl = new URL(path, `https://${site.hostname}`).toString();
+
+            if (siteHostUrl !== new URL(path, host).toString()) {
+                urls.push({
+                    label: 'uve.toolbar.page.site.url',
+                    value: siteHostUrl
+                });
+            }
+        }
+
+        return urls;
     });
 
     protected triggerCopyToast(): void {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1473,8 +1473,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
 
         if (site?.hostname && !site.systemHost) {
             try {
-                const { protocol } = new URL(host);
-                const siteHostUrl = new URL(path, `${protocol}//${site.hostname}`).toString();
+                const siteHostUrl = new URL(path, `https://${site.hostname}`).toString();
 
                 if (siteHostUrl !== liveUrl) {
                     urls.push({
@@ -1482,9 +1481,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
                         value: siteHostUrl
                     });
                 }
-            } catch {
-                // empty
-            }
+            } catch {}
         }
 
         return urls;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1471,15 +1471,10 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
             }
         ];
 
-        // Site URL: https:// assumed since DotSite has no protocol field (prod is always HTTPS).
-        // WHATWG normalises the host to lowercase so no manual toLowerCase() needed.
-        // Dedup compares full URLs so port-only differences are not suppressed.
-        // systemHost excludes the non-addressable System Host pseudo-site.
-        // try/catch covers any remaining malformed hostname values.
-        // TODO: also check site.aliases to avoid duplicates when admin is reached via an alias.
         if (site?.hostname && !site.systemHost) {
             try {
-                const siteHostUrl = new URL(path, `https://${site.hostname}`).toString();
+                const { protocol } = new URL(host);
+                const siteHostUrl = new URL(path, `${protocol}//${site.hostname}`).toString();
 
                 if (siteHostUrl !== liveUrl) {
                     urls.push({
@@ -1488,7 +1483,7 @@ export class EditEmaEditorComponent implements OnInit, OnDestroy, AfterViewInit 
                     });
                 }
             } catch {
-                // Malformed hostname — skip Site URL entry
+                // empty
             }
         }
 

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6073,6 +6073,7 @@ uve.toolbar.style.editor=Style Editor
 uve.toolbar.page.api.url=Page API URL
 uve.toolbar.page.live.url=Live URL
 uve.toolbar.page.current.view.url=Current View URL
+uve.toolbar.page.site.url=Site URL
 uve.preview.mode=Preview Mode
 uve.preview.mode.device.subheader=Custom Devices
 uve.preview.mode.social.media.subheader=Social Media Tiles


### PR DESCRIPTION
## What does this PR do?

Adds a third **Site URL** entry to the copy URL popover in the UVE page editor. Previously, both the Live URL and Current View URL were always built from the admin login origin (or `clientHost` for headless pages), giving users no way to copy a link scoped to the currently selected site's public hostname.

The new entry appears only when `site.hostname` is set **and** it produces a URL that differs from the Live URL already shown, avoiding redundant entries.

## Fixes

Closes #35448

## Changes

- `edit-ema-editor.component.ts` — Extended `$pageURLS` computed to push a `uve.toolbar.page.site.url` entry when the site hostname differs from the current host.
- `Language.properties` — Added `uve.toolbar.page.site.url=Site URL` i18n key.
- `edit-ema-editor.component.spec.ts` — Added three new unit tests covering: site URL shown when hostname differs, suppressed when hostname matches clientHost, and suppressed when hostname is empty.

## Test plan

- [ ] Open the page editor for a traditional (non-headless) page whose site hostname differs from the admin URL — the copy URL popover should now show a third "Site URL" entry pointing to `https://<site-hostname>/<page-path>`
- [ ] Open the page editor for a headless page where `clientHost` already matches the site hostname — only two URL entries should appear (no duplicate)
- [ ] Unit tests: `yarn nx test portlets-edit-ema-portlet --testPathPattern=edit-ema-editor.component.spec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)