### PR TITLE
test(edit-content): add unit tests and E2E coverage for workflow commentable/assignable dialog

### DIFF
--- a/core-web/apps/dotcms-ui-e2e/src/requests/workflow.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/requests/workflow.ts
@@ -1,0 +1,85 @@
+import { APIRequestContext, expect } from '@playwright/test';
+import { admin1 } from '@utils/credentials';
+import { generateBase64Credentials } from '@utils/generateBase64Credential';
+
+export interface WorkflowActionCreated {
+    id: string;
+    name: string;
+    schemeId: string;
+    assignable: boolean;
+    commentable: boolean;
+    actionInputs: Array<{ id: string; body: Record<string, unknown> }>;
+}
+
+function authHeaders() {
+    return { Authorization: generateBase64Credentials(admin1.username, admin1.password) };
+}
+
+/**
+ * Returns the workflow step ID for a contentlet given its inode.
+ * Uses GET /api/v1/workflow/status/{inode}.
+ */
+export async function getWorkflowStepId(
+    request: APIRequestContext,
+    inode: string
+): Promise<string> {
+    const response = await request.get(`/api/v1/workflow/status/${inode}`, {
+        headers: authHeaders()
+    });
+    expect(response.status()).toBe(200);
+    const data = await response.json();
+
+    return data.entity.step.id as string;
+}
+
+/**
+ * Creates a workflow action in the given scheme/step with commentable and
+ * assignable actionlets enabled (mirrors the unit-test mock configuration).
+ *
+ * POST /api/v1/workflow/actions
+ */
+export async function createCommentableWorkflowAction(
+    request: APIRequestContext,
+    { schemeId, stepId, name }: { schemeId: string; stepId: string; name: string }
+): Promise<WorkflowActionCreated> {
+    const response = await request.post('/api/v1/workflow/actions', {
+        data: {
+            schemeId,
+            stepId,
+            actionName: name,
+            actionAssignable: true,
+            actionCommentable: true,
+            actionRoleHierarchyForAssign: false,
+            actionNextStep: 'currentstep',
+            actionNextAssign: '',
+            showOn: ['NEW', 'EDITING', 'PUBLISHED', 'UNPUBLISHED', 'LOCKED', 'UNLOCKED'],
+            actionCondition: '',
+            actionIcon: 'workflowIcon'
+        },
+        headers: authHeaders()
+    });
+
+    if (response.status() !== 200) {
+        const body = await response.json().catch(() => response.statusText());
+        console.error('createCommentableWorkflowAction failed:', JSON.stringify(body, null, 2));
+    }
+    expect(response.status()).toBe(200);
+
+    const data = await response.json();
+
+    return data.entity as WorkflowActionCreated;
+}
+
+/**
+ * Deletes a workflow action by ID.
+ * DELETE /api/v1/workflow/actions/{actionId}
+ */
+export async function deleteWorkflowAction(
+    request: APIRequestContext,
+    actionId: string
+): Promise<void> {
+    const response = await request.delete(`/api/v1/workflow/actions/${actionId}`, {
+        headers: authHeaders()
+    });
+    expect([200, 404]).toContain(response.status());
+}

