### PR TITLE
(docs) OpenSearch 1.x to 3.x migration docker-compose stack

### DIFF
--- a/docker/docker-compose-examples/single-node-os-migration/.claude/settings.local.json
+++ b/docker/docker-compose-examples/single-node-os-migration/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(chmod +x *)",
-      "WebSearch",
-      "Bash(docker compose *)"
-    ]
-  }
-}

--- a/docker/docker-compose-examples/single-node-os-migration/.claude/settings.local.json
+++ b/docker/docker-compose-examples/single-node-os-migration/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(chmod +x *)",
+      "WebSearch",
+      "Bash(docker compose *)"
+    ]
+  }
+}

--- a/docker/docker-compose-examples/single-node-os-migration/Dockerfile-opensearch-py
+++ b/docker/docker-compose-examples/single-node-os-migration/Dockerfile-opensearch-py
@@ -1,0 +1,5 @@
+FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
+
+COPY opensearch.py /app/opensearch.py
+
+ENTRYPOINT ["uv", "run", "--python", "3.14", "--python-preference", "managed", "--script", "/app/opensearch.py"]

--- a/docker/docker-compose-examples/single-node-os-migration/README.md
+++ b/docker/docker-compose-examples/single-node-os-migration/README.md
@@ -31,14 +31,14 @@ docker compose up -d
 | Cluster | Username | Password |
 |---|---|---|
 | OpenSearch 1.x | `admin` | `admin` |
-| OpenSearch 3.x | `admin` | `FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025` |
+| OpenSearch 3.x | `admin` | `Dev!Strong-OSAdmin-2026` |
 
 ### Provisioned user (dotCMS)
 
 | Field | Value |
 |---|---|
 | Username | `dotcms-es-user` |
-| Password | `dotcmsEsUser7Kx9mQvR3nW2026` |
+| Password | `Dev!dotcms-EsUser-2026` |
 
 ## Sample curl Commands
 
@@ -56,24 +56,24 @@ curl -sk https://localhost:9200/_plugins/_security/api/internalusers?pretty -u a
 
 ```bash
 # List indices
-curl -sk https://localhost:9200/_cat/indices?v -u dotcms-es-user:dotcmsEsUser7Kx9mQvR3nW2026
+curl -sk https://localhost:9200/_cat/indices?v -u dotcms-es-user:Dev!dotcms-EsUser-2026
 ```
 
 ### OpenSearch 3.x — admin
 
 ```bash
 # List indices
-curl -sk https://localhost:9201/_cat/indices?v -u admin:FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025
+curl -sk https://localhost:9201/_cat/indices?v -u admin:Dev!Strong-OSAdmin-2026
 
 # List internal users
-curl -sk https://localhost:9201/_plugins/_security/api/internalusers?pretty -u admin:FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025
+curl -sk https://localhost:9201/_plugins/_security/api/internalusers?pretty -u admin:Dev!Strong-OSAdmin-2026
 ```
 
 ### OpenSearch 3.x — provisioned user
 
 ```bash
 # List indices
-curl -sk https://localhost:9201/_cat/indices?v -u dotcms-es-user:dotcmsEsUser7Kx9mQvR3nW2026
+curl -sk https://localhost:9201/_cat/indices?v -u dotcms-es-user:Dev!dotcms-EsUser-2026
 ```
 
 ## Migration Phases

