### PR TITLE
feat(content-type): add inode parameter support for content type 

### DIFF
--- a/.claude/skills/vtl-migration/SKILL.md
+++ b/.claude/skills/vtl-migration/SKILL.md
@@ -38,7 +38,7 @@ For the full migration rules, all code examples, the DaisyUI styling section, an
 4. **Store field references once** — call `getField()` once per field at the top of `ready()`, then reuse the reference.
 5. **Migrate each pattern** — follow the migration rules in `references/migration-guide.md`.
 6. **Apply DaisyUI for styling** — use DaisyUI component classes (`btn`, `input`, `select`, `modal`, `link`, etc.) and Tailwind utilities instead of inline styles or ad-hoc CSS; see “Styling with DaisyUI” in the guide.
-7. **Preserve VTL variables** — `${fieldId}`, `$maxChar`, `$variableName` are server-side; never change them.
+7. **Preserve VTL variables** — `${fieldId}`, `$maxChar`, `$variableName`, and server-side context variables (`$inode`, `$identifier`, `$lang`, `$contentlet`, `$structure`, `$field`) are server-side; never change them.
 8. **Output three files** — see the File Output Pattern below.
 
 ## File Output Pattern
@@ -87,6 +87,7 @@ This pattern lets both legacy and new edit modes coexist safely — old editor u
 - Dijit CSS classes (any `class="dijit*"`) must be removed
 - **Styling:** Prefer DaisyUI component classes + Tailwind utilities; keep custom CSS only when the guide says so
 - Translate non-English comments to English
+- Server-side VTL variables (`$inode`, `$identifier`, `$lang`, `$contentlet`, `$structure`, `$field`) are resolved at render time — do not confuse them with `DotCustomFieldApi` JavaScript APIs
 
 ## Key Patterns to Know
 
