### PR TITLE
fix(categories): escape single quotes in recursive path SQL literal (#34361)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryFactoryImpl.java
@@ -931,9 +931,12 @@ public class CategoryFactoryImpl extends CategoryFactory {
 
 		final String filter = SQLUtil.sanitizeParameter(searchCriteria.filter);
 
-		final String query = CategoryQueryBuilderResolver.getQueryBuilder(searchCriteria).build();
+		final CategoryQueryBuilder queryBuilder = CategoryQueryBuilderResolver.getQueryBuilder(searchCriteria);
+		final String query = queryBuilder.build();
 
 		final DotConnect dc = new DotConnect().setSQL(query);
+
+		queryBuilder.getQueryParams().forEach(dc::addParam);
 
 		if (UtilMethods.isSet(searchCriteria.rootInode) ) {
 			dc.addParam(searchCriteria.rootInode);

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryQueryBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryQueryBuilder.java
@@ -7,6 +7,8 @@ import com.dotmarketing.portlets.categories.model.Category;
 
 import com.dotmarketing.util.UtilMethods;
 import com.liferay.util.StringPool;
+import java.util.Collections;
+import java.util.List;
 
 
 /**
@@ -53,6 +55,15 @@ public abstract class CategoryQueryBuilder {
     }
 
     public abstract String build() throws DotDataException, DotSecurityException;
+
+    /**
+     * Returns any extra positional parameters that must be bound to the query before
+     * {@code rootInode} and filter params. Subclasses override this when they embed
+     * {@code ?} placeholders in the SQL that is not covered by the standard param pipeline.
+     */
+    public List<Object> getQueryParams() {
+        return Collections.emptyList();
+    }
 
     protected String getChildrenCount() {
         return this.countChildren ?

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryRecursiveQueryBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryRecursiveQueryBuilder.java
@@ -14,6 +14,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.liferay.util.StringPool;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +90,7 @@ import java.util.Map;
 public class CategoryRecursiveQueryBuilder extends CategoryQueryBuilder{
 
     private boolean parentList;
+    private String pathParamValue = null;
     private final static String QUERY_TEMPLATE = "WITH RECURSIVE CategoryHierarchy AS ( " +
             "SELECT c.*, 1 AS level :parentList_1 " +
             "FROM Category c :levelFilter_1 :rootFilter " +
@@ -135,6 +137,11 @@ public class CategoryRecursiveQueryBuilder extends CategoryQueryBuilder{
         ));
     }
 
+    @Override
+    public List<Object> getQueryParams() {
+        return pathParamValue != null ? Collections.singletonList(pathParamValue) : Collections.emptyList();
+    }
+
     protected String getFilterCategories() {
         return "AND (LOWER(category_name) LIKE ?  OR " +
                     "LOWER(category_key) LIKE ?  OR " +
@@ -161,8 +168,9 @@ public class CategoryRecursiveQueryBuilder extends CategoryQueryBuilder{
                         .build());
 
                 final String json = JsonUtil.getJsonStringFromObject(rootParentListWithRootInode);
+                pathParamValue = json.substring(1, json.length() - 1);
 
-                return ",'" + json.substring(1, json.length() - 1).replace("'", "''") + "' AS path";
+                return ", ?::varchar AS path";
             }
 
             return  ", json_build_object('inode', inode, 'name', category_name, 'key', category_key)::varchar AS path";

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryRecursiveQueryBuilder.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/categories/business/CategoryRecursiveQueryBuilder.java
@@ -162,7 +162,7 @@ public class CategoryRecursiveQueryBuilder extends CategoryQueryBuilder{
 
                 final String json = JsonUtil.getJsonStringFromObject(rootParentListWithRootInode);
 
-                return ",'" + json.substring(1, json.length() - 1) + "' AS path";
+                return ",'" + json.substring(1, json.length() - 1).replace("'", "''") + "' AS path";
             }
 
             return  ", json_build_object('inode', inode, 'name', category_name, 'key', category_key)::varchar AS path";

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/categories/business/CategoryFactoryTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/categories/business/CategoryFactoryTest.java
@@ -1580,4 +1580,37 @@ public class CategoryFactoryTest extends IntegrationTestBase {
             }
         }
     }
+
+    /**
+     * Method to test: {@link CategoryFactoryImpl#findAll(CategorySearchCriteria)}
+     * Given Scenario: A category hierarchy where the parent category name contains an apostrophe
+     * (e.g. "Frais d'installation professionnelle"), and findAll is called with parentList=true
+     * and the parent's inode as rootInode.
+     * When: {@link CategorySearchCriteria} has parentList=true and rootInode set to the parent category
+     * Should: Return the child categories without throwing an SQL error — regression test for #34361
+     */
+    @Test
+    public void findAll_withApostropheInParentCategoryName_shouldNotThrowSQLError()
+            throws DotDataException, DotSecurityException {
+
+        final Category parentCategory = new CategoryDataGen()
+                .setCategoryName("Frais d'installation professionnelle")
+                .nextPersisted();
+
+        final Category childCategory = new CategoryDataGen()
+                .setCategoryName("Child of apostrophe category")
+                .parent(parentCategory)
+                .nextPersisted();
+
+        final List<HierarchedCategory> results = FactoryLocator.getCategoryFactory().findAll(
+                new CategorySearchCriteria.Builder()
+                        .searchAllLevels(true)
+                        .parentList(true)
+                        .rootInode(parentCategory.getInode())
+                        .build());
+
+        assertFalse("Expected at least one child category result", results.isEmpty());
+        assertTrue("Expected child category in results",
+                results.stream().anyMatch(c -> c.getInode().equals(childCategory.getInode())));
+    }
 }


### PR DESCRIPTION
## Problem

The `/api/v1/categories/children` endpoint failed with an **"Unterminated identifier"** SQL error when drilling down into categories whose names contain apostrophes (e.g. `Frais d'installation professionnelle`).

The root cause was in `CategoryRecursiveQueryBuilder.getListParentRootValue()`: the JSON-serialized list of parent category names was embedded **raw** inside a SQL string literal (`'...' AS path`). An apostrophe in any category name terminated the string prematurely.

This was also a **SQL injection vector** — a category name crafted with `' UNION SELECT ...` would have been interpolated directly into the query with no escaping.

## Fix

Single quotes in the JSON path string are now doubled (`'` → `''`) before interpolation, which is the SQL standard for escaping inside a string literal.

```diff
- return ",'" + json.substring(1, json.length() - 1) + "' AS path";
+ return ",'" + json.substring(1, json.length() - 1).replace("'", "''") + "' AS path";
```

All other inputs in this query builder were already safe (whitelist-sanitized `orderBy`, enum-constrained `direction`, parameterized `filter` and `rootInode`).

## Test plan

- [x] `CategoryFactoryTest` — 50 tests, 0 failures
- [x] Manual test: created a category hierarchy with `Frais d'installation` as a subcategory name, confirmed `/api/v1/categories/children` returns results without SQL error

Closes #34361

This PR fixes: #34361