### PR TITLE
feat(Content Analytics) #35525 : Add docker-compose examples for Experiments and new CA infrastructure.

### DIFF
--- a/docker/docker-compose-examples/analytics/README.md
+++ b/docker/docker-compose-examples/analytics/README.md
@@ -6,6 +6,6 @@ duplicating configuration files across repos:
 
 **https://github.com/dotCMS/dot-ca-event-manager**
 
-Refer to the `docker/` directory in that repository for the full setup,
+Refer to the `docker/analytics-infra-example/` directory in that repository for the full setup,
 including the ClickHouse keeper, replica nodes, initialization scripts, and
 the event manager service.

--- a/docker/docker-compose-examples/single-node/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node/docker-compose.yml
@@ -62,14 +62,6 @@ services:
       #CMS_SSL_CERTIFICATE_FILE: '/certs/localhost.pem'    # Can create cert with mkcert tool
       #CMS_SSL_CERTIFICATE_KEY_FILE: '/certs/localhost-key.pem'
       #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260211/starter-20260211.zip'
-
-      DOT_ANALYTICS_BASE_URL: 'http://host.docker.internal:8080'
-      DOT_ANALYTICS_TENANT: 'cust-001'
-      DOT_ANALYTICS_PASSWORD: 'abc'
-      DOT_ANALYTICS_PROJECT: 'dev'
-
-      DOT_ALLOW_ACCESS_TO_PRIVATE_SUBNETS: 'true'
-      DOT_FEATURE_FLAG_CONTENT_ANALYTICS_AUTO_INJECT: 'true'
     depends_on:
       - db
       - opensearch      


### PR DESCRIPTION
## Summary

This is **Part 2** of the work for #35525. It cleans up two issues introduced alongside the new Content Analytics docker-compose examples:

### Changes

#### 1. Fix stale directory reference in `analytics/README.md`

The README was pointing readers to the `docker/` root of the [`dot-ca-event-manager`](https://github.com/dotCMS/dot-ca-event-manager) repo, which is too broad. Updated to point directly to `docker/analytics-infra-example/` — the actual directory containing the ClickHouse keeper, replica nodes, init scripts, and event manager service.

#### 2. Remove hardcoded analytics env vars from `single-node/docker-compose.yml`

The generic single-node example had analytics-specific environment variables baked in:

```yaml
DOT_ANALYTICS_BASE_URL: 'http://host.docker.internal:8080'
DOT_ANALYTICS_TENANT: 'cust-001'
DOT_ANALYTICS_PASSWORD: 'abc'
DOT_ANALYTICS_PROJECT: 'dev'
DOT_ALLOW_ACCESS_TO_PRIVATE_SUBNETS: 'true'
DOT_FEATURE_FLAG_CONTENT_ANALYTICS_AUTO_INJECT: 'true'
```

These don't belong in a general-purpose compose file — they expose internal credentials as defaults, enable a feature flag globally, and cause confusion for developers not working with analytics. These settings now live exclusively in the analytics-specific compose example where they are relevant.

## Why it matters

- Developers following the single-node example no longer inherit analytics-specific flags they didn't ask for.
- The analytics README now gives a precise path rather than dumping developers at the repo root.
- Keeps each compose example **focused and self-contained**, which is the whole point of #35525.

## Testing

- [ ] Verify `single-node/docker-compose.yml` starts cleanly without the removed vars
- [ ] Confirm the `analytics/README.md` link resolves to the correct directory in `dot-ca-event-manager`

This PR fixes: #35525

This PR fixes: #35525