### PR TITLE
test(cli): fix default-language test env state, not just retry (#35780)

### DIFF
--- a/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/api/LanguageAPI.java
+++ b/tools/dotcms-cli/api-data-model/src/main/java/com/dotcms/api/LanguageAPI.java
@@ -8,6 +8,7 @@ import com.dotcms.model.views.CommonViews;
 import com.dotcms.model.views.CommonViews.LanguageFileView;
 import com.fasterxml.jackson.annotation.JsonView;
 import java.util.List;
+import java.util.Map;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -120,4 +121,14 @@ public interface LanguageAPI {
             summary = " Deletes an existing language from the system"
     )
     ResponseEntityView<String> delete(@PathParam("languageId") String languageId);
+
+    @PUT
+    @Path("/{languageId}/_makedefault")
+    @Operation(
+            summary = " Makes the language with the given id the default language. The body field "
+                    + "'fireTransferAssetsJob' controls whether a background job is scheduled to "
+                    + "transfer assets from the previous default language."
+    )
+    ResponseEntityView<Language> makeDefault(@PathParam("languageId") String languageId,
+            Map<String, Boolean> form);
 }

--- a/tools/dotcms-cli/api-data-model/src/test/java/com/dotcms/api/SiteAPIIT.java
+++ b/tools/dotcms-cli/api-data-model/src/test/java/com/dotcms/api/SiteAPIIT.java
@@ -17,6 +17,7 @@ import io.quarkus.test.junit.TestProfile;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Supplier;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
@@ -63,12 +64,21 @@ class SiteAPIIT {
     }
 
     /**
-     * Warms the dotCMS language cache by listing languages, retrying up to 3 times to
-     * cover the race window right after a fresh dotCMS start where the default-language
-     * lookup can briefly return a non-positive id. When that happens, downstream site
-     * creation fails with HTTP 500 "Language cannot be null" because the contentlet ends
-     * up with languageId <= 0 and a unique-field validation tries to resolve it back to
-     * a Language. See issue #35780.
+     * Ensures the dotCMS test environment has a real default language (id &gt; 0) before
+     * the SiteAPIIT tests run. Without this, {@code POST /api/v1/site} resolves the Host
+     * contentlet's languageId from {@code getDefaultLanguage()} — which in some CI test
+     * environments returns the {@code LANG__404} sentinel with id=-1, breaking the
+     * downstream unique-field validation with HTTP 500 "Language cannot be null".
+     * See issue #35780.
+     *
+     * <p>Strategy:
+     * <ol>
+     *   <li>List languages</li>
+     *   <li>If the entry marked {@code defaultLanguage=true} has a valid id, we are done.</li>
+     *   <li>Otherwise pick the first language with id &gt; 0 (English in starter data)
+     *       and call {@code PUT /api/v2/languages/{id}/_makedefault} to fix the broken
+     *       default. {@code fireTransferAssetsJob=false} so this is a fast metadata change.</li>
+     * </ol>
      */
     private void warmLanguageCacheIfNeeded() {
         if (languageCacheWarmed) {
@@ -77,14 +87,18 @@ class SiteAPIIT {
         final int maxAttempts = 3;
         for (int attempt = 1; attempt <= maxAttempts; attempt++) {
             try {
-                final ResponseEntityView<List<Language>> response =
-                        clientFactory.getClient(LanguageAPI.class).list();
-                final List<Language> languages = response != null ? response.entity() : null;
-                final boolean hasValidLanguage = languages != null && languages.stream()
-                        .anyMatch(l -> l != null && l.id().isPresent() && l.id().get() > 0);
-                if (hasValidLanguage) {
+                final List<Language> languages = listLanguages();
+                if (hasValidDefault(languages)) {
                     languageCacheWarmed = true;
                     return;
+                }
+                final Long fallbackId = pickFallbackLanguageId(languages);
+                if (fallbackId != null && tryMakeDefault(fallbackId)) {
+                    // Re-list to confirm the fix took before declaring success.
+                    if (hasValidDefault(listLanguages())) {
+                        languageCacheWarmed = true;
+                        return;
+                    }
                 }
             } catch (Exception ignored) {
                 // fall through to retry
@@ -95,6 +109,44 @@ class SiteAPIIT {
                 Thread.currentThread().interrupt();
                 return;
             }
+        }
+    }
+
+    private List<Language> listLanguages() {
+        final ResponseEntityView<List<Language>> response =
+                clientFactory.getClient(LanguageAPI.class).list();
+        return response != null ? response.entity() : null;
+    }
+
+    private static boolean hasValidDefault(final List<Language> languages) {
+        if (languages == null) {
+            return false;
+        }
+        return languages.stream().anyMatch(l ->
+                l != null
+                        && l.id().isPresent() && l.id().get() > 0
+                        && l.defaultLanguage().orElse(false));
+    }
+
+    private static Long pickFallbackLanguageId(final List<Language> languages) {
+        if (languages == null) {
+            return null;
+        }
+        return languages.stream()
+                .filter(l -> l != null && l.id().isPresent() && l.id().get() > 0)
+                .map(l -> l.id().get())
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean tryMakeDefault(final Long languageId) {
+        try {
+            clientFactory.getClient(LanguageAPI.class)
+                    .makeDefault(String.valueOf(languageId),
+                            Map.of("fireTransferAssetsJob", Boolean.FALSE));
+            return true;
+        } catch (Exception ignored) {
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to PR #35803 (the retry workaround). After that PR merged, the CLI tests in `SiteAPIIT` were still failing. Diagnosing the latest run ([26301904102](https://github.com/dotCMS/core/actions/runs/26301904102/job/77433938782?pr=35771)) showed this is **not a timing race** — it is deterministic test-environment state.

## What the diagnosis showed

- dotCMS finished startup at `17:55:44`. First failing test ran at `17:56:05` — 21 seconds later. Cache fully populated by then.
- The existing `warmLanguageCacheIfNeeded()` warmup succeeded on its first attempt (HTTP 200).
- The `retryOnLanguageNull` retry from #35803 **did fire** (test elapsed went from ~250ms → ~1100ms = 3 attempts × ~250ms backoff). All three attempts hit the same 500 error.

But look at what the warmup response actually contains:

```json
{
  "entity": [
    {"language": "LANG__404", "id": -1, "defaultLanguage": true},
    {"language": "English",   "id":  1, "defaultLanguage": false}
  ]
}
```

The "default language" is permanently the `LANG__404` sentinel (id=-1). English exists with id=1 but is not marked default. So:

1. `SiteResource.create()` calls `getDefaultLanguage().getId()` → gets `-1`
2. The Host contentlet is saved with `languageId = -1`
3. `UniqueFieldCriteria` calls `getLanguage(-1)` → returns null
4. `Objects.requireNonNull(language, "Language cannot be null")` → NPE → HTTP 500

The existing warmup passed because it only verified that **any** language had `id > 0` (English does). It did not verify that the **default** language had `id > 0`.

## What this PR changes

**`LanguageAPI.java`** (CLI interface) — adds:

```java
@PUT
@Path("/{languageId}/_makedefault")
ResponseEntityView<Language> makeDefault(@PathParam("languageId") String languageId,
        Map<String, Boolean> form);
```

**`SiteAPIIT.warmLanguageCacheIfNeeded()`** — strengthens the warmup:

1. List languages.
2. If the entry marked `defaultLanguage=true` has `id > 0`, we are done.
3. Otherwise pick the first language with `id > 0` (English in starter data) and call `PUT /api/v2/languages/{id}/_makedefault` with `fireTransferAssetsJob=false` to **fix** the broken default.
4. Re-list to confirm the fix before declaring success.
5. Up to 3 attempts with 200 ms backoff (unchanged loop shape).

The `retryOnLanguageNull` workaround from #35803 is **preserved** as defense-in-depth around the 4 `.create(...)` call sites — if the warmup somehow doesn't fix the state, the retry will still try. But it should not be needed.

## Why this works when retries do not

Retries assume a transient state that will clear if we wait. The CI evidence shows the state is stable — `getDefaultLanguage()` returns `LANG__404` every time, indefinitely. Only an actionable fix (forcing a real language as the default) changes that state.

`_makedefault` is the same endpoint the dotCMS admin UI uses for "switch default language". `fireTransferAssetsJob=false` skips the heavy background job, so the call is a fast metadata update — appropriate for test setup.

## What this PR does NOT do

- No server-side change. The deeper question — why this dotCMS test env has `LANG__404` as the default in the first place — is left for a future investigation tracked under #35780.
- Touches only `SiteAPIIT` and `LanguageAPI`. No production CLI code paths affected.

## Test plan

- [x] `./mvnw test-compile -pl :dotcms-api-data-model` → `BUILD SUCCESS`.
- [x] Retry workaround from #35803 preserved (4 call sites still wrapped in `retryOnLanguageNull`).
- [ ] CI verifies — `PR Test / CLI Tests` should pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35780