--- a/docker/docker-compose-examples/single-node-os-migration/README.md
+++ b/docker/docker-compose-examples/single-node-os-migration/README.md
@@ -1,0 +1,103 @@
+# Single Node OS Migration Stack
+
+Runs two OpenSearch clusters side-by-side for ES → OpenSearch migration testing:
+
+| Service | Version | URL |
+|---|---|---|
+| OpenSearch 1.x (primary) | 1.3.x | https://localhost:9200 |
+| OpenSearch 3.x (shadow) | 3.4.0 | https://localhost:9201 |
+| OS 1.x Dashboards | 1.3.x | http://localhost:5601 |
+| OS 3.x Dashboards | 3.0.0 | http://localhost:5602 |
+| dotCMS | latest | http://localhost:8082 |
+| Glowroot | - | http://localhost:4000 |
+| PostgreSQL | 18 | localhost:5432 |
+
+## Quick Start
+
+```bash
+docker compose up -d
+```
+
+## Startup Order
+
+1. PostgreSQL + OpenSearch 1.x + OpenSearch 3.x start in parallel
+2. Provisioning scripts wait for healthchecks, then create `dotcms-es-user` on both clusters
+3. dotCMS starts after both provisioners complete
+
+## Credentials
+
+### Admin (cluster management)
+
+| Cluster | Username | Password |
+|---|---|---|
+| OpenSearch 1.x | `admin` | `admin` |
+| OpenSearch 3.x | `admin` | `FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025` |
+
+### Provisioned user (dotCMS)
+
+| Field | Value |
+|---|---|
+| Username | `dotcms-es-user` |
+| Password | `dotcmsEsUser7Kx9mQvR3nW2026` |
+
+## Sample curl Commands
+
+### OpenSearch 1.x — admin
+
+```bash
+# List indices
+curl -sk https://localhost:9200/_cat/indices?v -u admin:admin
+
+# List internal users
+curl -sk https://localhost:9200/_plugins/_security/api/internalusers?pretty -u admin:admin
+```
+
+### OpenSearch 1.x — provisioned user
+
+```bash
+# List indices
+curl -sk https://localhost:9200/_cat/indices?v -u dotcms-es-user:dotcmsEsUser7Kx9mQvR3nW2026
+```
+
+### OpenSearch 3.x — admin
+
+```bash
+# List indices
+curl -sk https://localhost:9201/_cat/indices?v -u admin:FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025
+
+# List internal users
+curl -sk https://localhost:9201/_plugins/_security/api/internalusers?pretty -u admin:FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025
+```
+
+### OpenSearch 3.x — provisioned user
+
+```bash
+# List indices
+curl -sk https://localhost:9201/_cat/indices?v -u dotcms-es-user:dotcmsEsUser7Kx9mQvR3nW2026
+```
+
+## Migration Phases
+
+Controlled by `DOT_FEATURE_FLAG_OPEN_SEARCH_PHASE` in docker-compose.yml:
+
+| Phase | Writes | Reads | Description |
+|---|---|---|---|
+| 0 | OS 1.x only | OS 1.x only | Migration not started |
+| 1 | OS 1.x + OS 3.x | OS 1.x only | Dual-write, validate OS 3.x data |
+| 2 | OS 1.x + OS 3.x | OS 3.x only | Reads from OS 3.x, ES fallback |
+| 3 | OS 3.x only | OS 3.x only | Migration complete |
+
+Currently set to **Phase 1** (dual-write).
+
+## Provisioning Script
+
+`opensearch.py` creates on each cluster:
+- Internal user (`dotcms-es-user`)
+- Role (`dotcms-role`)
+- Role mapping (`dotcms-role` → `dotcms-es-user`)
+- Action groups (cluster, index, all-indices permissions)
+
+Run standalone:
+```bash
+./opensearch.py --admin-user admin --admin-pass admin --password mypass --customer dotcms --host localhost --port 9200
+```

--- a/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
@@ -100,7 +100,7 @@ services:
       discovery.type: "single-node"
       bootstrap.memory_lock: "true"
       OPENSEARCH_JAVA_OPTS: "-Xmx1G"
-      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025"
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "Dev!Strong-OSAdmin-2026"
     ulimits:
       memlock:
         soft: -1
@@ -116,7 +116,7 @@ services:
     networks:
       - search_net
     healthcheck:
