### PR TITLE
fix(uve): sort content palette by 'Most Popular' in descending usage …

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/utils/index.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/utils/index.ts
@@ -112,9 +112,9 @@ export function buildPaletteMenuItems({
             items: [
                 {
                     label: 'uve.palette.menu.sort.option.popular',
-                    command: () => onSortSelect({ orderby: 'usage', direction: 'ASC' }),
+                    command: () => onSortSelect({ orderby: 'usage', direction: 'DESC' }),
                     isActive: getSortActiveClass(
-                        { orderby: 'usage', direction: 'ASC' },
+                        { orderby: 'usage', direction: 'DESC' },
                         currentSort
                     )
                 },

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/utils/utils.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/utils/utils.spec.ts
@@ -164,7 +164,7 @@ describe('Dot UVE Palette Utils', () => {
             const result = buildPaletteMenuItems(mockCallbacks);
             const sortItems = result[0].items;
 
-            expect(sortItems[0].isActive).toBe(false); // popular (usage ASC) not active
+            expect(sortItems[0].isActive).toBe(false); // popular (usage DESC) not active
             expect(sortItems[1].isActive).toBe(true); // name ASC is active
             expect(sortItems[2].isActive).toBe(false); // name DESC not active
         });
@@ -198,7 +198,23 @@ describe('Dot UVE Palette Utils', () => {
 
             sortItems[0].command({} as unknown as MenuItemCommandEvent);
 
-            expect(onSortSelect).toHaveBeenCalledWith({ orderby: 'usage', direction: 'ASC' });
+            expect(onSortSelect).toHaveBeenCalledWith({ orderby: 'usage', direction: 'DESC' });
+        });
+
+        it('should mark popular option as active when currentSort is usage DESC', () => {
+            const mockCallbacks = {
+                viewMode: 'grid' as const,
+                currentSort: { orderby: 'usage' as const, direction: 'DESC' as const },
+                onSortSelect: jest.fn(),
+                onViewSelect: jest.fn()
+            };
+
+            const result = buildPaletteMenuItems(mockCallbacks);
+            const sortItems = result[0].items;
+
+            expect(sortItems[0].isActive).toBe(true); // popular (usage DESC) is active
+            expect(sortItems[1].isActive).toBe(false); // name ASC not active
+            expect(sortItems[2].isActive).toBe(false); // name DESC not active
         });
 
         it('should call onViewSelect when view command is executed', () => {


### PR DESCRIPTION
…order (#35848)

The 'Sort by Most Popular' option was passing direction: 'ASC' to the sort command, which put the lowest-usage content types first. Changed to 'DESC' so highest-usage content types appear at the top.

Also updated the corresponding unit tests to reflect the corrected direction, and added a new test asserting that the popular option is marked active when currentSort is { orderby: 'usage', direction: 'DESC' }.


https://github.com/user-attachments/assets/5fcb089f-3942-44c6-83a7-9adcb7240d24


This PR fixes: #35848