### PR TITLE
fix(template-builder): stop echoing layout changes synchronously in templates portlet

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -215,13 +215,70 @@ describe('DotTemplateBuilderComponent', () => {
 
             expect(reloadSpy).toHaveBeenCalledTimes(1);
             expect(dotRouterService.forbidRouteDeactivation).toHaveBeenCalledTimes(1);
-            expect(updateSpy).toHaveBeenCalledWith(updated);
+            // updateTemplate is intentionally NOT emitted on every change — that previously
+            // caused a synchronous echo back into the designer's [layout] input and crashed
+            // updateOldRows when state had stale y values after a row removal.
+            expect(updateSpy).not.toHaveBeenCalled();
 
             tick(AUTOSAVE_DEBOUNCE_TIME - 1);
             expect(saveSpy).not.toHaveBeenCalled();
 
             tick(1);
             expect(saveSpy).toHaveBeenCalledWith(updated);
+        }));
+
+        // Regression guard: a row removal in the designer fires templateChange twice in
+        // quick succession (once from `removeRow`, once from `moveRow` after gridstack
+        // auto-compacts). If updateTemplate were emitted synchronously on either, the
+        // parent store's `working` signal would update and echo the layout straight back
+        // into the designer's `[layout]` input, triggering `updateOldRows` mid-cycle while
+        // state still had y gaps — producing corrupt rows / column reorders / duplicates.
+        // Keep this test alongside any future refactor: rapid templateChange MUST NOT emit
+        // updateTemplate synchronously.
+        it('should never echo templateChange synchronously back to parent (regression)', fakeAsync(() => {
+            const item = createDesignItem({ identifier: 'id-1' });
+            spectator.setInput('item', item);
+
+            const updateSpy = jest.spyOn(spectator.component.updateTemplate, 'emit');
+            const saveSpy = jest.spyOn(spectator.component.save, 'emit');
+
+            spectator.detectChanges();
+
+            const afterRemoveRow = createDesignItem({
+                identifier: 'id-1',
+                layout: { body: { rows: [{ stale: 'y=2' } as any] } }
+            });
+            const afterMoveRow = createDesignItem({
+                identifier: 'id-1',
+                layout: { body: { rows: [{ compact: 'y=1' } as any] } }
+            });
+
+            // First emission — state immediately after removeRow (y gap present).
+            spectator.triggerEventHandler(
+                'dotcms-template-builder-lib',
+                'templateChange',
+                afterRemoveRow
+            );
+            // Second emission — state after moveRow auto-compaction. Fires synchronously
+            // in the same tick as the first because moveRow runs inside the rows.changes
+            // subscriber during CD.
+            spectator.triggerEventHandler(
+                'dotcms-template-builder-lib',
+                'templateChange',
+                afterMoveRow
+            );
+
+            // Critical: neither emission should have synchronously echoed back.
+            expect(updateSpy).not.toHaveBeenCalled();
+            expect(saveSpy).not.toHaveBeenCalled();
+            expect(spectator.component.lastTemplate).toBe(afterMoveRow);
+
+            // After debounce, exactly one save with the LATEST item — proving the dual
+            // emission collapses to a single backend round-trip with consistent state.
+            tick(AUTOSAVE_DEBOUNCE_TIME);
+            expect(saveSpy).toHaveBeenCalledTimes(1);
+            expect(saveSpy).toHaveBeenCalledWith(afterMoveRow);
+            expect(updateSpy).not.toHaveBeenCalled();
         }));
     });
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.spec.ts
@@ -233,8 +233,15 @@ describe('DotTemplateBuilderComponent', () => {
         // parent store's `working` signal would update and echo the layout straight back
         // into the designer's `[layout]` input, triggering `updateOldRows` mid-cycle while
         // state still had y gaps — producing corrupt rows / column reorders / duplicates.
-        // Keep this test alongside any future refactor: rapid templateChange MUST NOT emit
-        // updateTemplate synchronously.
+        //
+        // Two assertions matter and they're complementary:
+        //   (1) `updateTemplate.emit` is never called synchronously — the wrapper contract.
+        //   (2) The lib's `[layout]` input reference does not change across the rapid
+        //       templateChange emissions in the same tick — the actual bug shape. A future
+        //       refactor that re-introduces the echo via an indirect path (e.g. moving
+        //       update logic into the parent's (templateChange) handler) would still pass
+        //       assertion (1) but fail (2), which is the one that actually keeps the
+        //       designer's state-merging path quiet during the rapid emissions.
         it('should never echo templateChange synchronously back to parent (regression)', fakeAsync(() => {
             const item = createDesignItem({ identifier: 'id-1' });
             spectator.setInput('item', item);
@@ -243,6 +250,9 @@ describe('DotTemplateBuilderComponent', () => {
             const saveSpy = jest.spyOn(spectator.component.save, 'emit');
 
             spectator.detectChanges();
+
+            const builderDe = spectator.debugElement.query(By.css('dotcms-template-builder-lib'));
+            const layoutBefore = builderDe.componentInstance.layout;
 
             const afterRemoveRow = createDesignItem({
                 identifier: 'id-1',
@@ -259,6 +269,10 @@ describe('DotTemplateBuilderComponent', () => {
                 'templateChange',
                 afterRemoveRow
             );
+            spectator.detectChanges();
+            // (2) The lib's [layout] input MUST NOT have been replaced by an echo.
+            expect(builderDe.componentInstance.layout).toBe(layoutBefore);
+
             // Second emission — state after moveRow auto-compaction. Fires synchronously
             // in the same tick as the first because moveRow runs inside the rows.changes
             // subscriber during CD.
@@ -267,8 +281,11 @@ describe('DotTemplateBuilderComponent', () => {
                 'templateChange',
                 afterMoveRow
             );
+            spectator.detectChanges();
+            // (2) Still the same reference after the second emission.
+            expect(builderDe.componentInstance.layout).toBe(layoutBefore);
 
-            // Critical: neither emission should have synchronously echoed back.
+            // (1) Wrapper contract — no synchronous emit from either templateChange.
             expect(updateSpy).not.toHaveBeenCalled();
             expect(saveSpy).not.toHaveBeenCalled();
             expect(spectator.component.lastTemplate).toBe(afterMoveRow);

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
@@ -92,7 +92,14 @@ export class DotTemplateBuilderComponent implements OnInit, OnDestroy {
 
         this.#dotRouterService.forbidRouteDeactivation();
         this.lastTemplate = item;
-        this.updateTemplate.emit(item);
+        // We intentionally do NOT call `updateTemplate.emit(item)` here. Doing so updates
+        // the parent store's `working` state, which echoes back through `[item]="vm.working"`
+        // → `[layout]="item.layout"` → ngOnChanges → updateOldRows. That round-trip happens
+        // synchronously on each templateChange and assumes state.row.y matches newRows.y.
+        // After removeRow, state has gaps in y (e.g. [0, 2]) while parsed newRows has
+        // sequential y ([0, 1]), so updateOldRows produced corrupt rows. Mirrors the EMA
+        // pattern (edit-ema-layout.component.ts) — the layout only flows back to the
+        // designer after a successful save (via onSaveTemplate updating original+working).
         this.templateUpdate$.next(item);
     }
 

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-templates/dot-template-create-edit/dot-template-builder/dot-template-builder.component.ts
@@ -94,12 +94,18 @@ export class DotTemplateBuilderComponent implements OnInit, OnDestroy {
         this.lastTemplate = item;
         // We intentionally do NOT call `updateTemplate.emit(item)` here. Doing so updates
         // the parent store's `working` state, which echoes back through `[item]="vm.working"`
-        // → `[layout]="item.layout"` → ngOnChanges → updateOldRows. That round-trip happens
-        // synchronously on each templateChange and assumes state.row.y matches newRows.y.
-        // After removeRow, state has gaps in y (e.g. [0, 2]) while parsed newRows has
-        // sequential y ([0, 1]), so updateOldRows produced corrupt rows. Mirrors the EMA
+        // → `[layout]="item.layout"` → ngOnChanges → updateOldRows (see
+        // libs/template-builder/.../template-builder.component.ts ngOnChanges). That round-
+        // trip happens synchronously on each templateChange and assumes state.row.y matches
+        // newRows.y. After removeRow, state has gaps in y (e.g. [0, 2]) while parsed newRows
+        // has sequential y ([0, 1]), so updateOldRows produced corrupt rows. Mirrors the EMA
         // pattern (edit-ema-layout.component.ts) — the layout only flows back to the
         // designer after a successful save (via onSaveTemplate updating original+working).
+        // NOTE: the layout still echoes back on save-emit via the store's synchronous
+        // updateWorkingTemplate in saveTemplate (store/dot-template.store.ts:199-202), but
+        // only at debounce-fire time when the lib has been idle for 5s — narrowed, not
+        // eliminated. If you ever change the save trigger to fire faster or in response
+        // to a non-debounced event, re-evaluate this cycle.
         this.templateUpdate$.next(item);
     }
 


### PR DESCRIPTION
## Summary

Closes #35697.

- Drop the immediate `updateTemplate.emit(item)` in the templates portlet wrapper (`dot-template-builder.component.ts`). It was echoing layout changes synchronously back into the designer's `[layout]` input, triggering `updateOldRows` mid-cycle while state had gaps in `y` (e.g. `[0, 2]` right after `removeRow`, before grid auto-compact + `moveRow` collapse to `[0, 1]`). That mismatch silently produced rows with `children: undefined` and missing `x/y/w/h` — visible as columns reordering or rows duplicating after a row deletion.
- Now mirrors the EMA pattern (`edit-ema-layout.component.ts`): layout only flows back to the designer after a **successful save** (`onSaveTemplate` updates both `working` and `original`). Auto-save still fires via the existing 5s `templateUpdate$` debounce; `forbidRouteDeactivation()` continues to block navigation on every edit.
- The template-builder library (`libs/template-builder`) is **untouched** — root cause was in the consumer.

## Why this regressed now

Commit `ab89c85e10` (PR #35277) switched `@for` row tracking from `identify(row)` (id+index) to `row.id`. Before that change, removing a row shifted indices and forced Angular to destroy/recreate every subsequent row, which incidentally reset GridStack state and masked this latent `updateOldRows` corruption. EMA was always immune because its layout signal only changes after save.

## Test plan

### Demo

https://github.com/user-attachments/assets/33a2ca11-9974-48a7-ba7f-260f6aea5eb0


### Manual

- [ ] Open a design template in `/templates/edit/<id>`, ≥ 3 rows with non-zero-x columns.
- [ ] Delete a middle row → only that row goes; other rows' columns stay put; no duplicates.
- [ ] Make a change, wait ~5s → auto-save fires.
- [ ] Make a change, immediately navigate away → page-leave prompt blocks navigation until save completes.
- [ ] EMA layout editor unchanged — repeat row delete there to confirm no regression.

### Automated

- [x] New regression test in `dot-template-builder.component.spec.ts` fires two rapid `templateChange` emissions (simulating `removeRow` → `moveRow`) and asserts `updateTemplate.emit` is never called synchronously, while a single debounced `save.emit` fires with the latest item.
- [x] Existing `should react to templateChange output` updated to match the new contract.
- [x] `yarn nx test dotcms-ui` — 2129 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)