### PR TITLE
feat(ci): enhance SDK release workflow 

### DIFF
--- a/.github/workflows/cicd_comp_deployment-phase.yml
+++ b/.github/workflows/cicd_comp_deployment-phase.yml
@@ -398,3 +398,18 @@ jobs:
             > This automated script is happy to announce that a new *_SDK libs_* version *tagged as:* [ `${{ steps.sdks_publish.outputs.npm-package-version }}` ] is now available on the `NPM` registry :package:!
             > *Introduced by:* <${{ steps.pr_info.outputs.pr_url }}|${{ steps.pr_info.outputs.pr_ref }}>
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      # Send Slack failure notification if SDK publish failed
+      - name: Slack Notification (SDK publish failure)
+        if: failure() && steps.sdks_publish.outcome == 'failure'
+        continue-on-error: true
+        uses: ./.github/actions/core-cicd/notification/notify-slack
+        with:
+          channel-id: "log-sdk-libs"
+          payload: |
+            > :red_circle: *SDK publish FAILED on trunk!*
+            >
+            > The automated SDK `@next` publish failed. The packages were *not* updated on the NPM registry.
+            > *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
+            > <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run — check logs for details>
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/cicd_manual-release-sdks.yml
+++ b/.github/workflows/cicd_manual-release-sdks.yml
@@ -105,11 +105,26 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          git checkout -b "$RELEASE_BRANCH"
+          # Idempotent: if branch exists from a previous failed run, reset it to main and re-use it.
+          # These are bot-managed branches so force push is safe.
+          if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" > /dev/null 2>&1; then
+            echo "Branch $RELEASE_BRANCH already exists remotely — resetting to origin/main."
+            git fetch origin main "$RELEASE_BRANCH"
+            git checkout -B "$RELEASE_BRANCH" origin/main
+          else
+            git checkout -b "$RELEASE_BRANCH"
+          fi
+
           echo "$RELEASE_VERSION" > core-web/libs/sdk/VERSION
           git add core-web/libs/sdk/VERSION
-          git commit -m "chore(sdk): bump SDK version to $RELEASE_VERSION"
-          git push origin "$RELEASE_BRANCH"
+
+          if git diff --cached --quiet; then
+            echo "VERSION already at $RELEASE_VERSION — nothing to commit."
+          else
+            git commit -m "chore(sdk): bump SDK version to $RELEASE_VERSION"
+          fi
+
+          git push --force origin "$RELEASE_BRANCH"
 
       - name: 'Publish @latest from release branch'
         id: deploy-javascript-sdk
@@ -120,21 +135,9 @@ jobs:
           publish-latest: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Slack Notification (SDK release announcement)'
-        if: success() && steps.deploy-javascript-sdk.outputs.published == 'true'
-        continue-on-error: true
-        uses: ./.github/actions/core-cicd/notification/notify-slack
-        with:
-          channel-id: "log-sdk-libs"
-          payload: |
-            > :large_green_circle: *Attention dotters:* SDK libs (Angular, Client, Experiments and React) officially released!
-            >
-            > This automated script is happy to announce that a new *_SDK libs_* version *tagged as:* [ `${{ steps.deploy-javascript-sdk.outputs.npm-package-version }}` ] is now available on the `NPM` registry :package:!
-            > *Release type:* `${{ inputs.version-type }}`  |  *Triggered by:* `${{ github.actor }}`
-            > <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>
-          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-
       - name: 'Open post-release PR to bump VERSION on main'
+        id: post_release_pr
+        if: success()
         env:
           RELEASE_VERSION: ${{ steps.compute_version.outputs.release_version }}
           NEXT_DEV_VERSION: ${{ steps.compute_version.outputs.next_dev_version }}
@@ -149,19 +152,62 @@ jobs:
           git reset --hard
           git clean -fdx
           git fetch origin main
-          git checkout main
-          git reset --hard origin/main
-          git checkout -b "$PR_BRANCH"
+
+          # Idempotent: reset branch to origin/main regardless of whether it already exists.
+          git checkout -B "$PR_BRANCH" origin/main
           echo "$NEXT_DEV_VERSION" > core-web/libs/sdk/VERSION
           git add core-web/libs/sdk/VERSION
-          git commit -m "chore(sdk): bump SDK version to $NEXT_DEV_VERSION after $RELEASE_VERSION release"
-          git push origin "$PR_BRANCH"
 
