### PR TITLE
fix(edit-content): normalize string lockedBy shape for Pages in lock warning

### DIFF
--- a/core-web/libs/dotcms-models/src/lib/dot-contentlet.model.ts
+++ b/core-web/libs/dotcms-models/src/lib/dot-contentlet.model.ts
@@ -24,7 +24,8 @@ export interface DotCMSContentlet {
     language?: string | DotLanguage;
     live: boolean;
     locked: boolean;
-    lockedBy?: DotContentletLockUser;
+    lockedBy?: DotContentletLockUser | string;
+    lockedByName?: string;
     mimeType?: string;
     modDate: string;
     modUser: string;

--- a/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.spec.ts
@@ -161,6 +161,44 @@ describe('LockFeature', () => {
             expect(store.lockWarningMessage()).toBe('Content is locked by Doe');
         });
 
+        it('should use lockedByName when lockedBy is a string (Page content type)', () => {
+            store.updateCurrentUser({ userId: '456' });
+            store.updateCanLock(true);
+
+            store.updateContent({
+                locked: true,
+                lockedBy: '123',
+                lockedByName: 'Adrian Marquez'
+            } as unknown as DotCMSContentlet);
+
+            expect(store.lockWarningMessage()).toBe('Content is locked by Adrian Marquez');
+        });
+
+        it('should return null when lockedBy is a string matching the current user (Page locked by self)', () => {
+            store.updateCurrentUser({ userId: '123' });
+            store.updateCanLock(true);
+
+            store.updateContent({
+                locked: true,
+                lockedBy: '123',
+                lockedByName: 'Adrian Marquez'
+            } as unknown as DotCMSContentlet);
+
+            expect(store.lockWarningMessage()).toBe(null);
+        });
+
+        it('should fall back to empty name when lockedBy is a string and lockedByName is missing', () => {
+            store.updateCurrentUser({ userId: '456' });
+            store.updateCanLock(true);
+
+            store.updateContent({
+                locked: true,
+                lockedBy: '123'
+            } as unknown as DotCMSContentlet);
+
+            expect(store.lockWarningMessage()).toBe('Content is locked by ');
+        });
+
         it('should return empty message when content is not locked', () => {
             store.updateCanLock(true);
             store.updateContent({ locked: false });

--- a/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.spec.ts
@@ -199,6 +199,21 @@ describe('LockFeature', () => {
             expect(store.lockWarningMessage()).toBe('Content is locked by ');
         });
 
+        it('should return no-permission message when lockedBy is a string and user cannot unlock', () => {
+            store.updateCurrentUser({ userId: '456' });
+            // canLock stays false (default)
+
+            store.updateContent({
+                locked: true,
+                lockedBy: '123',
+                lockedByName: 'Adrian Marquez'
+            } as unknown as DotCMSContentlet);
+
+            expect(store.lockWarningMessage()).toBe(
+                "Content is locked by Adrian Marquez. You don't have permissions to unlock this content."
+            );
+        });
+
         it('should return empty message when content is not locked', () => {
             store.updateCanLock(true);
             store.updateContent({ locked: false });

--- a/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.spec.ts
@@ -59,6 +59,8 @@ describe('LockFeature', () => {
             if (key === 'edit.content.locked.by.user') return `Content is locked by ${args[0]}`;
             if (key === 'edit.content.locked.no.permission.user')
                 return `Content is locked by ${args[0]}. You don't have permissions to unlock this content.`;
+            if (key === 'edit.content.locked.no.permission')
+                return "You don't have permissions to unlock this content.";
 
             return key;
         });
@@ -125,7 +127,7 @@ describe('LockFeature', () => {
             expect(store.lockWarningMessage()).toBe('Content is locked by John Doe');
         });
 
-        it('should handle null/undefined firstName or lastName gracefully', () => {
+        it('should suppress the banner when firstName and lastName are both missing', () => {
             store.updateCurrentUser({ userId: '456' });
             store.updateCanLock(true);
 
@@ -134,7 +136,8 @@ describe('LockFeature', () => {
                 lockedBy: { userId: '123', firstName: null, lastName: null }
             });
 
-            expect(store.lockWarningMessage()).toBe('Content is locked by ');
+            // No display name → don't render a misleading "Content locked by ." banner.
+            expect(store.lockWarningMessage()).toBe(null);
         });
 
         it('should handle missing lastName gracefully', () => {
@@ -187,7 +190,7 @@ describe('LockFeature', () => {
             expect(store.lockWarningMessage()).toBe(null);
         });
 
-        it('should fall back to empty name when lockedBy is a string and lockedByName is missing', () => {
+        it('should suppress the banner when lockedBy is a string and lockedByName is missing', () => {
             store.updateCurrentUser({ userId: '456' });
             store.updateCanLock(true);
 
@@ -196,7 +199,22 @@ describe('LockFeature', () => {
                 lockedBy: '123'
             } as unknown as DotCMSContentlet);
 
-            expect(store.lockWarningMessage()).toBe('Content is locked by ');
+            // PageViewStrategy.getLockedByUserName can return null on DotSecurityException —
+            // without a name, suppress the banner instead of rendering "Content locked by .".
+            expect(store.lockWarningMessage()).toBe(null);
+        });
+
+        it('should suppress the banner when lockedBy is a string and lockedByName is blank/whitespace', () => {
+            store.updateCurrentUser({ userId: '456' });
+            store.updateCanLock(true);
+
+            store.updateContent({
+                locked: true,
+                lockedBy: '123',
+                lockedByName: '   '
+            } as unknown as DotCMSContentlet);
+
+            expect(store.lockWarningMessage()).toBe(null);
         });
 
         it('should return no-permission message when lockedBy is a string and user cannot unlock', () => {
@@ -211,6 +229,20 @@ describe('LockFeature', () => {
 
             expect(store.lockWarningMessage()).toBe(
                 "Content is locked by Adrian Marquez. You don't have permissions to unlock this content."
+            );
+        });
+
+        it('should fall back to the name-less no-permission key when locker has no display name', () => {
+            store.updateCurrentUser({ userId: '456' });
+            // canLock stays false (default)
+
+            store.updateContent({
+                locked: true,
+                lockedBy: '123'
+            } as unknown as DotCMSContentlet);
+
+            expect(store.lockWarningMessage()).toBe(
+                "You don't have permissions to unlock this content."
             );
         });
 

--- a/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
@@ -64,22 +64,35 @@ export function withLock() {
                 // The `lockedBy` field has two shapes depending on the API endpoint:
                 // a plain string (userId) when `lockedByName` carries the display name,
                 // or a { userId, firstName, lastName } object.
+                // TODO: remove this branching once the backend normalizes the shape across content types.
                 const isLockedByString = typeof lockedBy === 'string';
                 const lockerUserId = isLockedByString ? lockedBy : lockedBy.userId;
-                const userDisplay = isLockedByString
-                    ? (lockedByName ?? '')
-                    : [lockedBy.firstName, lockedBy.lastName].filter(Boolean).join(' ');
+                const userDisplay = (
+                    isLockedByString
+                        ? lockedByName ?? ''
+                        : [lockedBy.firstName, lockedBy.lastName].filter(Boolean).join(' ')
+                ).trim();
 
                 if (currentUser?.userId === lockerUserId) {
                     return null;
                 }
 
-                // If user doesn't have permission to lock, use the no permission message
+                // If user doesn't have permission to lock, use the no permission message.
+                // Fall back to the name-less key when the locker's display name is unavailable.
                 if (!userCanLock) {
-                    return dotMessageService.get(
-                        'edit.content.locked.no.permission.user',
-                        userDisplay
-                    );
+                    return userDisplay
+                        ? dotMessageService.get(
+                              'edit.content.locked.no.permission.user',
+                              userDisplay
+                          )
+                        : dotMessageService.get('edit.content.locked.no.permission');
+                }
+
+                // Without a display name, the "Content locked by <b>{name}.</b>" template would
+                // render as "Content locked by ." — suppress the banner instead. The lock switch
+                // UI still indicates the locked state.
+                if (!userDisplay) {
+                    return null;
                 }
 
                 return dotMessageService.get('edit.content.locked.by.user', userDisplay);

--- a/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
@@ -61,8 +61,9 @@ export function withLock() {
                     return null;
                 }
 
-                // Pages return `lockedBy` as a string (userId) with the full name in `lockedByName`;
-                // other content types return `lockedBy` as an object { userId, firstName, lastName }.
+                // The `lockedBy` field has two shapes depending on the API endpoint:
+                // a plain string (userId) when `lockedByName` carries the display name,
+                // or a { userId, firstName, lastName } object.
                 const isLockedByString = typeof lockedBy === 'string';
                 const lockerUserId = isLockedByString ? lockedBy : lockedBy.userId;
                 const userDisplay = isLockedByString

--- a/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
@@ -69,7 +69,7 @@ export function withLock() {
                 const lockerUserId = isLockedByString ? lockedBy : lockedBy.userId;
                 const userDisplay = (
                     isLockedByString
-                        ? lockedByName ?? ''
+                        ? (lockedByName ?? '')
                         : [lockedBy.firstName, lockedBy.lastName].filter(Boolean).join(' ')
                 ).trim();
 

--- a/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts
@@ -55,18 +55,23 @@ export function withLock() {
                     return null;
                 }
 
-                const { lockedBy } = contentlet;
+                const { lockedBy, lockedByName } = contentlet;
 
-                const isLockedByCurrentUser = currentUser?.userId === lockedBy?.userId;
-
-                // content is not locked or locked by the current user
-                if (!lockedBy || isLockedByCurrentUser) {
+                if (!lockedBy) {
                     return null;
                 }
 
-                const userDisplay = [lockedBy.firstName, lockedBy.lastName]
-                    .filter(Boolean)
-                    .join(' ');
+                // Pages return `lockedBy` as a string (userId) with the full name in `lockedByName`;
+                // other content types return `lockedBy` as an object { userId, firstName, lastName }.
+                const isLockedByString = typeof lockedBy === 'string';
+                const lockerUserId = isLockedByString ? lockedBy : lockedBy.userId;
+                const userDisplay = isLockedByString
+                    ? (lockedByName ?? '')
+                    : [lockedBy.firstName, lockedBy.lastName].filter(Boolean).join(' ');
+
+                if (currentUser?.userId === lockerUserId) {
+                    return null;
+                }
 
                 // If user doesn't have permission to lock, use the no permission message
                 if (!userCanLock) {


### PR DESCRIPTION
## Summary

- Re-fix for #34541 after QA found a regression on **Pages** in new Edit Content: the lock banner showed **"Content locked by ."** and also appeared when the *current user* had locked the Page.
- Root cause: the backend returns `lockedBy` in two shapes — `DefaultTransformStrategy` produces an object `{ userId, firstName, lastName }`, but `PageViewStrategy` overwrites it with the raw userId **string** plus a separate `lockedByName`. The frontend lock warning assumed only the object shape.
- Fix is frontend-only: normalize both shapes inside `lockWarningMessage` (use `lockedByName` for display when `lockedBy` is a string, compare the string directly to `currentUser.userId`). Widen the model type to document the dual contract.

## Why frontend-only

Roughly 37 frontend files (UVE, edit-ema, sdk) already treat Page's `lockedBy` as a string. Normalizing the backend would have a much broader blast radius and is out of scope for this QA fix.

## Acceptance Criteria

- [x] Pages locked by another user → banner shows that user's full name (from `lockedByName`)
- [x] Pages locked by the current user → no banner
- [x] Object-shape `lockedBy` (non-Page content types) still works
- [x] Null firstName/lastName handling from prior PR #35245 still passes

## Test Plan

- [x] `yarn nx test edit-content --testPathPattern=lock.feature` — all tests pass, 3 new tests added
- [x] `yarn nx lint edit-content` — clean
- [ ] Manual: lock a Page as user A, open as user B → expect full name in banner
- [ ] Manual: lock a Page as user A, reopen as user A → expect no banner
- [ ] Manual: lock a non-Page contentlet as another user → expect firstName/lastName

## Changed Files

| File | Change |
|------|--------|
| `core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.ts` | Normalize string vs object `lockedBy` |
| `core-web/libs/dotcms-models/src/lib/dot-contentlet.model.ts` | Widen `lockedBy?: DotContentletLockUser \| string`, add `lockedByName?: string` |
| `core-web/libs/edit-content/src/lib/store/features/lock/lock.feature.spec.ts` | 3 new tests for Page shape |

Closes #34541