### PR TITLE
fix(husky): make LTS pre-commit hook work in git worktrees

### DIFF
--- a/core-web/.husky/pre-commit
+++ b/core-web/.husky/pre-commit
@@ -88,7 +88,7 @@ check_sdk_client_affected() {
         printf "%s does not exist\n" "$dir_to_remove"
     fi
 
-    if ! git add "${root_dir}/dotCMS/src/main/webapp/html/js/editor-js/sdk-editor.js"; then
+    if ! git -C "${root_dir}" add -- "dotCMS/src/main/webapp/html/js/editor-js/sdk-editor.js"; then
         print_color "$RED" "Failed to stage computed sdk-client.js"
         exit 1
     fi
@@ -132,7 +132,7 @@ perform_frontend_fixes() {
         return 1
     else
         printf "Completed yarn install adding yarn.lock if it was modified\n"
-        git add "${root_dir}/core-web/yarn.lock"
+        git -C "${root_dir}" add -- "core-web/yarn.lock"
     fi
 
     if ! yarn nx affected -t lint --exclude='tag:skip:lint' --fix=true; then
@@ -151,7 +151,7 @@ perform_frontend_fixes() {
 
         for file in $files; do
             if echo "$modified_files" | grep -Fxq "$file"; then
-                if ! git add -- "${root_dir}/${file}"; then
+                if ! git -C "${root_dir}" add -- "${file}"; then
                     has_errors=true
                 fi
             else
@@ -165,7 +165,7 @@ perform_frontend_fixes() {
             printf "\n"
             for file in "${unmatched_files[@]}"; do
                 printf "    %s\n" "${file}"
-                git restore "${file}"
+                git -C "${root_dir}" restore -- "${file}"
             done
             printf "\n"
             print_color "$YELLOW" "You can fix these files by running the following commands:"
@@ -282,7 +282,7 @@ if [ "$backup_untracked" = true ] && [ -n "${untracked_files}" ]; then
             cp "${root_dir}/${file}" "${temp_dir}/${file}"  # Copy the file to the temp directory, preserving the directory structure
             printf "Backing up %s to %s\n" "${file}" "${temp_dir}/${file}"
             # Restore the original file state in the repo, removing unstaged changes
-            git restore "${root_dir}/${file}"  # Using relative path relative to current directory
+            git -C "${root_dir}" restore -- "${file}"  # use -C to keep git rooted at repo root in worktrees
         fi
     done
 
@@ -291,7 +291,7 @@ if [ "$backup_untracked" = true ] && [ -n "${untracked_files}" ]; then
 
     for file in $untracked_files; do
             if echo "${staged_files}" | grep -q "^${file}$"; then
-                git restore "${root_dir}/${file}"  # Using relative path relative to current directory
+                git -C "${root_dir}" restore -- "${file}"  # use -C to keep git rooted at repo root in worktrees
             fi
     done
 


### PR DESCRIPTION
## Summary

Closes #35799 for the 24.12.27 LTS line. Companion to #35800 (same fix on 25.07.10 LTS).

The `core-web/.husky/pre-commit` hook fails on **non-core-web** commits when authored from a **git worktree** (rather than a fresh clone). The hook `cd`s into `core-web/` mid-execution and then runs git on absolute paths to files outside that subtree. In a normal clone this works because git rediscovers the repo root from cwd. In a worktree, the calling `git commit` sets `GIT_DIR` to an absolute path; the hook inherits it, and subsequent `git` calls from `core-web/` infer `GIT_WORK_TREE=core-web` from cwd — they then reject absolute paths to files outside `core-web/`:

```
fatal: .../parent/pom.xml: '.../parent/pom.xml' is outside repository at '.../core-web'
```

This blocked worktree-based dev for LTS branches and forced PR #35798 to be authored from a fresh shallow clone rather than a worktree.

## Fix

Replace every `git add "${root_dir}/<path>"` or `git restore "${root_dir}/<path>"` with `git -C "${root_dir}" add -- "<path>"` / `git -C "${root_dir}" restore -- "<path>"`. The `-C` flag tells git to operate as if it were invoked from `root_dir`, which is unambiguous regardless of cwd or any inherited `GIT_DIR`. Six sites updated in `core-web/.husky/pre-commit`:

| Line | Function | Operation |
|---|---|---|
| 91 | `check_sdk_client_affected` | `add sdk-editor.js` |
| 135 | `perform_frontend_fixes` | `add yarn.lock` |
| 154 | `perform_frontend_fixes` | `add ${file}` |
| 168 | `perform_frontend_fixes` | `restore ${file}` |
| 285 | backup loop | `restore ${file}` (the one that surfaced the bug) |
| 294 | backup loop tail | `restore ${file}` |

(25.07.10 LTS has a 7th site for the OpenAPI add that doesn't exist on 24.12.27 LTS.)

No behavior change in normal-clone workflows; `git -C` and the previous absolute-path form are equivalent there.

## Test plan

- [ ] Commit a non-core-web change from a normal clone — hook completes (regression check)
- [ ] Commit a non-core-web change from a `git worktree add` worktree — hook completes (this was the failing scenario)
- [ ] Commit a core-web change from either — lint/format steps still run as before