### PR TITLE
fix(ci): use matching Java base image for dotcms-dev variant builds

### DIFF
--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -165,9 +165,12 @@ jobs:
           # This convention may be revisited in future.
 
           # Use provided java-version if set, otherwise read from .sdkmanrc
+          JAVA_MAJOR=""
           if [ -n "${{ inputs.java-version }}" ]; then
             SDKMAN_JAVA_VERSION="${{ inputs.java-version }}"
             echo "Using override Java version: ${SDKMAN_JAVA_VERSION}"
+
+            JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
 
             # Compute Java suffix for artifact isolation
             # Priority: explicit artifact-suffix > derived from java-version major
@@ -175,7 +178,6 @@ jobs:
               RAW_SUFFIX="${{ inputs.artifact-suffix }}"
               echo "Using explicit artifact suffix: ${RAW_SUFFIX}"
             else
-              JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
               RAW_SUFFIX="java-${JAVA_MAJOR}"
               echo "Using derived artifact suffix: ${RAW_SUFFIX}"
             fi
@@ -196,6 +198,7 @@ jobs:
           elif [ -f .sdkmanrc ]; then
             SDKMAN_JAVA_VERSION=$(awk -F "=" '/^java=/ {print $2}' .sdkmanrc)
             echo "Using default Java version from .sdkmanrc: ${SDKMAN_JAVA_VERSION}"
+            JAVA_MAJOR=$(echo "${SDKMAN_JAVA_VERSION}" | grep -oE '^[0-9]+')
             RAW_SUFFIX=""
             MAVEN_SUFFIX=""
             DOCKER_SUFFIX=""
