### PR TITLE
Implement strict allowlist for apps secrets deserialization

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/security/apps/VersionOverrideObjectInputStream.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/VersionOverrideObjectInputStream.java
@@ -6,12 +6,36 @@ import java.io.InputStream;
 import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This class is used to override the default ObjectInputStream class to handle version mismatch
  * in case of any mismatch in the serialVersionUID of the class we override the class descriptor with the local class descriptor
  */
 public class VersionOverrideObjectInputStream extends ObjectInputStream {
+
+    private static final Set<String> ALLOWED_CLASSES = new HashSet<>(Arrays.asList(
+            "com.dotcms.security.apps.AppsSecretsImportExport",
+            "com.dotcms.security.apps.AppSecrets",
+            "com.dotcms.security.apps.AppSecrets$Builder",
+            "com.dotcms.security.apps.Secret",
+            "com.dotcms.security.apps.Secret$Builder",
+            "com.dotcms.security.apps.Type",
+            "java.lang.String",
+            "java.lang.Boolean",
+            "java.lang.Integer",
+            "java.lang.Long",
+            "java.lang.Number",
+            "java.util.HashMap",
+            "java.util.ArrayList",
+            "com.google.common.collect.ImmutableMap$SerializedForm",
+            "com.google.common.collect.ImmutableList$SerializedForm",
+            "com.google.common.collect.ImmutableMap$1",
+            "[C", // char array
+            "[Ljava.lang.Object;" // object array
+    ));
 
     /**
      * Constructor
@@ -20,6 +44,20 @@ public class VersionOverrideObjectInputStream extends ObjectInputStream {
      */
     public VersionOverrideObjectInputStream(InputStream in) throws IOException {
         super(in);
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        String className = desc.getName();
+        if (!ALLOWED_CLASSES.contains(className)) {
+            throw new InvalidClassException("Unauthorized deserialization attempt", className);
+        }
+        return super.resolveClass(desc);
+    }
+
+    @Override
+    protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+        throw new InvalidClassException("Unauthorized deserialization attempt (Proxy)");
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/security/apps/VersionOverrideObjectInputStreamTest.java
+++ b/dotCMS/src/test/java/com/dotcms/security/apps/VersionOverrideObjectInputStreamTest.java
@@ -1,0 +1,115 @@
+package com.dotcms.security.apps;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+
+public class VersionOverrideObjectInputStreamTest {
+
+    @Test
+    public void testDeserializeAllowedClass() throws IOException, ClassNotFoundException {
+        Map<String, List<AppSecrets>> secretsMap = new HashMap<>();
+        List<AppSecrets> secretsList = new ArrayList<>();
+        secretsList.add(AppSecrets.builder().withKey("test").build());
+        secretsMap.put("site1", secretsList);
+        AppsSecretsImportExport importExport = new AppsSecretsImportExport(secretsMap);
+
+        byte[] serialized = serialize(importExport);
+
+        try (ByteArrayInputStream bin = new ByteArrayInputStream(serialized);
+                VersionOverrideObjectInputStream vOIS = new VersionOverrideObjectInputStream(bin)) {
+            Object deserialized = vOIS.readObject();
+            assertNotNull(deserialized);
+            assertTrue(deserialized instanceof AppsSecretsImportExport);
+        }
+    }
+
+    @Test
+    public void testRejectUnauthorizedClass() throws IOException, ClassNotFoundException {
+        java.util.BitSet unauthorized = new java.util.BitSet();
+        byte[] serialized = serialize(unauthorized);
+
+        try (ByteArrayInputStream bin = new ByteArrayInputStream(serialized);
+                VersionOverrideObjectInputStream vOIS = new VersionOverrideObjectInputStream(bin)) {
+            vOIS.readObject();
+            fail("Should have thrown InvalidClassException");
+        } catch (InvalidClassException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testRejectProxy() throws IOException, ClassNotFoundException {
+        InvocationHandler handler = new MyInvocationHandler();
+        Object proxy = Proxy.newProxyInstance(
+                VersionOverrideObjectInputStreamTest.class.getClassLoader(),
+                new Class[] { Runnable.class, Serializable.class },
+                handler);
+        byte[] serialized = serialize(proxy);
+
+        try (ByteArrayInputStream bin = new ByteArrayInputStream(serialized);
+                VersionOverrideObjectInputStream vOIS = new VersionOverrideObjectInputStream(bin)) {
+            vOIS.readObject();
+            fail("Should have thrown InvalidClassException for proxy");
+        } catch (InvalidClassException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testRejectGadgetBeforeReadObject() throws IOException, ClassNotFoundException {
+        GadgetClass gadget = new GadgetClass();
+        GadgetClass.readObjectCalled = false;
+        byte[] serialized = serialize(gadget);
+
+        try (ByteArrayInputStream bin = new ByteArrayInputStream(serialized);
+                VersionOverrideObjectInputStream vOIS = new VersionOverrideObjectInputStream(bin)) {
+            vOIS.readObject();
+            fail("Should have thrown InvalidClassException for gadget");
+        } catch (InvalidClassException e) {
+            // expected
+        }
+        assertFalse("readObject should not have been called", GadgetClass.readObjectCalled);
+    }
+
+    private byte[] serialize(Object obj) throws IOException {
+        ByteArrayOutputStream bout = new ByteArrayOutputStream();
+        try (ObjectOutputStream oout = new ObjectOutputStream(bout)) {
+            oout.writeObject(obj);
+        }
+        return bout.toByteArray();
+    }
+
+    public static class MyInvocationHandler implements InvocationHandler, Serializable {
+        private static final long serialVersionUID = 1L;
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            return null;
+        }
+    }
+
+    public static class GadgetClass implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public static boolean readObjectCalled = false;
+        private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
+            readObjectCalled = true;
+            in.defaultReadObject();
+        }
+    }
+}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] [A08 / CWE-502] Implement strict allowlist for apps secrets deserialization

- 🚨 **Severity**: High (Remote Code Execution risk)
- 🧭 **OWASP mapping**: A08:2021 / CWE-502 / ASVS V5.5.3
- 💡 **Issue**: `VersionOverrideObjectInputStream` was used to deserialize app secrets from external files without any class validation, allowing potential Remote Code Execution (RCE) via gadget chains.
- 🎯 **Impact**: An attacker with knowledge of the import password could achieve RCE by uploading a malicious serialized object.
- 🔧 **Fix**: Implemented a strict allowlist of permitted classes and disabled dynamic proxy resolution.
- ✅ **Verification**: 
  - Ran `VersionOverrideObjectInputStreamTest` which verifies:
    - Authorized classes are allowed.
    - Unauthorized classes (e.g., `BitSet`) are blocked.
    - Dynamic proxies are blocked.
    - Gadgets are rejected before any `readObject` side effects.
  - Ran related unit tests in `dotCMS` module to ensure no regressions.


---
*PR created automatically by Jules for task [12020699059298275999](https://jules.google.com/task/12020699059298275999) started by @oidacra*