### PR TITLE
🛡️ Sentinel: [HIGH] [A08 / CWE-502] Harden VersionOverrideObjectInputStream

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/security/apps/VersionOverrideObjectInputStream.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/VersionOverrideObjectInputStream.java
@@ -6,12 +6,35 @@ import java.io.InputStream;
 import java.io.InvalidClassException;
 import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
 
 /**
  * This class is used to override the default ObjectInputStream class to handle version mismatch
- * in case of any mismatch in the serialVersionUID of the class we override the class descriptor with the local class descriptor
+ * in case of any mismatch in the serialVersionUID of the class we override the class descriptor with the local class descriptor.
+ * It also implements a strict allowlist for class deserialization to prevent insecure deserialization attacks.
  */
 public class VersionOverrideObjectInputStream extends ObjectInputStream {
+
+    private static final Set<String> ALLOWED_CLASSES = Set.of(
+            AppsSecretsImportExport.class.getName(),
+            AppSecrets.class.getName(),
+            Secret.class.getName(),
+            AbstractProperty.class.getName(),
+            Type.class.getName(),
+            HashMap.class.getName(),
+            ArrayList.class.getName(),
+            String.class.getName(),
+            Boolean.class.getName(),
+            Enum.class.getName(),
+            "com.google.common.collect.ImmutableMap$SerializedForm",
+            "com.google.common.collect.ImmutableBiMap$SerializedForm",
+            "com.google.common.collect.ImmutableList$SerializedForm",
+            "com.google.common.collect.ImmutableSet$SerializedForm",
+            "[C", // char[]
+            "[Ljava.lang.Object;" // Object[]
+    );
 
     /**
      * Constructor
@@ -20,6 +43,20 @@ public class VersionOverrideObjectInputStream extends ObjectInputStream {
      */
     public VersionOverrideObjectInputStream(InputStream in) throws IOException {
         super(in);
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        final String name = desc.getName();
+        if (!ALLOWED_CLASSES.contains(name)) {
+            throw new InvalidClassException("Unauthorized deserialization attempt", name);
+        }
+        return super.resolveClass(desc);
+    }
+
+    @Override
+    protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+        throw new InvalidClassException("Dynamic Proxy Deserialization is not allowed");
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/security/apps/VersionOverrideObjectInputStreamTest.java
+++ b/dotCMS/src/test/java/com/dotcms/security/apps/VersionOverrideObjectInputStreamTest.java
@@ -1,0 +1,61 @@
+package com.dotcms.security.apps;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectOutputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class VersionOverrideObjectInputStreamTest {
+
+    @Test
+    public void testDeserializationAllowlist() throws IOException, ClassNotFoundException {
+        Map<String, List<AppSecrets>> secretsMap = new HashMap<>();
+        List<AppSecrets> secretsList = new ArrayList<>();
+        secretsList.add(AppSecrets.builder()
+                .withKey("test-app")
+                .withSecret("secret1", "value1")
+                .build());
+        secretsMap.put("host1", secretsList);
+        AppsSecretsImportExport original = new AppsSecretsImportExport(secretsMap);
+
+        byte[] serialized;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(original);
+            serialized = baos.toByteArray();
+        }
+
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                VersionOverrideObjectInputStream voois = new VersionOverrideObjectInputStream(bais)) {
+            AppsSecretsImportExport deserialized = (AppsSecretsImportExport) voois.readObject();
+            assertNotNull(deserialized);
+            assertNotNull(deserialized.getSecrets().get("host1"));
+        }
+    }
+
+    @Test
+    public void testDeserializationBlocked() throws IOException {
+        URL unauthorizedObject = new URL("http://localhost");
+        byte[] serialized;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(unauthorizedObject);
+            serialized = baos.toByteArray();
+        }
+
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                VersionOverrideObjectInputStream voois = new VersionOverrideObjectInputStream(bais)) {
+            assertThrows(InvalidClassException.class, voois::readObject);
+        }
+    }
+}


### PR DESCRIPTION
### 🛡️ Sentinel: [HIGH] [A08 / CWE-502] Harden VersionOverrideObjectInputStream

- 🚨 **Severity** — High (CVSS: 7.5 AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H)
- 🧭 **OWASP mapping** — A08:2021 – Software and Data Integrity Failures / CWE-502 / ASVS V5.5.3
- 💡 **Issue** — `VersionOverrideObjectInputStream` extended `ObjectInputStream` to handle version mismatches but did not restrict the classes that could be deserialized. This allowed an attacker to provide a malicious serialized object (e.g., via the Apps Import feature) to trigger Remote Code Execution (RCE) using common gadget chains.
- 🎯 **Impact** — High (C/I/A). An unauthenticated or low-privileged attacker with access to the Apps Secrets import could potentially execute arbitrary code on the server.
- 🔧 **Fix** — Overrode `resolveClass` to implement a strict, minimal allowlist of classes required for dotCMS App Secrets (including domain models, collections, and Guava serialization proxies). Overrode `resolveProxyClass` to reject all dynamic proxies.
- ✅ **Verification** — 
  - Ran `./mvnw test -pl dotCMS -Dtest=VersionOverrideObjectInputStreamTest -Ddocker.skip=true`
  - Created `dotCMS/src/test/java/com/dotcms/security/apps/VersionOverrideObjectInputStreamTest.java` which verifies:
    - Successful deserialization of legitimate `AppsSecretsImportExport` objects.
    - Blocking of unauthorized classes (e.g., `java.net.URL`).
    - Support for Guava's `ImmutableMap$SerializedForm` and other internal proxies.

---
*PR created automatically by Jules for task [12870648850670372793](https://jules.google.com/task/12870648850670372793) started by @oidacra*