### PR TITLE
🛡️ Sentinel: [HIGH] [A08 / CWE-502] Harden App Secrets Deserialization

### DIFF
--- a/.sentinel/journal.md
+++ b/.sentinel/journal.md
@@ -1,0 +1,4 @@
+## 2026-05-12 — Insecure Deserialization in App Secrets Import [A08 / CWE-502]
+**Pattern**: Use of `ObjectInputStream` without class filtering in a security-sensitive context (importing encrypted secrets).
+**Root cause**: `VersionOverrideObjectInputStream` only handled version mismatches but did not restrict which classes could be instantiated, allowing attackers to trigger gadget chains.
+**Prevention**: Always implement `resolveClass` with a strict FQCN allowlist and `resolveProxyClass` to reject dynamic proxies when using Java serialization for untrusted or user-supplied data.

--- a/dotCMS/src/main/java/com/dotcms/security/apps/VersionOverrideObjectInputStream.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/VersionOverrideObjectInputStream.java
@@ -6,12 +6,40 @@ import java.io.InputStream;
 import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This class is used to override the default ObjectInputStream class to handle version mismatch
- * in case of any mismatch in the serialVersionUID of the class we override the class descriptor with the local class descriptor
+ * in case of any mismatch in the serialVersionUID of the class we override the class descriptor with the local class descriptor.
+ * It also implements a strict class allowlist to prevent insecure deserialization.
  */
 public class VersionOverrideObjectInputStream extends ObjectInputStream {
+
+    private static final Set<String> ALLOWED_CLASSES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            AppsSecretsImportExport.class.getName(),
+            AppSecrets.class.getName(),
+            Secret.class.getName(),
+            AbstractProperty.class.getName(),
+            Type.class.getName(),
+            "java.util.ArrayList",
+            "java.util.HashMap",
+            "java.lang.String",
+            "java.lang.Boolean",
+            "java.lang.Integer",
+            "java.lang.Long",
+            "java.lang.Number",
+            "java.lang.Enum",
+            "[C", // char[]
+            "[Ljava.lang.Object;", // Object[]
+            "com.google.common.collect.ImmutableMap",
+            "com.google.common.collect.RegularImmutableMap",
+            "com.google.common.collect.SingletonImmutableMap",
+            "com.google.common.collect.ImmutableMap$SerializedForm",
+            "com.google.common.collect.ImmutableBiMap$SerializedForm"
+    )));
 
     /**
      * Constructor
@@ -20,6 +48,19 @@ public class VersionOverrideObjectInputStream extends ObjectInputStream {
      */
     public VersionOverrideObjectInputStream(InputStream in) throws IOException {
         super(in);
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        if (!ALLOWED_CLASSES.contains(desc.getName())) {
+            throw new InvalidClassException("Unauthorized deserialization attempt", desc.getName());
+        }
+        return super.resolveClass(desc);
+    }
+
+    @Override
+    protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+        throw new InvalidClassException("Proxy classes are not allowed for deserialization");
     }
 
     /**
@@ -31,6 +72,11 @@ public class VersionOverrideObjectInputStream extends ObjectInputStream {
     @Override
     protected ObjectStreamClass readClassDescriptor() throws IOException, ClassNotFoundException {
         ObjectStreamClass resultClassDescriptor = super.readClassDescriptor(); // initially streams descriptor
+
+        if (!ALLOWED_CLASSES.contains(resultClassDescriptor.getName())) {
+            throw new InvalidClassException("Unauthorized deserialization attempt", resultClassDescriptor.getName());
+        }
+
         Class<?> localClass; // the class in the local JVM that this descriptor represents.
         try {
             localClass = Class.forName(resultClassDescriptor.getName());

--- a/dotCMS/src/test/java/com/dotcms/security/apps/VersionOverrideObjectInputStreamTest.java
+++ b/dotCMS/src/test/java/com/dotcms/security/apps/VersionOverrideObjectInputStreamTest.java
@@ -1,0 +1,57 @@
+package com.dotcms.security.apps;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectOutputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class VersionOverrideObjectInputStreamTest {
+
+    @Test
+    public void testDeserializeAllowedClass() throws Exception {
+        Map<String, List<AppSecrets>> secretsMap = new HashMap<>();
+        List<AppSecrets> appSecretsList = new ArrayList<>();
+        appSecretsList.add(AppSecrets.builder()
+                .withKey("testApp")
+                .withSecret("secret1", "value1")
+                .build());
+        secretsMap.put("site1", appSecretsList);
+        AppsSecretsImportExport original = new AppsSecretsImportExport(secretsMap);
+
+        byte[] serialized = serialize(original);
+        try (VersionOverrideObjectInputStream voois = new VersionOverrideObjectInputStream(new ByteArrayInputStream(serialized))) {
+            AppsSecretsImportExport deserialized = (AppsSecretsImportExport) voois.readObject();
+            assertNotNull(deserialized);
+            assertTrue(deserialized.getSecrets().containsKey("site1"));
+        }
+    }
+
+    @Test(expected = InvalidClassException.class)
+    public void testDeserializeBlockedClass() throws Exception {
+        URL url = new URL("http://localhost");
+        byte[] serialized = serialize(url);
+
+        try (VersionOverrideObjectInputStream voois = new VersionOverrideObjectInputStream(new ByteArrayInputStream(serialized))) {
+            voois.readObject();
+        }
+    }
+
+    private byte[] serialize(Object obj) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(obj);
+        }
+        return baos.toByteArray();
+    }
+}


### PR DESCRIPTION
Harden `VersionOverrideObjectInputStream` with a strict FQCN allowlist and proxy rejection to mitigate insecure deserialization (CWE-502) in the App Secrets import feature. Includes a regression test.

---
*PR created automatically by Jules for task [3198852171244979129](https://jules.google.com/task/3198852171244979129) started by @oidacra*