### PR TITLE
fix(docker): install cached custom starter on container restart

### DIFF
--- a/dotCMS/src/main/docker/original/ROOT/srv/40-custom-starter-zip.sh
+++ b/dotCMS/src/main/docker/original/ROOT/srv/40-custom-starter-zip.sh
@@ -49,14 +49,16 @@ else
       curl -k -s -L -o $CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER "$CUSTOM_STARTER_URL" || echo "Failed to download starter"
     fi
 
-		if [[ -s $CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER ]] ; then
-			export DOT_STARTER_DATA_LOAD=$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER
-		else
-			rm -f $CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER
+		if [[ ! -s "$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER" ]] ; then
+			rm -f "$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER"
 			echo "No starter downloaded, skipping"
 		fi
 	else
 		echo "custom starter already downloaded"
 		echo "if you need to redownload a new starter, delete the existing custom starter file found here: $CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER"
+	fi
+
+	if [[ -s "$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER" ]] ; then
+		export DOT_STARTER_DATA_LOAD="$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER"
 	fi
 fi

--- a/dotCMS/src/main/docker/original/ROOT/srv/40-custom-starter-zip.sh
+++ b/dotCMS/src/main/docker/original/ROOT/srv/40-custom-starter-zip.sh
@@ -17,14 +17,14 @@ CUSTOM_STARTER_DATA_FOLDER=${CUSTOM_STARTER_DATA_FOLDER:-"/data/shared"}
 
 
 ## if we dont have a custom starter
-if [ -z ${CUSTOM_STARTER_URL} ]; then
+if [ -z "${CUSTOM_STARTER_URL}" ]; then
 	echo "Using default starter";
 else
 
   HASHED_URL=$(echo -n "$CUSTOM_STARTER_URL" | md5sum | cut -d ' ' -f 1)
   CUSTOM_STARTER=dotcms-starter-$HASHED_URL.zip
 
-	if [[ ! -f $CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER ]]; then
+	if [[ ! -s "$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER" ]]; then
 
   echo "CUSTOM_STARTER_DATA_FOLDER: $CUSTOM_STARTER_DATA_FOLDER"
   echo "CUSTOM_STARTER_URL: $CUSTOM_STARTER_URL"
@@ -36,17 +36,17 @@ else
   if [[ -n  $CUSTOM_STARTER_URL_AUTH_TOKEN ]]; then
     echo "CUSTOM_STARTER_URL_BASIC_AUTH: XXXXXX:XXXXXX"
   fi
-	  mkdir -p  $CUSTOM_STARTER_DATA_FOLDER
+	  mkdir -p  "$CUSTOM_STARTER_DATA_FOLDER"
     if [[ -n  $CUSTOM_STARTER_URL_AUTH_TOKEN ]]; then
-      echo "Downloading Custom Starter with Auth Token:" $CUSTOM_STARTER_URL
+      echo "Downloading Custom Starter with Auth Token:" "$CUSTOM_STARTER_URL"
       echo "curl -s -L -o $CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER -HAuthorization: Bearer $CUSTOM_STARTER_URL_AUTH_TOKEN $CUSTOM_STARTER_URL"
-      curl -k -s -L -o $CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER -H"Authorization: Bearer $CUSTOM_STARTER_URL_AUTH_TOKEN" "$CUSTOM_STARTER_URL" || echo "Failed to download starter with auth token"
+      curl -k -s -L -o "$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER" -H"Authorization: Bearer $CUSTOM_STARTER_URL_AUTH_TOKEN" "$CUSTOM_STARTER_URL" || echo "Failed to download starter with auth token"
     elif [[ -n $CUSTOM_STARTER_URL_BASIC_AUTH ]]; then
-      echo "Downloading Custom Starter with Basic Auth:" $CUSTOM_STARTER_URL
-      curl -k -s -L -o $CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER -u"$CUSTOM_STARTER_URL_BASIC_AUTH" "$CUSTOM_STARTER_URL" || echo "Failed to download starter with basic auth"
+      echo "Downloading Custom Starter with Basic Auth:" "$CUSTOM_STARTER_URL"
+      curl -k -s -L -o "$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER" -u"$CUSTOM_STARTER_URL_BASIC_AUTH" "$CUSTOM_STARTER_URL" || echo "Failed to download starter with basic auth"
     else
-      echo "Downloading Custom Starter:" $CUSTOM_STARTER_URL
-      curl -k -s -L -o $CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER "$CUSTOM_STARTER_URL" || echo "Failed to download starter"
+      echo "Downloading Custom Starter:" "$CUSTOM_STARTER_URL"
+      curl -k -s -L -o "$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER" "$CUSTOM_STARTER_URL" || echo "Failed to download starter"
     fi
 
 		if [[ ! -s "$CUSTOM_STARTER_DATA_FOLDER/$CUSTOM_STARTER" ]] ; then


### PR DESCRIPTION
## Summary
- The Docker init script `40-custom-starter-zip.sh` only exported `DOT_STARTER_DATA_LOAD` inside the download branch, so a cached starter zip was never applied on restart.
- Moved the export to run whenever the cached file exists and is non-empty, so cached starters install on every boot.
- Quoted path expansions to satisfy shellcheck.

Fixes #35788

## Test plan
- [ ] Start container with `CUSTOM_STARTER_URL` set → fresh download, starter installed.
- [ ] Restart container with cached zip on disk → no re-download, starter still installed (`DOT_STARTER_DATA_LOAD` exported).
- [ ] Failed/zero-byte download is cleaned up and no starter export occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)