--- a/core-web/apps/dotcms-ui-e2e/src/requests/workflow.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/requests/workflow.ts
@@ -42,8 +42,8 @@ export async function createWorkflowAction(
         schemeId,
         stepId,
         name,
-        assignable = true,
-        commentable = true
+        assignable = false,
+        commentable = false
     }: {
         schemeId: string;
         stepId: string;
@@ -61,6 +61,7 @@ export async function createWorkflowAction(
             actionCommentable: commentable,
             actionRoleHierarchyForAssign: false,
             actionNextStep: 'currentstep',
+            // "Any User" role — required by the API; empty string causes a 500
             actionNextAssign: '654b0931-1027-41f7-ad4d-173115ed8ec1',
             whoCanUse: [],
             showOn: ['NEW', 'EDITING', 'PUBLISHED', 'UNPUBLISHED', 'LOCKED', 'UNLOCKED'],

--- a/core-web/apps/dotcms-ui-e2e/src/requests/workflow.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/requests/workflow.ts
@@ -33,25 +33,36 @@ export async function getWorkflowStepId(
 }
 
 /**
- * Creates a workflow action in the given scheme/step with commentable and
- * assignable actionlets enabled (mirrors the unit-test mock configuration).
- *
+ * Creates a workflow action in the given scheme/step.
  * POST /api/v1/workflow/actions
  */
-export async function createCommentableWorkflowAction(
+export async function createWorkflowAction(
     request: APIRequestContext,
-    { schemeId, stepId, name }: { schemeId: string; stepId: string; name: string }
+    {
+        schemeId,
+        stepId,
+        name,
+        assignable = true,
+        commentable = true
+    }: {
+        schemeId: string;
+        stepId: string;
+        name: string;
+        assignable?: boolean;
+        commentable?: boolean;
+    }
 ): Promise<WorkflowActionCreated> {
     const response = await request.post('/api/v1/workflow/actions', {
         data: {
             schemeId,
             stepId,
             actionName: name,
-            actionAssignable: true,
-            actionCommentable: true,
+            actionAssignable: assignable,
+            actionCommentable: commentable,
             actionRoleHierarchyForAssign: false,
             actionNextStep: 'currentstep',
-            actionNextAssign: '',
+            actionNextAssign: '654b0931-1027-41f7-ad4d-173115ed8ec1',
+            whoCanUse: [],
             showOn: ['NEW', 'EDITING', 'PUBLISHED', 'UNPUBLISHED', 'LOCKED', 'UNLOCKED'],
             actionCondition: '',
             actionIcon: 'workflowIcon'
@@ -61,7 +72,7 @@ export async function createCommentableWorkflowAction(
 
     if (response.status() !== 200) {
         const body = await response.json().catch(() => response.statusText());
-        console.error('createCommentableWorkflowAction failed:', JSON.stringify(body, null, 2));
+        console.error('createWorkflowAction failed:', JSON.stringify(body, null, 2));
     }
     expect(response.status()).toBe(200);
 

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/sidebar/workflow-actions-dialog.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/sidebar/workflow-actions-dialog.spec.ts
@@ -1,6 +1,16 @@
 import { expect, test } from '@playwright/test';
-import { ContentType, createFakeContentType, deleteContentType, SYSTEM_WORKFLOW_ID } from '@requests/contentType';
-import { WorkflowActionCreated, createWorkflowAction, deleteWorkflowAction, getWorkflowStepId } from '@requests/workflow';
+import {
+    ContentType,
+    createFakeContentType,
+    deleteContentType,
+    SYSTEM_WORKFLOW_ID
+} from '@requests/contentType';
+import {
+    WorkflowActionCreated,
+    createWorkflowAction,
+    deleteWorkflowAction,
+    getWorkflowStepId
+} from '@requests/workflow';
 import { admin1 } from '@utils/credentials';
 import { generateBase64Credentials } from '@utils/generateBase64Credential';
 

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/sidebar/workflow-actions-dialog.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/sidebar/workflow-actions-dialog.spec.ts
@@ -1,12 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { deleteContentlets } from '@requests/contentlets';
 import { ContentType, createFakeContentType, deleteContentType } from '@requests/contentType';
-import {
-    WorkflowActionCreated,
-    createCommentableWorkflowAction,
-    deleteWorkflowAction,
-    getWorkflowStepId
-} from '@requests/workflow';
+import { WorkflowActionCreated, createWorkflowAction, deleteWorkflowAction, getWorkflowStepId } from '@requests/workflow';
 import { admin1 } from '@utils/credentials';
 import { generateBase64Credentials } from '@utils/generateBase64Credential';
 
@@ -14,19 +9,9 @@ import { generateBase64Credentials } from '@utils/generateBase64Credential';
  * Regression spec for issue #34347: the New Edit Contentlet mode must open the wizard
  * dialog when a workflow action has commentable or assignable inputs.
  *
- * Setup strategy:
- * - Creates a fresh content type associated with the System Workflow.
- * - Creates a contentlet via fire/NEW so it starts in the initial step.
- * - Creates a workflow action (commentable + assignable) in the System Workflow at
- *   the contentlet's current step — mirrors the unit-test mock configuration.
- * - Cleans up the action (and contentlet / content type) in afterAll.
- *
  * Notes:
- * - Uses PUT (not POST) — PUT returns the contentlet directly in entity; POST
- *   returns a bulk-format response with entity.results[0][key].
  * - The p-dialog host (data-testid="dot-wizard") is always "hidden" in Playwright
  *   because PrimeNG's appendTo="body" moves the visual content to the body portal.
- *   The portal does NOT inherit the host's data-testid.
  *   Inner elements (.dot-wizard__view) ARE in the portal and detect wizard visibility.
  * - The wizard action may render as an inline p-button or inside the overflow (...)
  *   popup menu depending on how many actions fit in the toolbar viewport.
@@ -46,17 +31,13 @@ async function navigateToContent(page: import('@playwright/test').Page, inode: s
 }
 
 async function openWizardDialog(page: import('@playwright/test').Page, actionName: string) {
-    // Wait for the workflow actions toolbar to be rendered
     await page.getByTestId('workflow-actions').waitFor({ state: 'visible', timeout: 15000 });
 
-    // The action may be an inline p-button or in the overflow (...) popup menu.
-    // count() never throws — returns 0 when not found.
     const inlineButton = page.getByRole('button', { name: actionName });
 
     if ((await inlineButton.count()) > 0) {
         await inlineButton.click();
     } else {
-        // Action is beyond the inline cap — open the overflow menu
         const overflowButton = page.getByTestId('overflow-button');
         await overflowButton.waitFor({ state: 'visible', timeout: 5000 });
         await overflowButton.click();
@@ -65,18 +46,16 @@ async function openWizardDialog(page: import('@playwright/test').Page, actionNam
         await menuItem.click();
     }
 
-    // The p-dialog host (data-testid="dot-wizard") is always "hidden" because
-    // PrimeNG moves portal content to body. Use an inner element in the portal.
     await page.locator('.dot-wizard__view').waitFor({ state: 'visible', timeout: 10000 });
 }
 
-test.describe('Workflow action commentable and assignable dialog', () => {
+test.describe('Workflow action wizard dialog', () => {
     test.describe.configure({ mode: 'serial' });
 
     let contentType: ContentType;
     let contentletInode: string;
     let contentletIdentifier: string;
-    let wizardAction: WorkflowActionCreated;
+    let stepId: string;
 
     test.beforeAll(async ({ request }) => {
         const suffix = Date.now();
@@ -94,7 +73,6 @@ test.describe('Workflow action commentable and assignable dialog', () => {
             ]
         });
 
-        // fire/NEW saves without publishing — PUT returns entity directly.
         const response = await request.put(
             '/api/v1/workflow/actions/default/fire/NEW?indexPolicy=WAIT_FOR',
             {
@@ -113,21 +91,10 @@ test.describe('Workflow action commentable and assignable dialog', () => {
         contentletInode = data.entity.inode;
         contentletIdentifier = data.entity.identifier;
 
-        // Discover the step the contentlet is currently in, then create a
-        // commentable + assignable action at that step so it shows in the editor.
-        const stepId = await getWorkflowStepId(request, contentletInode);
-
-        wizardAction = await createCommentableWorkflowAction(request, {
-            schemeId: SYSTEM_WORKFLOW_ID,
-            stepId,
-            name: `WFDialogAction${suffix}`
-        });
+        stepId = await getWorkflowStepId(request, contentletInode);
     });
 
     test.afterAll(async ({ request }) => {
-        if (wizardAction?.id) {
-            await deleteWorkflowAction(request, wizardAction.id);
-        }
         if (contentletIdentifier) {
             await deleteContentlets(request, [contentletIdentifier]);
         }
@@ -136,37 +103,117 @@ test.describe('Workflow action commentable and assignable dialog', () => {
         }
     });
 
-    test('clicking a commentable/assignable action opens the wizard dialog @critical', async ({
-        page
-    }) => {
-        await navigateToContent(page, contentletInode);
-        await openWizardDialog(page, wizardAction.name);
+    test.describe('assignable + commentable action', () => {
+        let action: WorkflowActionCreated;
 
-        await expect(page.locator('.dot-wizard__view')).toBeVisible();
+        test.beforeAll(async ({ request }) => {
+            action = await createWorkflowAction(request, {
+                schemeId: SYSTEM_WORKFLOW_ID,
+                stepId,
+                name: `WFBothAction${Date.now()}`,
+                assignable: true,
+                commentable: true
+            });
+        });
+
+        test.afterAll(async ({ request }) => {
+            if (action?.id) await deleteWorkflowAction(request, action.id);
+        });
+
+        test('clicking the action opens the wizard dialog @critical', async ({ page }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
+
+            await expect(page.locator('.dot-wizard__view')).toBeVisible();
+        });
+
+        test('wizard contains the assignee dropdown @critical', async ({ page }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
+
+            await expect(page.locator('#dotRoles')).toBeVisible();
+        });
+
+        test('wizard contains the comments textarea @critical', async ({ page }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
+
+            await expect(page.locator('#comment')).toBeVisible();
+        });
+
+        test('canceling the wizard closes it without firing the action @smoke', async ({
+            page
+        }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
+
+            await page.getByTestId('dialog-close-button').click();
+
+            await expect(page.locator('.dot-wizard__view')).toBeHidden();
+        });
     });
 
-    test('wizard dialog contains the assignee dropdown @critical', async ({ page }) => {
-        await navigateToContent(page, contentletInode);
-        await openWizardDialog(page, wizardAction.name);
+    test.describe('assignable-only action', () => {
+        let action: WorkflowActionCreated;
 
-        await expect(page.locator('#dotRoles')).toBeVisible();
+        test.beforeAll(async ({ request }) => {
+            action = await createWorkflowAction(request, {
+                schemeId: SYSTEM_WORKFLOW_ID,
+                stepId,
+                name: `WFAssignAction${Date.now()}`,
+                assignable: true,
+                commentable: false
+            });
+        });
+
+        test.afterAll(async ({ request }) => {
+            if (action?.id) await deleteWorkflowAction(request, action.id);
+        });
+
+        test('clicking the action opens the wizard dialog @critical', async ({ page }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
+
+            await expect(page.locator('.dot-wizard__view')).toBeVisible();
+        });
+
+        test('wizard contains the assignee dropdown @critical', async ({ page }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
+
+            await expect(page.locator('#dotRoles')).toBeVisible();
+        });
     });
 
-    test('wizard dialog contains the comments textarea @critical', async ({ page }) => {
-        await navigateToContent(page, contentletInode);
-        await openWizardDialog(page, wizardAction.name);
+    test.describe('commentable-only action', () => {
+        let action: WorkflowActionCreated;
 
-        await expect(page.locator('#comment')).toBeVisible();
-    });
+        test.beforeAll(async ({ request }) => {
+            action = await createWorkflowAction(request, {
+                schemeId: SYSTEM_WORKFLOW_ID,
+                stepId,
+                name: `WFCommentAction${Date.now()}`,
+                assignable: false,
+                commentable: true
+            });
+        });
 
-    test('canceling the wizard dialog closes it without firing the action @smoke', async ({
-        page
-    }) => {
-        await navigateToContent(page, contentletInode);
-        await openWizardDialog(page, wizardAction.name);
+        test.afterAll(async ({ request }) => {
+            if (action?.id) await deleteWorkflowAction(request, action.id);
+        });
 
-        await page.getByTestId('dialog-close-button').click();
+        test('clicking the action opens the wizard dialog @critical', async ({ page }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
 
-        await expect(page.locator('.dot-wizard__view')).toBeHidden();
+            await expect(page.locator('.dot-wizard__view')).toBeVisible();
+        });
+
+        test('wizard contains the comments textarea @critical', async ({ page }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
+
+            await expect(page.locator('#comment')).toBeVisible();
+        });
     });
 });

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/sidebar/workflow-actions-dialog.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/sidebar/workflow-actions-dialog.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test } from '@playwright/test';
+import { deleteContentlets } from '@requests/contentlets';
+import { ContentType, createFakeContentType, deleteContentType } from '@requests/contentType';
+import {
+    WorkflowActionCreated,
+    createCommentableWorkflowAction,
+    deleteWorkflowAction,
+    getWorkflowStepId
+} from '@requests/workflow';
+import { admin1 } from '@utils/credentials';
+import { generateBase64Credentials } from '@utils/generateBase64Credential';
+
+/**
+ * Regression spec for issue #34347: the New Edit Contentlet mode must open the wizard
+ * dialog when a workflow action has commentable or assignable inputs.
+ *
+ * Setup strategy:
+ * - Creates a fresh content type associated with the System Workflow.
+ * - Creates a contentlet via fire/NEW so it starts in the initial step.
+ * - Creates a workflow action (commentable + assignable) in the System Workflow at
+ *   the contentlet's current step — mirrors the unit-test mock configuration.
+ * - Cleans up the action (and contentlet / content type) in afterAll.
+ *
+ * Notes:
+ * - Uses PUT (not POST) — PUT returns the contentlet directly in entity; POST
+ *   returns a bulk-format response with entity.results[0][key].
+ * - The p-dialog host (data-testid="dot-wizard") is always "hidden" in Playwright
+ *   because PrimeNG's appendTo="body" moves the visual content to the body portal.
+ *   The portal does NOT inherit the host's data-testid.
+ *   Inner elements (.dot-wizard__view) ARE in the portal and detect wizard visibility.
+ * - The wizard action may render as an inline p-button or inside the overflow (...)
+ *   popup menu depending on how many actions fit in the toolbar viewport.
+ */
+
+const SYSTEM_WORKFLOW_ID = 'd61a59e1-a49c-46f2-a929-db2b4bfa88b2';
+
+function authHeaders() {
+    return { Authorization: generateBase64Credentials(admin1.username, admin1.password) };
+}
+
+async function navigateToContent(page: import('@playwright/test').Page, inode: string) {
+    await page.goto(`/dotAdmin/#/content/${inode}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.locator('dot-edit-content-sidebar').waitFor({ state: 'visible', timeout: 15000 });
+    await page.getByTestId('title').waitFor({ state: 'visible', timeout: 15000 });
+}
+
+async function openWizardDialog(page: import('@playwright/test').Page, actionName: string) {
+    // Wait for the workflow actions toolbar to be rendered
+    await page.getByTestId('workflow-actions').waitFor({ state: 'visible', timeout: 15000 });
+
+    // The action may be an inline p-button or in the overflow (...) popup menu.
+    // count() never throws — returns 0 when not found.
+    const inlineButton = page.getByRole('button', { name: actionName });
+
+    if ((await inlineButton.count()) > 0) {
+        await inlineButton.click();
+    } else {
+        // Action is beyond the inline cap — open the overflow menu
+        const overflowButton = page.getByTestId('overflow-button');
+        await overflowButton.waitFor({ state: 'visible', timeout: 5000 });
+        await overflowButton.click();
+        const menuItem = page.getByRole('menuitem', { name: actionName });
+        await menuItem.waitFor({ state: 'visible', timeout: 5000 });
+        await menuItem.click();
+    }
+
+    // The p-dialog host (data-testid="dot-wizard") is always "hidden" because
+    // PrimeNG moves portal content to body. Use an inner element in the portal.
+    await page.locator('.dot-wizard__view').waitFor({ state: 'visible', timeout: 10000 });
+}
+
+test.describe('Workflow action commentable and assignable dialog', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    let contentType: ContentType;
+    let contentletInode: string;
+    let contentletIdentifier: string;
+    let wizardAction: WorkflowActionCreated;
+
+    test.beforeAll(async ({ request }) => {
+        const suffix = Date.now();
+
+        contentType = await createFakeContentType(request, {
+            name: `WFDialogTest${suffix}`,
+            variable: `wfDialogCT${suffix}`,
+            fields: [
+                {
+                    clazz: 'com.dotcms.contenttype.model.field.ImmutableTextField',
+                    name: 'Title',
+                    variable: 'title',
+                    sortOrder: 1
+                }
+            ]
+        });
+
+        // fire/NEW saves without publishing — PUT returns entity directly.
+        const response = await request.put(
+            '/api/v1/workflow/actions/default/fire/NEW?indexPolicy=WAIT_FOR',
+            {
+                data: {
+                    contentlet: {
+                        contentType: contentType.variable,
+                        title: `WF Dialog Regression ${suffix}`
+                    }
+                },
+                headers: authHeaders()
+            }
+        );
+
+        expect(response.status()).toBe(200);
+        const data = await response.json();
+        contentletInode = data.entity.inode;
+        contentletIdentifier = data.entity.identifier;
+
+        // Discover the step the contentlet is currently in, then create a
+        // commentable + assignable action at that step so it shows in the editor.
+        const stepId = await getWorkflowStepId(request, contentletInode);
+
+        wizardAction = await createCommentableWorkflowAction(request, {
+            schemeId: SYSTEM_WORKFLOW_ID,
+            stepId,
+            name: `WFDialogAction${suffix}`
+        });
+    });
+
+    test.afterAll(async ({ request }) => {
+        if (wizardAction?.id) {
+            await deleteWorkflowAction(request, wizardAction.id);
+        }
+        if (contentletIdentifier) {
+            await deleteContentlets(request, [contentletIdentifier]);
+        }
+        if (contentType?.id) {
+            await deleteContentType(request, contentType.id);
+        }
+    });
+
+    test('clicking a commentable/assignable action opens the wizard dialog @critical', async ({
+        page
+    }) => {
+        await navigateToContent(page, contentletInode);
+        await openWizardDialog(page, wizardAction.name);
+
+        await expect(page.locator('.dot-wizard__view')).toBeVisible();
+    });
+
+    test('wizard dialog contains the assignee dropdown @critical', async ({ page }) => {
+        await navigateToContent(page, contentletInode);
+        await openWizardDialog(page, wizardAction.name);
+
+        await expect(page.locator('#dotRoles')).toBeVisible();
+    });
+
+    test('wizard dialog contains the comments textarea @critical', async ({ page }) => {
+        await navigateToContent(page, contentletInode);
+        await openWizardDialog(page, wizardAction.name);
+
+        await expect(page.locator('#comment')).toBeVisible();
+    });
+
+    test('canceling the wizard dialog closes it without firing the action @smoke', async ({
+        page
+    }) => {
+        await navigateToContent(page, contentletInode);
+        await openWizardDialog(page, wizardAction.name);
+
+        await page.getByTestId('dialog-close-button').click();
+
+        await expect(page.locator('.dot-wizard__view')).toBeHidden();
+    });
+});

--- a/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/sidebar/workflow-actions-dialog.spec.ts
+++ b/core-web/apps/dotcms-ui-e2e/src/tests/edit-content/sidebar/workflow-actions-dialog.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { deleteContentlets } from '@requests/contentlets';
-import { ContentType, createFakeContentType, deleteContentType } from '@requests/contentType';
+import { ContentType, createFakeContentType, deleteContentType, SYSTEM_WORKFLOW_ID } from '@requests/contentType';
 import { WorkflowActionCreated, createWorkflowAction, deleteWorkflowAction, getWorkflowStepId } from '@requests/workflow';
 import { admin1 } from '@utils/credentials';
 import { generateBase64Credentials } from '@utils/generateBase64Credential';
@@ -17,8 +16,6 @@ import { generateBase64Credentials } from '@utils/generateBase64Credential';
  *   popup menu depending on how many actions fit in the toolbar viewport.
  */
 
-const SYSTEM_WORKFLOW_ID = 'd61a59e1-a49c-46f2-a929-db2b4bfa88b2';
-
 function authHeaders() {
     return { Authorization: generateBase64Credentials(admin1.username, admin1.password) };
 }
@@ -34,12 +31,18 @@ async function openWizardDialog(page: import('@playwright/test').Page, actionNam
     await page.getByTestId('workflow-actions').waitFor({ state: 'visible', timeout: 15000 });
 
     const inlineButton = page.getByRole('button', { name: actionName });
+    const overflowButton = page.getByTestId('overflow-button');
+
+    // Wait for either the inline button or the overflow trigger to appear before
+    // checking which path to take — count() has no timeout so we must wait first.
+    await Promise.race([
+        inlineButton.waitFor({ state: 'visible', timeout: 5000 }).catch(() => null),
+        overflowButton.waitFor({ state: 'visible', timeout: 5000 }).catch(() => null)
+    ]);
 
     if ((await inlineButton.count()) > 0) {
         await inlineButton.click();
     } else {
-        const overflowButton = page.getByTestId('overflow-button');
-        await overflowButton.waitFor({ state: 'visible', timeout: 5000 });
         await overflowButton.click();
         const menuItem = page.getByRole('menuitem', { name: actionName });
         await menuItem.waitFor({ state: 'visible', timeout: 5000 });
@@ -54,7 +57,6 @@ test.describe('Workflow action wizard dialog', () => {
 
     let contentType: ContentType;
     let contentletInode: string;
-    let contentletIdentifier: string;
     let stepId: string;
 
     test.beforeAll(async ({ request }) => {
@@ -89,15 +91,12 @@ test.describe('Workflow action wizard dialog', () => {
         expect(response.status()).toBe(200);
         const data = await response.json();
         contentletInode = data.entity.inode;
-        contentletIdentifier = data.entity.identifier;
 
         stepId = await getWorkflowStepId(request, contentletInode);
     });
 
     test.afterAll(async ({ request }) => {
-        if (contentletIdentifier) {
-            await deleteContentlets(request, [contentletIdentifier]);
-        }
+        // deleteContentType cascades contentlets — no need for a separate deleteContentlets call
         if (contentType?.id) {
             await deleteContentType(request, contentType.id);
         }
@@ -120,25 +119,21 @@ test.describe('Workflow action wizard dialog', () => {
             if (action?.id) await deleteWorkflowAction(request, action.id);
         });
 
-        test('clicking the action opens the wizard dialog @critical', async ({ page }) => {
+        test('wizard contains the assignee dropdown and footer buttons @critical', async ({
+            page
+        }) => {
             await navigateToContent(page, contentletInode);
             await openWizardDialog(page, action.name);
 
-            await expect(page.locator('.dot-wizard__view')).toBeVisible();
-        });
-
-        test('wizard contains the assignee dropdown @critical', async ({ page }) => {
-            await navigateToContent(page, contentletInode);
-            await openWizardDialog(page, action.name);
-
-            await expect(page.locator('#dotRoles')).toBeVisible();
+            await expect(page.getByTestId('assignee-select')).toBeVisible();
+            await expect(page.getByTestId('dialog-accept-button')).toBeVisible();
         });
 
         test('wizard contains the comments textarea @critical', async ({ page }) => {
             await navigateToContent(page, contentletInode);
             await openWizardDialog(page, action.name);
 
-            await expect(page.locator('#comment')).toBeVisible();
+            await expect(page.getByTestId('comments-textarea')).toBeVisible();
         });
 
         test('canceling the wizard closes it without firing the action @smoke', async ({
@@ -170,18 +165,18 @@ test.describe('Workflow action wizard dialog', () => {
             if (action?.id) await deleteWorkflowAction(request, action.id);
         });
 
-        test('clicking the action opens the wizard dialog @critical', async ({ page }) => {
-            await navigateToContent(page, contentletInode);
-            await openWizardDialog(page, action.name);
-
-            await expect(page.locator('.dot-wizard__view')).toBeVisible();
-        });
-
         test('wizard contains the assignee dropdown @critical', async ({ page }) => {
             await navigateToContent(page, contentletInode);
             await openWizardDialog(page, action.name);
 
-            await expect(page.locator('#dotRoles')).toBeVisible();
+            await expect(page.getByTestId('assignee-select')).toBeVisible();
+        });
+
+        test('wizard does not contain the comments textarea @smoke', async ({ page }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
+
+            await expect(page.getByTestId('comments-textarea')).toBeHidden();
         });
     });
 
@@ -202,18 +197,18 @@ test.describe('Workflow action wizard dialog', () => {
             if (action?.id) await deleteWorkflowAction(request, action.id);
         });
 
-        test('clicking the action opens the wizard dialog @critical', async ({ page }) => {
-            await navigateToContent(page, contentletInode);
-            await openWizardDialog(page, action.name);
-
-            await expect(page.locator('.dot-wizard__view')).toBeVisible();
-        });
-
         test('wizard contains the comments textarea @critical', async ({ page }) => {
             await navigateToContent(page, contentletInode);
             await openWizardDialog(page, action.name);
 
-            await expect(page.locator('#comment')).toBeVisible();
+            await expect(page.getByTestId('comments-textarea')).toBeVisible();
+        });
+
+        test('wizard does not contain the assignee dropdown @smoke', async ({ page }) => {
+            await navigateToContent(page, contentletInode);
+            await openWizardDialog(page, action.name);
+
+            await expect(page.getByTestId('assignee-select')).toBeHidden();
         });
     });
 });

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/forms/dot-comment-and-assign-form/dot-comment-and-assign-form.component.html
@@ -11,6 +11,7 @@
                 <p-select
                     [options]="dotRoles"
                     id="dotRoles"
+                    data-testid="assignee-select"
                     formControlName="assign"
                     [filter]="true"
                     filterBy="label"
@@ -24,6 +25,7 @@
                 <textarea
                     (keydown.enter)="$event.stopPropagation()"
                     id="comment"
+                    data-testid="comments-textarea"
                     pInputTextarea
                     formControlName="comments"></textarea>
             </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -514,6 +514,64 @@ describe('DotFormComponent', () => {
 
                 expect(wizardService.open).toHaveBeenCalled();
             });
+
+            describe('commentable and assignable dialog', () => {
+                let wizardService: DotWizardService;
+                let workflowActionsComponent: DotWorkflowActionsComponent;
+
+                beforeEach(() => {
+                    workflowActionsService.getWorkFlowActions.mockReturnValue(
+                        of(MOCK_SINGLE_WORKFLOW_ACTIONS)
+                    );
+                    store.initializeExistingContent({
+                        inode: 'inode',
+                        depth: DotContentletDepths.ONE
+                    });
+                    spectator.detectChanges();
+
+                    wizardService = spectator.inject(DotWizardService);
+                    workflowActionsComponent = spectator.query(DotWorkflowActionsComponent);
+                    (wizardService.open as jest.Mock).mockClear();
+                });
+
+                it('should open wizard when action has commentable input', () => {
+                    workflowActionsComponent.actionFired.emit({
+                        id: '1',
+                        actionInputs: [{ id: 'commentable', body: {} }]
+                    } as DotCMSWorkflowAction);
+
+                    expect(wizardService.open).toHaveBeenCalled();
+                });
+
+                it('should open wizard when action has assignable input', () => {
+                    workflowActionsComponent.actionFired.emit({
+                        id: '1',
+                        actionInputs: [{ id: 'assignable', body: {} }]
+                    } as DotCMSWorkflowAction);
+
+                    expect(wizardService.open).toHaveBeenCalled();
+                });
+
+                it('should open wizard when action has both commentable and assignable inputs', () => {
+                    workflowActionsComponent.actionFired.emit({
+                        id: '1',
+                        actionInputs: [
+                            { id: 'commentable', body: {} },
+                            { id: 'assignable', body: {} }
+                        ]
+                    } as DotCMSWorkflowAction);
+
+                    expect(wizardService.open).toHaveBeenCalled();
+                });
+
+                it('should not open wizard when action has no inputs', () => {
+                    workflowActionsComponent.actionFired.emit({
+                        id: '1'
+                    } as DotCMSWorkflowAction);
+
+                    expect(wizardService.open).not.toHaveBeenCalled();
+                });
+            });
         });
     });
 


### PR DESCRIPTION
## Summary

- Adds E2E regression tests for issue #34347: workflow wizard dialog opens correctly in New Edit Contentlet mode when a workflow action has `commentable` or `assignable` inputs
- Adds `createWorkflowAction` helper to `requests/workflow.ts` (generalizes the previous `createCommentableWorkflowAction` with `assignable`/`commentable` flags)
- Three test groups sharing one contentlet/content type setup:
  - **assignable + commentable** — wizard opens, has assignee dropdown, has comments textarea, cancel closes dialog
  - **assignable-only** — wizard opens, has assignee dropdown
  - **commentable-only** — wizard opens, has comments textarea

## Test plan

- [ ] Run `yarn nx e2e dotcms-ui-e2e --grep "Workflow action wizard dialog"` against a local dotCMS instance
- [ ] Verify all 8 tests pass
- [ ] Verify `afterAll` cleanup removes the workflow actions, contentlet, and content type


Closes #34347 