### PR TITLE
fix(ui): show full tag value in legacy edit content chip

### DIFF
--- a/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
+++ b/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
@@ -9031,10 +9031,6 @@ Styles for commons fields along the backend
   text-decoration: none;
   border: 1px solid rgba(0, 0, 0, 0.1);
   width: auto;
-  max-width: 112px;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
   padding-left: 1.25rem;
   position: relative;
 }

--- a/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
+++ b/dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css
@@ -9020,7 +9020,8 @@ Styles for commons fields along the backend
 }
 
 .tagLink {
-  height: 1.5rem;
+  min-height: 1.5rem;
+  height: auto;
   padding: 0.5rem;
   background: var(--color-palette-primary-200);
   border-radius: 0.25rem;
@@ -9031,6 +9032,7 @@ Styles for commons fields along the backend
   text-decoration: none;
   border: 1px solid rgba(0, 0, 0, 0.1);
   width: auto;
+  overflow-wrap: anywhere;
   padding-left: 1.25rem;
   position: relative;
 }


### PR DESCRIPTION
## Problem

In the legacy (DOJO) Edit Content screen, tag chips in the Tags field were being clipped at `112px` due to `max-width`, `overflow: hidden`, `white-space: nowrap`, and `text-overflow: ellipsis` in `.tagLink` inside `dijit-dotcms/dotcms.css`. Long tag values were truncated with no way to read the full text from the chip itself.

## Solution

Removed the four truncation CSS properties from `.tagLink` so the chip grows to fit its full text content, matching the behavior already present in `dot_admin.css`.

## Changes

- `dotCMS/src/main/webapp/html/css/dijit-dotcms/dotcms.css` — removed `max-width: 112px`, `overflow: hidden`, `white-space: nowrap`, `text-overflow: ellipsis` from `.tagLink`

## Test plan

- [ ] Open the legacy Edit Content screen for a content type with a Tag field
- [ ] Add a tag with a long value (e.g. `a really really really long tag value`)
- [ ] Save and reopen the contentlet
- [ ] Verify the chip displays the full tag text without truncation
- [ ] Verify the close (✕) affordance and click-to-remove behavior still work
- [ ] Verify persona tags also render correctly
- [ ] Verify no visual regression in the new Angular Edit Content tag field

Closes #35519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35519