-          gh pr create \
-            --title "chore(sdk): bump SDK version to $NEXT_DEV_VERSION after $RELEASE_VERSION release" \
-            --body "Automated post-release bump. Moves the VERSION file from \`$RELEASE_VERSION\` to \`$NEXT_DEV_VERSION\` so trunk \`@next\` builds stay ahead of \`@latest\`." \
-            --base main \
-            --head "$PR_BRANCH"
+          if git diff --cached --quiet; then
+            echo "VERSION already at $NEXT_DEV_VERSION — nothing to commit."
+          else
+            git commit -m "chore(sdk): bump SDK version to $NEXT_DEV_VERSION after $RELEASE_VERSION release"
+          fi
+
+          git push --force origin "$PR_BRANCH"
+
+          # Reuse the PR if it was already created by a previous run.
+          EXISTING_PR=$(gh pr list --head "$PR_BRANCH" --base main --json url --jq '.[0].url' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR already exists: $EXISTING_PR"
+            PR_URL="$EXISTING_PR"
+          else
+            PR_URL=$(gh pr create \
+              --title "chore(sdk): bump SDK version to $NEXT_DEV_VERSION after $RELEASE_VERSION release" \
+              --body "Automated post-release bump. Moves the VERSION file from \`$RELEASE_VERSION\` to \`$NEXT_DEV_VERSION\` so trunk \`@next\` builds stay ahead of \`@latest\`." \
+              --base main \
+              --head "$PR_BRANCH")
+          fi
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+
+      - name: 'Slack Notification (SDK release announcement)'
+        if: success() && steps.deploy-javascript-sdk.outputs.published == 'true'
+        continue-on-error: true
+        uses: ./.github/actions/core-cicd/notification/notify-slack
+        with:
+          channel-id: "log-sdk-libs"
+          payload: |
+            > :large_green_circle: *Attention dotters:* SDK libs (Angular, Client, Experiments and React) officially released!
+            >
+            > This automated script is happy to announce that a new *_SDK libs_* version *tagged as:* [ `${{ steps.deploy-javascript-sdk.outputs.npm-package-version }}` ] is now available on the `NPM` registry :package:!
+            > *Release type:* `${{ inputs.version-type }}`  |  *Triggered by:* `${{ github.actor }}`
+            > :memo: *Please review and merge the post-release PR ASAP:* <${{ steps.post_release_pr.outputs.pr_url }}|View PR>
+            > <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+
+      - name: 'Slack Notification (SDK release failure)'
+        if: failure()
+        continue-on-error: true
+        uses: ./.github/actions/core-cicd/notification/notify-slack
+        with:
+          channel-id: "log-sdk-libs"
+          payload: |
+            > :red_circle: *SDK Release FAILED!*
+            >
+            > The SDK release workflow failed while trying to publish version `${{ steps.compute_version.outputs.release_version }}`.
+            > *Release type:* `${{ inputs.version-type }}`  |  *Triggered by:* `${{ github.actor }}`
+            > <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run — check logs for details>
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
 
       - name: 'Display results'
         if: always()
@@ -172,4 +218,5 @@ jobs:
           echo "Published to latest: ${{ steps.deploy-javascript-sdk.outputs.published-latest || 'unknown' }}"
           echo "Published to next:   ${{ steps.deploy-javascript-sdk.outputs.published-next || 'unknown' }}"
           echo "NPM package version: ${{ steps.deploy-javascript-sdk.outputs.npm-package-version || 'unknown' }}"
+          echo "Post-release PR:     ${{ steps.post_release_pr.outputs.pr_url || 'not created' }}"
           echo "::endgroup::"


### PR DESCRIPTION
  - Failure notifications: Both the trunk (@next) and manual release (@latest) workflows now post a Slack message to #log-sdk-libs when the publish fails. Previously failures were silent —
   the channel only received success messages.
  - Idempotent branch handling: The manual release workflow created sdk/release-X.Y.Z and sdk/post-release-X.Y.Z branches using git checkout -b, which fails if a branch already exists from
   a previous failed run. Re-triggering the workflow would always fail at that step. Both branches are now handled idempotently: if the branch exists on the remote it is reset to
  origin/main and force-pushed; if the post-release PR already exists it is reused instead of re-created.
  - Post-release PR link in Slack: The success notification for @latest releases now includes a direct link to the VERSION bump PR and an "ASAP review" callout. The notification was also
  moved to fire after the PR is created so the link is available.
  
These changes improve the reliability and transparency of the SDK release process.

Examples of the new messages:

  ---
  Deploy fail — @next (trunk, cicd_comp_deployment-phase.yml)
  🔴 SDK publish FAILED on trunk!

  The automated SDK `@next` publish failed. The packages were *not* updated on the NPM registry.
  Commit: <link to commit sha>
  <link to workflow run — check logs for details>

  ---
  Deploy success — @latest (manual, cicd_manual-release-sdks.yml)
  🟢 Attention dotters: SDK libs (Angular, Client, Experiments and React) officially released!

  This automated script is happy to announce that a new SDK libs version tagged as:
  [ `1.3.0 (latest) and 1.3.0-next.12345 (next)` ] is now available on the NPM registry 📦!
  Release type: `patch`  |  Triggered by: `kevin.davila`
  📝 Please review and merge the post-release PR ASAP: <link to PR>
  <link to workflow run>

  ---
  Deploy success — @next (trunk, cicd_comp_deployment-phase.yml)
  🟠 Attention dotters: SDK libs (Angular, Client, Experiments and React) published!

  This automated script is happy to announce that a new SDK libs version tagged as:
  [ `1.3.0-next.12345 (next)` ] is now available on the NPM registry 📦!
  Introduced by: <link to PR #456>

  ---
  Deploy fail — @latest (manual, cicd_manual-release-sdks.yml)
  🔴 SDK Release FAILED!

  The SDK release workflow failed while trying to publish version `1.3.0`.
  Release type: `patch`  |  Triggered by: `kevin.davila`
  <link to workflow run — check logs for details>

This PR fixes: #35670

This PR fixes: #35670