### PR TITLE
fix: Feature flag boolean parsing error (#35551)

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
@@ -58,7 +58,7 @@ export class DotCustomEventHandlerService {
             .getKeys([FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED])
             .subscribe((response) => {
                 const contentEditorFeatureFlag =
-                    response[FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED] === 'true';
+                    response[FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED] === true;
 
                 if (!this.handlers) {
                     this.handlers = {

--- a/core-web/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/api/services/dot-custom-event-handler/dot-custom-event-handler.service.ts
@@ -57,8 +57,10 @@ export class DotCustomEventHandlerService {
         this.dotPropertiesService
             .getKeys([FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED])
             .subscribe((response) => {
-                const contentEditorFeatureFlag =
-                    response[FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED] === true;
+                // Accept native boolean true (current backend) or the legacy string 'true'
+                // (N-1 backend during a rollback window).
+                const val = response[FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED];
+                const contentEditorFeatureFlag = val === true || val === 'true';
 
                 if (!this.handlers) {
                     this.handlers = {

--- a/dotCMS/src/main/java/com/dotcms/featureflag/FeatureFlagName.java
+++ b/dotCMS/src/main/java/com/dotcms/featureflag/FeatureFlagName.java
@@ -64,4 +64,11 @@ public interface FeatureFlagName {
     String FEATURE_FLAG_OPEN_SEARCH_PHASE = "FEATURE_FLAG_OPEN_SEARCH_PHASE";
 
     String FEATURE_FLAG_NEW_BLOCK_EDITOR = "FEATURE_FLAG_NEW_BLOCK_EDITOR";
+
+    /**
+     * Enables the new content editor (Edit Content v2).
+     * Also checked in content-type metadata to opt individual types out.
+     * Frontend equivalent: {@code FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED}.
+     */
+    String FEATURE_FLAG_CONTENT_EDITOR2_ENABLED = "CONTENT_EDITOR2_ENABLED";
 }

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
@@ -65,6 +65,11 @@ public class ConfigurationResource implements Serializable {
     /**
      * Feature flag keys in WHITE_LIST that must be serialised as native JSON booleans.
      * All other WHITE_LIST entries (strings, numbers, lists) are left as-is.
+     *
+     * <p><b>Maintenance rule:</b> every key added here MUST also be present in WHITE_LIST,
+     * and every frontend caller that reads the key via {@code getKeys()} must compare with
+     * {@code === true} (boolean), not {@code === 'true'} (string). Adding a key here without
+     * updating both lists and all callers reproduces the exact bug this class was written to fix.
      */
     private static final Set<String> BOOLEAN_FEATURE_FLAGS = ImmutableSet.of(
             FeatureFlagName.FEATURE_FLAG_EXPERIMENTS,
@@ -82,14 +87,14 @@ public class ConfigurationResource implements Serializable {
             FeatureFlagName.FEATURE_FLAG_PAGE_SCANNER,
             FeatureFlagName.FEATURE_FLAG_UVE_LEGACY_SCRIPT_INJECTION,
             FeatureFlagName.FEATURE_FLAG_NEW_BLOCK_EDITOR,
-            "CONTENT_EDITOR2_ENABLED");  // FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED
+            FeatureFlagName.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED);
 
 	private static final Set<String> WHITE_LIST = ImmutableSet.copyOf(
 			Config.getStringArrayProperty("CONFIGURATION_WHITE_LIST",
 					new String[] {"EMAIL_SYSTEM_ADDRESS", "WYSIWYG_IMAGE_URL_PATTERN", "CHARSET","CONTENT_PALETTE_HIDDEN_CONTENT_TYPES", "DEFAULT_CONTAINER",
 							FeatureFlagName.FEATURE_FLAG_EXPERIMENTS, FeatureFlagName.DOTFAVORITEPAGE_FEATURE_ENABLE, FeatureFlagName.FEATURE_FLAG_TEMPLATE_BUILDER_2,
 					"SHOW_VIDEO_THUMBNAIL", "EXPERIMENTS_MIN_DURATION", "EXPERIMENTS_MAX_DURATION", "EXPERIMENTS_DEFAULT_DURATION", FeatureFlagName.FEATURE_FLAG_SEO_IMPROVEMENTS,
-							FeatureFlagName.FEATURE_FLAG_SEO_PAGE_TOOLS, FeatureFlagName.FEATURE_FLAG_EDIT_URL_CONTENT_MAP, "CONTENT_EDITOR2_ENABLED", "CONTENT_EDITOR2_CONTENT_TYPE",
+							FeatureFlagName.FEATURE_FLAG_SEO_PAGE_TOOLS, FeatureFlagName.FEATURE_FLAG_EDIT_URL_CONTENT_MAP, FeatureFlagName.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED, "CONTENT_EDITOR2_CONTENT_TYPE",
 							FeatureFlagName.FEATURE_FLAG_NEW_BINARY_FIELD, FeatureFlagName.FEATURE_FLAG_ANNOUNCEMENTS, FeatureFlagName.FEATURE_FLAG_NEW_EDIT_PAGE,
 							FeatureFlagName.FEATURE_FLAG_UVE_PREVIEW_MODE, FeatureFlagName.FEATURE_FLAG_UVE_TOGGLE_LOCK, FeatureFlagName.FEATURE_FLAG_UVE_STYLE_EDITOR,
 							FeatureFlagName.FEATURE_FLAG_PAGE_SCANNER,
@@ -209,7 +214,7 @@ public class ConfigurationResource implements Serializable {
 				return Boolean.FALSE;
 			default:
 				Logger.warn(ConfigurationResource.class,
-						"Feature flag '" + key + "' has unrecognized value '" + rawValue + "'; treating as false.");
+						() -> "Feature flag '" + key + "' has unrecognized value '" + rawValue + "'; treating as false.");
 				return Boolean.FALSE;
 		}
 	}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
@@ -66,10 +66,10 @@ public class ConfigurationResource implements Serializable {
      * Feature flag keys in WHITE_LIST that must be serialised as native JSON booleans.
      * All other WHITE_LIST entries (strings, numbers, lists) are left as-is.
      *
-     * <p><b>Maintenance rule:</b> every key added here MUST also be present in WHITE_LIST,
-     * and every frontend caller that reads the key via {@code getKeys()} must compare with
-     * {@code === true} (boolean), not {@code === 'true'} (string). Adding a key here without
-     * updating both lists and all callers reproduces the exact bug this class was written to fix.
+     * <p><b>Maintenance rule:</b> every key added here MUST also be present in WHITE_LIST.
+     * The wire format is the normalised lowercase string {@code "true"} or {@code "false"} —
+     * frontend callers should compare with {@code === 'true'}.  Adding a key here without
+     * also adding it to WHITE_LIST will silently exclude it from the response.
      */
     private static final Set<String> BOOLEAN_FEATURE_FLAGS = ImmutableSet.of(
             FeatureFlagName.FEATURE_FLAG_EXPERIMENTS,
@@ -192,11 +192,15 @@ public class ConfigurationResource implements Serializable {
 	}
 
 	/**
-	 * Resolves a feature flag property to a native boolean, or the sentinel "NOT_FOUND"
-	 * when the key is not defined anywhere (no .properties entry, no DOT_* env override).
-	 * Accepted truthy values (case-insensitive, whitespace-trimmed): "true", "1".
-	 * Accepted falsy values: "false", "0", "".
-	 * Unrecognised values are logged as WARN and resolve to false.
+	 * Normalises a feature flag property to the canonical lowercase string {@code "true"} or
+	 * {@code "false"}, preserving the existing string wire format so that consumers built
+	 * against the pre-existing contract continue to work without changes.
+	 * Returns the sentinel {@code "NOT_FOUND"} when the key is not defined anywhere
+	 * (no .properties entry, no DOT_* env override).
+	 *
+	 * <p>Accepted truthy values (case-insensitive, whitespace-trimmed): {@code "true"}, {@code "1"}.
+	 * Accepted falsy values: {@code "false"}, {@code "0"}, {@code ""}.
+	 * Unrecognised values are logged as WARN and normalise to {@code "false"}.
 	 */
 	private static Object parseBooleanFlag(final String key) {
 		final String rawValue = Config.getStringProperty(key, null);
@@ -207,15 +211,15 @@ public class ConfigurationResource implements Serializable {
 		switch (normalized) {
 			case "true":
 			case "1":
-				return Boolean.TRUE;
+				return "true";
 			case "false":
 			case "0":
 			case "":
-				return Boolean.FALSE;
+				return "false";
 			default:
 				Logger.warn(ConfigurationResource.class,
 						() -> "Feature flag '" + key + "' has unrecognized value '" + rawValue + "'; treating as false.");
-				return Boolean.FALSE;
+				return "false";
 		}
 	}
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
@@ -12,7 +12,6 @@ import com.google.common.collect.ImmutableSet;
 import com.liferay.util.StringPool;
 import io.vavr.Tuple2;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -31,8 +30,13 @@ import com.dotcms.rest.WebResource;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
 import org.glassfish.jersey.server.JSONP;
 import com.dotcms.rest.ResponseEntityView;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import com.dotcms.rest.annotation.NoCache;
 import com.dotcms.rest.exception.mapper.ExceptionMapperUtil;
@@ -124,18 +128,49 @@ public class ConfigurationResource implements Serializable {
 	}
 
 	/**
-	 * Retrieve the keys from dotcms Configuration (allowed on WHITE_LIST and are not restricted by the BLACK_LIST)
-	 * @param request
-	 * @param response
-	 * @param keysQuery
-	 * @return
-	 * @throws IOException
+	 * Returns a subset of dotCMS configuration values for the requested keys.
+	 * Only keys present in {@code WHITE_LIST} and not blocked by the obfuscation
+	 * blacklist are included in the response; unknown or blacklisted keys are
+	 * silently omitted.
+	 *
+	 * @param request   the current HTTP request
+	 * @param response  the current HTTP response
+	 * @param keysQuery comma-separated list of configuration keys to retrieve;
+	 *                  keys may carry a type prefix ({@code list:}, {@code boolean:},
+	 *                  {@code number:}) to control deserialisation
+	 * @return 200 with a {@code Map} of key → value pairs
 	 */
 	@Path("/config")
 	@GET
 	@JSONP
 	@NoCache
 	@Produces({MediaType.APPLICATION_JSON, "application/javascript"})
+	@Operation(
+			operationId = "getConfigVariables",
+			summary = "Retrieve whitelisted configuration values",
+			description = "Returns a map of configuration key to value for each requested key "
+					+ "that is present in the server whitelist. "
+					+ "Boolean feature-flag keys (those in BOOLEAN_FEATURE_FLAGS) are normalised to "
+					+ "the lowercase strings \"true\" or \"false\" regardless of how they are stored "
+					+ "in the properties file; undefined flags return the sentinel string \"NOT_FOUND\". "
+					+ "Keys prefixed with \"number:\" return an Integer, \"list:\" returns an array of "
+					+ "strings, \"boolean:\" returns a native JSON boolean. All other whitelisted keys "
+					+ "return their raw string value. Keys not on the whitelist are silently excluded.",
+			responses = {
+					@ApiResponse(responseCode = "200", description = "Map of key to configuration value",
+							content = @Content(mediaType = MediaType.APPLICATION_JSON,
+									schema = @Schema(type = "object",
+											description = "Map of configuration key to value. "
+													+ "Value type depends on the key: normalised string \"true\"/\"false\" "
+													+ "for boolean feature flags, \"NOT_FOUND\" for undefined flags, "
+													+ "Integer for number:-prefixed keys, array for list:-prefixed keys, "
+													+ "native boolean for boolean:-prefixed keys, raw string otherwise.",
+											example = "{\"FEATURE_FLAG_EXPERIMENTS\":\"true\","
+													+ "\"EMAIL_SYSTEM_ADDRESS\":\"admin@example.com\","
+													+ "\"FEATURE_FLAG_UVE_STYLE_EDITOR\":\"NOT_FOUND\"}"))),
+					@ApiResponse(responseCode = "401", description = "User is not authenticated")
+			}
+	)
 	public final Response getConfigVariables(@Context final HttpServletRequest request,
 											 @Context final HttpServletResponse response,
 											 @QueryParam("keys") final String keysQuery) {
@@ -146,14 +181,18 @@ public class ConfigurationResource implements Serializable {
 				.rejectWhenNoUser(true)
 				.init();
 
-		final String [] keys = StringUtils.splitByCommas(keysQuery);
 		final Map<String,Object> resultMap = new LinkedHashMap<>();
+		if (!UtilMethods.isSet(keysQuery)) {
+			return Response.ok(new ResponseEntityView(resultMap)).build();
+		}
+
+		final String[] keys = StringUtils.splitByCommas(keysQuery);
 		if (null != keys) {
 
 			for (final String key : keys) {
 
-				final String keyWithoutPrefix = this.removePrefix (key);
-				if (this.WHITE_LIST.contains(keyWithoutPrefix) && !this.isOnBlackList(keyWithoutPrefix)) {
+				final String keyWithoutPrefix = this.removePrefix(key);
+				if (WHITE_LIST.contains(keyWithoutPrefix) && !this.isOnBlackList(keyWithoutPrefix)) {
 
 					resultMap.put(keyWithoutPrefix, recoveryFromConfig(key));
 				}

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/ConfigurationResource.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.Response;
 import com.dotcms.rest.WebResource;
 import com.dotmarketing.business.Role;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
 import org.glassfish.jersey.server.JSONP;
 import com.dotcms.rest.ResponseEntityView;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -58,7 +59,30 @@ import com.liferay.util.LocaleUtil;
 public class ConfigurationResource implements Serializable {
 
 	private final ConfigurationHelper helper;
+	private final WebResource webResource;
     private static final String REPORT_ISSUE_INCLUDE_USER_PII = "REPORT_ISSUE_INCLUDE_USER_PII";
+
+    /**
+     * Feature flag keys in WHITE_LIST that must be serialised as native JSON booleans.
+     * All other WHITE_LIST entries (strings, numbers, lists) are left as-is.
+     */
+    private static final Set<String> BOOLEAN_FEATURE_FLAGS = ImmutableSet.of(
+            FeatureFlagName.FEATURE_FLAG_EXPERIMENTS,
+            FeatureFlagName.DOTFAVORITEPAGE_FEATURE_ENABLE,
+            FeatureFlagName.FEATURE_FLAG_TEMPLATE_BUILDER_2,
+            FeatureFlagName.FEATURE_FLAG_SEO_IMPROVEMENTS,
+            FeatureFlagName.FEATURE_FLAG_SEO_PAGE_TOOLS,
+            FeatureFlagName.FEATURE_FLAG_EDIT_URL_CONTENT_MAP,
+            FeatureFlagName.FEATURE_FLAG_NEW_BINARY_FIELD,
+            FeatureFlagName.FEATURE_FLAG_ANNOUNCEMENTS,
+            FeatureFlagName.FEATURE_FLAG_NEW_EDIT_PAGE,
+            FeatureFlagName.FEATURE_FLAG_UVE_PREVIEW_MODE,
+            FeatureFlagName.FEATURE_FLAG_UVE_TOGGLE_LOCK,
+            FeatureFlagName.FEATURE_FLAG_UVE_STYLE_EDITOR,
+            FeatureFlagName.FEATURE_FLAG_PAGE_SCANNER,
+            FeatureFlagName.FEATURE_FLAG_UVE_LEGACY_SCRIPT_INJECTION,
+            FeatureFlagName.FEATURE_FLAG_NEW_BLOCK_EDITOR,
+            "CONTENT_EDITOR2_ENABLED");  // FeaturedFlags.FEATURE_FLAG_CONTENT_EDITOR2_ENABLED
 
 	private static final Set<String> WHITE_LIST = ImmutableSet.copyOf(
 			Config.getStringArrayProperty("CONFIGURATION_WHITE_LIST",
@@ -83,6 +107,15 @@ public class ConfigurationResource implements Serializable {
 	 */
 	public ConfigurationResource() {
 		this.helper = ConfigurationHelper.INSTANCE;
+		this.webResource = new WebResource();
+	}
+
+	/**
+	 * Test constructor — allows injecting a mock {@link WebResource}.
+	 */
+	ConfigurationResource(final WebResource webResource) {
+		this.helper = ConfigurationHelper.INSTANCE;
+		this.webResource = webResource;
 	}
 
 	/**
@@ -100,10 +133,9 @@ public class ConfigurationResource implements Serializable {
 	@Produces({MediaType.APPLICATION_JSON, "application/javascript"})
 	public final Response getConfigVariables(@Context final HttpServletRequest request,
 											 @Context final HttpServletResponse response,
-											 @QueryParam("keys") final String keysQuery)
-			throws IOException {
+											 @QueryParam("keys") final String keysQuery) {
 
-		new WebResource.InitBuilder(request, response)
+		new WebResource.InitBuilder(webResource)
 				.requiredBackendUser(true)
 				.requestAndResponse(request, response)
 				.rejectWhenNoUser(true)
@@ -147,7 +179,39 @@ public class ConfigurationResource implements Serializable {
 			return Config.getIntProperty(key.replace("number:", StringPool.BLANK), 0);
 		}
 
+		if (BOOLEAN_FEATURE_FLAGS.contains(key)) {
+			return parseBooleanFlag(key);
+		}
+
 		return Config.getStringProperty(key, "NOT_FOUND");
+	}
+
+	/**
+	 * Resolves a feature flag property to a native boolean, or the sentinel "NOT_FOUND"
+	 * when the key is not defined anywhere (no .properties entry, no DOT_* env override).
+	 * Accepted truthy values (case-insensitive, whitespace-trimmed): "true", "1".
+	 * Accepted falsy values: "false", "0", "".
+	 * Unrecognised values are logged as WARN and resolve to false.
+	 */
+	private static Object parseBooleanFlag(final String key) {
+		final String rawValue = Config.getStringProperty(key, null);
+		if (rawValue == null) {
+			return "NOT_FOUND";
+		}
+		final String normalized = rawValue.trim().toLowerCase(Locale.ROOT);
+		switch (normalized) {
+			case "true":
+			case "1":
+				return Boolean.TRUE;
+			case "false":
+			case "0":
+			case "":
+				return Boolean.FALSE;
+			default:
+				Logger.warn(ConfigurationResource.class,
+						"Feature flag '" + key + "' has unrecognized value '" + rawValue + "'; treating as false.");
+				return Boolean.FALSE;
+		}
 	}
 
 	/**

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -5202,6 +5202,14 @@ paths:
       - System Configuration
   /v1/configuration/config:
     get:
+      description: "Returns a map of configuration key to value for each requested\
+        \ key that is present in the server whitelist. Boolean feature-flag keys (those\
+        \ in BOOLEAN_FEATURE_FLAGS) are normalised to the lowercase strings \"true\"\
+        \ or \"false\" regardless of how they are stored in the properties file; undefined\
+        \ flags return the sentinel string \"NOT_FOUND\". Keys prefixed with \"number:\"\
+        \ return an Integer, \"list:\" returns an array of strings, \"boolean:\" returns\
+        \ a native JSON boolean. All other whitelisted keys return their raw string\
+        \ value. Keys not on the whitelist are silently excluded."
       operationId: getConfigVariables
       parameters:
       - in: query
@@ -5209,11 +5217,24 @@ paths:
         schema:
           type: string
       responses:
-        default:
+        "200":
           content:
-            application/javascript: {}
-            application/json: {}
-          description: default response
+            application/json:
+              schema:
+                type: object
+                description: "Map of configuration key to value. Value type depends\
+                  \ on the key: normalised string \"true\"/\"false\" for boolean feature\
+                  \ flags, \"NOT_FOUND\" for undefined flags, Integer for number:-prefixed\
+                  \ keys, array for list:-prefixed keys, native boolean for boolean:-prefixed\
+                  \ keys, raw string otherwise."
+                example:
+                  FEATURE_FLAG_EXPERIMENTS: "true"
+                  EMAIL_SYSTEM_ADDRESS: admin@example.com
+                  FEATURE_FLAG_UVE_STYLE_EDITOR: NOT_FOUND
+          description: Map of key to configuration value
+        "401":
+          description: User is not authenticated
+      summary: Retrieve whitelisted configuration values
       tags:
       - System Configuration
   /v1/configuration/locale:

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/system/ConfigurationResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/system/ConfigurationResourceTest.java
@@ -2,8 +2,8 @@ package com.dotcms.rest.api.v1.system;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -14,6 +14,7 @@ import com.dotcms.rest.ResponseEntityView;
 import com.dotcms.rest.WebResource;
 import com.dotmarketing.util.Config;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -28,11 +29,10 @@ import java.util.Map;
  *
  * <p>This class is the single home for all unit-level assertions about
  * {@code ConfigurationResource}. Add new test methods here as new behaviour
- * is introduced;
+ * is introduced.
  *
  * <p>Integration-level tests (requiring a running dotCMS instance) live in
  * {@code dotcms-integration/.../ConfigurationResourceTest.java}.
- *
  */
 public class ConfigurationResourceTest {
 
@@ -46,11 +46,27 @@ public class ConfigurationResourceTest {
     private ConfigurationResource resource;
     private HttpServletRequest request;
     private HttpServletResponse response;
+    private MockedStatic<Config> mockedConfig;
 
     // ── Setup / teardown ──────────────────────────────────────────────────────
 
     @BeforeEach
     void setUp() {
+        // Open the Config mock BEFORE constructing ConfigurationResource so that
+        // any static initializer that calls Config (WHITE_LIST, and
+        // JVMInfoResource.obfuscatePattern via isOnBlackList) receives a safe
+        // default instead of null.  Without this, Pattern.compile(null) inside
+        // JVMInfoResource throws NullPointerException on first class load.
+        //
+        // Default answer: return the caller-supplied default (second argument)
+        // for any getStringProperty / getStringArrayProperty call that is not
+        // individually stubbed by a test.
+        mockedConfig = mockStatic(Config.class);
+        mockedConfig.when(() -> Config.getStringProperty(anyString(), anyString()))
+                .thenAnswer(inv -> inv.getArgument(1));
+        mockedConfig.when(() -> Config.getStringArrayProperty(anyString(), any(String[].class)))
+                .thenAnswer(inv -> inv.getArgument(1));
+
         webResource = mock(WebResource.class);
         resource = new ConfigurationResource(webResource);
         request = mock(HttpServletRequest.class);
@@ -58,6 +74,11 @@ public class ConfigurationResourceTest {
 
         final InitDataObject initData = mock(InitDataObject.class);
         when(webResource.init(any(WebResource.InitBuilder.class))).thenReturn(initData);
+    }
+
+    @AfterEach
+    void tearDown() {
+        mockedConfig.close();
     }
 
     // ── Truthy variants (AC: "true", "True", "TRUE", " true ", "1" → true) ──
@@ -69,13 +90,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToLowercaseTrue_returnsNativeBooleanTrue() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("true");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("true");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.TRUE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.TRUE, entity.get(FLAG));
     }
 
     /**
@@ -86,13 +105,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToCapitalizedTrue_returnsNativeBooleanTrue() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("True");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("True");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.TRUE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.TRUE, entity.get(FLAG));
     }
 
     /**
@@ -102,13 +119,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToUppercaseTrue_returnsNativeBooleanTrue() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("TRUE");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("TRUE");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.TRUE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.TRUE, entity.get(FLAG));
     }
 
     /**
@@ -118,13 +133,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToTrueWithWhitespace_returnsNativeBooleanTrue() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn(" true ");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn(" true ");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.TRUE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.TRUE, entity.get(FLAG));
     }
 
     /**
@@ -134,13 +147,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToNumericOne_returnsNativeBooleanTrue() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("1");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("1");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.TRUE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.TRUE, entity.get(FLAG));
     }
 
     // ── Falsy variants (AC: "false", "False", "FALSE", " false ", "0", "" → false) ──
@@ -152,13 +163,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToLowercaseFalse_returnsNativeBooleanFalse() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("false");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("false");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.FALSE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.FALSE, entity.get(FLAG));
     }
 
     /**
@@ -168,13 +177,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToUppercaseFalse_returnsNativeBooleanFalse() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("FALSE");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("FALSE");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.FALSE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.FALSE, entity.get(FLAG));
     }
 
     /**
@@ -184,13 +191,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToNumericZero_returnsNativeBooleanFalse() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("0");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("0");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.FALSE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.FALSE, entity.get(FLAG));
     }
 
     /**
@@ -200,13 +205,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToEmptyString_returnsNativeBooleanFalse() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.FALSE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.FALSE, entity.get(FLAG));
     }
 
     // ── NOT_FOUND sentinel ────────────────────────────────────────────────────
@@ -220,14 +223,12 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagNotDefined_returnsNotFoundSentinel() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(UNDEFINED_FLAG, null)).thenReturn(null);
+        mockedConfig.when(() -> Config.getStringProperty(UNDEFINED_FLAG, null)).thenReturn(null);
 
-            final Map<String, Object> entity = entityMap(
-                    resource.getConfigVariables(request, response, UNDEFINED_FLAG));
+        final Map<String, Object> entity = entityMap(
+                resource.getConfigVariables(request, response, UNDEFINED_FLAG));
 
-            assertEquals("NOT_FOUND", entity.get(UNDEFINED_FLAG));
-        }
+        assertEquals("NOT_FOUND", entity.get(UNDEFINED_FLAG));
     }
 
     // ── Unrecognised value ────────────────────────────────────────────────────
@@ -239,13 +240,11 @@ public class ConfigurationResourceTest {
      */
     @Test
     void getConfigVariables_flagSetToUnrecognizedValue_returnsNativeBooleanFalse() {
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("enabled");
+        mockedConfig.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("enabled");
 
-            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+        final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-            assertEquals(Boolean.FALSE, entity.get(FLAG));
-        }
+        assertEquals(Boolean.FALSE, entity.get(FLAG));
     }
 
     // ── Whitelist filtering ───────────────────────────────────────────────────
@@ -275,14 +274,12 @@ public class ConfigurationResourceTest {
     @Test
     void getConfigVariables_nonFlagWhitelistedKey_returnsRawStringValue() {
         final String testAddress = "admin@example.com";
-        try (MockedStatic<Config> config = mockStatic(Config.class)) {
-            config.when(() -> Config.getStringProperty(NON_FLAG_KEY, "NOT_FOUND")).thenReturn(testAddress);
+        mockedConfig.when(() -> Config.getStringProperty(NON_FLAG_KEY, "NOT_FOUND")).thenReturn(testAddress);
 
-            final Map<String, Object> entity = entityMap(
-                    resource.getConfigVariables(request, response, NON_FLAG_KEY));
+        final Map<String, Object> entity = entityMap(
+                resource.getConfigVariables(request, response, NON_FLAG_KEY));
 
-            assertEquals(testAddress, entity.get(NON_FLAG_KEY));
-        }
+        assertEquals(testAddress, entity.get(NON_FLAG_KEY));
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/system/ConfigurationResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/system/ConfigurationResourceTest.java
@@ -86,7 +86,7 @@ public class ConfigurationResourceTest {
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag is set to lowercase {@code "true"}.
-     * Expected result: Response contains native boolean {@code true} (not the string).
+     * Expected result: Response contains the normalised string {@code "true"}.
      */
     @Test
     void getConfigVariables_flagSetToLowercaseTrue_returnsNativeBooleanTrue() {
@@ -94,14 +94,14 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.TRUE, entity.get(FLAG));
+        assertEquals("true", entity.get(FLAG));
     }
 
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag is set to capitalized {@code "True"} —
      *   the customer-reported reproduction case.
-     * Expected result: Response contains native boolean {@code true}.
+     * Expected result: Response contains the normalised string {@code "true"}.
      */
     @Test
     void getConfigVariables_flagSetToCapitalizedTrue_returnsNativeBooleanTrue() {
@@ -109,13 +109,13 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.TRUE, entity.get(FLAG));
+        assertEquals("true", entity.get(FLAG));
     }
 
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag is set to all-caps {@code "TRUE"}.
-     * Expected result: Response contains native boolean {@code true}.
+     * Expected result: Response contains the normalised string {@code "true"}.
      */
     @Test
     void getConfigVariables_flagSetToUppercaseTrue_returnsNativeBooleanTrue() {
@@ -123,13 +123,13 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.TRUE, entity.get(FLAG));
+        assertEquals("true", entity.get(FLAG));
     }
 
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag is set to {@code " true "} with surrounding whitespace.
-     * Expected result: Response contains native boolean {@code true} — whitespace is trimmed.
+     * Expected result: Response contains the normalised string {@code "true"} — whitespace is trimmed.
      */
     @Test
     void getConfigVariables_flagSetToTrueWithWhitespace_returnsNativeBooleanTrue() {
@@ -137,13 +137,13 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.TRUE, entity.get(FLAG));
+        assertEquals("true", entity.get(FLAG));
     }
 
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag is set to the numeric shorthand {@code "1"}.
-     * Expected result: Response contains native boolean {@code true}.
+     * Expected result: Response contains the normalised string {@code "true"}.
      */
     @Test
     void getConfigVariables_flagSetToNumericOne_returnsNativeBooleanTrue() {
@@ -151,7 +151,7 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.TRUE, entity.get(FLAG));
+        assertEquals("true", entity.get(FLAG));
     }
 
     // ── Falsy variants (AC: "false", "False", "FALSE", " false ", "0", "" → false) ──
@@ -159,7 +159,7 @@ public class ConfigurationResourceTest {
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag is set to lowercase {@code "false"}.
-     * Expected result: Response contains native boolean {@code false}.
+     * Expected result: Response contains the normalised string {@code "false"}.
      */
     @Test
     void getConfigVariables_flagSetToLowercaseFalse_returnsNativeBooleanFalse() {
@@ -167,13 +167,13 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.FALSE, entity.get(FLAG));
+        assertEquals("false", entity.get(FLAG));
     }
 
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag is set to all-caps {@code "FALSE"}.
-     * Expected result: Response contains native boolean {@code false}.
+     * Expected result: Response contains the normalised string {@code "false"}.
      */
     @Test
     void getConfigVariables_flagSetToUppercaseFalse_returnsNativeBooleanFalse() {
@@ -181,13 +181,13 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.FALSE, entity.get(FLAG));
+        assertEquals("false", entity.get(FLAG));
     }
 
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag is set to the numeric shorthand {@code "0"}.
-     * Expected result: Response contains native boolean {@code false}.
+     * Expected result: Response contains the normalised string {@code "false"}.
      */
     @Test
     void getConfigVariables_flagSetToNumericZero_returnsNativeBooleanFalse() {
@@ -195,13 +195,13 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.FALSE, entity.get(FLAG));
+        assertEquals("false", entity.get(FLAG));
     }
 
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag is set to an empty string.
-     * Expected result: Response contains native boolean {@code false}.
+     * Expected result: Response contains the normalised string {@code "false"}.
      */
     @Test
     void getConfigVariables_flagSetToEmptyString_returnsNativeBooleanFalse() {
@@ -209,7 +209,7 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.FALSE, entity.get(FLAG));
+        assertEquals("false", entity.get(FLAG));
     }
 
     // ── NOT_FOUND sentinel ────────────────────────────────────────────────────
@@ -236,7 +236,7 @@ public class ConfigurationResourceTest {
     /**
      * Method to test: {@link ConfigurationResource#getConfigVariables}
      * Given scenario: A boolean feature flag has an unrecognized value such as {@code "enabled"}.
-     * Expected result: Response contains native boolean {@code false} — safe default preserved.
+     * Expected result: Response contains the normalised string {@code "false"} — safe default preserved.
      */
     @Test
     void getConfigVariables_flagSetToUnrecognizedValue_returnsNativeBooleanFalse() {
@@ -244,7 +244,7 @@ public class ConfigurationResourceTest {
 
         final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
 
-        assertEquals(Boolean.FALSE, entity.get(FLAG));
+        assertEquals("false", entity.get(FLAG));
     }
 
     // ── Whitelist filtering ───────────────────────────────────────────────────

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/system/ConfigurationResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/system/ConfigurationResourceTest.java
@@ -1,0 +1,293 @@
+package com.dotcms.rest.api.v1.system;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.dotcms.featureflag.FeatureFlagName;
+import com.dotcms.rest.InitDataObject;
+import com.dotcms.rest.ResponseEntityView;
+import com.dotcms.rest.WebResource;
+import com.dotmarketing.util.Config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+/**
+ * Unit tests for {@link ConfigurationResource}.
+ *
+ * <p>This class is the single home for all unit-level assertions about
+ * {@code ConfigurationResource}. Add new test methods here as new behaviour
+ * is introduced;
+ *
+ * <p>Integration-level tests (requiring a running dotCMS instance) live in
+ * {@code dotcms-integration/.../ConfigurationResourceTest.java}.
+ *
+ */
+public class ConfigurationResourceTest {
+
+    private static final String FLAG = FeatureFlagName.FEATURE_FLAG_UVE_TOGGLE_LOCK;
+    private static final String UNDEFINED_FLAG = FeatureFlagName.FEATURE_FLAG_UVE_STYLE_EDITOR;
+    private static final String NON_FLAG_KEY = "EMAIL_SYSTEM_ADDRESS";
+    private static final String UNLISTED_KEY = "SOME_INTERNAL_SECRET";
+
+    private WebResource webResource;
+    private ConfigurationResource resource;
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+
+    // ── Setup / teardown ──────────────────────────────────────────────────────
+
+    @BeforeEach
+    void setUp() {
+        webResource = mock(WebResource.class);
+        resource = new ConfigurationResource(webResource);
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+
+        final InitDataObject initData = mock(InitDataObject.class);
+        when(webResource.init(any(WebResource.InitBuilder.class))).thenReturn(initData);
+    }
+
+    // ── Truthy variants (AC: "true", "True", "TRUE", " true ", "1" → true) ──
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag is set to lowercase {@code "true"}.
+     * Expected result: Response contains native boolean {@code true} (not the string).
+     */
+    @Test
+    void getConfigVariables_flagSetToLowercaseTrue_returnsNativeBooleanTrue() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("true");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.TRUE, entity.get(FLAG));
+        }
+    }
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag is set to capitalized {@code "True"} —
+     *   the customer-reported reproduction case.
+     * Expected result: Response contains native boolean {@code true}.
+     */
+    @Test
+    void getConfigVariables_flagSetToCapitalizedTrue_returnsNativeBooleanTrue() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("True");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.TRUE, entity.get(FLAG));
+        }
+    }
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag is set to all-caps {@code "TRUE"}.
+     * Expected result: Response contains native boolean {@code true}.
+     */
+    @Test
+    void getConfigVariables_flagSetToUppercaseTrue_returnsNativeBooleanTrue() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("TRUE");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.TRUE, entity.get(FLAG));
+        }
+    }
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag is set to {@code " true "} with surrounding whitespace.
+     * Expected result: Response contains native boolean {@code true} — whitespace is trimmed.
+     */
+    @Test
+    void getConfigVariables_flagSetToTrueWithWhitespace_returnsNativeBooleanTrue() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn(" true ");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.TRUE, entity.get(FLAG));
+        }
+    }
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag is set to the numeric shorthand {@code "1"}.
+     * Expected result: Response contains native boolean {@code true}.
+     */
+    @Test
+    void getConfigVariables_flagSetToNumericOne_returnsNativeBooleanTrue() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("1");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.TRUE, entity.get(FLAG));
+        }
+    }
+
+    // ── Falsy variants (AC: "false", "False", "FALSE", " false ", "0", "" → false) ──
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag is set to lowercase {@code "false"}.
+     * Expected result: Response contains native boolean {@code false}.
+     */
+    @Test
+    void getConfigVariables_flagSetToLowercaseFalse_returnsNativeBooleanFalse() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("false");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.FALSE, entity.get(FLAG));
+        }
+    }
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag is set to all-caps {@code "FALSE"}.
+     * Expected result: Response contains native boolean {@code false}.
+     */
+    @Test
+    void getConfigVariables_flagSetToUppercaseFalse_returnsNativeBooleanFalse() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("FALSE");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.FALSE, entity.get(FLAG));
+        }
+    }
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag is set to the numeric shorthand {@code "0"}.
+     * Expected result: Response contains native boolean {@code false}.
+     */
+    @Test
+    void getConfigVariables_flagSetToNumericZero_returnsNativeBooleanFalse() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("0");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.FALSE, entity.get(FLAG));
+        }
+    }
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag is set to an empty string.
+     * Expected result: Response contains native boolean {@code false}.
+     */
+    @Test
+    void getConfigVariables_flagSetToEmptyString_returnsNativeBooleanFalse() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.FALSE, entity.get(FLAG));
+        }
+    }
+
+    // ── NOT_FOUND sentinel ────────────────────────────────────────────────────
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag key is not defined anywhere on the server
+     *   ({@code Config.getStringProperty} returns {@code null}).
+     * Expected result: Response contains the literal string {@code "NOT_FOUND"}, never a boolean —
+     *   the frontend uses this sentinel to apply its own enabled-by-default opt-out logic.
+     */
+    @Test
+    void getConfigVariables_flagNotDefined_returnsNotFoundSentinel() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(UNDEFINED_FLAG, null)).thenReturn(null);
+
+            final Map<String, Object> entity = entityMap(
+                    resource.getConfigVariables(request, response, UNDEFINED_FLAG));
+
+            assertEquals("NOT_FOUND", entity.get(UNDEFINED_FLAG));
+        }
+    }
+
+    // ── Unrecognised value ────────────────────────────────────────────────────
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: A boolean feature flag has an unrecognized value such as {@code "enabled"}.
+     * Expected result: Response contains native boolean {@code false} — safe default preserved.
+     */
+    @Test
+    void getConfigVariables_flagSetToUnrecognizedValue_returnsNativeBooleanFalse() {
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(FLAG, null)).thenReturn("enabled");
+
+            final Map<String, Object> entity = entityMap(resource.getConfigVariables(request, response, FLAG));
+
+            assertEquals(Boolean.FALSE, entity.get(FLAG));
+        }
+    }
+
+    // ── Whitelist filtering ───────────────────────────────────────────────────
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: The caller requests a key that is not on the whitelist.
+     * Expected result: The key is absent from the response — it is silently excluded.
+     */
+    @Test
+    void getConfigVariables_keyNotOnWhitelist_isExcludedFromResponse() {
+        final Map<String, Object> entity = entityMap(
+                resource.getConfigVariables(request, response, UNLISTED_KEY));
+
+        assertFalse(entity.containsKey(UNLISTED_KEY));
+    }
+
+    // ── Non-boolean whitelisted key ───────────────────────────────────────────
+
+    /**
+     * Method to test: {@link ConfigurationResource#getConfigVariables}
+     * Given scenario: The caller requests a whitelisted key that is not a boolean feature flag
+     *   (e.g. {@code EMAIL_SYSTEM_ADDRESS}).
+     * Expected result: The raw string value is returned unchanged — boolean coercion is not applied
+     *   to non-flag keys.
+     */
+    @Test
+    void getConfigVariables_nonFlagWhitelistedKey_returnsRawStringValue() {
+        final String testAddress = "admin@example.com";
+        try (MockedStatic<Config> config = mockStatic(Config.class)) {
+            config.when(() -> Config.getStringProperty(NON_FLAG_KEY, "NOT_FOUND")).thenReturn(testAddress);
+
+            final Map<String, Object> entity = entityMap(
+                    resource.getConfigVariables(request, response, NON_FLAG_KEY));
+
+            assertEquals(testAddress, entity.get(NON_FLAG_KEY));
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> entityMap(final Response response) {
+        return (Map<String, Object>) ((ResponseEntityView) response.getEntity()).getEntity();
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/system/ConfigurationResourceTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/system/ConfigurationResourceTest.java
@@ -39,7 +39,8 @@ public class ConfigurationResourceTest {
     private static final String FLAG = FeatureFlagName.FEATURE_FLAG_UVE_TOGGLE_LOCK;
     private static final String UNDEFINED_FLAG = FeatureFlagName.FEATURE_FLAG_UVE_STYLE_EDITOR;
     private static final String NON_FLAG_KEY = "EMAIL_SYSTEM_ADDRESS";
-    private static final String UNLISTED_KEY = "SOME_INTERNAL_SECRET";
+    // A key guaranteed never to appear in WHITE_LIST (fixed UUID-shaped string).
+    private static final String UNLISTED_KEY = "TEST_KEY_THAT_WILL_NEVER_BE_WHITELISTED_a1b2c3d4";
 
     private WebResource webResource;
     private ConfigurationResource resource;


### PR DESCRIPTION
## Summary

Fixes #35551 — Feature flag boolean parsing is case-sensitive.

### What was broken

`recoveryFromConfig` had no branch for unprefixed boolean feature-flag keys. They fell through to `Config.getStringProperty(key, "NOT_FOUND")`, returning raw strings (`"True"`, `"FALSE"`, `"1"`) verbatim. The frontend compared with `=== 'true'`, so anything other than the exact lowercase string silently evaluated to `false`.

### What this PR does

- **Backend (`ConfigurationResource`):** Introduces a `BOOLEAN_FEATURE_FLAGS` set identifying every boolean flag in the whitelist. For those keys, a new `parseBooleanFlag` helper normalises the raw property value to the canonical lowercase strings `"true"` or `"false"` (case-insensitive, whitespace-trimmed), regardless of how it is stored in the properties file. The `"NOT_FOUND"` sentinel is preserved for keys that have no definition anywhere on the server. Unrecognised values log a `WARN` and resolve to `"false"`.

- **Wire format — strings, not native booleans:** The response value type stays `string`, matching the pre-existing contract documented by the Postman collection. Changing the type to native boolean would have been an M-3 API contract break with rollback risk. The original bug is fully fixed by normalising the string value server-side; the frontend comparison `=== 'true'` continues to work correctly.

- **Frontend (`DotCustomEventHandlerService`):** Updated the `CONTENT_EDITOR2_ENABLED` check to a tolerant compare (`val === true || val === 'true'`) so it handles both the normalised string (current) and a potential native boolean (future) without a silent regression.

- **`FeatureFlagName` constant:** Added `FEATURE_FLAG_CONTENT_EDITOR2_ENABLED = "CONTENT_EDITOR2_ENABLED"` — previously hardcoded as a string literal in two places in `ConfigurationResource`.

- **Testability:** Added constructor injection of `WebResource` (package-private, following the same pattern as `PageScannerResource` and `ReportIssueResource`) so the endpoint can be tested without a running container.

- **Swagger / OpenAPI:** Added `@Operation` / `@ApiResponse` / `@Schema(type = "object")` to `getConfigVariables` describing the polymorphic response contract. `openapi.yaml` regenerated.

## Accepted normalisation values

| Raw property value | Resolved wire value |
|---|---|
| `true`, `True`, `TRUE`, ` true ` | `"true"` |
| `1` | `"true"` |
| `false`, `False`, `FALSE`, ` false ` | `"false"` |
| `0`, `` (empty string) | `"false"` |
| key not defined anywhere on the server | `"NOT_FOUND"` (sentinel preserved for frontend opt-out logic) |
| any other unrecognised string | `"false"` + `WARN` log |

## Test plan

- `ConfigurationResourceTest` (unit test in `dotCMS/src/test/java`) — covers all truthy/falsy variants, `NOT_FOUND` sentinel, whitelist exclusion, and raw-string passthrough for non-flag keys. Runs without a container via class-level `mockStatic(Config.class)` with a default answer that prevents `JVMInfoResource` static initialisation from failing.
- Existing `dotcms-integration/.../ConfigurationResourceTest` continues to pass unchanged.
- Postman `ConfigurationResource` collection passes unchanged — wire format remains string-typed.
- Manual reproduction: set `FEATURE_FLAG_UVE_TOGGLE_LOCK=True` (capitalised) in `dotmarketing-config.properties`, restart, call `GET /api/v1/configuration/config?keys=FEATURE_FLAG_UVE_TOGGLE_LOCK` — response now contains `"true"` and the UVE lock/unlock button renders correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35551