-      test: ["CMD-SHELL", "curl -sk https://localhost:9200 -u admin:FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025 | grep -q cluster_name"]
+      test: ["CMD-SHELL", "curl -sk https://localhost:9200 -u admin:Dev!Strong-OSAdmin-2026 | grep -q cluster_name"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -137,7 +137,7 @@ services:
       OPENSEARCH_HOSTS: '["https://opensearch3:9200"]'
       opensearch.ssl.verificationMode: "none"
       opensearch.username: "admin"
-      opensearch.password: "FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025"
+      opensearch.password: "Dev!Strong-OSAdmin-2026"
     ports:
       - "5602:5601"
     networks:
@@ -159,7 +159,7 @@ services:
       OS_PORT: "9200"
       OS_ADMIN_USER: "admin"
       OS_ADMIN_PASS: "admin"
-      OS_PASSWORD: "dotcmsEsUser7Kx9mQvR3nW2026"
+      OS_PASSWORD: "Dev!dotcms-EsUser-2026"
       OS_CUSTOMER: "dotcms"
       OS_DEBUG: "true"
     networks:
@@ -180,8 +180,8 @@ services:
       OS_HOST: "opensearch3"
       OS_PORT: "9200"
       OS_ADMIN_USER: "admin"
-      OS_ADMIN_PASS: "FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025"
-      OS_PASSWORD: "dotcmsEsUser7Kx9mQvR3nW2026"
+      OS_ADMIN_PASS: "Dev!Strong-OSAdmin-2026"
+      OS_PASSWORD: "Dev!dotcms-EsUser-2026"
       OS_CUSTOMER: "dotcms"
       OS_DEBUG: "true"
     networks:
@@ -212,12 +212,12 @@ services:
       DOT_ES_ENDPOINTS: 'https://opensearch1:9200'
       DOT_ES_AUTH_TYPE: 'BASIC'
       DOT_ES_AUTH_BASIC_USER: 'dotcms-es-user'
-      DOT_ES_AUTH_BASIC_PASSWORD: 'dotcmsEsUser7Kx9mQvR3nW2026'
+      DOT_ES_AUTH_BASIC_PASSWORD: 'Dev!dotcms-EsUser-2026'
       # --- OS 3.x (shadow writes in Phase 1–2, primary in Phase 3) ---
       DOT_OS_ENDPOINTS: 'https://opensearch3:9200'
       DOT_OS_AUTH_TYPE: 'BASIC'
       DOT_OS_AUTH_BASIC_USER: 'dotcms-es-user'
-      DOT_OS_AUTH_BASIC_PASSWORD: 'dotcmsEsUser7Kx9mQvR3nW2026'
+      DOT_OS_AUTH_BASIC_PASSWORD: 'Dev!dotcms-EsUser-2026'
       DOT_OS_TLS_TRUST_SELF_SIGNED: 'true'
       # --- Migration phase: 0=ES only, 1=dual-write/ES-reads, 2=dual-write/OS-reads, 3=OS only ---
       DOT_FEATURE_FLAG_OPEN_SEARCH_PHASE: '1'

--- a/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
@@ -39,7 +39,7 @@ services:
   # REST API  → http://localhost:9200
   # ---------------------------------------------------------------------------
   opensearch1:
-    image: opensearchproject/opensearch:1
+    image: opensearchproject/opensearch:1.3
     environment:
       cluster.name: "opensearch1-cluster"
       discovery.type: "single-node"
@@ -75,7 +75,7 @@ services:
   # UI → http://localhost:5601
   # ---------------------------------------------------------------------------
   opensearch1-dashboards:
-    image: opensearchproject/opensearch-dashboards:1
+    image: opensearchproject/opensearch-dashboards:1.3
     environment:
       OPENSEARCH_HOSTS: '["https://opensearch1:9200"]'
       opensearch.ssl.verificationMode: "none"

--- a/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
@@ -1,15 +1,15 @@
 # dotCMS — Single Node OS Migration Stack
 #
-# Runs BOTH search backends side-by-side for the ES → OpenSearch migration:
-#   - Elasticsearch 7.9.1  + Kibana 7.9.1       → http://localhost:5601
-#   - OpenSearch 3.4.0     + OS Dashboards 3.0.0 → http://localhost:5602
+# Runs BOTH search backends side-by-side for the OS 1.x → OS 3.x migration:
+#   - OpenSearch 1.3.x  + OS Dashboards 1.3.x → http://localhost:5601
+#   - OpenSearch 3.4.0  + OS Dashboards 3.0.0  → http://localhost:5602
 #
-# dotCMS is configured to write to Elasticsearch (primary) while OpenSearch
-# shadows the traffic. Flip DOT_ES_ENDPOINTS to the opensearch service URL
-# to promote OS as primary once the migration is validated.
+# dotCMS is configured to write to OpenSearch 1.x (primary) while OpenSearch 3.x
+# shadows the traffic. Flip DOT_ES_ENDPOINTS to the opensearch3 service URL
+# to promote OS 3.x as primary once the migration is validated.
 #
 # Usage:
-#   docker compose -f docker/docker-compose-examples/single-node-os-migration/docker-compose.yml up -d
+#   docker compose up -d
 
 services:
 
@@ -35,16 +35,16 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
-  # Elasticsearch 7.9.1  (primary — dotCMS writes here during migration)
+  # OpenSearch 1.3.x  (primary — dotCMS writes here during migration)
   # REST API  → http://localhost:9200
   # ---------------------------------------------------------------------------
-  elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+  opensearch1:
+    image: opensearchproject/opensearch:1
     environment:
-      cluster.name: "elastic-cluster"
+      cluster.name: "opensearch1-cluster"
       discovery.type: "single-node"
       bootstrap.memory_lock: "true"
-      ES_JAVA_OPTS: "-Xmx1G"
+      OPENSEARCH_JAVA_OPTS: "-Xmx1G"
     ulimits:
       memlock:
         soft: -1
@@ -55,9 +55,14 @@ services:
     ports:
       - "9200:9200"
     volumes:
-      - es-data:/usr/share/elasticsearch/data
+      - opensearch1-data:/usr/share/opensearch/data
     networks:
       - search_net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sk https://localhost:9200 -u admin:admin | grep -q cluster_name"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
     deploy:
       resources:
         limits:
@@ -66,34 +71,36 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
-  # Kibana 7.9.1  (visualiza índices de ES)
+  # OpenSearch Dashboards 1.3.x  (visualize OpenSearch 1.x indices)
   # UI → http://localhost:5601
   # ---------------------------------------------------------------------------
-  kibana:
-    image: docker.elastic.co/kibana/kibana:7.9.1
+  opensearch1-dashboards:
+    image: opensearchproject/opensearch-dashboards:1
     environment:
-      ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+      OPENSEARCH_HOSTS: '["https://opensearch1:9200"]'
+      opensearch.ssl.verificationMode: "none"
+      opensearch.username: "admin"
+      opensearch.password: "admin"
     ports:
       - "5601:5601"
     networks:
       - search_net
     depends_on:
-      - elasticsearch
+      - opensearch1
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
-  # OpenSearch 3.4.0  (shadow/target — recibe escrituras duales durante migración)
+  # OpenSearch 3.4.0  (shadow/target)
   # REST API → http://localhost:9201
   # ---------------------------------------------------------------------------
-  opensearch:
+  opensearch3:
     image: opensearchproject/opensearch:3.4.0
     environment:
-      cluster.name: "opensearch-cluster"
+      cluster.name: "opensearch3-cluster"
       discovery.type: "single-node"
       bootstrap.memory_lock: "true"
       OPENSEARCH_JAVA_OPTS: "-Xmx1G"
-      DISABLE_INSTALL_DEMO_CONFIG: "true"
-      DISABLE_SECURITY_PLUGIN: "true"
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025"
     ulimits:
       memlock:
         soft: -1
@@ -105,9 +112,14 @@ services:
       - "9201:9200"
       - "9601:9600"
     volumes:
-      - opensearch-data:/usr/share/opensearch/data
+      - opensearch3-data:/usr/share/opensearch/data
     networks:
       - search_net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sk https://localhost:9200 -u admin:FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025 | grep -q cluster_name"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
     deploy:
       resources:
         limits:
@@ -116,21 +128,67 @@ services:
     restart: unless-stopped
 
   # ---------------------------------------------------------------------------
-  # OpenSearch Dashboards 3.0.0  (visualiza índices de OS)
+  # OpenSearch Dashboards 3.0.0
   # UI → http://localhost:5602
   # ---------------------------------------------------------------------------
-  opensearch-dashboards:
+  opensearch3-dashboards:
     image: opensearchproject/opensearch-dashboards:3.0.0
     environment:
-      OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
-      DISABLE_SECURITY_DASHBOARDS_PLUGIN: "true"
+      OPENSEARCH_HOSTS: '["https://opensearch3:9200"]'
+      opensearch.ssl.verificationMode: "none"
+      opensearch.username: "admin"
+      opensearch.password: "FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025"
     ports:
       - "5602:5601"
     networks:
       - search_net
     depends_on:
-      - opensearch
+      - opensearch3
     restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # OpenSearch 1.x user provisioning
+  # ---------------------------------------------------------------------------
+  opensearch1-provision:
+    build:
+      context: .
+      dockerfile: Dockerfile-opensearch-py
+    environment:
+      OS_SCHEME: "https"
+      OS_HOST: "opensearch1"
+      OS_PORT: "9200"
+      OS_ADMIN_USER: "admin"
+      OS_ADMIN_PASS: "admin"
+      OS_PASSWORD: "dotcmsEsUser7Kx9mQvR3nW2026"
+      OS_CUSTOMER: "dotcms"
+      OS_DEBUG: "true"
+    networks:
+      - search_net
+    depends_on:
+      opensearch1:
+        condition: service_healthy
+
+  # ---------------------------------------------------------------------------
+  # OpenSearch 3.x user provisioning
+  # ---------------------------------------------------------------------------
+  opensearch3-provision:
+    build:
+      context: .
+      dockerfile: Dockerfile-opensearch-py
+    environment:
+      OS_SCHEME: "https"
+      OS_HOST: "opensearch3"
+      OS_PORT: "9200"
+      OS_ADMIN_USER: "admin"
+      OS_ADMIN_PASS: "FENMSCuN4wsRps4ftYwxsx8PfkBEYiAv2025"
+      OS_PASSWORD: "dotcmsEsUser7Kx9mQvR3nW2026"
+      OS_CUSTOMER: "dotcms"
+      OS_DEBUG: "true"
+    networks:
+      - search_net
+    depends_on:
+      opensearch3:
+        condition: service_healthy
 
   # ---------------------------------------------------------------------------
   # dotCMS
@@ -138,8 +196,8 @@ services:
   # HTTPS → https://localhost:8443
   #
   # During migration:
-  #   DOT_ES_ENDPOINTS points to Elasticsearch (primary).
-  #   When ready to promote OS, switch to: http://opensearch:9200
+  #   DOT_ES_ENDPOINTS points to opensearch1 (primary).
+  #   When ready to promote OS 3.x, switch to: https://opensearch3:9200
   # ---------------------------------------------------------------------------
   dotcms:
     image: dotcms/dotcms:latest
@@ -150,9 +208,19 @@ services:
       DB_BASE_URL: "jdbc:postgresql://db/dotcms"
       DB_USERNAME: 'dotcmsdbuser'
       DB_PASSWORD: 'password'
-      # Primary search backend (ES). Flip to http://opensearch:9200 to promote OS.
-      DOT_ES_ENDPOINTS: 'http://elasticsearch:9200'
-      DOT_ES_AUTH_BASIC_PASSWORD: 'admin'
+      # --- ES / OS 1.x (primary reads+writes in Phase 0–2) ---
+      DOT_ES_ENDPOINTS: 'https://opensearch1:9200'
+      DOT_ES_AUTH_TYPE: 'BASIC'
+      DOT_ES_AUTH_BASIC_USER: 'dotcms-es-user'
+      DOT_ES_AUTH_BASIC_PASSWORD: 'dotcmsEsUser7Kx9mQvR3nW2026'
+      # --- OS 3.x (shadow writes in Phase 1–2, primary in Phase 3) ---
+      DOT_OS_ENDPOINTS: 'https://opensearch3:9200'
+      DOT_OS_AUTH_TYPE: 'BASIC'
+      DOT_OS_AUTH_BASIC_USER: 'dotcms-es-user'
+      DOT_OS_AUTH_BASIC_PASSWORD: 'dotcmsEsUser7Kx9mQvR3nW2026'
+      DOT_OS_TLS_TRUST_SELF_SIGNED: 'true'
+      # --- Migration phase: 0=ES only, 1=dual-write/ES-reads, 2=dual-write/OS-reads, 3=OS only ---
+      DOT_FEATURE_FLAG_OPEN_SEARCH_PHASE: '1'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-os-migration'
       GLOWROOT_ENABLED: 'true'
@@ -161,10 +229,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
-      elasticsearch:
-        condition: service_started
-      opensearch:
-        condition: service_started
+      opensearch1-provision:
+        condition: service_completed_successfully
+      opensearch3-provision:
+        condition: service_completed_successfully
     volumes:
       - cms-shared:/data/shared
       # - {license_local_path}/license.zip:/data/shared/assets/license.zip
@@ -184,5 +252,5 @@ networks:
 volumes:
   cms-shared:
   dbdata:
-  es-data:
-  opensearch-data:
+  opensearch1-data:
+  opensearch3-data:

--- a/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
@@ -39,7 +39,7 @@ services:
   # REST API  → http://localhost:9200
   # ---------------------------------------------------------------------------
   opensearch1:
-    image: opensearchproject/opensearch:1.3
+    image: opensearchproject/opensearch:1.3.20
     environment:
       cluster.name: "opensearch1-cluster"
       discovery.type: "single-node"
@@ -75,7 +75,7 @@ services:
   # UI → http://localhost:5601
   # ---------------------------------------------------------------------------
   opensearch1-dashboards:
-    image: opensearchproject/opensearch-dashboards:1.3
+    image: opensearchproject/opensearch-dashboards:1
     environment:
       OPENSEARCH_HOSTS: '["https://opensearch1:9200"]'
       opensearch.ssl.verificationMode: "none"
@@ -100,7 +100,7 @@ services:
       discovery.type: "single-node"
       bootstrap.memory_lock: "true"
       OPENSEARCH_JAVA_OPTS: "-Xmx1G"
-      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "Dev!Strong-OSAdmin-2026"
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: "Dev!Search3-Kx9mP-2026"
     ulimits:
       memlock:
         soft: -1
@@ -116,7 +116,7 @@ services:
     networks:
       - search_net
     healthcheck:
-      test: ["CMD-SHELL", "curl -sk https://localhost:9200 -u admin:Dev!Strong-OSAdmin-2026 | grep -q cluster_name"]
+      test: ["CMD-SHELL", "curl -sk https://localhost:9200 -u admin:Dev!Search3-Kx9mP-2026 | grep -q cluster_name"]
       interval: 10s
       timeout: 5s
       retries: 12
@@ -137,7 +137,7 @@ services:
       OPENSEARCH_HOSTS: '["https://opensearch3:9200"]'
       opensearch.ssl.verificationMode: "none"
       opensearch.username: "admin"
-      opensearch.password: "Dev!Strong-OSAdmin-2026"
+      opensearch.password: "Dev!Search3-Kx9mP-2026"
     ports:
       - "5602:5601"
     networks:
@@ -180,7 +180,7 @@ services:
       OS_HOST: "opensearch3"
       OS_PORT: "9200"
       OS_ADMIN_USER: "admin"
-      OS_ADMIN_PASS: "Dev!Strong-OSAdmin-2026"
+      OS_ADMIN_PASS: "Dev!Search3-Kx9mP-2026"
       OS_PASSWORD: "Dev!dotcms-EsUser-2026"
       OS_CUSTOMER: "dotcms"
       OS_DEBUG: "true"

--- a/docker/docker-compose-examples/single-node-os-migration/opensearch.py
+++ b/docker/docker-compose-examples/single-node-os-migration/opensearch.py
@@ -140,7 +140,7 @@ class OpenSearchClient:
                 verify=False,
                 timeout=timeout,
             )
