### PR TITLE
test: stabilize Template_Resource Postman + SiteAPIIT against missing default language (#35780)

### DIFF
--- a/dotcms-postman/src/main/resources/postman/Template_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Template_Resource.postman_collection.json
@@ -6346,7 +6346,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"contentlet\":{\n\t\t\"stName\": \"htmlpageasset\",\n\t\t\"title\": \"PageAsset Using Not Anonymous Template\",\n        \"url\": \"notAnonymousTemplatePage\",\n        \"friendlyName\":\"PageAsset Using not Anonymous Template\",\n        \"template\": \"{{notAnonymousTemplateId}}\",\n        \"sortOrder\": \"0\",\n        \"cachettl\": \"100\",\n        \"hostFolder\":\"8a7d5e23-da1e-420a-b4f0-471e7da8ea2d\"\n\t}\n}",
+							"raw": "{\n\t\"contentlet\":{\n\t\t\"stName\": \"htmlpageasset\",\n\t\t\"title\": \"PageAsset Using Not Anonymous Template\",\n        \"url\": \"notAnonymousTemplatePage\",\n        \"friendlyName\":\"PageAsset Using not Anonymous Template\",\n        \"template\": \"{{notAnonymousTemplateId}}\",\n        \"sortOrder\": \"0\",\n        \"cachettl\": \"100\",\n        \"hostFolder\":\"8a7d5e23-da1e-420a-b4f0-471e7da8ea2d\",\n        \"languageId\": \"{{defaultLanguageId}}\"\n\t}\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -7524,7 +7524,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"contentlet\":{\n\t\t\"stName\": \"htmlpageasset\",\n\t\t\"title\": \"PageAsset Using File Template\",\n        \"url\": \"pageassetfiletemplate\",\n        \"friendlyName\":\"PageAsset Using File Template\",\n        \"template\": \"//default/application/templates/system/\",\n        \"sortOrder\": \"0\",\n        \"cachettl\": \"100\",\n        \"hostFolder\":\"8a7d5e23-da1e-420a-b4f0-471e7da8ea2d\"\n\t}\n}",
+					"raw": "{\n\t\"contentlet\":{\n\t\t\"stName\": \"htmlpageasset\",\n\t\t\"title\": \"PageAsset Using File Template\",\n        \"url\": \"pageassetfiletemplate\",\n        \"friendlyName\":\"PageAsset Using File Template\",\n        \"template\": \"//default/application/templates/system/\",\n        \"sortOrder\": \"0\",\n        \"cachettl\": \"100\",\n        \"hostFolder\":\"8a7d5e23-da1e-420a-b4f0-471e7da8ea2d\",\n        \"languageId\": \"{{defaultLanguageId}}\"\n\t}\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -7551,6 +7551,56 @@
 				"description": "Creates a page successfully using the path of a template as a file as templateId"
 			},
 			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					"// Resolve the default language id once per run with up to 3 retries and cache it",
+					"// as a collection variable. Guards against the cold-cache window where the lookup",
+					"// transiently returns nothing valid and a downstream contentlet save fails with",
+					"// fk_contentlet_lang. See issue #35780.",
+					"(function resolveDefaultLanguageId() {",
+					"    const existing = pm.collectionVariables.get('defaultLanguageId');",
+					"    if (existing && Number(existing) > 0) { return; }",
+					"    const host = (pm.environment.get('serverURL') || 'http://localhost:8080').replace(/\\/$/, '');",
+					"    const auth = 'Basic ' + Buffer.from('admin@dotcms.com:admin').toString('base64');",
+					"    const maxAttempts = 3;",
+					"    const attempt = (n) => {",
+					"        pm.sendRequest({",
+					"            url: host + '/api/v2/languages',",
+					"            method: 'GET',",
+					"            header: { 'Authorization': auth, 'Content-Type': 'application/json' }",
+					"        }, (err, res) => {",
+					"            let id = null;",
+					"            if (!err && res && res.code === 200) {",
+					"                try {",
+					"                    const body = res.json();",
+					"                    const list = Array.isArray(body) ? body",
+					"                        : (body && Array.isArray(body.entity)) ? body.entity",
+					"                        : Object.values(body || {});",
+					"                    const def = list.find(l => l && l.defaultLanguage === true && Number(l.id) > 0)",
+					"                             || list.find(l => l && Number(l.id) > 0);",
+					"                    if (def && Number(def.id) > 0) { id = Number(def.id); }",
+					"                } catch (e) { /* fall through to retry */ }",
+					"            }",
+					"            if (id !== null) {",
+					"                pm.collectionVariables.set('defaultLanguageId', id);",
+					"            } else if (n < maxAttempts) {",
+					"                attempt(n + 1);",
+					"            } else {",
+					"                console.warn('[Template_Resource] defaultLanguageId lookup failed after ' + maxAttempts + ' attempts; falling back to 1');",
+					"                pm.collectionVariables.set('defaultLanguageId', 1);",
+					"            }",
+					"        });",
+					"    };",
+					"    attempt(1);",
+					"})();"
+				]
+			}
 		}
 	],
 	"variable": [
@@ -7652,6 +7702,10 @@
 		},
 		{
 			"key": "notAnonymousPageId",
+			"value": ""
+		},
+		{
+			"key": "defaultLanguageId",
 			"value": ""
 		}
 	]

