### PR TITLE
Fixing layout error

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/templates/business/TemplateAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/templates/business/TemplateAPIImpl.java
@@ -1348,7 +1348,7 @@ public class TemplateAPIImpl extends BaseWebAssetAPI implements TemplateAPI, Dot
 														final int layoutVersionDelta,
 														final LayoutChanges.Builder builder) {
 		oldContainers.stream().forEach(oldContainer -> {
-			final String uuid = oldContainer.getUUID();
+			final String uuid = getOldUUID(oldContainer);
 
 			final Optional<ContainerUUID> newContainerUUIDMatch = newContainers.stream()
 					.filter(newContainer -> oldContainer.getIdentifier().equals(newContainer.getIdentifier()))
@@ -1356,7 +1356,7 @@ public class TemplateAPIImpl extends BaseWebAssetAPI implements TemplateAPI, Dot
 					.findAny();
 
 			if (newContainerUUIDMatch.isPresent() && !uuid.equals(newContainerUUIDMatch.get().getUUID())) {
-				builder.change(oldContainer.getIdentifier(), oldContainer.getUUID(),
+				builder.change(oldContainer.getIdentifier(), getOldUUID(oldContainer),
 						newContainerUUIDMatch.get().getUUID());
 			} else if (newContainerUUIDMatch.isEmpty()) {
 				builder.remove(oldContainer.getIdentifier(), uuid);
@@ -1558,13 +1558,17 @@ public class TemplateAPIImpl extends BaseWebAssetAPI implements TemplateAPI, Dot
 		oldContainers.stream().forEach(oldContainer -> {
 			Optional<ContainerUUID> newContainer = newContainers.stream()
 					.filter(containerUUID -> containerUUID.getIdentifier().equals(oldContainer.getIdentifier()))
-					.filter(containerUUID -> containerUUID.getUUID().equals(oldContainer.getUUID()))
+					.filter(containerUUID -> containerUUID.getUUID().equals(getOldUUID(oldContainer)))
 					.findFirst();
 
 			if (!newContainer.isPresent()) {
-				builder.remove(oldContainer.getIdentifier(), oldContainer.getUUID());
+				builder.remove(oldContainer.getIdentifier(), getOldUUID(oldContainer));
 			}
 		});
+	}
+
+	private static String getOldUUID(ContainerUUID oldContainer) {
+		return ContainerUUID.UUID_LEGACY_VALUE.equals(oldContainer.getUUID()) ? "1" : oldContainer.getUUID();
 	}
 
 	/**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/templates/design/bean/LayoutChanges.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/templates/design/bean/LayoutChanges.java
@@ -109,7 +109,9 @@ public class LayoutChanges {
         }
 
         public String getOldInstanceId() {
-            return oldInstanceId;
+            return ContainerUUID.UUID_LEGACY_VALUE.equals(oldInstanceId)
+                    ? ContainerUUID.UUID_START_VALUE
+                    : oldInstanceId;
         }
 
         public boolean isRemove() {

--- a/dotCMS/src/test/java/com/dotmarketing/portlets/templates/design/bean/LayoutChangesTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/portlets/templates/design/bean/LayoutChangesTest.java
@@ -1,0 +1,82 @@
+package com.dotmarketing.portlets.templates.design.bean;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LayoutChangesTest {
+
+    @Test
+    public void getOldInstanceId_whenLegacyValue_returnsStartValue() {
+        final LayoutChanges.ContainerChanged changed = new LayoutChanges.ContainerChanged(
+                "container-1",
+                ContainerUUID.UUID_LEGACY_VALUE,
+                "2"
+        );
+
+        assertEquals(ContainerUUID.UUID_START_VALUE, changed.getOldInstanceId());
+    }
+
+    @Test
+    public void getOldInstanceId_whenNormalValue_returnsItUnchanged() {
+        final LayoutChanges.ContainerChanged changed = new LayoutChanges.ContainerChanged(
+                "container-1",
+                "5",
+                "6"
+        );
+
+        assertEquals("5", changed.getOldInstanceId());
+    }
+
+    @Test
+    public void getOldInstanceId_whenStartValue_returnsItUnchanged() {
+        final LayoutChanges.ContainerChanged changed = new LayoutChanges.ContainerChanged(
+                "container-1",
+                ContainerUUID.UUID_START_VALUE,
+                "2"
+        );
+
+        assertEquals(ContainerUUID.UUID_START_VALUE, changed.getOldInstanceId());
+    }
+
+    @Test
+    public void isRemove_whenNewInstanceIsDefault_returnsTrue() {
+        final LayoutChanges.ContainerChanged changed = new LayoutChanges.ContainerChanged(
+                "container-1",
+                "1",
+                ContainerUUID.UUID_DEFAULT_VALUE
+        );
+
+        assertTrue(changed.isRemove());
+        assertFalse(changed.isNew());
+        assertFalse(changed.isMoved());
+    }
+
+    @Test
+    public void isNew_whenOldInstanceIsDefault_returnsTrue() {
+        final LayoutChanges.ContainerChanged changed = new LayoutChanges.ContainerChanged(
+                "container-1",
+                ContainerUUID.UUID_DEFAULT_VALUE,
+                "1"
+        );
+
+        assertTrue(changed.isNew());
+        assertFalse(changed.isRemove());
+        assertFalse(changed.isMoved());
+    }
+
+    @Test
+    public void isMoved_whenBothInstancesAreNonDefault_returnsTrue() {
+        final LayoutChanges.ContainerChanged changed = new LayoutChanges.ContainerChanged(
+                "container-1",
+                "1",
+                "2"
+        );
+
+        assertTrue(changed.isMoved());
+        assertFalse(changed.isNew());
+        assertFalse(changed.isRemove());
+    }
+}


### PR DESCRIPTION
## Proposed Changes

Fixes incorrect layout diff computation when containers have legacy UUID values (`UUID_LEGACY_VALUE`), which caused move/remove operations to be missed or misidentified during template layout changes.

* **`TemplateAPIImpl` — `getOldUUID()` helper**: Extracted a private static method that normalises `UUID_LEGACY_VALUE` to `"1"` (`UUID_START_VALUE`) before any UUID comparison. Applied consistently in `addMoveAndRemoveChangesWithHistory` (both the equality check and the `builder.change()` call) and `addRemoveChanges`, replacing raw `oldContainer.getUUID()` calls that were silently passing the legacy sentinel through.

* **`LayoutChanges.ContainerChanged#getOldInstanceId()`**: Same normalisation applied at the DTO level — returns `UUID_START_VALUE` when the stored `oldInstanceId` is `UUID_LEGACY_VALUE`, so callers always receive a consistent, comparable value.

Without these fixes, a container with a legacy UUID would fail to match its counterpart in the new layout (because `"-1" != "1"`), causing valid moves to be reported as remove+add pairs and breaking the layout change history.

## Checklist
- [x] Tests — `LayoutChangesTest` covers all `ContainerChanged` state transitions: legacy→start normalisation, unchanged normal values, `isRemove`, `isNew`, and `isMoved` scenarios
- [ ] Translations
- [x] Security Implications Contemplated — no user-facing input; pure internal UUID normalisation with no security surface

## Additional Info

Relates to: #35594

This PR fixes: #35629

This PR fixes: #35629