### PR TITLE
fix(postman): hardcode language_id=1 on page-related Postman tests (#35780)

### DIFF
--- a/dotcms-postman/src/main/resources/postman/Experiments_Resource.postman_collection.json
+++ b/dotcms-postman/src/main/resources/postman/Experiments_Resource.postman_collection.json
@@ -1393,7 +1393,7 @@
                   }
                 },
                 "url": {
-                  "raw": "{{serverURL}}/api/v1/page/{{page_version_keep_contentlet}}/content",
+                  "raw": "{{serverURL}}/api/v1/page/{{page_version_keep_contentlet}}/content?language_id=1",
                   "host": ["{{serverURL}}"],
                   "path": [
                     "api",
@@ -1401,6 +1401,12 @@
                     "page",
                     "{{page_version_keep_contentlet}}",
                     "content"
+                  ],
+                  "query": [
+                    {
+                      "key": "language_id",
+                      "value": "1"
+                    }
                   ]
                 }
               },
@@ -1640,7 +1646,7 @@
                   }
                 },
                 "url": {
-                  "raw": "{{serverURL}}/api/v1/page/{{page_version_keep_contentlet}}/content?variantName=dotexperiment-{{experimentShortId}}-variant-1",
+                  "raw": "{{serverURL}}/api/v1/page/{{page_version_keep_contentlet}}/content?variantName=dotexperiment-{{experimentShortId}}-variant-1&language_id=1",
                   "host": ["{{serverURL}}"],
                   "path": [
                     "api",
@@ -1653,6 +1659,10 @@
                     {
                       "key": "variantName",
                       "value": "dotexperiment-{{experimentShortId}}-variant-1"
+                    },
+                    {
+                      "key": "language_id",
+                      "value": "1"
                     }
                   ]
                 }
@@ -2371,7 +2381,7 @@
                   }
                 },
                 "url": {
-                  "raw": "{{serverURL}}/api/v1/page/{{add_contentlet_default_specific_variant_page_id}}/content",
+                  "raw": "{{serverURL}}/api/v1/page/{{add_contentlet_default_specific_variant_page_id}}/content?language_id=1",
                   "host": ["{{serverURL}}"],
                   "path": [
                     "api",
@@ -2379,6 +2389,12 @@
                     "page",
                     "{{add_contentlet_default_specific_variant_page_id}}",
                     "content"
+                  ],
+                  "query": [
+                    {
+                      "key": "language_id",
+                      "value": "1"
+                    }
                   ]
                 }
               },
@@ -2692,7 +2708,7 @@
                   }
                 },
                 "url": {
-                  "raw": "{{serverURL}}/api/v1/page/{{add_contentlet_default_specific_variant_page_id}}/content",
+                  "raw": "{{serverURL}}/api/v1/page/{{add_contentlet_default_specific_variant_page_id}}/content?language_id=1",
                   "host": ["{{serverURL}}"],
                   "path": [
                     "api",
@@ -2700,6 +2716,12 @@
                     "page",
                     "{{add_contentlet_default_specific_variant_page_id}}",
                     "content"
+                  ],
+                  "query": [
+                    {
+                      "key": "language_id",
+                      "value": "1"
+                    }
                   ]
                 }
               },
@@ -12818,7 +12840,7 @@
               }
             },
             "url": {
-              "raw": "{{serverURL}}/api/v1/page/{{page_version_spanish_content}}/content",
+              "raw": "{{serverURL}}/api/v1/page/{{page_version_spanish_content}}/content?language_id=1",
               "host": ["{{serverURL}}"],
               "path": [
                 "api",
@@ -12826,6 +12848,12 @@
                 "page",
                 "{{page_version_spanish_content}}",
                 "content"
+              ],
+              "query": [
+                {
+                  "key": "language_id",
+                  "value": "1"
+                }
               ]
             }
           },

--- a/dotcms-postman/src/main/resources/postman/PagesResourceTests.json
+++ b/dotcms-postman/src/main/resources/postman/PagesResourceTests.json
@@ -64,7 +64,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n\t\n\t\"contentlet\": {\n\t\t\"contentType\":\"htmlpageasset\",\n        \"title\":\"testPageInvalidation{{$timestamp}}\",\n        \"url\":\"testPageInvalidation{{$timestamp}}\",\n        \"hostFolder\":\"{{hostname}}\",\n        \"template\":\"SYSTEM_TEMPLATE\",\n        \"friendlyName\":\"testPageInvalidation{{$timestamp}}\",\n        \"cachettl\":0\n\t\t\n\t}\n}",
+              "raw": "{\n\t\n\t\"contentlet\": {\n\t\t\"contentType\":\"htmlpageasset\",\n        \"title\":\"testPageInvalidation{{$timestamp}}\",\n        \"url\":\"testPageInvalidation{{$timestamp}}\",\n        \"hostFolder\":\"{{hostname}}\",\n        \"template\":\"SYSTEM_TEMPLATE\",\n        \"friendlyName\":\"testPageInvalidation{{$timestamp}}\",\n        \"cachettl\":0,\n        \"languageId\":1\n\t\t\n\t}\n}",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
## Summary

Same `language=-1` class of failure as #35780, surfacing in `Experiments_Resource.postman_collection.json` this time. CI run [26312707306](https://github.com/dotCMS/core/actions/runs/26312707306/job/77472990761?pr=35771) hit:

```
expected response to have status code 200 but got 404
inside "Variants / Keep Content after change Layout to a Specific Variant / Add contetlet into DEFAULT variant"
```

## Server-side diagnosis

```
ERROR page.PageResource - HTMLPageAssetNotFoundException on PageResource.addContent,
      pageId: f41ac5d4f5a2e854e1d79ea6ca39df27
```

`PageResourceHelper.getPage()` looks the page up via:

```java
final Language currentLanguage = WebAPILocator.getLanguageWebAPI().getLanguage(request);
...
APILocator.getVersionableAPI().getContentletVersionInfo(pageId,
        renderContext.getCurrentLanguageId(), ...)
```

`getLanguage(request)` falls back to `getDefaultLanguage()` when no language is on the request — and in this test env that returns the `LANG__404` sentinel (`id=-1`). The page was created in the previous step with `languageId=1` (verified in the test bodies), so the `(id, -1)` lookup misses and the server returns 404.

## Fix

Add `language_id=1` to the 5 URLs that target page-content endpoints without specifying language. All affected pages are created earlier in the flow with `languageId=1` (English), so hardcoding `1` matches the test data exactly — no need for the `_getdefault` resolver dance here.

Patched URLs:

| Section | Test |
|---|---|
| Variants / Keep Content after change Layout to a Specific Variant | `Add contetlet into DEFAULT variant` |
| Variants / Keep Content after change Layout to a Specific Variant | `Add Contentlet into a specific variant` *(already had `variantName`, now also `language_id`)* |
| Variants / Add Contentlet on Default Variant after A Specific Variant exists | `Add contetlet into DEFAULT variant` |
| Variants / Add Contentlet on Default Variant after A Specific Variant exists | `Add Another Contentlet into a DEFAULTvariant` |
| Add Spanish Contentlet inside Variant | `Add contetlet into DEFAULT variant` |

## Diff

`+33 / −5` — surgical text patches that preserve the file's mixed inline/multi-line array style. Each patched URL got `?language_id=1` (or `&language_id=1`) in `raw` plus a matching `query` array entry, consistent with the other URLs in this collection that already specify query params (e.g. `variantName`).

## Test plan

- [x] JSON validity verified.
- [ ] CI verifies — `PR Test / Postman Tests - Experiment` should now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35780