### PR TITLE
fix(content-types): preserve editor state across tab navigation

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/app.routes.ts
+++ b/core-web/apps/dotcms-ui/src/app/app.routes.ts
@@ -48,9 +48,6 @@ const PORTLETS_ANGULAR: Route[] = [
         path: 'content-types-angular',
         canActivate: [MenuGuardService],
         canActivateChild: [MenuGuardService],
-        data: {
-            reuseRoute: false
-        },
         loadChildren: () =>
             import('@portlets/dot-content-types/dot-content-types.routes').then(
                 (m) => m.dotContentTypesRoutes


### PR DESCRIPTION
## Summary

Removes `data: { reuseRoute: false }` from the `content-types-angular` wrapper route in `app.routes.ts`. The flag was forcing destruction of the entire content-type editor subtree on every internal tab navigation, wiping the in-memory layout that `DotContentTypesEditComponent` had just updated from a successful field mutation.

Closes #35812

## The bug

In the content-type editor (`/dotAdmin/#/content-types-angular/edit/{id}/fields`), when the user mutated the field layout in any way and then switched to another tab (e.g. `style-editor`, `permissions`, `push-history`) and came back, the mutation appeared lost. A full page refresh was the only way to see the real current state.

This affected **every** local layout mutation:

- **Add field** — the new field disappeared on tab return
- **Delete field** — the deleted field reappeared on tab return
- **Edit field** — name/setting changes were rolled back on tab return
- **Drag and drop reorder** — the reordering was lost on tab return

## Root cause

`DotCustomReuseStrategyService.shouldReuseRoute()` reads `future.data?.reuseRoute` and returns `false` when that flag is `false`. When Angular's `RouteReuseStrategy` returns `false` for any route segment, **it destroys that segment and all its descendants**, even if the descendants themselves would have been reused.

The `content-types-angular` wrapper route had `data: { reuseRoute: false }` set directly. The flag has no semantic effect at this level (it is a `loadChildren` wrapper without a component) but Angular still evaluates the strategy for it. Every internal tab navigation (`fields ↔ style-editor ↔ …`) caused Angular to destroy this segment together with its entire subtree, including:

```
content-types-angular        ← reuseRoute: false caused destruction
└── edit/:id
    └── '' (DotContentTypesEditComponent)   ← held `this.layout` with the updated layout
        ├── fields
        └── style-editor
```

When the subtree was recreated, the resolver did not re-run (default `runGuardsAndResolvers: 'paramsChange'`) so the new `DotContentTypesEditComponent` instance was rehydrated from the **stale** `contentType.layout` cached on the Router snapshot from the initial load, discarding the field added/deleted/edited/reordered moments earlier.

Verified end-to-end via instrumented logs:

1. `[PARENT saveFields RESPONSE]` response fields: 6 → `this.layout = 6 ✓`
2. User clicks `style-editor` tab
3. `[REUSE STRATEGY] curr: content-types-angular → future: content-types-angular | reuseFlag: false | RESULT: false`
4. `[DROPZONE ngOnDestroy] Last fieldRows: 6`
5. `[PARENT ngOnDestroy] Last layout fields: 6`
6. `[PARENT route.data EMIT] isFirstLoad: true | incoming contentType.layout fields: 5` ← stale resolver cache

## The fix

Remove the `data: { reuseRoute: false }` block from the `content-types-angular` route definition. There is no component at this routing level, so the flag never served a meaningful purpose here, but its side effect was destroying everything beneath it.

The original behaviors that any consumer might have relied on are preserved by other mechanisms already in place:

- **Switching between different content types** (`edit/A → edit/B`): `:id` paramChange triggers the resolver re-run.
- **Entering/leaving the portlet** (`content-types-angular → pages`): the differing `routeConfig` naturally destroys the subtree.
- **Re-clicking the menu link to the same URL**: `onSameUrlNavigation: 'reload'` (already set globally in `app.config.ts`) handles re-trigger.

## Diff

```diff
 {
     path: 'content-types-angular',
     canActivate: [MenuGuardService],
     canActivateChild: [MenuGuardService],
-    data: {
-        reuseRoute: false
-    },
     loadChildren: () =>
         import('@portlets/dot-content-types/dot-content-types.routes').then(
             (m) => m.dotContentTypesRoutes
         )
 }
```

## Test plan

- [ ] Open a content type editor at `/dotAdmin/#/content-types-angular/edit/{id}/fields`
- [ ] **Add a field** → switch to `style-editor` → switch back to `fields` → new field is still present
- [ ] **Delete a field** → switch to `style-editor` → switch back to `fields` → field stays deleted
- [ ] **Edit a field** name → switch tabs → return → change persists
- [ ] **Drag and drop** reorder fields → switch tabs → return → new order persists
- [ ] **Switch between content types** from the listing — each editor loads the correct content type
- [ ] **Re-click the "Content Types" menu link** while inside the editor — portlet reloads to the listing as before
- [ ] Existing Jest suites still pass (`yarn nx test dotcms-ui --testPathPattern=content-type-fields-drop-zone.component.spec` and `--testPathPattern=dot-custom-reuse-strategy`)

## Notes for reviewers

The `reuseRoute: false` pattern is repeated on **every** top-level portlet route in `app.routes.ts` (`templates`, `containers`, `locales`, `pages`, etc.). Each one is likely a latent occurrence of the same bug whenever that portlet introduces a sub-tab UI. This PR scopes the change to `content-types-angular` only to keep the blast radius small and unblock #35812. A follow-up could audit the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35812