@@ -206,6 +209,7 @@ jobs:
 
           {
             echo "SDKMAN_JAVA_VERSION=${SDKMAN_JAVA_VERSION}"
+            echo "java_major=${JAVA_MAJOR}"
             echo "raw_suffix=${RAW_SUFFIX}"
             echo "maven_suffix=${MAVEN_SUFFIX}"
             echo "docker_suffix=${DOCKER_SUFFIX}"
@@ -306,6 +310,7 @@ jobs:
             DOTCMS_DOCKER_TAG=${{ steps.docker-tags.outputs.base_tag }}
             DEV_REQUEST_TOKEN=${{ secrets.DEV_REQUEST_TOKEN }}
             SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
+            JAVA_BASE_IMAGE=mcr.microsoft.com/openjdk/jdk:${{ steps.get-sdkman-version.outputs.java_major }}-ubuntu
           artifact_suffix: ${{ steps.get-sdkman-version.outputs.maven_suffix }}
           identifier-tag: ${{ steps.docker-tags.outputs.identifier_tag }}
           extra-tags: ${{ steps.get-sdkman-version.outputs.raw_suffix != '' && format('type=raw,value={0},enable=true', steps.get-sdkman-version.outputs.raw_suffix) || '' }}

--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -165,12 +165,9 @@ jobs:
           # This convention may be revisited in future.
 
           # Use provided java-version if set, otherwise read from .sdkmanrc
-          JAVA_MAJOR=""
           if [ -n "${{ inputs.java-version }}" ]; then
             SDKMAN_JAVA_VERSION="${{ inputs.java-version }}"
             echo "Using override Java version: ${SDKMAN_JAVA_VERSION}"
-
-            JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
 
             # Compute Java suffix for artifact isolation
             # Priority: explicit artifact-suffix > derived from java-version major
@@ -178,6 +175,7 @@ jobs:
               RAW_SUFFIX="${{ inputs.artifact-suffix }}"
               echo "Using explicit artifact suffix: ${RAW_SUFFIX}"
             else
+              JAVA_MAJOR=$(echo "${{ inputs.java-version }}" | grep -oE '^[0-9]+')
               RAW_SUFFIX="java-${JAVA_MAJOR}"
               echo "Using derived artifact suffix: ${RAW_SUFFIX}"
             fi
@@ -198,7 +196,6 @@ jobs:
           elif [ -f .sdkmanrc ]; then
             SDKMAN_JAVA_VERSION=$(awk -F "=" '/^java=/ {print $2}' .sdkmanrc)
             echo "Using default Java version from .sdkmanrc: ${SDKMAN_JAVA_VERSION}"
-            JAVA_MAJOR=$(echo "${SDKMAN_JAVA_VERSION}" | grep -oE '^[0-9]+')
             RAW_SUFFIX=""
             MAVEN_SUFFIX=""
             DOCKER_SUFFIX=""
@@ -209,7 +206,6 @@ jobs:
 
           {
             echo "SDKMAN_JAVA_VERSION=${SDKMAN_JAVA_VERSION}"
-            echo "java_major=${JAVA_MAJOR}"
             echo "raw_suffix=${RAW_SUFFIX}"
             echo "maven_suffix=${MAVEN_SUFFIX}"
             echo "docker_suffix=${DOCKER_SUFFIX}"
@@ -306,11 +302,10 @@ jobs:
           docker_io_username: ${{ secrets.DOCKER_USERNAME }}
           docker_io_token: ${{ secrets.DOCKER_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          pull: true
           build_args: |
             DOTCMS_DOCKER_TAG=${{ steps.docker-tags.outputs.base_tag }}
             DEV_REQUEST_TOKEN=${{ secrets.DEV_REQUEST_TOKEN }}
-            SDKMAN_JAVA_VERSION=${{ steps.get-sdkman-version.outputs.SDKMAN_JAVA_VERSION }}
-            JAVA_BASE_IMAGE=mcr.microsoft.com/openjdk/jdk:${{ steps.get-sdkman-version.outputs.java_major }}-ubuntu
           artifact_suffix: ${{ steps.get-sdkman-version.outputs.maven_suffix }}
           identifier-tag: ${{ steps.docker-tags.outputs.identifier_tag }}
           extra-tags: ${{ steps.get-sdkman-version.outputs.raw_suffix != '' && format('type=raw,value={0},enable=true', steps.get-sdkman-version.outputs.raw_suffix) || '' }}

--- a/docker/dev-env/Dockerfile
+++ b/docker/dev-env/Dockerfile
@@ -2,12 +2,10 @@
 # Stage 1:  Build dotCMS from our builder image
 # ----------------------------------------------
 ARG DOTCMS_DOCKER_TAG="latest"
-ARG JAVA_BASE_IMAGE="mcr.microsoft.com/openjdk/jdk:21-ubuntu"
 
 FROM dotcms/dotcms:${DOTCMS_DOCKER_TAG} AS dotcms
 
-FROM ${JAVA_BASE_IMAGE} AS dev-env-builder
-
+FROM ubuntu:24.04 AS dev-env-builder
 # Defining default non-root user UID, GID, and name 
 ARG USER_UID="65001"
 ARG USER_GID="65001"
@@ -54,15 +52,12 @@ RUN apt-get autoremove -y && \
 COPY --from=opensearchproject/opensearch:1 --chown=$USER_NAME:$USER_GROUP /usr/share/opensearch /usr/share/opensearch
 
 
-
-
-
 RUN echo "discovery.type: single-node\nbootstrap.memory_lock: true\ncluster.routing.allocation.disk.threshold_enabled: true\ncluster.routing.allocation.disk.watermark.low: 1g\ncluster.routing.allocation.disk.watermark.high: 500m\ncluster.routing.allocation.disk.watermark.flood_stage: 400m\ncluster.info.update.interval: 5m" >> /usr/share/opensearch/config/opensearch.yml
 
-
+ENV OPENSEARCH_JAVA_HOME=/usr/share/opensearch/jdk
+ENV JAVA_HOME=/java
 ENV PATH=$PATH:/usr/share/opensearch/bin
 RUN /usr/share/opensearch/opensearch-onetime-setup.sh
-RUN rm -rf /usr/share/opensearch/jdk
 RUN chown -R dotcms.dotcms /usr/share/opensearch/config
 COPY entrypoint.sh /
 RUN chmod 755 /entrypoint.sh

--- a/docker/dev-env/Dockerfile
+++ b/docker/dev-env/Dockerfile
@@ -2,10 +2,11 @@
 # Stage 1:  Build dotCMS from our builder image
 # ----------------------------------------------
 ARG DOTCMS_DOCKER_TAG="latest"
+ARG JAVA_BASE_IMAGE="mcr.microsoft.com/openjdk/jdk:21-ubuntu"
 
 FROM dotcms/dotcms:${DOTCMS_DOCKER_TAG} AS dotcms
 
-FROM mcr.microsoft.com/openjdk/jdk:21-ubuntu AS dev-env-builder
+FROM ${JAVA_BASE_IMAGE} AS dev-env-builder
 
 # Defining default non-root user UID, GID, and name 
 ARG USER_UID="65001"

--- a/docker/dev-env/entrypoint.sh
+++ b/docker/dev-env/entrypoint.sh
@@ -3,6 +3,7 @@
 ASSETS_BACKUP_FILE=/data/assets.zip
 DB_BACKUP_FILE=/data/dotcms_db.sql.gz
 STARTER_ZIP=/data/starter.zip
+
 export JAVA_HOME=/java
 export ES_JAVA_OPTS=${ES_JAVA_OPTS:-"-Xmx512m"}
 export DOTCMS_CLONE_TYPE=${DOTCMS_CLONE_TYPE:-"dump"}
@@ -10,6 +11,7 @@ export ALL_ASSETS=${ALL_ASSETS:-"false"}
 export MAX_ASSET_SIZE=${MAX_ASSET_SIZE:-"100mb"}
 export PG_VERSION=${PG_VERSION:-"18"}
 export PATH=$PATH:$JAVA_HOME/bin:/usr/local/pgsql/bin:/usr/lib/postgresql/$PG_VERSION/bin/
+
 
 
 
@@ -49,7 +51,6 @@ setup_postgres () {
 
 setup_opensearch () {
 
-
     if [ ! -d "/data/opensearch" ]; then
         mv /usr/share/opensearch/data /data/opensearch
         chown dotcms.dotcms /data/opensearch
@@ -62,7 +63,7 @@ setup_opensearch () {
     echo "Starting OPENSEARCH"
     # Start up Elasticsearch
     #su -c "/usr/share/opensearch/bin/opensearch 1> /dev/null" dotcms &
-    su -c "OPENSEARCH_JAVA_HOME=/usr /usr/share/opensearch/bin/opensearch " dotcms &
+    su -c "OPENSEARCH_JAVA_HOME=/usr/share/opensearch/jdk /usr/share/opensearch/bin/opensearch " dotcms &
 }
 
 


### PR DESCRIPTION
Fixes: #35719


## Summary
- `docker/dev-env/Dockerfile` hardcoded `mcr.microsoft.com/openjdk/jdk:21-ubuntu` as its second-stage base, so the `dotcms/dotcms-dev:java-25` tag (and any future variant) was being built on top of Java 21 even though the workflow tagged it as `java-25`.
- Parameterize the base via a new `JAVA_BASE_IMAGE` build-arg (defaults to `jdk:21-ubuntu` for backward compatibility).
- In `cicd_comp_deployment-phase.yml`, emit `java_major` from the `Get SDKMan Version` step (covers both explicit `java-version` override and `.sdkmanrc` fallback) and pass `JAVA_BASE_IMAGE=mcr.microsoft.com/openjdk/jdk:${java_major}-ubuntu` to the dev-image build.

After this change, when `cicd_7-release-java-variant.yml` runs with `java_version=25.x.y-ms`, the dev image is built on `jdk:25-ubuntu`. Standard releases (no override) continue to use `jdk:21-ubuntu` via `.sdkmanrc`.

## Test plan
- [ ] Verify `mcr.microsoft.com/openjdk/jdk:25-ubuntu` manifest exists for both `amd64` and `arm64` (confirmed locally via `docker manifest inspect`)
- [ ] Local build smoke test:
  ```bash
  cd docker/dev-env
  docker buildx build --platform linux/amd64 \
    --build-arg DOTCMS_DOCKER_TAG=java-25 \
    --build-arg JAVA_BASE_IMAGE=mcr.microsoft.com/openjdk/jdk:25-ubuntu \
    -t dotcms-dev:java25-test --load .
  docker run --rm --entrypoint bash dotcms-dev:java25-test -c \
    'echo "=== system java ==="; java -version; echo "=== /java ==="; /java/bin/java -version'
  ```
  Both `java -version` outputs should report Java 25.
- [ ] Trigger `cicd_7-release-java-variant.yml` (workflow_dispatch) against a release branch and confirm the dev-image build step shows the new build-arg and the pushed image runs Java 25.
- [ ] Confirm a standard release build (no `java_version` override) still produces a Java-21 dev image (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)