@@ -206,6 +207,59 @@ titleField.onChange((value) => {
 ```
 
 **Styling (DaisyUI):** Buttons → `btn`, `btn-primary`, `btn-ghost`, `btn-sm`. Inputs → `input input-bordered`. Selects → `select select-bordered`. Links → `link link-primary`. Use Tailwind for layout (`flex`, `gap`, `w-full`). Full reference in `references/migration-guide.md` → “Styling with DaisyUI”.
+
+## Available Velocity Context Variables
+
+Custom field templates can use **server-side VTL variables** injected by dotCMS when the field is rendered. These are resolved on the server before HTML reaches the browser — they are **not** available in JavaScript and must not be confused with `DotCustomFieldApi`.
+
+| Variable | Type | Description |
+|---|---|---|
+| `$inode` | `String` | The contentlet's inode (version ID) |
+| `$identifier` | `String` | The contentlet's persistent identifier |
+| `$lang` | `long` | The contentlet's language ID |
+| `$contentlet` | `Contentlet` | The full Contentlet object |
+| `$structure` | `ContentType` | The content type (structure) |
+| `$field` | `Field` | The current field being rendered |
+
+**Availability:**
+- `$structure` and `$field` are always available when the custom field is rendered.
+- `$inode`, `$identifier`, `$lang`, and `$contentlet` are populated only when **editing an existing contentlet** (when an inode is known). On new content, those four variables are empty/unset.
+- Both the new editor (REST API component mode and iframe mode) and the legacy editor expose the same variables.
+
+**Example — display context variables in the template:**
+
+```html
+<p>
+  <strong>inode:</strong> $inode
+</p>
+<p>
+  <strong>identifier:</strong> $identifier
+</p>
+<p>
+  <strong>lang:</strong> $lang
+</p>
+<p>
+  <strong>contentlet:</strong> $contentlet
+</p>
+<p>
+  <strong>structure:</strong> $structure
+</p>
+<p>
+  <strong>field:</strong> $field
+</p>
+```
+
+**Example — guard for new vs existing content:**
+
+```html
+#if($utilMethods.isSet($inode))
+  <input type="hidden" id="contentInode" value="$inode" />
+#else
+  <p class="text-sm text-base-content/70">Save the content first to access inode-specific features.</p>
+#end
+```
+
+For full details, availability rules, and practical examples → read `references/migration-guide.md` → “Server-Side Velocity Context Variables”.
 
 ## Before Outputting
 

--- a/.claude/skills/vtl-migration/references/migration-guide.md
+++ b/.claude/skills/vtl-migration/references/migration-guide.md
@@ -2,13 +2,14 @@
 
 ## Table of Contents
 1. [The New DotCustomFieldApi](#the-new-dotcustomfieldapi)
-2. [Migration Rules](#migration-rules)
-3. [Styling with DaisyUI](#styling-with-daisyui)
-4. [Best Practices](#best-practices)
-5. [Step-by-Step Checklist](#step-by-step-checklist)
-6. [Common Pitfalls](#common-pitfalls)
-7. [Special Cases](#special-cases)
-8. [Complete Migration Examples](#complete-migration-examples)
+2. [Server-Side Velocity Context Variables](#server-side-velocity-context-variables)
+3. [Migration Rules](#migration-rules)
+4. [Styling with DaisyUI](#styling-with-daisyui)
+5. [Best Practices](#best-practices)
+6. [Step-by-Step Checklist](#step-by-step-checklist)
+7. [Common Pitfalls](#common-pitfalls)
+8. [Special Cases](#special-cases)
+9. [Complete Migration Examples](#complete-migration-examples)
 
 ---
 
@@ -56,6 +57,156 @@ DotCustomFieldApi.ready(() => {
 | `disable()` | Prevents user interaction and applies disabled styling |
 
 Always wrap all field access code inside `DotCustomFieldApi.ready()` to ensure the API is initialized.
+
+---
+
+## Server-Side Velocity Context Variables
+
+Custom field VTL templates can access **server-side context variables** that dotCMS injects into the Velocity context when rendering the field. These variables are resolved on the server before HTML reaches the browser. They are **not** JavaScript values and must not be confused with `DotCustomFieldApi.getField()`.
+
+### Available variables
+
+| Variable | Type | Description |
+|---|---|---|
+| `$inode` | `String` | The contentlet's inode (version ID) |
+| `$identifier` | `String` | The contentlet's persistent identifier |
+| `$lang` | `long` | The contentlet's language ID |
+| `$contentlet` | `Contentlet` | The full Contentlet object |
+| `$structure` | `ContentType` | The content type (structure) |
+| `$field` | `Field` | The current field being rendered |
+
+### When each variable is available
+
+| Variable | New content | Existing content |
+|---|---|---|
+| `$structure` | Yes | Yes |
+| `$field` | Yes | Yes |
+| `$inode` | No | Yes |
+| `$identifier` | No | Yes |
+| `$lang` | No | Yes |
+| `$contentlet` | No | Yes |
+
+When creating new content, there is no contentlet yet — `$inode`, `$identifier`, `$lang`, and `$contentlet` are empty or unset. Always guard usage with `#if($utilMethods.isSet($inode))` when the template depends on contentlet context.
+
+### Rendering paths (new editor)
+
+Both new-editor rendering paths inject the same variables as the legacy editor:
+
+| Path | Endpoint / JSP | Notes |
+|---|---|---|
+| **Component mode** | `GET /api/v1/contenttype/render/id/{idOrVar}?inode={inode}` | Pass the contentlet inode as query param when editing existing content |
+| **Iframe mode** | `legacy-custom-field.jsp?inode={inode}` | Loads contentlet from query param and injects variables into Velocity context |
+
+The legacy editor (`edit_contentlet.jsp` + `EditContentletAction`) sets the same variables via `request.setAttribute`, which Velocity exposes automatically.
+
+### Legacy editor mapping
+
+| VTL variable | Legacy source |
+|---|---|
+| `$inode` | `edit_contentlet.jsp` → `request.setAttribute("inode", ...)` |
+| `$identifier` | `EditContentletAction.java` → `request.setAttribute("identifier", ...)` |
+| `$lang` | `EditContentletAction.java` → `request.setAttribute("lang", ...)` |
+| `$contentlet` | `edit_contentlet.jsp` → `request.setAttribute("contentlet", ...)` |
+| `$structure` | `edit_contentlet.jsp` → `request.setAttribute("structure", ...)` |
+| `$field` | `edit_contentlet.jsp` → `request.setAttribute("field", ...)` per field loop |
+
+Migrators do not need to change these variables — they work the same in both editors when the contentlet context is present.
+
+### Example 1: Debug / info panel
+
+Use this pattern to verify that all context variables resolve correctly:
+
+```html
+<p>
+  <strong>inode:</strong> $inode
+</p>
+<p>
+  <strong>identifier:</strong> $identifier
+</p>
+<p>
+  <strong>lang:</strong> $lang
+</p>
+<p>
+  <strong>contentlet:</strong> $contentlet
+</p>
+<p>
+  <strong>structure:</strong> $structure
+</p>
+<p>
+  <strong>field:</strong> $field
+</p>
+```
+
+When testing via REST API, call:
+
+```
+GET /api/v1/contenttype/render/id/{contentTypeVar}?inode={contentletInode}
+```
+
+The `rendered` property on each custom field in the response should show resolved values instead of literal `$inode`, `$structure`, etc.
+
+### Example 2: Conditional UI based on contentlet state
+
+Show different UI for published vs draft content:
+
+```html
+#if($utilMethods.isSet($contentlet))
+  #if($contentlet.isLive())
+    <p class="text-sm text-success">This content is published. Changes will create a new working version.</p>
+  #else
+    <p class="text-sm text-warning">This content is a draft.</p>
+  #end
+
+  <input type="hidden" id="contentIdentifier" value="$identifier" />
+  <input type="hidden" id="contentLang" value="$lang" />
+#else
+  <p class="text-sm text-base-content/70">Save the content first to enable advanced options.</p>
+#end
+```
+
+### Example 3: Use field metadata from `$field`
+
+Access properties of the current field being rendered:
+
+```html
+<p class="text-sm">
+  Field: <strong>$field.name</strong> (variable: <code>$field.variable</code>)
+</p>
+
+#if($utilMethods.isSet($field.defaultValue))
+  <p class="text-xs text-base-content/60">Default: $field.defaultValue</p>
+#end
+```
+
+### Example 4: Pass server values into JavaScript
+
+VTL runs on the server; JavaScript runs in the browser. To use contentlet context in JS, embed resolved values at render time:
+
+```html
+#if($utilMethods.isSet($inode))
+<script type="application/javascript">
+  const CONTENT_INODE = '$inode';
+  const CONTENT_IDENTIFIER = '$identifier';
+
+  DotCustomFieldApi.ready(() => {
+    // Use CONTENT_INODE in API calls, analytics, etc.
+    console.log('Editing content:', CONTENT_INODE);
+  });
+</script>
+#end
+```
+
+**Important:** Never assume `$inode` or `$identifier` exist on new content. Always wrap JS that depends on them in `#if($utilMethods.isSet($inode))`.
+
+### What to preserve during migration
+
+**DO NOT change:**
+- References to `$inode`, `$identifier`, `$lang`, `$contentlet`, `$structure`, `$field`
+- VTL conditionals that guard on these variables
+- Hidden inputs or data attributes populated from these variables
+
+**DO change:**
+- Only the JavaScript API calls (`DotCustomFieldApi`, Dojo/Dijit) and styling approach — not the server-side VTL context usage
 
 ---
 
@@ -590,6 +741,7 @@ Be consistent when writing `<script>` tags in migrated VTL files:
 
 **DO NOT change:**
 - VTL variables: `${fieldId}`, `$maxChar`, `$variableName`
+- Server-side context variables: `$inode`, `$identifier`, `$lang`, `$contentlet`, `$structure`, `$field`
 - Business logic and algorithms
 - HTML structure (except removing dojoType/dijit attributes)
 - Comments (but translate to English if written in another language)

--- a/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.spec.ts
@@ -603,6 +603,69 @@ describe('DotContentletService', () => {
             req.flush({ entity: responseEntity });
         });
 
+        it('should pass inode as query param when provided', (done) => {
+            const id = 'inode-param-test';
+            const inode = 'abc-123-def-456';
+            const contentTypeExpected: DotCMSContentType = {
+                ...dotcmsContentTypeBasicMock,
+                clazz: 'clazz' as DotCMSClazz,
+                defaultType: false,
+                fixed: false,
+                folder: 'folder',
+                host: 'host',
+                id: id,
+                name: 'Inode Param Test',
+                owner: 'user',
+                system: false
+            };
+
+            dotContentTypeService
+                .getContentTypeWithRender(id, inode)
+                .subscribe((contentType: DotCMSContentType) => {
+                    expect(contentType).toEqual(contentTypeExpected);
+                    done();
+                });
+
+            const req = httpMock.expectOne(
+                (request) =>
+                    request.url === `/api/v1/contenttype/render/id/${id}` &&
+                    request.params.get('inode') === inode
+            );
+            expect(req.request.method).toBe('GET');
+            req.flush({ entity: contentTypeExpected });
+        });
+
+        it('should not include inode param when not provided', (done) => {
+            const id = 'no-inode-test';
+            const contentTypeExpected: DotCMSContentType = {
+                ...dotcmsContentTypeBasicMock,
+                clazz: 'clazz' as DotCMSClazz,
+                defaultType: false,
+                fixed: false,
+                folder: 'folder',
+                host: 'host',
+                id: id,
+                name: 'No Inode Test',
+                owner: 'user',
+                system: false
+            };
+
+            dotContentTypeService
+                .getContentTypeWithRender(id)
+                .subscribe((contentType: DotCMSContentType) => {
+                    expect(contentType).toEqual(contentTypeExpected);
+                    done();
+                });
+
+            const req = httpMock.expectOne(
+                (request) =>
+                    request.url === `/api/v1/contenttype/render/id/${id}` &&
+                    !request.params.has('inode')
+            );
+            expect(req.request.method).toBe('GET');
+            req.flush({ entity: contentTypeExpected });
+        });
+
         it('should only take the first emission due to take(1) operator', (done) => {
             const id = 'take-operator-test';
             const contentTypeExpected: DotCMSContentType = {

--- a/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-content-type/dot-content-type.service.ts
@@ -55,13 +55,23 @@ export class DotContentTypeService {
     }
 
     /**
-     * Get a content type by id or variable name with render mode
+     * Get a content type by id or variable name with render mode.
+     * When an inode is provided, contentlet-specific Velocity variables
+     * ($inode, $identifier, $lang, etc.) will be resolved in custom fields.
      * @param idOrVar content type's id or variable name
+     * @param inode optional contentlet inode for Velocity variable resolution
      * @returns Content Type
      */
-    getContentTypeWithRender(idOrVar: string): Observable<DotCMSContentType> {
+    getContentTypeWithRender(idOrVar: string, inode?: string): Observable<DotCMSContentType> {
+        let params = new HttpParams();
+        if (inode) {
+            params = params.set('inode', inode);
+        }
+
         return this.#httpClient
-            .get<{ entity: DotCMSContentType }>(`/api/v1/contenttype/render/id/${idOrVar}`)
+            .get<{ entity: DotCMSContentType }>(`/api/v1/contenttype/render/id/${idOrVar}`, {
+                params
+            })
             .pipe(
                 take(1),
                 map((data) => data.entity)

--- a/core-web/libs/edit-content/src/lib/store/features/content/content.feature.spec.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/content/content.feature.spec.ts
@@ -437,6 +437,16 @@ describe('ContentFeature', () => {
             expect(globalStore.addNewBreadcrumb).not.toHaveBeenCalled();
         }));
 
+        it('should pass inode to getContentTypeWithRender for Velocity variable resolution', fakeAsync(() => {
+            store.initializeExistingContent({ inode: testInode });
+            tick();
+
+            expect(contentTypeService.getContentTypeWithRender).toHaveBeenCalledWith(
+                mockContentlet.contentType,
+                testInode
+            );
+        }));
+
         it('should set initialContentletState to reset when no scheme or step', fakeAsync(() => {
             const mockContentlet = {
                 inode: '123',

--- a/core-web/libs/edit-content/src/lib/store/features/content/content.feature.ts
+++ b/core-web/libs/edit-content/src/lib/store/features/content/content.feature.ts
@@ -242,10 +242,10 @@ export function withContent() {
                                     const { contentType } = contentlet;
 
                                     return forkJoin({
-                                        contentType:
-                                            dotContentTypeService.getContentTypeWithRender(
-                                                contentType
-                                            ),
+                                        contentType: dotContentTypeService.getContentTypeWithRender(
+                                            contentType,
+                                            inode
+                                        ),
                                         // Allowed actions for this inode
                                         currentContentActions: workflowActionService.getByInode(
                                             inode,

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelper.java
@@ -559,23 +559,12 @@ public class ContentTypeHelper implements Serializable {
                 .collect(Collectors.toMap(Field::variable, f -> f, (a, b) -> a));
         try {
             final Context velocityContext = VelocityWebUtil.getVelocityContext(request, response);
-            velocityContext.put("structure", contentType);
-            if (contentlet != null) {
-                velocityContext.put("inode", contentlet.getInode());
-                velocityContext.put("identifier", contentlet.getIdentifier());
-                velocityContext.put("lang", contentlet.getLanguageId());
-                velocityContext.put("contentlet", contentlet);
-            }
             fieldsMap.forEach(fieldMap -> {
                 if (fieldMap.get("clazz").equals(ImmutableCustomField.class.getName())
                         && getCustomFieldRenderMode(fieldMap).equals(CustomField.RenderMode.COMPONENT)) {
                     try {
                         final Field fieldObj = fieldsByVar.get(fieldMap.get("variable"));
-                        if (fieldObj != null) {
-                            velocityContext.put("field", fieldObj);
-                        } else {
-                            velocityContext.remove("field");
-                        }
+                        loadVelocityContextVariables(velocityContext, contentType, contentlet, fieldObj);
                         final String textValue = (String) fieldMap.getOrDefault("values", BLANK);
                         final String htmlString = new VelocityUtil().parseVelocity(textValue, velocityContext);
                         fieldMap.put("rendered", htmlString);
@@ -589,6 +578,36 @@ public class ContentTypeHelper implements Serializable {
             Logger.error(ContentTypeHelper.class, String.format(
                     "Failed to initialize Velocity context for Custom Field rendering: %s",
                     ExceptionUtil.getErrorMessage(e)));
+        }
+    }
+
+    /**
+     * Injects Velocity context variables available during Custom Field rendering.
+     * <p>
+     * Always: {@code $structure}. Per field: {@code $field}.
+     * When a contentlet is present: {@code $inode}, {@code $identifier}, {@code $lang},
+     * {@code $contentlet}.
+     *
+     * @param velocityContext The Velocity context to enrich.
+     * @param contentType     The content type being rendered.
+     * @param contentlet      The contentlet being edited, or {@code null} for new content.
+     * @param field           The field currently being rendered, or {@code null} if not found.
+     */
+    private void loadVelocityContextVariables(final Context velocityContext,
+                                              final ContentType contentType,
+                                              final Contentlet contentlet,
+                                              final Field field) {
+        velocityContext.put("structure", contentType);
+        if (contentlet != null) {
+            velocityContext.put("inode", contentlet.getInode());
+            velocityContext.put("identifier", contentlet.getIdentifier());
+            velocityContext.put("lang", contentlet.getLanguageId());
+            velocityContext.put("contentlet", contentlet);
+        }
+        if (field != null) {
+            velocityContext.put("field", field);
+        } else {
+            velocityContext.remove("field");
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelper.java
@@ -511,7 +511,7 @@ public class ContentTypeHelper implements Serializable {
                 contentType, contentTypeInternationalization
         ).mapObject();
         if (renderCustomFields) {
-            this.includeRenderedCustomFields(contentTypeMap, user, contentletInode);
+            this.includeRenderedCustomFields(contentTypeMap, contentType, user, contentletInode);
         }
         try {
             // Add the detail page path to the map
@@ -531,40 +531,52 @@ public class ContentTypeHelper implements Serializable {
      * Custom Field. When it does that, it adds a new attribute named {@code 'rendered'} with the
      * generated HTML/JavaScript code.
      * <p>
-     * If a contentlet inode is provided, contentlet-specific Velocity variables ({@code $inode},
-     * {@code $identifier}, {@code $lang}, {@code $contentlet}) will be available during rendering,
-     * matching the behavior of the legacy content editor.
+     * The following Velocity variables are always available during rendering:
+     * {@code $structure} (the Content Type) and {@code $field} (the current field being rendered).
+     * <p>
+     * If a contentlet inode is provided, contentlet-specific variables ({@code $inode},
+     * {@code $identifier}, {@code $lang}, {@code $contentlet}) are also injected, matching the
+     * behavior of the legacy content editor.
      *
      * @param contentTypeMap  The {@link Map} containing all the Content Type's properties,
      *                        including its fields.
+     * @param contentType     The {@link ContentType} object being rendered.
      * @param user            The {@link User} requesting this information.
      * @param contentletInode Optional contentlet inode for enriching the Velocity context.
      */
     @SuppressWarnings("unchecked")
     private void includeRenderedCustomFields(final Map<String, Object> contentTypeMap,
+                                             final ContentType contentType,
                                              final User user,
                                              final String contentletInode) {
         final List<Map<String, Object>> fieldsMap = (List<Map<String, Object>>) contentTypeMap.get("fields");
         final HttpServletRequest request = HttpServletRequestThreadLocal.INSTANCE.getRequest();
         final HttpServletResponse response = HttpServletResponseThreadLocal.INSTANCE.getResponse();
         final Contentlet contentlet = loadContentletIfPresent(contentletInode, user);
-        fieldsMap.forEach(field -> {
-            if (field.get("clazz").equals(ImmutableCustomField.class.getName())
-                    && getCustomFieldRenderMode(field).equals(CustomField.RenderMode.COMPONENT)) {
+        final Map<String, Field> fieldsByVar = contentType.fields().stream()
+                .collect(Collectors.toMap(Field::variable, f -> f, (a, b) -> a));
+        fieldsMap.forEach(fieldMap -> {
+            if (fieldMap.get("clazz").equals(ImmutableCustomField.class.getName())
+                    && getCustomFieldRenderMode(fieldMap).equals(CustomField.RenderMode.COMPONENT)) {
                 try {
                     final Context velocityContext = VelocityWebUtil.getVelocityContext(request, response);
+                    velocityContext.put("structure", contentType);
+                    final Field fieldObj = fieldsByVar.get(fieldMap.get("variable"));
+                    if (fieldObj != null) {
+                        velocityContext.put("field", fieldObj);
+                    }
                     if (contentlet != null) {
                         velocityContext.put("inode", contentlet.getInode());
                         velocityContext.put("identifier", contentlet.getIdentifier());
                         velocityContext.put("lang", contentlet.getLanguageId());
                         velocityContext.put("contentlet", contentlet);
                     }
-                    final String textValue = (String) field.getOrDefault("values", BLANK);
+                    final String textValue = (String) fieldMap.getOrDefault("values", BLANK);
                     final String htmlString = new VelocityUtil().parseVelocity(textValue, velocityContext);
-                    field.put("rendered", htmlString);
+                    fieldMap.put("rendered", htmlString);
                 } catch (final Exception e) {
                     Logger.error(JsonContentTypeTransformer.class, String.format("Failed to render Custom Field " +
-                            "'%s': %s", field.get("variable"), ExceptionUtil.getErrorMessage(e)));
+                            "'%s': %s", fieldMap.get("variable"), ExceptionUtil.getErrorMessage(e)));
                 }
             }
         });

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelper.java
@@ -535,71 +535,98 @@ public class ContentTypeHelper implements Serializable {
      * {@code $structure} (the Content Type) and {@code $field} (the current field being rendered).
      * <p>
      * If a contentlet inode is provided, contentlet-specific variables ({@code $inode},
-     * {@code $identifier}, {@code $lang}, {@code $contentlet}) are also injected, matching the
-     * behavior of the legacy content editor.
+     * {@code $identifier}, {@code $lang}, {@code $contentlet}) are also injected when the
+     * contentlet can be loaded and belongs to the requested content type.
      *
      * @param contentTypeMap  The {@link Map} containing all the Content Type's properties,
      *                        including its fields.
      * @param contentType     The {@link ContentType} object being rendered.
      * @param user            The {@link User} requesting this information.
      * @param contentletInode Optional contentlet inode for enriching the Velocity context.
+     *
+     * @throws DotSecurityException If the user lacks permission to read the specified contentlet.
      */
     @SuppressWarnings("unchecked")
     private void includeRenderedCustomFields(final Map<String, Object> contentTypeMap,
                                              final ContentType contentType,
                                              final User user,
-                                             final String contentletInode) {
+                                             final String contentletInode) throws DotSecurityException {
         final List<Map<String, Object>> fieldsMap = (List<Map<String, Object>>) contentTypeMap.get("fields");
         final HttpServletRequest request = HttpServletRequestThreadLocal.INSTANCE.getRequest();
         final HttpServletResponse response = HttpServletResponseThreadLocal.INSTANCE.getResponse();
-        final Contentlet contentlet = loadContentletIfPresent(contentletInode, user);
+        final Contentlet contentlet = loadContentletIfPresent(contentletInode, contentType, user);
         final Map<String, Field> fieldsByVar = contentType.fields().stream()
                 .collect(Collectors.toMap(Field::variable, f -> f, (a, b) -> a));
-        fieldsMap.forEach(fieldMap -> {
-            if (fieldMap.get("clazz").equals(ImmutableCustomField.class.getName())
-                    && getCustomFieldRenderMode(fieldMap).equals(CustomField.RenderMode.COMPONENT)) {
-                try {
-                    final Context velocityContext = VelocityWebUtil.getVelocityContext(request, response);
-                    velocityContext.put("structure", contentType);
-                    final Field fieldObj = fieldsByVar.get(fieldMap.get("variable"));
-                    if (fieldObj != null) {
-                        velocityContext.put("field", fieldObj);
-                    }
-                    if (contentlet != null) {
-                        velocityContext.put("inode", contentlet.getInode());
-                        velocityContext.put("identifier", contentlet.getIdentifier());
-                        velocityContext.put("lang", contentlet.getLanguageId());
-                        velocityContext.put("contentlet", contentlet);
-                    }
-                    final String textValue = (String) fieldMap.getOrDefault("values", BLANK);
-                    final String htmlString = new VelocityUtil().parseVelocity(textValue, velocityContext);
-                    fieldMap.put("rendered", htmlString);
-                } catch (final Exception e) {
-                    Logger.error(JsonContentTypeTransformer.class, String.format("Failed to render Custom Field " +
-                            "'%s': %s", fieldMap.get("variable"), ExceptionUtil.getErrorMessage(e)));
-                }
+        try {
+            final Context velocityContext = VelocityWebUtil.getVelocityContext(request, response);
+            velocityContext.put("structure", contentType);
+            if (contentlet != null) {
+                velocityContext.put("inode", contentlet.getInode());
+                velocityContext.put("identifier", contentlet.getIdentifier());
+                velocityContext.put("lang", contentlet.getLanguageId());
+                velocityContext.put("contentlet", contentlet);
             }
-        });
+            fieldsMap.forEach(fieldMap -> {
+                if (fieldMap.get("clazz").equals(ImmutableCustomField.class.getName())
+                        && getCustomFieldRenderMode(fieldMap).equals(CustomField.RenderMode.COMPONENT)) {
+                    try {
+                        final Field fieldObj = fieldsByVar.get(fieldMap.get("variable"));
+                        if (fieldObj != null) {
+                            velocityContext.put("field", fieldObj);
+                        } else {
+                            velocityContext.remove("field");
+                        }
+                        final String textValue = (String) fieldMap.getOrDefault("values", BLANK);
+                        final String htmlString = new VelocityUtil().parseVelocity(textValue, velocityContext);
+                        fieldMap.put("rendered", htmlString);
+                    } catch (final Exception e) {
+                        Logger.error(JsonContentTypeTransformer.class, String.format("Failed to render Custom Field " +
+                                "'%s': %s", fieldMap.get("variable"), ExceptionUtil.getErrorMessage(e)));
+                    }
+                }
+            });
+        } catch (final Exception e) {
+            Logger.error(ContentTypeHelper.class, String.format(
+                    "Failed to initialize Velocity context for Custom Field rendering: %s",
+                    ExceptionUtil.getErrorMessage(e)));
+        }
     }
 
     /**
-     * Loads a {@link Contentlet} by inode if the inode is set.
+     * Loads a {@link Contentlet} by inode if the inode is set and belongs to the given content type.
      *
      * @param contentletInode The inode of the contentlet to load.
+     * @param contentType     The content type being rendered; used to validate the contentlet.
      * @param user            The user performing the lookup.
      *
-     * @return The {@link Contentlet} if found, or {@code null} if the inode is not set or the
-     *         contentlet cannot be found.
+     * @return The {@link Contentlet} if found and matching the content type, or {@code null} if
+     *         the inode is not set, the contentlet cannot be found, or it belongs to another type.
+     *
+     * @throws DotSecurityException If the user lacks permission to read the contentlet.
      */
-    private Contentlet loadContentletIfPresent(final String contentletInode, final User user) {
+    @VisibleForTesting
+    Contentlet loadContentletIfPresent(final String contentletInode, final ContentType contentType,
+                                       final User user) throws DotSecurityException {
         if (!UtilMethods.isSet(contentletInode)) {
             return null;
         }
-        return Try.of(() -> APILocator.getContentletAPI().find(contentletInode, user, false))
-                .onFailure(e -> Logger.warn(ContentTypeHelper.class,
-                        String.format("Could not load contentlet with inode '%s' for Custom Field " +
-                                "rendering: %s", contentletInode, e.getMessage())))
-                .getOrNull();
+        try {
+            final Contentlet contentlet = APILocator.getContentletAPI().find(contentletInode, user, false);
+            if (contentlet != null && !contentType.id().equals(contentlet.getContentType().id())) {
+                Logger.warn(ContentTypeHelper.class, String.format(
+                        "Contentlet inode '%s' does not belong to content type '%s'; ignoring inode for Custom Field rendering.",
+                        contentletInode, contentType.id()));
+                return null;
+            }
+            return contentlet;
+        } catch (final DotSecurityException e) {
+            throw e;
+        } catch (final Exception e) {
+            Logger.warn(ContentTypeHelper.class,
+                    String.format("Could not load contentlet with inode '%s' for Custom Field " +
+                            "rendering: %s", contentletInode, e.getMessage()));
+            return null;
+        }
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelper.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.dotcms.workflow.form.WorkflowSystemActionForm;
 import com.dotcms.workflow.helper.WorkflowHelper;
 import com.dotmarketing.business.APILocator;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
@@ -477,12 +478,40 @@ public class ContentTypeHelper implements Serializable {
                                                 final ContentTypeInternationalization contentTypeInternationalization,
                                                 final boolean renderCustomFields, final User user)
             throws DotDataException, DotSecurityException {
+        return contentTypeToMap(contentType, contentTypeInternationalization,
+                renderCustomFields, user, null);
+    }
+
+    /**
+     * Converts a ContentType object to a Map representation for use as a response.
+     *
+     * @param contentType                     The {@link ContentType} object to convert.
+     * @param contentTypeInternationalization The {@link ContentTypeInternationalization} object
+     *                                        with the parameters to internationalize the Content
+     *                                        Type's fields.
+     * @param renderCustomFields              Defaults to {@code false}. If Custom Fields must
+     *                                        include an attribute with their Velocity code parsed,
+     *                                        set this to {@code true}.
+     * @param user                            The {@link User} requesting this information.
+     * @param contentletInode                 Optional contentlet inode for providing
+     *                                        contentlet-specific Velocity variables when rendering.
+     *
+     * @return The Map with properties from the specified Content Type.
+     *
+     * @throws DotDataException     An error occurred while interacting with the database.
+     * @throws DotSecurityException If there are security restrictions preventing the conversion.
+     */
+    public Map<String, Object> contentTypeToMap(final ContentType contentType,
+                                                final ContentTypeInternationalization contentTypeInternationalization,
+                                                final boolean renderCustomFields, final User user,
+                                                final String contentletInode)
+            throws DotDataException, DotSecurityException {
         // Transform the content type to a map
         var contentTypeMap = new JsonContentTypeTransformer(
                 contentType, contentTypeInternationalization
         ).mapObject();
         if (renderCustomFields) {
-            this.includeRenderedCustomFields(contentTypeMap);
+            this.includeRenderedCustomFields(contentTypeMap, user, contentletInode);
         }
         try {
             // Add the detail page path to the map
@@ -501,20 +530,35 @@ public class ContentTypeHelper implements Serializable {
      * Inspects the fields inside a Content Type, and parses the Velocity code in every single
      * Custom Field. When it does that, it adds a new attribute named {@code 'rendered'} with the
      * generated HTML/JavaScript code.
+     * <p>
+     * If a contentlet inode is provided, contentlet-specific Velocity variables ({@code $inode},
+     * {@code $identifier}, {@code $lang}, {@code $contentlet}) will be available during rendering,
+     * matching the behavior of the legacy content editor.
      *
-     * @param contentTypeMap The {@link Map} containing all the Content Type's properties, including
-     *                       its fields.
+     * @param contentTypeMap  The {@link Map} containing all the Content Type's properties,
+     *                        including its fields.
+     * @param user            The {@link User} requesting this information.
+     * @param contentletInode Optional contentlet inode for enriching the Velocity context.
      */
     @SuppressWarnings("unchecked")
-    private void includeRenderedCustomFields(final Map<String, Object> contentTypeMap) {
+    private void includeRenderedCustomFields(final Map<String, Object> contentTypeMap,
+                                             final User user,
+                                             final String contentletInode) {
         final List<Map<String, Object>> fieldsMap = (List<Map<String, Object>>) contentTypeMap.get("fields");
         final HttpServletRequest request = HttpServletRequestThreadLocal.INSTANCE.getRequest();
         final HttpServletResponse response = HttpServletResponseThreadLocal.INSTANCE.getResponse();
+        final Contentlet contentlet = loadContentletIfPresent(contentletInode, user);
         fieldsMap.forEach(field -> {
             if (field.get("clazz").equals(ImmutableCustomField.class.getName())
                     && getCustomFieldRenderMode(field).equals(CustomField.RenderMode.COMPONENT)) {
                 try {
                     final Context velocityContext = VelocityWebUtil.getVelocityContext(request, response);
+                    if (contentlet != null) {
+                        velocityContext.put("inode", contentlet.getInode());
+                        velocityContext.put("identifier", contentlet.getIdentifier());
+                        velocityContext.put("lang", contentlet.getLanguageId());
+                        velocityContext.put("contentlet", contentlet);
+                    }
                     final String textValue = (String) field.getOrDefault("values", BLANK);
                     final String htmlString = new VelocityUtil().parseVelocity(textValue, velocityContext);
                     field.put("rendered", htmlString);
@@ -524,6 +568,26 @@ public class ContentTypeHelper implements Serializable {
                 }
             }
         });
+    }
+
+    /**
+     * Loads a {@link Contentlet} by inode if the inode is set.
+     *
+     * @param contentletInode The inode of the contentlet to load.
+     * @param user            The user performing the lookup.
+     *
+     * @return The {@link Contentlet} if found, or {@code null} if the inode is not set or the
+     *         contentlet cannot be found.
+     */
+    private Contentlet loadContentletIfPresent(final String contentletInode, final User user) {
+        if (!UtilMethods.isSet(contentletInode)) {
+            return null;
+        }
+        return Try.of(() -> APILocator.getContentletAPI().find(contentletInode, user, false))
+                .onFailure(e -> Logger.warn(ContentTypeHelper.class,
+                        String.format("Could not load contentlet with inode '%s' for Custom Field " +
+                                "rendering: %s", contentletInode, e.getMessage())))
+                .getOrNull();
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/contenttype/ContentTypeResource.java
@@ -1172,7 +1172,7 @@ public class ContentTypeResource implements Serializable {
 			@QueryParam("live") @Parameter(
 					description = "Determines whether live versions of language variables are used in the returned object.",
 					schema = @Schema(type = "boolean")) final Boolean paramLive) throws DotDataException {
-		return retrieveContentType(req, res, idOrVar, languageId, paramLive, false);
+		return retrieveContentType(req, res, idOrVar, languageId, paramLive, false, null);
 	}
 
 	@GET
@@ -1253,9 +1253,14 @@ public class ContentTypeResource implements Serializable {
 					schema = @Schema(type = "integer")) final Long languageId,
 			@QueryParam("live") @Parameter(
 					description = "Determines whether live versions of language variables are used in the returned object.",
-					schema = @Schema(type = "boolean")) final Boolean paramLive) throws DotDataException {
+					schema = @Schema(type = "boolean")) final Boolean paramLive,
+			@QueryParam("inode") @Parameter(
+					description = "Optional contentlet inode. When provided, contentlet-specific " +
+								  "Velocity variables ($inode, $identifier, $lang, etc.) will be " +
+								  "available when rendering Custom Fields.",
+					schema = @Schema(type = "string")) final String contentletInode) throws DotDataException {
 		req.setAttribute("contentTypeId", idOrVar);
-		return retrieveContentType(req, res, idOrVar, languageId, paramLive, true);
+		return retrieveContentType(req, res, idOrVar, languageId, paramLive, true, contentletInode);
 	}
 
 	/**
@@ -1270,6 +1275,8 @@ public class ContentTypeResource implements Serializable {
 	 *                           the returned object.
 	 * @param renderCustomFields If the Velocity code in all Custom Fields must be parsed, set this
 	 *                           to {@code true}.
+	 * @param contentletInode    Optional contentlet inode for providing contentlet-specific
+	 *                           Velocity variables when rendering Custom Fields.
 	 *
 	 * @return The specified {@link ContentType} in its JSON format.
 	 *
@@ -1278,7 +1285,8 @@ public class ContentTypeResource implements Serializable {
 	private Response retrieveContentType(final HttpServletRequest httpRequest,
 										 final HttpServletResponse httpResponse, final String idOrVar,
 										 final Long languageId, final Boolean paramLive,
-										 final boolean renderCustomFields) throws DotDataException {
+										 final boolean renderCustomFields,
+										 final String contentletInode) throws DotDataException {
 		final InitDataObject initData = this.webResource.init(null, httpRequest, httpResponse, false, null);
 		final User user = initData.getUser();
 		final ContentTypeAPI tapi = APILocator.getContentTypeAPI(user, true);
@@ -1305,7 +1313,8 @@ public class ContentTypeResource implements Serializable {
 					new ContentTypeInternationalization(languageId, live, user) : null;
 			final ImmutableMap<String, Object> resultMap = ImmutableMap.<String, Object>builder()
 					.putAll(contentTypeHelper.contentTypeToMap(type,
-							contentTypeInternationalization, renderCustomFields, user))
+							contentTypeInternationalization, renderCustomFields, user,
+							contentletInode))
 					.put(MAP_KEY_WORKFLOWS, this.workflowHelper.findSchemesByContentType(
 							type.id(), initData.getUser()))
 					.put(MAP_KEY_SYSTEM_ACTION_MAPPINGS,

--- a/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
+++ b/dotCMS/src/main/webapp/WEB-INF/openapi/openapi.yaml
@@ -8322,6 +8322,13 @@ paths:
         name: live
         schema:
           type: boolean
+      - description: "Optional contentlet inode. When provided, contentlet-specific\
+          \ Velocity variables ($inode, $identifier, $lang, etc.) will be available\
+          \ when rendering Custom Fields."
+        in: query
+        name: inode
+        schema:
+          type: string
       responses:
         "200":
           content:

--- a/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/text_count_new.vtl
+++ b/dotCMS/src/main/webapp/WEB-INF/velocity/static/htmlpage_assets/text_count_new.vtl
@@ -11,8 +11,6 @@
     const countRemaining = document.getElementById(
       "charactersRemaining-${fieldId}",
     );
-    console.log(countRemaining);
-    console.log(textEntered);
     const counterText = document.getElementById("${fieldId}-counter-text");
 
     countRemaining.textContent = counter;

--- a/dotCMS/src/main/webapp/html/legacy_custom_field/legacy-custom-field.jsp
+++ b/dotCMS/src/main/webapp/html/legacy_custom_field/legacy-custom-field.jsp
@@ -325,7 +325,14 @@
 
                 if(UtilMethods.isSet(textValue)){
                     org.apache.velocity.context.Context velocityContext =  com.dotmarketing.util.web.VelocityWebUtil.getVelocityContext(request,response);
-                    // Set velocity variable if not already set
+                    if (contentlet != null && UtilMethods.isSet(contentlet.getInode())) {
+                        velocityContext.put("inode", contentlet.getInode());
+                        velocityContext.put("identifier", contentlet.getIdentifier());
+                        velocityContext.put("lang", contentlet.getLanguageId());
+                        velocityContext.put("contentlet", contentlet);
+                        velocityContext.put("structure", contentType);
+                    }
+                    velocityContext.put("field", field);
                     if(!UtilMethods.isSet(velocityContext.get(field.variable()))){
                         if(UtilMethods.isSet(value)){
                             velocityContext.put(field.variable(), value);

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
@@ -564,8 +564,8 @@
                                 request.setAttribute("host", hostId);
                             }
                         }
-							request.setAttribute("inode",contentlet.getInode());
-							request.setAttribute("counter", catCounter.toString());
+						request.setAttribute("inode",contentlet.getInode());
+						request.setAttribute("counter", catCounter.toString());
                     %>
 
                     <%if(contentlet.isCalendarEvent()){

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/edit_contentlet.jsp
@@ -564,8 +564,8 @@
                                 request.setAttribute("host", hostId);
                             }
                         }
-                        request.setAttribute("inode",contentlet.getInode());
-                        request.setAttribute("counter", catCounter.toString());
+							request.setAttribute("inode",contentlet.getInode());
+							request.setAttribute("counter", catCounter.toString());
                     %>
 
                     <%if(contentlet.isCalendarEvent()){

--- a/dotCMS/src/test/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelperInodeTest.java
+++ b/dotCMS/src/test/java/com/dotcms/rest/api/v1/contenttype/ContentTypeHelperInodeTest.java
@@ -1,0 +1,145 @@
+package com.dotcms.rest.api.v1.contenttype;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.dotcms.UnitTestBase;
+import com.dotcms.contenttype.business.ContentTypeAPI;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.ContentTypeBuilder;
+import com.dotcms.contenttype.model.type.SimpleContentType;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
+import com.liferay.portal.model.User;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for {@link ContentTypeHelper#loadContentletIfPresent(String, ContentType, User)}.
+ */
+public class ContentTypeHelperInodeTest extends UnitTestBase {
+
+    private static final String INODE = "test-inode-123";
+    private static final String TYPE_A_ID = "content-type-a";
+    private static final String TYPE_B_ID = "content-type-b";
+
+    private ContentType contentTypeA() {
+        return ContentTypeBuilder.builder(SimpleContentType.class)
+                .id(TYPE_A_ID)
+                .name("Type A")
+                .variable("typeA")
+                .build();
+    }
+
+    private ContentType contentTypeB() {
+        return ContentTypeBuilder.builder(SimpleContentType.class)
+                .id(TYPE_B_ID)
+                .name("Type B")
+                .variable("typeB")
+                .build();
+    }
+
+    private Contentlet contentletOfType(final ContentType type) {
+        final Contentlet contentlet = new Contentlet();
+        contentlet.setInode(INODE);
+        contentlet.setContentType(type);
+        return contentlet;
+    }
+
+    @Test
+    public void testLoadContentletIfPresent_whenInodeNotSet_returnsNull() throws DotSecurityException {
+        final ContentTypeHelper helper = ContentTypeHelper.getInstance();
+        assertNull(helper.loadContentletIfPresent(null, contentTypeA(), mock(User.class)));
+        assertNull(helper.loadContentletIfPresent("", contentTypeA(), mock(User.class)));
+    }
+
+    @Test
+    public void testLoadContentletIfPresent_whenContentletMatchesType_returnsContentlet()
+            throws Exception {
+        final User user = mock(User.class);
+        final ContentType requestedType = contentTypeA();
+        final Contentlet contentlet = contentletOfType(requestedType);
+        final ContentletAPI contentletAPI = mock(ContentletAPI.class);
+        final ContentTypeAPI contentTypeAPI = mock(ContentTypeAPI.class);
+
+        when(contentletAPI.find(INODE, user, false)).thenReturn(contentlet);
+        when(contentTypeAPI.find(TYPE_A_ID)).thenReturn(requestedType);
+
+        try (MockedStatic<APILocator> apiLocator = Mockito.mockStatic(APILocator.class)) {
+            apiLocator.when(APILocator::getContentletAPI).thenReturn(contentletAPI);
+            apiLocator.when(() -> APILocator.getContentTypeAPI(user)).thenReturn(contentTypeAPI);
+            apiLocator.when(APILocator::systemUser).thenReturn(user);
+
+            final Contentlet result = ContentTypeHelper.getInstance()
+                    .loadContentletIfPresent(INODE, requestedType, user);
+
+            assertSame(contentlet, result);
+        }
+    }
+
+    @Test
+    public void testLoadContentletIfPresent_whenContentletTypeMismatch_returnsNull() throws Exception {
+        final User user = mock(User.class);
+        final ContentType requestedType = contentTypeA();
+        final ContentType actualType = contentTypeB();
+        final Contentlet contentlet = contentletOfType(actualType);
+        final ContentletAPI contentletAPI = mock(ContentletAPI.class);
+        final ContentTypeAPI contentTypeAPI = mock(ContentTypeAPI.class);
+
+        when(contentletAPI.find(INODE, user, false)).thenReturn(contentlet);
+        when(contentTypeAPI.find(TYPE_B_ID)).thenReturn(actualType);
+
+        try (MockedStatic<APILocator> apiLocator = Mockito.mockStatic(APILocator.class)) {
+            apiLocator.when(APILocator::getContentletAPI).thenReturn(contentletAPI);
+            apiLocator.when(() -> APILocator.getContentTypeAPI(user)).thenReturn(contentTypeAPI);
+            apiLocator.when(APILocator::systemUser).thenReturn(user);
+
+            final Contentlet result = ContentTypeHelper.getInstance()
+                    .loadContentletIfPresent(INODE, requestedType, user);
+
+            assertNull(result);
+        }
+    }
+
+    @Test
+    public void testLoadContentletIfPresent_whenSecurityException_propagates() throws Exception {
+        final User user = mock(User.class);
+        final ContentletAPI contentletAPI = mock(ContentletAPI.class);
+        final DotSecurityException securityException = new DotSecurityException("access denied");
+
+        when(contentletAPI.find(INODE, user, false)).thenThrow(securityException);
+
+        try (MockedStatic<APILocator> apiLocator = Mockito.mockStatic(APILocator.class)) {
+            apiLocator.when(APILocator::getContentletAPI).thenReturn(contentletAPI);
+
+            try {
+                ContentTypeHelper.getInstance().loadContentletIfPresent(INODE, contentTypeA(), user);
+                fail("Expected DotSecurityException");
+            } catch (DotSecurityException e) {
+                assertSame(securityException, e);
+            }
+        }
+    }
+
+    @Test
+    public void testLoadContentletIfPresent_whenDataException_returnsNull() throws Exception {
+        final User user = mock(User.class);
+        final ContentletAPI contentletAPI = mock(ContentletAPI.class);
+
+        when(contentletAPI.find(INODE, user, false)).thenThrow(new DotDataException("not found"));
+
+        try (MockedStatic<APILocator> apiLocator = Mockito.mockStatic(APILocator.class)) {
+            apiLocator.when(APILocator::getContentletAPI).thenReturn(contentletAPI);
+
+            assertNull(ContentTypeHelper.getInstance()
+                    .loadContentletIfPresent(INODE, contentTypeA(), user));
+        }
+    }
+}


### PR DESCRIPTION
This pull request enhances the rendering of custom fields in content types by allowing contentlet-specific Velocity variables (such as `$inode`, `$identifier`, `$lang`, and `$contentlet`) to be resolved when an inode is provided. This enables more dynamic and context-aware rendering of custom fields, especially for scenarios that require contentlet-specific information. The changes span both backend (Java) and frontend (Angular) code, ensuring that the optional inode parameter is supported end-to-end, and that tests cover the new behavior.

**Backend: Content Type Rendering Enhancements**

* Added support for an optional `inode` query parameter to the `/contenttype/render/id/{idOrVar}` endpoint, making contentlet-specific Velocity variables available when rendering custom fields. This includes updating the API, resource, and helper methods to accept and utilize the inode for Velocity context enrichment.
* The Velocity context used for rendering custom fields now includes contentlet-specific variables when a valid inode is provided and the contentlet belongs to the requested content type. Mismatched or unloadable inodes are ignored; permission errors propagate as 403.
* Added backend unit tests for inode loading, content-type validation, and security error propagation.

**Frontend: Service and Store Updates**

* Updated `DotContentTypeService.getContentTypeWithRender` to accept an optional `inode` parameter and include it as a query param when provided.
* Modified the content feature store to pass the inode to `getContentTypeWithRender` when initializing existing content, ensuring the backend receives the necessary context for Velocity variable resolution.

**Testing Improvements**

* Added and updated unit tests to verify that the inode parameter is correctly handled in the service, that the content feature store passes the inode as expected, and that backend inode validation behaves correctly.

**Documentation**

* Updated the VTL migration skill with server-side context variable documentation (`$inode`, `$identifier`, `$lang`, `$contentlet`, `$structure`, `$field`).

**Minor Cleanups**

* Removed unnecessary debug logging from a Velocity template.

These changes ensure that custom field rendering is more robust and context-aware, particularly for use cases that depend on contentlet-specific data.

This PR fixes: #35686

This PR fixes: #35686