### PR TITLE
fix(edit-content): Custom Field shows inline required validation

### DIFF
--- a/.claude/skills/vtl-migration/SKILL.md
+++ b/.claude/skills/vtl-migration/SKILL.md
@@ -151,8 +151,9 @@ DotCustomFieldApi.ready(() => {
     input.classList.toggle('input-error', showError);
   };
 
-  // Emit current state once, then subscribe for further changes.
-  applyValidation(field.getValidationState());
+  // onValidationChange emits the initial state synchronously, so a separate
+  // getValidationState() call up front is redundant. The bridge auto-cleans
+  // on form destroy, so the unsubscribe return value can be ignored here.
   field.onValidationChange(applyValidation);
 });
 ```

--- a/.claude/skills/vtl-migration/SKILL.md
+++ b/.claude/skills/vtl-migration/SKILL.md
@@ -139,24 +139,36 @@ DotCustomFieldApi.ready(() => {
 ```
 
 **Reacting to validation state (required, errors, touched):**
-```js
-DotCustomFieldApi.ready(() => {
-  const field = DotCustomFieldApi.getField('urlTitle');
-  const input = document.getElementById('slugInput');
+```html
+<style>
+  /* Self-contained: legacy iframe pages do NOT load DaisyUI, so we ship the rule with the template. */
+  #slugInput.is-invalid {
+    border-color: #ef4444;
+    outline-color: #ef4444;
+  }
+</style>
 
-  const applyValidation = (state) => {
-    // Only show the error after the user (or Save) has marked the control as touched —
-    // mirrors how Angular's built-in fields paint the red border.
-    const showError = state.invalid && state.touched;
-    input.classList.toggle('input-error', showError);
-  };
+<script type="module">
+  DotCustomFieldApi.ready(() => {
+    const field = DotCustomFieldApi.getField('urlTitle');
+    const input = document.getElementById('slugInput');
 
-  // onValidationChange emits the initial state synchronously, so a separate
-  // getValidationState() call up front is redundant. The bridge auto-cleans
-  // on form destroy, so the unsubscribe return value can be ignored here.
-  field.onValidationChange(applyValidation);
-});
+    const applyValidation = (state) => {
+      // Only show the error after the user (or Save) has marked the control as touched —
+      // mirrors how Angular's built-in fields paint the red border.
+      const showError = state.invalid && state.touched;
+      input.classList.toggle('is-invalid', showError);
+    };
+
+    // onValidationChange emits the initial state synchronously, so a separate
+    // getValidationState() call up front is redundant. The bridge auto-cleans
+    // on form destroy, so the unsubscribe return value can be ignored here.
+    field.onValidationChange(applyValidation);
+  });
+</script>
 ```
+
+> Use a self-contained `is-invalid` class with inline `<style>` instead of DaisyUI's `input-error`. The legacy iframe page (`legacy-custom-field.jsp`) does NOT load DaisyUI or Tailwind, so an `input-error` toggle would silently produce no visual feedback there. In iframe mode the callback also never fires (the Dojo bridge's `onValidationChange` is a no-op) — the legacy editor has its own validation surface. See Rule 13 in `references/migration-guide.md` for the full gotchas list.
 
 `state` shape: `{ valid, invalid, touched, dirty, errors }` (mirrors Angular's `AbstractControl`). `errors` is `null` when valid, otherwise a record like `{ required: true }`.
 

--- a/.claude/skills/vtl-migration/SKILL.md
+++ b/.claude/skills/vtl-migration/SKILL.md
@@ -19,6 +19,8 @@ For the full migration rules, all code examples, the DaisyUI styling section, an
 | `DotCustomFieldApi.onChangeField('id', cb)` | `DotCustomFieldApi.getField('id').onChange(cb)` |
 | Manual DOM show/hide of a field | `DotCustomFieldApi.getField('id').show()` / `.hide()` |
 | Manual DOM enable/disable of a field | `DotCustomFieldApi.getField('id').enable()` / `.disable()` |
+| Manual checks against dijit validation state | `DotCustomFieldApi.getField('id').getValidationState()` |
+| No legacy equivalent | `DotCustomFieldApi.getField('id').onValidationChange(cb)` |
 | `dojo.ready(fn)` | `DotCustomFieldApi.ready(fn)` |
 | `dojo.byId('el')` | `document.getElementById('el')` |
 | `dijit.byId('id')` | `DotCustomFieldApi.getField('id')` |
@@ -135,6 +137,27 @@ DotCustomFieldApi.ready(() => {
   mediaFileField.enable();  // restores interactivity
 });
 ```
