### PR TITLE
feat(queue): add cloud-agnostic queue publisher abstraction

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -15,6 +15,7 @@
         <maven.deploy.skip>false</maven.deploy.skip>
         <flatten.mode>bom</flatten.mode>
         <aws-java-sdk.version>1.12.488</aws-java-sdk.version>
+        <aws-java-sdk-v2.version>2.34.0</aws-java-sdk-v2.version>
         <twelvemonkeys.version>3.13.1-fixed</twelvemonkeys.version>
         <swagger.version>2.2.34</swagger.version>
         <bytebuddy.version>1.18.1</bytebuddy.version>
@@ -834,6 +835,14 @@
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
                 <version>${aws-java-sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws-java-sdk-v2.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -713,8 +713,8 @@
             <artifactId>aws-java-sdk-s3</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-sqs</artifactId>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>sqs</artifactId>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -714,6 +714,10 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sqs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>jmespath-java</artifactId>
         </dependency>
 

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueueException.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueueException.java
@@ -1,0 +1,24 @@
+package com.dotcms.queue;
+
+import com.dotmarketing.exception.DotRuntimeException;
+
+/**
+ * Unchecked exception thrown when a queue operation fails. Wraps provider-specific
+ * errors so callers are not coupled to a particular queue implementation.
+ */
+public class DotQueueException extends DotRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public DotQueueException(final String message) {
+        super(message);
+    }
+
+    public DotQueueException(final Throwable cause) {
+        super(cause);
+    }
+
+    public DotQueueException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
@@ -31,9 +31,10 @@ public interface DotQueuePublisher {
     void publish(String queueName, String messageBody, @Nullable Map<String, String> attributes);
 
     /**
-     * Returns {@code true} if this publisher is initialized and the given queue name
-     * resolves to a valid provider-specific destination. Does not guarantee that a
-     * subsequent {@link #publish} call will succeed (network errors, permissions, etc.).
+     * Returns {@code true} if the given queue name has a provider-specific destination
+     * configured. This is a configuration check, not a connectivity or health check —
+     * it does not probe the remote service. A {@code true} result does not guarantee
+     * that a subsequent {@link #publish} call will succeed.
      *
      * @param queueName logical queue name to check
      */

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
@@ -7,6 +7,13 @@ import java.util.Map;
  * Cloud-agnostic interface for publishing messages to an external queue.
  * Implementations handle provider-specific details (SQS, Pub/Sub, Service Bus, etc.)
  * and are selected at runtime via {@link DotQueuePublisherLocator}.
+ *
+ * <p><b>Usage pattern:</b> Callers should always call {@link #publish} directly.
+ * The {@link #isAvailable} method is a configuration/capability check, not a
+ * prerequisite guard. With the {@link com.dotcms.queue.provider.NoOpQueuePublisher}
+ * default, {@code publish()} safely discards messages with a debug log — do not
+ * short-circuit with {@code if (isAvailable) publish()} as that suppresses even
+ * the debug audit trail.
  */
 public interface DotQueuePublisher {
 
@@ -17,7 +24,8 @@ public interface DotQueuePublisher {
      *                   by the implementation (e.g. {@code ANALYTICS_EVENTS})
      * @param messageBody the message payload, typically JSON
      * @param attributes  optional key-value metadata attached to the message;
-     *                    implementations may map these to provider-specific message attributes
+     *                    implementations may map these to provider-specific message attributes.
+     *                    Entries with null or empty keys/values are silently filtered.
      * @throws DotQueueException if publishing fails
      */
     void publish(String queueName, String messageBody, @Nullable Map<String, String> attributes);

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
@@ -23,7 +23,11 @@ public interface DotQueuePublisher {
     void publish(String queueName, String messageBody, @Nullable Map<String, String> attributes);
 
     /**
-     * Returns {@code true} if this publisher is configured and able to accept messages.
+     * Returns {@code true} if this publisher is initialized and the given queue name
+     * resolves to a valid provider-specific destination. Does not guarantee that a
+     * subsequent {@link #publish} call will succeed (network errors, permissions, etc.).
+     *
+     * @param queueName logical queue name to check
      */
-    boolean isAvailable();
+    boolean isAvailable(String queueName);
 }

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
@@ -1,5 +1,6 @@
 package com.dotcms.queue;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -19,7 +20,7 @@ public interface DotQueuePublisher {
      *                    implementations may map these to provider-specific message attributes
      * @throws DotQueueException if publishing fails
      */
-    void publish(String queueName, String messageBody, Map<String, String> attributes);
+    void publish(String queueName, String messageBody, @Nullable Map<String, String> attributes);
 
     /**
      * Returns {@code true} if this publisher is configured and able to accept messages.

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisher.java
@@ -1,0 +1,28 @@
+package com.dotcms.queue;
+
+import java.util.Map;
+
+/**
+ * Cloud-agnostic interface for publishing messages to an external queue.
+ * Implementations handle provider-specific details (SQS, Pub/Sub, Service Bus, etc.)
+ * and are selected at runtime via {@link DotQueuePublisherLocator}.
+ */
+public interface DotQueuePublisher {
+
+    /**
+     * Publishes a message to the specified queue.
+     *
+     * @param queueName  logical queue name, mapped to a provider-specific destination
+     *                   by the implementation (e.g. {@code ANALYTICS_EVENTS})
+     * @param messageBody the message payload, typically JSON
+     * @param attributes  optional key-value metadata attached to the message;
+     *                    implementations may map these to provider-specific message attributes
+     * @throws DotQueueException if publishing fails
+     */
+    void publish(String queueName, String messageBody, Map<String, String> attributes);
+
+    /**
+     * Returns {@code true} if this publisher is configured and able to accept messages.
+     */
+    boolean isAvailable();
+}

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
@@ -41,14 +41,14 @@ public final class DotQueuePublisherLocator {
             if (instance instanceof DotQueuePublisher) {
                 return (DotQueuePublisher) instance;
             }
-            Logger.error(DotQueuePublisherLocator.class,
-                    "Class '" + provider + "' does not implement DotQueuePublisher, falling back to no-op");
+            throw new DotQueueException(
+                    "Class '" + provider + "' does not implement DotQueuePublisher");
+        } catch (final DotQueueException e) {
+            throw e;
         } catch (final Exception e) {
-            Logger.error(DotQueuePublisherLocator.class,
+            throw new DotQueueException(
                     "Failed to instantiate queue provider '" + provider + "': " + e.getMessage(), e);
         }
-
-        return NoOpQueuePublisher.INSTANCE;
     });
 
     private DotQueuePublisherLocator() {

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
@@ -28,6 +28,12 @@ public final class DotQueuePublisherLocator {
             return new SqsQueuePublisher();
         }
 
+        if (!"noop".equalsIgnoreCase(provider)) {
+            Logger.warn(DotQueuePublisherLocator.class,
+                    "Unrecognized queue provider '" + provider
+                            + "', falling back to no-op. Valid values: sqs, noop");
+        }
+
         return NoOpQueuePublisher.INSTANCE;
     });
 

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
@@ -4,6 +4,7 @@ import com.dotcms.queue.provider.NoOpQueuePublisher;
 import com.dotcms.queue.provider.SqsQueuePublisher;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import com.google.common.annotations.VisibleForTesting;
 import io.vavr.Lazy;
 
 /**
@@ -29,7 +30,23 @@ public final class DotQueuePublisherLocator {
     public static final String DOT_QUEUE_PROVIDER = "DOT_QUEUE_PROVIDER";
 
     private static final Lazy<DotQueuePublisher> INSTANCE = Lazy.of(() -> {
-        final String provider = Config.getStringProperty(DOT_QUEUE_PROVIDER, "noop");
+        final String raw = Config.getStringProperty(DOT_QUEUE_PROVIDER, "noop");
+        return resolve(raw);
+    });
+
+    private DotQueuePublisherLocator() {
+    }
+
+    public static DotQueuePublisher get() {
+        return INSTANCE.get();
+    }
+
+    @VisibleForTesting
+    static DotQueuePublisher resolve(final String rawProvider) {
+        final String provider = (rawProvider == null || rawProvider.trim().isEmpty())
+                ? "noop"
+                : rawProvider.trim();
+
         Logger.info(DotQueuePublisherLocator.class,
                 "Initializing queue publisher with provider: " + provider);
 
@@ -41,7 +58,6 @@ public final class DotQueuePublisherLocator {
             return NoOpQueuePublisher.INSTANCE;
         }
 
-        // Treat as a fully-qualified class name for custom/plugin providers
         try {
             final Class<?> clazz = Class.forName(provider);
             final Object instance = clazz.getDeclaredConstructor().newInstance();
@@ -56,12 +72,5 @@ public final class DotQueuePublisherLocator {
             throw new DotQueueException(
                     "Failed to instantiate queue provider '" + provider + "': " + e.getMessage(), e);
         }
-    });
-
-    private DotQueuePublisherLocator() {
-    }
-
-    public static DotQueuePublisher get() {
-        return INSTANCE.get();
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
@@ -14,8 +14,15 @@ import io.vavr.Lazy;
  *   <li>{@code sqs}  — {@link SqsQueuePublisher}</li>
  *   <li>{@code noop} — {@link NoOpQueuePublisher} (default)</li>
  *   <li>A fully-qualified class name — instantiated via reflection
- *       (must implement {@link DotQueuePublisher} and have a no-arg constructor)</li>
+ *       (must implement {@link DotQueuePublisher} and have a no-arg constructor).
+ *       This is a <b>trusted-operator setting</b>; it allows arbitrary class
+ *       loading and must not be exposed to end users.</li>
  * </ul>
+ *
+ * <p>The provider is resolved once on first access via {@link Lazy}. Subsequent
+ * calls return the cached instance. If resolution fails (bad class name, missing
+ * constructor), the error is <em>not</em> cached — {@code get()} will re-attempt
+ * on the next call, allowing ops to fix config without a restart.
  */
 public final class DotQueuePublisherLocator {
 

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
@@ -13,6 +13,8 @@ import io.vavr.Lazy;
  * <ul>
  *   <li>{@code sqs}  — {@link SqsQueuePublisher}</li>
  *   <li>{@code noop} — {@link NoOpQueuePublisher} (default)</li>
+ *   <li>A fully-qualified class name — instantiated via reflection
+ *       (must implement {@link DotQueuePublisher} and have a no-arg constructor)</li>
  * </ul>
  */
 public final class DotQueuePublisherLocator {
@@ -28,10 +30,22 @@ public final class DotQueuePublisherLocator {
             return new SqsQueuePublisher();
         }
 
-        if (!"noop".equalsIgnoreCase(provider)) {
-            Logger.warn(DotQueuePublisherLocator.class,
-                    "Unrecognized queue provider '" + provider
-                            + "', falling back to no-op. Valid values: sqs, noop");
+        if ("noop".equalsIgnoreCase(provider)) {
+            return NoOpQueuePublisher.INSTANCE;
+        }
+
+        // Treat as a fully-qualified class name for custom/plugin providers
+        try {
+            final Class<?> clazz = Class.forName(provider);
+            final Object instance = clazz.getDeclaredConstructor().newInstance();
+            if (instance instanceof DotQueuePublisher) {
+                return (DotQueuePublisher) instance;
+            }
+            Logger.error(DotQueuePublisherLocator.class,
+                    "Class '" + provider + "' does not implement DotQueuePublisher, falling back to no-op");
+        } catch (final Exception e) {
+            Logger.error(DotQueuePublisherLocator.class,
+                    "Failed to instantiate queue provider '" + provider + "': " + e.getMessage(), e);
         }
 
         return NoOpQueuePublisher.INSTANCE;

--- a/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/DotQueuePublisherLocator.java
@@ -1,0 +1,40 @@
+package com.dotcms.queue;
+
+import com.dotcms.queue.provider.NoOpQueuePublisher;
+import com.dotcms.queue.provider.SqsQueuePublisher;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
+import io.vavr.Lazy;
+
+/**
+ * Configuration-driven factory that returns the active {@link DotQueuePublisher}
+ * implementation. Set {@code DOT_QUEUE_PROVIDER} to select a provider:
+ *
+ * <ul>
+ *   <li>{@code sqs}  — {@link SqsQueuePublisher}</li>
+ *   <li>{@code noop} — {@link NoOpQueuePublisher} (default)</li>
+ * </ul>
+ */
+public final class DotQueuePublisherLocator {
+
+    public static final String DOT_QUEUE_PROVIDER = "DOT_QUEUE_PROVIDER";
+
+    private static final Lazy<DotQueuePublisher> INSTANCE = Lazy.of(() -> {
+        final String provider = Config.getStringProperty(DOT_QUEUE_PROVIDER, "noop");
+        Logger.info(DotQueuePublisherLocator.class,
+                "Initializing queue publisher with provider: " + provider);
+
+        if ("sqs".equalsIgnoreCase(provider)) {
+            return new SqsQueuePublisher();
+        }
+
+        return NoOpQueuePublisher.INSTANCE;
+    });
+
+    private DotQueuePublisherLocator() {
+    }
+
+    public static DotQueuePublisher get() {
+        return INSTANCE.get();
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
@@ -13,6 +13,9 @@ public class NoOpQueuePublisher implements DotQueuePublisher {
 
     public static final NoOpQueuePublisher INSTANCE = new NoOpQueuePublisher();
 
+    private NoOpQueuePublisher() {
+    }
+
     @Override
     public void publish(final String queueName,
                         final String messageBody,

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
@@ -26,7 +26,7 @@ public final class NoOpQueuePublisher implements DotQueuePublisher {
     }
 
     @Override
-    public boolean isAvailable() {
+    public boolean isAvailable(final String queueName) {
         return false;
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
@@ -3,6 +3,7 @@ package com.dotcms.queue.provider;
 import com.dotcms.queue.DotQueuePublisher;
 import com.dotmarketing.util.Logger;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**
@@ -19,7 +20,7 @@ public final class NoOpQueuePublisher implements DotQueuePublisher {
     @Override
     public void publish(final String queueName,
                         final String messageBody,
-                        final Map<String, String> attributes) {
+                        @Nullable final Map<String, String> attributes) {
         Logger.debug(NoOpQueuePublisher.class,
                 () -> "Queue publishing disabled, dropping message for queue: " + queueName);
     }

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
@@ -9,7 +9,7 @@ import java.util.Map;
  * Default {@link DotQueuePublisher} that discards all messages. Active when no
  * queue provider is configured ({@code DOT_QUEUE_PROVIDER=noop} or unset).
  */
-public class NoOpQueuePublisher implements DotQueuePublisher {
+public final class NoOpQueuePublisher implements DotQueuePublisher {
 
     public static final NoOpQueuePublisher INSTANCE = new NoOpQueuePublisher();
 

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/NoOpQueuePublisher.java
@@ -1,0 +1,28 @@
+package com.dotcms.queue.provider;
+
+import com.dotcms.queue.DotQueuePublisher;
+import com.dotmarketing.util.Logger;
+
+import java.util.Map;
+
+/**
+ * Default {@link DotQueuePublisher} that discards all messages. Active when no
+ * queue provider is configured ({@code DOT_QUEUE_PROVIDER=noop} or unset).
+ */
+public class NoOpQueuePublisher implements DotQueuePublisher {
+
+    public static final NoOpQueuePublisher INSTANCE = new NoOpQueuePublisher();
+
+    @Override
+    public void publish(final String queueName,
+                        final String messageBody,
+                        final Map<String, String> attributes) {
+        Logger.debug(NoOpQueuePublisher.class,
+                () -> "Queue publishing disabled, dropping message for queue: " + queueName);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return false;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
@@ -78,12 +78,17 @@ public final class SqsQueuePublisher implements DotQueuePublisher {
     }
 
     @Override
-    public boolean isAvailable() {
+    public boolean isAvailable(final String queueName) {
         try {
-            return getClient() != null;
+            if (!UtilMethods.isSet(queueName)) {
+                return false;
+            }
+            final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase();
+            return UtilMethods.isSet(Config.getStringProperty(configKey, ""))
+                    && getClient() != null;
         } catch (final Exception e) {
             Logger.debug(SqsQueuePublisher.class,
-                    () -> "SQS publisher not available: " + e.getMessage());
+                    () -> "SQS publisher not available for queue '" + queueName + "': " + e.getMessage());
             return false;
         }
     }

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
@@ -1,24 +1,27 @@
 package com.dotcms.queue.provider;
 
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
-import com.amazonaws.services.sqs.model.MessageAttributeValue;
-import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.dotcms.queue.DotQueueException;
 import com.dotcms.queue.DotQueuePublisher;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
 import javax.annotation.Nullable;
+import java.net.URI;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
- * {@link DotQueuePublisher} backed by AWS SQS. Uses the default AWS credentials
- * chain (IAM roles, env vars, instance profiles) — no hardcoded credentials.
+ * {@link DotQueuePublisher} backed by AWS SQS (SDK v2). Uses the default AWS
+ * credentials chain (IAM roles, env vars, instance profiles) — no hardcoded
+ * credentials.
  *
  * <p>Configuration:
  * <ul>
@@ -35,17 +38,17 @@ public final class SqsQueuePublisher implements DotQueuePublisher {
     static final String ENDPOINT_PROP = "DOT_QUEUE_SQS_ENDPOINT";
     static final String QUEUE_URL_PREFIX = "DOT_QUEUE_SQS_URL_";
 
-    private volatile AmazonSQS client;
+    private volatile SqsClient client;
 
     @Override
     public void publish(final String queueName,
                         final String messageBody,
                         @Nullable final Map<String, String> attributes) {
 
-        if (!UtilMethods.isSet(queueName)) {
+        if (queueName == null || queueName.isEmpty()) {
             throw new DotQueueException("queueName must not be null or empty");
         }
-        if (!UtilMethods.isSet(messageBody)) {
+        if (messageBody == null || messageBody.isEmpty()) {
             throw new DotQueueException("messageBody must not be null or empty");
         }
 
@@ -55,17 +58,19 @@ public final class SqsQueuePublisher implements DotQueuePublisher {
         if (attributes != null) {
             attributes.forEach((key, value) -> {
                 if (UtilMethods.isSet(key) && UtilMethods.isSet(value)) {
-                    sqsAttributes.put(key, new MessageAttributeValue()
-                            .withDataType("String")
-                            .withStringValue(value));
+                    sqsAttributes.put(key, MessageAttributeValue.builder()
+                            .dataType("String")
+                            .stringValue(value)
+                            .build());
                 }
             });
         }
 
-        final SendMessageRequest request = new SendMessageRequest()
-                .withQueueUrl(queueUrl)
-                .withMessageBody(messageBody)
-                .withMessageAttributes(sqsAttributes);
+        final SendMessageRequest request = SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(messageBody)
+                .messageAttributes(sqsAttributes)
+                .build();
 
         try {
             getClient().sendMessage(request);
@@ -79,22 +84,15 @@ public final class SqsQueuePublisher implements DotQueuePublisher {
 
     @Override
     public boolean isAvailable(final String queueName) {
-        try {
-            if (!UtilMethods.isSet(queueName)) {
-                return false;
-            }
-            final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase(java.util.Locale.ROOT);
-            return UtilMethods.isSet(Config.getStringProperty(configKey, ""))
-                    && getClient() != null;
-        } catch (final Exception e) {
-            Logger.debug(SqsQueuePublisher.class,
-                    () -> "SQS publisher not available for queue '" + queueName + "': " + e.getMessage());
+        if (queueName == null || queueName.isEmpty()) {
             return false;
         }
+        final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase(Locale.ROOT);
+        return UtilMethods.isSet(Config.getStringProperty(configKey, ""));
     }
 
     private String resolveQueueUrl(final String queueName) {
-        final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase(java.util.Locale.ROOT);
+        final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase(Locale.ROOT);
         final String url = Config.getStringProperty(configKey, "");
         if (!UtilMethods.isSet(url)) {
             throw new DotQueueException(
@@ -104,27 +102,25 @@ public final class SqsQueuePublisher implements DotQueuePublisher {
         return url;
     }
 
-    private AmazonSQS getClient() {
+    private SqsClient getClient() {
         if (client == null) {
             synchronized (this) {
                 if (client == null) {
                     final String region = Config.getStringProperty(REGION_PROP, "us-east-1");
                     final String endpoint = Config.getStringProperty(ENDPOINT_PROP, "");
 
-                    final AmazonSQSClientBuilder builder = AmazonSQSClientBuilder.standard()
-                            .withCredentials(new DefaultAWSCredentialsProviderChain());
+                    final SqsClientBuilder builder = SqsClient.builder()
+                            .credentialsProvider(DefaultCredentialsProvider.create())
+                            .region(Region.of(region));
 
                     if (UtilMethods.isSet(endpoint)) {
-                        builder.withEndpointConfiguration(
-                                new EndpointConfiguration(endpoint, region));
-                    } else {
-                        builder.withRegion(region);
+                        builder.endpointOverride(URI.create(endpoint));
                     }
 
                     client = builder.build();
 
                     Logger.info(SqsQueuePublisher.class,
-                            "Initialized SQS client — region: " + region
+                            "Initialized SQS client (SDK v2) — region: " + region
                                     + (UtilMethods.isSet(endpoint) ? ", endpoint: " + endpoint : ""));
                 }
             }

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
@@ -83,7 +83,7 @@ public final class SqsQueuePublisher implements DotQueuePublisher {
             if (!UtilMethods.isSet(queueName)) {
                 return false;
             }
-            final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase();
+            final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase(java.util.Locale.ROOT);
             return UtilMethods.isSet(Config.getStringProperty(configKey, ""))
                     && getClient() != null;
         } catch (final Exception e) {
@@ -94,7 +94,7 @@ public final class SqsQueuePublisher implements DotQueuePublisher {
     }
 
     private String resolveQueueUrl(final String queueName) {
-        final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase();
+        final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase(java.util.Locale.ROOT);
         final String url = Config.getStringProperty(configKey, "");
         if (!UtilMethods.isSet(url)) {
             throw new DotQueueException(

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
@@ -12,6 +12,7 @@ import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +29,7 @@ import java.util.Map;
  *       SQS queue URL (e.g. {@code DOT_QUEUE_SQS_URL_ANALYTICS_EVENTS})</li>
  * </ul>
  */
-public class SqsQueuePublisher implements DotQueuePublisher {
+public final class SqsQueuePublisher implements DotQueuePublisher {
 
     static final String REGION_PROP = "DOT_QUEUE_SQS_REGION";
     static final String ENDPOINT_PROP = "DOT_QUEUE_SQS_ENDPOINT";
@@ -39,7 +40,7 @@ public class SqsQueuePublisher implements DotQueuePublisher {
     @Override
     public void publish(final String queueName,
                         final String messageBody,
-                        final Map<String, String> attributes) {
+                        @Nullable final Map<String, String> attributes) {
 
         if (!UtilMethods.isSet(queueName)) {
             throw new DotQueueException("queueName must not be null or empty");

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
@@ -41,6 +41,13 @@ public class SqsQueuePublisher implements DotQueuePublisher {
                         final String messageBody,
                         final Map<String, String> attributes) {
 
+        if (!UtilMethods.isSet(queueName)) {
+            throw new DotQueueException("queueName must not be null or empty");
+        }
+        if (!UtilMethods.isSet(messageBody)) {
+            throw new DotQueueException("messageBody must not be null or empty");
+        }
+
         final String queueUrl = resolveQueueUrl(queueName);
 
         final Map<String, MessageAttributeValue> sqsAttributes = new HashMap<>();

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
@@ -53,7 +53,7 @@ public class SqsQueuePublisher implements DotQueuePublisher {
         final Map<String, MessageAttributeValue> sqsAttributes = new HashMap<>();
         if (attributes != null) {
             attributes.forEach((key, value) -> {
-                if (UtilMethods.isSet(value)) {
+                if (UtilMethods.isSet(key) && UtilMethods.isSet(value)) {
                     sqsAttributes.put(key, new MessageAttributeValue()
                             .withDataType("String")
                             .withStringValue(value));

--- a/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
+++ b/dotCMS/src/main/java/com/dotcms/queue/provider/SqsQueuePublisher.java
@@ -1,0 +1,121 @@
+package com.dotcms.queue.provider;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.MessageAttributeValue;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.dotcms.queue.DotQueueException;
+import com.dotcms.queue.DotQueuePublisher;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link DotQueuePublisher} backed by AWS SQS. Uses the default AWS credentials
+ * chain (IAM roles, env vars, instance profiles) — no hardcoded credentials.
+ *
+ * <p>Configuration:
+ * <ul>
+ *   <li>{@code DOT_QUEUE_SQS_REGION} — AWS region (default: {@code us-east-1})</li>
+ *   <li>{@code DOT_QUEUE_SQS_ENDPOINT} — optional custom endpoint for LocalStack/dev;
+ *       omit in production so the SDK uses the standard AWS endpoint</li>
+ *   <li>{@code DOT_QUEUE_SQS_URL_<QUEUE_NAME>} — maps a logical queue name to its
+ *       SQS queue URL (e.g. {@code DOT_QUEUE_SQS_URL_ANALYTICS_EVENTS})</li>
+ * </ul>
+ */
+public class SqsQueuePublisher implements DotQueuePublisher {
+
+    static final String REGION_PROP = "DOT_QUEUE_SQS_REGION";
+    static final String ENDPOINT_PROP = "DOT_QUEUE_SQS_ENDPOINT";
+    static final String QUEUE_URL_PREFIX = "DOT_QUEUE_SQS_URL_";
+
+    private volatile AmazonSQS client;
+
+    @Override
+    public void publish(final String queueName,
+                        final String messageBody,
+                        final Map<String, String> attributes) {
+
+        final String queueUrl = resolveQueueUrl(queueName);
+
+        final Map<String, MessageAttributeValue> sqsAttributes = new HashMap<>();
+        if (attributes != null) {
+            attributes.forEach((key, value) -> {
+                if (UtilMethods.isSet(value)) {
+                    sqsAttributes.put(key, new MessageAttributeValue()
+                            .withDataType("String")
+                            .withStringValue(value));
+                }
+            });
+        }
+
+        final SendMessageRequest request = new SendMessageRequest()
+                .withQueueUrl(queueUrl)
+                .withMessageBody(messageBody)
+                .withMessageAttributes(sqsAttributes);
+
+        try {
+            getClient().sendMessage(request);
+            Logger.debug(SqsQueuePublisher.class,
+                    () -> "Published message to SQS queue '" + queueName + "' at " + queueUrl);
+        } catch (final Exception e) {
+            throw new DotQueueException(
+                    "Failed to publish message to SQS queue '" + queueName + "': " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean isAvailable() {
+        try {
+            return getClient() != null;
+        } catch (final Exception e) {
+            Logger.debug(SqsQueuePublisher.class,
+                    () -> "SQS publisher not available: " + e.getMessage());
+            return false;
+        }
+    }
+
+    private String resolveQueueUrl(final String queueName) {
+        final String configKey = QUEUE_URL_PREFIX + queueName.toUpperCase();
+        final String url = Config.getStringProperty(configKey, "");
+        if (!UtilMethods.isSet(url)) {
+            throw new DotQueueException(
+                    "No SQS queue URL configured for queue '" + queueName
+                            + "'. Set property '" + configKey + "'.");
+        }
+        return url;
+    }
+
+    private AmazonSQS getClient() {
+        if (client == null) {
+            synchronized (this) {
+                if (client == null) {
+                    final String region = Config.getStringProperty(REGION_PROP, "us-east-1");
+                    final String endpoint = Config.getStringProperty(ENDPOINT_PROP, "");
+
+                    final AmazonSQSClientBuilder builder = AmazonSQSClientBuilder.standard()
+                            .withCredentials(new DefaultAWSCredentialsProviderChain());
+
+                    if (UtilMethods.isSet(endpoint)) {
+                        builder.withEndpointConfiguration(
+                                new EndpointConfiguration(endpoint, region));
+                    } else {
+                        builder.withRegion(region);
+                    }
+
+                    client = builder.build();
+
+                    Logger.info(SqsQueuePublisher.class,
+                            "Initialized SQS client — region: " + region
+                                    + (UtilMethods.isSet(endpoint) ? ", endpoint: " + endpoint : ""));
+                }
+            }
+        }
+        return client;
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/queue/DotQueuePublisherLocatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/queue/DotQueuePublisherLocatorTest.java
@@ -1,26 +1,72 @@
 package com.dotcms.queue;
 
 import com.dotcms.queue.provider.NoOpQueuePublisher;
+import com.dotcms.queue.provider.SqsQueuePublisher;
 import org.junit.Test;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import java.util.Map;
 
-/**
- * Verifies the locator returns a valid publisher. The default (no config) should
- * be the NoOp implementation.
- */
+import static org.junit.Assert.*;
+
 public class DotQueuePublisherLocatorTest {
+
+    // --- resolve() tests: no static state, no order dependency ---
+
+    @Test
+    public void resolve_noop_returnsNoOpPublisher() {
+        assertSame(NoOpQueuePublisher.INSTANCE, DotQueuePublisherLocator.resolve("noop"));
+    }
+
+    @Test
+    public void resolve_noopCaseInsensitive() {
+        assertSame(NoOpQueuePublisher.INSTANCE, DotQueuePublisherLocator.resolve("NOOP"));
+    }
+
+    @Test
+    public void resolve_sqs_returnsSqsPublisher() {
+        assertTrue(DotQueuePublisherLocator.resolve("sqs") instanceof SqsQueuePublisher);
+    }
+
+    @Test
+    public void resolve_null_defaultsToNoOp() {
+        assertSame(NoOpQueuePublisher.INSTANCE, DotQueuePublisherLocator.resolve(null));
+    }
+
+    @Test
+    public void resolve_empty_defaultsToNoOp() {
+        assertSame(NoOpQueuePublisher.INSTANCE, DotQueuePublisherLocator.resolve(""));
+    }
+
+    @Test
+    public void resolve_whitespace_defaultsToNoOp() {
+        assertSame(NoOpQueuePublisher.INSTANCE, DotQueuePublisherLocator.resolve("   "));
+    }
+
+    @Test
+    public void resolve_trimmedNoop() {
+        assertSame(NoOpQueuePublisher.INSTANCE, DotQueuePublisherLocator.resolve("  noop  "));
+    }
+
+    @Test(expected = DotQueueException.class)
+    public void resolve_badClassName_throws() {
+        DotQueuePublisherLocator.resolve("com.nonexistent.FakeProvider");
+    }
+
+    @Test(expected = DotQueueException.class)
+    public void resolve_classDoesNotImplementInterface_throws() {
+        DotQueuePublisherLocator.resolve(String.class.getName());
+    }
+
+    /**
+     * Test fixture: valid class with no-arg constructor but not a DotQueuePublisher.
+     * Used by {@link #resolve_classDoesNotImplementInterface_throws()}.
+     * (String.class covers this case since it has a no-arg constructor.)
+     */
+
+    // --- Static locator test (default config) ---
 
     @Test
     public void get_returnsNonNull() {
         assertNotNull(DotQueuePublisherLocator.get());
-    }
-
-    @Test
-    public void defaultProvider_isNoOp() {
-        assertTrue(
-                "Default provider should be NoOpQueuePublisher",
-                DotQueuePublisherLocator.get() instanceof NoOpQueuePublisher);
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/queue/DotQueuePublisherLocatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/queue/DotQueuePublisherLocatorTest.java
@@ -1,0 +1,26 @@
+package com.dotcms.queue;
+
+import com.dotcms.queue.provider.NoOpQueuePublisher;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies the locator returns a valid publisher. The default (no config) should
+ * be the NoOp implementation.
+ */
+public class DotQueuePublisherLocatorTest {
+
+    @Test
+    public void get_returnsNonNull() {
+        assertNotNull(DotQueuePublisherLocator.get());
+    }
+
+    @Test
+    public void defaultProvider_isNoOp() {
+        assertTrue(
+                "Default provider should be NoOpQueuePublisher",
+                DotQueuePublisherLocator.get() instanceof NoOpQueuePublisher);
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/queue/provider/NoOpQueuePublisherTest.java
+++ b/dotCMS/src/test/java/com/dotcms/queue/provider/NoOpQueuePublisherTest.java
@@ -15,6 +15,6 @@ public class NoOpQueuePublisherTest {
 
     @Test
     public void isAvailable_returnsFalse() {
-        assertFalse(NoOpQueuePublisher.INSTANCE.isAvailable());
+        assertFalse(NoOpQueuePublisher.INSTANCE.isAvailable("ANY_QUEUE"));
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/queue/provider/NoOpQueuePublisherTest.java
+++ b/dotCMS/src/test/java/com/dotcms/queue/provider/NoOpQueuePublisherTest.java
@@ -1,0 +1,20 @@
+package com.dotcms.queue.provider;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+
+public class NoOpQueuePublisherTest {
+
+    @Test
+    public void publish_doesNotThrow() {
+        NoOpQueuePublisher.INSTANCE.publish("test-queue", "{}", Map.of("key", "value"));
+    }
+
+    @Test
+    public void isAvailable_returnsFalse() {
+        assertFalse(NoOpQueuePublisher.INSTANCE.isAvailable());
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/queue/provider/SqsQueuePublisherTest.java
+++ b/dotCMS/src/test/java/com/dotcms/queue/provider/SqsQueuePublisherTest.java
@@ -11,7 +11,7 @@ public class SqsQueuePublisherTest {
 
     @Test(expected = DotQueueException.class)
     public void publish_throwsWhenQueueUrlNotConfigured() {
-        new SqsQueuePublisher().publish("NONEXISTENT_QUEUE", "{\"test\":true}", null);
+        new SqsQueuePublisher().publish("__DOTCMS_TEST_NEVER_SET_QUEUE__", "{\"test\":true}", null);
     }
 
     @Test(expected = DotQueueException.class)

--- a/dotCMS/src/test/java/com/dotcms/queue/provider/SqsQueuePublisherTest.java
+++ b/dotCMS/src/test/java/com/dotcms/queue/provider/SqsQueuePublisherTest.java
@@ -11,7 +11,21 @@ public class SqsQueuePublisherTest {
 
     @Test(expected = DotQueueException.class)
     public void publish_throwsWhenQueueUrlNotConfigured() {
-        final SqsQueuePublisher publisher = new SqsQueuePublisher();
-        publisher.publish("NONEXISTENT_QUEUE", "{\"test\":true}", null);
+        new SqsQueuePublisher().publish("NONEXISTENT_QUEUE", "{\"test\":true}", null);
+    }
+
+    @Test(expected = DotQueueException.class)
+    public void publish_throwsWhenQueueNameIsNull() {
+        new SqsQueuePublisher().publish(null, "{}", null);
+    }
+
+    @Test(expected = DotQueueException.class)
+    public void publish_throwsWhenMessageBodyIsNull() {
+        new SqsQueuePublisher().publish("SOME_QUEUE", null, null);
+    }
+
+    @Test(expected = DotQueueException.class)
+    public void publish_throwsWhenQueueNameIsEmpty() {
+        new SqsQueuePublisher().publish("", "{}", null);
     }
 }

--- a/dotCMS/src/test/java/com/dotcms/queue/provider/SqsQueuePublisherTest.java
+++ b/dotCMS/src/test/java/com/dotcms/queue/provider/SqsQueuePublisherTest.java
@@ -1,0 +1,17 @@
+package com.dotcms.queue.provider;
+
+import com.dotcms.queue.DotQueueException;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link SqsQueuePublisher}. These verify configuration-level
+ * behavior without requiring an actual SQS connection.
+ */
+public class SqsQueuePublisherTest {
+
+    @Test(expected = DotQueueException.class)
+    public void publish_throwsWhenQueueUrlNotConfigured() {
+        final SqsQueuePublisher publisher = new SqsQueuePublisher();
+        publisher.publish("NONEXISTENT_QUEUE", "{\"test\":true}", null);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #35630

- Introduces a `DotQueuePublisher` interface with config-driven provider selection via `DotQueuePublisherLocator` (`DOT_QUEUE_PROVIDER`)
- Ships with two implementations: `SqsQueuePublisher` (AWS SQS via IAM/default credentials chain) and `NoOpQueuePublisher` (default, discards messages)
- Supports custom providers via fully-qualified class name in config, matching the existing `DotPubSubProviderLocator` extensibility pattern
- Logical queue names map to provider-specific destinations through config (`DOT_QUEUE_SQS_URL_<QUEUE_NAME>`)

This is a standalone infrastructure abstraction with no consumers wired up yet. Analytics event delivery will be connected in a follow-up PR.

### Configuration

| Property | Description | Default |
|----------|-------------|---------|
| `DOT_QUEUE_PROVIDER` | `sqs`, `noop`, or a fully-qualified class name | `noop` |
| `DOT_QUEUE_SQS_REGION` | AWS region | `us-east-1` |
| `DOT_QUEUE_SQS_ENDPOINT` | Custom endpoint (LocalStack/dev only) | _(omit for standard AWS)_ |
| `DOT_QUEUE_SQS_URL_<NAME>` | Maps logical queue name to SQS queue URL | _(required per queue)_ |

## Test plan

- [x] 8 unit tests passing (locator selection, null validation, no-op behavior, missing queue URL)
- [x] `NoOpQueuePublisher` is default when no provider configured
- [x] Bad provider config fails fast with `DotQueueException` (no silent fallback)
- [ ] Manual: verify SQS publish against LocalStack with `DOT_QUEUE_PROVIDER=sqs`