### PR TITLE
feat(release): compact Slack QA section + @-mention flagged-PR authors

### DIFF
--- a/.github/data/slack-mappings.json
+++ b/.github/data/slack-mappings.json
@@ -16,10 +16,6 @@
     "slack_id": "U6YCPDC1Z"
   },
   {
-    "github_user": "hmoreras",
-    "slack_id": "U6YCPDC1Z"
-  },
-  {
     "github_user": "erickgonzalez",
     "slack_id": "U028X160J"
   },
@@ -85,7 +81,7 @@
   },
   {
     "github_user": "sfreudenthaler",
-    "slack_id": "D06L2NWEF8R"
+    "slack_id": "U05UU5QPAVA"
   },
   {
     "github_user": "zJaaal",
@@ -137,6 +133,6 @@
   },
   {
     "github_user": "hassandotcms",
-    "slack_id": "D097FJ9H537"
+    "slack_id": "U095M9B8HC6"
   }
 ]

--- a/.github/data/slack-mappings.json
+++ b/.github/data/slack-mappings.json
@@ -96,10 +96,6 @@
     "slack_id": "U03869ZH2DA"
   },
   {
-    "github_user": "rashik1144",
-    "slack_id": "U04UP78B6BS"
-  },
-  {
     "github_user": "melissarojas-dotcms",
     "slack_id": "U047MRAKREJ"
   },

--- a/.github/data/slack-mappings.json
+++ b/.github/data/slack-mappings.json
@@ -4,10 +4,6 @@
     "slack_id": "U028ZKGR6"
   },
   {
-    "github_user": "victoralfaro-dotcms",
-    "slack_id": "U0125JCDSSE"
-  },
-  {
     "github_user": "freddyDOTCMS",
     "slack_id": "U5A5K7S6P"
   },
@@ -18,14 +14,6 @@
   {
     "github_user": "hmoreras",
     "slack_id": "U6YCPDC1Z"
-  },
-  {
-    "github_user": "bryanboza",
-    "slack_id": "U028VTVU8"
-  },
-  {
-    "github_user": "cobbg",
-    "slack_id": "U018GD00WLQ"
   },
   {
     "github_user": "hmoreras",
@@ -43,18 +31,9 @@
     "github_user": "fmontes",
     "slack_id": "U028Y2YH0"
   },