-            if int(response.status_code) != 201:
+            if int(response.status_code) not in (200, 201):
                 response_error = True
         if self.debug or response_error:
             print("### OPENSEARCH DEBUG ###")

--- a/docker/docker-compose-examples/single-node-os-migration/opensearch.py
+++ b/docker/docker-compose-examples/single-node-os-migration/opensearch.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env -S uv run --python 3.14 --python-preference managed
+# /// script
+# requires-python = ">=3.14"
+# dependencies = [
+#     "requests",
+#     "urllib3",
+# ]
+# ///
+import argparse
+import json
+import logging
+import secrets
+import string
+from datetime import datetime, timedelta
+
+import requests
+import urllib3
+from requests.auth import HTTPBasicAuth
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(name="opensearch-py")
+
+# suppress https warnings for self-signed certs on ES server
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+es_names_min_length = 3
+es_names_max_length = 32
+
+
+class OpenSearchClientException(Exception):
+    """received error response from OpenSearch server"""
+
+
+class IntrnalUserException(OpenSearchClientException):
+    """user unexpectedly present or absent"""
+
+
+def generate_opensearch_password(length=24):
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*"
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+class OpenSearchClient:
+    """
+    sends HTTP requests to OpenSearch server
+
+    scheme str: http or https
+    host str: server ip or hostname
+    port int: server port
+    username str: admin username
+    password str: admin password
+
+    usage:
+        os_client = OpenSearchClient("admin", "pass!", host="es1.example.com")
+        os_client.create_all
+    """
+
+    def __init__(
+        self,
+        username,
+        password,
+        scheme="https",
+        host="127.0.0.1",
+        port=9200,
+        debug=False,
+    ):
+        self.server = f"{scheme}://{host}:{port}"
+        if username and password:
+            self.auth = HTTPBasicAuth(username, password)
+        else:
+            self.auth = None
+        self.debug = debug
+        # see https://github.com/dotCMS/infrastructure-as-code/tree/master/kubernetes/guides/10.%20Managed%20Elasticsearch#kibana---permissions
+        self.index_permissions = ["indices_all", "indices_monitor"]
+        self.cluster_permissions = [
+            "cluster:monitor/health",
+            "indices:data/write/bulk",
+            "cluster:monitor/state",
+            "cluster:monitor/nodes/stats",
+            "indices:data/read/scroll",
+            "indices:data/read/scroll/clear",
+        ]
+        self.all_index_permissions = [
+            "indices:monitor/stats",
+            "indices:monitor/settings/get",
+            "indices:admin/aliases/get",
+        ]
+
+    def create_all(self, customer_name, password=None):
+        """create new ES user, roles, mapping"""
+        customer_name = customer_name.strip()
+        username = self.username_from_customer(customer_name)
+        if password:
+            password = password.strip()
+        else:
+            password = generate_opensearch_password()
+        assert len(customer_name) >= es_names_min_length
+        assert len(customer_name) <= es_names_max_length
+        assert len(username) >= es_names_min_length
+        assert len(username) <= es_names_max_length
+        self.create_user(username, password, customer_name)
+        self.create_action_groups(customer_name)
+        self.create_role(customer_name)
+        self.create_role_mapping(customer_name, username)
+        return {"username": username, "password": password}
+
+    def delete_all(self, customer_name):
+        """create ES user, roles, mapping"""
+        customer_name = customer_name.strip()
+        username = self.username_from_customer(customer_name)
+        self.delete_role_mapping(customer_name)
+        self.delete_action_groups(customer_name)
+        self.delete_role(customer_name)
+        self.delete_user(username)
+        if self.get_users(username) is not None:
+            raise IntrnalUserException(f"User '{username}' still exists")
+
+    def http_request(self, verb, uri, payload=None, headers=None, timeout=20):
+        """
+        requests wrapper
+        """
+        verb = verb.lower()
+        url = self.urljoin(self.server, uri)
+        response_error = False
+        if verb in ["get", "delete"]:
+            response = requests.request(
+                verb,
+                url,
+                auth=self.auth,
+                verify=False,
+                timeout=timeout,
+            )
+        elif verb == "put":
+            response = requests.request(
+                verb,
+                url,
+                data=payload,
+                headers=headers,
+                auth=self.auth,
+                verify=False,
+                timeout=timeout,
+            )
+            if int(response.status_code) != 201:
+                response_error = True
+        if self.debug or response_error:
+            print("### OPENSEARCH DEBUG ###")
+            print("# REQUEST:")
+            print(verb.upper())
+            print(url)
+            if payload:
+                print("data:")
+                print(json.dumps(json.loads(payload), indent=2))
+            print("# RESPONSE:")
+            if response_error:
+                logger.error("status: %s", response.status_code)
+            else:
+                print(f"status: {response.status_code}")
+            print(json.dumps(json.loads(response.content.decode()), indent=2))
+            print()
+        if response_error:
+            raise OpenSearchClientException("Unexpected response to OpenSearch request")
+        return response
+
+    def urljoin(self, *args):
+        """Joins given arguments into an url, removing extra slashes"""
+        return "/".join(
+            (x.rstrip("/") if x.startswith("//") else x.strip("/") for x in args),
+        )
+
+    def username_from_customer(self, customer):
+        return f"{customer}-es-user"
+
+    def get_users(self, username):
+        URI = f"_plugins/_security/api/internalusers/{username}"
+        r = self.http_request("get", URI)
+        response_body = str((r.content.decode()))
+        if "NOT_FOUND" in response_body:
+            return None
+        return json.loads(response_body)
+
+    def create_user(self, username, password, customer_name):
+        assert username
+        if self.get_users(username):
+            logger.info("User '%s' already exists, skipping creation", username)
+            return
+        URI = f"_plugins/_security/api/internalusers/{username}"
+        headers = {"Content-type": "application/json"}
+        payload = {
+            "password": f"{password}",
+            "attributes": {"dotcms.client.name.short": f"{customer_name}"},
+        }
+        payload = json.dumps(payload)
+        self.http_request("put", URI, payload, headers)
+
+    def delete_user(self, username):
+        URI = f"_plugins/_security/api/internalusers/{username}"
+        self.http_request("delete", URI)
+
+    def create_role(self, customer_name):
+        URI = f"_plugins/_security/api/roles/{customer_name}-role"
+        headers = {"Content-type": "application/json"}
+        payload = {
+            "cluster_permissions": [f"{customer_name}-cluster"],
+            "index_permissions": [
+                {
+                    "index_patterns": [f"cluster_{customer_name}*"],
+                    "allowed_actions": [f"{customer_name}-index"],
+                },
+                {
+                    "index_patterns": ["*"],
+                    "allowed_actions": [f"{customer_name}-all-indices"],
+                },
+            ],
+        }
+        payload = json.dumps(payload)
+        self.http_request("put", URI, payload, headers)
+
+    def delete_role(self, customer_name):
+        URI = f"_plugins/_security/api/roles/{customer_name}-role"
+        self.http_request("delete", URI)
+
+    def create_action_groups(self, customer_name):
+        # Cluster permissions
+        URI = f"_plugins/_security/api/actiongroups/{customer_name}-cluster"
+        headers = {"Content-type": "application/json"}
+        payload = {"allowed_actions": self.cluster_permissions}
+        payload = json.dumps(payload)
+        self.http_request("put", URI, payload, headers)
+
+        # Index permissions
+        URI = f"_plugins/_security/api/actiongroups/{customer_name}-index"
+        payload = {"allowed_actions": self.index_permissions}
+        payload = json.dumps(payload)
+        self.http_request("put", URI, payload, headers)
+
+        # All indices permissions
+        URI = f"_plugins/_security/api/actiongroups/{customer_name}-all-indices"
+        payload = {"allowed_actions": self.all_index_permissions}
+        payload = json.dumps(payload)
+        self.http_request("put", URI, payload, headers)
+
+    def delete_action_groups(self, customer_name):
+        # Delete cluster permissions/action group
+        URI = f"_plugins/_security/api/actiongroups/{customer_name}-cluster"
+        self.http_request("delete", URI)
+
+        # Delete index permissions/action group
+        URI = f"_plugins/_security/api/actiongroups/{customer_name}-index"
+        self.http_request("delete", URI)
+
+        # Delete all indices permissions/action group
+        URI = f"_plugins/_security/api/actiongroups/{customer_name}-all-indices"
+        self.http_request("delete", URI)
+
+    def create_role_mapping(self, customer_name, username):
+        URI = f"_plugins/_security/api/rolesmapping/{customer_name}-role"
+        headers = {"Content-type": "application/json"}
+        payload = {"users": [f"{username}"]}
+        payload = json.dumps(payload)
+        self.http_request("put", URI, payload, headers)
+
+    def delete_role_mapping(self, customer_name):
+        URI = f"_plugins/_security/api/rolesmapping/{customer_name}-role"
+        self.http_request("delete", URI)
+
+    def get_dotcms_indices(self):
+        URI = "_cluster/health?level=indices"
+        r = self.http_request("get", URI)
+        return sorted(
+            [index for index in r.json()["indices"] if index.startswith("cluster_")]
+        )
+
+    def get_all_aliases(self):
+        URI = "_alias"
+        r = self.http_request("get", URI)
+        return r.json()
+
+    def get_sitesearch_without_aliases(self, exclude_recent=True):
+        """
+        Used to find old sitesearch indices that have no aliases and can therefore be deleted
+        '_alias' returns
+        {
+            'cluster_ppf-bulgaria-prod.sitesearch_20240321230000_bf022347-e7d6-11ee-9e41-3a83af152fac': {
+                'aliases': {}
+            },
+            'cluster_arqiva-uat-2310.live_20240212205204': {'aliases': {}},
+            'cluster_worldline-dev.sitesearch_20240322042500_25ec4c32-e804-11ee-a536-12b1dcc3cd97': {
+                'aliases': {'cluster_worldline-dev.support-viveum_ecom-psp_com_NL': {}}
+            },
+        older_than_days: int - only return indices older than this many days, for cleanup tasks
+        """
+        without_aliases = set()
+        ss = ".sitesearch_"
+        today_ss = ss + datetime.now().strftime("%Y%m%d")
+        yesterday_ss = ss + (datetime.now() - timedelta(days=1)).strftime("%Y%m%d")
+        for index, data in self.get_all_aliases().items():
+            if ss not in index:
+                continue
+            if exclude_recent and (today_ss in index or yesterday_ss in index):
+                continue
+            if not data["aliases"]:
+                without_aliases.add(index)
+        return without_aliases
+
+    def parse_index_name(self, full_name):
+        """
+        index name format:
+          cluster_worldline-prod.sitesearch_20240322052500_87b9dbdb-e80c-11ee-8f1c-06e1bcb1d229
+        return (customer, env, is_sitesearch)
+        """
+        try:
+            owner, index = full_name.split(".")
+            owner = owner.split("_")[1]
+            customer, env = owner.split("-", 1)
+            logger.debug("%s, %s, %s", customer, env, index.startswith("sitesearch."))
+            return [customer, env, index.startswith("sitesearch_")]
+        except ValueError:
+            logger.debug("Unable to unpack index name '%s', skipping", full_name)
+
+    def filter_dotcms_indices_by_customer(self):
+        """
+        return a dict
+        { customer_name:
+           env_name:
+             indices: []
+             site_search_indices: [],
+
+        """
+        customers = dict()
+        for index in self.get_dotcms_indices():
+            try:
+                (customer, env, is_site_search) = self.parse_index_name(index)
+            except TypeError:
+                continue
+            if customer not in customers:
+                customers[customer] = {"count": 0}
+            if env not in customers[customer]:
+                customers[customer][env] = {
+                    "indices": [],
+                    "site_search_indices": [],
+                }
+            customers[customer]["count"] += 1
+            if is_site_search:
+                customers[customer][env]["site_search_indices"].append(index)
+            else:
+                customers[customer][env]["indices"].append(index)
+        return sorted(
+            customers.items(),
+            key=lambda item: item[1]["count"],
+        )
+
+    def get_sitesearch_indices(self):
+        [index for index in self.get_dotcms_indices() if ".sitesearch_" in index]
+
+    def delete_index(self, index):
+        if not index.startswith("cluster_"):
+            msg = f"Index name must start with 'cluster_', received '{index}'"
+            logger.error(msg)
+            raise ValueError(msg)
+        URI = f"{index}"
+        self.http_request("delete", URI)
+
+
+if __name__ == "__main__":
+    import os
+
+    parser = argparse.ArgumentParser(description="OpenSearch user provisioning")
+    parser.add_argument("--scheme", default=os.environ.get("OS_SCHEME", "https"))
+    parser.add_argument("--host", default=os.environ.get("OS_HOST", "127.0.0.1"))
+    parser.add_argument("--port", type=int, default=int(os.environ.get("OS_PORT", "9200")))
+    parser.add_argument("--admin-user", default=os.environ.get("OS_ADMIN_USER"))
+    parser.add_argument("--admin-pass", default=os.environ.get("OS_ADMIN_PASS"))
+    parser.add_argument("--password", default=os.environ.get("OS_PASSWORD"))
+    parser.add_argument("--customer", default=os.environ.get("OS_CUSTOMER"))
+    parser.add_argument("--debug", action="store_true",
+                        default=os.environ.get("OS_DEBUG", "").lower() in ("1", "true"))
+    args = parser.parse_args()
+
+    for field in ("admin_user", "admin_pass", "password", "customer"):
+        if not getattr(args, field):
+            parser.error(f"--{field.replace('_', '-')} or {('OS_' + field).upper()} required")
+
+    client = OpenSearchClient(
+        username=args.admin_user,
+        password=args.admin_pass,
+        scheme=args.scheme,
+        host=args.host,
+        port=args.port,
+        debug=args.debug,
+    )
+    result = client.create_all(args.customer, password=args.password)
+    logger.info("Created user: %s", result["username"])


