### PR TITLE
fix(uve): use new edit content dialog from UVE hover toolbar pencil icon

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.spec.ts
@@ -35,6 +35,7 @@ describe('DotEditContentDialogComponent', () => {
     let spectator: Spectator<DotEditContentDialogComponent>;
     let component: DotEditContentDialogComponent;
     let onCloseSubject: Subject<DotCMSContentlet | null>;
+    let closeSpy: jest.Mock;
 
     const createComponent = createComponentFactory({
         component: DotEditContentDialogComponent,
@@ -87,6 +88,9 @@ describe('DotEditContentDialogComponent', () => {
 
     beforeEach(() => {
         onCloseSubject = new Subject<DotCMSContentlet | null>();
+        // Capture the original mock before DotEditContentLayoutComponent's
+        // #interceptDirtyClose() replaces dialogRef.close with its override.
+        closeSpy = jest.fn();
 
         spectator = createComponent({
             providers: [
@@ -94,7 +98,7 @@ describe('DotEditContentDialogComponent', () => {
                     provide: DynamicDialogRef,
                     useValue: {
                         onClose: onCloseSubject.asObservable(),
-                        close: jest.fn()
+                        close: closeSpy
                     }
                 },
                 {
@@ -168,7 +172,6 @@ describe('DotEditContentDialogComponent', () => {
 
     it('should close dialog with saved contentlet when closeDialog is called and content was saved', () => {
         // Arrange
-        const dialogRef = spectator.inject(DynamicDialogRef);
         const dialogConfig = spectator.inject(DynamicDialogConfig);
         dialogConfig.data = { mode: 'edit', contentletInode: 'inode' };
         spectator.detectChanges();
@@ -179,13 +182,13 @@ describe('DotEditContentDialogComponent', () => {
         component.onContentSaved(contentlet);
         component.closeDialog();
 
-        // Assert
-        expect(dialogRef.close).toHaveBeenCalledWith(contentlet);
+        // Assert: closeSpy is the original close fn captured before #interceptDirtyClose
+        // overrides dialogRef.close. The override passes through when the form is clean.
+        expect(closeSpy).toHaveBeenCalledWith(contentlet);
     });
 
     it('should close dialog with null when no content was saved', () => {
         // Arrange
-        const dialogRef = spectator.inject(DynamicDialogRef);
         const dialogConfig = spectator.inject(DynamicDialogConfig);
         dialogConfig.data = { mode: 'new', contentTypeId: 'blog-post' };
         spectator.detectChanges();
@@ -193,7 +196,7 @@ describe('DotEditContentDialogComponent', () => {
         // Act
         component.closeDialog();
 
-        // Assert
-        expect(dialogRef.close).toHaveBeenCalledWith(null);
+        // Assert: same as above — closeSpy is the underlying mock the override delegates to.
+        expect(closeSpy).toHaveBeenCalledWith(null);
     });
 });

--- a/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.spec.ts
@@ -139,64 +139,58 @@ describe('DotEditContentDialogComponent', () => {
         expect(component['state']()).toBe(ComponentStatus.LOADED);
     });
 
-    it('should call onContentSaved callback when dialog closes and content was saved', () => {
-        // Arrange
+    it('should call onContentSaved callback only after onClose emits', () => {
         const onContentSaved = jest.fn();
         const dialogConfig = spectator.inject(DynamicDialogConfig);
         dialogConfig.data = { mode: 'edit', contentletInode: 'inode', onContentSaved };
         spectator.detectChanges();
 
         const contentlet = { inode: 'inode' } as DotCMSContentlet;
-
-        // Act
         component.onContentSaved(contentlet);
-        onCloseSubject.next(null);
 
-        // Assert
+        // Callback must NOT fire before the close actually completes
+        component.closeDialog();
+        expect(onContentSaved).not.toHaveBeenCalled();
+
+        // Fires only when onClose emits (i.e. close was not cancelled by dirty guard)
+        onCloseSubject.next(null);
         expect(onContentSaved).toHaveBeenCalledWith(contentlet);
     });
 
-    it('should call onCancel callback when closeDialog is called', () => {
-        // Arrange
+    it('should call onCancel callback only after onClose emits', () => {
         const onCancel = jest.fn();
         const dialogConfig = spectator.inject(DynamicDialogConfig);
         dialogConfig.data = { mode: 'edit', contentletInode: 'inode', onCancel };
         spectator.detectChanges();
 
-        // Act
         component.closeDialog();
+        expect(onCancel).not.toHaveBeenCalled();
 
-        // Assert
+        onCloseSubject.next(null);
         expect(onCancel).toHaveBeenCalled();
     });
 
     it('should close dialog with saved contentlet when closeDialog is called and content was saved', () => {
-        // Arrange
         const dialogConfig = spectator.inject(DynamicDialogConfig);
         dialogConfig.data = { mode: 'edit', contentletInode: 'inode' };
         spectator.detectChanges();
 
         const contentlet = { inode: 'inode', title: 'Test Content' } as DotCMSContentlet;
 
-        // Act
         component.onContentSaved(contentlet);
         component.closeDialog();
 
-        // Assert: closeSpy is the original close fn captured before #interceptDirtyClose
-        // overrides dialogRef.close. The override passes through when the form is clean.
+        // closeSpy is the original close fn captured before #interceptDirtyClose overrides it.
         expect(closeSpy).toHaveBeenCalledWith(contentlet);
     });
 
     it('should close dialog with null when no content was saved', () => {
-        // Arrange
         const dialogConfig = spectator.inject(DynamicDialogConfig);
         dialogConfig.data = { mode: 'new', contentTypeId: 'blog-post' };
         spectator.detectChanges();
 
-        // Act
         component.closeDialog();
 
-        // Assert: same as above — closeSpy is the underlying mock the override delegates to.
         expect(closeSpy).toHaveBeenCalledWith(null);
     });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.spec.ts
@@ -199,4 +199,27 @@ describe('DotEditContentDialogComponent', () => {
         // Assert: same as above — closeSpy is the underlying mock the override delegates to.
         expect(closeSpy).toHaveBeenCalledWith(null);
     });
+
+    it('should render the footer cancel button', () => {
+        const dialogConfig = spectator.inject(DynamicDialogConfig);
+        dialogConfig.data = { mode: 'edit', contentletInode: 'inode' };
+        spectator.detectChanges();
+
+        expect(spectator.query('[data-testid="edit-content-dialog-footer"]')).toBeTruthy();
+        expect(spectator.query('[data-testid="edit-content-dialog-cancel-btn"]')).toBeTruthy();
+    });
+
+    it('should call closeDialog when the footer cancel button is clicked', () => {
+        const dialogConfig = spectator.inject(DynamicDialogConfig);
+        dialogConfig.data = { mode: 'edit', contentletInode: 'inode' };
+        spectator.detectChanges();
+
+        const closeDialogSpy = jest.spyOn(component, 'closeDialog');
+        const cancelBtn = spectator
+            .query('[data-testid="edit-content-dialog-cancel-btn"]')
+            ?.querySelector('button');
+        spectator.click(cancelBtn!);
+
+        expect(closeDialogSpy).toHaveBeenCalledTimes(1);
+    });
 });

--- a/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
+import { ButtonModule } from 'primeng/button';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { DotCMSContentlet, ComponentStatus } from '@dotcms/dotcms-models';
@@ -44,7 +45,7 @@ import { DotEditContentLayoutComponent } from '../dot-edit-content-layout/dot-ed
  */
 @Component({
     selector: 'dot-edit-content-dialog',
-    imports: [DotEditContentLayoutComponent, DotMessagePipe],
+    imports: [DotEditContentLayoutComponent, DotMessagePipe, ButtonModule],
     templateUrl: './dot-edit-content-dialog.component.html',
     styleUrls: ['./dot-edit-content-dialog.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush

--- a/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-create-content-dialog.component.ts
@@ -63,7 +63,6 @@ export class DotEditContentDialogComponent implements OnInit, OnDestroy {
     // Track content changes for callback when dialog closes
     readonly #savedContentlet = signal<DotCMSContentlet | null>(null);
     readonly #hasContentBeenSaved = signal<boolean>(false);
-    #isClosing = false;
 
     /**
      * Expose ComponentStatus enum to template
@@ -83,11 +82,10 @@ export class DotEditContentDialogComponent implements OnInit, OnDestroy {
 
     constructor() {
         pushFormBridge();
-        // Subscribe to dialog close events to handle callback when dialog is closed by any means
+        // Single source of truth for callbacks — only fires when the close actually completes.
+        // This prevents callbacks from firing if the dirty-close guard cancels the close.
         this.#dialogRef.onClose.pipe(takeUntilDestroyed()).subscribe(() => {
-            if (!this.#isClosing) {
-                this.#handleDialogClose();
-            }
+            this.#handleDialogClose();
         });
 
         // Effect to monitor layout component errors
@@ -107,17 +105,20 @@ export class DotEditContentDialogComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Handles the dialog close event and executes callbacks if content was saved
+     * Fires all close callbacks. Called only from the onClose subscription so
+     * callbacks never run if the dirty-close guard cancels the close.
      */
     #handleDialogClose(): void {
         const data: EditContentDialogData = this.#dialogConfig.data;
-
-        // Check if content was saved during the dialog session
         const savedContent = this.#savedContentlet();
         const hasBeenSaved = this.#hasContentBeenSaved();
 
         if (hasBeenSaved && savedContent && data.onContentSaved) {
             data.onContentSaved(savedContent);
+        }
+
+        if (data.onCancel) {
+            data.onCancel();
         }
     }
 
@@ -133,31 +134,16 @@ export class DotEditContentDialogComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Handles dialog cancellation and cleanup
+     * Requests the dialog to close. Callbacks fire only if the dirty-close guard
+     * does not cancel the close (i.e. from #handleDialogClose via onClose).
      */
     closeDialog(): void {
-        this.#isClosing = true;
-
-        const data: EditContentDialogData = this.#dialogConfig.data;
-
-        // Check if content was saved during the dialog session
-        const savedContent = this.#savedContentlet();
         const hasBeenSaved = this.#hasContentBeenSaved();
-
-        if (hasBeenSaved && savedContent && data.onContentSaved) {
-            data.onContentSaved(savedContent);
-        }
-
-        if (data.onCancel) {
-            data.onCancel();
-        }
-
-        // Close dialog and return the final saved contentlet (or null if nothing was saved)
+        const savedContent = this.#savedContentlet();
         this.#dialogRef.close(hasBeenSaved ? savedContent : null);
     }
 
     ngOnDestroy(): void {
-        this.#isClosing = true;
         popFormBridge();
     }
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-edit-content-dialog.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-edit-content-dialog.component.html
@@ -1,40 +1,51 @@
 <div class="edit-content-dialog flex flex-col" data-testid="edit-content-dialog">
-    @switch (state()) {
-        @case (ComponentStatus.LOADED) {
-            <dot-edit-content-form-layout
-                #editContentLayout
-                [contentTypeId]="data?.contentTypeId"
-                [contentletInode]="data?.contentletInode"
-                (contentSaved)="onContentSaved($event)"
-                data-testid="edit-content-layout" />
-        }
-        @case (ComponentStatus.ERROR) {
-            <div
-                class="edit-content-dialog__error flex flex-col items-center justify-center text-center flex-1"
-                data-testid="error-state">
-                <i class="pi pi-exclamation-triangle edit-content-dialog__error-icon"></i>
-                <h3 class="edit-content-dialog__error-title">
-                    {{ 'edit.content.dialog.error.title' | dm }}
-                </h3>
-                <p class="edit-content-dialog__error-message">
-                    {{ 'edit.content.dialog.error.loading' | dm }}
-                </p>
-                <p class="edit-content-dialog__error-details">
-                    {{ error() }}
-                </p>
-            </div>
-        }
-        @default {
-            <div
-                class="edit-content-dialog__loading flex flex-col items-center justify-center text-center flex-1"
-                data-testid="loading-state">
-                <div class="edit-content-dialog__loading-spinner">
-                    <i class="pi pi-spin pi-spinner"></i>
+    <div class="flex-1 overflow-hidden">
+        @switch (state()) {
+            @case (ComponentStatus.LOADED) {
+                <dot-edit-content-form-layout
+                    #editContentLayout
+                    [contentTypeId]="data?.contentTypeId"
+                    [contentletInode]="data?.contentletInode"
+                    (contentSaved)="onContentSaved($event)"
+                    data-testid="edit-content-layout" />
+            }
+            @case (ComponentStatus.ERROR) {
+                <div
+                    class="edit-content-dialog__error flex flex-col items-center justify-center text-center flex-1"
+                    data-testid="error-state">
+                    <i class="pi pi-exclamation-triangle edit-content-dialog__error-icon"></i>
+                    <h3 class="edit-content-dialog__error-title">
+                        {{ 'edit.content.dialog.error.title' | dm }}
+                    </h3>
+                    <p class="edit-content-dialog__error-message">
+                        {{ 'edit.content.dialog.error.loading' | dm }}
+                    </p>
+                    <p class="edit-content-dialog__error-details">
+                        {{ error() }}
+                    </p>
                 </div>
-                <p class="edit-content-dialog__loading-text">
-                    {{ 'edit.content.dialog.loading' | dm }}
-                </p>
-            </div>
+            }
+            @default {
+                <div
+                    class="edit-content-dialog__loading flex flex-col items-center justify-center text-center flex-1"
+                    data-testid="loading-state">
+                    <div class="edit-content-dialog__loading-spinner">
+                        <i class="pi pi-spin pi-spinner"></i>
+                    </div>
+                    <p class="edit-content-dialog__loading-text">
+                        {{ 'edit.content.dialog.loading' | dm }}
+                    </p>
+                </div>
+            }
         }
-    }
+    </div>
+    <div
+        class="flex justify-end gap-2 p-4 border-t border-gray-300"
+        data-testid="edit-content-dialog-footer">
+        <p-button
+            [text]="true"
+            [label]="'cancel' | dm"
+            (onClick)="closeDialog()"
+            data-testid="edit-content-dialog-cancel-btn" />
+    </div>
 </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-edit-content-dialog.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-create-content-dialog/dot-edit-content-dialog.component.html
@@ -44,7 +44,7 @@
         data-testid="edit-content-dialog-footer">
         <p-button
             [text]="true"
-            [label]="'cancel' | dm"
+            [label]="'close' | dm"
             (onClick)="closeDialog()"
             data-testid="edit-content-dialog-cancel-btn" />
     </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.spec.ts
@@ -13,10 +13,10 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { fakeAsync, tick } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 
-import { ConfirmationService, MessageService } from 'primeng/api';
+import { ConfirmationService, ConfirmEventType, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ConfirmDialog } from 'primeng/confirmdialog';
-import { DialogService } from 'primeng/dynamicdialog';
+import { DialogService, DynamicDialog, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { MessageModule } from 'primeng/message';
 
 import {
@@ -570,6 +570,91 @@ describe('EditContentLayoutComponent', () => {
         });
     });
 
+    describe('Pending Locale Switch', () => {
+        it('should call confirmPendingLocaleSwitch directly when the form is clean', () => {
+            const ds = createComponent({ detectChanges: false });
+            const dsStore = ds.inject(DotEditContentStore, true);
+
+            jest.spyOn(dsStore, 'pendingLocaleInode').mockReturnValue('abc123');
+            const confirmSpy = jest.spyOn(dsStore, 'confirmPendingLocaleSwitch');
+            const cancelSpy = jest.spyOn(dsStore, 'cancelPendingLocaleSwitch');
+
+            ds.detectChanges();
+
+            expect(confirmSpy).toHaveBeenCalledTimes(1);
+            expect(cancelSpy).not.toHaveBeenCalled();
+        });
+
+        it('should open the confirm dialog when the form is dirty', () => {
+            const ds = createComponent({ detectChanges: false });
+            const dsStore = ds.inject(DotEditContentStore, true);
+            const dsConfirmService = ds.inject(ConfirmationService, true);
+
+            jest.spyOn(dsStore, 'pendingLocaleInode').mockReturnValue('abc123');
+            jest.spyOn(ds.component, 'hasUnsavedChanges').mockReturnValue(true);
+            const confirmDialogSpy = jest.spyOn(dsConfirmService, 'confirm');
+
+            ds.detectChanges();
+
+            expect(confirmDialogSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call confirmPendingLocaleSwitch when the user discards changes', () => {
+            const ds = createComponent({ detectChanges: false });
+            const dsStore = ds.inject(DotEditContentStore, true);
+            const dsConfirmService = ds.inject(ConfirmationService, true);
+
+            jest.spyOn(dsStore, 'pendingLocaleInode').mockReturnValue('abc123');
+            jest.spyOn(ds.component, 'hasUnsavedChanges').mockReturnValue(true);
+            const confirmSwitchSpy = jest.spyOn(dsStore, 'confirmPendingLocaleSwitch');
+
+            let rejectFn: ((type?: ConfirmEventType) => void) | undefined;
+            jest.spyOn(dsConfirmService, 'confirm').mockImplementation((opts) => {
+                rejectFn = opts.reject as (type?: ConfirmEventType) => void;
+            });
+
+            ds.detectChanges();
+            rejectFn!(ConfirmEventType.REJECT);
+
+            expect(confirmSwitchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should call cancelPendingLocaleSwitch when the user keeps editing', () => {
+            const ds = createComponent({ detectChanges: false });
+            const dsStore = ds.inject(DotEditContentStore, true);
+            const dsConfirmService = ds.inject(ConfirmationService, true);
+
+            jest.spyOn(dsStore, 'pendingLocaleInode').mockReturnValue('abc123');
+            jest.spyOn(ds.component, 'hasUnsavedChanges').mockReturnValue(true);
+            const cancelSwitchSpy = jest.spyOn(dsStore, 'cancelPendingLocaleSwitch');
+
+            let acceptFn: (() => void) | undefined;
+            jest.spyOn(dsConfirmService, 'confirm').mockImplementation((opts) => {
+                acceptFn = opts.accept;
+            });
+
+            ds.detectChanges();
+            acceptFn!();
+
+            expect(cancelSwitchSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should not trigger confirm or switch when pendingLocaleInode is null', () => {
+            const ds = createComponent({ detectChanges: false });
+            const dsStore = ds.inject(DotEditContentStore, true);
+            const dsConfirmService = ds.inject(ConfirmationService, true);
+
+            jest.spyOn(dsStore, 'pendingLocaleInode').mockReturnValue(null);
+            const confirmSwitchSpy = jest.spyOn(dsStore, 'confirmPendingLocaleSwitch');
+            const confirmDialogSpy = jest.spyOn(dsConfirmService, 'confirm');
+
+            ds.detectChanges();
+
+            expect(confirmDialogSpy).not.toHaveBeenCalled();
+            expect(confirmSwitchSpy).not.toHaveBeenCalled();
+        });
+    });
+
     describe('Warning Messages', () => {
         beforeEach(() => {
             dotContentTypeService.getContentTypeWithRender.mockReturnValue(of(CONTENT_TYPE_MOCK));
@@ -653,6 +738,220 @@ describe('EditContentLayoutComponent', () => {
                 // When lockWarningMessage returns a message, the store value should be used
                 expect(store.lockWarningMessage()).toBe(mockMessage);
             }));
+        });
+    });
+});
+
+// Separate top-level describe so the outer beforeEach above (which creates a component and
+// instantiates TestBed) never runs before these tests. Provider overrides via
+// createComponent({ providers: [...] }) require a fresh TestBed — calling them after
+// TestBed is already instantiated throws "Cannot override provider when the test module
+// has already been instantiated".
+describe('EditContentLayoutComponent - Dialog Dirty-Close Guard', () => {
+    let dialogCloseMock: jest.Mock;
+
+    const createDialogComponent = createComponentFactory({
+        component: DotEditContentLayoutComponent,
+        imports: [
+            MessageModule,
+            ButtonModule,
+            MockComponent(DotEditContentFormComponent),
+            MockComponent(DotEditContentSidebarComponent),
+            DotMessagePipe
+        ],
+        componentProviders: [
+            DotEditContentStore,
+            mockProvider(DotWorkflowsActionsService),
+            mockProvider(DotWorkflowActionsFireService),
+            mockProvider(DotEditContentService),
+            mockProvider(DotContentTypeService),
+            mockProvider(DotWorkflowService),
+            mockProvider(DotContentletService),
+            mockProvider(DotVersionableService),
+            ConfirmationService
+        ],
+        providers: [
+            mockProvider(DotHttpErrorManagerService),
+            mockProvider(MessageService),
+            mockProvider(DialogService),
+            mockProvider(DotLanguagesService),
+            mockProvider(DotSiteService, {
+                getCurrentSite: jest
+                    .fn()
+                    .mockReturnValue(of({ identifier: 'default', hostname: 'demo.dotcms.com' }))
+            }),
+            mockProvider(DotSystemConfigService, {
+                getSystemConfig: jest.fn().mockReturnValue(of({}))
+            }),
+            GlobalStore,
+            {
+                provide: DotCurrentUserService,
+                useValue: {
+                    getCurrentUser: () =>
+                        of({
+                            userId: '123',
+                            userName: 'John Doe'
+                        })
+                }
+            },
+            {
+                provide: ActivatedRoute,
+                useValue: {
+                    get snapshot() {
+                        return { params: { id: '', contentType: '' } };
+                    }
+                }
+            },
+            mockProvider(Router, {
+                navigate: jest.fn().mockReturnValue(Promise.resolve(true)),
+                url: '/test-url',
+                events: of()
+            }),
+            provideHttpClient(),
+            provideHttpClientTesting(),
+            mockProvider(DotMessageService, {
+                get: jest.fn((key: string, ...args: unknown[]) =>
+                    key === 'edit.content.locked.by.user' ? `Content is locked by ${args[0]}` : key
+                )
+            })
+        ]
+    });
+
+    beforeEach(() => {
+        dialogCloseMock = jest.fn();
+    });
+
+    const createWithDialogRef = (extraProviders: unknown[] = []) =>
+        createDialogComponent({
+            detectChanges: false,
+            providers: [
+                { provide: DynamicDialogRef, useValue: { close: dialogCloseMock } },
+                ...extraProviders
+            ]
+        });
+
+    describe('programmatic close (dialogRef.close override)', () => {
+        it('should pass through when the form is clean', () => {
+            const ds = createWithDialogRef();
+            const dialogRef = ds.inject(DynamicDialogRef);
+            ds.detectChanges();
+
+            dialogRef.close('result');
+
+            expect(dialogCloseMock).toHaveBeenCalledWith('result');
+        });
+
+        it('should open the confirm dialog instead of closing when the form is dirty', () => {
+            const ds = createWithDialogRef();
+            const dsStore = ds.inject(DotEditContentStore, true);
+            const dsConfirmService = ds.inject(ConfirmationService, true);
+            const dialogRef = ds.inject(DynamicDialogRef);
+
+            ds.detectChanges();
+            jest.spyOn(ds.component, 'hasUnsavedChanges').mockReturnValue(true);
+            jest.spyOn(dsStore, 'workflowActionSuccess').mockReturnValue(null);
+            const confirmSpy = jest.spyOn(dsConfirmService, 'confirm');
+
+            dialogRef.close('result');
+
+            expect(confirmSpy).toHaveBeenCalledTimes(1);
+            expect(dialogCloseMock).not.toHaveBeenCalled();
+        });
+
+        it('should close after the user discards changes', () => {
+            const ds = createWithDialogRef();
+            const dsStore = ds.inject(DotEditContentStore, true);
+            const dsConfirmService = ds.inject(ConfirmationService, true);
+            const dialogRef = ds.inject(DynamicDialogRef);
+
+            ds.detectChanges();
+            jest.spyOn(ds.component, 'hasUnsavedChanges').mockReturnValue(true);
+            jest.spyOn(dsStore, 'workflowActionSuccess').mockReturnValue(null);
+
+            let rejectFn: ((type?: ConfirmEventType) => void) | undefined;
+            jest.spyOn(dsConfirmService, 'confirm').mockImplementation((opts) => {
+                rejectFn = opts.reject as (type?: ConfirmEventType) => void;
+            });
+
+            dialogRef.close('result');
+            rejectFn!(ConfirmEventType.REJECT);
+
+            expect(dialogCloseMock).toHaveBeenCalledWith('result');
+        });
+
+        it('should not close when the user chooses keep editing', () => {
+            const ds = createWithDialogRef();
+            const dsStore = ds.inject(DotEditContentStore, true);
+            const dsConfirmService = ds.inject(ConfirmationService, true);
+            const dialogRef = ds.inject(DynamicDialogRef);
+
+            ds.detectChanges();
+            jest.spyOn(ds.component, 'hasUnsavedChanges').mockReturnValue(true);
+            jest.spyOn(dsStore, 'workflowActionSuccess').mockReturnValue(null);
+
+            let acceptFn: (() => void) | undefined;
+            jest.spyOn(dsConfirmService, 'confirm').mockImplementation((opts) => {
+                acceptFn = opts.accept;
+            });
+
+            dialogRef.close('result');
+            acceptFn!();
+
+            expect(dialogCloseMock).not.toHaveBeenCalled();
+        });
+
+        it('should bypass dirty check when a workflow action has just succeeded', () => {
+            const ds = createWithDialogRef();
+            const dsStore = ds.inject(DotEditContentStore, true);
+            const dialogRef = ds.inject(DynamicDialogRef);
+
+            ds.detectChanges();
+            jest.spyOn(ds.component, 'hasUnsavedChanges').mockReturnValue(true);
+            jest.spyOn(dsStore, 'workflowActionSuccess').mockReturnValue(MOCK_CONTENTLET_1_TAB);
+
+            dialogRef.close('result');
+
+            expect(dialogCloseMock).toHaveBeenCalledWith('result');
+        });
+    });
+
+    describe('UI close (pDialog.close override)', () => {
+        it('should pass through when the form is clean', () => {
+            const pDialogCloseMock = jest.fn();
+            const mockDynamicDialog = { dialog: { close: pDialogCloseMock } };
+
+            const ds = createWithDialogRef([
+                { provide: DynamicDialog, useValue: mockDynamicDialog }
+            ]);
+            ds.detectChanges();
+
+            const mockEvent = { preventDefault: jest.fn() } as unknown as Event;
+            mockDynamicDialog.dialog.close(mockEvent);
+
+            expect(pDialogCloseMock).toHaveBeenCalledWith(mockEvent);
+        });
+
+        it('should call preventDefault and open confirm dialog when the form is dirty', () => {
+            const pDialogCloseMock = jest.fn();
+            const mockDynamicDialog = { dialog: { close: pDialogCloseMock } };
+
+            const ds = createWithDialogRef([
+                { provide: DynamicDialog, useValue: mockDynamicDialog }
+            ]);
+            const dsStore = ds.inject(DotEditContentStore, true);
+            const dsConfirmService = ds.inject(ConfirmationService, true);
+
+            ds.detectChanges();
+            jest.spyOn(ds.component, 'hasUnsavedChanges').mockReturnValue(true);
+            jest.spyOn(dsStore, 'workflowActionSuccess').mockReturnValue(null);
+            const confirmSpy = jest.spyOn(dsConfirmService, 'confirm');
+
+            const mockEvent = { preventDefault: jest.fn() } as unknown as Event;
+            mockDynamicDialog.dialog.close(mockEvent);
+
+            expect((mockEvent as { preventDefault: jest.Mock }).preventDefault).toHaveBeenCalled();
+            expect(confirmSpy).toHaveBeenCalledTimes(1);
+            expect(pDialogCloseMock).not.toHaveBeenCalled();
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-layout/dot-edit-content.layout.component.ts
@@ -6,19 +6,26 @@ import {
     input,
     model,
     output,
+    untracked,
     viewChild
 } from '@angular/core';
 
-import { ConfirmationService } from 'primeng/api';
+import { ConfirmationService, ConfirmEventType } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
-import { DialogService, DynamicDialogModule } from 'primeng/dynamicdialog';
+import {
+    DialogService,
+    DynamicDialog,
+    DynamicDialogModule,
+    DynamicDialogRef
+} from 'primeng/dynamicdialog';
 import { MessageModule } from 'primeng/message';
 import { ToastModule } from 'primeng/toast';
 
 import {
     DotContentletService,
     DotLanguagesService,
+    DotMessageService,
     DotVersionableService,
     DotWorkflowActionsFireService,
     DotWorkflowsActionsService,
@@ -157,9 +164,47 @@ export class DotEditContentLayoutComponent {
      */
     readonly confirmationService = inject(ConfirmationService);
 
+    readonly #dotMessageService = inject(DotMessageService);
+
+    /**
+     * Present when rendered inside a PrimeNG DynamicDialog; null in route mode.
+     * Used to intercept dialog close events for the dirty-content guard.
+     */
+    readonly #dialogRef = inject(DynamicDialogRef, { optional: true });
+
+    /**
+     * The DynamicDialog host component. Injected optionally to access its inner
+     * p-dialog instance (via `dialog`) so we can override `p-dialog.close()` and
+     * prevent the hide animation from starting when there are unsaved changes.
+     */
+    readonly #dynamicDialog = inject(DynamicDialog, { optional: true });
+
     readonly $editContentForm = viewChild(DotEditContentFormComponent);
 
     constructor() {
+        if (this.#dialogRef) {
+            this.#interceptDirtyClose();
+        }
+
+        // When switchLocale sets a pendingLocaleInode, ask the user to confirm
+        // discarding unsaved changes before reloading for the new locale.
+        // If the form is clean, switch immediately without prompting.
+        effect(() => {
+            const pendingInode = this.$store.pendingLocaleInode();
+            if (!pendingInode) return;
+
+            untracked(() => {
+                if (this.hasUnsavedChanges()) {
+                    this.#confirmIfDirty(
+                        () => this.$store.confirmPendingLocaleSwitch(),
+                        () => this.$store.cancelPendingLocaleSwitch()
+                    );
+                } else {
+                    this.$store.confirmPendingLocaleSwitch();
+                }
+            });
+        });
+
         // Initialize component based on input parameters
         effect(() => {
             const contentTypeId = this.$contentTypeId();
@@ -193,6 +238,86 @@ export class DotEditContentLayoutComponent {
             }
 
             this.$store.clearWorkflowActionSuccess();
+        });
+    }
+
+    /**
+     * Sets up two intercepts for dirty-content confirmation in dialog mode:
+     *
+     * 1. pDialog.close override — catches all UI-triggered closes (X button, ESC
+     *    key, mask click). p-dialog.close() sets _visible = false synchronously
+     *    before emitting visibleChange, so we must intercept here — before the
+     *    internal state changes — to prevent the hide animation from starting.
+     *
+     * 2. dialogRef.close override — catches programmatic closes (dialogRef.close()
+     *    called directly from code, e.g. DotEditContentDialogComponent.closeDialog()).
+     */
+    #interceptDirtyClose(): void {
+        const dialogRef = this.#dialogRef!;
+        const originalClose = dialogRef.close.bind(dialogRef);
+
+        // --- Programmatic close path ---
+        dialogRef.close = (value?: unknown) => {
+            if (!this.hasUnsavedChanges() || this.$store.workflowActionSuccess()) {
+                originalClose(value);
+
+                return;
+            }
+
+            this.#confirmIfDirty(
+                () => originalClose(value),
+                () => undefined
+            );
+        };
+
+        // --- UI close path (X button, ESC, mask click) ---
+        // Access p-dialog directly via DynamicDialog.dialog to intercept close()
+        // before it sets _visible = false and starts the hide animation.
+        const pDialog = this.#dynamicDialog?.dialog;
+        if (pDialog) {
+            const originalPDialogClose = pDialog.close.bind(pDialog);
+            pDialog.close = (event: Event) => {
+                if (!this.hasUnsavedChanges() || this.$store.workflowActionSuccess()) {
+                    originalPDialogClose(event);
+
+                    return;
+                }
+
+                event?.preventDefault();
+                this.#confirmIfDirty(
+                    () => originalPDialogClose(event),
+                    () => undefined
+                );
+            };
+        }
+    }
+
+    /**
+     * Shows the unsaved-changes confirmation dialog.
+     * Calls onConfirm when the user chooses "Discard changes",
+     * calls onCancel when the user chooses "Keep editing" or dismisses.
+     */
+    #confirmIfDirty(onConfirm: () => void, onCancel: () => void): void {
+        this.confirmationService.confirm({
+            header: this.#dotMessageService.get('edit.content.unsaved.changes.title'),
+            message: this.#dotMessageService.get('edit.content.unsaved.changes.message'),
+            acceptLabel: this.#dotMessageService.get('edit.content.unsaved.changes.keep'),
+            rejectLabel: this.#dotMessageService.get('edit.content.unsaved.changes.discard'),
+            acceptIcon: 'hidden',
+            rejectIcon: 'hidden',
+            rejectButtonStyleClass: 'p-button-outlined',
+            // "Keep editing" → cancel action
+            accept: () => onCancel(),
+            reject: (type?: ConfirmEventType) => {
+                if (type === ConfirmEventType.REJECT) {
+                    // "Discard changes" → proceed
+                    this.markFormPristine();
+                    onConfirm();
+                } else {
+                    // X / ESC on the confirm dialog itself → keep editing
+                    onCancel();
+                }
+            }
         });
     }
 

--- a/core-web/libs/edit-content/src/lib/store/edit-content.store.ts
+++ b/core-web/libs/edit-content/src/lib/store/edit-content.store.ts
@@ -102,6 +102,12 @@ export interface EditContentState {
         status: ComponentStatus;
         error: string;
     };
+    /**
+     * Set by switchLocale (dialog mode) when a translated-locale switch is pending
+     * confirmation. The layout component watches this, shows the unsaved-changes
+     * dialog if needed, then calls confirmPendingLocaleSwitch or cancelPendingLocaleSwitch.
+     */
+    pendingLocaleInode: string | null;
 
     // Activities state
     activities: Activity[];
@@ -226,6 +232,7 @@ export const initialRootState: EditContentState = {
         status: ComponentStatus.INIT,
         error: null
     },
+    pendingLocaleInode: null,
 
     // Activities state
     activities: [],

--- a/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.spec.ts
@@ -34,6 +34,10 @@ const SYSTEM_LANGUAGES = [
     { id: 2, isoCode: 'it-it', defaultLanguage: true }
 ] as DotLanguage[];
 
+// Module-level mock used to track initializeExistingContent calls from within
+// withLocales() closures, where jest.spyOn can't reach the closure's store reference.
+const initializeExistingContentMock = jest.fn();
+
 const withTest = () =>
     signalStoreFeature(
         withState({
@@ -47,8 +51,13 @@ const withTest = () =>
             setDialogMode: (isDialogMode: boolean) => {
                 patchState(store, { isDialogMode });
             },
-            initializeExistingContent: (_params: { inode: string; depth: string }) => {
-                // Mock implementation replaced per test via jest.spyOn
+            setPendingLocaleInode: (inode: string | null) => {
+                patchState(store, { pendingLocaleInode: inode });
+            },
+            initializeExistingContent: (
+                ...args: Parameters<typeof initializeExistingContentMock>
+            ) => {
+                initializeExistingContentMock(...args);
             }
         }))
     );
@@ -83,6 +92,7 @@ describe('LocalesFeature', () => {
     });
 
     beforeEach(() => {
+        initializeExistingContentMock.mockClear();
         spectator = createStore();
         store = spectator.service;
         dotLanguagesService = spectator.inject(DotLanguagesService);
@@ -149,9 +159,8 @@ describe('LocalesFeature', () => {
             });
         }));
 
-        it('should call initializeExistingContent instead of navigating in dialog mode', fakeAsync(() => {
+        it('should set pendingLocaleInode instead of navigating in dialog mode', fakeAsync(() => {
             store.setDialogMode(true);
-            const initSpy = jest.spyOn(store, 'initializeExistingContent');
 
             spectator.flushEffects();
             store.switchLocale(MOCK_LANGUAGES[1]);
@@ -162,7 +171,8 @@ describe('LocalesFeature', () => {
                 languageId: 2
             });
 
-            expect(initSpy).toHaveBeenCalledWith({ inode: '456', depth: '2' });
+            expect(store.pendingLocaleInode()).toEqual('456');
+            expect(initializeExistingContentMock).not.toHaveBeenCalled();
             expect(router.navigate).not.toHaveBeenCalled();
         }));
 
@@ -226,5 +236,47 @@ describe('LocalesFeature', () => {
 
             expect(store.isManualTranslation()).toBe(false);
         }));
+
+        describe('after a translated-locale switch in dialog mode', () => {
+            beforeEach(fakeAsync(() => {
+                store.setDialogMode(true);
+                spectator.flushEffects();
+                store.switchLocale(MOCK_LANGUAGES[1]);
+                tick();
+                // pendingLocaleInode is now '456' (mocked inode from outer beforeEach)
+            }));
+
+            describe('confirmPendingLocaleSwitch', () => {
+                it('should clear pendingLocaleInode and call initializeExistingContent', fakeAsync(() => {
+                    expect(store.pendingLocaleInode()).toEqual('456');
+
+                    store.confirmPendingLocaleSwitch();
+
+                    expect(store.pendingLocaleInode()).toBeNull();
+                    expect(initializeExistingContentMock).toHaveBeenCalledWith({
+                        inode: '456',
+                        depth: '2'
+                    });
+                }));
+            });
+
+            describe('cancelPendingLocaleSwitch', () => {
+                it('should clear pendingLocaleInode without switching', fakeAsync(() => {
+                    expect(store.pendingLocaleInode()).toEqual('456');
+
+                    store.cancelPendingLocaleSwitch();
+
+                    expect(store.pendingLocaleInode()).toBeNull();
+                }));
+            });
+        });
+    });
+
+    describe('confirmPendingLocaleSwitch', () => {
+        it('should be a no-op when pendingLocaleInode is null', () => {
+            store.confirmPendingLocaleSwitch();
+
+            expect(initializeExistingContentMock).not.toHaveBeenCalled();
+        });
     });
 });

--- a/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.spec.ts
@@ -43,6 +43,12 @@ const withTest = () =>
         withMethods((store) => ({
             updateContent: (content) => {
                 patchState(store, { contentlet: content });
+            },
+            setDialogMode: (isDialogMode: boolean) => {
+                patchState(store, { isDialogMode });
+            },
+            initializeExistingContent: (_params: { inode: string; depth: string }) => {
+                // Mock implementation replaced per test via jest.spyOn
             }
         }))
     );
@@ -127,7 +133,7 @@ describe('LocalesFeature', () => {
             store.updateContent({ identifier: '123', languageId: 1 } as DotCMSContentlet);
         });
 
-        it('should switch to a translated locale', fakeAsync(() => {
+        it('should switch to a translated locale in portlet mode', fakeAsync(() => {
             spectator.flushEffects();
             store.switchLocale(MOCK_LANGUAGES[1]);
             spectator.flushEffects();
@@ -141,6 +147,23 @@ describe('LocalesFeature', () => {
                 replaceUrl: true,
                 queryParamsHandling: 'preserve'
             });
+        }));
+
+        it('should call initializeExistingContent instead of navigating in dialog mode', fakeAsync(() => {
+            store.setDialogMode(true);
+            const initSpy = jest.spyOn(store, 'initializeExistingContent');
+
+            spectator.flushEffects();
+            store.switchLocale(MOCK_LANGUAGES[1]);
+            tick();
+
+            expect(dotEditContentService.getContentById).toHaveBeenCalledWith({
+                id: '123',
+                languageId: 2
+            });
+
+            expect(initSpy).toHaveBeenCalledWith({ inode: '456', depth: '2' });
+            expect(router.navigate).not.toHaveBeenCalled();
         }));
 
         it('should open dialog and update state for untranslated locale doing populate copy', fakeAsync(() => {

--- a/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
@@ -25,7 +25,13 @@ import {
     DotMessageService,
     DotWorkflowsActionsService
 } from '@dotcms/data-access';
-import { ComponentStatus, DotCMSContentlet, DotContentletDepth, DotContentletDepths, DotLanguage } from '@dotcms/dotcms-models';
+import {
+    ComponentStatus,
+    DotCMSContentlet,
+    DotContentletDepth,
+    DotContentletDepths,
+    DotLanguage
+} from '@dotcms/dotcms-models';
 
 import { DotEditContentSidebarUntranslatedLocaleComponent } from '../../../components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-untranslated-locale/dot-edit-content-sidebar-untranslated-locale.component';
 import { DotEditContentService } from '../../../services/dot-edit-content.service';

--- a/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
@@ -25,7 +25,7 @@ import {
     DotMessageService,
     DotWorkflowsActionsService
 } from '@dotcms/data-access';
-import { ComponentStatus, DotCMSContentlet, DotContentletDepths, DotLanguage } from '@dotcms/dotcms-models';
+import { ComponentStatus, DotCMSContentlet, DotContentletDepth, DotContentletDepths, DotLanguage } from '@dotcms/dotcms-models';
 
 import { DotEditContentSidebarUntranslatedLocaleComponent } from '../../../components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-untranslated-locale/dot-edit-content-sidebar-untranslated-locale.component';
 import { DotEditContentService } from '../../../services/dot-edit-content.service';
@@ -41,7 +41,10 @@ export function withLocales() {
         {
             state: type<EditContentState>(),
             methods: type<{
-                initializeExistingContent: (params: { inode: string; depth: string }) => void;
+                initializeExistingContent: (params: {
+                    inode: string;
+                    depth: DotContentletDepth;
+                }) => void;
             }>()
         },
         withComputed((store) => ({
@@ -162,6 +165,25 @@ export function withLocales() {
                 ),
 
                 /**
+                 * Clears the pending locale and proceeds with the switch.
+                 * Called by the layout after the user confirms discarding unsaved changes.
+                 */
+                confirmPendingLocaleSwitch: () => {
+                    const inode = store.pendingLocaleInode();
+                    if (!inode) return;
+                    patchState(store, { pendingLocaleInode: null });
+                    store.initializeExistingContent({ inode, depth: DotContentletDepths.TWO });
+                },
+
+                /**
+                 * Clears the pending locale without switching.
+                 * Called by the layout when the user chooses to keep editing.
+                 */
+                cancelPendingLocaleSwitch: () => {
+                    patchState(store, { pendingLocaleInode: null });
+                },
+
+                /**
                  * Switches the locale and updates the state accordingly.
                  *
                  * @param {DotLanguage} locale - The locale to switch to.
@@ -185,9 +207,11 @@ export function withLocales() {
                                                 patchState(store, { isManualTranslation: false });
 
                                                 if (store.isDialogMode()) {
-                                                    store.initializeExistingContent({
-                                                        inode: contentlet.inode,
-                                                        depth: DotContentletDepths.TWO
+                                                    // Signal the layout to handle the dirty-content
+                                                    // check before reloading. The layout watches
+                                                    // pendingLocaleInode and calls confirm/cancel.
+                                                    patchState(store, {
+                                                        pendingLocaleInode: contentlet.inode
                                                     });
                                                 } else {
                                                     router.navigate(

--- a/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/locales/locales.feature.ts
@@ -25,7 +25,7 @@ import {
     DotMessageService,
     DotWorkflowsActionsService
 } from '@dotcms/data-access';
-import { ComponentStatus, DotCMSContentlet, DotLanguage } from '@dotcms/dotcms-models';
+import { ComponentStatus, DotCMSContentlet, DotContentletDepths, DotLanguage } from '@dotcms/dotcms-models';
 
 import { DotEditContentSidebarUntranslatedLocaleComponent } from '../../../components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-untranslated-locale/dot-edit-content-sidebar-untranslated-locale.component';
 import { DotEditContentService } from '../../../services/dot-edit-content.service';
@@ -38,7 +38,12 @@ import { EditContentState } from '../../edit-content.store';
 
 export function withLocales() {
     return signalStoreFeature(
-        { state: type<EditContentState>() },
+        {
+            state: type<EditContentState>(),
+            methods: type<{
+                initializeExistingContent: (params: { inode: string; depth: string }) => void;
+            }>()
+        },
         withComputed((store) => ({
             /**
              * Computed property that indicates whether the locales are currently being loaded.
@@ -178,10 +183,21 @@ export function withLocales() {
                                         tapResponse({
                                             next: (contentlet) => {
                                                 patchState(store, { isManualTranslation: false });
-                                                router.navigate(['/content', contentlet.inode], {
-                                                    replaceUrl: true,
-                                                    queryParamsHandling: 'preserve'
-                                                });
+
+                                                if (store.isDialogMode()) {
+                                                    store.initializeExistingContent({
+                                                        inode: contentlet.inode,
+                                                        depth: DotContentletDepths.TWO
+                                                    });
+                                                } else {
+                                                    router.navigate(
+                                                        ['/content', contentlet.inode],
+                                                        {
+                                                            replaceUrl: true,
+                                                            queryParamsHandling: 'preserve'
+                                                        }
+                                                    );
+                                                }
                                             },
                                             error: (error: HttpErrorResponse) => {
                                                 dotHttpErrorManagerService.handle(error);

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2277,6 +2277,210 @@ describe('EditEmaEditorComponent', () => {
                 });
             });
 
+            describe('handleEditWithCopyDecision', () => {
+                const MULTI_PAGE_PAYLOAD: ActionPayload = {
+                    ...EDIT_ACTION_PAYLOAD_MOCK,
+                    contentlet: {
+                        ...EDIT_ACTION_PAYLOAD_MOCK.contentlet,
+                        onNumberOfPages: 2
+                    }
+                };
+
+                afterEach(() => {
+                    jest.restoreAllMocks();
+                });
+
+                describe('single-page contentlet (onNumberOfPages: 1)', () => {
+                    it('should open legacy dialog when feature flag is disabled', () => {
+                        const dotContentTypeService =
+                            spectator.debugElement.injector.get(DotContentTypeService);
+                        jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
+                            of(
+                                createFakeContentType({
+                                    variable: 'test',
+                                    name: 'Test',
+                                    metadata: {
+                                        [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: false
+                                    }
+                                })
+                            )
+                        );
+                        const dialogSpy = jest.spyOn(
+                            spectator.component.dialog,
+                            'editContentlet'
+                        );
+                        const dialogServiceOpenSpy = jest.spyOn(
+                            spectator.inject(DialogService),
+                            'open'
+                        );
+
+                        spectator.component['handleEditWithCopyDecision'](
+                            EDIT_ACTION_PAYLOAD_MOCK
+                        );
+                        spectator.detectChanges();
+
+                        expect(dialogSpy).toHaveBeenCalledWith(
+                            expect.objectContaining({ inode: 'contentlet-inode-123' })
+                        );
+                        expect(dialogServiceOpenSpy).not.toHaveBeenCalled();
+                    });
+
+                    it('should open new edit content dialog when feature flag is enabled', async () => {
+                        const dotContentTypeService =
+                            spectator.debugElement.injector.get(DotContentTypeService);
+                        jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
+                            of(
+                                createFakeContentType({
+                                    variable: 'test',
+                                    name: 'Test',
+                                    metadata: {
+                                        [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: true
+                                    }
+                                })
+                            )
+                        );
+                        const dialogSpy = jest.spyOn(
+                            spectator.component.dialog,
+                            'editContentlet'
+                        );
+                        const dialogRefMock = {
+                            onClose: new Subject<void | unknown>(),
+                            close: jest.fn()
+                        };
+                        const dialogServiceOpenSpy = jest
+                            .spyOn(spectator.inject(DialogService), 'open')
+                            .mockReturnValue(dialogRefMock as unknown as DynamicDialogRef);
+
+                        spectator.component['handleEditWithCopyDecision'](
+                            EDIT_ACTION_PAYLOAD_MOCK
+                        );
+                        spectator.detectChanges();
+
+                        await spectator.fixture.whenStable();
+
+                        expect(dialogSpy).not.toHaveBeenCalled();
+                        expect(dialogServiceOpenSpy).toHaveBeenCalled();
+                        const [, config] = dialogServiceOpenSpy.mock.calls[0];
+                        expect(config.data).toEqual(
+                            expect.objectContaining({
+                                mode: 'edit',
+                                contentletInode: 'contentlet-inode-123'
+                            })
+                        );
+                    });
+
+                    it('should fall back to legacy dialog when getContentType throws', () => {
+                        const dotContentTypeService =
+                            spectator.debugElement.injector.get(DotContentTypeService);
+                        jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
+                            throwError(() => new Error('network error'))
+                        );
+                        const dialogSpy = jest.spyOn(
+                            spectator.component.dialog,
+                            'editContentlet'
+                        );
+                        const dialogServiceOpenSpy = jest.spyOn(
+                            spectator.inject(DialogService),
+                            'open'
+                        );
+
+                        spectator.component['handleEditWithCopyDecision'](
+                            EDIT_ACTION_PAYLOAD_MOCK
+                        );
+                        spectator.detectChanges();
+
+                        expect(dialogSpy).toHaveBeenCalledWith(
+                            expect.objectContaining({ inode: 'contentlet-inode-123' })
+                        );
+                        expect(dialogServiceOpenSpy).not.toHaveBeenCalled();
+                    });
+                });
+
+                describe('multi-page contentlet (onNumberOfPages > 1)', () => {
+                    it('should open legacy dialog when flag is disabled and user edits all pages', () => {
+                        const dotContentTypeService =
+                            spectator.debugElement.injector.get(DotContentTypeService);
+                        jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
+                            of(
+                                createFakeContentType({
+                                    variable: 'test',
+                                    name: 'Test',
+                                    metadata: {
+                                        [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: false
+                                    }
+                                })
+                            )
+                        );
+                        jest.spyOn(
+                            spectator.inject(DotCopyContentModalService),
+                            'open'
+                        ).mockReturnValue(of({ shouldCopy: false }));
+                        const dialogSpy = jest.spyOn(
+                            spectator.component.dialog,
+                            'editContentlet'
+                        );
+                        const dialogServiceOpenSpy = jest.spyOn(
+                            spectator.inject(DialogService),
+                            'open'
+                        );
+
+                        spectator.component['handleEditWithCopyDecision'](MULTI_PAGE_PAYLOAD);
+                        spectator.detectChanges();
+
+                        expect(dialogSpy).toHaveBeenCalledWith(
+                            expect.objectContaining({ inode: 'contentlet-inode-123' })
+                        );
+                        expect(dialogServiceOpenSpy).not.toHaveBeenCalled();
+                    });
+
+                    it('should open new edit content dialog when flag is enabled and user edits all pages', async () => {
+                        const dotContentTypeService =
+                            spectator.debugElement.injector.get(DotContentTypeService);
+                        jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
+                            of(
+                                createFakeContentType({
+                                    variable: 'test',
+                                    name: 'Test',
+                                    metadata: {
+                                        [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: true
+                                    }
+                                })
+                            )
+                        );
+                        jest.spyOn(
+                            spectator.inject(DotCopyContentModalService),
+                            'open'
+                        ).mockReturnValue(of({ shouldCopy: false }));
+                        const dialogSpy = jest.spyOn(
+                            spectator.component.dialog,
+                            'editContentlet'
+                        );
+                        const dialogRefMock = {
+                            onClose: new Subject<void | unknown>(),
+                            close: jest.fn()
+                        };
+                        const dialogServiceOpenSpy = jest
+                            .spyOn(spectator.inject(DialogService), 'open')
+                            .mockReturnValue(dialogRefMock as unknown as DynamicDialogRef);
+
+                        spectator.component['handleEditWithCopyDecision'](MULTI_PAGE_PAYLOAD);
+                        spectator.detectChanges();
+
+                        await spectator.fixture.whenStable();
+
+                        expect(dialogSpy).not.toHaveBeenCalled();
+                        expect(dialogServiceOpenSpy).toHaveBeenCalled();
+                        const [, config] = dialogServiceOpenSpy.mock.calls[0];
+                        expect(config.data).toEqual(
+                            expect.objectContaining({
+                                mode: 'edit',
+                                contentletInode: 'contentlet-inode-123'
+                            })
+                        );
+                    });
+                });
+            });
+
             describe('placeItem - content-type drag', () => {
                 const contentTypeDragItem = {
                     baseType: 'CONTENT',

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2507,6 +2507,40 @@ describe('EditEmaEditorComponent', () => {
                             })
                         );
                     });
+
+                    it('should fall back to legacy dialog and still reload page when getContentType throws after copy', () => {
+                        const dotContentTypeService =
+                            spectator.debugElement.injector.get(DotContentTypeService);
+                        jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
+                            throwError(() => new Error('network error'))
+                        );
+                        jest.spyOn(
+                            spectator.inject(DotCopyContentModalService),
+                            'open'
+                        ).mockReturnValue(of({ shouldCopy: true }));
+                        const COPIED_INODE = 'copied-contentlet-inode-456';
+                        jest.spyOn(
+                            spectator.inject(DotCopyContentService),
+                            'copyInPage'
+                        ).mockReturnValue(
+                            of({ inode: COPIED_INODE, contentType: 'test' } as DotCMSContentlet)
+                        );
+                        const pageReloadSpy = jest.spyOn(store, 'pageReload');
+                        const dialogSpy = jest.spyOn(spectator.component.dialog, 'editContentlet');
+                        const dialogServiceOpenSpy = jest.spyOn(
+                            spectator.inject(DialogService),
+                            'open'
+                        );
+
+                        spectator.component['handleEditWithCopyDecision'](MULTI_PAGE_PAYLOAD);
+                        spectator.detectChanges();
+
+                        expect(pageReloadSpy).toHaveBeenCalled();
+                        expect(dialogSpy).toHaveBeenCalledWith(
+                            expect.objectContaining({ inode: COPIED_INODE })
+                        );
+                        expect(dialogServiceOpenSpy).not.toHaveBeenCalled();
+                    });
                 });
             });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.spec.ts
@@ -2305,18 +2305,13 @@ describe('EditEmaEditorComponent', () => {
                                 })
                             )
                         );
-                        const dialogSpy = jest.spyOn(
-                            spectator.component.dialog,
-                            'editContentlet'
-                        );
+                        const dialogSpy = jest.spyOn(spectator.component.dialog, 'editContentlet');
                         const dialogServiceOpenSpy = jest.spyOn(
                             spectator.inject(DialogService),
                             'open'
                         );
 
-                        spectator.component['handleEditWithCopyDecision'](
-                            EDIT_ACTION_PAYLOAD_MOCK
-                        );
+                        spectator.component['handleEditWithCopyDecision'](EDIT_ACTION_PAYLOAD_MOCK);
                         spectator.detectChanges();
 
                         expect(dialogSpy).toHaveBeenCalledWith(
@@ -2339,10 +2334,7 @@ describe('EditEmaEditorComponent', () => {
                                 })
                             )
                         );
-                        const dialogSpy = jest.spyOn(
-                            spectator.component.dialog,
-                            'editContentlet'
-                        );
+                        const dialogSpy = jest.spyOn(spectator.component.dialog, 'editContentlet');
                         const dialogRefMock = {
                             onClose: new Subject<void | unknown>(),
                             close: jest.fn()
@@ -2351,9 +2343,7 @@ describe('EditEmaEditorComponent', () => {
                             .spyOn(spectator.inject(DialogService), 'open')
                             .mockReturnValue(dialogRefMock as unknown as DynamicDialogRef);
 
-                        spectator.component['handleEditWithCopyDecision'](
-                            EDIT_ACTION_PAYLOAD_MOCK
-                        );
+                        spectator.component['handleEditWithCopyDecision'](EDIT_ACTION_PAYLOAD_MOCK);
                         spectator.detectChanges();
 
                         await spectator.fixture.whenStable();
@@ -2375,18 +2365,13 @@ describe('EditEmaEditorComponent', () => {
                         jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
                             throwError(() => new Error('network error'))
                         );
-                        const dialogSpy = jest.spyOn(
-                            spectator.component.dialog,
-                            'editContentlet'
-                        );
+                        const dialogSpy = jest.spyOn(spectator.component.dialog, 'editContentlet');
                         const dialogServiceOpenSpy = jest.spyOn(
                             spectator.inject(DialogService),
                             'open'
                         );
 
-                        spectator.component['handleEditWithCopyDecision'](
-                            EDIT_ACTION_PAYLOAD_MOCK
-                        );
+                        spectator.component['handleEditWithCopyDecision'](EDIT_ACTION_PAYLOAD_MOCK);
                         spectator.detectChanges();
 
                         expect(dialogSpy).toHaveBeenCalledWith(
@@ -2415,10 +2400,7 @@ describe('EditEmaEditorComponent', () => {
                             spectator.inject(DotCopyContentModalService),
                             'open'
                         ).mockReturnValue(of({ shouldCopy: false }));
-                        const dialogSpy = jest.spyOn(
-                            spectator.component.dialog,
-                            'editContentlet'
-                        );
+                        const dialogSpy = jest.spyOn(spectator.component.dialog, 'editContentlet');
                         const dialogServiceOpenSpy = jest.spyOn(
                             spectator.inject(DialogService),
                             'open'
@@ -2451,10 +2433,7 @@ describe('EditEmaEditorComponent', () => {
                             spectator.inject(DotCopyContentModalService),
                             'open'
                         ).mockReturnValue(of({ shouldCopy: false }));
-                        const dialogSpy = jest.spyOn(
-                            spectator.component.dialog,
-                            'editContentlet'
-                        );
+                        const dialogSpy = jest.spyOn(spectator.component.dialog, 'editContentlet');
                         const dialogRefMock = {
                             onClose: new Subject<void | unknown>(),
                             close: jest.fn()
@@ -2475,6 +2454,56 @@ describe('EditEmaEditorComponent', () => {
                             expect.objectContaining({
                                 mode: 'edit',
                                 contentletInode: 'contentlet-inode-123'
+                            })
+                        );
+                    });
+
+                    it('should open new edit content dialog with copied contentlet inode when flag is enabled and user copies', async () => {
+                        const COPIED_INODE = 'copied-contentlet-inode-456';
+                        const dotContentTypeService =
+                            spectator.debugElement.injector.get(DotContentTypeService);
+                        jest.spyOn(dotContentTypeService, 'getContentType').mockReturnValue(
+                            of(
+                                createFakeContentType({
+                                    variable: 'test',
+                                    name: 'Test',
+                                    metadata: {
+                                        [FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED]: true
+                                    }
+                                })
+                            )
+                        );
+                        jest.spyOn(
+                            spectator.inject(DotCopyContentModalService),
+                            'open'
+                        ).mockReturnValue(of({ shouldCopy: true }));
+                        jest.spyOn(
+                            spectator.inject(DotCopyContentService),
+                            'copyInPage'
+                        ).mockReturnValue(
+                            of({ inode: COPIED_INODE, contentType: 'test' } as DotCMSContentlet)
+                        );
+                        const dialogSpy = jest.spyOn(spectator.component.dialog, 'editContentlet');
+                        const dialogRefMock = {
+                            onClose: new Subject<void | unknown>(),
+                            close: jest.fn()
+                        };
+                        const dialogServiceOpenSpy = jest
+                            .spyOn(spectator.inject(DialogService), 'open')
+                            .mockReturnValue(dialogRefMock as unknown as DynamicDialogRef);
+
+                        spectator.component['handleEditWithCopyDecision'](MULTI_PAGE_PAYLOAD);
+                        spectator.detectChanges();
+
+                        await spectator.fixture.whenStable();
+
+                        expect(dialogSpy).not.toHaveBeenCalled();
+                        expect(dialogServiceOpenSpy).toHaveBeenCalled();
+                        const [, config] = dialogServiceOpenSpy.mock.calls[0];
+                        expect(config.data).toEqual(
+                            expect.objectContaining({
+                                mode: 'edit',
+                                contentletInode: COPIED_INODE
                             })
                         );
                     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1253,17 +1253,7 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
             return;
         }
 
-        const contentTypeVariable = contentlet.contentType;
-        if (!contentTypeVariable) {
-            this.dialog?.editContentlet(contentlet);
-            return;
-        }
-
-        this.#openNewContentDialogOrFallback(
-            contentTypeVariable,
-            () => this.#openNewEditContentDialog(contentlet),
-            () => this.dialog?.editContentlet(contentlet)
-        );
+        this.#openContentForEdit(contentlet);
     }
 
     /**
@@ -1307,6 +1297,24 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
                     legacyFallback();
                 }
             });
+    }
+
+    /**
+     * Opens the new Angular editor if the content type has the flag enabled, otherwise the legacy dialog.
+     * Single entry point used by handleOpenFullEditor and handleEditWithCopyDecision.
+     */
+    #openContentForEdit(contentlet: DotCMSContentlet): void {
+        const contentTypeVariable = contentlet.contentType;
+        if (!contentTypeVariable) {
+            this.dialog?.editContentlet(contentlet);
+            return;
+        }
+
+        this.#openNewContentDialogOrFallback(
+            contentTypeVariable,
+            () => this.#openNewEditContentDialog(contentlet),
+            () => this.dialog?.editContentlet(contentlet)
+        );
     }
 
     /**
@@ -1396,17 +1404,7 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
 
         const onMultiplePages = Number(contentlet.onNumberOfPages ?? 1) > 1;
         if (!onMultiplePages) {
-            const contentTypeVariable = contentlet.contentType;
-            if (!contentTypeVariable) {
-                this.dialog?.editContentlet(contentlet as unknown as DotCMSContentlet);
-                return;
-            }
-
-            this.#openNewContentDialogOrFallback(
-                contentTypeVariable,
-                () => this.#openNewEditContentDialog(contentlet as unknown as DotCMSContentlet),
-                () => this.dialog?.editContentlet(contentlet as unknown as DotCMSContentlet)
-            );
+            this.#openContentForEdit(contentlet as unknown as DotCMSContentlet);
             return;
         }
 
@@ -1429,17 +1427,7 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
                         this.uveStore.pageReload();
                     }
 
-                    const contentTypeVariable = target.contentType;
-                    if (!contentTypeVariable) {
-                        this.dialog?.editContentlet(target);
-                        return;
-                    }
-
-                    this.#openNewContentDialogOrFallback(
-                        contentTypeVariable,
-                        () => this.#openNewEditContentDialog(target),
-                        () => this.dialog?.editContentlet(target)
-                    );
+                    this.#openContentForEdit(target);
                 },
                 error: (error: HttpErrorResponse) => {
                     this.dotHttpErrorManagerService.handle(error);

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -3,7 +3,7 @@ import { EMPTY, Observable, fromEvent, of } from 'rxjs';
 
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { NgClass, NgStyle } from '@angular/common';
-import { HttpErrorResponse, HttpParams } from '@angular/common/http';
+import { HttpErrorResponse } from '@angular/common/http';
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
@@ -26,7 +26,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
-import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { DialogService } from 'primeng/dynamicdialog';
 import { InputGroupModule } from 'primeng/inputgroup';
 import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
 import { PopoverModule } from 'primeng/popover';
@@ -35,7 +35,7 @@ import { TabsModule } from 'primeng/tabs';
 import { ToolbarModule } from 'primeng/toolbar';
 import { TooltipModule } from 'primeng/tooltip';
 
-import { catchError, filter, map, skip, switchMap, take, tap } from 'rxjs/operators';
+import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
 
 import {
     DotContentTypeService,
@@ -270,39 +270,6 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
 
     readonly host = '*';
     readonly $ogTags: WritableSignal<SeoMetaTags> = signal(undefined);
-
-    #editContentDialogRef: DynamicDialogRef | null = null;
-    #editContentIdentifier: string | null = null;
-    protected readonly $hasOpenEditDialog = signal(false);
-
-    // When the edit content dialog is open and the page language changes,
-    // fetch the same contentlet in the new language and reopen the dialog.
-    readonly #watchDialogLanguage = toObservable(this.uveStore.pageLanguageId)
-        .pipe(
-            skip(1),
-            filter(() => this.$hasOpenEditDialog()),
-            switchMap((languageId) => {
-                const identifier = this.#editContentIdentifier;
-                if (!identifier) {
-                    return of(null);
-                }
-
-                return this.dotContentletService
-                    .getContentletByInode(
-                        identifier,
-                        new HttpParams().set('language', languageId.toString())
-                    )
-                    .pipe(catchError(() => of(null)));
-            }),
-            filter((contentlet): contentlet is DotCMSContentlet => !!contentlet?.inode),
-            takeUntilDestroyed(this.destroyRef)
-        )
-        .subscribe((contentlet) => {
-            const oldRef = this.#editContentDialogRef;
-            this.#editContentDialogRef = null;
-            oldRef?.close();
-            this.#openNewEditContentDialog(contentlet);
-        });
 
     // Component builds its own editor props locally
     protected readonly $showDialogs = computed<boolean>(() => {
@@ -1301,21 +1268,7 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
             }
         };
 
-        this.#editContentIdentifier = contentlet.identifier;
-        this.$hasOpenEditDialog.set(true);
-
-        const ref = this.#openDotEditContentShell(contentlet.title ?? '', dialogData);
-        this.#editContentDialogRef = ref;
-
-        // Only clean up if THIS ref is still the active dialog (i.e. user closed it,
-        // not a programmatic close during a language switch that already set a new ref).
-        ref.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
-            if (this.#editContentDialogRef === ref) {
-                this.#editContentIdentifier = null;
-                this.#editContentDialogRef = null;
-                this.$hasOpenEditDialog.set(false);
-            }
-        });
+        this.#openDotEditContentShell(contentlet.title ?? '', dialogData);
     }
 
     /**
@@ -1411,8 +1364,8 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
     /**
      * Opens the DotEditContentDialogComponent shell with the given header and dialog data.
      */
-    #openDotEditContentShell(header: string, dialogData: EditContentDialogData): DynamicDialogRef {
-        return this.dialogService.open(DotEditContentDialogComponent, {
+    #openDotEditContentShell(header: string, dialogData: EditContentDialogData): void {
+        this.dialogService.open(DotEditContentDialogComponent, {
             appendTo: 'body',
             baseZIndex: 10000,
             closable: true,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1396,7 +1396,17 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
 
         const onMultiplePages = Number(contentlet.onNumberOfPages ?? 1) > 1;
         if (!onMultiplePages) {
-            this.dialog?.editContentlet(contentlet as unknown as DotCMSContentlet);
+            const contentTypeVariable = contentlet.contentType;
+            if (!contentTypeVariable) {
+                this.dialog?.editContentlet(contentlet as unknown as DotCMSContentlet);
+                return;
+            }
+
+            this.#openNewContentDialogOrFallback(
+                contentTypeVariable,
+                () => this.#openNewEditContentDialog(contentlet as unknown as DotCMSContentlet),
+                () => this.dialog?.editContentlet(contentlet as unknown as DotCMSContentlet)
+            );
             return;
         }
 
@@ -1418,7 +1428,18 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
                     if (copied) {
                         this.uveStore.pageReload();
                     }
-                    this.dialog?.editContentlet(target);
+
+                    const contentTypeVariable = target.contentType;
+                    if (!contentTypeVariable) {
+                        this.dialog?.editContentlet(target);
+                        return;
+                    }
+
+                    this.#openNewContentDialogOrFallback(
+                        contentTypeVariable,
+                        () => this.#openNewEditContentDialog(target),
+                        () => this.dialog?.editContentlet(target)
+                    );
                 },
                 error: (error: HttpErrorResponse) => {
                     this.dotHttpErrorManagerService.handle(error);

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -3,7 +3,7 @@ import { EMPTY, Observable, fromEvent, of } from 'rxjs';
 
 import { ClipboardModule } from '@angular/cdk/clipboard';
 import { NgClass, NgStyle } from '@angular/common';
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpParams } from '@angular/common/http';
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
@@ -26,7 +26,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
-import { DialogService } from 'primeng/dynamicdialog';
+import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { InputGroupModule } from 'primeng/inputgroup';
 import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
 import { PopoverModule } from 'primeng/popover';
@@ -35,7 +35,7 @@ import { TabsModule } from 'primeng/tabs';
 import { ToolbarModule } from 'primeng/toolbar';
 import { TooltipModule } from 'primeng/tooltip';
 
-import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { catchError, filter, map, skip, switchMap, take, tap } from 'rxjs/operators';
 
 import {
     DotContentTypeService,
@@ -270,6 +270,39 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
 
     readonly host = '*';
     readonly $ogTags: WritableSignal<SeoMetaTags> = signal(undefined);
+
+    #editContentDialogRef: DynamicDialogRef | null = null;
+    #editContentIdentifier: string | null = null;
+    protected readonly $hasOpenEditDialog = signal(false);
+
+    // When the edit content dialog is open and the page language changes,
+    // fetch the same contentlet in the new language and reopen the dialog.
+    readonly #watchDialogLanguage = toObservable(this.uveStore.pageLanguageId)
+        .pipe(
+            skip(1),
+            filter(() => this.$hasOpenEditDialog()),
+            switchMap((languageId) => {
+                const identifier = this.#editContentIdentifier;
+                if (!identifier) {
+                    return of(null);
+                }
+
+                return this.dotContentletService
+                    .getContentletByInode(
+                        identifier,
+                        new HttpParams().set('language', languageId.toString())
+                    )
+                    .pipe(catchError(() => of(null)));
+            }),
+            filter((contentlet): contentlet is DotCMSContentlet => !!contentlet?.inode),
+            takeUntilDestroyed(this.destroyRef)
+        )
+        .subscribe((contentlet) => {
+            const oldRef = this.#editContentDialogRef;
+            this.#editContentDialogRef = null;
+            oldRef?.close();
+            this.#openNewEditContentDialog(contentlet);
+        });
 
     // Component builds its own editor props locally
     protected readonly $showDialogs = computed<boolean>(() => {
@@ -1268,7 +1301,21 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
             }
         };
 
-        this.#openDotEditContentShell(contentlet.title ?? '', dialogData);
+        this.#editContentIdentifier = contentlet.identifier;
+        this.$hasOpenEditDialog.set(true);
+
+        const ref = this.#openDotEditContentShell(contentlet.title ?? '', dialogData);
+        this.#editContentDialogRef = ref;
+
+        // Only clean up if THIS ref is still the active dialog (i.e. user closed it,
+        // not a programmatic close during a language switch that already set a new ref).
+        ref.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+            if (this.#editContentDialogRef === ref) {
+                this.#editContentIdentifier = null;
+                this.#editContentDialogRef = null;
+                this.$hasOpenEditDialog.set(false);
+            }
+        });
     }
 
     /**
@@ -1364,8 +1411,8 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
     /**
      * Opens the DotEditContentDialogComponent shell with the given header and dialog data.
      */
-    #openDotEditContentShell(header: string, dialogData: EditContentDialogData): void {
-        this.dialogService.open(DotEditContentDialogComponent, {
+    #openDotEditContentShell(header: string, dialogData: EditContentDialogData): DynamicDialogRef {
+        return this.dialogService.open(DotEditContentDialogComponent, {
             appendTo: 'body',
             baseZIndex: 10000,
             closable: true,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -1379,6 +1379,7 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
             height: '95%',
             maskStyleClass: 'p-dialog-mask-dynamic p-dialog-create-content',
             style: { 'max-width': '1400px', 'max-height': '900px' },
+            contentStyle: { padding: '0' },
             data: dialogData,
             header
         });


### PR DESCRIPTION
## Summary

- The pencil icon in the UVE hover toolbar now opens the Angular-based new edit content dialog when the feature flag `CONTENT_EDITOR2_ENABLED` is enabled for the content type
- Applies to both single-page and multi-page contentlets (after the copy decision modal)
- Follows the same pattern already used in `handleOpenFullEditor` (quick-edit panel) and the drag-and-drop flow


https://github.com/user-attachments/assets/c94e1cea-452a-49eb-921c-9707a99a0a1f


Closes #33235
Related to #35572

## Test plan

- [ ] Enable new edit content for a content type
- [ ] In UVE, hover over a contentlet of that type → pencil icon should open the Angular editor
- [ ] Repeat with a contentlet on multiple pages → copy decision modal appears → after choice, opens Angular editor
- [ ] With flag disabled → pencil still opens legacy iframe dialog
