### PR TITLE
fix(tomcat): correct RemoteIpValve internalProxies regex and add CGNAT (#35804)

### DIFF
--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -99,7 +99,7 @@ export CMS_ACCESSLOG_ROTATABLE=${CMS_ACCESSLOG_ROTATABLE:-"true"}
 
 # Remote IP Valve settings
 export CMS_REMOTEIP_REMOTEIPHEADER=${CMS_REMOTEIP_REMOTEIPHEADER:-"x-forwarded-for"}
-export CMS_REMOTEIP_INTERNALPROXIES=${CMS_REMOTEIP_INTERNALPROXIES:-"10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3}|169\\.254\\.\\d{1,3}\\.\\d{1,3}|127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|172\\.1[6-9]{1}\\.\\d{1,3}\\.\\d{1,3}|172\\.2[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|172\\.3[0-1]{1}\\.\\d{1,3}\\.\\d{1,3}|0:0:0:0:0:0:0:1"}
+export CMS_REMOTEIP_INTERNALPROXIES=${CMS_REMOTEIP_INTERNALPROXIES:-"(10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1"}
 # Cookie settings
 export DOT_SAMESITE_COOKIES=${DOT_SAMESITE_COOKIES:-"lax"}
 

--- a/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
+++ b/dotCMS/src/main/resources/container/tomcat9/bin/setenv.sh
@@ -99,7 +99,7 @@ export CMS_ACCESSLOG_ROTATABLE=${CMS_ACCESSLOG_ROTATABLE:-"true"}
 
 # Remote IP Valve settings
 export CMS_REMOTEIP_REMOTEIPHEADER=${CMS_REMOTEIP_REMOTEIPHEADER:-"x-forwarded-for"}
-export CMS_REMOTEIP_INTERNALPROXIES=${CMS_REMOTEIP_INTERNALPROXIES:-"(10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1"}
+export CMS_REMOTEIP_INTERNALPROXIES=${CMS_REMOTEIP_INTERNALPROXIES:-"(10|127)\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1|::1"}
 # Cookie settings
 export DOT_SAMESITE_COOKIES=${DOT_SAMESITE_COOKIES:-"lax"}
 

--- a/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
+++ b/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
@@ -169,7 +169,7 @@
             remoteIpHeader="${CMS_REMOTEIP_REMOTEIPHEADER:-x-forwarded-for}"
             remoteIpPortHeader="${CMS_REMOTEIP_PORTHEADER:-x-forwarded-port}"
             <!-- regex uses \d\d?\d? instead of \d{1,3} — bare braces clash with IntrospectionUtils ${...} resolver -->
-            internalProxies="${CMS_REMOTEIP_INTERNALPROXIES:-(10|127)\.\d\d?\d?\.\d\d?\d?\.\d\d?\d?|192\.168\.\d\d?\d?\.\d\d?\d?|169\.254\.\d\d?\d?\.\d\d?\d?|172\.(1[6-9]|2\d|3[01])\.\d\d?\d?\.\d\d?\d?|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d\d?\d?\.\d\d?\d?|0:0:0:0:0:0:0:1}"
+            internalProxies="${CMS_REMOTEIP_INTERNALPROXIES:-(10|127)\.\d\d?\d?\.\d\d?\d?\.\d\d?\d?|192\.168\.\d\d?\d?\.\d\d?\d?|169\.254\.\d\d?\d?\.\d\d?\d?|172\.(1[6-9]|2\d|3[01])\.\d\d?\d?\.\d\d?\d?|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d\d?\d?\.\d\d?\d?|0:0:0:0:0:0:0:1|::1}"
         />
 
         <!-- Do not show server details up on BadRequest -->

--- a/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
+++ b/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
@@ -168,6 +168,7 @@
             className="org.apache.catalina.valves.RemoteIpValve"
             remoteIpHeader="${CMS_REMOTEIP_REMOTEIPHEADER:-x-forwarded-for}"
             remoteIpPortHeader="${CMS_REMOTEIP_PORTHEADER:-x-forwarded-port}"
+            <!-- regex uses \d\d?\d? instead of \d{1,3} — bare braces clash with IntrospectionUtils ${...} resolver -->
             internalProxies="${CMS_REMOTEIP_INTERNALPROXIES:-(10|127)\.\d\d?\d?\.\d\d?\d?\.\d\d?\d?|192\.168\.\d\d?\d?\.\d\d?\d?|169\.254\.\d\d?\d?\.\d\d?\d?|172\.(1[6-9]|2\d|3[01])\.\d\d?\d?\.\d\d?\d?|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d\d?\d?\.\d\d?\d?|0:0:0:0:0:0:0:1}"
         />
 

--- a/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
+++ b/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
@@ -168,7 +168,7 @@
             className="org.apache.catalina.valves.RemoteIpValve"
             remoteIpHeader="${CMS_REMOTEIP_REMOTEIPHEADER:-x-forwarded-for}"
             remoteIpPortHeader="${CMS_REMOTEIP_PORTHEADER:-x-forwarded-port}"
-            internalProxies="${CMS_REMOTEIP_INTERNALPROXIES:-10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|169\.254\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|0:0:0:0:0:0:0:1}"
+            internalProxies="${CMS_REMOTEIP_INTERNALPROXIES:-(10|127)\.\d\d?\d?\.\d\d?\d?\.\d\d?\d?|192\.168\.\d\d?\d?\.\d\d?\d?|169\.254\.\d\d?\d?\.\d\d?\d?|172\.(1[6-9]|2\d|3[01])\.\d\d?\d?\.\d\d?\d?|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d\d?\d?\.\d\d?\d?|0:0:0:0:0:0:0:1}"
         />
 
         <!-- Do not show server details up on BadRequest -->

--- a/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
+++ b/dotCMS/src/main/resources/container/tomcat9/conf/server.xml
@@ -163,12 +163,12 @@
       <!-- The remote IP valve picks up the X-FORWARDED-FOR header (by default) and uses it as the source ip
            remoteIpHeader and internalProxies may need to change when behind some WAF or proxy servers
            Also handles port forwarding for Docker scenarios via X-Forwarded-Port
+           internalProxies regex uses \d\d?\d? instead of \d{1,3} — bare braces clash with IntrospectionUtils ${...} resolver
       -->
         <Valve
             className="org.apache.catalina.valves.RemoteIpValve"
             remoteIpHeader="${CMS_REMOTEIP_REMOTEIPHEADER:-x-forwarded-for}"
             remoteIpPortHeader="${CMS_REMOTEIP_PORTHEADER:-x-forwarded-port}"
-            <!-- regex uses \d\d?\d? instead of \d{1,3} — bare braces clash with IntrospectionUtils ${...} resolver -->
             internalProxies="${CMS_REMOTEIP_INTERNALPROXIES:-(10|127)\.\d\d?\d?\.\d\d?\d?\.\d\d?\d?|192\.168\.\d\d?\d?\.\d\d?\d?|169\.254\.\d\d?\d?\.\d\d?\d?|172\.(1[6-9]|2\d|3[01])\.\d\d?\d?\.\d\d?\d?|100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d\d?\d?\.\d\d?\d?|0:0:0:0:0:0:0:1|::1}"
         />
 


### PR DESCRIPTION
## Summary

- Simplify regex escaping in `setenv.sh` — single `\` (readable, equivalent in sh/bash double quotes)
- Consolidate `10.*`/`127.*` and `172.16-31` alternations into grouped patterns
- Add CGNAT `100.64.0.0/10` (RFC 6598) range — used by cloud load balancers, Kubernetes overlay networks, and Tailscale.
- Fix pre-existing Tomcat `IntrospectionUtils.replaceProperties()` bug in `server.xml`: bare `{`/`}` in `\d{1,3}` broke property resolution (first `}` closed `${...}` prematurely). Replaced with `\d\d?\d?` — regex-equivalent, brace-safe

## Test plan

The `RemoteIpValve` processes the `X-Forwarded-For` header and replaces `request.getRemoteAddr()` with the real client IP — but **only when the immediate connecting IP matches `internalProxies`**. Validation must confirm Tomcat's resolved remote IP, not just header presence.

### Setup

1. Deploy dotCMS **without** setting `CMS_REMOTEIP_INTERNALPROXIES` (use the default regex)
2. You need a way to see what `request.getRemoteAddr()` returns after the valve processes the request. Options:
   - **Access log** (easiest): the default access log pattern uses `%{org.apache.catalina.AccessLog.RemoteAddr}r` — this logs the IP *after* `RemoteIpValve` processes it. Compare against `%a` (raw remote addr) or add both to the pattern
   - **`/api/v1/appconfiguration`** or any endpoint that echoes the client IP in its response/logs
   - **Temporary VTL**: `$request.getRemoteAddr()` in a page to see the resolved IP directly

### Test cases

- [ ] **RFC 1918 proxies trusted** — send request through `10.x.x.x`, `192.168.x.x`, or `172.16-31.x.x` proxy with `X-Forwarded-For: <real-client-ip>`. Verify access log / `getRemoteAddr()` shows `<real-client-ip>`, not the proxy IP
- [ ] **Loopback trusted** — request via `127.0.0.1` with XFF header. Verify real client IP resolved
- [ ] **IPv6 loopback trusted** — request via `0:0:0:0:0:0:0:1` (::1) with XFF header. Verify real client IP resolved
- [ ] **CGNAT trusted** — request via `100.64.x.x` through `100.127.x.x` with XFF header. Verify real client IP resolved
- [ ] **Link-local trusted** — request via `169.254.x.x` with XFF header. Verify real client IP resolved
- [ ] **External IP NOT trusted** — request from a public IP (e.g., `203.0.113.1`) with `X-Forwarded-For: 1.2.3.4`. Verify `getRemoteAddr()` still shows `203.0.113.1` (valve should NOT substitute)
- [ ] **CGNAT boundary** — `100.63.255.255` should NOT be trusted (below range). `100.128.0.0` should NOT be trusted (above range)
- [ ] **Env var override** — set `CMS_REMOTEIP_INTERNALPROXIES` to a custom regex. Verify custom value takes precedence over the default

### Quick Docker test

```bash
# Start dotCMS with default config
docker run -p 8080:8080 dotcms/dotcms:latest

# Simulate proxy request (curl connects from 127.0.0.1 = loopback = trusted)
curl -H "X-Forwarded-For: 203.0.113.42" http://localhost:8080/api/v1/appconfiguration

# Check access log for resolved IP
docker exec <container> cat /srv/dotserver/tomcat-*/logs/dotcms_access*.log
# Should show 203.0.113.42 (the XFF value), not 127.0.0.1
```

Closes #35804

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35804