### PR TITLE
feat(maintenance): add REST endpoints for session management (#35206)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/cmsmaintenance/ajax/UserSessionAjax.java
+++ b/dotCMS/src/main/java/com/dotcms/cmsmaintenance/ajax/UserSessionAjax.java
@@ -2,7 +2,6 @@ package com.dotcms.cmsmaintenance.ajax;
 
 import com.liferay.portal.util.PortalUtil;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -11,14 +10,12 @@ import java.util.UUID;
 import java.time.Duration;
 import java.time.Instant;
 
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
-import javax.mail.Session;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import com.dotcms.repackage.org.directwebremoting.WebContextFactory;
 import com.dotcms.listeners.SessionMonitor;
+import com.dotcms.rest.api.v1.maintenance.SessionTokenUtil;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.NoSuchUserException;
 import com.dotmarketing.cms.factories.PublicCompanyFactory;
@@ -27,7 +24,6 @@ import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.util.DateUtil;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.WebKeys;
 import com.liferay.portal.model.User;
 
 /**
@@ -38,7 +34,6 @@ public class UserSessionAjax {
     private static final String CSRF_TOKEN_ATTRIBUTE = "csrfToken";
     private static final String CSRF_TOKEN_TIMESTAMP_ATTRIBUTE = "csrfTokenTimestamp";
     private static final Duration TOKEN_EXPIRY_DURATION = Duration.ofMinutes(15);
-    private static final String HMAC_ALGORITHM = "HmacSHA256";
 
     /**
      * Validates if the current user has access to the CMS Maintenance Portlet.
@@ -187,19 +182,11 @@ public class UserSessionAjax {
      * @param sessionId the session ID to obfuscate
      * @param secretKey the secret key for HMAC
      * @return the obfuscated session ID
+     * @deprecated use {@link SessionTokenUtil#obfuscateSessionId(String, String)} directly.
      */
+    @Deprecated
     public static String obfuscateSessionId(String sessionId, String secretKey) {
-        try {
-            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
-            SecretKeySpec key = new SecretKeySpec(secretKey.getBytes(), HMAC_ALGORITHM);
-            mac.init(key);
-            byte[] hash = mac.doFinal(sessionId.getBytes());
-            byte[] truncatedHash = new byte[16];
-            System.arraycopy(hash, 0, truncatedHash, 0, 16);
-            return Base64.getUrlEncoder().withoutPadding().encodeToString(truncatedHash);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        return SessionTokenUtil.obfuscateSessionId(sessionId, secretKey);
     }
 
     /**
@@ -209,10 +196,11 @@ public class UserSessionAjax {
      * @param secretKey the secret key for HMAC
      * @param obfuscatedId the obfuscated session ID to validate
      * @return true if the session IDs match, false otherwise
+     * @deprecated use {@link SessionTokenUtil#validateSessionId(String, String, String)} directly.
      */
+    @Deprecated
     public static boolean validateSessionId(String sessionId, String secretKey, String obfuscatedId) {
-        String generatedObfuscatedId = obfuscateSessionId(sessionId, secretKey);
-        return generatedObfuscatedId.equals(obfuscatedId);
+        return SessionTokenUtil.validateSessionId(sessionId, secretKey, obfuscatedId);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/AbstractKillSessionsResultView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/AbstractKillSessionsResultView.java
@@ -1,0 +1,26 @@
+package com.dotcms.rest.api.v1.maintenance;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.immutables.value.Value;
+
+/**
+ * Immutable view representing the result of bulk session invalidation.
+ *
+ * @author hassandotcms
+ */
+@Value.Style(typeImmutable = "*", typeAbstract = "Abstract*")
+@Value.Immutable
+@JsonSerialize(as = KillSessionsResultView.class)
+@JsonDeserialize(as = KillSessionsResultView.class)
+@Schema(description = "Result of invalidating all sessions except the caller's")
+public interface AbstractKillSessionsResultView {
+
+    @Schema(
+            description = "Number of sessions invalidated (the caller's own session is always skipped).",
+            example = "5",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    int killedCount();
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/AbstractSessionView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/AbstractSessionView.java
@@ -1,0 +1,78 @@
+package com.dotcms.rest.api.v1.maintenance;
+
+import com.dotcms.annotations.Nullable;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.immutables.value.Value;
+
+/**
+ * Immutable view of a single active HTTP session as displayed in the Logged Users tab.
+ * <p>
+ * The real session id is never exposed; clients receive {@link #token()} (HMAC-SHA256
+ * of the session id keyed by the caller's CSRF secret) and pass it back to
+ * {@code DELETE /v1/maintenance/_sessions/{token}}.
+ *
+ * @author hassandotcms
+ */
+@Value.Style(typeImmutable = "*", typeAbstract = "Abstract*")
+@Value.Immutable
+@JsonSerialize(as = SessionView.class)
+@JsonDeserialize(as = SessionView.class)
+@Schema(description = "Active HTTP session entry exposed in the Logged Users tab")
+public interface AbstractSessionView {
+
+    @Schema(
+            description = "HMAC-obfuscated session token. Pass this value back to "
+                    + "DELETE /v1/maintenance/_sessions/{token} to invalidate the session.",
+            example = "a1b2c3d4e5f6g7h8",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String token();
+
+    @Schema(
+            description = "True if this entry represents the caller's own session.",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    boolean isCurrent();
+
+    @Schema(
+            description = "User id associated with the session (anonymous user id if no login).",
+            example = "dotcms.org.1",
+            requiredMode = Schema.RequiredMode.REQUIRED
+    )
+    String userId();
+
+    @Nullable
+    @Schema(
+            description = "Email of the user associated with the session. Null for sessions "
+                    + "without an associated user account.",
+            example = "admin@dotcms.com"
+    )
+    String userEmail();
+
+    @Nullable
+    @Schema(
+            description = "Full name of the user associated with the session. Null for sessions "
+                    + "without an associated user account.",
+            example = "Admin User"
+    )
+    String userFullName();
+
+    @Nullable
+    @Schema(
+            description = "Remote IP address recorded when the session was created. Null if "
+                    + "the address was never captured (e.g. the session was created outside the "
+                    + "servlet request pipeline that records it).",
+            example = "192.168.1.100"
+    )
+    String address();
+
+    @Nullable
+    @Schema(
+            description = "Human-readable elapsed time since the session was created.",
+            example = "2 hours ago"
+    )
+    String sessionTime();
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/MaintenanceResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/MaintenanceResource.java
@@ -5,6 +5,7 @@ import com.dotcms.auth.providers.jwt.factories.ApiTokenAPI;
 import com.dotcms.cluster.bean.Server;
 import com.dotcms.cluster.business.ServerAPI;
 import com.dotcms.concurrent.DotConcurrentFactory;
+import com.dotcms.listeners.SessionMonitor;
 import com.google.common.annotations.VisibleForTesting;
 import com.dotcms.rest.InitDataObject;
 import com.dotcms.rest.ResponseEntityStringView;
@@ -13,12 +14,15 @@ import com.dotcms.rest.WebResource;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.rest.exception.ConflictException;
+import com.dotcms.rest.exception.ForbiddenException;
+import com.dotcms.rest.exception.NotFoundException;
 import com.dotcms.util.ConversionUtils;
 import com.dotcms.util.DbExporterUtil;
 import com.dotcms.util.SizeUtil;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.ApiProvider;
 import com.dotmarketing.business.Role;
+import com.dotmarketing.cms.factories.PublicCompanyFactory;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.portlets.cmsmaintenance.factories.CMSMaintenanceFactory;
@@ -35,6 +39,7 @@ import com.dotmarketing.util.UtilMethods;
 import com.dotmarketing.util.starter.ExportStarterUtil;
 import com.liferay.portal.model.Portlet;
 import com.liferay.portal.model.User;
+import com.liferay.portal.util.PortalUtil;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
 import org.apache.commons.io.IOUtils;
@@ -49,6 +54,7 @@ import org.glassfish.jersey.server.JSONP;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -77,6 +83,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -989,6 +996,254 @@ public class MaintenanceResource implements Serializable {
         assertBackendUser(request, response);
         return new ResponseEntityView<>(
                 jobHelper().getLatestJob(MaintenanceJobHelper.CLEAN_ASSETS_QUEUE));
+    }
+
+    // -------------------------------------------------------------------------
+    //  Session management endpoints — back the Logged Users tab
+    // -------------------------------------------------------------------------
+
+    /**
+     * HTTP session attribute that holds the CSRF token issued by
+     * {@link #listSessions} and required by {@link #killSession}.
+     */
+    @VisibleForTesting
+    static final String CSRF_TOKEN_ATTRIBUTE = "maintenanceSessionCsrf";
+
+    /**
+     * HTTP session attribute that holds the {@link Instant} at which the
+     * {@link #CSRF_TOKEN_ATTRIBUTE} was issued. Used to enforce the 15-minute expiry.
+     */
+    @VisibleForTesting
+    static final String CSRF_TOKEN_TIMESTAMP_ATTRIBUTE = "maintenanceSessionCsrfTimestamp";
+
+    /**
+     * Lifetime of a CSRF token issued by {@link #listSessions}. After this window
+     * a subsequent call to {@link #killSession} will return 403 and the client
+     * must call {@link #listSessions} again to refresh the token.
+     */
+    private static final Duration CSRF_TOKEN_EXPIRY = Duration.ofMinutes(15);
+
+    /**
+     * Lists all active HTTP sessions tracked by {@link SessionMonitor}. Issues a fresh
+     * CSRF token, stores it in the caller's HTTP session, and uses it to HMAC each
+     * real session id before returning. Real session ids are never sent to the client.
+     *
+     * @param request  The current {@link HttpServletRequest}
+     * @param response The current {@link HttpServletResponse}
+     * @return All active sessions with HMAC-obfuscated tokens.
+     */
+    @Operation(
+            summary = "List active HTTP sessions",
+            description = "Returns every active HTTP session tracked by SessionMonitor. "
+                    + "Real session ids are never exposed; each entry instead carries a "
+                    + "short HMAC-derived token that must be passed back to "
+                    + "DELETE /v1/maintenance/_sessions/{token} to invalidate the session. "
+                    + "The CSRF secret used to derive these tokens is stored in the caller's "
+                    + "HTTP session and is valid for 15 minutes — re-call this endpoint to refresh."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "List of active sessions",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseEntitySessionListView.class))),
+            @ApiResponse(responseCode = "401",
+                    description = "Unauthorized - authentication required",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "403",
+                    description = "Forbidden - CMS Administrator role required",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @GET
+    @Path("/_sessions")
+    @NoCache
+    @Produces({MediaType.APPLICATION_JSON})
+    public final ResponseEntitySessionListView listSessions(
+            @Parameter(hidden = true) @Context final HttpServletRequest request,
+            @Parameter(hidden = true) @Context final HttpServletResponse response) {
+
+        assertBackendUser(request, response);
+
+        final HttpSession callingSession = request.getSession();
+        final String csrfToken = UUID.randomUUID().toString();
+        callingSession.setAttribute(CSRF_TOKEN_ATTRIBUTE, csrfToken);
+        callingSession.setAttribute(CSRF_TOKEN_TIMESTAMP_ATTRIBUTE, Instant.now());
+
+        final SessionMonitor sessionMonitor = new SessionMonitor();
+        final List<SessionView> sessions = new ArrayList<>();
+
+        for (final HttpSession session : sessionMonitor.getUserSessions().values()) {
+            User sessionUser = Try.of(() -> PortalUtil.getUser(session)).getOrNull();
+            if (sessionUser == null) {
+                sessionUser = Try.of(() -> APILocator.getUserAPI().getAnonymousUser())
+                        .getOrElseThrow(e -> new DotRuntimeException(
+                                "Unable to resolve anonymous user", e));
+            }
+
+            sessions.add(SessionView.builder()
+                    .token(SessionTokenUtil.obfuscateSessionId(session.getId(), csrfToken))
+                    .isCurrent(callingSession.getId().equals(session.getId()))
+                    .userId(sessionUser.getUserId())
+                    .userEmail(sessionUser.getEmailAddress())
+                    .userFullName(sessionUser.getFullName())
+                    .address((String) session.getAttribute(SessionMonitor.USER_REMOTE_ADDR))
+                    .sessionTime(DateUtil.prettyDateSince(
+                            new Date(session.getCreationTime()),
+                            PublicCompanyFactory.getDefaultCompany().getLocale()))
+                    .build());
+        }
+
+        return new ResponseEntitySessionListView(sessions);
+    }
+
+    /**
+     * Invalidates a single session identified by its HMAC-obfuscated token.
+     * <p>
+     * Requires a fresh CSRF secret stored in the caller's HTTP session (issued by
+     * {@link #listSessions}); the caller cannot invalidate its own session.
+     *
+     * @param request  The current {@link HttpServletRequest}
+     * @param response The current {@link HttpServletResponse}
+     * @param token    HMAC-obfuscated session token returned by {@link #listSessions}
+     * @return A success message when the session was invalidated.
+     */
+    @Operation(
+            summary = "Invalidate a single session",
+            description = "Invalidates the session whose HMAC-obfuscated token is supplied. "
+                    + "The caller's own session cannot be invalidated this way. The CSRF secret "
+                    + "must have been issued by GET /v1/maintenance/_sessions within the last "
+                    + "15 minutes — otherwise this endpoint returns 403 and the client must "
+                    + "re-list to refresh."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Session invalidated",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseEntityStringView.class))),
+            @ApiResponse(responseCode = "400",
+                    description = "Bad request - attempting to invalidate caller's own session",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "401",
+                    description = "Unauthorized - authentication required",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "403",
+                    description = "Forbidden - missing or expired CSRF token, or insufficient role",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404",
+                    description = "No active session matches the supplied token",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @DELETE
+    @Path("/_sessions/{token}")
+    @NoCache
+    @Produces({MediaType.APPLICATION_JSON})
+    public final ResponseEntityStringView killSession(
+            @Parameter(hidden = true) @Context final HttpServletRequest request,
+            @Parameter(hidden = true) @Context final HttpServletResponse response,
+            @Parameter(description = "HMAC-obfuscated session token returned by GET /_sessions",
+                    required = true)
+            @PathParam("token") final String token) {
+
+        final User user = assertBackendUser(request, response).getUser();
+
+        if (!UtilMethods.isSet(token)) {
+            throw new BadRequestException("token path parameter is required");
+        }
+
+        final HttpSession callingSession = request.getSession();
+        final String csrfSecret = getValidCsrfSecret(callingSession);
+
+        final SessionMonitor sessionMonitor = new SessionMonitor();
+        for (final HttpSession session : sessionMonitor.getUserSessions().values()) {
+            if (!SessionTokenUtil.validateSessionId(session.getId(), csrfSecret, token)) {
+                continue;
+            }
+            if (callingSession.getId().equals(session.getId())) {
+                throw new BadRequestException("Cannot invalidate your own session");
+            }
+
+            SecurityLogger.logInfo(this.getClass(),
+                    String.format("User '%s' invalidating session of user '%s' from ip: %s",
+                            user.getUserId(),
+                            Try.of(() -> PortalUtil.getUser(session).getUserId())
+                                    .getOrElse("unknown"),
+                            request.getRemoteAddr()));
+
+            session.setAttribute(SessionMonitor.IGNORE_REMEMBER_ME_ON_INVALIDATION, true);
+            session.invalidate();
+            return new ResponseEntityStringView("Session invalidated");
+        }
+
+        throw new NotFoundException("No active session matches the supplied token");
+    }
+
+    /**
+     * Invalidates every active HTTP session except the caller's own.
+     *
+     * @param request  The current {@link HttpServletRequest}
+     * @param response The current {@link HttpServletResponse}
+     * @return The number of sessions invalidated.
+     */
+    @Operation(
+            summary = "Invalidate all sessions except the caller's",
+            description = "Walks every active HTTP session tracked by SessionMonitor, "
+                    + "skips the caller's own session, and invalidates the rest. "
+                    + "Returns the count of invalidated sessions."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Sessions invalidated",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ResponseEntityKillSessionsResultView.class))),
+            @ApiResponse(responseCode = "401",
+                    description = "Unauthorized - authentication required",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "403",
+                    description = "Forbidden - CMS Administrator role required",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @DELETE
+    @Path("/_sessions")
+    @NoCache
+    @Produces({MediaType.APPLICATION_JSON})
+    public final ResponseEntityKillSessionsResultView killAllSessions(
+            @Parameter(hidden = true) @Context final HttpServletRequest request,
+            @Parameter(hidden = true) @Context final HttpServletResponse response) {
+
+        final User user = assertBackendUser(request, response).getUser();
+        final HttpSession callingSession = request.getSession();
+        final SessionMonitor sessionMonitor = new SessionMonitor();
+
+        SecurityLogger.logInfo(this.getClass(),
+                String.format("User '%s' is invalidating all other sessions from ip: %s",
+                        user.getUserId(), request.getRemoteAddr()));
+
+        int killed = 0;
+        for (final HttpSession session : sessionMonitor.getUserSessions().values()) {
+            if (callingSession.getId().equals(session.getId())) {
+                continue;
+            }
+            session.setAttribute(SessionMonitor.IGNORE_REMEMBER_ME_ON_INVALIDATION, true);
+            session.invalidate();
+            killed++;
+        }
+
+        return new ResponseEntityKillSessionsResultView(
+                KillSessionsResultView.builder().killedCount(killed).build());
+    }
+
+    /**
+     * Returns the unexpired CSRF secret previously stored by {@link #listSessions},
+     * or throws {@link ForbiddenException} if it is missing or older than
+     * {@link #CSRF_TOKEN_EXPIRY}.
+     */
+    private static String getValidCsrfSecret(final HttpSession callingSession) {
+        final String csrf = (String) callingSession.getAttribute(CSRF_TOKEN_ATTRIBUTE);
+        final Object rawTimestamp = callingSession.getAttribute(CSRF_TOKEN_TIMESTAMP_ATTRIBUTE);
+        if (csrf == null || !(rawTimestamp instanceof Instant)
+                || Instant.now().isAfter(((Instant) rawTimestamp).plus(CSRF_TOKEN_EXPIRY))) {
+            throw new ForbiddenException("CSRF token is missing or expired; call GET /_sessions to refresh");
+        }
+        return csrf;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/ResponseEntityKillSessionsResultView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/ResponseEntityKillSessionsResultView.java
@@ -1,0 +1,15 @@
+package com.dotcms.rest.api.v1.maintenance;
+
+import com.dotcms.rest.ResponseEntityView;
+
+/**
+ * Response wrapper for the kill-all-sessions endpoint.
+ *
+ * @author hassandotcms
+ */
+public class ResponseEntityKillSessionsResultView extends ResponseEntityView<KillSessionsResultView> {
+
+    public ResponseEntityKillSessionsResultView(final KillSessionsResultView entity) {
+        super(entity);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/ResponseEntitySessionListView.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/ResponseEntitySessionListView.java
@@ -1,0 +1,17 @@
+package com.dotcms.rest.api.v1.maintenance;
+
+import com.dotcms.rest.ResponseEntityView;
+
+import java.util.List;
+
+/**
+ * Response wrapper for the list-active-sessions endpoint.
+ *
+ * @author hassandotcms
+ */
+public class ResponseEntitySessionListView extends ResponseEntityView<List<SessionView>> {
+
+    public ResponseEntitySessionListView(final List<SessionView> entity) {
+        super(entity);
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/SessionTokenUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/maintenance/SessionTokenUtil.java
@@ -1,0 +1,62 @@
+package com.dotcms.rest.api.v1.maintenance;
+
+import com.dotmarketing.exception.DotRuntimeException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Shared helpers used by the Maintenance Logged Users views (legacy DWR and REST)
+ * to keep raw HTTP session IDs off the wire.
+ * <p>
+ * Real session IDs are HMAC-SHA256'd with a per-caller CSRF secret, truncated to
+ * 16 bytes and Base64-URL encoded (no padding). Clients only ever see this
+ * derived token; the server validates a returned token by recomputing the HMAC
+ * for each active session.
+ *
+ * @author hassandotcms
+ */
+public final class SessionTokenUtil {
+
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+    private static final int TOKEN_BYTE_LENGTH = 16;
+
+    private SessionTokenUtil() {
+    }
+
+    /**
+     * Returns the HMAC-SHA256 of the given session id, truncated to 16 bytes and
+     * Base64-URL encoded without padding.
+     */
+    public static String obfuscateSessionId(final String sessionId, final String secretKey) {
+        try {
+            final Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
+            final byte[] hash = mac.doFinal(sessionId.getBytes(StandardCharsets.UTF_8));
+            final byte[] truncated = new byte[TOKEN_BYTE_LENGTH];
+            System.arraycopy(hash, 0, truncated, 0, TOKEN_BYTE_LENGTH);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(truncated);
+        } catch (final GeneralSecurityException e) {
+            throw new DotRuntimeException("HMAC-SHA256 is not available in this JVM", e);
+        }
+    }
+
+    /**
+     * Returns {@code true} when the supplied {@code token} is the HMAC of
+     * {@code sessionId} under {@code secretKey}. Uses a constant-time comparison
+     * to avoid leaking match progress through timing.
+     */
+    public static boolean validateSessionId(final String sessionId, final String secretKey, final String token) {
+        if (token == null) {
+            return false;
+        }
+        final byte[] expected = obfuscateSessionId(sessionId, secretKey).getBytes(StandardCharsets.UTF_8);
+        final byte[] provided = token.getBytes(StandardCharsets.UTF_8);
+        return MessageDigest.isEqual(expected, provided);
+    }
+}

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -11646,6 +11646,97 @@ paths:
       summary: Database-wide search and replace
       tags:
       - Maintenance
+  /v1/maintenance/_sessions:
+    delete:
+      description: "Walks every active HTTP session tracked by SessionMonitor, skips\
+        \ the caller's own session, and invalidates the rest. Returns the count of\
+        \ invalidated sessions."
+      operationId: killAllSessions
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityKillSessionsResultView"
+          description: Sessions invalidated
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: Forbidden - CMS Administrator role required
+      summary: Invalidate all sessions except the caller's
+      tags:
+      - Maintenance
+    get:
+      description: "Returns every active HTTP session tracked by SessionMonitor. Real\
+        \ session ids are never exposed; each entry instead carries a short HMAC-derived\
+        \ token that must be passed back to DELETE /v1/maintenance/_sessions/{token}\
+        \ to invalidate the session. The CSRF secret used to derive these tokens is\
+        \ stored in the caller's HTTP session and is valid for 15 minutes — re-call\
+        \ this endpoint to refresh."
+      operationId: listSessions
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntitySessionListView"
+          description: List of active sessions
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: Forbidden - CMS Administrator role required
+      summary: List active HTTP sessions
+      tags:
+      - Maintenance
+  /v1/maintenance/_sessions/{token}:
+    delete:
+      description: Invalidates the session whose HMAC-obfuscated token is supplied.
+        The caller's own session cannot be invalidated this way. The CSRF secret must
+        have been issued by GET /v1/maintenance/_sessions within the last 15 minutes
+        — otherwise this endpoint returns 403 and the client must re-list to refresh.
+      operationId: killSession
+      parameters:
+      - description: HMAC-obfuscated session token returned by GET /_sessions
+        in: path
+        name: token
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ResponseEntityStringView"
+          description: Session invalidated
+        "400":
+          content:
+            application/json: {}
+          description: Bad request - attempting to invalidate caller's own session
+        "401":
+          content:
+            application/json: {}
+          description: Unauthorized - authentication required
+        "403":
+          content:
+            application/json: {}
+          description: "Forbidden - missing or expired CSRF token, or insufficient\
+            \ role"
+        "404":
+          content:
+            application/json: {}
+          description: No active session matches the supplied token
+      summary: Invalidate a single session
+      tags:
+      - Maintenance
   /v1/maintenance/_shutdown:
     delete:
       operationId: shutdown
@@ -28175,6 +28266,17 @@ components:
       required:
       - key
       - value
+    KillSessionsResultView:
+      type: object
+      properties:
+        killedCount:
+          type: integer
+          format: int32
+          description: Number of sessions invalidated (the caller's own session is
+            always skipped).
+          example: 5
+      required:
+      - killedCount
     Language:
       type: object
       properties:
@@ -30839,6 +30941,29 @@ components:
           type: array
           items:
             type: string
+    ResponseEntityKillSessionsResultView:
+      type: object
+      properties:
+        entity:
+          $ref: "#/components/schemas/KillSessionsResultView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
     ResponseEntityLanguagesForPageView:
       type: object
       properties:
@@ -31886,6 +32011,31 @@ components:
       properties:
         entity:
           $ref: "#/components/schemas/SearchView"
+        errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorEntity"
+        i18nMessagesMap:
+          type: object
+          additionalProperties:
+            type: string
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MessageEntity"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+        permissions:
+          type: array
+          items:
+            type: string
+    ResponseEntitySessionListView:
+      type: object
+      properties:
+        entity:
+          type: array
+          items:
+            $ref: "#/components/schemas/SessionView"
         errors:
           type: array
           items:
@@ -34109,6 +34259,47 @@ components:
           type: string
         url:
           type: string
+    SessionView:
+      type: object
+      properties:
+        address:
+          type: string
+          description: Remote IP address recorded when the session was created. Null
+            if the address was never captured (e.g. the session was created outside
+            the servlet request pipeline that records it).
+          example: 192.168.1.100
+        isCurrent:
+          type: boolean
+          description: True if this entry represents the caller's own session.
+          example: true
+        sessionTime:
+          type: string
+          description: Human-readable elapsed time since the session was created.
+          example: 2 hours ago
+        token:
+          type: string
+          description: "HMAC-obfuscated session token. Pass this value back to DELETE\
+            \ /v1/maintenance/_sessions/{token} to invalidate the session."
+          example: a1b2c3d4e5f6g7h8
+        userEmail:
+          type: string
+          description: Email of the user associated with the session. Null for sessions
+            without an associated user account.
+          example: admin@dotcms.com
+        userFullName:
+          type: string
+          description: Full name of the user associated with the session. Null for
+            sessions without an associated user account.
+          example: Admin User
+        userId:
+          type: string
+          description: User id associated with the session (anonymous user id if no
+            login).
+          example: dotcms.org.1
+      required:
+      - isCurrent
+      - token
+      - userId
     SetForm:
       type: object
       properties:

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/maintenance/SessionTokenUtilTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/maintenance/SessionTokenUtilTest.java
@@ -1,0 +1,122 @@
+package com.dotcms.rest.api.v1.maintenance;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for {@link SessionTokenUtil}. Verifies that the REST migration of
+ * the Logged Users HMAC scheme produces byte-for-byte identical tokens to the
+ * legacy DWR implementation in {@code UserSessionAjax}, so existing clients see
+ * no regression in token shape or length.
+ *
+ * @author hassandotcms
+ */
+class SessionTokenUtilTest {
+
+    private static final String SESSION_ID = "ABC123sessionId";
+    private static final String SECRET = "csrf-secret";
+
+    /**
+     * Given scenario: same inputs hashed twice
+     * Expected result: deterministic, identical output
+     */
+    @Test
+    void obfuscateSessionId_isDeterministic() {
+        final String first = SessionTokenUtil.obfuscateSessionId(SESSION_ID, SECRET);
+        final String second = SessionTokenUtil.obfuscateSessionId(SESSION_ID, SECRET);
+        assertEquals(first, second);
+    }
+
+    /**
+     * Given scenario: 16-byte truncated HMAC-SHA256 Base64-URL encoded without padding
+     * Expected result: exactly 22 characters, no '=' padding, only URL-safe Base64 alphabet
+     */
+    @Test
+    void obfuscateSessionId_producesUrlSafeBase64Of16Bytes() {
+        final String token = SessionTokenUtil.obfuscateSessionId(SESSION_ID, SECRET);
+        assertEquals(22, token.length(),
+                "16 bytes Base64 URL-encoded without padding is exactly 22 chars");
+        assertFalse(token.contains("="), "no padding expected");
+        assertTrue(token.matches("[A-Za-z0-9_-]+"),
+                "tokens must use the URL-safe Base64 alphabet");
+    }
+
+    /**
+     * Given scenario: REST {@link SessionTokenUtil} and the legacy DWR-era reference
+     *                 implementation are run on the same inputs
+     * Expected result: identical tokens — guarantees the refactor is byte-for-byte
+     *                  compatible with any persisted/streamed values
+     */
+    @Test
+    void obfuscateSessionId_matchesLegacyReferenceImplementation() throws Exception {
+        final String legacy = legacyObfuscate(SESSION_ID, SECRET);
+        final String modern = SessionTokenUtil.obfuscateSessionId(SESSION_ID, SECRET);
+        assertEquals(legacy, modern,
+                "REST utility must produce the same token as the original UserSessionAjax code");
+    }
+
+    /**
+     * Given scenario: a token computed under secret A is validated under secret B
+     * Expected result: validation fails — the CSRF binding is enforced
+     */
+    @Test
+    void validateSessionId_rejectsTokenComputedUnderDifferentSecret() {
+        final String token = SessionTokenUtil.obfuscateSessionId(SESSION_ID, SECRET);
+        assertFalse(SessionTokenUtil.validateSessionId(SESSION_ID, "different-secret", token));
+    }
+
+    /**
+     * Given scenario: a token for session A is checked against session B
+     * Expected result: validation fails
+     */
+    @Test
+    void validateSessionId_rejectsTokenForDifferentSession() {
+        final String token = SessionTokenUtil.obfuscateSessionId(SESSION_ID, SECRET);
+        assertFalse(SessionTokenUtil.validateSessionId("other-session-id", SECRET, token));
+    }
+
+    /**
+     * Given scenario: matching session id, secret and token
+     * Expected result: validation succeeds
+     */
+    @Test
+    void validateSessionId_acceptsMatchingToken() {
+        final String token = SessionTokenUtil.obfuscateSessionId(SESSION_ID, SECRET);
+        assertTrue(SessionTokenUtil.validateSessionId(SESSION_ID, SECRET, token));
+    }
+
+    /**
+     * Given scenario: null token
+     * Expected result: validation rejects without NPE — defensive against bad inputs
+     */
+    @Test
+    void validateSessionId_rejectsNullToken() {
+        assertFalse(SessionTokenUtil.validateSessionId(SESSION_ID, SECRET, null));
+    }
+
+    /**
+     * Reference implementation copied verbatim from the pre-refactor
+     * {@code UserSessionAjax#obfuscateSessionId}. Lives only in this test to pin the
+     * wire format. If a future refactor changes the output, this test will fail.
+     */
+    private static String legacyObfuscate(final String sessionId, final String secretKey)
+            throws Exception {
+        final Mac mac = Mac.getInstance("HmacSHA256");
+        final SecretKeySpec key = new SecretKeySpec(
+                secretKey.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        mac.init(key);
+        final byte[] hash = mac.doFinal(sessionId.getBytes(StandardCharsets.UTF_8));
+        final byte[] truncatedHash = new byte[16];
+        System.arraycopy(hash, 0, truncatedHash, 0, 16);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(truncatedHash);
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/maintenance/MaintenanceResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/maintenance/MaintenanceResourceIntegrationTest.java
@@ -2,10 +2,13 @@ package com.dotcms.rest.api.v1.maintenance;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.dotcms.IntegrationTestBase;
+import com.dotcms.cmsmaintenance.ajax.UserSessionAjax;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.datagen.ContentTypeDataGen;
 import com.dotcms.datagen.ContentletDataGen;
@@ -15,8 +18,10 @@ import com.dotcms.jobs.business.api.JobQueueManagerAPI;
 import com.dotcms.jobs.business.job.Job;
 import com.dotcms.jobs.business.job.JobResult;
 import com.dotcms.jobs.business.job.JobState;
+import com.dotcms.listeners.SessionMonitor;
 import com.dotcms.mock.request.MockAttributeRequest;
 import com.dotcms.mock.request.MockHttpRequestIntegrationTest;
+import com.dotcms.mock.request.MockSession;
 import com.dotcms.mock.response.MockHttpResponse;
 import com.dotcms.rest.ResponseEntityJobStatusView;
 import com.dotcms.rest.ResponseEntityStringView;
@@ -24,6 +29,8 @@ import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.api.v1.job.JobStatusResponse;
 import com.dotcms.rest.exception.BadRequestException;
 import com.dotcms.rest.exception.ConflictException;
+import com.dotcms.rest.exception.ForbiddenException;
+import com.dotcms.rest.exception.NotFoundException;
 import com.dotcms.rest.exception.SecurityException;
 import com.dotcms.rest.exception.ValidationException;
 import com.dotcms.util.IntegrationTestInitService;
@@ -34,16 +41,23 @@ import com.dotmarketing.util.UUIDGenerator;
 import com.liferay.portal.model.User;
 import com.liferay.portal.util.WebKeys;
 import java.io.File;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -62,6 +76,9 @@ public class MaintenanceResourceIntegrationTest extends IntegrationTestBase {
     private static User adminUser;
     private static User nonAdminUser;
     private static JobQueueManagerAPI jobQueueManagerAPI;
+
+    /** Session ids planted in {@link SessionMonitor} by a test; cleaned up in {@link #cleanPlantedSessions()}. */
+    private final Set<String> plantedSessionIds = new HashSet<>();
 
     @BeforeClass
     public static void prepare() throws Exception {
@@ -569,6 +586,261 @@ public class MaintenanceResourceIntegrationTest extends IntegrationTestBase {
         new DeleteContentletsForm(null);
     }
 
+    // ==================== GET /_sessions ====================
+
+    /**
+     * Given scenario: a second admin session is planted in SessionMonitor and the caller's
+     *                 session is also registered there
+     * Expected result: both sessions are listed; the caller's entry has isCurrent=true,
+     *                  the planted entry has isCurrent=false, every token is the 22-char
+     *                  HMAC form (never the raw session id), and a fresh CSRF secret is
+     *                  stored on the caller's session
+     */
+    @Test
+    public void test_listSessions_asAdmin_returnsPlantedAndCallerSessions() {
+        final HttpServletRequest request = createAdminRequest();
+        final HttpSession callerSession = request.getSession();
+        callerSession.setAttribute(WebKeys.USER_ID, adminUser.getUserId());
+        plantSession(callerSession);
+
+        final HttpSession otherSession = newPlantedAdminSession("9.9.9.9");
+
+        final ResponseEntitySessionListView result = resource.listSessions(request, mockResponse);
+
+        assertNotNull(result);
+        final List<SessionView> sessions = result.getEntity();
+        assertNotNull(sessions);
+
+        SessionView callerView = null;
+        SessionView otherView = null;
+        for (final SessionView view : sessions) {
+            assertEquals("HMAC tokens are exactly 22 chars (16 bytes URL Base64 no padding)",
+                    22, view.token().length());
+            assertNotEquals("Raw session id must never leak in the token",
+                    callerSession.getId(), view.token());
+            assertNotEquals("Raw session id must never leak in the token",
+                    otherSession.getId(), view.token());
+
+            if (view.userId().equals(adminUser.getUserId())
+                    && view.isCurrent()) {
+                callerView = view;
+            } else if (view.userId().equals(adminUser.getUserId())
+                    && "9.9.9.9".equals(view.address())) {
+                otherView = view;
+            }
+        }
+        assertNotNull("The caller's session must appear with isCurrent=true", callerView);
+        assertNotNull("The planted session must appear in the list", otherView);
+        assertFalse("Planted session must not be marked as current", otherView.isCurrent());
+
+        final String csrf = (String) callerSession.getAttribute(
+                MaintenanceResource.CSRF_TOKEN_ATTRIBUTE);
+        assertNotNull("listSessions must persist a fresh CSRF token on the caller's session",
+                csrf);
+        assertTrue("CSRF timestamp must be stored alongside the token",
+                callerSession.getAttribute(MaintenanceResource.CSRF_TOKEN_TIMESTAMP_ATTRIBUTE)
+                        instanceof Instant);
+
+        assertEquals("Planted other session token must match the HMAC of its id under the issued CSRF",
+                SessionTokenUtil.obfuscateSessionId(otherSession.getId(), csrf),
+                otherView.token());
+    }
+
+    /**
+     * Given scenario: a non-admin user calls listSessions
+     * Expected result: SecurityException is thrown
+     */
+    @Test(expected = SecurityException.class)
+    public void test_listSessions_asNonAdmin_throwsSecurity() {
+        resource.listSessions(createRequestForUser(nonAdminUser), mockResponse);
+    }
+
+    // ==================== DELETE /_sessions/{token} ====================
+
+    /**
+     * Given scenario: admin issues a GET to receive a fresh CSRF, then DELETEs a planted
+     *                 session's token derived from that CSRF
+     * Expected result: the target session is invalidated (its USER_ID attribute is cleared
+     *                  by MockSession.invalidate()), the endpoint returns "Session invalidated"
+     */
+    @Test
+    public void test_killSession_validToken_invalidatesTarget() {
+        final HttpSession target = newPlantedAdminSession("1.2.3.4");
+        final HttpServletRequest request = createAdminRequest();
+        request.getSession().setAttribute(WebKeys.USER_ID, adminUser.getUserId());
+        plantSession(request.getSession());
+
+        resource.listSessions(request, mockResponse);
+        final String csrf = (String) request.getSession()
+                .getAttribute(MaintenanceResource.CSRF_TOKEN_ATTRIBUTE);
+        final String token = SessionTokenUtil.obfuscateSessionId(target.getId(), csrf);
+
+        final ResponseEntityStringView result =
+                resource.killSession(request, mockResponse, token);
+
+        assertNotNull(result);
+        assertEquals("Session invalidated", result.getEntity());
+        assertNull("Target session must have been invalidated (USER_ID cleared)",
+                target.getAttribute(WebKeys.USER_ID));
+    }
+
+    /**
+     * Given scenario: admin tries to invalidate its own session
+     * Expected result: BadRequestException — self-invalidation is forbidden
+     */
+    @Test(expected = BadRequestException.class)
+    public void test_killSession_ownToken_throwsBadRequest() {
+        final HttpServletRequest request = createAdminRequest();
+        final HttpSession callerSession = request.getSession();
+        callerSession.setAttribute(WebKeys.USER_ID, adminUser.getUserId());
+        plantSession(callerSession);
+
+        resource.listSessions(request, mockResponse);
+        final String csrf = (String) callerSession.getAttribute(
+                MaintenanceResource.CSRF_TOKEN_ATTRIBUTE);
+        final String selfToken = SessionTokenUtil.obfuscateSessionId(
+                callerSession.getId(), csrf);
+
+        resource.killSession(request, mockResponse, selfToken);
+    }
+
+    /**
+     * Given scenario: admin DELETEs a session without having called GET first
+     * Expected result: ForbiddenException — there is no CSRF secret on the caller's session
+     */
+    @Test(expected = ForbiddenException.class)
+    public void test_killSession_missingCsrf_throwsForbidden() {
+        final HttpServletRequest request = createAdminRequest();
+        resource.killSession(request, mockResponse, "any-token");
+    }
+
+    /**
+     * Given scenario: the CSRF secret on the caller's session was issued 20 minutes ago
+     * Expected result: ForbiddenException — exceeds the 15-minute expiry window
+     */
+    @Test(expected = ForbiddenException.class)
+    public void test_killSession_expiredCsrf_throwsForbidden() {
+        final HttpServletRequest request = createAdminRequest();
+        final HttpSession callerSession = request.getSession();
+        callerSession.setAttribute(MaintenanceResource.CSRF_TOKEN_ATTRIBUTE, "stale-csrf");
+        callerSession.setAttribute(MaintenanceResource.CSRF_TOKEN_TIMESTAMP_ATTRIBUTE,
+                Instant.now().minus(Duration.ofMinutes(20)));
+
+        resource.killSession(request, mockResponse, "any-token");
+    }
+
+    /**
+     * Given scenario: a syntactically valid HMAC is presented but it does not match any
+     *                 session currently tracked by SessionMonitor
+     * Expected result: NotFoundException
+     */
+    @Test(expected = NotFoundException.class)
+    public void test_killSession_unknownToken_throwsNotFound() {
+        final HttpServletRequest request = createAdminRequest();
+        resource.listSessions(request, mockResponse);
+        final String unknown = SessionTokenUtil.obfuscateSessionId(
+                "session-that-does-not-exist", "secret-that-was-never-issued");
+
+        resource.killSession(request, mockResponse, unknown);
+    }
+
+    /**
+     * Given scenario: non-admin DELETE
+     * Expected result: SecurityException — the auth gate runs before any session lookup
+     */
+    @Test(expected = SecurityException.class)
+    public void test_killSession_asNonAdmin_throwsSecurity() {
+        resource.killSession(createRequestForUser(nonAdminUser), mockResponse, "tok");
+    }
+
+    // ==================== DELETE /_sessions ====================
+
+    /**
+     * Given scenario: two planted sessions plus the caller's own (also planted) are in
+     *                 SessionMonitor
+     * Expected result: killedCount >= 2 (both planted), caller's session survives (USER_ID
+     *                  attribute is still set)
+     */
+    @Test
+    public void test_killAllSessions_killsEveryoneExceptCaller() {
+        final HttpSession a = newPlantedAdminSession("4.4.4.4");
+        final HttpSession b = newPlantedAdminSession("5.5.5.5");
+        final HttpServletRequest request = createAdminRequest();
+        final HttpSession caller = request.getSession();
+        caller.setAttribute(WebKeys.USER_ID, adminUser.getUserId());
+        plantSession(caller);
+
+        final ResponseEntityKillSessionsResultView result =
+                resource.killAllSessions(request, mockResponse);
+
+        assertNotNull(result);
+        final KillSessionsResultView view = result.getEntity();
+        assertNotNull(view);
+        assertTrue("Both planted sessions must be killed",
+                view.killedCount() >= 2);
+
+        assertNull("Planted session a should have been invalidated",
+                a.getAttribute(WebKeys.USER_ID));
+        assertNull("Planted session b should have been invalidated",
+                b.getAttribute(WebKeys.USER_ID));
+        assertEquals("Caller's session must survive",
+                adminUser.getUserId(), caller.getAttribute(WebKeys.USER_ID));
+    }
+
+    /**
+     * Given scenario: non-admin DELETE
+     * Expected result: SecurityException
+     */
+    @Test(expected = SecurityException.class)
+    public void test_killAllSessions_asNonAdmin_throwsSecurity() {
+        resource.killAllSessions(createRequestForUser(nonAdminUser), mockResponse);
+    }
+
+    // ==================== Legacy parity ====================
+
+    /**
+     * Given scenario: legacy DWR class still exposes obfuscateSessionId/validateSessionId
+     *                 as a backwards-compat shim
+     * Expected result: it produces and validates the same tokens as the REST utility — any
+     *                  pre-existing client code calling the static methods continues to work
+     */
+    @Test
+    public void test_legacy_userSessionAjax_delegates_to_sessionTokenUtil() {
+        final String sessionId = "session-" + UUIDGenerator.generateUuid();
+        final String csrf = "csrf-" + UUIDGenerator.generateUuid();
+
+        @SuppressWarnings("deprecation")
+        final String legacyToken = UserSessionAjax.obfuscateSessionId(sessionId, csrf);
+        final String modernToken = SessionTokenUtil.obfuscateSessionId(sessionId, csrf);
+        assertEquals("Legacy DWR shim must produce the same token as the REST utility",
+                modernToken, legacyToken);
+
+        @SuppressWarnings("deprecation")
+        final boolean legacyAccepts = UserSessionAjax.validateSessionId(
+                sessionId, csrf, legacyToken);
+        assertTrue("Legacy validate must accept its own token", legacyAccepts);
+
+        @SuppressWarnings("deprecation")
+        final boolean modernAcceptsLegacy = SessionTokenUtil.validateSessionId(
+                sessionId, csrf, legacyToken);
+        assertTrue("REST utility must accept tokens minted by the legacy shim",
+                modernAcceptsLegacy);
+    }
+
+    /**
+     * Removes any sessions planted by the current test from {@link SessionMonitor} so that
+     * subsequent tests start with a clean cache. Reflection is required because the cache
+     * is a private static field with no public mutator beyond {@link SessionMonitor}'s own
+     * listener callbacks.
+     */
+    @After
+    public void cleanPlantedSessions() throws Exception {
+        for (final String id : plantedSessionIds) {
+            sessionCache().invalidate(id);
+        }
+        plantedSessionIds.clear();
+    }
+
     // ==================== Helpers ====================
 
     private HttpServletRequest createAdminRequest() {
@@ -613,5 +885,44 @@ public class MaintenanceResourceIntegrationTest extends IntegrationTestBase {
         final Optional<Map<String, Object>> metadata = result.get().metadata();
         assertTrue("JobResult must carry a metadata map", metadata.isPresent());
         return metadata.get();
+    }
+
+    /**
+     * Creates a fresh {@link MockSession} that already carries the USER_ID and remote
+     * address attributes a real authenticated session would have, registers it with
+     * {@link SessionMonitor} via reflection, and tracks it for cleanup.
+     */
+    private HttpSession newPlantedAdminSession(final String remoteAddr) {
+        final HttpSession session = new MockSession(UUIDGenerator.generateUuid());
+        session.setAttribute(WebKeys.USER_ID, adminUser.getUserId());
+        session.setAttribute(SessionMonitor.USER_REMOTE_ADDR, remoteAddr);
+        plantSession(session);
+        return session;
+    }
+
+    /**
+     * Registers a pre-built session with {@link SessionMonitor}'s static cache via reflection.
+     * The cache is keyed by session id so multiple plants with the same id collide — every
+     * call uses a fresh UUID to keep tests independent.
+     */
+    private void plantSession(final HttpSession session) {
+        try {
+            sessionCache().put(session.getId(), session);
+            plantedSessionIds.add(session.getId());
+        } catch (final Exception e) {
+            throw new AssertionError("Could not plant session in SessionMonitor", e);
+        }
+    }
+
+    /**
+     * Reflectively grabs the {@code SessionMonitor.userSessions} static cache. The cache has
+     * no public accessor so tests need this hatch to set up a deterministic session list.
+     */
+    @SuppressWarnings("unchecked")
+    private static com.dotcms.cache.DynamicTTLCache<String, HttpSession> sessionCache()
+            throws Exception {
+        final Field field = SessionMonitor.class.getDeclaredField("userSessions");
+        field.setAccessible(true);
+        return (com.dotcms.cache.DynamicTTLCache<String, HttpSession>) field.get(null);
     }
 }


### PR DESCRIPTION
Migrates the Logged Users tab off the legacy UserSessionAjax DWR class by adding three REST endpoints on MaintenanceResource:

- GET    /api/v1/maintenance/_sessions           list active sessions
- DELETE /api/v1/maintenance/_sessions/{token}   invalidate one session
- DELETE /api/v1/maintenance/_sessions           invalidate all but caller

The HMAC obfuscation and 15-minute CSRF expiry from the legacy class are preserved so raw HTTP session ids never leave the JVM. HMAC helpers are extracted into a shared SessionTokenUtil; UserSessionAjax keeps the static obfuscate/validate methods as @Deprecated shims that delegate to the utility, so existing DWR call sites remain unchanged.

Covered by 7 unit tests (SessionTokenUtilTest) and 11 integration tests (MaintenanceResourceIntegrationTest) including byte-for-byte parity with the legacy implementation, CSRF expiry, self-kill rejection, and unknown-token 404 paths.