### PR DESCRIPTION
## Summary
- Docker Compose stack running OpenSearch 1.3.x and 3.4.0 side-by-side for ES→OS migration testing
- Python provisioning script (`opensearch.py`) creates internal users, roles, action groups, and role mappings on both clusters
- Provisioners run as init containers with healthcheck gates — dotCMS only starts after both clusters are provisioned
- dotCMS configured with `FEATURE_FLAG_OPEN_SEARCH_PHASE=1` (dual-write, ES-reads)
- Standalone `opensearch.py` uses `uv run` shebang with PEP 723 inline metadata — no virtualenv setup needed

## Services
| Service | Port |
|---|---|
| OpenSearch 1.x | https://localhost:9200 |
| OpenSearch 3.x | https://localhost:9201 |
| OS 1.x Dashboards | http://localhost:5601 |
| OS 3.x Dashboards | http://localhost:5602 |
| dotCMS | http://localhost:8082 |
| PostgreSQL | localhost:5432 |

## Test plan
- [ ] `docker compose up -d` starts all services without errors
- [ ] Both provisioners exit 0 (check `docker compose ps`)
- [ ] `curl -sk https://localhost:9200/_cat/indices?v -u dotcms-es-user:<pass>` returns 200
- [ ] `curl -sk https://localhost:9201/_cat/indices?v -u dotcms-es-user:<pass>` returns 200
- [ ] dotCMS starts and creates indices on both clusters
- [ ] Re-running `docker compose up` is idempotent (provisioners skip existing users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #35865