--- a/tools/dotcms-cli/api-data-model/src/test/java/com/dotcms/api/SiteAPIIT.java
+++ b/tools/dotcms-cli/api-data-model/src/test/java/com/dotcms/api/SiteAPIIT.java
@@ -6,6 +6,7 @@ import com.dotcms.api.client.model.ServiceManager;
 import com.dotcms.common.SiteTestHelperService;
 import com.dotcms.model.ResponseEntityView;
 import com.dotcms.model.config.ServiceBean;
+import com.dotcms.model.language.Language;
 import com.dotcms.model.site.CopySiteRequest;
 import com.dotcms.model.site.CreateUpdateSiteRequest;
 import com.dotcms.model.site.GetSiteByNameRequest;
@@ -27,6 +28,12 @@ import org.wildfly.common.Assert;
 @QuarkusTest
 @TestProfile(DotCMSITProfile.class)
 class SiteAPIIT {
+
+    /**
+     * One-shot guard so the language cache warm-up runs at most once per JVM regardless
+     * of how many @BeforeEach invocations happen across this test class.
+     */
+    private static volatile boolean languageCacheWarmed = false;
 
     @ConfigProperty(name = "com.dotcms.starter.site", defaultValue = "default")
     String siteName;
@@ -50,6 +57,44 @@ class SiteAPIIT {
         final String user = "admin@dotcms.com";
         final char[] passwd = "admin".toCharArray();
         authenticationContext.login(user, passwd);
+
+        warmLanguageCacheIfNeeded();
+    }
+
+    /**
+     * Warms the dotCMS language cache by listing languages, retrying up to 3 times to
+     * cover the race window right after a fresh dotCMS start where the default-language
+     * lookup can briefly return a non-positive id. When that happens, downstream site
+     * creation fails with HTTP 500 "Language cannot be null" because the contentlet ends
+     * up with languageId <= 0 and a unique-field validation tries to resolve it back to
+     * a Language. See issue #35780.
+     */
+    private void warmLanguageCacheIfNeeded() {
+        if (languageCacheWarmed) {
+            return;
+        }
+        final int maxAttempts = 3;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                final ResponseEntityView<List<Language>> response =
+                        clientFactory.getClient(LanguageAPI.class).list();
+                final List<Language> languages = response != null ? response.entity() : null;
+                final boolean hasValidLanguage = languages != null && languages.stream()
+                        .anyMatch(l -> l != null && l.id().isPresent() && l.id().get() > 0);
+                if (hasValidLanguage) {
+                    languageCacheWarmed = true;
+                    return;
+                }
+            } catch (Exception ignored) {
+                // fall through to retry
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Test-only stability fixes for the intermittent failures caused by the default-language lookup briefly returning a non-positive id on a cold dotCMS start. Two surfaces affected:

**Postman — `Template_Resource.postman_collection.json`**
- Collection-level pre-request resolves the default language id from `GET /api/v2/languages` with up to 3 retries and caches it in a new `defaultLanguageId` collection variable.
- `PUT Create Page Using NOT anonymous Template` and `PUT Create Page Using Template as a File` now send `"languageId": "{{defaultLanguageId}}"` so they no longer depend on the backend's silent `-1L` default that intermittently produced `fk_contentlet_lang` FK violations.

**CLI — `SiteAPIIT.java`**
- `@BeforeEach` now calls `LanguageAPI.list()` with up to 3 retries (200ms apart), gated by a static flag so the network call fires at most once per JVM.
- Covers the race window where the default-language lookup briefly returns `-1` and downstream site creation fails with HTTP 500 `"Language cannot be null"`.

Backend hardening for `MapToContentletPopulator` and the `SiteResource.copySitePropertiesFromForm` chokepoint is intentionally kept out of this PR so we can first observe the test stability in CI in isolation. Backend changes will follow in a separate PR.

Refs: #35780

## Test plan

- [ ] CI: `PR Test / Postman Tests - Template` job passes — and re-running the job a couple of times keeps it green.
- [ ] CI: CLI integration job covering `SiteAPIIT` passes (Test_Archive_Unarchive, Test_Copy_Site, Test_Create_New_Site_Then_Update_Then_Delete, Test_Publish_UnPublish_Site).
- [ ] Verify the Postman pre-request resolves a positive `defaultLanguageId` (look at the pre-request console output) and is not the fallback `1` from the clamp.
- [ ] Verify the SiteAPIIT warm-up runs once: `languageCacheWarmed` stays `true` after the first test in the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35780