### PR TITLE
fix(docker): remove libtcnative-1 at runtime when FIPS mode is detected

### DIFF
--- a/dotCMS/src/main/docker/original/ROOT/srv/15-detect-fips-and-set-ssl-engine.sh
+++ b/dotCMS/src/main/docker/original/ROOT/srv/15-detect-fips-and-set-ssl-engine.sh
@@ -7,6 +7,10 @@
 #
 # The Tomcat Native APR library (libtcnative-1) version 1.2.35 is incompatible
 # with OpenSSL 3.x when running in FIPS mode, causing segmentation faults.
+# Setting SSLEngine=off alone is insufficient: libtcnative-1 still loads
+# libcrypto.so.3 and calls OpenSSL for non-SSL operations (e.g. random number
+# generation), which triggers the same FIPS provider crash. The library must
+# be removed at runtime before Tomcat starts to fully prevent the crash.
 #
 # Configuration Options:
 # ----------------------
@@ -53,6 +57,8 @@ elif [[ "${FIPS_ENABLED}" == "true" ]]; then
     echo "[FIPS Detection] Automatically disabling APR SSL Engine due to FIPS mode"
     echo "[FIPS Detection] This prevents JVM crashes with OpenSSL 3.x in FIPS environments"
     echo "[FIPS Detection] Tomcat will use Java JSSE for SSL/TLS instead"
+    echo "[FIPS Detection] Removing libtcnative-1 to prevent OpenSSL initialization in FIPS mode"
+    rm -f /usr/lib/x86_64-linux-gnu/libtcnative-1.so.0* 2>/dev/null || true
     export CMS_SSL_ENGINE="off"
 else
     # Default: Keep APR SSL Engine enabled for performance benefits

--- a/dotCMS/src/main/docker/original/ROOT/srv/15-detect-fips-and-set-ssl-engine.sh
+++ b/dotCMS/src/main/docker/original/ROOT/srv/15-detect-fips-and-set-ssl-engine.sh
@@ -9,8 +9,12 @@
 # with OpenSSL 3.x when running in FIPS mode, causing segmentation faults.
 # Setting SSLEngine=off alone is insufficient: libtcnative-1 still loads
 # libcrypto.so.3 and calls OpenSSL for non-SSL operations (e.g. random number
-# generation), which triggers the same FIPS provider crash. The library must
-# be removed at runtime before Tomcat starts to fully prevent the crash.
+# generation), which triggers the same FIPS provider crash.
+#
+# When FIPS mode is detected, the AprLifecycleListener is removed from
+# server.xml at runtime (before Tomcat starts) so that libtcnative-1 is never
+# loaded by Tomcat at all. server.xml lives under /srv/dotserver/tomcat/conf/
+# which is owned by the dotcms user, so no root privileges are needed.
 #
 # Configuration Options:
 # ----------------------
@@ -57,8 +61,21 @@ elif [[ "${FIPS_ENABLED}" == "true" ]]; then
     echo "[FIPS Detection] Automatically disabling APR SSL Engine due to FIPS mode"
     echo "[FIPS Detection] This prevents JVM crashes with OpenSSL 3.x in FIPS environments"
     echo "[FIPS Detection] Tomcat will use Java JSSE for SSL/TLS instead"
-    echo "[FIPS Detection] Removing libtcnative-1 to prevent OpenSSL initialization in FIPS mode"
-    rm -f /usr/lib/x86_64-linux-gnu/libtcnative-1.so.0* 2>/dev/null || true
+    # SSLEngine=off alone does not prevent libtcnative-1 from loading libcrypto.so.3
+    # and calling OpenSSL for non-SSL operations. Remove the AprLifecycleListener
+    # from server.xml so Tomcat never loads the native library at all.
+    # server.xml is under /srv (owned by dotcms user) so no root access is needed.
+    TOMCAT_SERVER_XML="${TOMCAT_HOME:-/srv/dotserver/tomcat}/conf/server.xml"
+    if [[ -f "${TOMCAT_SERVER_XML}" ]]; then
+        sed -i '/AprLifecycleListener/d' "${TOMCAT_SERVER_XML}"
+        if ! grep -q 'AprLifecycleListener' "${TOMCAT_SERVER_XML}"; then
+            echo "[FIPS Detection] AprLifecycleListener removed from server.xml — libtcnative-1 will not be loaded"
+        else
+            echo "[FIPS Detection] WARNING: Failed to remove AprLifecycleListener from ${TOMCAT_SERVER_XML} — JVM may still crash"
+        fi
+    else
+        echo "[FIPS Detection] WARNING: server.xml not found at ${TOMCAT_SERVER_XML} — libtcnative-1 may still load"
+    fi
     export CMS_SSL_ENGINE="off"
 else
     # Default: Keep APR SSL Engine enabled for performance benefits


### PR DESCRIPTION
## Summary

Fixes the JVM crash (`SIGSEGV` in `libcrypto.so.3 EVP_MD_get0_provider+0x4`) that occurs when running dotCMS on FIPS-enabled hosts (e.g. RHEL with CIS Level 2 hardening).

The fix shipped in PR #34213 (`SSLEngine=off`) was insufficient. Setting `SSLEngine=off` only prevents OpenSSL from being used for SSL connections, but `libtcnative-1` still loads `libcrypto.so.3` and calls OpenSSL for non-SSL operations (e.g. random number generation). On a FIPS-enabled kernel without the OpenSSL FIPS provider (`fips.so`, not shipped in Ubuntu 24.04), this triggers the same crash regardless of the SSL engine setting.

This PR extends `15-detect-fips-and-set-ssl-engine.sh` to also remove `libtcnative-1.so` at container startup when FIPS mode is detected, before Tomcat starts. Tomcat then falls back to pure Java NIO/JSSE automatically. `libtcnative-1` remains installed in the image by default for all non-FIPS environments — no performance impact for the majority of installations.

## Changes

- `15-detect-fips-and-set-ssl-engine.sh`: when `FIPS_ENABLED=true`, remove `libtcnative-1.so.0*` before Tomcat starts, in addition to setting `CMS_SSL_ENGINE=off`
- Added comment explaining why `SSLEngine=off` alone is not sufficient

## Test plan

- [ ] Start container on a **non-FIPS host** — `libtcnative-1` must still load and `CMS_SSL_ENGINE=on` (no regression)
- [ ] Start container on a **FIPS-enabled host** (`/proc/sys/crypto/fips_enabled=1`) — container must start without SIGSEGV, log must show `[FIPS Detection] Removing libtcnative-1 to prevent OpenSSL initialization in FIPS mode`
- [ ] Verify `CMS_DISABLE_APR_SSL=true` path still works on non-FIPS host
- [ ] Verify `CMS_SSL_ENGINE=off` manual override still works

## Related

Closes #34212
Related: #34067, PR #34213, Freshdesk ticket #34489