### PR TITLE
test: Add integration test to catch cross-site content bleed regression (#35722)

### DIFF
--- a/dotcms-integration/src/test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
@@ -735,6 +735,67 @@ public class URLMapAPIImplTest {
     }
 
     /**
+     * Regression guard for the production incident in #35616 and the revert in #35621.
+     *
+     * <p>Models multi-brand setups where several sites share a URL map
+     * pattern such as {@code /products/{slug}}. The content type and detail page are configured on
+     * the requesting brand, but a <em>different</em> brand owns the only published content for that
+     * slug.</p>
+     *
+     * <p>With site isolation restored (revert of #35345 / #35622), {@code processURLMap} must return
+     * empty on the requesting brand. If the unrestricted cross-site ES fallback from
+     * <a href="https://github.com/dotCMS/core/pull/35345">PR #35345</a> is ever reintroduced, this
+     * test must fail.</p>
+     *
+     * @see <a href="https://github.com/dotCMS/core/issues/35616">#35616 — cross-site content bleed</a>
+     * @see <a href="https://github.com/dotCMS/core/issues/35621">#35621 — revert #35345</a>
+     */
+    @Test
+    public void processURLMap_mustNotReturnContentFromForeignHost_whenRequestingHostHasNoMatch()
+            throws DotDataException, DotSecurityException {
+
+        final Host brandA = new SiteDataGen().nextPersisted();
+        final Host brandB = new SiteDataGen().nextPersisted();
+
+        final Template template = new TemplateDataGen().nextPersisted();
+        final Folder productsFolder = new FolderDataGen()
+                .name("brand-products-" + System.currentTimeMillis())
+                .site(brandA)
+                .nextPersisted();
+        final HTMLPageAsset detailPage = new HTMLPageDataGen(productsFolder, template)
+                .pageURL("product-detail")
+                .title("product-detail")
+                .nextPersisted();
+
+        final String urlPattern = "/products-" + System.currentTimeMillis() + "/{urlTitle}";
+
+        // URL map is configured on brandA; detail page also lives on brandA.
+        final ContentType productType = getNewsLikeContentType(
+                "BrandProduct" + System.currentTimeMillis(),
+                brandA,
+                detailPage.getIdentifier(),
+                urlPattern);
+
+        final long langId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+        final String slugOnlyOnBrandB = "heat-pumps-" + System.currentTimeMillis();
+
+        // brandB publishes the slug; brandA has no content for it.
+        ContentletDataGen.publish(TestDataUtils.getNewsContent(
+                true, langId, productType.id(), brandB, new Date(), slugOnlyOnBrandB));
+
+        final UrlMapContext context = getUrlMapContext(systemUser, brandA,
+                urlPattern.replace("{urlTitle}", slugOnlyOnBrandB),
+                PageMode.LIVE);
+
+        final Optional<URLMapInfo> result = urlMapAPI.processURLMap(context);
+
+        assertFalse(
+                "Cross-site URL map bleed: brandB content resolved on brandA for slug ["
+                        + slugOnlyOnBrandB + "]",
+                result.isPresent());
+    }
+
+    /**
      * methodToTest {@link URLMapAPIImpl#processURLMap(UrlMapContext)}
      * Given Scenario: Process a URL Map url when both the Content Type and Content exists but the field to Map is a
      * {@link com.dotcms.contenttype.model.field.DataTypes#FLOAT}


### PR DESCRIPTION
## Summary

Adds a regression guard integration test for the cross-site URL map content bleed described in #35616.

- Closes #35722

## What this test covers

The test models a multi-site setup where two sites share a Content Type and URL map pattern (e.g. `/products/{slug}`). The URL map and detail page are configured on Site A; only Site B has published content for the requested slug; Site A has none.

The assertion is that `processURLMap` returns **empty** when Site A requests that slug — i.e., Site B's content must not bleed through.

**This test must fail** if the unrestricted cross-site ES fallback from #35345 is ever reintroduced:

```java
// The bad pattern this test guards against
if (contentletSearches.isEmpty()) {
    // second query with NO conhost filter — bleeds content across sites
    contentletSearches = ContentUtils.pull(buildContentQuery(..., false), ...);
}
```

**This test must pass** with the current single-pass query that always includes `+(conhost:<requestingSite> OR conhost:SYSTEM_HOST)`.

## Test plan

- [ ] Run `URLMapAPIImplTest#processURLMap_mustNotReturnContentFromForeignHost_whenRequestingHostHasNoMatch` — must pass
- [ ] Re-apply the two-step fallback from #35345 locally and re-run the test — must fail

This PR fixes: #35722