### PR TITLE
security: upgrade Apache Tomcat from 9.0.113 to 9.0.118 (25.07.10 LTS backport)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,7 +61,7 @@
         </java.module.args>
 
         <maven.deploy.skip>false</maven.deploy.skip>
-        <tomcat.version>9.0.113</tomcat.version>
+        <tomcat.version>9.0.118</tomcat.version>
         <!-- Add any properties here that are to have defaults and overrides set in the environment properties -->
         <!--suppress UnresolvedMavenProperty -->
         <mvn.environment.name>${ext.mvn.environment.name}</mvn.environment.name>


### PR DESCRIPTION
## Summary

Backport of #35796 to the **25.07.10 LTS** line.

Bumps the bundled Apache Tomcat version from `9.0.113` to `9.0.118` to resolve six published Apache Tomcat CVEs that affect 9.0.113.

Refs #35793.

## CVEs addressed

| CVE | Severity (Apache) | Affected range | Fixed in |
|---|---|---|---|
| CVE-2026-29146 | **Important** | 9.0.13 – 9.0.115 | 9.0.116 |
| CVE-2026-34500 | Moderate | 9.0.92 – 9.0.116 | 9.0.117 |
| CVE-2026-34487 | Low | 9.0.13 – 9.0.116 | 9.0.117 |
| CVE-2026-34483 | Low | 9.0.40 – 9.0.116 | 9.0.117 |
| CVE-2026-25854 | Low | 9.0.0.M23 – 9.0.115 | 9.0.116 |
| CVE-2026-24880 | Low | 9.0.0.M1 – 9.0.115 | 9.0.116 |

Source: https://tomcat.apache.org/security-9.html

## Diff

Single-property change in `parent/pom.xml`:

```diff
- <tomcat.version>9.0.113</tomcat.version>
+ <tomcat.version>9.0.118</tomcat.version>
```

The property propagates to BOM declarations, `dotCMS/pom.xml`, `dotcms-integration/pom.xml`, and the docker descriptor — no source-code changes needed; Tomcat 9.0.x is API-stable across patch versions.

## Why this LTS backport is prioritized

Two enterprise customers blocked on this Tomcat version. The 25.07.10 LTS customer (Freshdesk ticket #37386) has an explicit deployment-blocking security gate. The 24.12.27 LTS backport (#TBD) and the evergreen PR (#35796) are tracked separately in #35793.

## Test plan

- [ ] CI build succeeds on the LTS branch
- [ ] Full integration test suite passes
- [ ] Docker base image `tomcat:9.0.118-jdk11` resolves and pulls cleanly
- [ ] LTS release pipeline produces a clean `25.07.10_lts_v10` (or whichever the next revision is) artifact
- [ ] Smoke test push-publishing and HTTPS endpoint behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)