### PR TITLE
fix(husky): make LTS pre-commit hook work in git worktrees

### DIFF
--- a/core-web/.husky/pre-commit
+++ b/core-web/.husky/pre-commit
@@ -80,7 +80,7 @@ check_sdk_client_affected() {
         print_color "$BLUE" "ℹ️ ${file_to_remove} does not exist"
     fi
 
-    if ! git add "${root_dir}/dotCMS/src/main/webapp/ext/uve/dot-uve.js"; then
+    if ! git -C "${root_dir}" add -- "dotCMS/src/main/webapp/ext/uve/dot-uve.js"; then
         print_color "$RED" "❌ Failed to stage computed dot-uve.js"
         exit 1
     fi
@@ -124,7 +124,7 @@ perform_frontend_fixes() {
         return 1
     else
         print_color "$GREEN" "✅ Completed yarn install adding yarn.lock if it was modified"
-        git add "${root_dir}/core-web/yarn.lock"
+        git -C "${root_dir}" add -- "core-web/yarn.lock"
     fi
 
     if ! yarn nx affected -t lint --exclude='tag:skip:lint' --fix=true; then
@@ -143,7 +143,7 @@ perform_frontend_fixes() {
 
         for file in $files; do
             if echo "$modified_files" | grep -Fxq "$file"; then
-                if ! git add -- "${root_dir}/${file}"; then
+                if ! git -C "${root_dir}" add -- "${file}"; then
                     has_errors=true
                 fi
             else
@@ -157,7 +157,7 @@ perform_frontend_fixes() {
             printf "\n"
             for file in "${unmatched_files[@]}"; do
                 printf "    %s\n" "${file}"
-                git restore "${file}"
+                git -C "${root_dir}" restore -- "${file}"
             done
             printf "\n"
             print_color "$YELLOW" "💡 You can fix these files by running the following commands:"
@@ -303,7 +303,7 @@ if needs_maven; then
             print_color "$GREEN" "✅ Completed Maven compile with OpenAPI generation"
             # Stage the updated OpenAPI file if it was regenerated
             if [ -f "${root_dir}/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml" ]; then
-                git add "${root_dir}/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml"
+                git -C "${root_dir}" add -- "dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml"
                 print_color "$GREEN" "📋 Updated OpenAPI specification staged for commit"
             fi
         fi
@@ -384,7 +384,7 @@ if [ "$backup_untracked" = true ] && [ -n "${untracked_files}" ]; then
             cp "${root_dir}/${file}" "${temp_dir}/${file}"  # Copy the file to the temp directory, preserving the directory structure
             print_color "$BLUE" "💾 Backing up ${file}"
             # Restore the original file state in the repo, removing unstaged changes
-            git restore "${root_dir}/${file}"  # Using relative path relative to current directory
+            git -C "${root_dir}" restore -- "${file}"  # use -C to keep git rooted at repo root in worktrees
         fi
     done
 
@@ -393,7 +393,7 @@ if [ "$backup_untracked" = true ] && [ -n "${untracked_files}" ]; then
 
     for file in $untracked_files; do
             if echo "${staged_files}" | grep -q "^${file}$"; then
-                git restore "${root_dir}/${file}"  # Using relative path relative to current directory
+                git -C "${root_dir}" restore -- "${file}"  # use -C to keep git rooted at repo root in worktrees
             fi
     done
 


### PR DESCRIPTION
## Summary

Closes #35799 for the 25.07.10 LTS line.

The `core-web/.husky/pre-commit` hook fails on **non-core-web** commits when authored from a **git worktree** (rather than a fresh clone). The hook `cd`s into `core-web/` mid-execution and then runs git on absolute paths to files outside that subtree. In a normal clone this works because git rediscovers the repo root from cwd. In a worktree, the calling `git commit` sets `GIT_DIR` to an absolute path; the hook inherits it, and subsequent `git` calls from `core-web/` infer `GIT_WORK_TREE=core-web` from cwd — they then reject absolute paths to files outside `core-web/` with:

```
fatal: .../parent/pom.xml: '.../parent/pom.xml' is outside repository at '.../core-web'
```

This blocked worktree-based dev for LTS branches and forced PRs #35797 and #35798 to be authored from fresh shallow clones rather than worktrees.

## Fix

Replace every `git add "${root_dir}/<path>"` or `git restore "${root_dir}/<path>"` with `git -C "${root_dir}" add -- "<path>"` / `git -C "${root_dir}" restore -- "<path>"`. The `-C` flag tells git to operate as if it were invoked from `root_dir`, which is unambiguous regardless of cwd or any inherited `GIT_DIR`. Seven sites updated:

| Line | Function | Operation |
|---|---|---|
| 83 | `check_sdk_client_affected` | `add dot-uve.js` |
| 127 | `perform_frontend_fixes` | `add yarn.lock` |
| 146 | `perform_frontend_fixes` | `add ${file}` |
| 160 | `perform_frontend_fixes` | `restore ${file}` |
| 306 | OpenAPI block | `add openapi.yaml` |
| 387 | backup loop | `restore ${file}` (the one that surfaced the bug) |
| 396 | backup loop tail | `restore ${file}` |

No behavior change in normal-clone workflows; `git -C` and the previous absolute-path form are equivalent there.

## Test plan

- [ ] Commit a non-core-web change from a normal clone — hook completes (regression check)
- [ ] Commit a non-core-web change from a `git worktree add` worktree — hook completes (this was the failing scenario)
- [ ] Commit a core-web change from either — lint/format steps still run as before

## Companion work

- [ ] Mirror this fix to `release-24.12.27_lts` in a sibling PR
- `main` is not affected (different hook).