### PR TITLE
fix(language): never surface LANG_404 sentinel from getDefaultLanguage (#35780)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/business/LanguageFactoryImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/languagesmanager/business/LanguageFactoryImpl.java
@@ -215,7 +215,27 @@ public class LanguageFactoryImpl extends LanguageFactory {
 			createDefaultLanguageLock.set(defaultLanguage);
 		}
 
-		return createDefaultLanguageLock.get();
+		final Language resolved = createDefaultLanguageLock.get();
+
+		// Guard (issue #35780): the lock can transiently hold the LANG_404 sentinel
+		// (id=-1) while a concurrent caller is still resolving the default, and a
+		// cleared/uninitialized cache can surface the same sentinel. A non-positive
+		// language id must never reach callers: it causes fk_contentlet_lang FK
+		// violations on contentlet save and HTMLPageAssetNotFound (404) on page
+		// lookups. When that happens, resolve the default synchronously instead of
+		// handing back the sentinel.
+		if (resolved == null || resolved.getId() <= 0) {
+			final Language fresh = transactionalGetDefaultLanguage();
+			if (fresh != null && fresh.getId() > 0) {
+				languageCache.setDefaultLanguage(fresh);
+				createDefaultLanguageLock.set(fresh);
+				return fresh;
+			}
+			Logger.warn(this, "getDefaultLanguage could not resolve a valid default language; "
+					+ "returning " + resolved);
+		}
+
+		return resolved;
 	}
 
 	/**

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/languagesmanager/business/LanguageFactoryIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/languagesmanager/business/LanguageFactoryIntegrationTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 import com.dotcms.IntegrationTestBase;
 import com.dotcms.repackage.org.apache.struts.Globals;
 import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.business.CacheLocator;
 import com.dotmarketing.business.FactoryLocator;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
 import com.dotmarketing.portlets.languagesmanager.model.LanguageKey;
@@ -181,6 +182,54 @@ public class LanguageFactoryIntegrationTest extends IntegrationTestBase {
                 Collectors.toMap(LanguageKey::getKey, LanguageKey::getValue));
 
         Assert.assertEquals(generalKeys, mappedGeneral);
+    }
+
+    /**
+     * Method to test: {@link LanguageFactoryImpl#getDefaultLanguage()}
+     * Given Scenario: Reproduce the issue #35780 precondition where both the default-language
+     * cache and the internal resolution lock hold the {@code LANG_404} sentinel (id=-1) — the
+     * transient state a caller observes when it loses the default-language init race.
+     * Expected Result: getDefaultLanguage() must never surface the sentinel; it resolves a real
+     * language (id &gt; 0). A non-positive id would otherwise cause fk_contentlet_lang FK
+     * violations on contentlet save and HTMLPageAssetNotFound (404) on page lookups.
+     */
+    @Test
+    public void test_getDefaultLanguage_neverReturnsSentinel() throws Exception {
+
+        final LanguageCache languageCache = CacheLocator.getLanguageCache();
+        final Language originalDefault = languageFactory.getDefaultLanguage();
+        final Language originalLock = getDefaultLanguageLock();
+        try {
+            // Poison both the cache and the resolution lock with the sentinel.
+            languageCache.setDefaultLanguage(LanguageCacheImpl.LANG_404);
+            setDefaultLanguageLock(LanguageCacheImpl.LANG_404);
+
+            final Language resolved = languageFactory.getDefaultLanguage();
+
+            assertNotNull(resolved);
+            assertTrue("getDefaultLanguage must never return a non-positive id (was "
+                    + resolved.getId() + ")", resolved.getId() > 0);
+        } finally {
+            languageCache.setDefaultLanguage(originalDefault);
+            setDefaultLanguageLock(originalDefault);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static java.util.concurrent.atomic.AtomicReference<Language> defaultLanguageLockRef()
+            throws Exception {
+        final java.lang.reflect.Field field =
+                LanguageFactoryImpl.class.getDeclaredField("createDefaultLanguageLock");
+        field.setAccessible(true);
+        return (java.util.concurrent.atomic.AtomicReference<Language>) field.get(languageFactory);
+    }
+
+    private static Language getDefaultLanguageLock() throws Exception {
+        return defaultLanguageLockRef().get();
+    }
+
+    private static void setDefaultLanguageLock(final Language value) throws Exception {
+        defaultLanguageLockRef().set(value);
     }
 
 }


### PR DESCRIPTION
## Summary

The central, server-side fix for the #35780 class of failures. `getDefaultLanguage()` could return the `LANG_404` sentinel (`id=-1`), which then propagated into every downstream consumer and produced the symptoms we've been patching test-by-test:

| Consumer | Symptom when default = -1 |
|---|---|
| Contentlet save (`MapToContentletPopulator`) | `fk_contentlet_lang` FK violation |
| Page lookup (`PageResourceHelper.getPage`) | `HTMLPageAssetNotFound` → 404 |
| Variant fallback (`VariantWebAPIImpl.getContentletVersionInfoByFallback`) | `ResourceNotFoundException "lang:-1"` |
| AI search / Site create | 404 / "Language cannot be null" |

## Root cause

`LanguageFactoryImpl.getDefaultLanguage()` resolves through an `AtomicReference` lock. A thread that **loses** `createDefaultLanguageLock.compareAndSet(null, …)` falls straight to `return createDefaultLanguageLock.get()` while the winner is still inside `transactionalGetDefaultLanguage()` — at that instant the lock still holds the `LANG_404` sentinel. A cleared/uninitialized cache surfaces it too.

## Fix

Guard the return value: when the resolved default is null or has a non-positive id, resolve synchronously via `transactionalGetDefaultLanguage()` (which reads the company default or creates English) and cache that — never hand back the sentinel. One place, covers all consumers.

```java
final Language resolved = createDefaultLanguageLock.get();
if (resolved == null || resolved.getId() <= 0) {
    final Language fresh = transactionalGetDefaultLanguage();
    if (fresh != null && fresh.getId() > 0) {
        languageCache.setDefaultLanguage(fresh);
        createDefaultLanguageLock.set(fresh);
        return fresh;
    }
    Logger.warn(this, "...");
}
return resolved;
```

## Test

`LanguageFactoryIntegrationTest#test_getDefaultLanguage_neverReturnsSentinel` reproduces the cache+lock sentinel precondition (via reflection on the lock) and asserts a positive id is always returned.

## Follow-up

Once this lands, the per-collection Postman/CLI workarounds (#35795, #35816, #35818, #35847, the SiteAPIIT warmup in #35813) become redundant and can be reverted — they were all compensating for this single root cause.

## Test plan

- [x] `./mvnw compile -pl :dotcms-core` → BUILD SUCCESS
- [x] Integration test compiles
- [ ] CI runs `LanguageFactoryIntegrationTest` + the previously-failing Postman suites (Page/Template/AI/Experiments) to confirm the central fix clears them

🤖 Generated with [Claude Code](https://claude.com/claude-code)