### PR TITLE
fix(edit-content): keep lock toggle out of FormGroup so locked content opens pristine

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.html
@@ -105,6 +105,7 @@
                     data-testid="content-lock-controls">
                     <p-toggleSwitch
                         [ngModel]="isContentLocked"
+                        [ngModelOptions]="{ standalone: true }"
                         [disabled]="!canLock"
                         (onChange)="onContentLockChange($event)"
                         inputId="lockSwitch"

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -776,6 +776,172 @@ describe('DotFormComponent', () => {
                 expect(lockSwitch).toBe(null);
             });
         });
+
+        describe('Form dirty state after lock toggle', () => {
+            beforeEach(() => {
+                dotContentletService.canLock.mockReturnValue(
+                    of({ canLock: true } as DotContentletCanLock)
+                );
+
+                dotContentletService.lockContent.mockReturnValue(
+                    of({
+                        ...MOCK_CONTENTLET_1_OR_2_TABS,
+                        locked: true,
+                        lockedBy: 'dotcms.org.1',
+                        lockedByName: 'Admin User',
+                        lockedOn: new Date()
+                    } as DotCMSContentlet)
+                );
+
+                dotContentletService.unlockContent.mockReturnValue(
+                    of({
+                        ...MOCK_CONTENTLET_1_OR_2_TABS,
+                        locked: false,
+                        lockedBy: null,
+                        lockedByName: null,
+                        lockedOn: null
+                    } as DotCMSContentlet)
+                );
+
+                // tick(500) triggers downstream effects (history feature loads versions)
+                // that hit dotEditContentService — mock these so the fakeAsync flush
+                // doesn't crash with "Cannot read properties of undefined".
+                dotEditContentService.getVersions.mockReturnValue(
+                    of({
+                        entity: [],
+                        pagination: null,
+                        errors: [],
+                        i18nMessagesMap: {},
+                        messages: [],
+                        permissions: []
+                    })
+                );
+                dotEditContentService.getPushPublishHistory.mockReturnValue(
+                    of({
+                        entity: [],
+                        pagination: null,
+                        errors: [],
+                        i18nMessagesMap: {},
+                        messages: [],
+                        permissions: []
+                    })
+                );
+            });
+
+            it('should keep the form pristine when content opens locked (AC1, AC2, AC7)', fakeAsync(() => {
+                dotEditContentService.getContentById.mockReturnValue(
+                    of({
+                        ...MOCK_CONTENTLET_1_OR_2_TABS,
+                        locked: true,
+                        lockedBy: 'dotcms.org.1',
+                        lockedByName: 'Admin User',
+                        lockedOn: new Date()
+                    } as DotCMSContentlet)
+                );
+
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,
+                    depth: DotContentletDepths.ONE
+                });
+
+                spectator.detectChanges();
+
+                // Drain the 500ms fallback timer in #scheduleMarkPristineAfterInit
+                tick(500);
+                spectator.detectChanges();
+
+                expect(component.form.dirty).toBe(false);
+                expect(component.form.pristine).toBe(true);
+
+                flush();
+            }));
+
+            it('should not mark form dirty when the lock toggle emits onChange (AC2 regression guard)', fakeAsync(() => {
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,
+                    depth: DotContentletDepths.ONE
+                });
+
+                spectator.detectChanges();
+
+                tick(500);
+                spectator.detectChanges();
+
+                expect(component.form.pristine).toBe(true);
+
+                const lockSwitch = spectator.query(ToggleSwitch);
+                lockSwitch.onChange.emit({ checked: true } as ToggleSwitchChangeEvent);
+                spectator.detectChanges();
+
+                // After fix: the toggle is { standalone: true }, so it is not part of the form.
+                expect(dotContentletService.lockContent).toHaveBeenCalled();
+                expect(component.form.dirty).toBe(false);
+
+                flush();
+            }));
+
+            it('should mark form dirty when a real field is edited (AC5, AC8)', fakeAsync(() => {
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,
+                    depth: DotContentletDepths.ONE
+                });
+
+                spectator.detectChanges();
+
+                tick(500);
+                spectator.detectChanges();
+
+                expect(component.form.pristine).toBe(true);
+
+                const control = component.form.get('disabledWYSIWYG');
+                control?.setValue(['edited-field']);
+                control?.markAsDirty();
+
+                expect(component.form.dirty).toBe(true);
+
+                flush();
+            }));
+
+            it('should mark form dirty when locked content is unlocked and then a field is edited (AC6)', fakeAsync(() => {
+                const lockedMock = {
+                    ...MOCK_CONTENTLET_1_OR_2_TABS,
+                    locked: true,
+                    lockedBy: 'dotcms.org.1',
+                    lockedByName: 'Admin User',
+                    lockedOn: new Date()
+                } as DotCMSContentlet;
+                dotEditContentService.getContentById.mockReturnValue(of(lockedMock));
+
+                store.initializeExistingContent({
+                    inode: lockedMock.inode,
+                    depth: DotContentletDepths.ONE
+                });
+
+                spectator.detectChanges();
+
+                tick(500); // drain #scheduleMarkPristineAfterInit timer
+                spectator.detectChanges();
+
+                expect(component.form.pristine).toBe(true);
+                expect(component.form.dirty).toBe(false);
+
+                const lockSwitch = spectator.query(ToggleSwitch);
+                lockSwitch.onChange.emit({ checked: false } as ToggleSwitchChangeEvent);
+
+                expect(dotContentletService.unlockContent).toHaveBeenCalled();
+
+                spectator.detectChanges();
+
+                const control = component.form.get('disabledWYSIWYG');
+                control?.setValue(['edited-after-unlock']);
+                control?.markAsDirty();
+                spectator.detectChanges();
+
+                expect(component.form.dirty).toBe(true);
+
+                flush();
+            }));
+        });
     });
 
     describe('disabledWYSIWYG functionality', () => {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -941,6 +941,68 @@ describe('DotFormComponent', () => {
 
                 flush();
             }));
+
+            it('should not re-enable the form when toggling lock so field CVAs do not re-emit (#35754, AC2)', fakeAsync(() => {
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,
+                    depth: DotContentletDepths.ONE
+                });
+
+                spectator.detectChanges();
+
+                tick(500);
+                spectator.detectChanges();
+
+                expect(component.form.enabled).toBe(true);
+                expect(component.form.pristine).toBe(true);
+
+                const enableSpy = jest.spyOn(component.form, 'enable');
+
+                const lockSwitch = spectator.query(ToggleSwitch);
+                lockSwitch.onChange.emit({ checked: true } as ToggleSwitchChangeEvent);
+                spectator.detectChanges();
+
+                expect(dotContentletService.lockContent).toHaveBeenCalled();
+
+                // The lock patch replaces the contentlet reference, so the enable/disable
+                // effect re-runs — but the form is already enabled, so the idempotent guard
+                // must skip enable(). A redundant enable() would make async field CVAs (e.g.
+                // the date field) re-emit and wrongly dirty the form.
+                expect(enableSpy).not.toHaveBeenCalled();
+                expect(component.form.dirty).toBe(false);
+                expect(component.form.pristine).toBe(true);
+
+                flush();
+            }));
+
+            it('should preserve a real unsaved edit when toggling lock (#35754, AC6 regression)', fakeAsync(() => {
+                store.initializeExistingContent({
+                    inode: MOCK_CONTENTLET_1_OR_2_TABS.inode,
+                    depth: DotContentletDepths.ONE
+                });
+
+                spectator.detectChanges();
+
+                tick(500);
+                spectator.detectChanges();
+
+                expect(component.form.pristine).toBe(true);
+
+                // Real user edit before locking.
+                const control = component.form.get('disabledWYSIWYG');
+                control?.setValue(['user-edit']);
+                control?.markAsDirty();
+                expect(component.form.dirty).toBe(true);
+
+                const lockSwitch = spectator.query(ToggleSwitch);
+                lockSwitch.onChange.emit({ checked: true } as ToggleSwitchChangeEvent);
+                spectator.detectChanges();
+
+                // Locking must not clobber the user's real unsaved changes.
+                expect(component.form.dirty).toBe(true);
+
+                flush();
+            }));
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.spec.ts
@@ -778,6 +778,11 @@ describe('DotFormComponent', () => {
         });
 
         describe('Form dirty state after lock toggle', () => {
+            // Mirrors the fallback timer in #scheduleMarkPristineAfterInit
+            // (race(appRef.isStable, timer(500))). Named so the coupling is explicit
+            // and breaks loudly here if the production debounce changes.
+            const PRISTINE_RESET_DEBOUNCE_MS = 500;
+
             beforeEach(() => {
                 dotContentletService.canLock.mockReturnValue(
                     of({ canLock: true } as DotContentletCanLock)
@@ -847,7 +852,7 @@ describe('DotFormComponent', () => {
                 spectator.detectChanges();
 
                 // Drain the 500ms fallback timer in #scheduleMarkPristineAfterInit
-                tick(500);
+                tick(PRISTINE_RESET_DEBOUNCE_MS);
                 spectator.detectChanges();
 
                 expect(component.form.dirty).toBe(false);
@@ -864,7 +869,7 @@ describe('DotFormComponent', () => {
 
                 spectator.detectChanges();
 
-                tick(500);
+                tick(PRISTINE_RESET_DEBOUNCE_MS);
                 spectator.detectChanges();
 
                 expect(component.form.pristine).toBe(true);
@@ -888,15 +893,18 @@ describe('DotFormComponent', () => {
 
                 spectator.detectChanges();
 
-                tick(500);
+                tick(PRISTINE_RESET_DEBOUNCE_MS);
                 spectator.detectChanges();
 
                 expect(component.form.pristine).toBe(true);
 
-                const control = component.form.get('disabledWYSIWYG');
-                control?.setValue(['edited-field']);
-                control?.markAsDirty();
+                // Real user edit routed through the rendered field input, so Angular's forms
+                // machinery (not a manual markAsDirty) is what dirties the control.
+                const input = spectator.query(byTestId('text2')) as HTMLInputElement;
+                spectator.typeInElement('edited via DOM', input);
+                spectator.detectChanges();
 
+                expect(component.form.get('text2')?.dirty).toBe(true);
                 expect(component.form.dirty).toBe(true);
 
                 flush();
@@ -919,7 +927,7 @@ describe('DotFormComponent', () => {
 
                 spectator.detectChanges();
 
-                tick(500); // drain #scheduleMarkPristineAfterInit timer
+                tick(PRISTINE_RESET_DEBOUNCE_MS); // drain #scheduleMarkPristineAfterInit timer
                 spectator.detectChanges();
 
                 expect(component.form.pristine).toBe(true);
@@ -932,11 +940,12 @@ describe('DotFormComponent', () => {
 
                 spectator.detectChanges();
 
-                const control = component.form.get('disabledWYSIWYG');
-                control?.setValue(['edited-after-unlock']);
-                control?.markAsDirty();
+                // Real user edit routed through the rendered field input after unlocking.
+                const input = spectator.query(byTestId('text2')) as HTMLInputElement;
+                spectator.typeInElement('edited after unlock', input);
                 spectator.detectChanges();
 
+                expect(component.form.get('text2')?.dirty).toBe(true);
                 expect(component.form.dirty).toBe(true);
 
                 flush();
@@ -950,7 +959,7 @@ describe('DotFormComponent', () => {
 
                 spectator.detectChanges();
 
-                tick(500);
+                tick(PRISTINE_RESET_DEBOUNCE_MS);
                 spectator.detectChanges();
 
                 expect(component.form.enabled).toBe(true);
@@ -983,7 +992,7 @@ describe('DotFormComponent', () => {
 
                 spectator.detectChanges();
 
-                tick(500);
+                tick(PRISTINE_RESET_DEBOUNCE_MS);
                 spectator.detectChanges();
 
                 expect(component.form.pristine).toBe(true);

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -281,21 +281,24 @@ export class DotEditContentFormComponent implements OnInit {
         /**
          * Effect that enables or disables the form based on the loading state.
          *
-         * Reads `contentlet()` only as an existence guard, so the effect also re-runs on
-         * contentlet changes (e.g. a lock/unlock that replaces the contentlet reference
-         * without changing any field). To avoid that churn we make the enable/disable
-         * idempotent: only toggle when the form's current state actually differs from the
-         * desired one, and suppress events. Otherwise a redundant `form.enable()` would make
-         * async field CVAs (e.g. the date field) re-emit their value and wrongly mark the
-         * form dirty, triggering the unsaved-changes guard on a plain lock toggle (#35754).
+         * `isViewingHistoricalVersion` was intentionally dropped from the condition for now;
+         * it will be restored once all fields support a disabled state (see the TODO below).
+         *
+         * `contentlet()` is read with `untracked` as a mere existence guard, so the effect is
+         * driven only by `isLoading`: a lock/unlock that replaces the contentlet reference
+         * without changing any field must not re-run it. The enable/disable is also kept
+         * idempotent (toggle only when the current state differs) and uses `{ emitEvent: false }`,
+         * because a redundant `form.enable()` makes async field CVAs (e.g. the date field)
+         * re-emit their value and wrongly mark the form dirty, triggering the unsaved-changes
+         * guard on a plain lock toggle (#35754).
          */
         effect(() => {
             const isLoading = this.$store.isLoading();
             // const isViewingHistoricalVersion = this.$store.isViewingHistoricalVersion();
-            const contentlet = this.$store.contentlet();
+            const hasContentlet = untracked(() => !!this.$store.contentlet());
 
             // Only apply state changes if form exists
-            if (this.form && contentlet) {
+            if (this.form && hasContentlet) {
                 // TODO: put back isViewingHistoricalVersion in the
                 // condition after all fields have disabled state
                 if (isLoading && this.form.enabled) {

--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-form/dot-edit-content-form.component.ts
@@ -279,7 +279,15 @@ export class DotEditContentFormComponent implements OnInit {
         });
 
         /**
-         * Effect that enables or disables the form based on the loading state and historical view.
+         * Effect that enables or disables the form based on the loading state.
+         *
+         * Reads `contentlet()` only as an existence guard, so the effect also re-runs on
+         * contentlet changes (e.g. a lock/unlock that replaces the contentlet reference
+         * without changing any field). To avoid that churn we make the enable/disable
+         * idempotent: only toggle when the form's current state actually differs from the
+         * desired one, and suppress events. Otherwise a redundant `form.enable()` would make
+         * async field CVAs (e.g. the date field) re-emit their value and wrongly mark the
+         * form dirty, triggering the unsaved-changes guard on a plain lock toggle (#35754).
          */
         effect(() => {
             const isLoading = this.$store.isLoading();
@@ -290,10 +298,10 @@ export class DotEditContentFormComponent implements OnInit {
             if (this.form && contentlet) {
                 // TODO: put back isViewingHistoricalVersion in the
                 // condition after all fields have disabled state
-                if (isLoading) {
-                    this.form.disable();
-                } else {
-                    this.form.enable();
+                if (isLoading && this.form.enabled) {
+                    this.form.disable({ emitEvent: false });
+                } else if (!isLoading && this.form.disabled) {
+                    this.form.enable({ emitEvent: false });
                 }
             }
         });


### PR DESCRIPTION
## Summary

Fixes a UX bug in the new Edit Content experience where the form was marked `dirty`
without any user interaction, triggering a spurious "You have unsaved changes" dialog on
navigation. The unsaved-changes guard (`dot-edit-content.layout.component.ts:324`) keys off
`FormGroup.dirty`. Two independent code paths were dirtying the form:

### Case 1 — Opening locked content
The lock `<p-toggleSwitch [ngModel]="isContentLocked">` lives in `<ng-template #appendContent>`,
which `dotTabViewInsert` injects **inside** `<form [formGroup]="form">`. Without
`standalone`, Angular registered the template-driven `ngModel` as an implicit control on the
reactive `FormGroup`; the async lock-status write through `[ngModel]` then dirtied the form.

**Fix:** add `[ngModelOptions]="{ standalone: true }"` to the toggle so it lives outside the
reactive form (one-way `[ngModel]` and `(onChange)` are unchanged).

### Case 2 — Toggling lock/unlock inside the editor
`lockContent`/`unlockContent` `patchState` the contentlet with a **new object reference**
(only `locked/lockedBy/lockedByName/lockedOn` change). The enable/disable effect reads
`contentlet()` as an existence guard, so it re-runs on that reference change and calls
`form.enable()` even though the form is already enabled. `enable()` makes async field CVAs
(the date field, `postingDate`) re-emit their value, marking the control — and the whole
`FormGroup` — dirty. The user never touched the field.

**Fix:** make the enable/disable effect idempotent — only call `disable()`/`enable()` when the
form's current state differs from the desired one, and pass `{ emitEvent: false }`. On a lock
toggle the form is already enabled, so `enable()` is skipped and no CVA re-emits.

> Root cause for Case 2 confirmed live with `ng.getComponent`: each lock toggle called
> `enable()` once (stack originating from `runEffect`); neutralizing `enable()` made the bug
> disappear. After the fix, lock and unlock both leave `form.dirty === false` with `enable()`
> called 0 times.

## Acceptance Criteria

- [x] Opening locked content leaves the form pristine; no unsaved-changes dialog on navigation.
- [x] Toggling lock/unlock inside the editor does not dirty the form (no dialog).
- [x] A real unsaved edit is preserved across a lock toggle (form stays dirty).
- [x] Editing a real field still dirties the form (existing behavior unchanged).

## Test plan

- [x] `yarn nx test edit-content --testPathPattern=dot-edit-content-form.component.spec` — 1865 passed
  - New: `form.enable` is not re-called on a lock-only contentlet change (idempotent guard)
  - New: a real unsaved edit is preserved across a lock toggle
- [x] `yarn nx lint edit-content` — 0 errors (9 pre-existing warnings, unrelated)
- [x] Manual, live (`localhost:4213`): lock and unlock both keep `form.dirty === false`

Closes #35754

This PR fixes: #35754