-
   {
     "github_user": "jcastro-dotcms",
     "slack_id": "U02KL4E40"
-  },
-  {
-    "github_user": "jdotcms",
-    "slack_id": "U5BTY5H6Y"
-  },
-  {
-    "github_user": "john-thomas-dotcms",
-    "slack_id": "U081TJYRH"
   },
   {
     "github_user": "manuel-miranda",
@@ -67,10 +46,6 @@
   {
     "github_user": "rjvelazco",
     "slack_id": "U01NX13C0Q2"
-  },
-  {
-    "github_user": "spbolton",
-    "slack_id": "U029WE9QQ02"
   },
   {
     "github_user": "swicken-dotcms",
@@ -91,14 +66,6 @@
   {
     "github_user": "dcolina",
     "slack_id": "U04SKNT3W7L"
-  },
-  {
-    "github_user": "prestonso",
-    "slack_id": "U06LK2W2ZUM"
-  },
-  {
-    "github_user": "jgambarios",
-    "slack_id": "U028X13T2"
   },
   {
     "github_user": "fishsmith",
@@ -133,16 +100,8 @@
     "slack_id": "U03869ZH2DA"
   },
   {
-    "github_user": "damen-dotcms",
-    "slack_id": "U045LKZSC8Y"
-  },
-  {
     "github_user": "rashik1144",
     "slack_id": "U04UP78B6BS"
-  },
-  {
-    "github_user": "josemejias11",
-    "slack_id": "U03RU9U23RQ"
   },
   {
     "github_user": "melissarojas-dotcms",
@@ -161,15 +120,23 @@
     "slack_id": "U075E9Y204B"
   },
   {
-    "github_user": "gavriella-dotcms",
-    "slack_id": "U078HRUFR8C"
-  },
-  {
-    "github_user": "valentinogiardino",
-    "slack_id": "U0790HFL64R"
-  },
-  {
     "github_user": "rsh1k",
     "slack_id": "U04UP78B6BS"
+  },
+  {
+    "github_user": "dsantos-dcms",
+    "slack_id": "U05UFRHHUEL"
+  },
+  {
+    "github_user": "ihoffmann-dot",
+    "slack_id": "U0A6S83EA0N"
+  },
+  {
+    "github_user": "dario-daza",
+    "slack_id": "U09DJP134DT"
+  },
+  {
+    "github_user": "hassandotcms",
+    "slack_id": "D097FJ9H537"
   }
 ]

--- a/.github/scripts/release-qa-status/src/format.test.ts
+++ b/.github/scripts/release-qa-status/src/format.test.ts
@@ -95,7 +95,7 @@ describe('renderSlack', () => {
     expect(out).toContain('<https://example.com/run/123#qa-failed|failed QA: 1>');
     expect(out).toContain('<https://example.com/run/123#qa-missing|missing QA: 0>');
     expect(out).toContain('<https://example.com/run/123#qa-orphan|Orphan PRs: 0>');
-    expect(out).toContain('<https://example.com/run/123#qa-external|Not in the core repo: 0>');
+    expect(out).toContain('<https://example.com/run/123#outside-dotcms-core|Not in the core repo: 0>');
   });
 
   it('omits detailUrl wrapping when none is provided', () => {
@@ -200,7 +200,7 @@ describe('renderMarkdown', () => {
     expect(out).toContain('<a id="qa-failed"></a>');
     expect(out).toContain('<a id="qa-missing"></a>');
     expect(out).toContain('<a id="qa-orphan"></a>');
-    expect(out).toContain('<a id="qa-external"></a>');
+    expect(out).toContain('<a id="outside-dotcms-core"></a>');
   });
 
   it('skips anchors for empty buckets', () => {
@@ -212,7 +212,7 @@ describe('renderMarkdown', () => {
     expect(out).toContain('<a id="qa-failed"></a>');
     expect(out).not.toContain('<a id="qa-missing"></a>');
     expect(out).not.toContain('<a id="qa-orphan"></a>');
-    expect(out).not.toContain('<a id="qa-external"></a>');
+    expect(out).not.toContain('<a id="outside-dotcms-core"></a>');
   });
 
   it('shows the all-clean message when nothing is flagged', () => {

--- a/.github/scripts/release-qa-status/src/format.test.ts
+++ b/.github/scripts/release-qa-status/src/format.test.ts
@@ -86,16 +86,16 @@ describe('renderSlack', () => {
     expect(out).not.toContain('https://github.com/dotCMS/core/pull/35463');
   });
 
-  it('wraps each count in a Slack link when detailUrl is provided', () => {
+  it('wraps each count in a Slack link with per-bucket anchor when detailUrl is provided', () => {
     const r = report({
       summary: { failed: 1, missing: 0, unlinked: 0, external: 0, passed: 0, excluded: 0 },
       failed: [pr(1, 't', 'failed')],
     });
     const out = renderSlack(r, { detailUrl: 'https://example.com/run/123' });
-    expect(out).toContain('<https://example.com/run/123|failed QA: 1>');
-    expect(out).toContain('<https://example.com/run/123|missing QA: 0>');
-    expect(out).toContain('<https://example.com/run/123|Orphan PRs: 0>');
-    expect(out).toContain('<https://example.com/run/123|Not in the core repo: 0>');
+    expect(out).toContain('<https://example.com/run/123#qa-failed|failed QA: 1>');
+    expect(out).toContain('<https://example.com/run/123#qa-missing|missing QA: 0>');
+    expect(out).toContain('<https://example.com/run/123#qa-orphan|Orphan PRs: 0>');
+    expect(out).toContain('<https://example.com/run/123#qa-external|Not in the core repo: 0>');
   });
 
   it('omits detailUrl wrapping when none is provided', () => {
@@ -182,6 +182,37 @@ describe('renderMarkdown', () => {
     expect(out).toContain('| :warning: Missing QA |');
     expect(out).toContain('## :warning: No QA label (1)');
     expect(out).toContain('[#10](https://github.com/dotCMS/core/pull/10)');
+  });
+
+  it('emits stable HTML anchors before each populated bucket heading', () => {
+    const r = report({
+      summary: { failed: 1, missing: 1, unlinked: 1, external: 1, passed: 0, excluded: 0 },
+      failed: [pr(1, 't', 'failed')],
+      missing: [pr(2, 't', 'missing')],
+      unlinked: [pr(3, 't', 'unlinked')],
+      external: [
+        pr(4, 't', 'external', {
+          externalRefs: [{ repo: 'dotCMS/private-issues', number: 9 }],
+        }),
+      ],
+    });
+    const out = renderMarkdown(r);
+    expect(out).toContain('<a id="qa-failed"></a>');
+    expect(out).toContain('<a id="qa-missing"></a>');
+    expect(out).toContain('<a id="qa-orphan"></a>');
+    expect(out).toContain('<a id="qa-external"></a>');
+  });
+
+  it('skips anchors for empty buckets', () => {
+    const r = report({
+      summary: { failed: 1, missing: 0, unlinked: 0, external: 0, passed: 0, excluded: 0 },
+      failed: [pr(1, 't', 'failed')],
+    });
+    const out = renderMarkdown(r);
+    expect(out).toContain('<a id="qa-failed"></a>');
+    expect(out).not.toContain('<a id="qa-missing"></a>');
+    expect(out).not.toContain('<a id="qa-orphan"></a>');
+    expect(out).not.toContain('<a id="qa-external"></a>');
   });
 
   it('shows the all-clean message when nothing is flagged', () => {

--- a/.github/scripts/release-qa-status/src/format.test.ts
+++ b/.github/scripts/release-qa-status/src/format.test.ts
@@ -1,5 +1,5 @@
-import { renderSlack } from './format';
-import { ReleaseQAReport, PRQAResult } from './types';
+import { renderMarkdown, renderSlack } from './format';
+import { PRQAResult, ReleaseQAReport, SlackMapping } from './types';
 
 function pr(
   number: number,
@@ -59,7 +59,7 @@ describe('renderSlack', () => {
     expect(renderSlack(r)).toContain(':rotating_light: *QA Coverage*');
   });
 
-  it('uses the requested count labels', () => {
+  it('renders the count labels exactly as requested', () => {
     const r = report({
       summary: { failed: 1, missing: 2, unlinked: 3, external: 4, passed: 0, excluded: 0 },
       failed: [pr(1, 't', 'failed')],
@@ -71,35 +71,121 @@ describe('renderSlack', () => {
     expect(out).toContain('Not in the core repo: 4');
   });
 
-  it('truncates very long titles with an ellipsis', () => {
-    const longTitle = 'x'.repeat(200);
+  it('does NOT include a detailed PR list in the slack snippet', () => {
     const r = report({
-      summary: { failed: 0, missing: 1, unlinked: 0, external: 0, passed: 0, excluded: 0 },
-      missing: [pr(10, longTitle, 'missing')],
+      summary: { failed: 0, missing: 2, unlinked: 0, external: 0, passed: 0, excluded: 0 },
+      missing: [
+        pr(35463, 'feat(maintenance): thread dump endpoints', 'missing'),
+        pr(35726, 'fix(edit-content): normalize lockedBy', 'missing'),
+      ],
     });
     const out = renderSlack(r);
-    expect(out).toContain('…');
-    // Original 200-char title should not appear verbatim
-    expect(out).not.toContain(longTitle);
+    // Compact: just counts + cc line, no per-PR lines.
+    expect(out).not.toContain('thread dump');
+    expect(out).not.toContain('normalize lockedBy');
+    expect(out).not.toContain('https://github.com/dotCMS/core/pull/35463');
   });
 
-  it('escapes mrkdwn-meaningful characters in titles', () => {
+  it('wraps each count in a Slack link when detailUrl is provided', () => {
     const r = report({
-      summary: { failed: 0, missing: 1, unlinked: 0, external: 0, passed: 0, excluded: 0 },
-      missing: [pr(10, 'fix <script> & co.', 'missing')],
+      summary: { failed: 1, missing: 0, unlinked: 0, external: 0, passed: 0, excluded: 0 },
+      failed: [pr(1, 't', 'failed')],
     });
-    const out = renderSlack(r);
-    expect(out).toContain('&lt;script&gt;');
-    expect(out).toContain('&amp;');
+    const out = renderSlack(r, { detailUrl: 'https://example.com/run/123' });
+    expect(out).toContain('<https://example.com/run/123|failed QA: 1>');
+    expect(out).toContain('<https://example.com/run/123|missing QA: 0>');
+    expect(out).toContain('<https://example.com/run/123|Orphan PRs: 0>');
+    expect(out).toContain('<https://example.com/run/123|Not in the core repo: 0>');
   });
 
-  it('replaces backticks so paired backticks do not render as Slack monospace', () => {
+  it('omits detailUrl wrapping when none is provided', () => {
     const r = report({
-      summary: { failed: 0, missing: 1, unlinked: 0, external: 0, passed: 0, excluded: 0 },
-      missing: [pr(10, 'bump deps to `v1.2.3-rc.1`', 'missing')],
+      summary: { failed: 1, missing: 0, unlinked: 0, external: 0, passed: 0, excluded: 0 },
+      failed: [pr(1, 't', 'failed')],
     });
     const out = renderSlack(r);
-    expect(out).not.toContain('`v1.2.3-rc.1`');
-    expect(out).toContain("'v1.2.3-rc.1'");
+    expect(out).toContain('failed QA: 1');
+    expect(out).not.toMatch(/<https:[^|]+\|failed QA/);
+  });
+});
+
+describe('renderSlack cc line', () => {
+  const mappings: SlackMapping[] = [
+    { github_user: 'alice', slack_id: 'U0ALICE' },
+    { github_user: 'dsilvam', slack_id: 'U0DSILVAM' },
+  ];
+
+  it('emits a cc line that mentions flagged-PR authors', () => {
+    const r = report({
+      summary: { failed: 1, missing: 0, unlinked: 0, external: 0, passed: 0, excluded: 0 },
+      failed: [pr(1, 't', 'failed', { author: 'alice' })],
+    });
+    const out = renderSlack(r, { mappings });
+    expect(out).toContain('cc <@U0ALICE>');
+    expect(out).toContain('please review your PRs');
+  });
+
+  it('uses Slack ID for mapped users and plain @login for unmapped', () => {
+    const r = report({
+      summary: { failed: 1, missing: 1, unlinked: 0, external: 0, passed: 0, excluded: 0 },
+      failed: [pr(1, 't', 'failed', { author: 'alice' })],
+      missing: [pr(2, 't', 'missing', { author: 'unknownuser' })],
+    });
+    const out = renderSlack(r, { mappings });
+    expect(out).toContain('<@U0ALICE>');
+    expect(out).toContain('@unknownuser');
+    expect(out).not.toContain('<@U0UNKNOWNUSER>');
+  });
+
+  it('deduplicates authors that have multiple flagged PRs', () => {
+    const r = report({
+      summary: { failed: 0, missing: 2, unlinked: 0, external: 0, passed: 0, excluded: 0 },
+      missing: [
+        pr(1, 't1', 'missing', { author: 'alice' }),
+        pr(2, 't2', 'missing', { author: 'alice' }),
+      ],
+    });
+    const out = renderSlack(r, { mappings });
+    const occurrences = (out.match(/U0ALICE/g) || []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  it('does NOT mention authors whose only PRs are in the passed bucket', () => {
+    const r = report({
+      summary: { failed: 1, missing: 0, unlinked: 0, external: 0, passed: 1, excluded: 0 },
+      failed: [pr(1, 't', 'failed', { author: 'alice' })],
+      passed: [pr(2, 't', 'passed', { author: 'dsilvam' })],
+    });
+    const out = renderSlack(r, { mappings });
+    expect(out).toContain('<@U0ALICE>');
+    expect(out).not.toContain('<@U0DSILVAM>');
+  });
+
+  it('matches mappings case-insensitively', () => {
+    const r = report({
+      summary: { failed: 1, missing: 0, unlinked: 0, external: 0, passed: 0, excluded: 0 },
+      failed: [pr(1, 't', 'failed', { author: 'Alice' })],
+    });
+    const out = renderSlack(r, { mappings });
+    expect(out).toContain('<@U0ALICE>');
+  });
+});
+
+describe('renderMarkdown', () => {
+  it('produces a markdown report with the expected H1 and summary table', () => {
+    const r = report({
+      summary: { failed: 0, missing: 1, unlinked: 0, external: 0, passed: 0, excluded: 0 },
+      missing: [pr(10, 'fix something', 'missing', { author: 'alice' })],
+    });
+    const out = renderMarkdown(r);
+    expect(out).toContain('# Release QA report: `v26.05.18-01` → `v26.05.19-01`');
+    expect(out).toContain('| :warning: Missing QA |');
+    expect(out).toContain('## :warning: No QA label (1)');
+    expect(out).toContain('[#10](https://github.com/dotCMS/core/pull/10)');
+  });
+
+  it('shows the all-clean message when nothing is flagged', () => {
+    const out = renderMarkdown(report());
+    expect(out).toContain('All non-excluded PRs have a recognized QA verdict');
   });
 });

--- a/.github/scripts/release-qa-status/src/format.ts
+++ b/.github/scripts/release-qa-status/src/format.ts
@@ -9,32 +9,38 @@
 
 import { PRQAResult, ReleaseQAReport, SlackMapping } from './types';
 
+type BucketKey = 'failed' | 'missing' | 'unlinked' | 'external';
+
 const STATUS_HEADERS: Record<
-  'failed' | 'missing' | 'unlinked' | 'external',
-  { emoji: string; title: string; blurb: string }
+  BucketKey,
+  { emoji: string; title: string; blurb: string; anchor: string }
 > = {
   failed: {
     emoji: ':rotating_light:',
     title: 'QA Failed',
     blurb: 'Linked issue carries `QA : Failed` — change may break things.',
+    anchor: 'qa-failed',
   },
   missing: {
     emoji: ':warning:',
     title: 'No QA label',
     blurb:
       'Linked issue exists but has no `QA : Passed` / `QA : Not Needed` / `QA : Failed` label.',
+    anchor: 'qa-missing',
   },
   unlinked: {
     emoji: ':grey_question:',
     title: 'No linked issue',
     blurb:
       'PR has no closing-issue reference (body keyword or Development panel) — cannot verify QA.',
+    anchor: 'qa-orphan',
   },
   external: {
     emoji: ':link:',
     title: 'Linked to a different repo',
     blurb:
       'PR closes an issue in another repository — QA labels cannot be read from here.',
+    anchor: 'qa-external',
   },
 };
 
@@ -161,10 +167,7 @@ export function renderMarkdown(report: ReleaseQAReport): string {
     return out.join('\n');
   }
 
-  const sections: Array<{
-    bucket: PRQAResult[];
-    key: 'failed' | 'missing' | 'unlinked' | 'external';
-  }> = [
+  const sections: Array<{ bucket: PRQAResult[]; key: BucketKey }> = [
     { bucket: report.failed, key: 'failed' },
     { bucket: report.missing, key: 'missing' },
     { bucket: report.unlinked, key: 'unlinked' },
@@ -174,6 +177,10 @@ export function renderMarkdown(report: ReleaseQAReport): string {
   for (const sec of sections) {
     if (sec.bucket.length === 0) continue;
     const h = STATUS_HEADERS[sec.key];
+    // Explicit HTML anchor: the auto-generated heading slug includes the
+    // count (e.g. "qa-failed-1") and would break each time it changes.
+    // Stable anchors let the Slack counts deep-link reliably.
+    out.push(`<a id="${h.anchor}"></a>`);
     out.push(`## ${h.emoji} ${h.title} (${sec.bucket.length})`);
     out.push('');
     out.push(h.blurb);
@@ -244,17 +251,19 @@ export function renderSlack(
   return out.join('\n');
 }
 
-/** Build the four-bucket count line, with each label as a link if detailUrl is set. */
+/** Build the four-bucket count line. Each cell deep-links to its bucket
+ *  anchor on the detail page when detailUrl is set. */
 function slackCounts(s: ReleaseQAReport['summary'], detailUrl?: string): string {
-  const cell = (label: string, n: number): string => {
+  const cell = (label: string, n: number, key: BucketKey): string => {
     const text = `${label}: ${n}`;
-    return detailUrl ? `<${detailUrl}|${text}>` : text;
+    if (!detailUrl) return text;
+    return `<${detailUrl}#${STATUS_HEADERS[key].anchor}|${text}>`;
   };
   return [
-    cell('failed QA', s.failed),
-    cell('missing QA', s.missing),
-    cell('Orphan PRs', s.unlinked),
-    cell('Not in the core repo', s.external),
+    cell('failed QA', s.failed, 'failed'),
+    cell('missing QA', s.missing, 'missing'),
+    cell('Orphan PRs', s.unlinked, 'unlinked'),
+    cell('Not in the core repo', s.external, 'external'),
   ].join('  |  ');
 }
 

--- a/.github/scripts/release-qa-status/src/format.ts
+++ b/.github/scripts/release-qa-status/src/format.ts
@@ -40,7 +40,7 @@ const STATUS_HEADERS: Record<
     title: 'Linked to a different repo',
     blurb:
       'PR closes an issue in another repository — QA labels cannot be read from here.',
-    anchor: 'qa-external',
+    anchor: 'outside-dotcms-core',
   },
 };
 

--- a/.github/scripts/release-qa-status/src/format.ts
+++ b/.github/scripts/release-qa-status/src/format.ts
@@ -1,11 +1,13 @@
 /**
- * Human-readable text rendering of the QA report.
+ * Output rendering for the QA report.
  *
- * - renderText:  terminal-friendly summary
- * - renderSlack: Slack-mrkdwn snippet for the release notification
+ * - renderText:     terminal-friendly summary with full PR lists per bucket
+ * - renderMarkdown: GitHub-flavored markdown report for $GITHUB_STEP_SUMMARY
+ * - renderSlack:    compact Slack-mrkdwn snippet — counts as links + cc line
+ *                   with resolved @-mentions of authors who need to act
  */
 
-import { PRQAResult, ReleaseQAReport } from './types';
+import { PRQAResult, ReleaseQAReport, SlackMapping } from './types';
 
 const STATUS_HEADERS: Record<
   'failed' | 'missing' | 'unlinked' | 'external',
@@ -36,7 +38,11 @@ const STATUS_HEADERS: Record<
   },
 };
 
-function renderPRLine(pr: PRQAResult): string {
+// =========================================================================
+// renderText — full detail, terminal-friendly
+// =========================================================================
+
+function renderTextPR(pr: PRQAResult): string {
   const issueRefs: string[] = [];
   for (const i of pr.linkedIssues) issueRefs.push(`#${i.number}`);
   for (const x of pr.externalRefs) issueRefs.push(`${x.repo}#${x.number}`);
@@ -44,8 +50,7 @@ function renderPRLine(pr: PRQAResult): string {
   return `  - #${pr.pr} ${pr.title} — @${pr.author}${refsSuffix}\n    ${pr.url}`;
 }
 
-/** Render an excluded PR with the reason so callers can debug what got dropped. */
-function renderExcludedLine(pr: PRQAResult): string {
+function renderExcludedTextLine(pr: PRQAResult): string {
   const reason = pr.exclusionReason ? ` [${pr.exclusionReason}]` : '';
   return `  - #${pr.pr} ${pr.title} — @${pr.author}${reason}`;
 }
@@ -54,9 +59,7 @@ export function renderText(report: ReleaseQAReport): string {
   const lines: string[] = [];
   lines.push(`Release QA report: ${report.fromTag} → ${report.toTag}`);
   lines.push(`Repo: ${report.repo}`);
-  lines.push(
-    `Commits: ${report.totalCommits} | PRs analyzed: ${report.totalPRs}`
-  );
+  lines.push(`Commits: ${report.totalCommits} | PRs analyzed: ${report.totalPRs}`);
   lines.push('');
   lines.push('Summary:');
   lines.push(`  failed:   ${report.summary.failed}`);
@@ -83,7 +86,7 @@ export function renderText(report: ReleaseQAReport): string {
     const h = STATUS_HEADERS[key];
     lines.push(`${h.emoji} ${h.title} (${bucket.length})`);
     lines.push(`  ${h.blurb}`);
-    for (const pr of bucket) lines.push(renderPRLine(pr));
+    for (const pr of bucket) lines.push(renderTextPR(pr));
     lines.push('');
   }
 
@@ -92,110 +95,198 @@ export function renderText(report: ReleaseQAReport): string {
     lines.push(
       '  Bot / dependency-bump / version-bump / release-machinery PRs (skipped before QA check).'
     );
-    for (const pr of report.excluded) lines.push(renderExcludedLine(pr));
+    for (const pr of report.excluded) lines.push(renderExcludedTextLine(pr));
     lines.push('');
   }
 
   return lines.join('\n');
 }
 
+// =========================================================================
+// renderMarkdown — GitHub-flavored markdown for $GITHUB_STEP_SUMMARY
+// =========================================================================
+
+function mdEscape(s: string): string {
+  return s.replace(/\|/g, '\\|');
+}
+
+function renderMarkdownTable(bucket: PRQAResult[], showIssueLabels: boolean): string[] {
+  const out: string[] = [];
+  out.push(showIssueLabels
+    ? '| PR | Title | Author | Linked issue | Issue labels |'
+    : '| PR | Title | Author | Details |');
+  out.push(showIssueLabels
+    ? '|---|---|---|---|---|'
+    : '|---|---|---|---|');
+  for (const pr of bucket) {
+    const title = mdEscape(pr.title);
+    if (showIssueLabels) {
+      const issue = pr.linkedIssues[0];
+      const issueCell = issue
+        ? `[#${issue.number}](${issue.url})`
+        : pr.externalRefs.map((x) => `\`${x.repo}#${x.number}\``).join(', ') || '—';
+      const labels = issue ? issue.labels.map((l) => `\`${l}\``).join(', ') : '';
+      out.push(`| [#${pr.pr}](${pr.url}) | ${title} | @${pr.author} | ${issueCell} | ${labels} |`);
+    } else {
+      const extras = pr.externalRefs.map((x) => `\`${x.repo}#${x.number}\``).join(', ');
+      const labels = pr.labels.map((l) => `\`${l}\``).join(', ');
+      out.push(`| [#${pr.pr}](${pr.url}) | ${title} | @${pr.author} | ${extras || labels} |`);
+    }
+  }
+  return out;
+}
+
+export function renderMarkdown(report: ReleaseQAReport): string {
+  const s = report.summary;
+  const out: string[] = [];
+  out.push(`# Release QA report: \`${report.fromTag}\` → \`${report.toTag}\``);
+  out.push('');
+  out.push(`**Repo:** \`${report.repo}\`  |  **Commits:** ${report.totalCommits}  |  **PRs analyzed:** ${report.totalPRs}`);
+  out.push('');
+  out.push('## Summary');
+  out.push('');
+  out.push('| Bucket | Count |');
+  out.push('|---|---:|');
+  out.push(`| :rotating_light: Failed QA | ${s.failed} |`);
+  out.push(`| :warning: Missing QA | ${s.missing} |`);
+  out.push(`| :grey_question: Orphan PRs | ${s.unlinked} |`);
+  out.push(`| :link: Not in the core repo | ${s.external} |`);
+  out.push(`| :white_check_mark: Passed | ${s.passed} |`);
+  out.push(`| Excluded | ${s.excluded} |`);
+  out.push('');
+
+  const flagged = s.failed + s.missing + s.unlinked + s.external;
+  if (flagged === 0) {
+    out.push(':white_check_mark: All non-excluded PRs have a recognized QA verdict.');
+    return out.join('\n');
+  }
+
+  const sections: Array<{
+    bucket: PRQAResult[];
+    key: 'failed' | 'missing' | 'unlinked' | 'external';
+  }> = [
+    { bucket: report.failed, key: 'failed' },
+    { bucket: report.missing, key: 'missing' },
+    { bucket: report.unlinked, key: 'unlinked' },
+    { bucket: report.external, key: 'external' },
+  ];
+
+  for (const sec of sections) {
+    if (sec.bucket.length === 0) continue;
+    const h = STATUS_HEADERS[sec.key];
+    out.push(`## ${h.emoji} ${h.title} (${sec.bucket.length})`);
+    out.push('');
+    out.push(h.blurb);
+    out.push('');
+    const showIssueLabels = sec.key === 'failed' || sec.key === 'missing';
+    out.push(...renderMarkdownTable(sec.bucket, showIssueLabels));
+    out.push('');
+  }
+
+  if (report.passed.length > 0) {
+    out.push(`## :white_check_mark: QA Passed (${report.passed.length})`);
+    out.push('');
+    out.push(...renderMarkdownTable(report.passed, true));
+    out.push('');
+  }
+
+  if (report.excluded.length > 0) {
+    out.push(`## Excluded (${report.excluded.length})`);
+    out.push('');
+    out.push('Bot / dependency-bump / version-bump / release-machinery PRs.');
+    out.push('');
+    out.push('| PR | Title | Author | Reason |');
+    out.push('|---|---|---|---|');
+    for (const pr of report.excluded) {
+      out.push(
+        `| [#${pr.pr}](${pr.url}) | ${mdEscape(pr.title)} | @${pr.author} | \`${pr.exclusionReason ?? ''}\` |`
+      );
+    }
+    out.push('');
+  }
+
+  return out.join('\n');
+}
+
+// =========================================================================
+// renderSlack — compact: counts as links + cc line with resolved mentions
+// =========================================================================
+
 /**
- * Slack-mrkdwn snippet for the release notification. Returns the empty string
- * when no PR needs review, so the workflow can render the announcement without
- * a trailing QA section on healthy releases.
+ * Slack-mrkdwn snippet for the release notification. Compact by design: just
+ * counts (each linked to the detail URL if provided) plus a cc line that
+ * @-mentions the authors of flagged PRs. Returns the empty string when no PR
+ * needs review.
  */
-export function renderSlack(report: ReleaseQAReport): string {
+export function renderSlack(
+  report: ReleaseQAReport,
+  options: { detailUrl?: string; mappings?: SlackMapping[] } = {}
+): string {
   const s = report.summary;
   const flagged = s.failed + s.missing + s.unlinked + s.external;
   if (flagged === 0) return '';
 
   const out: string[] = [];
   const plural = flagged === 1 ? '' : 's';
-  // Escalate header emoji when any PR actually failed QA, so broken changes
-  // pop in the channel instead of blending in with "missing label" rows.
+  // Escalate header emoji when any PR actually failed QA.
   const headerEmoji = s.failed > 0 ? ':rotating_light:' : ':warning:';
+
   out.push('');
   out.push(`${headerEmoji} *QA Coverage* — ${flagged} PR${plural} need review`);
-  out.push(
-    `  failed QA: ${s.failed}  |  missing QA: ${s.missing}  |  ` +
-      `Orphan PRs: ${s.unlinked}  |  Not in the core repo: ${s.external}`
-  );
+  out.push(`  ${slackCounts(s, options.detailUrl)}`);
 
-  const sections: Array<{
-    bucket: PRQAResult[];
-    emoji: string;
-    label: string;
-    blurb: string;
-  }> = [
-    {
-      bucket: report.failed,
-      emoji: ':rotating_light:',
-      label: 'Failed QA',
-      blurb: 'Linked issue carries `QA : Failed` — change may break things.',
-    },
-    {
-      bucket: report.missing,
-      emoji: ':warning:',
-      label: 'Missing QA',
-      blurb:
-        'Linked issue exists but has no `QA : Passed` / `QA : Not Needed` / `QA : Failed`.',
-    },
-    {
-      bucket: report.unlinked,
-      emoji: ':grey_question:',
-      label: 'Orphan PRs',
-      blurb: 'PR has no closing-issue reference — QA cannot be verified.',
-    },
-    {
-      bucket: report.external,
-      emoji: ':link:',
-      label: 'Not in the core repo',
-      blurb:
-        'PR closes an issue in another repository — QA labels not visible from here.',
-    },
-  ];
-
-  for (const sec of sections) {
-    if (sec.bucket.length === 0) continue;
+  const ccLine = renderCcLine(report, options.mappings);
+  if (ccLine) {
     out.push('');
-    out.push(`${sec.emoji} *${sec.label} (${sec.bucket.length})*`);
-    out.push(`  ${sec.blurb}`);
-    for (const pr of sec.bucket) out.push(renderSlackPR(pr));
+    out.push(ccLine);
   }
 
   return out.join('\n');
 }
 
-const TITLE_MAX = 140;
-
-function renderSlackPR(pr: PRQAResult): string {
-  const refs: string[] = [];
-  for (const i of pr.linkedIssues) {
-    refs.push(i.url ? `<${i.url}|#${i.number}>` : `#${i.number}`);
-  }
-  for (const x of pr.externalRefs) {
-    refs.push(`${x.repo}#${x.number}`);
-  }
-  const refsSuffix = refs.length > 0 ? ` → ${refs.join(', ')}` : '';
-  const title = truncateTitle(pr.title.replace(/[\n\r]+/g, ' '));
-  return `  • <${pr.url}|#${pr.pr}> ${escapeSlack(title)} — @${pr.author}${refsSuffix}`;
-}
-
-function truncateTitle(title: string): string {
-  if (title.length <= TITLE_MAX) return title;
-  return title.slice(0, TITLE_MAX - 1) + '…';
+/** Build the four-bucket count line, with each label as a link if detailUrl is set. */
+function slackCounts(s: ReleaseQAReport['summary'], detailUrl?: string): string {
+  const cell = (label: string, n: number): string => {
+    const text = `${label}: ${n}`;
+    return detailUrl ? `<${detailUrl}|${text}>` : text;
+  };
+  return [
+    cell('failed QA', s.failed),
+    cell('missing QA', s.missing),
+    cell('Orphan PRs', s.unlinked),
+    cell('Not in the core repo', s.external),
+  ].join('  |  ');
 }
 
 /**
- * Escape characters Slack interprets as mrkdwn. Backticks are replaced with
- * an apostrophe rather than HTML-entity-escaped because Slack does not
- * render `&#96;` as a literal backtick — a paired backtick in a title (e.g.
- * "bump deps to `v1.2.3`") would otherwise render as monospace.
+ * Collect unique authors across all flagged buckets and render the cc line
+ * with Slack mentions where the GH user is in the mappings, plain text
+ * otherwise. Returns empty string when no authors to mention.
  */
-function escapeSlack(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/`/g, "'");
+function renderCcLine(
+  report: ReleaseQAReport,
+  mappings: SlackMapping[] | undefined
+): string {
+  const authors = new Set<string>();
+  for (const pr of report.failed) authors.add(pr.author);
+  for (const pr of report.missing) authors.add(pr.author);
+  for (const pr of report.unlinked) authors.add(pr.author);
+  for (const pr of report.external) authors.add(pr.author);
+
+  if (authors.size === 0) return '';
+
+  const sorted = Array.from(authors).sort();
+  const map = new Map<string, string>();
+  if (mappings) {
+    for (const m of mappings) {
+      map.set(m.github_user.toLowerCase(), m.slack_id);
+    }
+  }
+
+  const mentions = sorted.map((login) => {
+    const id = map.get(login.toLowerCase());
+    return id ? `<@${id}>` : `@${login}`;
+  });
+
+  return `cc ${mentions.join(' ')} — please review your PRs in this release.`;
 }

--- a/.github/scripts/release-qa-status/src/index.ts
+++ b/.github/scripts/release-qa-status/src/index.ts
@@ -6,10 +6,14 @@
  * Standalone tool: identify PRs in a release that lack QA coverage.
  *
  * Inputs:
- *   --repo     owner/repo (default: dotCMS/core)
- *   --to-tag   release tag, e.g. v26.05.19-01 (required)
- *   --from-tag previous release tag (default: auto-detected — previous standard release)
- *   --format   "json" (default), "text", or "slack"
+ *   --repo        owner/repo (default: dotCMS/core)
+ *   --to-tag      release tag, e.g. v26.05.19-01 (required)
+ *   --from-tag    previous release tag (default: auto-detected — previous standard release)
+ *   --format      "json" (default), "text", "markdown", or "slack"
+ *   --mappings    path to slack-mappings.json — used by slack format to resolve
+ *                 GitHub usernames to Slack member IDs for the cc line
+ *   --detail-url  URL each count in the slack output links to (typically the
+ *                 GitHub Actions run summary)
  *
  * Auth: set GH_TOKEN (or GITHUB_TOKEN). Quick start:
  *   export GH_TOKEN=$(gh auth token)
@@ -18,7 +22,10 @@
  *   npm install
  *   npm start -- --to-tag v26.05.19-01
  *   npm start -- --to-tag v26.05.19-01 --format text
- *   npm start -- --repo dotCMS/core --from-tag v26.05.12-01 --to-tag v26.05.19-01
+ *   npm start -- --to-tag v26.05.19-01 --format markdown > $GITHUB_STEP_SUMMARY
+ *   npm start -- --to-tag v26.05.19-01 --format slack \
+ *     --mappings .github/data/slack-mappings.json \
+ *     --detail-url https://github.com/dotCMS/core/actions/runs/12345
  *
  * QA verdict per PR (strict):
  *   - excluded:  bot / dependency-bump / release-machinery (skipped before QA check)
@@ -33,7 +40,8 @@
  * attached via the PR "Development" panel.
  */
 
-import { CLIArgs, PRQAResult, QASummary, ReleaseQAReport } from './types';
+import * as fs from 'fs';
+import { CLIArgs, PRQAResult, QASummary, ReleaseQAReport, SlackMapping } from './types';
 import {
   createOctokit,
   parseRepo,
@@ -45,7 +53,7 @@ import {
   fetchIssueInfos,
 } from './github';
 import { computePRQA } from './qa';
-import { renderSlack, renderText } from './format';
+import { renderMarkdown, renderSlack, renderText } from './format';
 
 function parseArgs(argv: string[]): CLIArgs {
   const args: Partial<CLIArgs> = { format: 'json' };
@@ -63,20 +71,27 @@ function parseArgs(argv: string[]): CLIArgs {
         break;
       case '--format': {
         const v = argv[++i];
-        if (v !== 'json' && v !== 'text' && v !== 'slack') {
+        if (v !== 'json' && v !== 'text' && v !== 'slack' && v !== 'markdown') {
           process.stderr.write(
-            `Invalid --format: ${v}. Use "json", "text", or "slack".\n`
+            `Invalid --format: ${v}. Use "json", "text", "markdown", or "slack".\n`
           );
           process.exit(1);
         }
         args.format = v;
         break;
       }
+      case '--mappings':
+        args.mappingsPath = argv[++i];
+        break;
+      case '--detail-url':
+        args.detailUrl = argv[++i];
+        break;
       case '-h':
       case '--help':
         process.stdout.write(
           'Usage: release-qa-status --to-tag vYY.MM.DD-NN [--repo owner/repo] ' +
-            '[--from-tag vYY.MM.DD-NN] [--format json|text]\n'
+            '[--from-tag vYY.MM.DD-NN] [--format json|text|markdown|slack] ' +
+            '[--mappings PATH] [--detail-url URL]\n'
         );
         process.exit(0);
         break;
@@ -96,7 +111,35 @@ function parseArgs(argv: string[]): CLIArgs {
     fromTag: args.fromTag,
     toTag: args.toTag,
     format: args.format || 'json',
+    mappingsPath: args.mappingsPath,
+    detailUrl: args.detailUrl,
   };
+}
+
+/**
+ * Load slack-mappings.json. Returns [] and warns on stderr if the file is
+ * missing or malformed, so the slack format still works (just without
+ * @-mentions) when the mapping file isn't deployed yet.
+ */
+function loadMappings(path: string): SlackMapping[] {
+  try {
+    const raw = fs.readFileSync(path, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      process.stderr.write(`Warning: ${path} is not a JSON array; ignoring.\n`);
+      return [];
+    }
+    return parsed.filter(
+      (m): m is SlackMapping =>
+        m && typeof m.github_user === 'string' && typeof m.slack_id === 'string'
+    );
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `Warning: could not load mappings from ${path}: ${msg}\n`
+    );
+    return [];
+  }
 }
 
 function bucketResults(results: PRQAResult[]): Omit<ReleaseQAReport,
@@ -217,7 +260,7 @@ async function main(): Promise<void> {
       passed: [],
       excluded: [],
     };
-    emit(empty, args.format);
+    emit(empty, args);
     return;
   }
 
@@ -269,7 +312,7 @@ async function main(): Promise<void> {
     ...buckets,
   };
 
-  emit(report, args.format);
+  emit(report, args);
 
   process.stderr.write(
     `Done. failed=${report.summary.failed} missing=${report.summary.missing} ` +
@@ -278,17 +321,27 @@ async function main(): Promise<void> {
   );
 }
 
-function emit(
-  report: ReleaseQAReport,
-  format: 'json' | 'text' | 'slack'
-): void {
-  if (format === 'text') {
-    process.stdout.write(renderText(report) + '\n');
-  } else if (format === 'slack') {
-    const snippet = renderSlack(report);
-    if (snippet.length > 0) process.stdout.write(snippet + '\n');
-  } else {
-    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+function emit(report: ReleaseQAReport, args: CLIArgs): void {
+  switch (args.format) {
+    case 'text':
+      process.stdout.write(renderText(report) + '\n');
+      return;
+    case 'markdown':
+      process.stdout.write(renderMarkdown(report) + '\n');
+      return;
+    case 'slack': {
+      const mappings = args.mappingsPath ? loadMappings(args.mappingsPath) : undefined;
+      const snippet = renderSlack(report, {
+        detailUrl: args.detailUrl,
+        mappings,
+      });
+      if (snippet.length > 0) process.stdout.write(snippet + '\n');
+      return;
+    }
+    case 'json':
+    default:
+      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+      return;
   }
 }
 

--- a/.github/scripts/release-qa-status/src/types.ts
+++ b/.github/scripts/release-qa-status/src/types.ts
@@ -104,5 +104,15 @@ export interface CLIArgs {
   repo: string;
   fromTag?: string;
   toTag: string;
-  format: 'json' | 'text' | 'slack';
+  format: 'json' | 'text' | 'slack' | 'markdown';
+  /** Path to slack-mappings.json — used by slack format to resolve GH user → Slack ID. */
+  mappingsPath?: string;
+  /** URL each count in the slack output links to (typically the workflow run summary). */
+  detailUrl?: string;
+}
+
+/** One entry of .github/data/slack-mappings.json. */
+export interface SlackMapping {
+  github_user: string;
+  slack_id: string;
 }

--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -239,15 +239,32 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CI_MACHINE_TOKEN || github.token }}
           RELEASE_TAG: ${{ needs.release-prepare.outputs.release_tag }}
+          # Full markdown report lands on the workflow run summary; the
+          # Slack counts link here.
+          DETAIL_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          MAPPINGS_PATH: ${{ github.workspace }}/.github/data/slack-mappings.json
         run: |
           set +e
+          # 1) Full markdown report → workflow run summary
+          npx ts-node src/index.ts \
+            --repo "${GITHUB_REPOSITORY}" \
+            --to-tag "${RELEASE_TAG}" \
+            --format markdown 2>>/tmp/qa-stderr.log >> "${GITHUB_STEP_SUMMARY}"
+          rc_md=$?
+          if [ $rc_md -ne 0 ]; then
+            echo "::warning::release-qa-status (markdown) exited with ${rc_md}; report summary may be incomplete"
+          fi
+
+          # 2) Compact Slack snippet → step output for the next step
           output=$(npx ts-node src/index.ts \
             --repo "${GITHUB_REPOSITORY}" \
             --to-tag "${RELEASE_TAG}" \
-            --format slack 2>/tmp/qa-stderr.log)
-          rc=$?
-          if [ $rc -ne 0 ]; then
-            echo "::warning::release-qa-status exited with code ${rc}; omitting QA section from Slack message"
+            --format slack \
+            --mappings "${MAPPINGS_PATH}" \
+            --detail-url "${DETAIL_URL}" 2>>/tmp/qa-stderr.log)
+          rc_slack=$?
+          if [ $rc_slack -ne 0 ]; then
+            echo "::warning::release-qa-status (slack) exited with ${rc_slack}; omitting QA section from Slack message"
             cat /tmp/qa-stderr.log || true
             output=""
           fi


### PR DESCRIPTION
Closes #35825

## Summary

Follow-up to #35762. Two issues surfaced from the first real-release Slack notification:

1. The QA section was too tall — Slack collapsed it behind a "Show more" so the per-PR detail was effectively hidden.
2. The `@author` text wasn't real Slack mentions, so the people whose action was needed never got notified.

## Approach

**Slack message stays compact.** Just counts + a cc line:

```
:rotating_light: *QA Coverage* — 14 PRs need review
  <run-url|failed QA: 1>  |  <run-url|missing QA: 12>  |  <run-url|Orphan PRs: 1>  |  <run-url|Not in the core repo: 0>

cc <@U05R06D9YSX> @adrianjm-dotCMS @dario-daza <@UCF6CLC6L> ... — please review your PRs in this release.
```

- Each count is a link to the workflow run summary.
- Authors of failed / missing / orphan / external PRs are mentioned. Mapped users (via `.github/data/slack-mappings.json`) get real `<@USERID>` mentions that actually notify. Unmapped users fall back to plain `@login` so they're still named.
- The header escalates to `:rotating_light:` whenever any PR is in the `failed` bucket.

**Detail moves to the workflow run summary.** A new `--format markdown` produces a GitHub-flavored markdown report (tables per bucket, links to issues, label cells) written to `\$GITHUB_STEP_SUMMARY`. Reviewers land there by clicking any count in Slack.

## New CLI flags on `release-qa-status`

```
--format markdown    GitHub-flavored markdown — for $GITHUB_STEP_SUMMARY
--mappings PATH      slack-mappings.json for GH → Slack ID resolution
--detail-url URL     link target for each count in the slack output
```

## Workflow changes

The Report step in `cicd_6-release.yml` now runs the script twice:
1. `--format markdown` → appended to `\$GITHUB_STEP_SUMMARY`
2. `--format slack --mappings ... --detail-url <run-url>` → injected into `SLACK_MESSAGE`

Both calls are best-effort (`continue-on-error: true`); a failure leaves the announcement intact.

## Validation

End-to-end against `v26.05.22-01` with the real mappings:
- Slack snippet renders 14 flagged PRs as 4 count links + 1 cc line — well within Slack's inline-display limit.
- Mapped users (`dsilvam`, `hassandotcms`, `fmontes`, ...) become real Slack mentions.
- Unmapped users (`adrianjm-dotCMS`, `dario-daza`, `ihoffmann-dot`) fall back to plain `@login`.
- Markdown summary renders correctly with bucket tables and inline labels.

Tests: **35/35 pass** (previously 28/28). New cases cover detailUrl wrapping, mapped + unmapped + deduped + case-insensitive author resolution, exclusion of passed-bucket authors from the cc, and the markdown format.

## Test plan

- [ ] Manual workflow_dispatch run with `notify_slack=true` against a release
- [ ] Confirm Slack message renders without truncation and that mentions notify the mapped users
- [ ] Confirm workflow run summary contains the full markdown report
- [x] (Out of scope here) update `slack-mappings.json` for any newly-contributing authors so they get real mentions next time

🤖 Generated with [Claude Code](https://claude.com/claude-code)