### PR TITLE
fix(page-cache): include original request URI in cache key for vanity URL 200-forwards (#35696)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityLiveMode.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/servlet/VelocityLiveMode.java
@@ -214,13 +214,22 @@ public class VelocityLiveMode extends VelocityModeHandler {
      * @param htmlPage the HTML page being served
      * @return PageCacheParameters instance with all cache keys
      */
-    private PageCacheParameters buildCacheParameters(final long langId, final IHTMLPage htmlPage) {
+    PageCacheParameters buildCacheParameters(final long langId, final IHTMLPage htmlPage) {
         String userId = (getUser() != null) ? getUser().getUserId() : "anonymous";
         String language = String.valueOf(langId);
         String urlMap = (String) request.getAttribute(WebKeys.WIKI_CONTENTLET_INODE);
         String vanityUrl = request.getAttribute(VANITY_URL_OBJECT) != null
                 ? ((CachedVanityUrl) request.getAttribute(VANITY_URL_OBJECT)).vanityUrlId
                 : "";
+
+        // When served via a vanity URL 200-forward, include the original request URI in the cache
+        // key so different incoming URLs forwarded to the same page don't share a cache entry.
+        // CMSFilter dispatches to VelocityServlet via RequestDispatcher.forward(), so Tomcat sets
+        // FORWARD_REQUEST_URI to the original browser URL before the forward happened.
+        String originalRequestUri = (request.getAttribute(VANITY_URL_OBJECT) != null
+                && ((CachedVanityUrl) request.getAttribute(VANITY_URL_OBJECT)).isForward())
+                ? (String) request.getAttribute(RequestDispatcher.FORWARD_REQUEST_URI)
+                : null;
 
         String queryString = PageCacheParameters.filterQueryString(request.getQueryString());
         String persona = Try.of(() -> visitorAPI.getVisitor(request, false).get().getPersona().getKeyTag())
@@ -241,6 +250,7 @@ public class VelocityLiveMode extends VelocityModeHandler {
                 "pageInode:" + htmlPage.getInode(),
                 "modDate:" + modDate.getTime(),
                 "vanity:" + vanityUrl,
+                originalRequestUri != null ? "originalUri:" + originalRequestUri : null,
                 "variant:" + variant
         );
     }

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/servlet/VelocityLiveModeTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/servlet/VelocityLiveModeTest.java
@@ -1,6 +1,8 @@
 package com.dotcms.rendering.velocity.servlet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -18,6 +20,9 @@ import com.dotcms.datagen.SiteDataGen;
 import com.dotcms.datagen.TemplateDataGen;
 import com.dotcms.mock.request.DotCMSMockRequestWithSession;
 import com.dotcms.security.ContentSecurityPolicyUtil;
+import com.dotcms.vanityurl.model.CachedVanityUrl;
+import com.dotmarketing.business.PageCacheParameters;
+import com.dotmarketing.filters.Constants;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotcms.visitor.domain.Visitor;
 import com.dotmarketing.beans.Clickstream;
@@ -35,6 +40,7 @@ import com.dotmarketing.util.WebKeys;
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
@@ -45,6 +51,7 @@ import org.junit.runner.RunWith;
 @RunWith(DataProviderRunner.class)
 public class VelocityLiveModeTest {
 
+    @BeforeClass
     public static void prepare() throws Exception {
         //Setting web app environment
         IntegrationTestInitService.getInstance().init();
@@ -162,6 +169,69 @@ public class VelocityLiveModeTest {
         } finally {
             Config.setProperty("ContentSecurityPolicy.header", previousValue);
         }
+    }
+
+    /**
+     * Method: {@link VelocityLiveMode#buildCacheParameters(long, IHTMLPage)}
+     * When: Two requests go through the same vanity URL 200-forward to the same page but carry
+     *       different original request URIs in FORWARD_REQUEST_URI
+     * Should: Produce different cache keys so each URL gets its own cache entry, preventing
+     *         the page cache collision bug where one affiliate's content is served to another
+     */
+    @Test
+    public void vanityForwardDifferentOriginalUriProducesDifferentCacheKeys()
+            throws DotDataException, DotSecurityException, WebAssetException {
+
+        final Host host = new SiteDataGen().nextPersisted();
+        final Template template = new TemplateDataGen().site(host).nextPersisted();
+        TemplateDataGen.publish(template);
+        final HTMLPageAsset detailPage = new HTMLPageDataGen(host, template)
+                .pageURL("detail-page")
+                .cacheTTL(3600)
+                .nextPersisted();
+        HTMLPageDataGen.publish(detailPage);
+
+        // A vanity URL that regex-forwards multiple incoming URLs to the same detail page
+        final CachedVanityUrl vanity = new CachedVanityUrl(
+                "test-vanity-id",
+                "/store/([0-9]+)/.*",
+                1L,
+                host.getIdentifier(),
+                detailPage.getURI(),
+                javax.servlet.http.HttpServletResponse.SC_OK, // 200 = forward
+                1
+        );
+
+        final HttpServletResponse response = mock(HttpServletResponse.class);
+        when(response.getStatus()).thenReturn(200);
+        when(response.getHeader("Cache-Control")).thenReturn(null);
+        final HttpSession session = mock(HttpSession.class);
+
+        // Request 1: affiliate 123 hits /store/123/acme/catalog/
+        final DotCMSMockRequestWithSession req1 = new DotCMSMockRequestWithSession(session, false);
+        req1.setRequestURI(detailPage.getURI());
+        req1.setAttribute(Constants.VANITY_URL_OBJECT, vanity);
+        req1.setAttribute(RequestDispatcher.FORWARD_REQUEST_URI, "/store/123/acme/catalog/");
+
+        // Request 2: affiliate 456 hits /store/456/globex/catalog/
+        final DotCMSMockRequestWithSession req2 = new DotCMSMockRequestWithSession(session, false);
+        req2.setRequestURI(detailPage.getURI());
+        req2.setAttribute(Constants.VANITY_URL_OBJECT, vanity);
+        req2.setAttribute(RequestDispatcher.FORWARD_REQUEST_URI, "/store/456/globex/catalog/");
+
+        final VelocityLiveMode handler1 = new VelocityLiveMode(req1, response, detailPage, host);
+        final VelocityLiveMode handler2 = new VelocityLiveMode(req2, response, detailPage, host);
+
+        final PageCacheParameters params1 = handler1.buildCacheParameters(1L, detailPage);
+        final PageCacheParameters params2 = handler2.buildCacheParameters(1L, detailPage);
+
+        assertNotEquals(
+                "Vanity URL forward requests with different original URIs must produce different cache keys",
+                params1.getKey(), params2.getKey());
+        assertTrue("Cache key must include the original request URI for request 1",
+                params1.getKey().contains("originalUri:/store/123/acme/catalog/"));
+        assertTrue("Cache key must include the original request URI for request 2",
+                params2.getKey().contains("originalUri:/store/456/globex/catalog/"));
     }
 
     private static class TestCase {


### PR DESCRIPTION
## What does this PR do?

Fixes a page cache key collision where multiple vanity URL 200-forward requests routed to the same detail page all shared an identical cache key. The first request warmed the cache and every subsequent request — regardless of the actual incoming URL — received that cached response.

Closes #35696

## Why is this a problem?

`VelocityLiveMode.buildCacheParameters()` composed the cache key from `pageUrl` (the forwarded-to path), `pageInode`, `vanityUrlId`, etc. — none of which differ between `/store/123/acme/catalog/` and `/store/456/globex/catalog/` when both forward to the same page via the same vanity URL rule.

On multi-node clusters with round-robin load balancing, different nodes cached different affiliates' content under the same key, causing wrong content on every other request for the full TTL duration (up to 1 hour).

## What is the fix?

When `VANITY_URL_OBJECT` is present on the request and `isForward() == true`, include `RequestDispatcher.FORWARD_REQUEST_URI` as an `originalUri:` component in the cache key. This is the original browser URL set by Tomcat when CMSFilter forwards to VelocityServlet via `RequestDispatcher.forward()`.

```java
String originalRequestUri = (request.getAttribute(VANITY_URL_OBJECT) != null
        && ((CachedVanityUrl) request.getAttribute(VANITY_URL_OBJECT)).isForward())
        ? (String) request.getAttribute(RequestDispatcher.FORWARD_REQUEST_URI)
        : null;
```

Non-vanity pages and vanity redirects (301/302) are unaffected — `null` is filtered out of the key by `PageCacheParameters`.

## Relation to #34879

PR #34879 fixed the same collision class for URL-mapped contentlets via `WIKI_CONTENTLET_INODE`. The vanity URL 200-forward path was not addressed by that fix.

## Testing

- New integration test: `VelocityLiveModeTest#vanityForwardDifferentOriginalUriProducesDifferentCacheKeys`
- Verified locally against customer's dev environment (Freshdesk #37004) — different affiliate URLs now produce different cache keys and serve correct content

## Checklist
- [x] Tests added
- [x] Existing tests pass
- [x] No new public API changes (package-private visibility change on `buildCacheParameters()` for testability only)