### PR TITLE
feat(security): periodic job to encrypt plaintext passwords in user_ table

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/init/DotInitScheduler.java
+++ b/dotCMS/src/main/java/com/dotmarketing/init/DotInitScheduler.java
@@ -16,6 +16,7 @@ import com.dotmarketing.quartz.job.CleanUnDeletedUsersJob;
 import com.dotmarketing.quartz.job.DeleteInactiveLiveWorkingIndicesJob;
 import com.dotmarketing.quartz.job.DeleteSiteSearchIndicesJob;
 import com.dotmarketing.quartz.job.DropOldContentVersionsJob;
+import com.dotmarketing.quartz.job.EncryptPlainPasswordsJob;
 import com.dotmarketing.quartz.job.FreeServerFromClusterJob;
 import com.dotmarketing.quartz.job.PruneTimeMachineBackupJob;
 import com.dotmarketing.quartz.job.ServerHeartbeatJob;
@@ -298,6 +299,50 @@ public class DotInitScheduler {
             } else {
                 if ((sched.getJobDetail(CUUjobName, CUUjobGroup)) != null) {
                     sched.deleteJob(CUUjobName, CUUjobGroup);
+                }
+            }
+
+            //Schedule EncryptPlainPasswordsJob
+            final String EPPjobName = "EncryptPlainPasswordsJob";
+            final String EPPjobGroup = DOTCMS_JOB_GROUP_NAME;
+            final String EPPtriggerName = "trigger27";
+            final String EPPtriggerGroup = "group27";
+
+            if (EncryptPlainPasswordsJob.isEnabled()) {
+                try {
+                    isNew = false;
+
+                    try {
+                        if ((job = sched.getJobDetail(EPPjobName, EPPjobGroup)) == null) {
+                            job = new JobDetail(EPPjobName, EPPjobGroup, EncryptPlainPasswordsJob.class);
+                            isNew = true;
+                        }
+                    } catch (SchedulerException se) {
+                        sched.deleteJob(EPPjobName, EPPjobGroup);
+                        job = new JobDetail(EPPjobName, EPPjobGroup, EncryptPlainPasswordsJob.class);
+                        isNew = true;
+                    }
+                    calendar = Calendar.getInstance();
+                    calendar.add(Calendar.MINUTE, 1);
+                    // By default, the job runs every minute
+                    trigger = new CronTrigger(EPPtriggerName, EPPtriggerGroup, EPPjobName, EPPjobGroup,
+                            calendar.getTime(), null,
+                            Config.getStringProperty(EncryptPlainPasswordsJob.CRON_PROPERTY,
+                                    EncryptPlainPasswordsJob.DEFAULT_CRON_EXPRESSION));
+                    trigger.setMisfireInstruction(CronTrigger.MISFIRE_INSTRUCTION_DO_NOTHING);
+                    sched.addJob(job, true);
+
+                    if (isNew) {
+                        sched.scheduleJob(trigger);
+                    } else {
+                        sched.rescheduleJob(EPPtriggerName, EPPtriggerGroup, trigger);
+                    }
+                } catch (Exception e) {
+                    Logger.error(DotInitScheduler.class, e.getMessage(), e);
+                }
+            } else {
+                if ((sched.getJobDetail(EPPjobName, EPPjobGroup)) != null) {
+                    sched.deleteJob(EPPjobName, EPPjobGroup);
                 }
             }
 

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJob.java
@@ -20,20 +20,32 @@ import org.quartz.StatefulJob;
  * {@link PasswordFactoryProxy#generateHash(String)}. Once hashed, the row is flipped to
  * {@code passwordEncrypted = true}.
  *
- * By default this job is scheduled to run every minute. It is stateful so concurrent firings
- * cannot overlap.
+ * Implementation notes:
+ * <ul>
+ *   <li>Stateful job — concurrent firings cannot overlap.</li>
+ *   <li>The UPDATE is guarded by {@code passwordEncrypted = false AND password_ = ?} so that a
+ *       concurrent password change (via {@code UserAPI}) cannot be silently regressed: if the row
+ *       was already rewritten between the SELECT and the UPDATE, the UPDATE affects zero rows
+ *       and is logged at debug.</li>
+ *   <li>Each firing processes at most {@code ENCRYPT_PLAIN_PASSWORDS_BATCH_SIZE} rows so a bulk
+ *       import depositing tens of thousands of plaintext rows cannot pin a Quartz worker thread
+ *       for hours. Remaining rows are caught on subsequent ticks.</li>
+ * </ul>
  */
 public class EncryptPlainPasswordsJob implements StatefulJob {
 
     public static final String ENABLE_PROPERTY = "ENABLE_ENCRYPT_PLAIN_PASSWORDS_JOB";
     public static final String CRON_PROPERTY = "ENCRYPT_PLAIN_PASSWORDS_CRON_EXPRESSION";
-    public static final String DEFAULT_CRON_EXPRESSION = "0 0/1 * * * ?";
+    public static final String BATCH_SIZE_PROPERTY = "ENCRYPT_PLAIN_PASSWORDS_BATCH_SIZE";
+    public static final String DEFAULT_CRON_EXPRESSION = "0 0/5 * * * ?";
+    public static final int DEFAULT_BATCH_SIZE = 500;
 
     private static final String SELECT_PLAINTEXT_USERS_SQL =
-            "select userId, password_ from user_ where passwordEncrypted = ? and password_ is not null";
+            "select userId, password_ from user_ where passwordEncrypted = ? and password_ is not null limit ?";
 
     private static final String UPDATE_HASHED_PASSWORD_SQL =
-            "update user_ set password_ = ?, passwordEncrypted = ? where userId = ?";
+            "update user_ set password_ = ?, passwordEncrypted = ? "
+                    + "where userId = ? and passwordEncrypted = ? and password_ = ?";
 
     /**
      * Runtime kill switch. The scheduler also checks this property at startup; checking it here
@@ -46,21 +58,24 @@ public class EncryptPlainPasswordsJob implements StatefulJob {
     @Override
     public void execute(final JobExecutionContext context) throws JobExecutionException {
         if (com.dotcms.shutdown.ShutdownCoordinator.isShutdownStarted()) {
-            Logger.info(this.getClass(),
+            Logger.info(EncryptPlainPasswordsJob.class,
                     "Shutdown in progress - skipping EncryptPlainPasswordsJob execution");
             return;
         }
 
         if (!isEnabled()) {
-            Logger.debug(this.getClass(),
+            Logger.debug(EncryptPlainPasswordsJob.class,
                     () -> ENABLE_PROPERTY + "=false - skipping EncryptPlainPasswordsJob execution");
             return;
         }
+
+        final int batchSize = Config.getIntProperty(BATCH_SIZE_PROPERTY, DEFAULT_BATCH_SIZE);
 
         try {
             final List<Map<String, Object>> rows = new DotConnect()
                     .setSQL(SELECT_PLAINTEXT_USERS_SQL)
                     .addParam(false)
+                    .addParam(batchSize)
                     .loadObjectResults();
 
             if (rows.isEmpty()) {
@@ -71,6 +86,7 @@ public class EncryptPlainPasswordsJob implements StatefulJob {
                     "Found " + rows.size() + " user(s) with unencrypted passwords. Hashing now.");
 
             int hashed = 0;
+            int skipped = 0;
             for (final Map<String, Object> row : rows) {
                 final String userId = (String) row.get("userid");
                 final String plaintext = (String) row.get("password_");
@@ -81,13 +97,18 @@ public class EncryptPlainPasswordsJob implements StatefulJob {
 
                 try {
                     final String hash = PasswordFactoryProxy.generateHash(plaintext);
-                    new DotConnect()
-                            .setSQL(UPDATE_HASHED_PASSWORD_SQL)
-                            .addParam(hash)
-                            .addParam(true)
-                            .addParam(userId)
-                            .loadResult();
-                    hashed++;
+                    final int updated = new DotConnect()
+                            .executeUpdate(UPDATE_HASHED_PASSWORD_SQL,
+                                    hash, true, userId, false, plaintext);
+                    if (updated == 0) {
+                        // Row changed between SELECT and UPDATE — another writer got there first.
+                        skipped++;
+                        Logger.debug(EncryptPlainPasswordsJob.class,
+                                () -> "Skipped userId=" + userId
+                                        + " — row was modified between select and update");
+                    } else {
+                        hashed++;
+                    }
                 } catch (PasswordException | DotDataException e) {
                     Logger.error(EncryptPlainPasswordsJob.class,
                             "Unable to hash password for userId=" + userId + ": " + e.getMessage(),
@@ -96,7 +117,8 @@ public class EncryptPlainPasswordsJob implements StatefulJob {
             }
 
             Logger.info(EncryptPlainPasswordsJob.class,
-                    "Encrypted " + hashed + " of " + rows.size() + " plaintext password row(s).");
+                    "Encrypted " + hashed + " of " + rows.size()
+                            + " plaintext password row(s) (skipped " + skipped + ").");
         } catch (DotDataException e) {
             Logger.error(EncryptPlainPasswordsJob.class,
                     "Error scanning user_ table for unencrypted passwords", e);

--- a/dotCMS/src/main/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJob.java
+++ b/dotCMS/src/main/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJob.java
@@ -1,0 +1,107 @@
+package com.dotmarketing.quartz.job;
+
+import com.dotcms.enterprise.PasswordFactoryProxy;
+import com.dotcms.enterprise.de.qaware.heimdall.PasswordException;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.db.DbConnectionFactory;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
+import java.util.List;
+import java.util.Map;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.StatefulJob;
+
+/**
+ * Sweeps the {@code user_} table for rows whose {@code passwordEncrypted} flag is {@code false}
+ * (plaintext passwords) and rewrites them with a securely hashed value via
+ * {@link PasswordFactoryProxy#generateHash(String)}. Once hashed, the row is flipped to
+ * {@code passwordEncrypted = true}.
+ *
+ * By default this job is scheduled to run every minute. It is stateful so concurrent firings
+ * cannot overlap.
+ */
+public class EncryptPlainPasswordsJob implements StatefulJob {
+
+    public static final String ENABLE_PROPERTY = "ENABLE_ENCRYPT_PLAIN_PASSWORDS_JOB";
+    public static final String CRON_PROPERTY = "ENCRYPT_PLAIN_PASSWORDS_CRON_EXPRESSION";
+    public static final String DEFAULT_CRON_EXPRESSION = "0 0/1 * * * ?";
+
+    private static final String SELECT_PLAINTEXT_USERS_SQL =
+            "select userId, password_ from user_ where passwordEncrypted = ? and password_ is not null";
+
+    private static final String UPDATE_HASHED_PASSWORD_SQL =
+            "update user_ set password_ = ?, passwordEncrypted = ? where userId = ?";
+
+    /**
+     * Runtime kill switch. The scheduler also checks this property at startup; checking it here
+     * lets an operator disable the job between firings without restarting the JVM.
+     */
+    public static boolean isEnabled() {
+        return Config.getBooleanProperty(ENABLE_PROPERTY, true);
+    }
+
+    @Override
+    public void execute(final JobExecutionContext context) throws JobExecutionException {
+        if (com.dotcms.shutdown.ShutdownCoordinator.isShutdownStarted()) {
+            Logger.info(this.getClass(),
+                    "Shutdown in progress - skipping EncryptPlainPasswordsJob execution");
+            return;
+        }
+
+        if (!isEnabled()) {
+            Logger.debug(this.getClass(),
+                    () -> ENABLE_PROPERTY + "=false - skipping EncryptPlainPasswordsJob execution");
+            return;
+        }
+
+        try {
+            final List<Map<String, Object>> rows = new DotConnect()
+                    .setSQL(SELECT_PLAINTEXT_USERS_SQL)
+                    .addParam(false)
+                    .loadObjectResults();
+
+            if (rows.isEmpty()) {
+                return;
+            }
+
+            Logger.info(EncryptPlainPasswordsJob.class,
+                    "Found " + rows.size() + " user(s) with unencrypted passwords. Hashing now.");
+
+            int hashed = 0;
+            for (final Map<String, Object> row : rows) {
+                final String userId = (String) row.get("userid");
+                final String plaintext = (String) row.get("password_");
+
+                if (!UtilMethods.isSet(userId) || !UtilMethods.isSet(plaintext)) {
+                    continue;
+                }
+
+                try {
+                    final String hash = PasswordFactoryProxy.generateHash(plaintext);
+                    new DotConnect()
+                            .setSQL(UPDATE_HASHED_PASSWORD_SQL)
+                            .addParam(hash)
+                            .addParam(true)
+                            .addParam(userId)
+                            .loadResult();
+                    hashed++;
+                } catch (PasswordException | DotDataException e) {
+                    Logger.error(EncryptPlainPasswordsJob.class,
+                            "Unable to hash password for userId=" + userId + ": " + e.getMessage(),
+                            e);
+                }
+            }
+
+            Logger.info(EncryptPlainPasswordsJob.class,
+                    "Encrypted " + hashed + " of " + rows.size() + " plaintext password row(s).");
+        } catch (DotDataException e) {
+            Logger.error(EncryptPlainPasswordsJob.class,
+                    "Error scanning user_ table for unencrypted passwords", e);
+        } finally {
+            DbConnectionFactory.closeSilently();
+        }
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite2b.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite2b.java
@@ -161,6 +161,7 @@ import com.dotmarketing.portlets.workflows.model.TestWorkflowAction;
 import com.dotmarketing.quartz.DotStatefulJobTest;
 import com.dotmarketing.quartz.job.CleanUpFieldReferencesJobTest;
 import com.dotmarketing.quartz.job.DropOldContentVersionsJobTest;
+import com.dotmarketing.quartz.job.EncryptPlainPasswordsJobTest;
 import com.dotmarketing.quartz.job.IntegrityDataGenerationJobTest;
 import com.dotmarketing.quartz.job.PopulateContentletAsJSONJobTest;
 import com.dotmarketing.quartz.job.PruneTimeMachineBackupJobTest;
@@ -471,6 +472,7 @@ import org.junit.runners.Suite.SuiteClasses;
         com.dotmarketing.tag.business.TagAPITest.class,
         OSGIUtilTest.class,
         CleanUpFieldReferencesJobTest.class,
+        EncryptPlainPasswordsJobTest.class,
         CachedParameterDecoratorTest.class,
         ContainerFactoryImplTest.class,
         TemplateFactoryImplTest.class,

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
@@ -11,6 +11,7 @@ import com.dotcms.enterprise.PasswordFactoryProxy;
 import com.dotcms.enterprise.PasswordFactoryProxy.AuthenticationStatus;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.cms.factories.PublicCompanyFactory;
+import com.dotmarketing.cms.login.factories.LoginFactory;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.init.DotInitScheduler;
@@ -166,6 +167,33 @@ public class EncryptPlainPasswordsJobTest extends IntegrationTestBase {
     }
 
     /**
+     * End-to-end auth roundtrip: the hash format produced by the job must be accepted by the
+     * platform's real authentication entry point.
+     *
+     * Given: a user with passwordEncrypted=false sitting in user_ with plaintext password "X".
+     * When:  the job runs and rewrites password_ as a hash.
+     * Then:  {@link LoginFactory#doLogin(String, String)} with the original plaintext returns
+     *        true; the same call with a wrong password returns false. This proves the job's
+     *        output is interchangeable with hashes produced via UserAPI / login flows.
+     */
+    @Test
+    public void test_user_can_authenticate_after_job_hashes_password() throws Exception {
+        final String userId = insertUser(PLAINTEXT, false);
+
+        TestJobExecutor.execute(job, new HashMap<>());
+
+        // Confirm the row was actually hashed before we test auth.
+        final Map<String, Object> row = loadRow(userId);
+        assertTrue("Pre-condition: row should be hashed before auth check",
+                toBool(row.get("passwordencrypted")));
+
+        assertTrue("doLogin with original plaintext must succeed against the job-produced hash",
+                LoginFactory.doLogin(userId, PLAINTEXT));
+        assertFalse("doLogin with a wrong password must fail",
+                LoginFactory.doLogin(userId, PLAINTEXT + "-wrong"));
+    }
+
+    /**
      * Given: a row that the SELECT will see as plaintext, but whose password_ is mutated by another
      *        writer between SELECT and UPDATE.
      * When:  the job runs.
@@ -200,14 +228,15 @@ public class EncryptPlainPasswordsJobTest extends IntegrationTestBase {
     private String insertUser(final String password, final boolean encrypted) throws DotDataException {
         final String userId = "test-encrypt-job-" + UUIDGenerator.generateUuid();
         new DotConnect()
-                .setSQL("insert into user_ (userId, companyId, password_, passwordEncrypted, " +
-                        "passwordReset, male, dottedSkins, roundedSkins, failedLoginAttempts, " +
-                        "agreedToTermsOfUse, active_) " +
-                        "values (?, ?, ?, ?, false, false, false, false, 0, false, true)")
+                .setSQL("insert into user_ (userId, companyId, password_, passwordEncrypted, "
+                        + "emailAddress, passwordReset, male, dottedSkins, roundedSkins, "
+                        + "failedLoginAttempts, agreedToTermsOfUse, active_) "
+                        + "values (?, ?, ?, ?, ?, false, false, false, false, 0, false, true)")
                 .addParam(userId)
                 .addParam(defaultCompanyId)
                 .addParam(password)
                 .addParam(encrypted)
+                .addParam(userId + "@test.dotcms")
                 .loadResult();
         insertedUserIds.add(userId);
         return userId;

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
@@ -63,7 +63,17 @@ public class EncryptPlainPasswordsJobTest extends IntegrationTestBase {
     @After
     public void cleanupInsertedRows() throws DotDataException {
         for (final String userId : insertedUserIds) {
-            new DotConnect().setSQL("delete from user_ where userId = ?").addParam(userId).loadResult();
+            // LoginFactory.doLogin loads the user via UserAPI, which auto-assigns default roles
+            // (users_cms_roles.user_id FKs back to user_). Clear those first to avoid a
+            // foreign-key violation on the user_ delete.
+            new DotConnect()
+                    .setSQL("delete from users_cms_roles where user_id = ?")
+                    .addParam(userId)
+                    .loadResult();
+            new DotConnect()
+                    .setSQL("delete from user_ where userId = ?")
+                    .addParam(userId)
+                    .loadResult();
         }
         insertedUserIds.clear();
         Config.setProperty(EncryptPlainPasswordsJob.ENABLE_PROPERTY, true);

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
@@ -12,6 +12,7 @@ import com.dotcms.enterprise.PasswordFactoryProxy.AuthenticationStatus;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.cms.factories.PublicCompanyFactory;
 import com.dotmarketing.cms.login.factories.LoginFactory;
+import com.liferay.portal.model.Company;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.init.DotInitScheduler;
@@ -187,10 +188,16 @@ public class EncryptPlainPasswordsJobTest extends IntegrationTestBase {
         assertTrue("Pre-condition: row should be hashed before auth check",
                 toBool(row.get("passwordencrypted")));
 
+        // doLogin resolves the user via the company's configured auth type — pass whichever
+        // identifier that resolver expects so the test is robust to AUTH_TYPE_EA vs AUTH_TYPE_ID.
+        final String identifier = Company.AUTH_TYPE_EA.equals(
+                PublicCompanyFactory.getDefaultCompany().getAuthType())
+                ? emailFor(userId) : userId;
+
         assertTrue("doLogin with original plaintext must succeed against the job-produced hash",
-                LoginFactory.doLogin(userId, PLAINTEXT));
+                LoginFactory.doLogin(identifier, PLAINTEXT));
         assertFalse("doLogin with a wrong password must fail",
-                LoginFactory.doLogin(userId, PLAINTEXT + "-wrong"));
+                LoginFactory.doLogin(identifier, PLAINTEXT + "-wrong"));
     }
 
     /**
@@ -236,10 +243,14 @@ public class EncryptPlainPasswordsJobTest extends IntegrationTestBase {
                 .addParam(defaultCompanyId)
                 .addParam(password)
                 .addParam(encrypted)
-                .addParam(userId + "@test.dotcms")
+                .addParam(emailFor(userId))
                 .loadResult();
         insertedUserIds.add(userId);
         return userId;
+    }
+
+    private static String emailFor(final String userId) {
+        return userId + "@test.dotcms";
     }
 
     private Map<String, Object> loadRow(final String userId) throws DotDataException {

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
@@ -1,0 +1,181 @@
+package com.dotmarketing.quartz.job;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.enterprise.PasswordFactoryProxy;
+import com.dotcms.enterprise.PasswordFactoryProxy.AuthenticationStatus;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.util.Config;
+import com.dotmarketing.util.UUIDGenerator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Integration tests for {@link EncryptPlainPasswordsJob}.
+ *
+ * Rows are inserted directly via {@link DotConnect} (rather than {@code UserAPI.save}) so the
+ * test controls exactly what lands in {@code user_.password_} and {@code user_.passwordEncrypted}.
+ */
+public class EncryptPlainPasswordsJobTest extends IntegrationTestBase {
+
+    private static final String COMPANY_ID = "dotcms.org";
+    private static final String PLAINTEXT = "s3cret-plain-password";
+
+    private final EncryptPlainPasswordsJob job = new EncryptPlainPasswordsJob();
+    private final java.util.List<String> insertedUserIds = new java.util.ArrayList<>();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    @After
+    public void cleanupInsertedRows() throws DotDataException {
+        for (final String userId : insertedUserIds) {
+            new DotConnect().setSQL("delete from user_ where userId = ?").addParam(userId).loadResult();
+        }
+        insertedUserIds.clear();
+        Config.setProperty(EncryptPlainPasswordsJob.ENABLE_PROPERTY, true);
+    }
+
+    /**
+     * Given: a row with passwordEncrypted=false and a plaintext password.
+     * When:  the job runs.
+     * Then:  passwordEncrypted flips to true, password_ no longer equals the plaintext, and
+     *        {@link PasswordFactoryProxy#authPassword} authenticates the original plaintext
+     *        against the stored hash.
+     */
+    @Test
+    public void test_hashes_plaintext_row() throws Exception {
+        final String userId = insertUser(PLAINTEXT, false);
+
+        TestJobExecutor.execute(job, new HashMap<>());
+
+        final Map<String, Object> row = loadRow(userId);
+        assertTrue("passwordEncrypted should be true after job runs",
+                toBool(row.get("passwordencrypted")));
+        final String storedPassword = (String) row.get("password_");
+        assertNotEquals("password_ should no longer be the plaintext",
+                PLAINTEXT, storedPassword);
+        assertEquals("Stored hash must authenticate the original plaintext",
+                AuthenticationStatus.AUTHENTICATED,
+                PasswordFactoryProxy.authPassword(PLAINTEXT, storedPassword));
+    }
+
+    /**
+     * Given: a row that is already passwordEncrypted=true.
+     * When:  the job runs.
+     * Then:  the row is untouched (password_ and flag are unchanged).
+     */
+    @Test
+    public void test_leaves_already_encrypted_row_alone() throws Exception {
+        final String alreadyHashed = PasswordFactoryProxy.generateHash(PLAINTEXT);
+        final String userId = insertUser(alreadyHashed, true);
+
+        TestJobExecutor.execute(job, new HashMap<>());
+
+        final Map<String, Object> row = loadRow(userId);
+        assertTrue("passwordEncrypted should still be true", toBool(row.get("passwordencrypted")));
+        assertEquals("password_ should be unchanged",
+                alreadyHashed, row.get("password_"));
+    }
+
+    /**
+     * Given: a row with passwordEncrypted=false and a null password_.
+     * When:  the job runs.
+     * Then:  the row is skipped — passwordEncrypted stays false (nothing to hash).
+     */
+    @Test
+    public void test_skips_row_with_null_password() throws Exception {
+        final String userId = insertUser(null, false);
+
+        TestJobExecutor.execute(job, new HashMap<>());
+
+        final Map<String, Object> row = loadRow(userId);
+        assertFalse("Row with null password_ must not be marked encrypted",
+                toBool(row.get("passwordencrypted")));
+        assertNull("password_ must remain null", row.get("password_"));
+    }
+
+    /**
+     * Given: multiple plaintext rows.
+     * When:  the job runs once.
+     * Then:  every row is hashed in the single pass.
+     */
+    @Test
+    public void test_hashes_multiple_rows_in_one_pass() throws Exception {
+        final String userIdA = insertUser(PLAINTEXT + "-a", false);
+        final String userIdB = insertUser(PLAINTEXT + "-b", false);
+        final String userIdC = insertUser(PLAINTEXT + "-c", false);
+
+        TestJobExecutor.execute(job, new HashMap<>());
+
+        for (final String userId : List.of(userIdA, userIdB, userIdC)) {
+            final Map<String, Object> row = loadRow(userId);
+            assertTrue("All rows should be flipped to encrypted",
+                    toBool(row.get("passwordencrypted")));
+        }
+    }
+
+    /**
+     * Given: the kill-switch property is set to false.
+     * When:  the job runs.
+     * Then:  the plaintext row is left alone (no-op at runtime).
+     */
+    @Test
+    public void test_disabled_flag_makes_job_noop() throws Exception {
+        final String userId = insertUser(PLAINTEXT, false);
+        Config.setProperty(EncryptPlainPasswordsJob.ENABLE_PROPERTY, false);
+
+        TestJobExecutor.execute(job, new HashMap<>());
+
+        final Map<String, Object> row = loadRow(userId);
+        assertFalse("Disabled job must not encrypt the row",
+                toBool(row.get("passwordencrypted")));
+        assertEquals("Disabled job must not rewrite password_",
+                PLAINTEXT, row.get("password_"));
+    }
+
+    private String insertUser(final String password, final boolean encrypted) throws DotDataException {
+        final String userId = "test-encrypt-job-" + UUIDGenerator.generateUuid();
+        new DotConnect()
+                .setSQL("insert into user_ (userId, companyId, password_, passwordEncrypted, " +
+                        "passwordReset, male, dottedSkins, roundedSkins, failedLoginAttempts, " +
+                        "agreedToTermsOfUse, active_) " +
+                        "values (?, ?, ?, ?, false, false, false, false, 0, false, true)")
+                .addParam(userId)
+                .addParam(COMPANY_ID)
+                .addParam(password)
+                .addParam(encrypted)
+                .loadResult();
+        insertedUserIds.add(userId);
+        return userId;
+    }
+
+    private Map<String, Object> loadRow(final String userId) throws DotDataException {
+        final List<Map<String, Object>> rows = new DotConnect()
+                .setSQL("select password_, passwordEncrypted from user_ where userId = ?")
+                .addParam(userId)
+                .loadObjectResults();
+        assertEquals("Expected exactly one row for userId=" + userId, 1, rows.size());
+        return rows.get(0);
+    }
+
+    private static boolean toBool(final Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        return value != null && Boolean.parseBoolean(value.toString());
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java
@@ -10,14 +10,19 @@ import com.dotcms.IntegrationTestBase;
 import com.dotcms.enterprise.PasswordFactoryProxy;
 import com.dotcms.enterprise.PasswordFactoryProxy.AuthenticationStatus;
 import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.cms.factories.PublicCompanyFactory;
 import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.init.DotInitScheduler;
+import com.dotmarketing.quartz.QuartzUtils;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.UUIDGenerator;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -26,18 +31,31 @@ import org.junit.Test;
  *
  * Rows are inserted directly via {@link DotConnect} (rather than {@code UserAPI.save}) so the
  * test controls exactly what lands in {@code user_.password_} and {@code user_.passwordEncrypted}.
+ *
+ * The scheduled cron firing is removed from Quartz in {@link #beforeClass()} so the every-N-minute
+ * job that {@link DotInitScheduler} registers cannot race the in-test invocations.
  */
 public class EncryptPlainPasswordsJobTest extends IntegrationTestBase {
 
-    private static final String COMPANY_ID = "dotcms.org";
+    private static final String JOB_NAME = "EncryptPlainPasswordsJob";
     private static final String PLAINTEXT = "s3cret-plain-password";
 
+    private static String defaultCompanyId;
+
     private final EncryptPlainPasswordsJob job = new EncryptPlainPasswordsJob();
-    private final java.util.List<String> insertedUserIds = new java.util.ArrayList<>();
+    private final List<String> insertedUserIds = new ArrayList<>();
 
     @BeforeClass
     public static void beforeClass() throws Exception {
         IntegrationTestInitService.getInstance().init();
+        defaultCompanyId = PublicCompanyFactory.getDefaultCompany().getCompanyId();
+        // Prevent the scheduled cron firing from racing the explicit job.execute() calls below.
+        QuartzUtils.getScheduler().deleteJob(JOB_NAME, DotInitScheduler.DOTCMS_JOB_GROUP_NAME);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        Config.setProperty(EncryptPlainPasswordsJob.ENABLE_PROPERTY, true);
     }
 
     @After
@@ -147,6 +165,38 @@ public class EncryptPlainPasswordsJobTest extends IntegrationTestBase {
                 PLAINTEXT, row.get("password_"));
     }
 
+    /**
+     * Given: a row that the SELECT will see as plaintext, but whose password_ is mutated by another
+     *        writer between SELECT and UPDATE.
+     * When:  the job runs.
+     * Then:  the guarded UPDATE affects zero rows and the concurrent writer's value is preserved.
+     */
+    @Test
+    public void test_concurrent_change_is_not_clobbered() throws Exception {
+        final String userId = insertUser(PLAINTEXT, false);
+
+        // Simulate the racing writer by changing the password_ value AFTER our SELECT would have
+        // captured the plaintext but BEFORE the UPDATE fires. We do it by pre-changing the row,
+        // then asking the job to hash using the original (stale) plaintext.
+        final String concurrentWriterHash = PasswordFactoryProxy.generateHash("a-different-password");
+        new DotConnect()
+                .setSQL("update user_ set password_ = ?, passwordEncrypted = ? where userId = ?")
+                .addParam(concurrentWriterHash)
+                .addParam(true)
+                .addParam(userId)
+                .loadResult();
+
+        // Now run the job. The SELECT will not match (encrypted=true), but even if a real race let
+        // the row through, the guarded UPDATE (where password_ = old plaintext) must miss.
+        TestJobExecutor.execute(job, new HashMap<>());
+
+        final Map<String, Object> row = loadRow(userId);
+        assertEquals("Concurrent writer's value must be preserved",
+                concurrentWriterHash, row.get("password_"));
+        assertTrue("Concurrent writer's encrypted flag must be preserved",
+                toBool(row.get("passwordencrypted")));
+    }
+
     private String insertUser(final String password, final boolean encrypted) throws DotDataException {
         final String userId = "test-encrypt-job-" + UUIDGenerator.generateUuid();
         new DotConnect()
@@ -155,7 +205,7 @@ public class EncryptPlainPasswordsJobTest extends IntegrationTestBase {
                         "agreedToTermsOfUse, active_) " +
                         "values (?, ?, ?, ?, false, false, false, false, 0, false, true)")
                 .addParam(userId)
-                .addParam(COMPANY_ID)
+                .addParam(defaultCompanyId)
                 .addParam(password)
                 .addParam(encrypted)
                 .loadResult();


### PR DESCRIPTION
## Proposed Changes

Adds **`EncryptPlainPasswordsJob`** — a Quartz `StatefulJob` that runs every 5 minutes, scans the `user_` table for rows whose `passwordEncrypted` flag is `false`, hashes the cleartext value via `PasswordFactoryProxy.generateHash`, and flips the flag to `true`.

Defense-in-depth against any code path that lands a plaintext password in `user_.password_` — migrations, bulk imports, manual SQL recovery, or older code that set the password without the encrypted flag. Once the job ticks, the row is hashed using the same utility as the rest of the platform, so existing login (`authPassword`) continues to work transparently.

## Files Touched

| File | Change |
| --- | --- |
| `dotCMS/src/main/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJob.java` | **New.** `StatefulJob` implementation. |
| `dotCMS/src/main/java/com/dotmarketing/init/DotInitScheduler.java` | Registers the new job (mirrors `FreeServerFromClusterJob` pattern). |
| `dotcms-integration/src/test/java/com/dotmarketing/quartz/job/EncryptPlainPasswordsJobTest.java` | **New.** Five integration tests. |

## Configuration

| Property | Default | Effect |
| --- | --- | --- |
| `ENABLE_ENCRYPT_PLAIN_PASSWORDS_JOB` | `true` | Kill switch. Checked at startup (job not scheduled if `false`) **and** at every firing — flip at runtime without a restart. |
| `ENCRYPT_PLAIN_PASSWORDS_CRON_EXPRESSION` | `0 0/5 * * * ?` | Standard Quartz cron. |

## Why a periodic job rather than a one-off migration

The risk of a fresh plaintext row landing in `user_` is non-zero on a live system (admin tooling, recovery scripts, bulk imports that bypass `UserAPI`). A standing sweep catches them within one minute regardless of how they got there.

The query is cheap: `passwordEncrypted = false` is an extremely selective predicate, so in steady state the job does an index/sequential check that finds zero rows and returns immediately. A partial index `CREATE INDEX ... ON user_ (userId) WHERE passwordEncrypted = false` would be the right escalation if perf ever becomes a concern, but is unnecessary today.

## Test Plan

Integration tests (`EncryptPlainPasswordsJobTest`):

- [x] **Happy path** — plaintext row gets hashed; `authPassword(plaintext, storedHash)` returns `AUTHENTICATED`.
- [x] **Already encrypted row** — left untouched (no double-hashing).
- [x] **Null password** — skipped (no UPDATE issued).
- [x] **Multiple rows** — all hashed in a single pass.
- [x] **Disabled flag** — `ENABLE_ENCRYPT_PLAIN_PASSWORDS_JOB=false` makes the firing a no-op.

Run locally:
```bash
./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=EncryptPlainPasswordsJobTest
```

## Rollback safety

Pure additive — new class, new scheduler registration, new test. No schema change, no API contract change, no frontend touched. If anything misbehaves in production, flip `ENABLE_ENCRYPT_PLAIN_PASSWORDS_JOB=false` and the job becomes a no-op immediately; revert the commit for a full backout.

Refs #35766

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35766