### PR TITLE
chore(slack-mappings): correct swicken login and add adrianjm-dotCMS

### DIFF
--- a/.github/data/slack-mappings.json
+++ b/.github/data/slack-mappings.json
@@ -44,7 +44,7 @@
     "slack_id": "U01NX13C0Q2"
   },
   {
-    "github_user": "swicken-dotcms",
+    "github_user": "swicken",
     "slack_id": "U01M8SU62NR"
   },
   {
@@ -130,5 +130,9 @@
   {
     "github_user": "hassandotcms",
     "slack_id": "U095M9B8HC6"
+  },
+  {
+    "github_user": "adrianjm-dotCMS",
+    "slack_id": "U09LGQVCBLK"
   }
 ]


### PR DESCRIPTION
Closes #35835

## Summary

Two updates to `.github/data/slack-mappings.json` so release QA notifications @-mention these contributors instead of falling back to plain `@login`:

- Rename `swicken-dotcms` → `swicken` (actual GitHub login)
- Add `adrianjm-dotCMS` → `U09LGQVCBLK`

## Notes

- Data-only change; no code touched.
- The Slack formatter (PR #35815) reads this file at release time and falls back to plain `@login` for anyone not listed, so this is a non-breaking incremental improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)