### PR TITLE
fix(ci): gate Docker :latest and "Next Release" relabel to main only

### DIFF
--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -121,7 +121,7 @@ jobs:
       tag-identifier: ${{ needs.release-prepare.outputs.release_version }}
       omit-environment-prefix: true
       artifact-run-id: ${{ github.run_id }}
-      latest: ${{ needs.release-prepare.outputs.is_latest == 'true' }}
+      latest: ${{ needs.release-prepare.outputs.is_latest == 'true' && github.ref_name == 'main' }}
       deploy-cli: true
       deploy-dev-image: true
       publish-npm-cli: false
@@ -150,7 +150,7 @@ jobs:
       deploy_artifact: ${{ github.event.inputs.deploy_artifact == 'true' }}
       upload_javadocs: ${{ github.event.inputs.upload_javadocs == 'true' }}
       update_plugins: ${{ github.event.inputs.update_plugins == 'true' }}
-      update_github_labels: ${{ github.event.inputs.update_github_labels == 'true' }}
+      update_github_labels: ${{ github.event.inputs.update_github_labels == 'true' && github.ref_name == 'main' }}
       java-version: ${{ github.event.inputs.java-version }}
       artifact-suffix: ${{ github.event.inputs.artifact-suffix }}
     secrets:


### PR DESCRIPTION
## Summary

- The `-6 Release Process` workflow can be dispatched from any branch, but it unconditionally pushed Docker `:latest` and relabeled GitHub issues tagged `Next Release` with the dispatched `release_version`.
- When the workflow was run from a non-`main` branch (e.g. `26.04.11`), this overwrote `:latest` with a non-`main` image and stamped `main`-only fixes with a release version that did not actually contain them.
- Adds a `github.ref_name == 'main'` guard to the deployment phase's `latest` input and the release phase's `update_github_labels` input so these two side effects fire only when releasing from `main`.

Plugin updates, Artifactory deploy, javadocs upload, SBOM, and Slack notification remain controllable via their existing workflow inputs and are intentionally **not** branch-gated — they are legitimate from non-`main` release branches.

Closes #35651

## Test plan

- [ ] Dispatch `-6 Release Process` from a non-`main` branch with a standard version (e.g. `26.04.11-01`) and `update_github_labels = true`. Confirm:
  - [ ] The `deploy-docker` step does **not** push the `:latest` tag.
  - [ ] The release phase does **not** relabel `Next Release` issues.
- [ ] Dispatch `-6 Release Process` from `main` with a standard version. Confirm:
  - [ ] Docker `:latest` **is** pushed (existing behavior).
  - [ ] `Next Release` issues **are** relabeled (existing behavior).
- [ ] Dispatch from `main` with an LTS version (e.g. `26.04.11_lts_v01`). Confirm `:latest` is **not** pushed (pre-existing LTS behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35651