### PR TITLE
fix(uve): stale breadcrumb title on page navigation

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1145,6 +1145,21 @@ describe('DotEmaShellComponent', () => {
                 );
             });
 
+            it('should not throw and should not call addNewBreadcrumb when resetPageParams nulls pageParams before effect tears down', async () => {
+                spectator.detectChanges();
+                await spectator.fixture.whenStable();
+                spectator.detectChanges();
+                mockGlobalStore.addNewBreadcrumb.mockClear();
+
+                // Simulate ngOnDestroy: pageParams becomes null while status stays LOADED
+                expect(() => {
+                    store.resetPageParams();
+                    spectator.detectChanges();
+                }).not.toThrow();
+
+                expect(mockGlobalStore.addNewBreadcrumb).not.toHaveBeenCalled();
+            });
+
             it('should not update breadcrumb with stale data while page is loading, then update once loaded', async () => {
                 // Initialize with the first page fully loaded
                 spectator.detectChanges();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '@ngneat/spectator/jest';
 import { patchState } from '@ngrx/signals';
 import { MockComponent } from 'ng-mocks';
-import { of } from 'rxjs';
+import { Subject, of } from 'rxjs';
 
 import { Location } from '@angular/common';
 import { provideHttpClient } from '@angular/common/http';
@@ -1141,6 +1141,45 @@ describe('DotEmaShellComponent', () => {
                 expect(mockGlobalStore.addNewBreadcrumb).toHaveBeenCalledWith(
                     expect.objectContaining({
                         url: INITIAL_PAGE_PARAMS.url
+                    })
+                );
+            });
+
+            it('should not update breadcrumb with stale data while page is loading, then update once loaded', async () => {
+                // Initialize with the first page fully loaded
+                spectator.detectChanges();
+                await spectator.fixture.whenStable();
+                spectator.detectChanges();
+                mockGlobalStore.addNewBreadcrumb.mockClear();
+
+                // Hold the HTTP response so we can inspect state during LOADING
+                const pendingRequest$ = new Subject<typeof MOCK_RESPONSE_HEADLESS>();
+                jest.spyOn(dotPageApiService, 'get').mockReturnValue(pendingRequest$);
+
+                // Navigate to a new page
+                store.pageLoad({ ...INITIAL_PAGE_PARAMS, url: '/new-page' });
+                spectator.detectChanges();
+
+                // While status is LOADING, stale pageAsset is present but breadcrumb must not be updated
+                expect(mockGlobalStore.addNewBreadcrumb).not.toHaveBeenCalled();
+
+                // Resolve the HTTP response with the new page's data
+                const newPageResponse = {
+                    ...MOCK_RESPONSE_HEADLESS,
+                    page: { ...MOCK_RESPONSE_HEADLESS.page, title: 'New Page Title', identifier: '999' }
+                };
+                pendingRequest$.next(newPageResponse);
+                pendingRequest$.complete();
+
+                await spectator.fixture.whenStable();
+                spectator.detectChanges();
+
+                // After loading completes, breadcrumb must reflect the new page
+                expect(mockGlobalStore.addNewBreadcrumb).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        label: 'New Page Title',
+                        id: '999',
+                        url: '/new-page'
                     })
                 );
             });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -69,7 +69,7 @@ import { DotEmaDialogComponent } from '../components/dot-ema-dialog/dot-ema-dial
 import { DotActionUrlService } from '../services/dot-action-url/dot-action-url.service';
 import { DotPageApiService } from '../services/dot-page-api/dot-page-api.service';
 import { DEFAULT_PERSONA, PERSONA_KEY } from '../shared/consts';
-import { FormStatus, NG_CUSTOM_EVENTS } from '../shared/enums';
+import { FormStatus, NG_CUSTOM_EVENTS, UVE_STATUS } from '../shared/enums';
 import {
     dotPropertiesServiceMock,
     MOCK_RESPONSE_HEADLESS,
@@ -1145,19 +1145,20 @@ describe('DotEmaShellComponent', () => {
                 );
             });
 
