### PR TITLE
fix(edit-content): polish History Tab in new Edit Contentlet side panel

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-compare/dot-edit-content-compare.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-compare/dot-edit-content-compare.component.html
@@ -10,6 +10,13 @@
         <div class="flex items-center gap-4 ml-auto">
             <button
                 pButton
+                class="p-button-tertiary p-button-text"
+                (click)="$store.exitCompareView()"
+                data-testId="return-to-current-version-button">
+                {{ 'edit.content.sidebar.history.return.to.current' | dm }}
+            </button>
+            <button
+                pButton
                 (click)="$store.restoreCurrentHistoricalVersion()"
                 data-testId="restore-historical-version-button">
                 {{ 'edit.content.sidebar.history.restore' | dm }}
@@ -58,6 +65,9 @@
     </div>
 
     <div class="flex-1 h-full overflow-y-auto p-6">
-        <dot-content-compare [showActions]="false" [data]="$store.compareData()" />
+        <dot-content-compare
+            [showActions]="false"
+            [reverseColumns]="true"
+            [data]="$store.compareData()" />
     </div>
 </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-activities/dot-edit-content-sidebar-activities.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-activities/dot-edit-content-sidebar-activities.component.html
@@ -3,7 +3,7 @@
     @if ($isLoading()) {
         <dot-edit-content-sidebar-activities-skeleton data-testid="loading-state" />
     } @else {
-        <div class="flex-1 min-h-0 overflow-y-auto py-3">
+        <div class="flex-1 min-h-0 overflow-y-auto px-4 py-3">
             <p-dataview
                 #dv
                 [value]="$activities()"
@@ -13,14 +13,14 @@
                 [paginator]="false"
                 data-testid="activities-list">
                 <ng-template #list let-activities>
-                    <div class="flex flex-col gap-5">
+                    <div class="flex flex-col gap-2">
                         @for (
                             activity of activities;
                             track activity.taskId + '_' + activity.createdDate
                         ) {
-                            <div
-                                class="activity-item flex flex-col border-b border-[var(--gray-200)] last:border-b-0 py-3 first:pt-0 animate-[fadeIn_0.2s_ease-out]"
+                            <p-card
                                 #activityItem
+                                styleClass="activity-item animate-[fadeIn_0.2s_ease-out] [&_.p-card-body]:p-3!"
                                 data-testid="activity-item">
                                 <div class="flex items-start gap-3">
                                     <p-avatar
@@ -49,7 +49,7 @@
                                         </p>
                                     </div>
                                 </div>
-                            </div>
+                            </p-card>
                         }
                     </div>
                 </ng-template>
@@ -62,7 +62,7 @@
         </div>
         @if (!$hideForm()) {
             <div
-                class="sticky bottom-0 z-[1] w-full py-3 border-t border-[var(--gray-200)]"
+                class="sticky bottom-0 z-[1] w-full px-4 py-3 border-t border-[var(--gray-200)]"
                 data-testid="activities-footer">
                 <form
                     [formGroup]="form"

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-activities/dot-edit-content-sidebar-activities.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-activities/dot-edit-content-sidebar-activities.component.scss
@@ -1,5 +1,13 @@
 /* PrimeNG/Lara + Tailwind handle all styling for this component. */
 
+/* p-dataview defaults to a white background; let the panel surface show
+ * through so the activity cards sit on the same gray as the rest of the tab.
+ */
+:host ::ng-deep .p-dataview,
+:host ::ng-deep .p-dataview-content {
+    background: transparent !important;
+}
+
 @keyframes fadeIn {
     from {
         opacity: 0;

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-activities/dot-edit-content-sidebar-activities.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-activities/dot-edit-content-sidebar-activities.component.ts
@@ -14,6 +14,7 @@ import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule } from '@angul
 
 import { AvatarModule } from 'primeng/avatar';
 import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
 import { DataViewModule } from 'primeng/dataview';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TextareaModule } from 'primeng/textarea';
@@ -41,6 +42,7 @@ const COMMENT_MAX_LENGTH = 500;
         ReactiveFormsModule,
         AvatarModule,
         ButtonModule,
+        CardModule,
         DataViewModule,
         TextareaModule,
         DotMessagePipe,
@@ -113,9 +115,11 @@ export class DotEditContentSidebarActivitiesComponent {
     $isActive = input<boolean>(false, { alias: 'isActive' });
 
     /**
-     * View children for the activity items
+     * View children for the activity items. We read `ElementRef` explicitly so
+     * that switching the underlying element to a PrimeNG component (e.g.
+     * `<p-card>`) still gives us a DOM element to scroll to.
      */
-    activityItems = viewChildren<ElementRef>('activityItem');
+    activityItems = viewChildren('activityItem', { read: ElementRef });
 
     /**
      * Effect to scroll to the last activity when the list changes or when the

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
@@ -38,7 +38,7 @@
             <div class="flex items-center gap-2 flex-wrap">
                 <span
                     data-testid="time-display"
-                    class="font-bold text-gray-900 text-[13px] leading-tight">
+                    class="font-bold text-gray-900 text-sm leading-tight">
                     @if ($item().working) {
                         {{ 'edit.content.sidebar.history.menu.current' | dm }}
                     } @else {
@@ -77,9 +77,7 @@
                         styleClass="w-6! h-6! text-[11px]! leading-none! [&_.p-avatar-text]:leading-none!"
                         data-testid="user-avatar" />
                 </div>
-                <span
-                    data-testid="history-user"
-                    class="text-[12.5px] text-gray-700 truncate min-w-0">
+                <span data-testid="history-user" class="text-xs text-gray-700 truncate min-w-0">
                     {{ $item().modUserName }}
                 </span>
             </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
@@ -1,12 +1,12 @@
-<div data-testid="history-item" class="block pb-5">
+<div data-testid="history-item" class="block pb-3">
     <div
         data-testid="content-wrapper"
-        class="group flex items-center justify-between gap-3 rounded-lg border p-2 mb-3 cursor-pointer transition-colors"
+        class="group flex items-center justify-between gap-2 rounded-md border pt-2.5 pr-2.5 pb-2.5 pl-3 cursor-pointer transition-colors"
         [class.bg-white]="!$isActive()"
         [class.border-transparent]="!$isActive()"
         [class.hover:bg-gray-100]="!$isActive()"
         [class.bg-primary-50]="$isActive()"
-        [class.border-primary-500]="$isActive()"
+        [class.border-primary-200]="$isActive()"
         [pTooltip]="tooltipContent"
         tooltipPosition="bottom"
         [tooltipOptions]="{
@@ -36,7 +36,9 @@
 
         <div class="flex flex-col gap-2 flex-1 min-w-0">
             <div class="flex items-center gap-2 flex-wrap">
-                <span data-testid="time-display" class="font-semibold text-gray-900">
+                <span
+                    data-testid="time-display"
+                    class="font-bold text-gray-900 text-[13px] leading-tight">
                     @if ($item().working) {
                         {{ 'edit.content.sidebar.history.menu.current' | dm }}
                     } @else {
@@ -67,14 +69,17 @@
 
             <div class="flex items-center gap-2">
                 <div
-                    class="w-8 h-8 shrink-0 overflow-hidden rounded-full [&_img]:w-full [&_img]:h-full [&_img]:object-cover">
+                    class="w-6 h-6 shrink-0 overflow-hidden rounded-full [&_img]:w-full [&_img]:h-full [&_img]:object-cover">
                     <p-avatar
                         dotGravatar
                         [email]="$item().modUserName"
                         shape="circle"
+                        styleClass="w-6! h-6! text-[11px]! leading-none! [&_.p-avatar-text]:leading-none!"
                         data-testid="user-avatar" />
                 </div>
-                <span data-testid="history-user" class="text-sm text-gray-700 truncate min-w-0">
+                <span
+                    data-testid="history-user"
+                    class="text-[12.5px] text-gray-700 truncate min-w-0">
                     {{ $item().modUserName }}
                 </span>
             </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
@@ -1,7 +1,7 @@
 <div data-testid="history-item" class="block pb-3">
     <div
         data-testid="content-wrapper"
-        class="group flex items-center justify-between gap-2 rounded-md border pt-2.5 pr-2.5 pb-2.5 pl-3 cursor-pointer transition-colors"
+        class="group flex items-stretch justify-between gap-2 rounded-md border pt-2.5 pr-2.5 pb-2.5 pl-3 cursor-pointer transition-colors"
         [class.bg-white]="!$isActive()"
         [class.border-transparent]="!$isActive()"
         [class.hover:bg-gray-100]="!$isActive()"
@@ -85,27 +85,38 @@
             </div>
         </div>
 
-        @if ($menuItems().length > 0) {
-            <div
-                [class]="
-                    'shrink-0 transition-opacity ' +
-                    ($isActive() ? 'opacity-100' : 'opacity-0 group-hover:opacity-100')
-                "
-                (mouseenter)="cancelHideMenu()"
-                (mouseleave)="scheduleHideMenu()">
-                <p-button
-                    icon="pi pi-ellipsis-v"
-                    styleClass="p-button-rounded p-button-sm p-button-text p-button-tertiary"
-                    (click)="versionMenu.toggle($event); $event.stopPropagation()"
-                    data-testid="version-menu-button" />
-                <p-menu
-                    #versionMenu
-                    [appendTo]="'body'"
-                    [model]="$menuItems()"
-                    [popup]="true"
-                    (onShow)="onMenuShown()"
-                    (onHide)="onMenuHidden()" />
-            </div>
-        }
+        <!-- Right column: kebab pinned top, inode copy pinned bottom -->
+        <div class="flex flex-col items-end shrink-0 gap-1">
+            @if ($menuItems().length > 0) {
+                <div
+                    [class]="
+                        'transition-opacity ' +
+                        ($isActive() ? 'opacity-100' : 'opacity-0 group-hover:opacity-100')
+                    "
+                    (mouseenter)="cancelHideMenu()"
+                    (mouseleave)="scheduleHideMenu()">
+                    <p-button
+                        icon="pi pi-ellipsis-v"
+                        styleClass="p-button-rounded p-button-sm p-button-text p-button-tertiary"
+                        (click)="versionMenu.toggle($event); $event.stopPropagation()"
+                        data-testid="version-menu-button" />
+                    <p-menu
+                        #versionMenu
+                        [appendTo]="'body'"
+                        [model]="$menuItems()"
+                        [popup]="true"
+                        (onShow)="onMenuShown()"
+                        (onHide)="onMenuHidden()" />
+                </div>
+            }
+            <dot-copy-button
+                class="mt-auto"
+                [copy]="$item().inode"
+                [label]="$inodeShort()"
+                [tooltipText]="'edit.content.sidebar.history.copy.inode' | dm"
+                customClass="p-0! [&_.p-button-label]:text-xs [&_.p-button-label]:normal-case [&_.p-button-label]:font-mono"
+                (click)="$event.stopPropagation()"
+                data-testid="copy-inode" />
+        </div>
     </div>
 </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
@@ -85,13 +85,21 @@
                 [class]="
                     'shrink-0 transition-opacity ' +
                     ($isActive() ? 'opacity-100' : 'opacity-0 group-hover:opacity-100')
-                ">
+                "
+                (mouseenter)="cancelHideMenu()"
+                (mouseleave)="scheduleHideMenu()">
                 <p-button
                     icon="pi pi-ellipsis-v"
                     styleClass="p-button-rounded p-button-sm p-button-text p-button-tertiary"
                     (click)="versionMenu.toggle($event); $event.stopPropagation()"
                     data-testid="version-menu-button" />
-                <p-menu #versionMenu [appendTo]="'body'" [model]="$menuItems()" [popup]="true" />
+                <p-menu
+                    #versionMenu
+                    [appendTo]="'body'"
+                    [model]="$menuItems()"
+                    [popup]="true"
+                    (onShow)="onMenuShown()"
+                    (onHide)="onMenuHidden()" />
             </div>
         }
     </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.html
@@ -1,7 +1,12 @@
 <div data-testid="history-item" class="block pb-5">
     <div
         data-testid="content-wrapper"
-        class="flex items-center justify-between gap-3 rounded-lg bg-white p-2 mb-3 cursor-pointer hover:bg-gray-100 transition-colors"
+        class="group flex items-center justify-between gap-3 rounded-lg border p-2 mb-3 cursor-pointer transition-colors"
+        [class.bg-white]="!$isActive()"
+        [class.border-transparent]="!$isActive()"
+        [class.hover:bg-gray-100]="!$isActive()"
+        [class.bg-primary-50]="$isActive()"
+        [class.border-primary-500]="$isActive()"
         [pTooltip]="tooltipContent"
         tooltipPosition="bottom"
         [tooltipOptions]="{
@@ -40,21 +45,21 @@
                 </span>
                 <div class="flex items-center gap-1">
                     @if ($item().live) {
-                        <p-tag
-                            [value]="'edit.content.sidebar.history.published' | dm"
-                            severity="success"
+                        <p-chip
+                            styleClass="bg-green-100! text-green-700! border-green-100! text-xs"
+                            [label]="'edit.content.sidebar.history.published' | dm"
                             data-testid="state-live" />
                     } @else if ($item().working) {
-                        <p-tag
-                            [value]="'edit.content.sidebar.history.draft' | dm"
-                            severity="warn"
+                        <p-chip
+                            styleClass="bg-yellow-100! text-yellow-700! border-yellow-100! text-xs"
+                            [label]="'edit.content.sidebar.history.draft' | dm"
                             data-testid="state-draft" />
                     }
 
                     @if ($item().experimentVariant) {
-                        <p-tag
-                            [value]="'edit.content.sidebar.history.variant.tag' | dm"
-                            severity="secondary"
+                        <p-chip
+                            styleClass="bg-blue-100! text-blue-700! border-blue-100! text-xs"
+                            [label]="'edit.content.sidebar.history.variant.tag' | dm"
                             data-testid="state-variant" />
                     }
                 </div>
@@ -76,7 +81,11 @@
         </div>
 
         @if ($menuItems().length > 0) {
-            <div class="shrink-0">
+            <div
+                [class]="
+                    'shrink-0 transition-opacity ' +
+                    ($isActive() ? 'opacity-100' : 'opacity-0 group-hover:opacity-100')
+                ">
                 <p-button
                     icon="pi pi-ellipsis-v"
                     styleClass="p-button-rounded p-button-sm p-button-text p-button-tertiary"

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.spec.ts
@@ -99,8 +99,15 @@ describe('DotHistoryTimelineItemComponent', () => {
             expect(userName.textContent?.trim()).toBe('admin@dotcms.com');
         });
 
-        it('should render menu button', () => {
+        it('should render menu button when item has actions', () => {
             expect(spectator.query(byTestId('version-menu-button'))).toBeTruthy();
+        });
+
+        it('should hide menu button for draft items (no actions)', () => {
+            spectator.setInput('item', { ...mockVersionItem, live: false, working: true });
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('version-menu-button'))).toBeFalsy();
         });
     });
 
@@ -142,28 +149,28 @@ describe('DotHistoryTimelineItemComponent', () => {
             const timeDisplay = spectator.query(byTestId('time-display'));
             expect(timeDisplay.textContent?.trim()).not.toBe('Current');
         });
+    });
 
-        it('should show compare and delete actions for live items', () => {
-            // Item is live by default (live: true, working: false)
-            const menuItems = spectator.component.$menuItems();
-            expect(menuItems).toHaveLength(2);
-            expect(menuItems[0].id).toBe('compare');
-            expect(menuItems[1].id).toBe('delete');
-        });
-
-        it('should show restore and delete actions for working items', () => {
-            // Set item to working (live: false, working: true)
+    describe('Menu Items by Status', () => {
+        it('should expose no actions for draft items (working && !live)', () => {
             spectator.setInput('item', { ...mockVersionItem, live: false, working: true });
             spectator.detectChanges();
 
             const menuItems = spectator.component.$menuItems();
-            expect(menuItems).toHaveLength(2);
-            expect(menuItems[0].id).toBe('restore');
-            expect(menuItems[1].id).toBe('delete');
+            expect(menuItems).toHaveLength(0);
         });
 
-        it('should show all actions (restore, compare, delete) for archived items', () => {
-            // Set item to archived (neither live nor working)
+        it('should expose restore and compare for published items (live)', () => {
+            // Default item is live: true, working: false
+            const menuItems = spectator.component.$menuItems();
+            expect(menuItems).toHaveLength(2);
+            expect(menuItems[0].id).toBe('restore');
+            expect(menuItems[0].label).toBe('Restore');
+            expect(menuItems[1].id).toBe('compare');
+            expect(menuItems[1].label).toBe('Compare');
+        });
+
+        it('should expose restore, compare and delete for historical items (!working && !live)', () => {
             spectator.setInput('item', { ...mockVersionItem, live: false, working: false });
             spectator.detectChanges();
 
@@ -188,69 +195,24 @@ describe('DotHistoryTimelineItemComponent', () => {
                 'dot-history-timeline-item__marker--draft'
             );
 
-            // Archived content
+            // Historical content
             spectator.setInput('item', { ...mockVersionItem, live: false, working: false });
             expect(spectator.component.$timelineMarkerClass()).toBe('');
-        });
-
-        it('should compute menu items with correct actions for live item', () => {
-            // Item is live by default (live: true, working: false)
-            const menuItems = spectator.component.$menuItems();
-
-            expect(menuItems).toHaveLength(2);
-            expect(menuItems[0].id).toBe('compare');
-            expect(menuItems[0].label).toBe('Compare');
-            expect(menuItems[1].id).toBe('delete');
-            expect(menuItems[1].label).toBe('Delete');
-        });
-
-        it('should compute menu items with correct actions for archived item', () => {
-            // Set item to archived (neither live nor working)
-            spectator.setInput('item', { ...mockVersionItem, live: false, working: false });
-            spectator.detectChanges();
-
-            const menuItems = spectator.component.$menuItems();
-
-            expect(menuItems).toHaveLength(3);
-            expect(menuItems[0].id).toBe('restore');
-            expect(menuItems[0].label).toBe('Restore');
-            expect(menuItems[1].id).toBe('compare');
-            expect(menuItems[1].label).toBe('Compare');
-            expect(menuItems[2].id).toBe('delete');
-            expect(menuItems[2].label).toBe('Delete');
         });
     });
 
     describe('Event Emission', () => {
-        it('should emit actionTriggered when menu actions are triggered', () => {
-            // Set item to archived to enable delete action
-            spectator.setInput('item', { ...mockVersionItem, live: false, working: false });
-            spectator.detectChanges();
-
-            const actionSpy = jest.spyOn(spectator.component.actionTriggered, 'emit');
-            const menuItems = spectator.component.$menuItems();
-
-            // Test delete action (enabled for archived items) - Delete is the second item
-            const deleteMenuItem = menuItems.find((item) => item.label === 'Delete');
-            deleteMenuItem?.command();
-            expect(actionSpy).toHaveBeenCalledWith({
-                type: DotHistoryTimelineItemActionType.DELETE,
-                item: { ...mockVersionItem, live: false, working: false }
-            });
-        });
-
         it('should emit RESTORE action when restore menu item is triggered', () => {
-            // Set item to archived to enable restore action
             spectator.setInput('item', { ...mockVersionItem, live: false, working: false });
             spectator.detectChanges();
 
             const actionSpy = jest.spyOn(spectator.component.actionTriggered, 'emit');
-            const menuItems = spectator.component.$menuItems();
+            const restoreMenuItem = spectator.component
+                .$menuItems()
+                .find((item) => item.id === 'restore');
 
-            // Find and trigger restore action (first menu item)
-            const restoreMenuItem = menuItems.find((item) => item.label === 'Restore');
             expect(restoreMenuItem).toBeDefined();
-            restoreMenuItem?.command();
+            restoreMenuItem?.command?.({} as never);
 
             expect(actionSpy).toHaveBeenCalledWith({
                 type: DotHistoryTimelineItemActionType.RESTORE,
@@ -259,21 +221,38 @@ describe('DotHistoryTimelineItemComponent', () => {
         });
 
         it('should emit COMPARE action when compare menu item is triggered', () => {
-            // Set item to live (working: false) to enable compare action
             spectator.setInput('item', { ...mockVersionItem, live: true, working: false });
             spectator.detectChanges();
 
             const actionSpy = jest.spyOn(spectator.component.actionTriggered, 'emit');
-            const menuItems = spectator.component.$menuItems();
+            const compareMenuItem = spectator.component
+                .$menuItems()
+                .find((item) => item.id === 'compare');
 
-            // Find and trigger compare action
-            const compareMenuItem = menuItems.find((item) => item.label === 'Compare');
             expect(compareMenuItem).toBeDefined();
-            compareMenuItem?.command();
+            compareMenuItem?.command?.({} as never);
 
             expect(actionSpy).toHaveBeenCalledWith({
                 type: DotHistoryTimelineItemActionType.COMPARE,
                 item: { ...mockVersionItem, live: true, working: false }
+            });
+        });
+
+        it('should emit DELETE action when delete menu item is triggered', () => {
+            spectator.setInput('item', { ...mockVersionItem, live: false, working: false });
+            spectator.detectChanges();
+
+            const actionSpy = jest.spyOn(spectator.component.actionTriggered, 'emit');
+            const deleteMenuItem = spectator.component
+                .$menuItems()
+                .find((item) => item.id === 'delete');
+
+            expect(deleteMenuItem).toBeDefined();
+            deleteMenuItem?.command?.({} as never);
+
+            expect(actionSpy).toHaveBeenCalledWith({
+                type: DotHistoryTimelineItemActionType.DELETE,
+                item: { ...mockVersionItem, live: false, working: false }
             });
         });
     });
@@ -290,89 +269,20 @@ describe('DotHistoryTimelineItemComponent', () => {
             expect(contentWrapper).toBeTruthy();
         });
 
-        it('should render when isActive is false', () => {
+        it('should apply active highlight class when isActive is true', () => {
+            spectator.setInput('isActive', true);
+            spectator.detectChanges();
+
+            const wrapper = spectator.query(byTestId('content-wrapper'));
+            expect(wrapper?.classList.contains('bg-primary-50')).toBe(true);
+        });
+
+        it('should not apply active highlight class when isActive is false', () => {
             spectator.setInput('isActive', false);
             spectator.detectChanges();
 
-            const historyItem = spectator.query(byTestId('history-item'));
-            const contentWrapper = spectator.query(byTestId('content-wrapper'));
-
-            expect(historyItem).toBeTruthy();
-            expect(contentWrapper).toBeTruthy();
-        });
-    });
-
-    describe('Menu Items Configuration', () => {
-        it('should not show restore action for live items', () => {
-            spectator.setInput('item', { ...mockVersionItem, live: true });
-            spectator.detectChanges();
-
-            const menuItems = spectator.component.$menuItems();
-            const restoreItem = menuItems.find((item) => item.id === 'restore');
-
-            expect(restoreItem).toBeUndefined();
-        });
-
-        it('should not show compare action for working items', () => {
-            spectator.setInput('item', { ...mockVersionItem, live: false, working: true });
-            spectator.detectChanges();
-
-            const menuItems = spectator.component.$menuItems();
-            const compareItem = menuItems.find((item) => item.id === 'compare');
-
-            expect(compareItem).toBeUndefined();
-        });
-
-        it('should not show delete action for items that are both live and working', () => {
-            spectator.setInput('item', { ...mockVersionItem, live: true, working: true });
-            spectator.detectChanges();
-
-            const menuItems = spectator.component.$menuItems();
-            const deleteItem = menuItems.find((item) => item.id === 'delete');
-
-            expect(deleteItem).toBeUndefined();
-        });
-    });
-
-    describe('Working Version Handling', () => {
-        it('should show "Current" text for working version regardless of itemIndex', () => {
-            spectator.setInput('item', { ...mockVersionItem, working: true, live: false });
-            spectator.setInput('itemIndex', 5); // Set to any index other than 0 to confirm it doesn't matter
-            spectator.detectChanges();
-
-            const timeDisplay = spectator.query(byTestId('time-display'));
-            expect(timeDisplay.textContent?.trim()).toBe('Current');
-        });
-
-        it('should show delete action for working versions (non-live)', () => {
-            spectator.setInput('item', { ...mockVersionItem, working: true, live: false });
-            spectator.detectChanges();
-
-            const menuItems = spectator.component.$menuItems();
-            const deleteItem = menuItems.find((item) => item.id === 'delete');
-
-            // Delete shows for working versions when they're not live
-            expect(deleteItem).toBeDefined();
-            expect(deleteItem?.label).toBe('Delete');
-        });
-
-        it('should apply draft marker class for working versions', () => {
-            spectator.setInput('item', { ...mockVersionItem, working: true, live: false });
-            spectator.detectChanges();
-
-            expect(spectator.component.$timelineMarkerClass()).toBe(
-                'dot-history-timeline-item__marker--draft'
-            );
-        });
-
-        it('should show relative date for non-working versions', () => {
-            spectator.setInput('item', { ...mockVersionItem, working: false, live: false });
-            spectator.detectChanges();
-
-            const timeDisplay = spectator.query(byTestId('time-display'));
-            expect(timeDisplay.textContent?.trim()).not.toBe('Current');
-            // The pipe might not render in test environment, but we verify it's not "Current"
-            expect(timeDisplay).toBeTruthy();
+            const wrapper = spectator.query(byTestId('content-wrapper'));
+            expect(wrapper?.classList.contains('bg-primary-50')).toBe(false);
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.ts
@@ -20,7 +20,12 @@ import { TooltipModule } from 'primeng/tooltip';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { DotCMSContentletVersion } from '@dotcms/dotcms-models';
-import { DotGravatarDirective, DotMessagePipe, DotRelativeDatePipe } from '@dotcms/ui';
+import {
+    DotCopyButtonComponent,
+    DotGravatarDirective,
+    DotMessagePipe,
+    DotRelativeDatePipe
+} from '@dotcms/ui';
 
 import {
     DotHistoryTimelineItemAction,
@@ -47,6 +52,7 @@ import {
         ChipModule,
         MenuModule,
         TooltipModule,
+        DotCopyButtonComponent,
         DotGravatarDirective,
         DotMessagePipe,
         DotRelativeDatePipe,
@@ -103,6 +109,16 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
         restore: this.dotMessageService.get('edit.content.sidebar.history.menu.restore'),
         compare: this.dotMessageService.get('edit.content.sidebar.history.menu.compare'),
         delete: this.dotMessageService.get('edit.content.sidebar.history.menu.delete')
+    });
+
+    /**
+     * Last 6 characters of the version inode — used as the label of the
+     * inode copy button so the user sees a short, recognizable handle
+     * while still being able to copy the full inode.
+     */
+    readonly $inodeShort = computed(() => {
+        const inode = this.$item().inode;
+        return inode ? inode.slice(-6) : '';
     });
 
     /**

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.ts
@@ -6,13 +6,15 @@ import {
     input,
     inject,
     output,
-    signal
+    signal,
+    viewChild
 } from '@angular/core';
 
+import { MenuItem } from 'primeng/api';
 import { AvatarModule } from 'primeng/avatar';
 import { ButtonModule } from 'primeng/button';
-import { MenuModule } from 'primeng/menu';
-import { TagModule } from 'primeng/tag';
+import { ChipModule } from 'primeng/chip';
+import { Menu, MenuModule } from 'primeng/menu';
 import { TooltipModule } from 'primeng/tooltip';
 
 import { DotMessageService } from '@dotcms/data-access';
@@ -41,8 +43,8 @@ import {
     imports: [
         AvatarModule,
         ButtonModule,
+        ChipModule,
         MenuModule,
-        TagModule,
         TooltipModule,
         DotGravatarDirective,
         DotMessagePipe,
@@ -82,6 +84,12 @@ export class DotHistoryTimelineItemComponent {
     actionTriggered = output<DotHistoryTimelineItemAction>();
 
     /**
+     * Reference to the PrimeNG menu so we can programmatically hide it
+     * after a command callback completes.
+     */
+    readonly versionMenu = viewChild<Menu>('versionMenu');
+
+    /**
      * Signal for cached translations map
      * Contains static translations for menu labels
      */
@@ -92,48 +100,58 @@ export class DotHistoryTimelineItemComponent {
     });
 
     /**
-     * Computed signal that generates menu items for version actions
-     * Uses reactive approach with computed signal for better performance
-     * Filters actions based on item position and business rules
+     * Computed signal that generates menu items for version actions based on
+     * the version's status:
+     * - Draft (working && !live): no actions
+     * - Published (live): Restore + Compare
+     * - Historical (!working && !live): Restore + Compare + Delete
      */
-    readonly $menuItems = computed(() => {
+    readonly $menuItems = computed<MenuItem[]>(() => {
         const labels = this.$labels();
         const item = this.$item();
+        const isDraft = item.working && !item.live;
+        const isPublished = item.live;
 
-        const items = [];
+        if (isDraft) {
+            return [];
+        }
 
-        if (!item.live) {
-            items.push({
+        const items: MenuItem[] = [
+            {
                 id: 'restore',
                 label: labels.restore,
-                command: () =>
+                command: () => {
+                    this.versionMenu()?.hide();
                     this.actionTriggered.emit({
                         type: DotHistoryTimelineItemActionType.RESTORE,
                         item
-                    })
-            });
-        }
-        if (!item.working) {
-            items.push({
+                    });
+                }
+            },
+            {
                 id: 'compare',
                 label: labels.compare,
-                command: () =>
+                command: () => {
+                    this.versionMenu()?.hide();
                     this.actionTriggered.emit({
                         type: DotHistoryTimelineItemActionType.COMPARE,
                         item
-                    })
-            });
-        }
+                    });
+                }
+            }
+        ];
 
-        if (!item.working || !item.live) {
+        if (!isPublished) {
             items.push({
                 id: 'delete',
                 label: labels.delete,
-                command: () =>
+                command: () => {
+                    this.versionMenu()?.hide();
                     this.actionTriggered.emit({
                         type: DotHistoryTimelineItemActionType.DELETE,
                         item
-                    })
+                    });
+                }
             });
         }
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.ts
@@ -67,9 +67,9 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
     private readonly dotMessageService = inject(DotMessageService);
 
     private static readonly MENU_HIDE_DELAY_MS = 200;
-    private hideTimer: ReturnType<typeof setTimeout> | null = null;
-    private menuEnterHandler: (() => void) | null = null;
-    private menuLeaveHandler: (() => void) | null = null;
+    #hideTimer: ReturnType<typeof setTimeout> | null = null;
+    #menuEnterHandler: (() => void) | null = null;
+    #menuLeaveHandler: (() => void) | null = null;
 
     /**
      * The version item to display
@@ -99,7 +99,7 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
      * Reference to the PrimeNG menu so we can programmatically hide it
      * after a command callback completes.
      */
-    readonly versionMenu = viewChild<Menu>('versionMenu');
+    readonly $versionMenu = viewChild<Menu>('versionMenu');
 
     /**
      * Signal for cached translations map
@@ -127,6 +127,13 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
      * - Draft (working && !live): no actions
      * - Published (live): Restore + Compare
      * - Historical (!working && !live): Restore + Compare + Delete
+     *
+     * Note: "Restore" is intentionally exposed on the live version per the
+     * AC of issue #35559 ("Published shows all options except Delete"), even
+     * though it is functionally a no-op (the working/live inode is already
+     * current). This reverses the earlier `disabled: item.live` guard added
+     * in PR #33320; product accepted the trade-off in favor of a uniform
+     * menu shape across non-draft states.
      */
     readonly $menuItems = computed<MenuItem[]>(() => {
         const labels = this.$labels();
@@ -143,7 +150,7 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
                 id: 'restore',
                 label: labels.restore,
                 command: () => {
-                    this.versionMenu()?.hide();
+                    this.$versionMenu()?.hide();
                     this.actionTriggered.emit({
                         type: DotHistoryTimelineItemActionType.RESTORE,
                         item
@@ -154,7 +161,7 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
                 id: 'compare',
                 label: labels.compare,
                 command: () => {
-                    this.versionMenu()?.hide();
+                    this.$versionMenu()?.hide();
                     this.actionTriggered.emit({
                         type: DotHistoryTimelineItemActionType.COMPARE,
                         item
@@ -168,7 +175,7 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
                 id: 'delete',
                 label: labels.delete,
                 command: () => {
-                    this.versionMenu()?.hide();
+                    this.$versionMenu()?.hide();
                     this.actionTriggered.emit({
                         type: DotHistoryTimelineItemActionType.DELETE,
                         item
@@ -203,9 +210,9 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
      */
     protected scheduleHideMenu(): void {
         this.cancelHideMenu();
-        this.hideTimer = setTimeout(() => {
-            this.versionMenu()?.hide();
-            this.hideTimer = null;
+        this.#hideTimer = setTimeout(() => {
+            this.$versionMenu()?.hide();
+            this.#hideTimer = null;
         }, DotHistoryTimelineItemComponent.MENU_HIDE_DELAY_MS);
     }
 
@@ -214,9 +221,9 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
      * wrapper or the menu overlay.
      */
     protected cancelHideMenu(): void {
-        if (this.hideTimer !== null) {
-            clearTimeout(this.hideTimer);
-            this.hideTimer = null;
+        if (this.#hideTimer !== null) {
+            clearTimeout(this.#hideTimer);
+            this.#hideTimer = null;
         }
     }
 
@@ -226,42 +233,42 @@ export class DotHistoryTimelineItemComponent implements OnDestroy {
      * menu closing.
      */
     protected onMenuShown(): void {
-        const overlay = this.getMenuOverlayElement();
+        const overlay = this.#getMenuOverlayElement();
         if (!overlay) {
             return;
         }
-        this.menuEnterHandler = () => this.cancelHideMenu();
-        this.menuLeaveHandler = () => this.scheduleHideMenu();
-        overlay.addEventListener('mouseenter', this.menuEnterHandler);
-        overlay.addEventListener('mouseleave', this.menuLeaveHandler);
+        this.#menuEnterHandler = () => this.cancelHideMenu();
+        this.#menuLeaveHandler = () => this.scheduleHideMenu();
+        overlay.addEventListener('mouseenter', this.#menuEnterHandler);
+        overlay.addEventListener('mouseleave', this.#menuLeaveHandler);
     }
 
     protected onMenuHidden(): void {
         this.cancelHideMenu();
-        this.detachOverlayListeners();
+        this.#detachOverlayListeners();
     }
 
     ngOnDestroy(): void {
         this.cancelHideMenu();
-        this.detachOverlayListeners();
+        this.#detachOverlayListeners();
     }
 
-    private detachOverlayListeners(): void {
-        const overlay = this.getMenuOverlayElement();
+    #detachOverlayListeners(): void {
+        const overlay = this.#getMenuOverlayElement();
         if (overlay) {
-            if (this.menuEnterHandler) {
-                overlay.removeEventListener('mouseenter', this.menuEnterHandler);
+            if (this.#menuEnterHandler) {
+                overlay.removeEventListener('mouseenter', this.#menuEnterHandler);
             }
-            if (this.menuLeaveHandler) {
-                overlay.removeEventListener('mouseleave', this.menuLeaveHandler);
+            if (this.#menuLeaveHandler) {
+                overlay.removeEventListener('mouseleave', this.#menuLeaveHandler);
             }
         }
-        this.menuEnterHandler = null;
-        this.menuLeaveHandler = null;
+        this.#menuEnterHandler = null;
+        this.#menuLeaveHandler = null;
     }
 
-    private getMenuOverlayElement(): HTMLElement | null {
-        const menu = this.versionMenu();
+    #getMenuOverlayElement(): HTMLElement | null {
+        const menu = this.$versionMenu();
         const ref = menu?.containerViewChild?.();
         return (ref?.nativeElement as HTMLElement | undefined) ?? null;
     }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-item/dot-history-timeline-item.component.ts
@@ -5,6 +5,7 @@ import {
     computed,
     input,
     inject,
+    OnDestroy,
     output,
     signal,
     viewChild
@@ -55,9 +56,14 @@ import {
     templateUrl: './dot-history-timeline-item.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DotHistoryTimelineItemComponent {
+export class DotHistoryTimelineItemComponent implements OnDestroy {
     private readonly datePipe = inject(DatePipe);
     private readonly dotMessageService = inject(DotMessageService);
+
+    private static readonly MENU_HIDE_DELAY_MS = 200;
+    private hideTimer: ReturnType<typeof setTimeout> | null = null;
+    private menuEnterHandler: (() => void) | null = null;
+    private menuLeaveHandler: (() => void) | null = null;
 
     /**
      * The version item to display
@@ -173,4 +179,74 @@ export class DotHistoryTimelineItemComponent {
 
         return '';
     });
+
+    /**
+     * Schedules hiding the version menu after a short delay so the user has time
+     * to move the cursor from the kebab button into the overlay (or vice versa)
+     * without it disappearing immediately.
+     */
+    protected scheduleHideMenu(): void {
+        this.cancelHideMenu();
+        this.hideTimer = setTimeout(() => {
+            this.versionMenu()?.hide();
+            this.hideTimer = null;
+        }, DotHistoryTimelineItemComponent.MENU_HIDE_DELAY_MS);
+    }
+
+    /**
+     * Cancels any pending hide; called when the cursor re-enters the kebab
+     * wrapper or the menu overlay.
+     */
+    protected cancelHideMenu(): void {
+        if (this.hideTimer !== null) {
+            clearTimeout(this.hideTimer);
+            this.hideTimer = null;
+        }
+    }
+
+    /**
+     * When the popup overlay is shown, attach mouseenter/mouseleave listeners so
+     * the cursor can leave the kebab wrapper and enter the overlay without the
+     * menu closing.
+     */
+    protected onMenuShown(): void {
+        const overlay = this.getMenuOverlayElement();
+        if (!overlay) {
+            return;
+        }
+        this.menuEnterHandler = () => this.cancelHideMenu();
+        this.menuLeaveHandler = () => this.scheduleHideMenu();
+        overlay.addEventListener('mouseenter', this.menuEnterHandler);
+        overlay.addEventListener('mouseleave', this.menuLeaveHandler);
+    }
+
+    protected onMenuHidden(): void {
+        this.cancelHideMenu();
+        this.detachOverlayListeners();
+    }
+
+    ngOnDestroy(): void {
+        this.cancelHideMenu();
+        this.detachOverlayListeners();
+    }
+
+    private detachOverlayListeners(): void {
+        const overlay = this.getMenuOverlayElement();
+        if (overlay) {
+            if (this.menuEnterHandler) {
+                overlay.removeEventListener('mouseenter', this.menuEnterHandler);
+            }
+            if (this.menuLeaveHandler) {
+                overlay.removeEventListener('mouseleave', this.menuLeaveHandler);
+            }
+        }
+        this.menuEnterHandler = null;
+        this.menuLeaveHandler = null;
+    }
+
+    private getMenuOverlayElement(): HTMLElement | null {
+        const menu = this.versionMenu();
+        const ref = menu?.containerViewChild?.();
+        return (ref?.nativeElement as HTMLElement | undefined) ?? null;
+    }
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-list/dot-history-timeline-list.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-list/dot-history-timeline-list.component.html
@@ -1,0 +1,25 @@
+<div
+    class="flex-1 min-h-0 overflow-y-auto px-4 pt-3 pb-2"
+    (scroll)="scrolled.emit($event)"
+    [attr.data-testid]="containerTestId()">
+    <p-timeline
+        [value]="$items()"
+        layout="vertical"
+        [pt]="{
+            eventOpposite: {
+                class: 'p-0! flex-none!'
+            }
+        }"
+        [attr.data-testid]="timelineTestId()">
+        <ng-template #marker let-item>
+            <ng-container
+                [ngTemplateOutlet]="markerTemplate()"
+                [ngTemplateOutletContext]="{ $implicit: item }" />
+        </ng-template>
+        <ng-template #content let-item>
+            <ng-container
+                [ngTemplateOutlet]="contentTemplate()"
+                [ngTemplateOutletContext]="{ $implicit: item }" />
+        </ng-template>
+    </p-timeline>
+</div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-list/dot-history-timeline-list.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-list/dot-history-timeline-list.component.scss
@@ -1,0 +1,6 @@
+/* Tighten PrimeNG timeline event padding so cards extend closer to the
+ * right edge of the sidebar (compact density layout).
+ */
+:host ::ng-deep .p-timeline-event-content {
+    padding-right: 0 !important;
+}

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-list/dot-history-timeline-list.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-list/dot-history-timeline-list.component.spec.ts
@@ -1,0 +1,111 @@
+import { byTestId, createComponentFactory, Spectator } from '@ngneat/spectator/jest';
+
+import { Component, TemplateRef, viewChild } from '@angular/core';
+
+import { DotHistoryTimelineListComponent } from './dot-history-timeline-list.component';
+
+interface TestItem {
+    id: string;
+    label: string;
+}
+
+/**
+ * Host wraps the timeline-list with concrete templates and a typed items
+ * array so we can validate input wiring, template projection, scroll
+ * emission, and test-id propagation from a real consumer's perspective.
+ */
+@Component({
+    selector: 'dot-test-host',
+    imports: [DotHistoryTimelineListComponent],
+    template: `
+        <ng-template #marker let-item>
+            <span [attr.data-testid]="'marker-' + item.id">{{ item.label }}-marker</span>
+        </ng-template>
+        <ng-template #content let-item>
+            <div [attr.data-testid]="'content-' + item.id">{{ item.label }}-content</div>
+        </ng-template>
+        <dot-history-timeline-list
+            [items]="items"
+            [markerTemplate]="$markerTpl()!"
+            [contentTemplate]="$contentTpl()!"
+            [containerTestId]="containerTestId"
+            [timelineTestId]="timelineTestId"
+            (scrolled)="onScrolled($event)" />
+    `
+})
+class TestHostComponent {
+    readonly $markerTpl = viewChild<TemplateRef<{ $implicit: TestItem }>>('marker');
+    readonly $contentTpl = viewChild<TemplateRef<{ $implicit: TestItem }>>('content');
+
+    items: TestItem[] = [
+        { id: '1', label: 'first' },
+        { id: '2', label: 'second' }
+    ];
+    containerTestId = 'host-container';
+    timelineTestId = 'host-timeline';
+
+    lastScrollEvent: Event | null = null;
+    onScrolled(event: Event): void {
+        this.lastScrollEvent = event;
+    }
+}
+
+describe('DotHistoryTimelineListComponent', () => {
+    let spectator: Spectator<TestHostComponent>;
+
+    const createHost = createComponentFactory({
+        component: TestHostComponent,
+        detectChanges: false
+    });
+
+    beforeEach(() => {
+        spectator = createHost();
+        spectator.detectChanges();
+    });
+
+    describe('test ids', () => {
+        it('should apply containerTestId on the scrollable wrapper', () => {
+            expect(spectator.query(byTestId('host-container'))).toBeTruthy();
+        });
+
+        it('should apply timelineTestId on the p-timeline element', () => {
+            expect(spectator.query(byTestId('host-timeline'))).toBeTruthy();
+        });
+    });
+
+    describe('template projection', () => {
+        it('should render the marker template for every item', () => {
+            const first = spectator.query(byTestId('marker-1'));
+            const second = spectator.query(byTestId('marker-2'));
+            expect(first?.textContent?.trim()).toBe('first-marker');
+            expect(second?.textContent?.trim()).toBe('second-marker');
+        });
+
+        it('should render the content template for every item', () => {
+            const first = spectator.query(byTestId('content-1'));
+            const second = spectator.query(byTestId('content-2'));
+            expect(first?.textContent?.trim()).toBe('first-content');
+            expect(second?.textContent?.trim()).toBe('second-content');
+        });
+
+        it('should re-render when items input changes', () => {
+            spectator.component.items = [{ id: '3', label: 'third' }];
+            spectator.detectChanges();
+            expect(spectator.query(byTestId('content-3'))?.textContent?.trim()).toBe(
+                'third-content'
+            );
+            expect(spectator.query(byTestId('content-1'))).toBeNull();
+            expect(spectator.query(byTestId('content-2'))).toBeNull();
+        });
+    });
+
+    describe('scroll output', () => {
+        it('should emit scrolled when the container scrolls', () => {
+            const container = spectator.query(byTestId('host-container'));
+            expect(container).toBeTruthy();
+            spectator.dispatchFakeEvent(container as Element, 'scroll');
+            expect(spectator.component.lastScrollEvent).toBeInstanceOf(Event);
+            expect(spectator.component.lastScrollEvent?.type).toBe('scroll');
+        });
+    });
+});

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-list/dot-history-timeline-list.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-history-timeline-list/dot-history-timeline-list.component.ts
@@ -1,0 +1,37 @@
+import { NgTemplateOutlet } from '@angular/common';
+import { ChangeDetectionStrategy, Component, input, output, TemplateRef } from '@angular/core';
+
+import { TimelineModule } from 'primeng/timeline';
+
+/**
+ * Shared scrollable wrapper around PrimeNG's `<p-timeline>` used by both the
+ * Versions and Push Publish accordions in the History tab. Consumers project
+ * a marker template and a content template; the wrapper handles layout,
+ * padding, scroll plumbing, and test-ids.
+ */
+@Component({
+    selector: 'dot-history-timeline-list',
+    imports: [NgTemplateOutlet, TimelineModule],
+    templateUrl: './dot-history-timeline-list.component.html',
+    styleUrls: ['./dot-history-timeline-list.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class DotHistoryTimelineListComponent<T> {
+    /** Items rendered along the timeline. */
+    readonly $items = input.required<T[]>({ alias: 'items' });
+
+    /** Template projected for each marker. Receives the item via `$implicit`. */
+    readonly markerTemplate = input.required<TemplateRef<{ $implicit: T }>>();
+
+    /** Template projected for each event content. Receives the item via `$implicit`. */
+    readonly contentTemplate = input.required<TemplateRef<{ $implicit: T }>>();
+
+    /** Test id applied to the scrollable container. */
+    readonly containerTestId = input<string>('timeline-container');
+
+    /** Test id applied to the `<p-timeline>` element. */
+    readonly timelineTestId = input<string>('timeline');
+
+    /** Emitted when the container scrolls. */
+    readonly scrolled = output<Event>();
+}

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.html
@@ -1,8 +1,8 @@
 @let item = $item();
-<div data-testid="pushpublish-item" class="block w-full">
+<div data-testid="pushpublish-item" class="block w-full pb-3">
     <div
         data-testid="content-wrapper"
-        class="flex items-center justify-between gap-2 rounded-lg bg-white p-2 mb-3 cursor-pointer hover:bg-gray-100 transition-colors min-w-0"
+        class="flex items-center justify-between gap-2 rounded-md border border-gray-200 bg-white pt-2.5 pr-2.5 pb-2.5 pl-3 min-w-0"
         [pTooltip]="tooltipContent"
         tooltipPosition="bottom"
         [tooltipOptions]="{
@@ -29,30 +29,31 @@
 
         <div class="flex flex-col w-full gap-2 flex-1 min-w-0">
             <div class="flex items-center justify-between gap-2 flex-wrap">
-                <span data-testid="time-display" class="font-semibold text-gray-900">
+                <span
+                    data-testid="time-display"
+                    class="font-bold text-gray-900 text-[13px] leading-tight">
                     {{ item.pushDate | dotRelativeDate }}
                 </span>
-                <div class="flex items-center gap-1" data-testid="bundle-id-section">
-                    <span data-testid="bundle-id-text" class="text-sm text-gray-700">
-                        {{ 'edit.content.sidebar.pushpublish.bundle.id.label' | dm }}
-                    </span>
-                    <dot-copy-button
-                        [copy]="item.bundleId"
-                        [tooltipText]="'edit.content.sidebar.pushpublish.copy.bundle.id' | dm"
-                        customClass="p-0! [&_.p-button-label]:text-sm"
-                        data-testid="copy-bundle-id" />
-                </div>
+                <dot-copy-button
+                    [copy]="item.bundleId"
+                    [label]="'edit.content.sidebar.pushpublish.bundle.id.label' | dm"
+                    [tooltipText]="'edit.content.sidebar.pushpublish.copy.bundle.id' | dm"
+                    customClass="p-0! [&_.p-button-label]:text-xs [&_.p-button-label]:normal-case"
+                    data-testid="copy-bundle-id" />
             </div>
 
             <div class="flex items-center gap-2">
                 <div
-                    class="w-8 h-8 shrink-0 overflow-hidden rounded-full [&_img]:w-full [&_img]:h-full [&_img]:object-cover">
+                    class="w-6 h-6 shrink-0 overflow-hidden rounded-full [&_img]:w-full [&_img]:h-full [&_img]:object-cover">
                     <p-avatar
                         dotGravatar
                         [label]="item.pushedBy.charAt(0).toUpperCase()"
+                        styleClass="w-6! h-6! text-[11px]! leading-none! [&_.p-avatar-text]:leading-none!"
                         data-testid="user-avatar" />
                 </div>
-                <span data-testid="pushpublish-user" class="text-sm text-gray-700 truncate min-w-0">
+                <span
+                    data-testid="pushpublish-user"
+                    class="text-[12.5px] text-gray-700 truncate min-w-0">
                     {{ item.pushedBy }}
                 </span>
             </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.html
@@ -33,12 +33,12 @@
                     {{ item.pushDate | dotRelativeDate }}
                 </span>
                 <div class="flex items-center gap-1" data-testid="bundle-id-section">
-                    <span data-testid="bundle-id-text" class="text-sm text-gray-700 font-mono">
-                        {{ $truncatedBundleId() }}
+                    <span data-testid="bundle-id-text" class="text-sm text-gray-700">
+                        {{ 'edit.content.sidebar.pushpublish.bundle.id.label' | dm }}
                     </span>
                     <dot-copy-button
                         [copy]="item.bundleId"
-                        [tooltipText]="'Copy Bundle ID'"
+                        [tooltipText]="'edit.content.sidebar.pushpublish.copy.bundle.id' | dm"
                         customClass="p-0! [&_.p-button-label]:text-sm"
                         data-testid="copy-bundle-id" />
                 </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.html
@@ -31,7 +31,7 @@
             <div class="flex items-center justify-between gap-2 flex-wrap">
                 <span
                     data-testid="time-display"
-                    class="font-bold text-gray-900 text-[13px] leading-tight">
+                    class="font-bold text-gray-900 text-sm leading-tight">
                     {{ item.pushDate | dotRelativeDate }}
                 </span>
                 <dot-copy-button
@@ -51,9 +51,7 @@
                         styleClass="w-6! h-6! text-[11px]! leading-none! [&_.p-avatar-text]:leading-none!"
                         data-testid="user-avatar" />
                 </div>
-                <span
-                    data-testid="pushpublish-user"
-                    class="text-[12.5px] text-gray-700 truncate min-w-0">
+                <span data-testid="pushpublish-user" class="text-xs text-gray-700 truncate min-w-0">
                     {{ item.pushedBy }}
                 </span>
             </div>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.spec.ts
@@ -68,9 +68,13 @@ describe('DotPushpublishTimelineItemComponent', () => {
             expect(userName.textContent?.trim()).toBe('Admin User');
         });
 
-        it('should display "Bundle ID" label instead of the raw UUID', () => {
-            const bundleIdText = spectator.query(byTestId('bundle-id-text'));
-            expect(bundleIdText.textContent?.trim()).toBe('Bundle ID');
+        it('should display "Bundle ID" label on the copy button instead of the raw UUID', () => {
+            const copyButtonDebugElement = spectator.debugElement.query(
+                By.css('[data-testid="copy-bundle-id"]')
+            );
+            const copyButtonComponent = copyButtonDebugElement?.componentInstance;
+            expect(copyButtonComponent).toBeTruthy();
+            expect(copyButtonComponent.label()).toBe('Bundle ID');
         });
 
         it('should display correct user avatar label', () => {
@@ -120,9 +124,13 @@ describe('DotPushpublishTimelineItemComponent', () => {
     });
 
     describe('Bundle ID Display', () => {
-        it('should display "Bundle ID" label (static i18n) instead of a computed truncated UUID', () => {
-            const bundleIdText = spectator.query(byTestId('bundle-id-text'));
-            expect(bundleIdText.textContent?.trim()).toBe('Bundle ID');
+        it('should render the static "Bundle ID" i18n label on the copy button', () => {
+            const copyButtonDebugElement = spectator.debugElement.query(
+                By.css('[data-testid="copy-bundle-id"]')
+            );
+            const copyButtonComponent = copyButtonDebugElement?.componentInstance;
+            expect(copyButtonComponent).toBeTruthy();
+            expect(copyButtonComponent.label()).toBe('Bundle ID');
         });
     });
 
@@ -139,10 +147,7 @@ describe('DotPushpublishTimelineItemComponent', () => {
             spectator.detectChanges();
 
             const userName = spectator.query(byTestId('pushpublish-user'));
-            const bundleIdText = spectator.query(byTestId('bundle-id-text'));
-
             expect(userName.textContent?.trim()).toBe('System Administrator');
-            expect(bundleIdText.textContent?.trim()).toBe('Bundle ID');
 
             // Access the PrimeNG Avatar component instance to verify label property
             const avatarDebugElement = spectator.debugElement.query(
@@ -152,13 +157,14 @@ describe('DotPushpublishTimelineItemComponent', () => {
             expect(avatarComponent).toBeTruthy();
             expect(avatarComponent.label).toBe('S');
 
-            // Access the DotCopyButtonComponent instance to verify copy property
+            // Access the DotCopyButtonComponent instance to verify copy + label
             const copyButtonDebugElement = spectator.debugElement.query(
                 By.css('[data-testid="copy-bundle-id"]')
             );
             const copyButtonComponent = copyButtonDebugElement?.componentInstance;
             expect(copyButtonComponent).toBeTruthy();
             expect(copyButtonComponent.copy()).toBe('XYZ789NEWBUNDLE123');
+            expect(copyButtonComponent.label()).toBe('Bundle ID');
         });
     });
 });

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.spec.ts
@@ -45,7 +45,9 @@ describe('DotPushpublishTimelineItemComponent', () => {
                 provide: DotMessageService,
                 useValue: new MockDotMessageService({
                     'edit.content.sidebar.pushpublish.bundle': 'Bundle',
-                    'edit.content.sidebar.pushpublish.environment': 'Environment'
+                    'edit.content.sidebar.pushpublish.environment': 'Environment',
+                    'edit.content.sidebar.pushpublish.bundle.id.label': 'Bundle ID',
+                    'edit.content.sidebar.pushpublish.copy.bundle.id': 'Copy Bundle ID'
                 })
             },
             mockProvider(DotFormatDateService)
@@ -66,9 +68,9 @@ describe('DotPushpublishTimelineItemComponent', () => {
             expect(userName.textContent?.trim()).toBe('Admin User');
         });
 
-        it('should display truncated bundle ID', () => {
+        it('should display "Bundle ID" label instead of the raw UUID', () => {
             const bundleIdText = spectator.query(byTestId('bundle-id-text'));
-            expect(bundleIdText.textContent?.trim()).toBe('01K6NY'); // First 6 characters
+            expect(bundleIdText.textContent?.trim()).toBe('Bundle ID');
         });
 
         it('should display correct user avatar label', () => {
@@ -117,9 +119,10 @@ describe('DotPushpublishTimelineItemComponent', () => {
         });
     });
 
-    describe('Computed Signals', () => {
-        it('should compute truncated bundle ID correctly', () => {
-            expect(spectator.component.$truncatedBundleId()).toBe('01K6NY');
+    describe('Bundle ID Display', () => {
+        it('should display "Bundle ID" label (static i18n) instead of a computed truncated UUID', () => {
+            const bundleIdText = spectator.query(byTestId('bundle-id-text'));
+            expect(bundleIdText.textContent?.trim()).toBe('Bundle ID');
         });
     });
 
@@ -139,7 +142,7 @@ describe('DotPushpublishTimelineItemComponent', () => {
             const bundleIdText = spectator.query(byTestId('bundle-id-text'));
 
             expect(userName.textContent?.trim()).toBe('System Administrator');
-            expect(bundleIdText.textContent?.trim()).toBe('XYZ789');
+            expect(bundleIdText.textContent?.trim()).toBe('Bundle ID');
 
             // Access the PrimeNG Avatar component instance to verify label property
             const avatarDebugElement = spectator.debugElement.query(

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component.ts
@@ -1,5 +1,5 @@
 import { DatePipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 import { AvatarModule } from 'primeng/avatar';
 import { TooltipModule } from 'primeng/tooltip';
@@ -41,12 +41,4 @@ export class DotPushpublishTimelineItemComponent {
      * @readonly
      */
     $item = input.required<DotPushPublishHistoryItem>({ alias: 'item' });
-
-    /**
-     * Computed signal that returns the first 6 characters of the bundle ID for display
-     */
-    readonly $truncatedBundleId = computed(() => {
-        const bundleId = this.$item().bundleId;
-        return bundleId ? bundleId.substring(0, 6) : '';
-    });
 }

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.html
@@ -53,7 +53,11 @@
                                 <dot-history-timeline-item
                                     [item]="item"
                                     [itemIndex]="getRealIndex(item)"
-                                    [isActive]="historicalVersionInode === item.inode"
+                                    [isActive]="
+                                        historicalVersionInode
+                                            ? historicalVersionInode === item.inode
+                                            : item.working
+                                    "
                                     (click)="
                                         timelineItemAction.emit({
                                             type: 'view',

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.html
@@ -29,45 +29,35 @@
                         [hideContactUsLink]="true" />
                 } @else {
                     <!-- History content -->
-                    <div
-                        class="flex-1 min-h-0 overflow-y-auto p-2"
-                        (scroll)="onTimelineScroll($event)"
-                        data-testid="history-timeline-container">
-                        <p-timeline
-                            [value]="$historyItems()"
-                            layout="vertical"
-                            [pt]="{
-                                eventOpposite: {
-                                    class: 'p-0! flex-none!'
-                                }
-                            }"
-                            data-testid="history-timeline">
-                            <ng-template #marker let-item>
-                                <span
-                                    [class]="'timeline-marker ' + getTimelineMarkerClass(item)"
-                                    [attr.data-testid]="
-                                        'timeline-marker-' + getRealIndex(item)
-                                    "></span>
-                            </ng-template>
-                            <ng-template #content let-item>
-                                <dot-history-timeline-item
-                                    [item]="item"
-                                    [itemIndex]="getRealIndex(item)"
-                                    [isActive]="
-                                        historicalVersionInode
-                                            ? historicalVersionInode === item.inode
-                                            : item.working
-                                    "
-                                    (click)="
-                                        timelineItemAction.emit({
-                                            type: 'view',
-                                            item
-                                        })
-                                    "
-                                    (actionTriggered)="timelineItemAction.emit($event)" />
-                            </ng-template>
-                        </p-timeline>
-                    </div>
+                    <ng-template #versionMarker let-item>
+                        <span
+                            [class]="'timeline-marker ' + getTimelineMarkerClass(item)"
+                            [attr.data-testid]="'timeline-marker-' + getRealIndex(item)"></span>
+                    </ng-template>
+                    <ng-template #versionContent let-item>
+                        <dot-history-timeline-item
+                            [item]="item"
+                            [itemIndex]="getRealIndex(item)"
+                            [isActive]="
+                                historicalVersionInode
+                                    ? historicalVersionInode === item.inode
+                                    : item.working
+                            "
+                            (click)="
+                                timelineItemAction.emit({
+                                    type: 'view',
+                                    item
+                                })
+                            "
+                            (actionTriggered)="timelineItemAction.emit($event)" />
+                    </ng-template>
+                    <dot-history-timeline-list
+                        [items]="$historyItems()"
+                        [markerTemplate]="versionMarker"
+                        [contentTemplate]="versionContent"
+                        containerTestId="history-timeline-container"
+                        timelineTestId="history-timeline"
+                        (scrolled)="onTimelineScroll($event)" />
                 }
             </div>
         </dot-sidebar-accordion-tab>
@@ -110,33 +100,25 @@
                         [hideContactUsLink]="true" />
                 } @else {
                     <!-- Push Publish History content -->
-                    <div
-                        class="flex-1 min-h-0 overflow-y-auto p-2"
-                        (scroll)="onPushPublishTimelineScroll($event)"
-                        data-testid="push-publish-timeline-container">
-                        <p-timeline
-                            [value]="$pushPublishHistoryItems()"
-                            layout="vertical"
-                            [pt]="{
-                                eventOpposite: {
-                                    class: 'p-0! flex-none!'
-                                }
-                            }"
-                            data-testid="push-publish-timeline">
-                            <ng-template #marker let-item>
-                                <span
-                                    class="timeline-marker timeline-marker--default"
-                                    [attr.data-testid]="
-                                        'pushpublish-timeline-marker-' + getPushPublishIndex(item)
-                                    "></span>
-                            </ng-template>
-                            <ng-template #content let-item>
-                                <dot-pushpublish-timeline-item
-                                    [item]="item"
-                                    data-testid="pushpublish-timeline-item" />
-                            </ng-template>
-                        </p-timeline>
-                    </div>
+                    <ng-template #pushPublishMarker let-item>
+                        <span
+                            class="timeline-marker timeline-marker--default"
+                            [attr.data-testid]="
+                                'pushpublish-timeline-marker-' + getPushPublishIndex(item)
+                            "></span>
+                    </ng-template>
+                    <ng-template #pushPublishContent let-item>
+                        <dot-pushpublish-timeline-item
+                            [item]="item"
+                            data-testid="pushpublish-timeline-item" />
+                    </ng-template>
+                    <dot-history-timeline-list
+                        [items]="$pushPublishHistoryItems()"
+                        [markerTemplate]="pushPublishMarker"
+                        [contentTemplate]="pushPublishContent"
+                        containerTestId="push-publish-timeline-container"
+                        timelineTestId="push-publish-timeline"
+                        (scrolled)="onPushPublishTimelineScroll($event)" />
                 }
             </div>
         </dot-sidebar-accordion-tab>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.html
@@ -76,17 +76,18 @@
         <dot-sidebar-accordion-tab
             id="push-publish"
             [label]="'edit.content.sidebar.history.push.publish' | dm">
-            <div
-                slot="header-content"
-                class="dot-edit-content-sidebar-history__push-publish__actions">
-                <p-button
-                    icon="pi pi-ellipsis-v"
-                    styleClass="p-button-rounded p-button-sm p-button-text dot-edit-content-sidebar-history__menu-button p-button-tertiary"
-                    (click)="ppMenu.toggle($event); $event.stopPropagation()"
-                    [disabled]="!$hasPushPublishHistoryItems()"
-                    data-testid="push-publish-menu-button" />
-                <p-menu #ppMenu [appendTo]="'body'" [model]="$menuItems()" [popup]="true" />
-            </div>
+            @if ($hasPushPublishHistoryItems()) {
+                <div
+                    slot="header-content"
+                    class="dot-edit-content-sidebar-history__push-publish__actions">
+                    <p-button
+                        icon="pi pi-ellipsis-v"
+                        styleClass="p-button-rounded p-button-sm p-button-text dot-edit-content-sidebar-history__menu-button p-button-tertiary"
+                        (click)="ppMenu.toggle($event); $event.stopPropagation()"
+                        data-testid="push-publish-menu-button" />
+                    <p-menu #ppMenu [appendTo]="'body'" [model]="$menuItems()" [popup]="true" />
+                </div>
+            }
             <div class="flex flex-col h-full min-h-0 gap-5">
                 @if ($isLoading()) {
                     <!-- Loading state for push publish -->

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.spec.ts
@@ -477,20 +477,14 @@ describe('DotEditContentSidebarHistoryComponent', () => {
                 expect(spy).toHaveBeenCalled();
             });
 
-            it('should disable menu button when no push publish history items', () => {
+            it('should not render the menu button when there are no push publish history items', () => {
                 spectator.setInput('pushPublishHistoryItems', []);
                 spectator.detectChanges();
 
                 const menuButtonComponent = spectator.query(
                     '[data-testid="push-publish-menu-button"]'
                 );
-                expect(menuButtonComponent).toBeTruthy();
-                // Access the actual button element inside PrimeNG component
-                const actualButton = menuButtonComponent.querySelector(
-                    'button'
-                ) as HTMLButtonElement;
-                expect(actualButton).toBeTruthy();
-                expect(actualButton.disabled).toBe(true);
+                expect(menuButtonComponent).toBeNull();
             });
 
             it('should enable menu button when push publish history items exist', () => {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-history/dot-edit-content-sidebar-history.component.ts
@@ -4,7 +4,6 @@ import { ChangeDetectionStrategy, Component, computed, input, inject, output } f
 import { ButtonModule } from 'primeng/button';
 import { MenuModule } from 'primeng/menu';
 import { SkeletonModule } from 'primeng/skeleton';
-import { TimelineModule } from 'primeng/timeline';
 import { TooltipModule } from 'primeng/tooltip';
 
 import { ComponentStatus, DotCMSContentletVersion, DotPagination } from '@dotcms/dotcms-models';
@@ -16,6 +15,7 @@ import {
 } from '@dotcms/ui';
 
 import { DotHistoryTimelineItemComponent } from './components/dot-history-timeline-item/dot-history-timeline-item.component';
+import { DotHistoryTimelineListComponent } from './components/dot-history-timeline-list/dot-history-timeline-list.component';
 import { DotPushpublishTimelineItemComponent } from './components/dot-pushpublish-timeline-item/dot-pushpublish-timeline-item.component';
 
 import {
@@ -31,7 +31,6 @@ import {
     selector: 'dot-edit-content-sidebar-history',
     imports: [
         SkeletonModule,
-        TimelineModule,
         TooltipModule,
         ButtonModule,
         MenuModule,
@@ -40,6 +39,7 @@ import {
         DotSidebarAccordionComponent,
         DotSidebarAccordionTabComponent,
         DotHistoryTimelineItemComponent,
+        DotHistoryTimelineListComponent,
         DotPushpublishTimelineItemComponent
     ],
     providers: [DatePipe, DotMessagePipe],

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-permissions/dot-edit-content-sidebar-permissions.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-permissions/dot-edit-content-sidebar-permissions.component.html
@@ -1,9 +1,9 @@
 <section
-    class="flex justify-content-center p-4 w-full overflow-hidden"
+    class="flex justify-content-center w-full overflow-hidden"
     role="region"
     aria-label="Content Permissions">
     <div
-        class="w-full cursor-pointer"
+        class="group w-full cursor-pointer"
         role="button"
         tabindex="0"
         (click)="openPermissionsDialog()"
@@ -11,7 +11,9 @@
         (keydown.space)="$event.preventDefault(); openPermissionsDialog()"
         [attr.aria-label]="'edit.content.sidebar.permissions.title' | dm"
         data-testId="permissions-card">
-        <p-card [header]="'edit.content.sidebar.permissions.title' | dm">
+        <p-card
+            styleClass="transition-colors group-hover:bg-gray-100! [&_.p-card-body]:group-hover:bg-gray-100!"
+            [header]="'edit.content.sidebar.permissions.title' | dm">
             <p class="m-0 text-600">
                 {{ 'edit.content.sidebar.permissions.setup' | dm }}
             </p>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-rules/dot-edit-content-sidebar-rules.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-rules/dot-edit-content-sidebar-rules.component.html
@@ -1,9 +1,9 @@
 <section
-    class="flex justify-content-center p-4 w-full overflow-hidden"
+    class="flex justify-content-center w-full overflow-hidden"
     role="region"
     aria-label="Content Rules">
     <div
-        class="w-full cursor-pointer"
+        class="group w-full cursor-pointer"
         role="button"
         tabindex="0"
         (click)="openRulesDialog()"
@@ -11,7 +11,9 @@
         (keydown.space)="$event.preventDefault(); openRulesDialog()"
         [attr.aria-label]="'edit.content.sidebar.rules.title' | dm"
         data-testId="rules-card">
-        <p-card [header]="'edit.content.sidebar.rules.title' | dm">
+        <p-card
+            styleClass="transition-colors group-hover:bg-gray-100! [&_.p-card-body]:group-hover:bg-gray-100!"
+            [header]="'edit.content.sidebar.rules.title' | dm">
             <p class="m-0 text-600">
                 {{ 'edit.content.sidebar.rules.setup' | dm }}
             </p>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.html
@@ -31,56 +31,60 @@
                 </p-tab>
             }
         </p-tablist>
-        <!-- bg-zinc-100! overrides PrimeNG's default p-tabpanels background -->
-        <p-tabpanels class="h-full min-h-0 flex-1 flex flex-col bg-zinc-100!">
+        <!-- p-tabpanels stays padding-free; each tab content controls its own internal padding -->
+        <p-tabpanels
+            class="h-full min-h-0 flex-1 flex flex-col bg-zinc-100! p-0! [&_.p-tabpanel]:p-0!">
             <p-tabpanel [value]="0" class="flex flex-col h-full min-h-0">
-                <!-- Information section -->
-                <dot-edit-content-sidebar-section
-                    [title]="'edit.content.sidebar.general.title' | dm">
-                    <ng-template #sectionAction>
-                        @if (!$store.isNew() && !$store.isCopyingLocale()) {
-                            <dot-copy-button
-                                [copy]="contentlet.identifier"
-                                [label]="contentlet.shortyId"
-                                [tooltipText]="'Identifier' | dm"
-                                customClass="p-0! [&_.p-button-label]:text-sm [&_.p-button-label]:normal-case" />
-                        }
-                    </ng-template>
+                <!-- Information tab content — padding lives on this first inner wrapper -->
+                <div class="flex flex-col h-full min-h-0 px-4 pt-3">
+                    <!-- Information section -->
+                    <dot-edit-content-sidebar-section
+                        [title]="'edit.content.sidebar.general.title' | dm">
+                        <ng-template #sectionAction>
+                            @if (!$store.isNew() && !$store.isCopyingLocale()) {
+                                <dot-copy-button
+                                    [copy]="contentlet.identifier"
+                                    [label]="contentlet.shortyId"
+                                    [tooltipText]="'Identifier' | dm"
+                                    customClass="p-0! [&_.p-button-label]:text-sm [&_.p-button-label]:normal-case" />
+                            }
+                        </ng-template>
 
-                    <dot-edit-content-sidebar-information
-                        [data]="{
-                            contentlet: contentlet,
-                            contentType: contentType,
-                            loading: isLoadingInformation,
-                            referencesPageCount: referencePagesCount
-                        }"
-                        data-testId="information" />
-                </dot-edit-content-sidebar-section>
+                        <dot-edit-content-sidebar-information
+                            [data]="{
+                                contentlet: contentlet,
+                                contentType: contentType,
+                                loading: isLoadingInformation,
+                                referencesPageCount: referencePagesCount
+                            }"
+                            data-testId="information" />
+                    </dot-edit-content-sidebar-section>
 
-                <dot-edit-content-sidebar-section [title]="'edit.content.sidebar.locales' | dm">
-                    <dot-edit-content-sidebar-locales
-                        [locales]="$store.locales()"
-                        [defaultLocale]="$store.systemDefaultLocale()"
-                        [currentLocale]="$store.currentLocale()"
-                        [isLoading]="$store.isLoadingLocales()"
-                        (switchLocale)="$store.switchLocale($event)"
-                        data-testId="locales" />
-                </dot-edit-content-sidebar-section>
+                    <dot-edit-content-sidebar-section [title]="'edit.content.sidebar.locales' | dm">
+                        <dot-edit-content-sidebar-locales
+                            [locales]="$store.locales()"
+                            [defaultLocale]="$store.systemDefaultLocale()"
+                            [currentLocale]="$store.currentLocale()"
+                            [isLoading]="$store.isLoadingLocales()"
+                            (switchLocale)="$store.switchLocale($event)"
+                            data-testId="locales" />
+                    </dot-edit-content-sidebar-section>
 
-                <!-- Workflow section -->
-                <dot-edit-content-sidebar-section
-                    [title]="'edit.content.sidebar.workflow.title' | dm"
-                    class="[&_.dot-section]:border-b-0">
-                    <dot-edit-content-sidebar-workflow
-                        [workflowSelection]="$workflowSelection()"
-                        [(showDialog)]="$showDialog"
-                        (onSelectWorkflow)="$store.setSelectedWorkflow($event)"
-                        [resetWorkflowAction]="$store.getResetWorkflowAction()"
-                        (onResetWorkflow)="fireWorkflowAction($event)"
-                        [workflow]="$workflow()"
-                        [isLoading]="$store.isLoadingWorkflow()"
-                        data-testId="workflow" />
-                </dot-edit-content-sidebar-section>
+                    <!-- Workflow section -->
+                    <dot-edit-content-sidebar-section
+                        [title]="'edit.content.sidebar.workflow.title' | dm"
+                        class="[&_.dot-section]:border-b-0">
+                        <dot-edit-content-sidebar-workflow
+                            [workflowSelection]="$workflowSelection()"
+                            [(showDialog)]="$showDialog"
+                            (onSelectWorkflow)="$store.setSelectedWorkflow($event)"
+                            [resetWorkflowAction]="$store.getResetWorkflowAction()"
+                            (onResetWorkflow)="fireWorkflowAction($event)"
+                            [workflow]="$workflow()"
+                            [isLoading]="$store.isLoadingWorkflow()"
+                            data-testId="workflow" />
+                    </dot-edit-content-sidebar-section>
+                </div>
             </p-tabpanel>
             <p-tabpanel [value]="1" class="h-full min-h-0 flex flex-col">
                 <!-- History section -->
@@ -110,17 +114,20 @@
             </p-tabpanel>
             @if (!isNew) {
                 <p-tabpanel [value]="3" class="h-full min-h-0 flex flex-col">
-                    <!-- Permissions section -->
-                    <dot-edit-content-sidebar-permissions
-                        [identifier]="$identifier() ?? ''"
-                        [languageId]="$contentlet()?.languageId ?? 0"
-                        data-testId="permissions" />
-                    <!-- Rules section (Page content type only) -->
-                    @if ($isPage()) {
-                        <dot-edit-content-sidebar-rules
+                    <!-- Settings tab content — padding lives on this first inner wrapper -->
+                    <div class="flex flex-col h-full min-h-0 px-4 pt-3">
+                        <!-- Permissions section -->
+                        <dot-edit-content-sidebar-permissions
                             [identifier]="$identifier() ?? ''"
-                            data-testId="rules" />
-                    }
+                            [languageId]="$contentlet()?.languageId ?? 0"
+                            data-testId="permissions" />
+                        <!-- Rules section (Page content type only) -->
+                        @if ($isPage()) {
+                            <dot-edit-content-sidebar-rules
+                                [identifier]="$identifier() ?? ''"
+                                data-testId="rules" />
+                        }
+                    </div>
                 </p-tabpanel>
             }
         </p-tabpanels>

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.scss
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.scss
@@ -1,1 +1,9 @@
 /* PrimeNG/Lara + Tailwind handle all styling for this component. */
+
+/* Sidebar cards use a borderless variant of `p-card` for a flat, uniform
+ * look across tabs (Information, Activities, Settings). The subtle card
+ * shadow handles visual separation from the panel background.
+ */
+:host ::ng-deep .p-card {
+    border: none !important;
+}

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.ts
@@ -40,6 +40,7 @@ import { DotEditContentStore } from '../../store/edit-content.store';
 @Component({
     selector: 'dot-edit-content-sidebar',
     templateUrl: './dot-edit-content-sidebar.component.html',
+    styleUrl: './dot-edit-content-sidebar.component.scss',
     providers: [ConfirmationService],
     imports: [
         DotMessagePipe,

--- a/core-web/libs/edit-content/src/lib/store/features/history/history.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/history/history.feature.spec.ts
@@ -428,7 +428,11 @@ describe('HistoryFeature', () => {
                     limit: DEFAULT_PUSH_PUBLISH_HISTORY_PER_PAGE
                 }
             );
-            expect(store.pushPublishHistory()).toEqual(mockPushPublishHistoryResponse.entity);
+            // Store sorts push publish history by pushDate descending
+            const expectedSorted = [...mockPushPublishHistoryResponse.entity].sort(
+                (a, b) => b.pushDate - a.pushDate
+            );
+            expect(store.pushPublishHistory()).toEqual(expectedSorted);
             expect(store.pushPublishHistoryPagination()).toEqual(
                 mockPushPublishHistoryResponse.pagination
             );
@@ -450,10 +454,13 @@ describe('HistoryFeature', () => {
             store.loadPushPublishHistory({ identifier: 'test-identifier', page: 2 });
             tick();
 
-            expect(store.pushPublishHistory()).toEqual([
+            // Store sorts accumulated push publish history by pushDate descending
+            const accumulated = [
                 mockPushPublishHistoryItem,
                 ...mockPushPublishHistoryResponsePage2.entity
-            ]);
+            ];
+            const expectedSorted = [...accumulated].sort((a, b) => b.pushDate - a.pushDate);
+            expect(store.pushPublishHistory()).toEqual(expectedSorted);
         }));
 
         it('should handle errors and update error state', fakeAsync(() => {
@@ -867,7 +874,11 @@ describe('HistoryFeature', () => {
                 'new-identifier-123',
                 { offset: 1, limit: DEFAULT_PUSH_PUBLISH_HISTORY_PER_PAGE }
             );
-            expect(store.pushPublishHistory()).toEqual(mockPushPublishHistoryResponse.entity);
+            // Store sorts push publish history by pushDate descending
+            const expectedSortedHistory = [...mockPushPublishHistoryResponse.entity].sort(
+                (a, b) => b.pushDate - a.pushDate
+            );
+            expect(store.pushPublishHistory()).toEqual(expectedSortedHistory);
         }));
 
         it('should automatically load versions when contentlet languageId changes', fakeAsync(() => {
@@ -907,7 +918,11 @@ describe('HistoryFeature', () => {
 
             // Both datasets should be cleared and then reloaded
             expect(store.versions()).toEqual(mockVersionsResponse.entity);
-            expect(store.pushPublishHistory()).toEqual(mockPushPublishHistoryResponse.entity);
+            // Store sorts push publish history by pushDate descending
+            const expectedSortedAfterClear = [...mockPushPublishHistoryResponse.entity].sort(
+                (a, b) => b.pushDate - a.pushDate
+            );
+            expect(store.pushPublishHistory()).toEqual(expectedSortedAfterClear);
         }));
 
         it('should not load data if contentlet has no identifier', fakeAsync(() => {
@@ -1105,7 +1120,7 @@ describe('HistoryFeature', () => {
             expect(confirmCall.header).toBe('Restore Version');
             expect(confirmCall.acceptLabel).toBe('Restore');
             expect(confirmCall.rejectLabel).toBe('Cancel');
-            expect(confirmCall.icon).toBe('pi pi-exclamation-triangle text-warning-yellow');
+            expect(confirmCall.icon).toBeUndefined();
             expect(confirmCall.acceptIcon).toBe('hidden');
             expect(confirmCall.rejectIcon).toBe('hidden');
             expect(confirmCall.rejectButtonStyleClass).toBe('p-button-outlined');

--- a/core-web/libs/edit-content/src/lib/store/features/history/history.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/history/history.feature.ts
@@ -181,7 +181,6 @@ export function withHistory() {
                         header: dotMessageService.get(
                             'edit.content.sidebar.history.restore.confirm.header'
                         ),
-                        icon: 'pi pi-exclamation-triangle text-warning-yellow',
                         acceptLabel: dotMessageService.get(
                             'edit.content.sidebar.history.restore.confirm.accept'
                         ),
@@ -253,6 +252,23 @@ export function withHistory() {
                             originalContentlet: null
                         });
                     }
+                };
+
+                /**
+                 * Exits compare view and returns to the original content / form view.
+                 * Clears compare-related state without affecting other tabs.
+                 */
+                const exitCompareView = () => {
+                    const originalContentlet = store.originalContentlet();
+                    patchState(store, {
+                        compareContentlet: null,
+                        historicalVersionInode: null,
+                        isViewingHistoricalVersion: false,
+                        ...(originalContentlet
+                            ? { contentlet: originalContentlet, originalContentlet: null }
+                            : {}),
+                        uiState: { ...store.uiState(), view: 'form' }
+                    });
                 };
 
                 const loadCompareVersionContent = rxMethod<string>(
@@ -449,6 +465,11 @@ export function withHistory() {
                                                     ];
                                                 }
 
+                                                // Ensure newest-first ordering regardless of API order
+                                                newPushPublishHistory = [
+                                                    ...newPushPublishHistory
+                                                ].sort((a, b) => b.pushDate - a.pushDate);
+
                                                 patchState(store, {
                                                     pushPublishHistory: newPushPublishHistory, // All accumulated items for display
                                                     pushPublishHistoryPagination:
@@ -641,7 +662,6 @@ export function withHistory() {
                                     header: dotMessageService.get(
                                         'edit.content.sidebar.history.delete.confirm.header'
                                     ),
-                                    icon: 'pi pi-exclamation-triangle text-warning-yellow',
                                     acceptLabel: dotMessageService.get(
                                         'edit.content.sidebar.history.delete.confirm.accept'
                                     ),
@@ -668,6 +688,11 @@ export function withHistory() {
                      * Exits historical version view and returns to original content
                      */
                     exitHistoricalView: exitHistoricalView,
+
+                    /**
+                     * Exits compare view and returns to the form view
+                     */
+                    exitCompareView: exitCompareView,
 
                     /**
                      * Restores the currently viewed historical version with confirmation

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
@@ -20,6 +20,10 @@
                             </div>
                             @if ($showActions()) {
                                 <div class="dot-content-compare-table__controls">
+                                    <!-- Note: [ngModel]="data.compare" + dataKey="inode" are required
+                                     for the dropdown to show its selected value on first load
+                                     (see PR #35341). Keep both branches of [reverseColumns]
+                                     in sync if you edit one. -->
                                     <p-select
                                         [ngModel]="data.compare"
                                         (onChange)="changeVersion.emit($event.value)"
@@ -71,6 +75,10 @@
                             </div>
                             @if ($showActions()) {
                                 <div class="dot-content-compare-table__controls">
+                                    <!-- Note: [ngModel]="data.compare" + dataKey="inode" are required
+                                     for the dropdown to show its selected value on first load
+                                     (see PR #35341). Keep both branches of [reverseColumns]
+                                     in sync if you edit one. -->
                                     <p-select
                                         [ngModel]="data.compare"
                                         (onChange)="changeVersion.emit($event.value)"

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.html
@@ -3,61 +3,119 @@
         <ng-template pTemplate="header">
             <tr>
                 <th></th>
-                <th>
-                    <span class="dot-content-compare-table__title" data-testId="table-tittle">
-                        {{ 'edit.content.sidebar.history.menu.current' | dm }}
-                    </span>
-                </th>
-                <th>
-                    <div class="flex flex-col gap-2">
-                        <div class="flex">
-                            <span
-                                class="dot-content-compare-table__title"
-                                data-testId="table-tittle">
-                                {{ 'edit.content.sidebar.history.menu.previous' | dm }}
-                            </span>
-                        </div>
-                        @if ($showActions()) {
-                            <div class="dot-content-compare-table__controls">
-                                <p-select
-                                    [ngModel]="data.compare"
-                                    (onChange)="changeVersion.emit($event.value)"
-                                    [options]="data.versions"
-                                    dataKey="inode"
-                                    data-testid="versions-dropdown"
-                                    appendTo="body">
-                                    <ng-template let-selected pTemplate="selectedItem">
-                                        {{
-                                            (selected.modDate
-                                                | dotRelativeDate: 'MM/dd/yyyy - hh:mm aa') +
-                                                (' by ' | dm) +
-                                                selected.modUserName
-                                        }}
-                                    </ng-template>
-                                    <ng-template let-item pTemplate="item">
-                                        {{
-                                            (item.modDate
-                                                | dotRelativeDate: 'MM/dd/yyyy - hh:mm aa') +
-                                                (' by ' | dm) +
-                                                item.modUserName
-                                        }}
-                                    </ng-template>
-                                </p-select>
-                                <p-selectButton
-                                    (onChange)="changeDiff.emit($event.value)"
-                                    [(ngModel)]="showDiff"
-                                    [options]="displayOptions"
-                                    styleClass="p-button-compact"
-                                    data-testid="show-diff" />
-                                <p-button
-                                    (click)="bringBack.emit(data.compare.inode)"
-                                    [label]="'Bring-Back' | dm"
-                                    size="small"
-                                    data-testId="table-bring-back" />
+                @if (!$reverseColumns()) {
+                    <th>
+                        <span class="dot-content-compare-table__title" data-testId="table-tittle">
+                            {{ 'edit.content.sidebar.history.menu.current' | dm }}
+                        </span>
+                    </th>
+                    <th>
+                        <div class="flex flex-col gap-2">
+                            <div class="flex">
+                                <span
+                                    class="dot-content-compare-table__title"
+                                    data-testId="table-tittle">
+                                    {{ 'edit.content.sidebar.history.menu.previous' | dm }}
+                                </span>
                             </div>
-                        }
-                    </div>
-                </th>
+                            @if ($showActions()) {
+                                <div class="dot-content-compare-table__controls">
+                                    <p-select
+                                        [ngModel]="data.compare"
+                                        (onChange)="changeVersion.emit($event.value)"
+                                        [options]="data.versions"
+                                        dataKey="inode"
+                                        data-testid="versions-dropdown"
+                                        appendTo="body">
+                                        <ng-template let-selected pTemplate="selectedItem">
+                                            {{
+                                                (selected.modDate
+                                                    | dotRelativeDate: 'MM/dd/yyyy - hh:mm aa') +
+                                                    (' by ' | dm) +
+                                                    selected.modUserName
+                                            }}
+                                        </ng-template>
+                                        <ng-template let-item pTemplate="item">
+                                            {{
+                                                (item.modDate
+                                                    | dotRelativeDate: 'MM/dd/yyyy - hh:mm aa') +
+                                                    (' by ' | dm) +
+                                                    item.modUserName
+                                            }}
+                                        </ng-template>
+                                    </p-select>
+                                    <p-selectButton
+                                        (onChange)="changeDiff.emit($event.value)"
+                                        [(ngModel)]="showDiff"
+                                        [options]="displayOptions"
+                                        styleClass="p-button-compact"
+                                        data-testid="show-diff" />
+                                    <p-button
+                                        (click)="bringBack.emit(data.compare.inode)"
+                                        [label]="'Bring-Back' | dm"
+                                        size="small"
+                                        data-testId="table-bring-back" />
+                                </div>
+                            }
+                        </div>
+                    </th>
+                } @else {
+                    <th>
+                        <div class="flex flex-col gap-2">
+                            <div class="flex">
+                                <span
+                                    class="dot-content-compare-table__title"
+                                    data-testId="table-tittle">
+                                    {{ 'edit.content.sidebar.history.menu.previous' | dm }}
+                                </span>
+                            </div>
+                            @if ($showActions()) {
+                                <div class="dot-content-compare-table__controls">
+                                    <p-select
+                                        [ngModel]="data.compare"
+                                        (onChange)="changeVersion.emit($event.value)"
+                                        [options]="data.versions"
+                                        dataKey="inode"
+                                        data-testid="versions-dropdown"
+                                        appendTo="body">
+                                        <ng-template let-selected pTemplate="selectedItem">
+                                            {{
+                                                (selected.modDate
+                                                    | dotRelativeDate: 'MM/dd/yyyy - hh:mm aa') +
+                                                    (' by ' | dm) +
+                                                    selected.modUserName
+                                            }}
+                                        </ng-template>
+                                        <ng-template let-item pTemplate="item">
+                                            {{
+                                                (item.modDate
+                                                    | dotRelativeDate: 'MM/dd/yyyy - hh:mm aa') +
+                                                    (' by ' | dm) +
+                                                    item.modUserName
+                                            }}
+                                        </ng-template>
+                                    </p-select>
+                                    <p-selectButton
+                                        (onChange)="changeDiff.emit($event.value)"
+                                        [(ngModel)]="showDiff"
+                                        [options]="displayOptions"
+                                        styleClass="p-button-compact"
+                                        data-testid="show-diff" />
+                                    <p-button
+                                        (click)="bringBack.emit(data.compare.inode)"
+                                        [label]="'Bring-Back' | dm"
+                                        size="small"
+                                        data-testId="table-bring-back" />
+                                </div>
+                            }
+                        </div>
+                    </th>
+                    <th>
+                        <span class="dot-content-compare-table__title" data-testId="table-tittle">
+                            {{ 'edit.content.sidebar.history.menu.current' | dm }}
+                        </span>
+                    </th>
+                }
             </tr>
         </ng-template>
         <ng-template pTemplate="body" let-field>
@@ -65,112 +123,230 @@
                 <td>{{ field.name }}</td>
                 @switch (field?.fieldType) {
                     @case ('Image') {
-                        <td>
-                            @if (data.working[field.variable]) {
-                                <img
-                                    [alt]="data.working[field.variable]"
-                                    [src]="'/dA/' + data.working[field.variable] + '/20q'"
-                                    data-testId="table-image-working" />
-                            }
-                        </td>
-                        <td>
-                            @if (data.compare[field.variable]) {
-                                <img
-                                    [alt]="data.compare[field.variable]"
-                                    [src]="'/dA/' + data.compare[field.variable] + '/20q'"
-                                    data-testId="table-image-compare" />
-                            }
-                        </td>
+                        @if (!$reverseColumns()) {
+                            <td>
+                                @if (data.working[field.variable]) {
+                                    <img
+                                        [alt]="data.working[field.variable]"
+                                        [src]="'/dA/' + data.working[field.variable] + '/20q'"
+                                        data-testId="table-image-working" />
+                                }
+                            </td>
+                            <td>
+                                @if (data.compare[field.variable]) {
+                                    <img
+                                        [alt]="data.compare[field.variable]"
+                                        [src]="'/dA/' + data.compare[field.variable] + '/20q'"
+                                        data-testId="table-image-compare" />
+                                }
+                            </td>
+                        } @else {
+                            <td>
+                                @if (data.compare[field.variable]) {
+                                    <img
+                                        [alt]="data.compare[field.variable]"
+                                        [src]="'/dA/' + data.compare[field.variable] + '/20q'"
+                                        data-testId="table-image-compare" />
+                                }
+                            </td>
+                            <td>
+                                @if (data.working[field.variable]) {
+                                    <img
+                                        [alt]="data.working[field.variable]"
+                                        [src]="'/dA/' + data.working[field.variable] + '/20q'"
+                                        data-testId="table-image-working" />
+                                }
+                            </td>
+                        }
                     }
                     @case ('File') {
-                        <td>
-                            @if (data.working[field.variable]) {
-                                <dot-content-compare-preview-field
-                                    [fileURL]="
-                                        '/dA/' + data.working[field.variable] + '/fileAsset/'
-                                    "
-                                    [label]="'/dA/' + data.working[field.variable] + '/fileAsset/'"
-                                    data-testId="table-file-working" />
-                            }
-                        </td>
-                        <td>
-                            @if (data.compare[field.variable]) {
-                                <dot-content-compare-preview-field
-                                    [fileURL]="
-                                        '/dA/' + data.compare[field.variable] + '/fileAsset/'
-                                    "
-                                    [label]="
-                                        '/dA/' + data.working[field.variable] + '/fileAsset/'
-                                            | dotDiff
-                                                : '/dA/' +
-                                                      data.compare[field.variable] +
-                                                      '/fileAsset/'
-                                                : showDiff
-                                    "
-                                    data-testId="table-file-compare" />
-                            }
-                        </td>
+                        @if (!$reverseColumns()) {
+                            <td>
+                                @if (data.working[field.variable]) {
+                                    <dot-content-compare-preview-field
+                                        [fileURL]="
+                                            '/dA/' + data.working[field.variable] + '/fileAsset/'
+                                        "
+                                        [label]="
+                                            '/dA/' + data.working[field.variable] + '/fileAsset/'
+                                        "
+                                        data-testId="table-file-working" />
+                                }
+                            </td>
+                            <td>
+                                @if (data.compare[field.variable]) {
+                                    <dot-content-compare-preview-field
+                                        [fileURL]="
+                                            '/dA/' + data.compare[field.variable] + '/fileAsset/'
+                                        "
+                                        [label]="
+                                            '/dA/' + data.working[field.variable] + '/fileAsset/'
+                                                | dotDiff
+                                                    : '/dA/' +
+                                                          data.compare[field.variable] +
+                                                          '/fileAsset/'
+                                                    : showDiff
+                                        "
+                                        data-testId="table-file-compare" />
+                                }
+                            </td>
+                        } @else {
+                            <td>
+                                @if (data.compare[field.variable]) {
+                                    <dot-content-compare-preview-field
+                                        [fileURL]="
+                                            '/dA/' + data.compare[field.variable] + '/fileAsset/'
+                                        "
+                                        [label]="
+                                            '/dA/' + data.working[field.variable] + '/fileAsset/'
+                                                | dotDiff
+                                                    : '/dA/' +
+                                                          data.compare[field.variable] +
+                                                          '/fileAsset/'
+                                                    : showDiff
+                                        "
+                                        data-testId="table-file-compare" />
+                                }
+                            </td>
+                            <td>
+                                @if (data.working[field.variable]) {
+                                    <dot-content-compare-preview-field
+                                        [fileURL]="
+                                            '/dA/' + data.working[field.variable] + '/fileAsset/'
+                                        "
+                                        [label]="
+                                            '/dA/' + data.working[field.variable] + '/fileAsset/'
+                                        "
+                                        data-testId="table-file-working" />
+                                }
+                            </td>
+                        }
                     }
                     @case ('Binary') {
-                        <td>
-                            @if (data.working[field.variable + 'Version']) {
-                                <dot-content-compare-preview-field
-                                    [fileURL]="data.working[field.variable + 'Version']"
-                                    [label]="data.working[field.variable + 'Version']"
-                                    data-testId="table-binary-working" />
-                            }
-                        </td>
-                        <td>
-                            @if (data.compare[field.variable + 'Version']) {
-                                <dot-content-compare-preview-field
-                                    [fileURL]="data.compare[field.variable + 'Version']"
-                                    [label]="
-                                        data.working[field.variable + 'Version']
-                                            | dotDiff
-                                                : data.compare[field.variable + 'Version']
-                                                : showDiff
-                                    "
-                                    data-testId="table-binary-compare" />
-                            }
-                        </td>
+                        @if (!$reverseColumns()) {
+                            <td>
+                                @if (data.working[field.variable + 'Version']) {
+                                    <dot-content-compare-preview-field
+                                        [fileURL]="data.working[field.variable + 'Version']"
+                                        [label]="data.working[field.variable + 'Version']"
+                                        data-testId="table-binary-working" />
+                                }
+                            </td>
+                            <td>
+                                @if (data.compare[field.variable + 'Version']) {
+                                    <dot-content-compare-preview-field
+                                        [fileURL]="data.compare[field.variable + 'Version']"
+                                        [label]="
+                                            data.working[field.variable + 'Version']
+                                                | dotDiff
+                                                    : data.compare[field.variable + 'Version']
+                                                    : showDiff
+                                        "
+                                        data-testId="table-binary-compare" />
+                                }
+                            </td>
+                        } @else {
+                            <td>
+                                @if (data.compare[field.variable + 'Version']) {
+                                    <dot-content-compare-preview-field
+                                        [fileURL]="data.compare[field.variable + 'Version']"
+                                        [label]="
+                                            data.working[field.variable + 'Version']
+                                                | dotDiff
+                                                    : data.compare[field.variable + 'Version']
+                                                    : showDiff
+                                        "
+                                        data-testId="table-binary-compare" />
+                                }
+                            </td>
+                            <td>
+                                @if (data.working[field.variable + 'Version']) {
+                                    <dot-content-compare-preview-field
+                                        [fileURL]="data.working[field.variable + 'Version']"
+                                        [label]="data.working[field.variable + 'Version']"
+                                        data-testId="table-binary-working" />
+                                }
+                            </td>
+                        }
                     }
                     @case ('JSON-Field') {
-                        <td
-                            [innerHTML]="data.working[field.variable] | json"
-                            data-testId="table-json-working"></td>
-                        <td
-                            [innerHTML]="
-                                data.working[field.variable]
-                                    | json
-                                    | dotDiff: (data.compare[field.variable] | json) : showDiff
-                            "
-                            data-testId="table-json-compare"></td>
+                        @if (!$reverseColumns()) {
+                            <td
+                                [innerHTML]="data.working[field.variable] | json"
+                                data-testId="table-json-working"></td>
+                            <td
+                                [innerHTML]="
+                                    data.working[field.variable]
+                                        | json
+                                        | dotDiff: (data.compare[field.variable] | json) : showDiff
+                                "
+                                data-testId="table-json-compare"></td>
+                        } @else {
+                            <td
+                                [innerHTML]="
+                                    data.working[field.variable]
+                                        | json
+                                        | dotDiff: (data.compare[field.variable] | json) : showDiff
+                                "
+                                data-testId="table-json-compare"></td>
+                            <td
+                                [innerHTML]="data.working[field.variable] | json"
+                                data-testId="table-json-working"></td>
+                        }
                     }
                     @case ('Story-Block') {
-                        <td>
-                            <dot-content-compare-block-editor
-                                [field]="field.variable"
-                                [data]="data"
-                                [showAsCompare]="false" />
-                        </td>
-                        <td>
-                            <dot-content-compare-block-editor
-                                [showDiff]="showDiff"
-                                [field]="field.variable"
-                                [data]="data"
-                                [showAsCompare]="true" />
-                        </td>
+                        @if (!$reverseColumns()) {
+                            <td>
+                                <dot-content-compare-block-editor
+                                    [field]="field.variable"
+                                    [data]="data"
+                                    [showAsCompare]="false" />
+                            </td>
+                            <td>
+                                <dot-content-compare-block-editor
+                                    [showDiff]="showDiff"
+                                    [field]="field.variable"
+                                    [data]="data"
+                                    [showAsCompare]="true" />
+                            </td>
+                        } @else {
+                            <td>
+                                <dot-content-compare-block-editor
+                                    [showDiff]="showDiff"
+                                    [field]="field.variable"
+                                    [data]="data"
+                                    [showAsCompare]="true" />
+                            </td>
+                            <td>
+                                <dot-content-compare-block-editor
+                                    [field]="field.variable"
+                                    [data]="data"
+                                    [showAsCompare]="false" />
+                            </td>
+                        }
                     }
                     @default {
-                        <td
-                            [innerHTML]="data.working[field.variable]"
-                            data-testId="table-field-working"></td>
-                        <td
-                            [innerHTML]="
-                                data.working[field.variable]
-                                    | dotDiff: data.compare[field.variable] : showDiff
-                            "
-                            data-testId="table-field-compare"></td>
+                        @if (!$reverseColumns()) {
+                            <td
+                                [innerHTML]="data.working[field.variable]"
+                                data-testId="table-field-working"></td>
+                            <td
+                                [innerHTML]="
+                                    data.working[field.variable]
+                                        | dotDiff: data.compare[field.variable] : showDiff
+                                "
+                                data-testId="table-field-compare"></td>
+                        } @else {
+                            <td
+                                [innerHTML]="
+                                    data.working[field.variable]
+                                        | dotDiff: data.compare[field.variable] : showDiff
+                                "
+                                data-testId="table-field-compare"></td>
+                            <td
+                                [innerHTML]="data.working[field.variable]"
+                                data-testId="table-field-working"></td>
+                        }
                     }
                 }
             </tr>

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.ts
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/components/dot-content-compare-table/dot-content-compare-table.component.ts
@@ -39,6 +39,12 @@ export class DotContentCompareTableComponent {
     @Input() data: DotContentCompareTableData;
     @Input() showDiff: boolean;
     $showActions = input<boolean>(true, { alias: 'showActions' });
+    /**
+     * When `true`, swap the column order so the PREVIOUS (compare) version
+     * renders on the LEFT and the CURRENT (working) version on the RIGHT.
+     * Default `false` preserves the legacy layout (current LEFT / previous RIGHT).
+     */
+    readonly $reverseColumns = input<boolean>(false, { alias: 'reverseColumns' });
 
     @Output() changeVersion = new EventEmitter<DotCMSContentlet>();
     @Output() changeDiff = new EventEmitter<boolean>();

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/dot-content-compare.component.html
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/dot-content-compare.component.html
@@ -2,6 +2,7 @@
     @if (vm.data) {
         <dot-content-compare-table
             [showActions]="$showActions()"
+            [reverseColumns]="$reverseColumns()"
             (changeDiff)="store.updateShowDiff($event)"
             (changeVersion)="store.updateCompare($event)"
             (bringBack)="bringBack($event)"

--- a/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/dot-content-compare.component.ts
+++ b/core-web/libs/portlets/edit-ema/ui/src/lib/dot-content-compare/dot-content-compare.component.ts
@@ -28,6 +28,12 @@ export class DotContentCompareComponent {
         }
     }
     $showActions = input<boolean>(true, { alias: 'showActions' });
+    /**
+     * Forwards to `dot-content-compare-table`'s `reverseColumns` input.
+     * When `true`, the previous (compare) version renders on the LEFT and
+     * the current (working) version on the RIGHT.
+     */
+    readonly $reverseColumns = input<boolean>(false, { alias: 'reverseColumns' });
     @Output() shutdown = new EventEmitter<boolean>();
     @Output() letMeBringBack = new EventEmitter<{ name: string; args: string[] }>();
     vm$: Observable<DotContentCompareState> = this.store.vm$;

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6295,6 +6295,7 @@ edit.content.sidebar.history.restore.confirm.header=Are you sure you want to res
 edit.content.sidebar.history.restore.confirm.accept=Restore Version
 edit.content.sidebar.history.restore.confirm.reject=Cancel
 edit.content.sidebar.history.return.to.current=Return to current version
+edit.content.sidebar.history.copy.inode=Copy Inode
 edit.content.sidebar.pushpublish.bundle.id.label=Bundle ID
 edit.content.sidebar.pushpublish.copy.bundle.id=Copy Bundle ID
 

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6294,6 +6294,9 @@ edit.content.sidebar.history.restore.confirm.message=By restoring this version y
 edit.content.sidebar.history.restore.confirm.header=Are you sure you want to restore this version?
 edit.content.sidebar.history.restore.confirm.accept=Restore Version
 edit.content.sidebar.history.restore.confirm.reject=Cancel
+edit.content.sidebar.history.return.to.current=Return to current version
+edit.content.sidebar.pushpublish.bundle.id.label=Bundle ID
+edit.content.sidebar.pushpublish.copy.bundle.id=Copy Bundle ID
 
 edit.content.sidebar.permissions.title=Permissions
 edit.content.sidebar.permissions.setup=Set up


### PR DESCRIPTION
## Summary

Polish the History tab Versions and Push Publish accordions in the new Edit Contentlet side panel. Addresses 10 small UI/UX bugs.

Closes #35559

## Acceptance Criteria

### Versions Accordion
- [x] Draft card (`working && !live`): no context-menu options
- [x] Published card (`live`): menu shows Restore + Compare (no Delete)
- [x] Other (`!working && !live`): menu shows Restore + Compare + Delete
- [x] Current viewed version card has distinct active highlight (defaults to working; switches when user clicks a historical card)
- [x] Status chips match Content Drive (`p-chip` with Tailwind classes `bg-{color}-100! text-{color}-700! border-{color}-100!`)
- [x] Kebab button visible only on active card OR on hover
- [x] Clicking outside an open p-menu closes it (PrimeNG default — preserved)
- [x] Selecting a menu action that opens a dialog also closes the p-menu (`versionMenu.hide()` in each command)
- [x] Compare view: previous version on left, current on right (opt-in `[reverseColumns]` on shared table, default false preserves legacy compare dialog)
- [x] Tertiary 'Return to current version' button in compare view, wired to new `exitCompareView()` store method
- [x] Restore confirmation dialog renders without icon
- [x] Delete confirmation dialog renders without icon

### Push Publish Accordion
- [x] Entries sorted newest-first by `pushDate` desc (applied in the store after API response)
- [x] 'Bundle ID' label rendered instead of truncated UUID; full UUID still copyable via `dot-copy-button`

## Changes

- `dot-history-timeline-item.component.{ts,html}` — rewrote `$menuItems` to filter by status; added `viewChild(Menu)` + `versionMenu.hide()` in each command; swapped `p-tag` for `p-chip` with Content Drive Tailwind classes; added group/group-hover + active-state opacity to the kebab wrapper; active-state styling on the card wrapper.
- `dot-edit-content-sidebar-history.component.html` — `[isActive]` binding now falls back to `item.working` when no historical version is being viewed.
- `dot-pushpublish-timeline-item.component.{ts,html}` — replaced truncated UUID display with i18n label 'Bundle ID'; removed `$truncatedBundleId` computed (no longer used).
- `dot-edit-content-compare.component.html` — added tertiary 'Return to current version' button and `[reverseColumns]=\"true\"` on `dot-content-compare`.
- `history.feature.ts` — added `exitCompareView()` method; removed `icon` property from Restore and Delete confirmation dialogs; sort push-publish history newest-first.
- `dot-content-compare-table.component.{ts,html}` + `dot-content-compare.component.{ts,html}` — added opt-in `reverseColumns` input (default false). When true, swaps the header labels and column data so previous renders left / current renders right. Legacy `dot-content-compare-dialog` consumes the table with the default false, so its layout is unchanged.
- `Language.properties` — added i18n keys: `edit.content.sidebar.history.return.to.current`, `edit.content.sidebar.pushpublish.bundle.id.label`, `edit.content.sidebar.pushpublish.copy.bundle.id`.
- Specs updated for the affected components.

## Test plan

- [x] `yarn nx affected:lint --base=origin/main` — clean (0 errors)
- [x] `yarn nx affected:test --base=origin/main` — all suites pass
- [ ] Manual smoke in dev server: open a contentlet in new Edit Contentlet mode, walk through each AC against the issue's video.

## Visual Changes

Pending screenshots — UI smoke test with the dev server is needed before this PR is marked ready.