### PR TITLE
fix(edit-content): treat X / ESC dismissal of unsaved-changes dialog as Keep editing

### DIFF
--- a/core-web/libs/edit-content/src/lib/guards/unsaved-changes.guard.spec.ts
+++ b/core-web/libs/edit-content/src/lib/guards/unsaved-changes.guard.spec.ts
@@ -3,7 +3,7 @@ import { mockProvider } from '@ngneat/spectator/jest';
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, RouterStateSnapshot, type CanDeactivateFn } from '@angular/router';
 
-import { Confirmation, ConfirmationService } from 'primeng/api';
+import { Confirmation, ConfirmationService, ConfirmEventType } from 'primeng/api';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
@@ -150,12 +150,37 @@ describe('unsavedChangesGuard', () => {
 
         const confirmation = capturedConfirmation as Confirmation;
 
-        // Simulate clicking the secondary "Discard changes" button.
-        confirmation.reject?.();
+        // PrimeNG emits `ConfirmEventType.REJECT` when the user clicks the
+        // secondary action button (vs `CANCEL` for X / ESC dismissals).
+        confirmation.reject?.(ConfirmEventType.REJECT);
 
         await expect(result).resolves.toBe(true);
         // Form should be reset to pristine so any downstream beforeunload
         // does not re-prompt with the browser's native dialog.
         expect(markFormPristine).toHaveBeenCalledTimes(1);
+    });
+
+    // PrimeNG routes the close-icon and ESC dismissals through the same
+    // `reject` callback as the "Discard changes" button — only the
+    // `ConfirmEventType` argument differs. The guard must treat these
+    // dismissals as "Keep editing" so an accidental click on the X (or
+    // a stray ESC keypress) never silently discards the user's work.
+    it('should cancel navigation when the user dismisses the dialog (X / ESC → CANCEL)', async () => {
+        const markFormPristine = jest.fn();
+        const component = buildComponent({
+            hasUnsavedChanges: () => true,
+            markFormPristine
+        });
+
+        const result = runGuard(component) as Promise<boolean>;
+
+        const confirmation = capturedConfirmation as Confirmation;
+
+        confirmation.reject?.(ConfirmEventType.CANCEL);
+
+        await expect(result).resolves.toBe(false);
+        // Dismissal must NOT reset the form's dirty state — the user is
+        // staying on the editor and their changes must remain intact.
+        expect(markFormPristine).not.toHaveBeenCalled();
     });
 });

--- a/core-web/libs/edit-content/src/lib/guards/unsaved-changes.guard.ts
+++ b/core-web/libs/edit-content/src/lib/guards/unsaved-changes.guard.ts
@@ -1,6 +1,8 @@
 import { inject } from '@angular/core';
 import { CanDeactivateFn } from '@angular/router';
 
+import { ConfirmEventType } from 'primeng/api';
+
 import { DotMessageService } from '@dotcms/data-access';
 
 import { DotEditContentLayoutComponent } from '../components/dot-edit-content-layout/dot-edit-content.layout.component';
@@ -56,13 +58,26 @@ export const unsavedChangesGuard: CanDeactivateFn<DotEditContentLayoutComponent>
             rejectButtonStyleClass: 'p-button-outlined',
             // Primary "Keep editing": cancel navigation, user stays on the editor.
             accept: () => resolve(false),
-            // Secondary "Discard changes": allow navigation. Reset the form's
-            // dirty state first so a downstream `beforeunload` (e.g. when the
-            // destination triggers a hard navigation) does not re-prompt with
-            // the browser's native dialog.
-            reject: () => {
-                component.markFormPristine();
-                resolve(true);
+            // PrimeNG routes three different user actions through this single
+            // callback. Discriminate by `ConfirmEventType` so dismissals
+            // (close icon, ESC, mask click) behave like "Keep editing"
+            // instead of silently discarding the user's work.
+            //   REJECT → user clicked the secondary "Discard changes" button.
+            //            Reset the form's dirty state first so a downstream
+            //            `beforeunload` (when the destination triggers a hard
+            //            navigation) does not re-prompt with the browser's
+            //            native dialog.
+            //   CANCEL → user dismissed the dialog via the X icon or ESC.
+            //            Treat as "Keep editing": stay on the editor with the
+            //            form still dirty.
+            reject: (type?: ConfirmEventType) => {
+                if (type === ConfirmEventType.REJECT) {
+                    component.markFormPristine();
+                    resolve(true);
+
+                    return;
+                }
+                resolve(false);
             }
         });
     });


### PR DESCRIPTION
## Summary

Follow-up to #35598 (issue #35533). On the new Edit Contentlet unsaved-changes confirm, dismissing the dialog via the **X close icon** or **ESC** key was discarding the user's changes and letting the navigation proceed — the opposite of the intended UX. Both dismissals now behave like the primary **"Keep editing"** button: dialog closes, user stays on the editor, form remains dirty.

https://github.com/user-attachments/assets/8ab2a6ac-dd00-4dbb-9038-8bdf3e1f8588




## Root cause

PrimeNG's `<p-confirmDialog />` routes three different user actions through the same `Confirmation.reject` callback, and only the `ConfirmEventType` argument distinguishes them:

| User action | `ConfirmEventType` |
| --- | --- |
| Click "Discard changes" button | `REJECT` |
| Click X close icon | `CANCEL` |
| Press ESC / click mask | `CANCEL` |

The previous `reject` callback ignored the argument and always treated the event as "Discard" — `markFormPristine()` + `resolve(true)`. Dismissing the dialog silently lost the user's work.

## Fix

Discriminate by `ConfirmEventType` inside the guard's `reject` callback:

- `REJECT` → existing behavior: `markFormPristine()`, allow navigation.
- `CANCEL` (X icon, ESC) → resolve `false`, like clicking "Keep editing". Form stays dirty.

Only `core-web/libs/edit-content/src/lib/guards/unsaved-changes.guard.ts` and its spec are touched. The `<p-confirmDialog />` template keeps its default `closable: true`, matching the `core-web/CLAUDE.md` rule that every dialog must be dismissable via X and ESC.

## Acceptance criteria

- [x] Form dirty → open the dialog → click the **X** → dialog closes, user stays on the editor, form still dirty
- [x] Form dirty → open the dialog → press **ESC** → same as above
- [x] Form dirty → open the dialog → click **"Discard changes"** → navigation completes, form reset to pristine (unchanged)
- [x] Form dirty → open the dialog → click **"Keep editing"** → user stays, form still dirty (unchanged)
- [x] Pristine form → no dialog appears (unchanged)
- [x] Just saved → no dialog appears (unchanged)

## Test plan

- [x] \`yarn nx test edit-content\` — 1831 tests pass; new test \`should cancel navigation when the user dismisses the dialog (X / ESC → CANCEL)\` exercises the regression. Existing "Discard changes" test updated to pass \`ConfirmEventType.REJECT\` explicitly to mirror PrimeNG's real wiring.
- [x] \`yarn nx lint edit-content\` — 0 errors (3 pre-existing warnings unrelated to this PR).
- [ ] Manual QA: open new Edit Content, edit a field, click another portlet → click the **X** on the dialog → verify user stays on the editor with the edited value still in the field.
- [ ] Manual QA: same setup, press **ESC** on the dialog → verify same behavior.
- [ ] Manual QA: same setup, click **"Discard changes"** → verify navigation completes and changes are gone (regression check).

This PR fixes: #35533