-            it('should not throw and should not call addNewBreadcrumb when resetPageParams nulls pageParams before effect tears down', async () => {
+            it('should not throw when resetPageParams() nulls pageParams and a tracked dep re-fires the effect', async () => {
                 spectator.detectChanges();
                 await spectator.fixture.whenStable();
                 spectator.detectChanges();
                 mockGlobalStore.addNewBreadcrumb.mockClear();
 
-                // Simulate ngOnDestroy: pageParams becomes null while status stays LOADED
-                expect(() => {
-                    store.resetPageParams();
-                    spectator.detectChanges();
-                }).not.toThrow();
+                // ngOnDestroy calls resetPageParams() (pageParams = null) but Angular tears
+                // down effects asynchronously, so the effect can re-run in that window.
+                // Cycling uveStatus on a tracked dep simulates that re-fire with null pageParams.
+                store.resetPageParams();
+                patchState(store, { uveStatus: UVE_STATUS.LOADING });
+                patchState(store, { uveStatus: UVE_STATUS.LOADED });
 
-                expect(mockGlobalStore.addNewBreadcrumb).not.toHaveBeenCalled();
+                expect(() => spectator.detectChanges()).not.toThrow();
             });
 
             it('should not update breadcrumb with stale data while page is loading, then update once loaded', async () => {
@@ -1181,7 +1182,11 @@ describe('DotEmaShellComponent', () => {
                 // Resolve the HTTP response with the new page's data
                 const newPageResponse = {
                     ...MOCK_RESPONSE_HEADLESS,
-                    page: { ...MOCK_RESPONSE_HEADLESS.page, title: 'New Page Title', identifier: '999' }
+                    page: {
+                        ...MOCK_RESPONSE_HEADLESS.page,
+                        title: 'New Page Title',
+                        identifier: '999'
+                    }
                 };
                 pendingRequest$.next(newPageResponse);
                 pendingRequest$.complete();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -210,9 +210,13 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
     readonly $updateBreadcrumbEffect = effect(() => {
         const page = this.uveStore.pageAsset()?.page;
         const status = this.uveStore.uveStatus();
-        const url = untracked(() => this.uveStore.pageParams()?.url);
 
         if (page && status === UVE_STATUS.LOADED) {
+            // untracked: (a) prevents URL-only changes from re-triggering the breadcrumb,
+            // (b) avoids a TypeError crash when ngOnDestroy calls resetPageParams() (pageParams = null)
+            // before Angular tears down the effect asynchronously.
+            const url = untracked(() => this.uveStore.pageParams()?.url);
+
             this.#globalStore.addNewBreadcrumb({
                 label: page.title,
                 url,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -210,11 +210,12 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
     readonly $updateBreadcrumbEffect = effect(() => {
         const page = this.uveStore.pageAsset()?.page;
         const status = this.uveStore.uveStatus();
+        const url = untracked(() => this.uveStore.pageParams()?.url);
 
         if (page && status === UVE_STATUS.LOADED) {
             this.#globalStore.addNewBreadcrumb({
                 label: page.title,
-                url: untracked(() => this.uveStore.pageParams()?.url),
+                url,
                 id: `${page.identifier}`
             });
         }

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -11,6 +11,7 @@ import {
     OnDestroy,
     OnInit,
     signal,
+    untracked,
     ViewChild
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -209,11 +210,12 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
     readonly $updateBreadcrumbEffect = effect(() => {
         const page = this.uveStore.pageAsset()?.page;
         const status = this.uveStore.uveStatus();
+
         if (page && status === UVE_STATUS.LOADED) {
             this.#globalStore.addNewBreadcrumb({
-                label: page?.title,
-                url: this.uveStore.pageParams().url,
-                id: `${page?.identifier}`
+                label: page.title,
+                url: untracked(() => this.uveStore.pageParams()?.url),
+                id: `${page.identifier}`
             });
         }
     });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -208,8 +208,8 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
 
     readonly $updateBreadcrumbEffect = effect(() => {
         const page = this.uveStore.pageAsset()?.page;
-
-        if (page) {
+        const status = this.uveStore.uveStatus();
+        if (page && status === UVE_STATUS.LOADED) {
             this.#globalStore.addNewBreadcrumb({
                 label: page?.title,
                 url: this.uveStore.pageParams().url,


### PR DESCRIPTION
## Summary

- Guards `$updateBreadcrumbEffect` with `status === UVE_STATUS.LOADED` so the breadcrumb only updates once the new page's data has fully resolved from the API
- Adds a regression test that verifies `addNewBreadcrumb` is not called with stale data during LOADING, and is called correctly once LOADED
- Adds untracked() on pageParams() to prevent a TypeError crash: ngOnDestroy calls resetPageParams() which sets pageParams = null, and Angular effects are torn down asynchronously — there is a window where the effect can re-run with status = LOADED, page truthy, but pageParams() = null, making .url throw

https://github.com/user-attachments/assets/93e91d6f-0a34-4d6a-8edf-40af9ca9f9bf


## Root cause

When navigating between pages, `pageAsset` is intentionally kept (not cleared) so the editor chrome stays mounted during the fetch. This caused `$updateBreadcrumbEffect` to fire with stale `pageAsset` (previous page title) + the new `pageParams.url`. Then `addNewBreadcrumb`'s URL deduplication guard (`isSameUrl`) blocked the correct update from ever landing when the real page data arrived.

Closes #35807

## Test plan

- [ ] Open any page in the UVE
- [ ] Select a different page from the Pages tree on the left
- [ ] Verify the dotAdmin header breadcrumb updates to the new page's title
- [ ] Navigate back to the first page — breadcrumb restores correctly
- [ ] Click links inside the iframe (in-iframe navigation) — breadcrumb updates correctly