+
+**Reacting to validation state (required, errors, touched):**
+```js
+DotCustomFieldApi.ready(() => {
+  const field = DotCustomFieldApi.getField('urlTitle');
+  const input = document.getElementById('slugInput');
+
+  const applyValidation = (state) => {
+    // Only show the error after the user (or Save) has marked the control as touched —
+    // mirrors how Angular's built-in fields paint the red border.
+    const showError = state.invalid && state.touched;
+    input.classList.toggle('input-error', showError);
+  };
+
+  // Emit current state once, then subscribe for further changes.
+  applyValidation(field.getValidationState());
+  field.onValidationChange(applyValidation);
+});
+```
+
+`state` shape: `{ valid, invalid, touched, dirty, errors }` (mirrors Angular's `AbstractControl`). `errors` is `null` when valid, otherwise a record like `{ required: true }`.
 
 **Multiple onChange for the same field** → combine into one handler:
 ```js

--- a/.claude/skills/vtl-migration/references/migration-guide.md
+++ b/.claude/skills/vtl-migration/references/migration-guide.md
@@ -401,7 +401,8 @@ Use `getValidationState()` for a one-shot read, and `onValidationChange()` to su
       input.classList.toggle('is-invalid', showError);
     };
 
-    applyValidation(field.getValidationState());
+    // onValidationChange emits the initial state synchronously, so no need
+    // to also call getValidationState() up front.
     field.onValidationChange(applyValidation);
   });
 </script>
@@ -412,6 +413,8 @@ Use `getValidationState()` for a one-shot read, and `onValidationChange()` to su
 - **Always gate on `state.touched`.** A required + empty field is `invalid: true` from the moment it mounts. If you toggle only on `invalid`, the input flashes red on first render before the user has done anything.
 - **Don't rely on DaisyUI's `input-error` modifier inside legacy iframe templates.** The legacy iframe page (`legacy-custom-field.jsp`) does NOT load DaisyUI or Tailwind. Ship your error styles inline in the template (the example above does that with a small `<style>` block).
 - The bridge handles late control registration internally — `onValidationChange` will re-attach when the FormGroup registers your field, and will emit the initial state when it appears. You don't need to retry.
+- The bridge tears down all validation subscriptions when the form is destroyed, so you can safely ignore the `unsubscribe` return value of `onValidationChange` for one-shot field templates. Capture it only if you need to detach the listener while the form is still alive.
+- `getValidationState()` on a Dojo (legacy editor) field, or on an Angular field whose control has not registered yet, returns a neutral `{ valid: true, invalid: false, touched: false, dirty: false, errors: null }`. Real state flows in once the control resolves — gating on `state.touched` keeps this neutral starter from painting the input red.
 
 ### Native Components and Platform Styles
 

--- a/.claude/skills/vtl-migration/references/migration-guide.md
+++ b/.claude/skills/vtl-migration/references/migration-guide.md
@@ -48,6 +48,8 @@ DotCustomFieldApi.ready(() => {
 | `getValue()` | Returns the current value of the field |
 | `setValue(value)` | Sets the field's value |
 | `onChange(callback)` | Subscribes to value changes |
+| `getValidationState()` | Returns a snapshot of the field's validation state — `{ valid, invalid, touched, dirty, errors }` |
+| `onValidationChange(callback)` | Subscribes to validation state changes (status, errors, touched, dirty) |
 | `show()` | Makes the field visible (input and associated label) |
 | `hide()` | Hides the field from view (input and associated label) |
 | `enable()` | Restores interactivity to the field |
@@ -355,6 +357,61 @@ DotCustomFieldApi.ready(() => {
   mediaField.onChange(toggleVisibility);
 });
 ```
+
+### Rule 13: Use `field.getValidationState()` / `field.onValidationChange()` to reflect required errors inline
+
+The custom field renders inside the host form. The host paints the "This field is mandatory" message in the field footer, but **the inner input lives in the custom field's template** — only the template can decide how to style its own input on error (red border, error icon, etc.).
+
+Use `getValidationState()` for a one-shot read, and `onValidationChange()` to subscribe.
+
+**State shape:**
+
+```js
+{
+  valid: boolean,
+  invalid: boolean,
+  touched: boolean,
+  dirty: boolean,
+  errors: Record<string, unknown> | null   // e.g. { required: true }
+}
+```
+
+**Pattern — paint the input red when required and empty after Save:**
+
+```html
+<style>
+  /* Self-contained: legacy iframe pages do NOT load DaisyUI, so we ship the rule with the template. */
+  #slugInput.is-invalid {
+    border-color: #ef4444;
+    outline-color: #ef4444;
+  }
+</style>
+
+<input id="slugInput" class="input input-bordered w-full" />
+
+<script type="module">
+  DotCustomFieldApi.ready(() => {
+    const field = DotCustomFieldApi.getField('urlTitle');
+    const input = document.getElementById('slugInput');
+
+    const applyValidation = (state) => {
+      // Always gate on touched — mirrors how Angular's built-in fields behave.
+      // Without this, the input would show red on first load when empty + required.
+      const showError = state.invalid && state.touched;
+      input.classList.toggle('is-invalid', showError);
+    };
+
+    applyValidation(field.getValidationState());
+    field.onValidationChange(applyValidation);
+  });
+</script>
+```
+
+**Important gotchas:**
+
+- **Always gate on `state.touched`.** A required + empty field is `invalid: true` from the moment it mounts. If you toggle only on `invalid`, the input flashes red on first render before the user has done anything.
+- **Don't rely on DaisyUI's `input-error` modifier inside legacy iframe templates.** The legacy iframe page (`legacy-custom-field.jsp`) does NOT load DaisyUI or Tailwind. Ship your error styles inline in the template (the example above does that with a small `<style>` block).
+- The bridge handles late control registration internally — `onValidationChange` will re-attach when the FormGroup registers your field, and will emit the initial state when it appears. You don't need to retry.
 
 ### Native Components and Platform Styles
 

--- a/core-web/apps/dotcms-ui/src/daisyui-theme.css
+++ b/core-web/apps/dotcms-ui/src/daisyui-theme.css
@@ -43,6 +43,7 @@ dot-native-field {
         font-feature-settings: inherit;
         outline-color: transparent;
         box-shadow: var(--p-inputtext-shadow);
+        --size: calc(var(--size-field, 0.25rem) * 10 + 4px);
         transition:
             background var(--p-inputtext-transition-duration),
             color var(--p-inputtext-transition-duration),

--- a/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.spec.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.spec.ts
@@ -78,6 +78,7 @@ describe('AngularFormBridge', () => {
         AngularFormBridge.resetInstance();
         mockFormGroup.get.mockReturnValue(mockFormControl);
         mockFormControl.valueChanges._callback = null;
+        mockFormControl.events._callback = null;
         mockDialogRef.onClose._callback = null;
         bridge = AngularFormBridge.getInstance(
             mockFormGroup as any,
@@ -562,8 +563,10 @@ describe('AngularFormBridge', () => {
 
                 const state = bridge.getField('missingField').getValidationState();
 
+                // Matches DojoFormBridge so VTL templates that read `state.valid`
+                // get the same answer in both editors when the control is unknown.
                 expect(state).toEqual({
-                    valid: false,
+                    valid: true,
                     invalid: false,
                     touched: false,
                     dirty: false,

--- a/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.spec.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.spec.ts
@@ -6,11 +6,21 @@ import { AngularFormBridge } from './angular-form-bridge';
 // Mock Angular dependencies
 const mockFormGroup = {
     get: jest.fn(),
-    setValue: jest.fn()
+    setValue: jest.fn(),
+    events: {
+        subscribe: jest.fn(() => {
+            return { unsubscribe: jest.fn() };
+        })
+    }
 };
 
 const mockFormControl = {
     value: '',
+    valid: true,
+    invalid: false,
+    touched: false,
+    dirty: false,
+    errors: null as Record<string, unknown> | null,
     setValue: jest.fn(),
     markAsTouched: jest.fn(),
     markAsDirty: jest.fn(),
@@ -26,6 +36,16 @@ const mockFormControl = {
             };
         }),
         _callback: null as ((value: string) => void) | null
+    },
+    events: {
+        subscribe: jest.fn((callback) => {
+            mockFormControl.events._callback = callback;
+
+            return {
+                unsubscribe: jest.fn()
+            };
+        }),
+        _callback: null as ((event: unknown) => void) | null
     }
 };
 
@@ -461,6 +481,8 @@ describe('AngularFormBridge', () => {
             expect(typeof fieldAPI.getValue).toBe('function');
             expect(typeof fieldAPI.setValue).toBe('function');
             expect(typeof fieldAPI.onChange).toBe('function');
+            expect(typeof fieldAPI.getValidationState).toBe('function');
+            expect(typeof fieldAPI.onValidationChange).toBe('function');
             expect(typeof fieldAPI.enable).toBe('function');
             expect(typeof fieldAPI.disable).toBe('function');
             expect(typeof fieldAPI.show).toBe('function');
@@ -497,6 +519,139 @@ describe('AngularFormBridge', () => {
                 mockFormControl.valueChanges._callback('changed value');
                 expect(callback).toHaveBeenCalledWith('changed value');
             }
+        });
+
+        describe('validation state', () => {
+            beforeEach(() => {
+                mockFormControl.valid = true;
+                mockFormControl.invalid = false;
+                mockFormControl.touched = false;
+                mockFormControl.dirty = false;
+                mockFormControl.errors = null;
+                mockFormControl.events._callback = null;
+            });
+
+            it('should return current validation snapshot via getValidationState', () => {
+                mockFormControl.valid = false;
+                mockFormControl.invalid = true;
+                mockFormControl.touched = true;
+                mockFormControl.dirty = true;
+                mockFormControl.errors = { required: true };
+
+                const state = bridge.getField('testField').getValidationState();
+
+                expect(state).toEqual({
+                    valid: false,
+                    invalid: true,
+                    touched: true,
+                    dirty: true,
+                    errors: { required: true }
+                });
+            });
+
+            it('should return a neutral validation state when control is missing', () => {
+                mockFormGroup.get.mockReturnValue(null);
+
+                const state = bridge.getField('missingField').getValidationState();
+
+                expect(state).toEqual({
+                    valid: false,
+                    invalid: false,
+                    touched: false,
+                    dirty: false,
+                    errors: null
+                });
+            });
+
+            it('should fire onValidationChange callback with initial state and on control events', () => {
+                const callback = jest.fn();
+                const fieldAPI = bridge.getField('testField');
+                const unsubscribe = fieldAPI.onValidationChange(callback);
+
+                expect(mockFormControl.events.subscribe).toHaveBeenCalled();
+                expect(typeof unsubscribe).toBe('function');
+
+                // Initial emit when the control is found on subscribe
+                expect(callback).toHaveBeenCalledTimes(1);
+                expect(callback).toHaveBeenLastCalledWith({
+                    valid: true,
+                    invalid: false,
+                    touched: false,
+                    dirty: false,
+                    errors: null
+                });
+
+                mockFormControl.invalid = true;
+                mockFormControl.touched = true;
+                mockFormControl.errors = { required: true };
+                mockFormControl.events._callback?.({});
+
+                expect(callback).toHaveBeenLastCalledWith({
+                    valid: true,
+                    invalid: true,
+                    touched: true,
+                    dirty: false,
+                    errors: { required: true }
+                });
+            });
+
+            it('should re-attach to the control when it is registered after onValidationChange is called', () => {
+                // Simulate the race condition: the control is not yet in the form when subscribe runs.
+                mockFormGroup.get.mockReturnValueOnce(null);
+                const formSubscribe = mockFormGroup.events.subscribe as jest.Mock;
+                let reconcileOnFormEvent: (() => void) | null = null;
+                formSubscribe.mockImplementationOnce((cb: () => void) => {
+                    reconcileOnFormEvent = cb;
+                    return { unsubscribe: jest.fn() };
+                });
+
+                const callback = jest.fn();
+                bridge.getField('testField').onValidationChange(callback);
+
+                // No initial emit because the control was missing.
+                expect(callback).not.toHaveBeenCalled();
+
+                // The control now appears in the form (e.g. after the FormGroup registers it).
+                mockFormGroup.get.mockReturnValue(mockFormControl);
+                reconcileOnFormEvent?.();
+
+                // Initial state of the now-registered control is emitted exactly once.
+                expect(callback).toHaveBeenCalledTimes(1);
+                expect(callback).toHaveBeenLastCalledWith({
+                    valid: true,
+                    invalid: false,
+                    touched: false,
+                    dirty: false,
+                    errors: null
+                });
+            });
+
+            it('should not emit when control is missing on subscribe', () => {
+                mockFormGroup.get.mockReturnValue(null);
+                const callback = jest.fn();
+                const unsubscribe = bridge.getField('missingField').onValidationChange(callback);
+
+                expect(callback).not.toHaveBeenCalled();
+                expect(typeof unsubscribe).toBe('function');
+                expect(() => unsubscribe()).not.toThrow();
+            });
+
+            it('should unsubscribe from events when the returned function is called', () => {
+                const controlUnsubscribeSpy = jest.fn();
+                const formUnsubscribeSpy = jest.fn();
+                mockFormControl.events.subscribe.mockReturnValueOnce({
+                    unsubscribe: controlUnsubscribeSpy
+                });
+                (mockFormGroup.events.subscribe as jest.Mock).mockReturnValueOnce({
+                    unsubscribe: formUnsubscribeSpy
+                });
+
+                const unsubscribe = bridge.getField('testField').onValidationChange(jest.fn());
+                unsubscribe();
+
+                expect(controlUnsubscribeSpy).toHaveBeenCalled();
+                expect(formUnsubscribeSpy).toHaveBeenCalled();
+            });
         });
 
         it('should enable field using enable', () => {

--- a/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.spec.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.spec.ts
@@ -303,7 +303,10 @@ describe('AngularFormBridge', () => {
         });
 
         it('should reset and return a new instance when getInstance is called with a different FormGroup', () => {
-            const differentFormGroup = { get: jest.fn() } as any;
+            const differentFormGroup = {
+                get: jest.fn(),
+                events: { subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })) }
+            } as any;
 
             const instance1 = AngularFormBridge.getInstance(
                 mockFormGroup as any,
@@ -316,7 +319,9 @@ describe('AngularFormBridge', () => {
                 mockDialogService as any
             );
 
-            // A new instance must be created so it binds to the new FormGroup's controls
+            // A fresh instance is created so it binds to the new FormGroup's controls
+            // and validation state from the previous form (e.g. touched controls after
+            // a Save) cannot leak across navigations.
             expect(instance1).not.toBe(instance2);
         });
 
@@ -332,7 +337,10 @@ describe('AngularFormBridge', () => {
             instance1.onChangeField('testField', () => {});
 
             // Simulate form recreation with a new FormGroup
-            const differentFormGroup = { get: jest.fn() } as any;
+            const differentFormGroup = {
+                get: jest.fn(),
+                events: { subscribe: jest.fn(() => ({ unsubscribe: jest.fn() })) }
+            } as any;
             AngularFormBridge.getInstance(
                 differentFormGroup,
                 mockNgZone as any,

--- a/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.ts
@@ -1,5 +1,7 @@
+import { Subscription } from 'rxjs';
+
 import { NgZone } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { AbstractControl, FormGroup } from '@angular/forms';
 
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -10,6 +12,7 @@ import {
     BrowserSelectorOptions,
     FieldCallback,
     FieldSubscription,
+    FieldValidationState,
     FormBridge,
     FormFieldAPI,
     FormFieldValue
@@ -30,6 +33,7 @@ export class AngularFormBridge implements FormBridge {
     private static refCount = 0;
     private static instanceStack: { instance: AngularFormBridge | null; refCount: number }[] = [];
     #fieldSubscriptions: Map<string, FieldSubscription> = new Map();
+    #validationSubscriptions: Set<() => void> = new Set();
     #form: FormGroup;
     #zone: NgZone;
     #dialogService: DialogService;
@@ -309,6 +313,9 @@ export class AngularFormBridge implements FormBridge {
         });
         this.#fieldSubscriptions.clear();
 
+        this.#validationSubscriptions.forEach((unsubscribe) => unsubscribe());
+        this.#validationSubscriptions.clear();
+
         this.#dialogRef?.close();
         this.#dialogRef = null;
     }
@@ -332,6 +339,72 @@ export class AngularFormBridge implements FormBridge {
 
             onChange: (callback: (value: FormFieldValue) => void): (() => void) => {
                 return this.onChangeField(fieldId, callback);
+            },
+
+            getValidationState: (): FieldValidationState => {
+                const control = this.#form.get(fieldId);
+
+                return {
+                    valid: !!control?.valid,
+                    invalid: !!control?.invalid,
+                    touched: !!control?.touched,
+                    dirty: !!control?.dirty,
+                    errors: control?.errors ?? null
+                };
+            },
+
+            onValidationChange: (callback: (state: FieldValidationState) => void): (() => void) => {
+                // The control may not be registered yet when this method is called
+                // (the custom field renders inside `@defer` and its template script
+                // can run before the FormGroup has registered every field's control).
+                // We listen to the form-level events so we re-attach to the control
+                // as soon as it appears, and re-emit on every change after that.
+                let activeControl: AbstractControl | null = null;
+                let activeControlSub: Subscription | null = null;
+
+                const emit = (control: AbstractControl) => {
+                    this.#zone.run(() =>
+                        callback({
+                            valid: control.valid,
+                            invalid: control.invalid,
+                            touched: control.touched,
+                            dirty: control.dirty,
+                            errors: control.errors
+                        })
+                    );
+                };
+
+                const reconcile = () => {
+                    const control = this.#form.get(fieldId);
+                    if (control === activeControl) {
+                        return;
+                    }
+
+                    activeControlSub?.unsubscribe();
+                    activeControl = control;
+                    activeControlSub = control
+                        ? control.events.subscribe(() => emit(control))
+                        : null;
+
+                    if (control) {
+                        emit(control);
+                    }
+                };
+
+                reconcile();
+                const formSub = this.#form.events.subscribe(() => reconcile());
+
+                const unsubscribe = () => {
+                    formSub.unsubscribe();
+                    activeControlSub?.unsubscribe();
+                    activeControl = null;
+                    activeControlSub = null;
+                    this.#validationSubscriptions.delete(unsubscribe);
+                };
+
+                this.#validationSubscriptions.add(unsubscribe);
+
+                return unsubscribe;
             },
 
             enable: (): void => {

--- a/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.ts
@@ -92,7 +92,11 @@ export class AngularFormBridge implements FormBridge {
             // freshly rendered custom fields. There is no reliable external call site for
             // resetInstance() because Angular tears down the form silently via @if; detecting
             // the change here and resetting is the only safe option.
-            if (AngularFormBridge.refCount > 0) {
+            if (AngularFormBridge.refCount > 1) {
+                // refCount === 1 is the routine single-consumer navigation case and
+                // is silently handled by resetInstance(). Higher counts mean multiple
+                // NativeFieldComponents still believe the old bridge is live — worth
+                // surfacing because their references will go stale.
                 console.warn(
                     `AngularFormBridge: replacing instance while refCount=${AngularFormBridge.refCount}. ` +
                         'Some custom fields may still hold a reference to the old bridge. ' +
@@ -346,13 +350,25 @@ export class AngularFormBridge implements FormBridge {
 
             getValidationState: (): FieldValidationState => {
                 const control = this.#form.get(fieldId);
+                if (!control) {
+                    // Neutral state — "no opinion". Matches DojoFormBridge so VTL templates
+                    // that read `state.valid` get the same answer in both editors.
+                    // Real validity flows in once the control registers.
+                    return {
+                        valid: true,
+                        invalid: false,
+                        touched: false,
+                        dirty: false,
+                        errors: null
+                    };
+                }
 
                 return {
-                    valid: !!control?.valid,
-                    invalid: !!control?.invalid,
-                    touched: !!control?.touched,
-                    dirty: !!control?.dirty,
-                    errors: control?.errors ?? null
+                    valid: control.valid,
+                    invalid: control.invalid,
+                    touched: control.touched,
+                    dirty: control.dirty,
+                    errors: control.errors
                 };
             },
 

--- a/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.ts
@@ -86,9 +86,12 @@ export class AngularFormBridge implements FormBridge {
             AngularFormBridge.instance.#zone !== zone
         ) {
             // FormGroup or NgZone changed — the form component was destroyed and recreated
-            // (e.g., navigation between content items). There is no reliable external call
-            // site for resetInstance() because Angular tears down the form silently via @if;
-            // detecting the change here and resetting is the only safe option.
+            // (e.g., navigation between content items, manual locale translation, or save +
+            // re-open of "new"). The previous instance is bound to a stale form whose controls
+            // may still report touched=true from a prior Save, leaking validation state to
+            // freshly rendered custom fields. There is no reliable external call site for
+            // resetInstance() because Angular tears down the form silently via @if; detecting
+            // the change here and resetting is the only safe option.
             if (AngularFormBridge.refCount > 0) {
                 console.warn(
                     `AngularFormBridge: replacing instance while refCount=${AngularFormBridge.refCount}. ` +

--- a/core-web/libs/edit-content-bridge/src/lib/bridges/dojo-form-bridge.spec.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/bridges/dojo-form-bridge.spec.ts
@@ -335,6 +335,27 @@ describe('DojoFormBridge', () => {
         });
     });
 
+    describe('getField validation state', () => {
+        it('should return a neutral validation state', () => {
+            const state = bridge.getField('anyField').getValidationState();
+
+            expect(state).toEqual({
+                valid: true,
+                invalid: false,
+                touched: false,
+                dirty: false,
+                errors: null
+            });
+        });
+
+        it('should return a no-op unsubscribe from onValidationChange', () => {
+            const unsubscribe = bridge.getField('anyField').onValidationChange(jest.fn());
+
+            expect(typeof unsubscribe).toBe('function');
+            expect(() => unsubscribe()).not.toThrow();
+        });
+    });
+
     describe('ready', () => {
         it('should execute callback when loaded', (done) => {
             bridge.ready((api) => {

--- a/core-web/libs/edit-content-bridge/src/lib/bridges/dojo-form-bridge.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/bridges/dojo-form-bridge.ts
@@ -1,6 +1,7 @@
 import {
     BrowserSelectorController,
     BrowserSelectorOptions,
+    FieldValidationState,
     FormBridge,
     FormFieldAPI,
     FormFieldValue
@@ -219,6 +220,27 @@ export class DojoFormBridge implements FormBridge {
 
             onChange: (callback: (value: FormFieldValue) => void): (() => void) => {
                 return this.onChangeField(fieldId, callback);
+            },
+
+            getValidationState: (): FieldValidationState => {
+                // Legacy Dojo editor has its own validation system; we surface a neutral state
+                // so consumers using the bridge API don't crash. Dojo-specific styling
+                // continues to be handled by the legacy editor itself.
+                return {
+                    valid: true,
+                    invalid: false,
+                    touched: false,
+                    dirty: false,
+                    errors: null
+                };
+            },
+
+            onValidationChange: (
+                _callback: (state: FieldValidationState) => void
+            ): (() => void) => {
+                // Legacy Dojo editor does not expose validation state changes through this bridge.
+                // eslint-disable-next-line @typescript-eslint/no-empty-function
+                return () => {};
             },
 
             enable: (): void => {

--- a/core-web/libs/edit-content-bridge/src/lib/interfaces/form-field.interface.ts
+++ b/core-web/libs/edit-content-bridge/src/lib/interfaces/form-field.interface.ts
@@ -6,6 +6,27 @@ import { Subscription } from 'rxjs';
 export type FormFieldValue = string | number | boolean | null;
 
 /**
+ * Validation state of a form field, mirroring Angular's AbstractControl state.
+ * Custom field implementations (VTL or native) can read this to apply their
+ * own visual feedback (red border, error icon, etc).
+ */
+export interface FieldValidationState {
+    /** True when the field passes all validators. */
+    valid: boolean;
+    /** True when the field fails at least one validator. */
+    invalid: boolean;
+    /** True after the user has interacted with the field (blurred at least once, or marked touched on save). */
+    touched: boolean;
+    /** True when the user has changed the field value. */
+    dirty: boolean;
+    /**
+     * Validation errors keyed by validator name (e.g. `{ required: true }`).
+     * Null when the field is valid.
+     */
+    errors: Record<string, unknown> | null;
+}
+
+/**
  * Interface for a form field API that provides methods to interact with a specific field.
  */
 export interface FormFieldAPI {
@@ -27,6 +48,19 @@ export interface FormFieldAPI {
      * @returns A function to unsubscribe this specific callback
      */
     onChange(callback: (value: FormFieldValue) => void): () => void;
+
+    /**
+     * Returns the current validation state of the field.
+     */
+    getValidationState(): FieldValidationState;
+
+    /**
+     * Subscribes to validation state changes. Fires whenever the field's value,
+     * status, errors, touched, or dirty state changes.
+     * @param callback - Function to execute with the new validation state
+     * @returns A function to unsubscribe this specific callback
+     */
+    onValidationChange(callback: (state: FieldValidationState) => void): () => void;
 
     /**
      * Enables the field, allowing user interaction.

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.html
@@ -18,17 +18,24 @@
             <dot-native-field [field]="field" [contentlet]="$contentlet()" />
         }
     </dot-card-field-content>
-    @if (field.hint) {
+    @if ((fieldHasError && isRequired) || (!fieldHasError && field.hint)) {
         <dot-card-field-footer>
-            <div class="flex justify-between items-center">
-                <div class="hint-message">
-                    <small
-                        [attr.data-testId]="'hint-' + field.variable"
-                        data-testid="calendar-field-hint">
-                        {{ field.hint }}
-                    </small>
+            @if (fieldHasError && isRequired) {
+                <small class="p-field-error">
+                    {{ 'dot.edit.content.form.field.required' | dm }}
+                </small>
+            }
+            @if (!fieldHasError && field.hint) {
+                <div class="flex justify-between items-center">
+                    <div class="hint-message">
+                        <small
+                            [attr.data-testId]="'hint-' + field.variable"
+                            data-testid="calendar-field-hint">
+                            {{ field.hint }}
+                        </small>
+                    </div>
                 </div>
-            </div>
+            }
         </dot-card-field-footer>
     }
 </dot-card-field>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.spec.ts
@@ -1,10 +1,11 @@
 import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 
 import { DotRenderModes, NEW_RENDER_MODE_VARIABLE_KEY } from '@dotcms/dotcms-models';
+import { DotMessagePipe as RealDotMessagePipe } from '@dotcms/ui';
 import { WINDOW } from '@dotcms/utils';
-import { createFakeContentlet, createFakeCustomField } from '@dotcms/utils-testing';
+import { createFakeContentlet, createFakeCustomField, DotMessagePipe } from '@dotcms/utils-testing';
 
 import { IframeFieldComponent } from './components/iframe-field/iframe-field.component';
 import { NativeFieldComponent } from './components/native-field/native-field.component';
@@ -312,6 +313,106 @@ describe('DotEditContentCustomFieldComponent', () => {
 
             expect(iframeField).toBeFalsy();
             expect(nativeField).toBeTruthy();
+        });
+    });
+
+    describe('Required Validation', () => {
+        // This block uses a separate factory that does NOT mock DotCardFieldComponent
+        // because the inline error message is content-projected through it.
+        const createHostNoMocks = createHostFactory({
+            component: DotEditContentCustomFieldComponent,
+            imports: [ReactiveFormsModule],
+            detectChanges: false,
+            // Replace the real DotMessagePipe with the test pipe that returns the i18n key as-is.
+            overrideComponents: [
+                [
+                    DotEditContentCustomFieldComponent,
+                    {
+                        remove: { imports: [RealDotMessagePipe] },
+                        add: { imports: [DotMessagePipe] }
+                    }
+                ]
+            ],
+            providers: [
+                {
+                    provide: WINDOW,
+                    useValue: window
+                },
+                {
+                    provide: DotEditContentStore,
+                    useValue: {
+                        setFieldVisibility: jest.fn()
+                    }
+                }
+            ]
+        });
+
+        const REQUIRED_FIELD = { ...createFakeCustomField(), required: true };
+
+        const renderRequiredField = (initialValue = '') => {
+            const formGroup = new FormGroup({
+                [REQUIRED_FIELD.variable]: new FormControl(initialValue, Validators.required)
+            });
+
+            spectator = createHostNoMocks(
+                `<form [formGroup]="formGroup">
+                    <dot-edit-content-custom-field
+                        [field]="field"
+                        [contentlet]="contentlet"
+                        [contentType]="contentTypeVariable" />
+                </form>`,
+                {
+                    hostProps: {
+                        formGroup,
+                        field: REQUIRED_FIELD,
+                        contentlet: createFakeContentlet({
+                            inode: MOCK_INODE,
+                            [REQUIRED_FIELD.variable]: ''
+                        }),
+                        contentTypeVariable: MOCK_CONTENT_TYPE_NAME
+                    }
+                }
+            );
+            spectator.detectChanges();
+            spectator.flushEffects();
+
+            return formGroup;
+        };
+
+        it('should not render the inline error before the control is touched', () => {
+            renderRequiredField();
+
+            expect(spectator.query('small.p-field-error')).toBeNull();
+        });
+
+        it('should render the inline error when the required field is empty and touched', () => {
+            const formGroup = renderRequiredField();
+
+            const control = formGroup.get(REQUIRED_FIELD.variable);
+            control.setErrors({ required: true });
+            control.markAsTouched();
+            spectator.detectChanges();
+
+            const errorEl = spectator.query('small.p-field-error');
+            expect(errorEl).toBeTruthy();
+            expect(errorEl.textContent.trim()).toBe('dot.edit.content.form.field.required');
+        });
+
+        it('should remove the inline error after the field receives a valid value', () => {
+            const formGroup = renderRequiredField();
+
+            const control = formGroup.get(REQUIRED_FIELD.variable);
+            control.setErrors({ required: true });
+            control.markAsTouched();
+            spectator.detectChanges();
+
+            expect(spectator.query('small.p-field-error')).toBeTruthy();
+
+            control.setValue('something');
+            control.setErrors(null);
+            spectator.detectChanges();
+
+            expect(spectator.query('small.p-field-error')).toBeNull();
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.ts
@@ -11,6 +11,7 @@ import {
     DotRenderModes,
     NEW_RENDER_MODE_VARIABLE_KEY
 } from '@dotcms/dotcms-models';
+import { DotMessagePipe } from '@dotcms/ui';
 
 import { IframeFieldComponent } from './components/iframe-field/iframe-field.component';
 import { NativeFieldComponent } from './components/native-field/native-field.component';
@@ -36,6 +37,7 @@ import { BaseWrapperField } from '../shared/base-wrapper-field';
         InputTextModule,
         DialogModule,
         ReactiveFormsModule,
+        DotMessagePipe,
         DotCardFieldComponent,
         DotCardFieldContentComponent,
         DotCardFieldFooterComponent,

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_new.vtl
@@ -35,7 +35,9 @@
             input.classList.toggle('is-invalid', showError);
         };
 
-        applyValidationState(targetField.getValidationState());
+        // onValidationChange emits the initial state synchronously, so no need
+        // to also call getValidationState() up front. Return value (unsubscribe)
+        // can be ignored — the bridge tears subscriptions down on form destroy.
         targetField.onValidationChange(applyValidationState);
 
         const hideSuggestion = () => {

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_new.vtl
@@ -30,6 +30,14 @@
             currentValue = savedValue;
         }
 
+        const applyValidationState = state => {
+            const showError = state.invalid && state.touched;
+            input.classList.toggle('is-invalid', showError);
+        };
+
+        applyValidationState(targetField.getValidationState());
+        targetField.onValidationChange(applyValidationState);
+
         const hideSuggestion = () => {
             suggestion.classList.add('hidden');
             suggestion.classList.remove('block');
@@ -82,6 +90,13 @@
         input.addEventListener('keyup', handleInput);
     });
 </script>
+
+<style>
+    #slugInput.is-invalid {
+        border-color: #ef4444;
+        outline-color: #ef4444;
+    }
+</style>
 
 <input
     type="text"


### PR DESCRIPTION
## Summary

In the new Edit Contentlet mode, a required **Custom Field** left empty on Save (or via any save-actionlet workflow action like Publish) now displays inline validation:
- "**This field is mandatory**" message below the field (rendered by the Angular wrapper).
- Red border on the input (rendered by the custom field's template, via a new validation API).

<img width="3370" height="2032" alt="CleanShot 2026-05-12 at 11 41 48@2x" src="https://github.com/user-attachments/assets/b8271bd1-5dbd-4a94-aa13-cbcdb3d801aa" />


Closes #35532

## How

`DotCustomFieldApi.getField('id')` now exposes two new methods so custom field templates (VTL or native) can read and react to the underlying Angular form control's validation state:

| Method | Returns |
|---|---|
| `getValidationState()` | `{ valid, invalid, touched, dirty, errors }` |
| `onValidationChange(cb)` | Subscription; emits initial state and on every change |

The Angular bridge handles late control registration internally (custom fields render via `@defer` and their template script can run before the FormGroup has registered every control). The Dojo bridge returns a neutral state — the legacy editor has its own validation surface.

The Custom Field component now renders the standard `<small class="p-field-error">` footer (i18n key `dot.edit.content.form.field.required`) when `fieldHasError && isRequired`, matching every other field type.

`url-title_new.vtl` is updated as the canonical consumer pattern — it subscribes to validation, gates on `touched`, and toggles a self-contained `.is-invalid` class on the slug input. **Note**: the legacy custom field iframe page does NOT load DaisyUI, so the red-border CSS rule ships inline in the VTL rather than relying on `input-error`.

## Acceptance criteria

- [x] Required Custom Field empty + Save → red border on input
- [x] Required Custom Field empty + Save → "This field is mandatory" message inline
- [x] Persona / Key Tag with Recommended Implementation repro no longer reproduces
- [x] Top error banner continues to appear alongside the new inline indicators
- [x] Filling the field and re-saving clears both indicators
- [ ] *Single E2E covering all 21 user-facing field types* — descoped per discussion (not a valid E2E case; covered by unit tests at the bridge and component level)

## Tests

- `edit-content-bridge` — 96 ✓ (+8 new tests for `getValidationState`/`onValidationChange`, including late registration race)
- `edit-content` Custom Field component — 1818 ✓ (+3 new tests for inline error footer)
- Lint: 0 errors

## Test plan

- [ ] In new Edit Content, create content from a type with a required Custom Field (Recommended Implementation). Click Save without filling → red border + "This field is mandatory" both appear inline.
- [ ] Fill the field, click Save again → both indicators clear.
- [ ] Confirm the top "Some required fields need your attention" banner still appears alongside the inline indicators.
- [ ] Repeat with iframe-rendered Custom Field (legacy strategy) — the footer message appears; the red border requires the VTL author to consume the new API (see `url-title_new.vtl`).

## Files

- `core-web/libs/edit-content-bridge/src/lib/interfaces/form-field.interface.ts` — new `FieldValidationState` interface + two methods
- `core-web/libs/edit-content-bridge/src/lib/bridges/angular-form-bridge.ts` — reconcile-pattern implementation, handles late control registration
- `core-web/libs/edit-content-bridge/src/lib/bridges/dojo-form-bridge.ts` — neutral stub for legacy editor
- `core-web/libs/edit-content/src/lib/fields/dot-edit-content-custom-field/dot-edit-content-custom-field.component.{html,ts}` — inline error footer
- `dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/url-title_new.vtl` — canonical consumer of the new API
- `.claude/skills/vtl-migration/{SKILL.md,references/migration-guide.md}` — documents the new methods + Rule 13 with gotchas

## Visual changes

Custom Field, required + empty + Save:
- Before: top error banner only.
- After: top banner + inline "This field is mandatory" + red border on the input.