### PR TITLE
fix(release-qa): deep-link Slack counts to bucket sections via user-content- anchors

### DIFF
--- a/.github/scripts/release-qa-status/src/format.test.ts
+++ b/.github/scripts/release-qa-status/src/format.test.ts
@@ -92,10 +92,10 @@ describe('renderSlack', () => {
       failed: [pr(1, 't', 'failed')],
     });
     const out = renderSlack(r, { detailUrl: 'https://example.com/run/123' });
-    expect(out).toContain('<https://example.com/run/123#qa-failed|failed QA: 1>');
-    expect(out).toContain('<https://example.com/run/123#qa-missing|missing QA: 0>');
-    expect(out).toContain('<https://example.com/run/123#qa-orphan|Orphan PRs: 0>');
-    expect(out).toContain('<https://example.com/run/123#outside-dotcms-core|Not in the core repo: 0>');
+    expect(out).toContain('<https://example.com/run/123#user-content-qa-failed|failed QA: 1>');
+    expect(out).toContain('<https://example.com/run/123#user-content-qa-missing|missing QA: 0>');
+    expect(out).toContain('<https://example.com/run/123#user-content-qa-orphan|Orphan PRs: 0>');
+    expect(out).toContain('<https://example.com/run/123#user-content-outside-dotcms-core|Not in the core repo: 0>');
   });
 
   it('omits detailUrl wrapping when none is provided', () => {

--- a/.github/scripts/release-qa-status/src/format.ts
+++ b/.github/scripts/release-qa-status/src/format.ts
@@ -252,12 +252,17 @@ export function renderSlack(
 }
 
 /** Build the four-bucket count line. Each cell deep-links to its bucket
- *  anchor on the detail page when detailUrl is set. */
+ *  anchor on the detail page when detailUrl is set.
+ *
+ *  GitHub's markdown sanitizer prefixes anchor ids in the job summary with
+ *  `user-content-`, so the working fragment is `#user-content-<anchor>` even
+ *  though the source markdown declares `<a id="<anchor>">`. Linking to the
+ *  bare `#<anchor>` lands at the top of the page. */
 function slackCounts(s: ReleaseQAReport['summary'], detailUrl?: string): string {
   const cell = (label: string, n: number, key: BucketKey): string => {
     const text = `${label}: ${n}`;
     if (!detailUrl) return text;
-    return `<${detailUrl}#${STATUS_HEADERS[key].anchor}|${text}>`;
+    return `<${detailUrl}#user-content-${STATUS_HEADERS[key].anchor}|${text}>`;
   };
   return [
     cell('failed QA', s.failed, 'failed'),


### PR DESCRIPTION
Closes #35841

## Problem

Each bucket count in the release QA Slack notification links to the workflow run summary with a per-bucket fragment (e.g. `#qa-missing`), but clicking it lands at the **top** of the run page rather than the bucket section.

Example: https://github.com/dotCMS/core/actions/runs/26459945291#qa-missing

## Root cause

GitHub's markdown sanitizer prefixes anchor `id`s in the job summary with `user-content-`. The summary declares `<a id="qa-missing">` but the rendered element is `id="user-content-qa-missing"`, so `#qa-missing` matches nothing.

## Fix

Point the Slack count links at `#user-content-<anchor>`. The markdown anchor markers are unchanged — GitHub adds the prefix on render. One-line change in `slackCounts` plus the corresponding test assertions.

## Notes

- Follow-up to merged PR #35815 (the original branch was deleted on merge, hence a new branch/PR).
- Tests: 37/37 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)