### PR TITLE
fix: switching to an existing lang version shows dialog 'Create new language version?'

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
@@ -275,6 +275,26 @@ describe('DotEmaDialogComponent', () => {
             expect(setSavedSpy).toHaveBeenCalled();
         });
 
+        it("should emit reloadFromDialog when the iframe's custom event is 'edit-contentlet-data-updated' and is a translation", () => {
+            const reloadFromDialogSpy = jest.spyOn(component.reloadFromDialog, 'emit');
+
+            component.translatePage({
+                page: MOCK_RESPONSE_HEADLESS.page,
+                newLanguage: '3'
+            }); // This is to make the dialog open
+            spectator.detectChanges();
+
+            triggerIframeCustomEvent({
+                detail: {
+                    name: NG_CUSTOM_EVENTS.EDIT_CONTENTLET_UPDATED,
+                    data: {},
+                    payload: {}
+                }
+            });
+
+            expect(reloadFromDialogSpy).toHaveBeenCalled();
+        });
+
         it("should trigger setSaved in the store when the iframe's custom event is 'edit-contentlet-data-updated', is a translation and payload is move action", () => {
             const reloadIframeSpy = jest.spyOn(component, 'reloadIframe');
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
@@ -28,7 +28,7 @@ import {
     PushPublishService
 } from '@dotcms/data-access';
 import { DotcmsConfigService, DotcmsEventsService } from '@dotcms/dotcms-js';
-import { DotCMSBaseTypesContentTypes } from '@dotcms/dotcms-models';
+import { DotCMSBaseTypesContentTypes, DotCMSWorkflowActionEvent } from '@dotcms/dotcms-models';
 import { DotContentCompareComponent } from '@dotcms/portlets/dot-ema/ui';
 import { DotCMSPage, DotCMSURLContentMap, DotCMSUVEAction } from '@dotcms/types';
 import {
@@ -238,6 +238,19 @@ describe('DotEmaDialogComponent', () => {
             expect(handleWorkflowEventSpy).toHaveBeenCalledWith({});
         });
 
+        it('should emit reloadFromDialog after a successful workflow action', () => {
+            const reloadFromDialogSpy = jest.spyOn(component.reloadFromDialog, 'emit');
+
+            component.addContentlet(PAYLOAD_MOCK);
+            spectator.detectChanges();
+
+            // dialog appends to body so @ViewChild('iframe') is not populated; stub it out
+            component.iframe = { nativeElement: { contentWindow: null } } as any;
+            component.handleWorkflowEvent({} as DotCMSWorkflowActionEvent);
+
+            expect(reloadFromDialogSpy).toHaveBeenCalled();
+        });
+
         it("should trigger setDirty in the store when the iframe's custom event is 'edit-contentlet-data-updated' and is not a translation", () => {
             const setDirtySpy = jest.spyOn(storeSpy, 'setDirty');
 
@@ -273,6 +286,26 @@ describe('DotEmaDialogComponent', () => {
             });
 
             expect(setSavedSpy).toHaveBeenCalled();
+        });
+
+        it("should NOT emit reloadFromDialog when the iframe's custom event is 'edit-contentlet-data-updated' and is a translation", () => {
+            const reloadFromDialogSpy = jest.spyOn(component.reloadFromDialog, 'emit');
+
+            component.translatePage({
+                page: MOCK_RESPONSE_HEADLESS.page,
+                newLanguage: '3'
+            });
+            spectator.detectChanges();
+
+            triggerIframeCustomEvent({
+                detail: {
+                    name: NG_CUSTOM_EVENTS.EDIT_CONTENTLET_UPDATED,
+                    data: {},
+                    payload: {}
+                }
+            });
+
+            expect(reloadFromDialogSpy).not.toHaveBeenCalled();
         });
 
         it("should trigger setSaved in the store when the iframe's custom event is 'edit-contentlet-data-updated', is a translation and payload is move action", () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
@@ -275,26 +275,6 @@ describe('DotEmaDialogComponent', () => {
             expect(setSavedSpy).toHaveBeenCalled();
         });
 
-        it("should emit reloadFromDialog when the iframe's custom event is 'edit-contentlet-data-updated' and is a translation", () => {
-            const reloadFromDialogSpy = jest.spyOn(component.reloadFromDialog, 'emit');
-
-            component.translatePage({
-                page: MOCK_RESPONSE_HEADLESS.page,
-                newLanguage: '3'
-            }); // This is to make the dialog open
-            spectator.detectChanges();
-
-            triggerIframeCustomEvent({
-                detail: {
-                    name: NG_CUSTOM_EVENTS.EDIT_CONTENTLET_UPDATED,
-                    data: {},
-                    payload: {}
-                }
-            });
-
-            expect(reloadFromDialogSpy).toHaveBeenCalled();
-        });
-
         it("should trigger setSaved in the store when the iframe's custom event is 'edit-contentlet-data-updated', is a translation and payload is move action", () => {
             const reloadIframeSpy = jest.spyOn(component, 'reloadIframe');
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.spec.ts
@@ -245,6 +245,7 @@ describe('DotEmaDialogComponent', () => {
             spectator.detectChanges();
 
             // dialog appends to body so @ViewChild('iframe') is not populated; stub it out
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             component.iframe = { nativeElement: { contentWindow: null } } as any;
             component.handleWorkflowEvent({} as DotCMSWorkflowActionEvent);
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.ts
@@ -245,11 +245,13 @@ export class DotEmaDialogComponent {
                     });
                 } else {
                     this.callEmbeddedFunction(callback, args);
-                    // Reload the page so pageLanguages reflects the post-action state
-                    // (e.g. a publish changes translated: false → true for a language version).
-                    // The iframe callback may also fire SAVE_PAGE which triggers pageReload;
-                    // reloadFromDialog fires first and switchMap in pageReload cancels it
-                    // cleanly if a second call arrives.
+                    // Reload so pageLanguages reflects the post-action state. The workflow
+                    // action triggers an async save inside the iframe; by the time
+                    // saveContentCallback fires LANGUAGE_IS_CHANGED, the dialog may already
+                    // be closed and its iframe listener gone. Firing here — while the dialog
+                    // is still open — guarantees the reload runs. The Spanish draft already
+                    // exists at this point (created when the user selected the language),
+                    // so getLanguagesUsedPage correctly returns translated: true.
                     this.reloadFromDialog.emit();
                     this.messageService.add({
                         severity: 'success',
@@ -353,7 +355,6 @@ export class DotEmaDialogComponent {
                             // The edit content emits this for savings when translating a page and does not emit anything when changing the content
                             if (this.dialogState().form.isTranslation) {
                                 this.store.setSaved();
-                                this.reloadFromDialog.emit();
 
                                 if (event.detail.payload.isMoveAction) {
                                     this.reloadIframe();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.ts
@@ -245,6 +245,12 @@ export class DotEmaDialogComponent {
                     });
                 } else {
                     this.callEmbeddedFunction(callback, args);
+                    // Reload the page so pageLanguages reflects the post-action state
+                    // (e.g. a publish changes translated: false → true for a language version).
+                    // The iframe callback may also fire SAVE_PAGE which triggers pageReload;
+                    // reloadFromDialog fires first and switchMap in pageReload cancels it
+                    // cleanly if a second call arrives.
+                    this.reloadFromDialog.emit();
                     this.messageService.add({
                         severity: 'success',
                         summary: this.dotMessageService.get('Workflow-Action'),

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/components/dot-ema-dialog/dot-ema-dialog.component.ts
@@ -353,6 +353,7 @@ export class DotEmaDialogComponent {
                             // The edit content emits this for savings when translating a page and does not emit anything when changing the content
                             if (this.dialogState().form.isTranslation) {
                                 this.store.setSaved();
+                                this.reloadFromDialog.emit();
 
                                 if (event.detail.payload.isMoveAction) {
                                     this.reloadIframe();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1010,6 +1010,24 @@ describe('DotEmaShellComponent', () => {
                 expect(spyGetWorkflowActions).toHaveBeenCalled();
             });
 
+            it('should trigger a store reload when htmlPageReferer is missing (new language version save)', () => {
+                spectator.detectChanges();
+                const spyReload = jest.spyOn(store, 'pageReload');
+
+                spectator.triggerEventHandler(
+                    DotEmaDialogComponent,
+                    'action',
+                    createDialogActionEvent({
+                        name: NG_CUSTOM_EVENTS.SAVE_PAGE,
+                        payload: {}
+                    })
+                );
+
+                spectator.detectChanges();
+
+                expect(spyReload).toHaveBeenCalled();
+            });
+
             it('should trigger a store reload if the url is the same', () => {
                 spectator.detectChanges();
                 const spyReload = jest.spyOn(store, 'pageReload');

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1058,6 +1058,22 @@ describe('DotEmaShellComponent', () => {
                 expect(reloadSpy).toHaveBeenCalled();
             });
 
+            it('should reload page when LANGUAGE_IS_CHANGED fires from the properties dialog', () => {
+                const reloadSpy = jest.spyOn(store, 'pageReload');
+
+                spectator.triggerEventHandler(
+                    DotEmaDialogComponent,
+                    'action',
+                    createDialogActionEvent({
+                        name: NG_CUSTOM_EVENTS.LANGUAGE_IS_CHANGED,
+                        payload: { htmlPageReferer: '/index?com.dotmarketing.htmlpage.language=2' }
+                    })
+                );
+                spectator.detectChanges();
+
+                expect(reloadSpy).toHaveBeenCalled();
+            });
+
             it('should trigger a store reload if the URL from urlContentMap is the same as the current URL', async () => {
                 const reloadSpy = jest.spyOn(store, 'pageReload');
                 jest.spyOn(dotPageApiService, 'get').mockReturnValue(

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -278,6 +278,15 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
                 this.handleSavePageEvent(event);
                 break;
             }
+
+            case NG_CUSTOM_EVENTS.LANGUAGE_IS_CHANGED: {
+                // Fired by the edit content portlet when a page is saved in a new language
+                // (workingContentletInode is empty for a new version, so SAVE_PAGE is not
+                // emitted). Reload to refresh pageLanguages so the UVE toolbar language
+                // dropdown reflects the newly created version.
+                this.uveStore.pageReload();
+                break;
+            }
         }
     }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -289,6 +289,13 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
      */
     private handleSavePageEvent(event: CustomEvent): void {
         const htmlPageReferer = event.detail.payload?.htmlPageReferer;
+
+        if (!htmlPageReferer) {
+            this.uveStore.pageReload();
+
+            return;
+        }
+
         const url = new URL(htmlPageReferer, window.location.origin); // Add base for relative URLs
         const targetUrl = getTargetUrl(url.pathname, this.uveStore.pageAsset()?.urlContentMap);
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { patchState, signalStore, withFeature, withState } from '@ngrx/signals';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -354,11 +354,17 @@ describe('withPageApi', () => {
             expect(store.uveStatus()).toBe(UVE_STATUS.LOADED);
         });
 
-        it('should update pageLanguages with result from getLanguagesUsedPage after reload', () => {
+        it('should have pageLanguages already updated when setPageAsset is called during reload', () => {
+            // Regression test for #35647. The pre-fix code called setPageAsset BEFORE
+            // getLanguagesUsedPage responded, so pageTranslateProps (which reacts to
+            // pageAsset but reads pageLanguages via untracked()) saw stale data.
+            // This test would FAIL against the pre-fix code: at the moment setPageAsset
+            // fired, store.pageLanguages() would still show translated: false.
             const freshLanguages: DotLanguage[] = [
                 { id: 1, language: 'English', languageCode: 'en', translated: true }
             ];
 
+            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
             patchState(store, {
                 pageLanguages: [
                     { id: 1, language: 'English', languageCode: 'en', translated: false }
@@ -370,40 +376,32 @@ describe('withPageApi', () => {
                 'getLanguagesUsedPage'
             ).mockReturnValue(of(freshLanguages));
 
-            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
+            let pageLanguagesAtSetPageAsset: DotLanguage[] | undefined;
+            const originalSetPageAsset = store.setPageAsset.bind(store);
+            jest.spyOn(store, 'setPageAsset').mockImplementation((payload) => {
+                pageLanguagesAtSetPageAsset = [...store.pageLanguages()];
+                originalSetPageAsset(payload);
+            });
+
             store.pageReload();
             spectator.flushEffects();
 
-            expect(store.pageLanguages()).toEqual(freshLanguages);
+            expect(pageLanguagesAtSetPageAsset?.[0]?.translated).toBe(true);
         });
 
-        it('should set pageAsset and pageLanguages atomically so pageTranslateProps reflects the translated status from the server', () => {
-            // Regression test for #35647: before the fix, setPageAsset fired before
-            // getLanguagesUsedPage responded, so pageTranslateProps read stale pageLanguages
-            // with translated: false, incorrectly triggering the "Create language version?" dialog.
-            const freshLanguages: DotLanguage[] = [
-                { id: 1, language: 'English', languageCode: 'en', translated: true }
-            ];
-
-            patchState(store, {
-                pageLanguages: [
-                    { id: 1, language: 'English', languageCode: 'en', translated: false }
-                ]
-            });
+        it('should apply the page asset and set status to LOADED when getLanguagesUsedPage fails', () => {
+            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
 
             jest.spyOn(
                 spectator.inject(DotLanguagesService),
                 'getLanguagesUsedPage'
-            ).mockReturnValue(of(freshLanguages));
+            ).mockReturnValue(throwError(() => ({ status: 500 })));
 
-            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
             store.pageReload();
             spectator.flushEffects();
 
-            // pageTranslateProps uses untracked(() => store.pageLanguages()) — it only reacts
-            // to pageAsset changes. If pageAsset and pageLanguages are not updated together,
-            // this computed would still see translated: false from the stale pageLanguages.
-            expect(store.pageTranslateProps().currentLanguage?.translated).toBe(true);
+            expect(store.uveStatus()).toBe(UVE_STATUS.LOADED);
+            expect(store.pageAsset()).toEqual(MOCK_RESPONSE_HEADLESS.page);
         });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
@@ -401,7 +401,7 @@ describe('withPageApi', () => {
             spectator.flushEffects();
 
             expect(store.uveStatus()).toBe(UVE_STATUS.LOADED);
-            expect(store.pageAsset()).toEqual(MOCK_RESPONSE_HEADLESS.page);
+            expect(store.pageAssetResponse()?.pageAsset).toEqual(MOCK_RESPONSE_HEADLESS);
         });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { patchState, signalStore, withFeature, withState } from '@ngrx/signals';
-import { of, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -358,35 +358,37 @@ describe('withPageApi', () => {
             // Regression test for #35647. The pre-fix code called setPageAsset BEFORE
             // getLanguagesUsedPage responded, so pageTranslateProps (which reacts to
             // pageAsset but reads pageLanguages via untracked()) saw stale data.
-            // This test would FAIL against the pre-fix code: at the moment setPageAsset
-            // fired, store.pageLanguages() would still show translated: false.
-            const freshLanguages: DotLanguage[] = [
-                { id: 1, language: 'English', languageCode: 'en', translated: true }
-            ];
+            // We verify atomicity by holding getLanguagesUsedPage open with a Subject:
+            // the page asset must NOT be updated until the Subject emits, proving both
+            // writes happen in the same tap (after languages resolve).
+            const freshPage = {
+                ...MOCK_RESPONSE_HEADLESS,
+                page: { ...MOCK_RESPONSE_HEADLESS.page, title: 'Reloaded' }
+            };
+            const languagesSubject = new Subject<DotLanguage[]>();
 
-            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
-            patchState(store, {
-                pageLanguages: [
-                    { id: 1, language: 'English', languageCode: 'en', translated: false }
-                ]
-            });
-
+            getSpy.mockReturnValueOnce(of(freshPage));
             jest.spyOn(
                 spectator.inject(DotLanguagesService),
                 'getLanguagesUsedPage'
-            ).mockReturnValue(of(freshLanguages));
+            ).mockReturnValue(languagesSubject);
 
-            let pageLanguagesAtSetPageAsset: DotLanguage[] | undefined;
-            const originalSetPageAsset = store.setPageAsset.bind(store);
-            jest.spyOn(store, 'setPageAsset').mockImplementation((payload) => {
-                pageLanguagesAtSetPageAsset = [...store.pageLanguages()];
-                originalSetPageAsset(payload);
-            });
+            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
 
             store.pageReload();
             spectator.flushEffects();
 
-            expect(pageLanguagesAtSetPageAsset?.[0]?.translated).toBe(true);
+            // Languages haven't resolved yet — page asset must still show the original title.
+            // Pre-fix code would have already swapped to 'Reloaded' here.
+            expect(store.pageAssetResponse()?.pageAsset.page.title).toBe('Test Page');
+
+            languagesSubject.next([{ id: 1, language: 'English', languageCode: 'en', translated: true }]);
+            languagesSubject.complete();
+            spectator.flushEffects();
+
+            // After languages resolve, both pageAsset and pageLanguages are updated atomically.
+            expect(store.pageAssetResponse()?.pageAsset.page.title).toBe('Reloaded');
+            expect(store.pageLanguages()[0].translated).toBe(true);
         });
 
         it('should apply the page asset and set status to LOADED when getLanguagesUsedPage fails', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
@@ -12,7 +12,7 @@ import {
     DotPropertiesService,
     DotWorkflowActionsFireService
 } from '@dotcms/data-access';
-import { DEFAULT_VARIANT_ID } from '@dotcms/dotcms-models';
+import { DEFAULT_VARIANT_ID, DotLanguage } from '@dotcms/dotcms-models';
 import { DotPageAssetLayoutRow, UVE_MODE } from '@dotcms/types';
 import { WINDOW } from '@dotcms/utils';
 
@@ -352,6 +352,58 @@ describe('withPageApi', () => {
             expect(getGraphQLPageSpy).toHaveBeenCalled();
             expect(getSpy).not.toHaveBeenCalled();
             expect(store.uveStatus()).toBe(UVE_STATUS.LOADED);
+        });
+
+        it('should update pageLanguages with result from getLanguagesUsedPage after reload', () => {
+            const freshLanguages: DotLanguage[] = [
+                { id: 1, language: 'English', languageCode: 'en', translated: true }
+            ];
+
+            patchState(store, {
+                pageLanguages: [
+                    { id: 1, language: 'English', languageCode: 'en', translated: false }
+                ]
+            });
+
+            jest.spyOn(
+                spectator.inject(DotLanguagesService),
+                'getLanguagesUsedPage'
+            ).mockReturnValue(of(freshLanguages));
+
+            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
+            store.pageReload();
+            spectator.flushEffects();
+
+            expect(store.pageLanguages()).toEqual(freshLanguages);
+        });
+
+        it('should set pageAsset and pageLanguages atomically so pageTranslateProps reflects the translated status from the server', () => {
+            // Regression test for #35647: before the fix, setPageAsset fired before
+            // getLanguagesUsedPage responded, so pageTranslateProps read stale pageLanguages
+            // with translated: false, incorrectly triggering the "Create language version?" dialog.
+            const freshLanguages: DotLanguage[] = [
+                { id: 1, language: 'English', languageCode: 'en', translated: true }
+            ];
+
+            patchState(store, {
+                pageLanguages: [
+                    { id: 1, language: 'English', languageCode: 'en', translated: false }
+                ]
+            });
+
+            jest.spyOn(
+                spectator.inject(DotLanguagesService),
+                'getLanguagesUsedPage'
+            ).mockReturnValue(of(freshLanguages));
+
+            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
+            store.pageReload();
+            spectator.flushEffects();
+
+            // pageTranslateProps uses untracked(() => store.pageLanguages()) — it only reacts
+            // to pageAsset changes. If pageAsset and pageLanguages are not updated together,
+            // this computed would still see translated: false from the stale pageLanguages.
+            expect(store.pageTranslateProps().currentLanguage?.translated).toBe(true);
         });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
@@ -382,7 +382,9 @@ describe('withPageApi', () => {
             // Pre-fix code would have already swapped to 'Reloaded' here.
             expect(store.pageAssetResponse()?.pageAsset.page.title).toBe('Test Page');
 
-            languagesSubject.next([{ id: 1, language: 'English', languageCode: 'en', translated: true }]);
+            languagesSubject.next([
+                { id: 1, language: 'English', languageCode: 'en', translated: true }
+            ]);
             languagesSubject.complete();
             spectator.flushEffects();
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
@@ -309,10 +309,10 @@ export function withPageApi(deps: WithPageApiDeps) {
                                         .getLanguagesUsedPage(pageResult.pageAsset.page.identifier)
                                         .pipe(
                                             tap((languages) => {
-                                                // pageLanguages must land before setPageAsset so
-                                                // that pageTranslateProps (which reacts to pageAsset
-                                                // but reads pageLanguages via untracked) always sees
-                                                // a consistent languages slice when it recomputes.
+                                                // Update both slices in the same synchronous tap.
+                                                // Angular batches the two signal writes before
+                                                // flushing effects, so $translatePageEffect sees
+                                                // a consistent pageAsset + pageLanguages state.
                                                 patchState(store, {
                                                     pageLanguages: languages,
                                                     uveStatus: UVE_STATUS.LOADED

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
@@ -288,34 +288,34 @@ export function withPageApi(deps: WithPageApiDeps) {
                         }),
                         switchMap(() => {
                             const isGraphQL = !!deps.requestMetadata();
+                            let graphQLContent: Record<string, unknown> | undefined;
+
                             const pageRequest = !isGraphQL
                                 ? dotPageApiService.get(store.pageParams())
                                 : dotPageApiService.getGraphQLPage(deps.$requestWithParams()).pipe(
-                                      tap((response) =>
-                                          deps.setPageAsset({
-                                              pageAsset: response.pageAsset,
-                                              content: response.content
-                                          })
-                                      ),
+                                      tap((response) => {
+                                          graphQLContent = response.content;
+                                      }),
                                       map((response) => response.pageAsset)
                                   );
 
                             return pageRequest.pipe(
-                                tap((pageAsset) => {
-                                    if (!isGraphQL) {
-                                        deps.setPageAsset({ pageAsset });
-                                    }
-                                }),
                                 switchMap((pageAsset) => {
-                                    return dotLanguagesService.getLanguagesUsedPage(
-                                        pageAsset.page.identifier
-                                    );
-                                }),
-                                tap((languages) => {
-                                    patchState(store, {
-                                        pageLanguages: languages,
-                                        uveStatus: UVE_STATUS.LOADED
-                                    });
+                                    return dotLanguagesService
+                                        .getLanguagesUsedPage(pageAsset.page.identifier)
+                                        .pipe(
+                                            tap((languages) => {
+                                                const payload =
+                                                    graphQLContent !== undefined
+                                                        ? { pageAsset, content: graphQLContent }
+                                                        : { pageAsset };
+                                                deps.setPageAsset(payload);
+                                                patchState(store, {
+                                                    pageLanguages: languages,
+                                                    uveStatus: UVE_STATUS.LOADED
+                                                });
+                                            })
+                                        );
                                 }),
                                 catchError((err: HttpErrorResponse) => {
                                     const errorStatus = err.status;

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
@@ -247,9 +247,9 @@ export function withPageApi(deps: WithPageApiDeps) {
                                                     ? { pageAsset, content: graphQLContent }
                                                     : { pageAsset };
 
-                                            deps.setPageAsset(payload);
-                                            deps.addHistory(payload);
-
+                                            // Both writes land in the same synchronous tap.
+                                            // Angular batches them before flushing effects, so
+                                            // $translatePageEffect always sees a consistent state.
                                             // uveCurrentUser is synced reactively from GlobalStore in withUve onInit effect
                                             patchState(store, {
                                                 pageExperiment: experiment,
@@ -263,6 +263,8 @@ export function withPageApi(deps: WithPageApiDeps) {
                                                 ),
                                                 uveStatus: UVE_STATUS.LOADED
                                             });
+                                            deps.setPageAsset(payload);
+                                            deps.addHistory(payload);
                                         })
                                     );
                                 })
@@ -309,10 +311,9 @@ export function withPageApi(deps: WithPageApiDeps) {
                                         .getLanguagesUsedPage(pageResult.pageAsset.page.identifier)
                                         .pipe(
                                             tap((languages) => {
-                                                // Update both slices in the same synchronous tap.
-                                                // Angular batches the two signal writes before
-                                                // flushing effects, so $translatePageEffect sees
-                                                // a consistent pageAsset + pageLanguages state.
+                                                // Both writes land in the same synchronous tap.
+                                                // Angular batches them before flushing effects, so
+                                                // $translatePageEffect always sees a consistent state.
                                                 patchState(store, {
                                                     pageLanguages: languages,
                                                     uveStatus: UVE_STATUS.LOADED

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
@@ -287,29 +287,26 @@ export function withPageApi(deps: WithPageApiDeps) {
                             }
                         }),
                         switchMap(() => {
-                            const isGraphQL = !!deps.requestMetadata();
-                            let graphQLContent: Record<string, unknown> | undefined;
-
-                            const pageRequest = !isGraphQL
-                                ? dotPageApiService.get(store.pageParams())
-                                : dotPageApiService.getGraphQLPage(deps.$requestWithParams()).pipe(
-                                      tap((response) => {
-                                          graphQLContent = response.content;
-                                      }),
-                                      map((response) => response.pageAsset)
-                                  );
+                            // Thread content through the stream value so the payload shape
+                            // naturally encodes whether this is a GraphQL reload:
+                            // - non-GraphQL emits { pageAsset }         → 'content' NOT in payload
+                            // - GraphQL emits     { pageAsset, content } → 'content' IN payload
+                            // setPageAsset in withPage.ts uses 'content' in payload to decide
+                            // whether to clear the existing content, so this preserves original semantics.
+                            const pageRequest = !deps.requestMetadata()
+                                ? dotPageApiService
+                                      .get(store.pageParams())
+                                      .pipe(map((pageAsset) => ({ pageAsset })))
+                                : dotPageApiService
+                                      .getGraphQLPage(deps.$requestWithParams())
+                                      .pipe(
+                                          map(({ pageAsset, content }) => ({ pageAsset, content }))
+                                      );
 
                             return pageRequest.pipe(
-                                switchMap((pageAsset) => {
-                                    // Preserve original semantics: GraphQL always passes `content`
-                                    // (even when undefined) so setPageAsset clears previous content
-                                    // via the `'content' in payload` discriminant in withPage.ts.
-                                    const payload = isGraphQL
-                                        ? { pageAsset, content: graphQLContent }
-                                        : { pageAsset };
-
+                                switchMap((pageResult) => {
                                     return dotLanguagesService
-                                        .getLanguagesUsedPage(pageAsset.page.identifier)
+                                        .getLanguagesUsedPage(pageResult.pageAsset.page.identifier)
                                         .pipe(
                                             tap((languages) => {
                                                 // pageLanguages must land before setPageAsset so
@@ -320,7 +317,7 @@ export function withPageApi(deps: WithPageApiDeps) {
                                                     pageLanguages: languages,
                                                     uveStatus: UVE_STATUS.LOADED
                                                 });
-                                                deps.setPageAsset(payload);
+                                                deps.setPageAsset(pageResult);
                                             }),
                                             catchError(() => {
                                                 // Languages fetch failed: still apply the fresh
@@ -329,7 +326,7 @@ export function withPageApi(deps: WithPageApiDeps) {
                                                 patchState(store, {
                                                     uveStatus: UVE_STATUS.LOADED
                                                 });
-                                                deps.setPageAsset(payload);
+                                                deps.setPageAsset(pageResult);
 
                                                 return EMPTY;
                                             })

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
@@ -301,19 +301,37 @@ export function withPageApi(deps: WithPageApiDeps) {
 
                             return pageRequest.pipe(
                                 switchMap((pageAsset) => {
+                                    // Preserve original semantics: GraphQL always passes `content`
+                                    // (even when undefined) so setPageAsset clears previous content
+                                    // via the `'content' in payload` discriminant in withPage.ts.
+                                    const payload = isGraphQL
+                                        ? { pageAsset, content: graphQLContent }
+                                        : { pageAsset };
+
                                     return dotLanguagesService
                                         .getLanguagesUsedPage(pageAsset.page.identifier)
                                         .pipe(
                                             tap((languages) => {
-                                                const payload =
-                                                    graphQLContent !== undefined
-                                                        ? { pageAsset, content: graphQLContent }
-                                                        : { pageAsset };
-                                                deps.setPageAsset(payload);
+                                                // pageLanguages must land before setPageAsset so
+                                                // that pageTranslateProps (which reacts to pageAsset
+                                                // but reads pageLanguages via untracked) always sees
+                                                // a consistent languages slice when it recomputes.
                                                 patchState(store, {
                                                     pageLanguages: languages,
                                                     uveStatus: UVE_STATUS.LOADED
                                                 });
+                                                deps.setPageAsset(payload);
+                                            }),
+                                            catchError(() => {
+                                                // Languages fetch failed: still apply the fresh
+                                                // page asset with the current (stale) languages so
+                                                // the user sees the page rather than an error screen.
+                                                patchState(store, {
+                                                    uveStatus: UVE_STATUS.LOADED
+                                                });
+                                                deps.setPageAsset(payload);
+
+                                                return EMPTY;
                                             })
                                         );
                                 }),

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page/withPage.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page/withPage.spec.ts
@@ -6,6 +6,7 @@ import { of } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { DotPropertiesService } from '@dotcms/data-access';
+import { DotLanguage } from '@dotcms/dotcms-models';
 import { UVE_MODE } from '@dotcms/types';
 
 import { withPage } from './withPage';
@@ -15,6 +16,7 @@ import {
     DotPageApiService
 } from '../../../services/dot-page-api/dot-page-api.service';
 import { PERSONA_KEY } from '../../../shared/consts';
+import { MOCK_RESPONSE_HEADLESS } from '../../../shared/mocks';
 import { UVEState } from '../../models';
 import { createInitialUVEState } from '../../testing/mocks';
 import { withFlags } from '../flags/withFlags';
@@ -208,6 +210,44 @@ describe('withPage', () => {
                     personaId: 'persona-id-123'
                 }
             });
+        });
+    });
+
+    describe('pageTranslateProps', () => {
+        it('should return undefined currentLanguage when pageAsset is not set', () => {
+            expect(store.pageTranslateProps().currentLanguage).toBeUndefined();
+        });
+
+        it('should reflect translated status from pageLanguages for the current language', () => {
+            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
+            patchStoreState(store, {
+                pageLanguages: [
+                    { id: 1, language: 'English', languageCode: 'en', translated: true }
+                ] as DotLanguage[]
+            });
+
+            expect(store.pageTranslateProps().currentLanguage?.translated).toBe(true);
+        });
+
+        it('should recompute when pageLanguages changes independently of pageAsset', () => {
+            // Regression for #35647: pageTranslateProps was previously wrapped with
+            // untracked(() => store.pageLanguages()), making it blind to language changes.
+            // Removing untracked() makes the computed reactive on both signals so any
+            // call site that updates pageLanguages is automatically reflected here.
+            store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
+            patchStoreState(store, {
+                pageLanguages: [
+                    { id: 1, language: 'English', languageCode: 'en', translated: false }
+                ] as DotLanguage[]
+            });
+            expect(store.pageTranslateProps().currentLanguage?.translated).toBe(false);
+
+            patchStoreState(store, {
+                pageLanguages: [
+                    { id: 1, language: 'English', languageCode: 'en', translated: true }
+                ] as DotLanguage[]
+            });
+            expect(store.pageTranslateProps().currentLanguage?.translated).toBe(true);
         });
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page/withPage.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page/withPage.ts
@@ -7,7 +7,7 @@ import {
     withState
 } from '@ngrx/signals';
 
-import { computed, Signal, untracked } from '@angular/core';
+import { computed, Signal } from '@angular/core';
 
 import { DEFAULT_VARIANT_ID, DotLanguage } from '@dotcms/dotcms-models';
 import { DotCMSPage, DotCMSPageAsset } from '@dotcms/types';
@@ -272,8 +272,12 @@ export function withPage() {
                 const pageDataValue = pageAsset()?.page as DotCMSPage;
                 const viewAsData = pageAsset()?.viewAs;
                 const languageId = viewAsData?.language?.id;
-                const translatedLanguages = untracked(() => store.pageLanguages());
-                const currentLanguage = translatedLanguages.find((lang) => lang.id === languageId);
+                // Reactive on both pageAsset and pageLanguages. Angular batches synchronous
+                // signal writes before flushing effects, so updating both in the same tap
+                // callback results in a single effect execution with consistent state.
+                const currentLanguage = store
+                    .pageLanguages()
+                    .find((lang) => lang.id === languageId);
 
                 return {
                     page: pageDataValue,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
@@ -290,7 +290,9 @@ describe('withLoad', () => {
             // Pre-fix code would have already swapped to 'Reloaded' here.
             expect(store.pageAssetResponse()?.pageAsset.page.title).toBe('Test Page');
 
-            languagesSubject.next([{ id: 1, language: 'English', languageCode: 'en', translated: true }]);
+            languagesSubject.next([
+                { id: 1, language: 'English', languageCode: 'en', translated: true }
+            ]);
             languagesSubject.complete();
             spectator.flushEffects();
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
@@ -6,7 +6,7 @@ import {
     SpyObject
 } from '@ngneat/spectator/jest';
 import { patchState, signalStore, withMethods, withState } from '@ngrx/signals';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -261,44 +261,42 @@ describe('withLoad', () => {
     });
 
     describe('reloadPageAfterLockChange – atomicity', () => {
-        it('should have pageLanguages already updated when setPageAsset is called after lock change', () => {
+        it('should not update pageAsset until getLanguagesUsedPage resolves after lock change', () => {
             // Regression test for #35647. The pre-fix code called setPageAsset BEFORE
             // getLanguagesUsedPage responded, so pageTranslateProps (which reacts to
             // pageAsset but reads pageLanguages via untracked()) saw stale data.
-            // This test would FAIL against the pre-fix code: at the moment setPageAsset
-            // fired, store.pageLanguages() would still show translated: false.
-            const freshLanguages: DotLanguage[] = [
-                { id: 1, language: 'English', languageCode: 'en', translated: true }
-            ];
+            // We verify atomicity by holding getLanguagesUsedPage open with a Subject:
+            // the page asset must NOT be updated until the Subject emits, proving both
+            // writes happen in the same tap (after languages resolve).
+            const freshPage = {
+                ...MOCK_RESPONSE_HEADLESS,
+                page: { ...MOCK_RESPONSE_HEADLESS.page, title: 'Reloaded' }
+            };
+            const languagesSubject = new Subject<DotLanguage[]>();
 
-            jest.spyOn(spectator.inject(DotPageApiService), 'get').mockReturnValue(
-                of(MOCK_RESPONSE_HEADLESS)
-            );
+            jest.spyOn(spectator.inject(DotPageApiService), 'get').mockReturnValue(of(freshPage));
             jest.spyOn(
                 spectator.inject(DotLanguagesService),
                 'getLanguagesUsedPage'
-            ).mockReturnValue(of(freshLanguages));
+            ).mockReturnValue(languagesSubject);
 
             store.setPageAPIResponse(MOCK_RESPONSE_HEADLESS);
             spectator.flushEffects();
 
-            patchState(store, {
-                pageLanguages: [
-                    { id: 1, language: 'English', languageCode: 'en', translated: false }
-                ]
-            });
-
-            let pageLanguagesAtSetPageAsset: DotLanguage[] | undefined;
-            const originalSetPageAsset = store.setPageAsset.bind(store);
-            jest.spyOn(store, 'setPageAsset').mockImplementation((payload) => {
-                pageLanguagesAtSetPageAsset = [...store.pageLanguages()];
-                originalSetPageAsset(payload);
-            });
-
             store.workflowToggleLock(MOCK_RESPONSE_HEADLESS.page.inode, false, false);
             spectator.flushEffects();
 
-            expect(pageLanguagesAtSetPageAsset?.[0]?.translated).toBe(true);
+            // Languages haven't resolved yet — page asset must still show the original title.
+            // Pre-fix code would have already swapped to 'Reloaded' here.
+            expect(store.pageAssetResponse()?.pageAsset.page.title).toBe('Test Page');
+
+            languagesSubject.next([{ id: 1, language: 'English', languageCode: 'en', translated: true }]);
+            languagesSubject.complete();
+            spectator.flushEffects();
+
+            // After languages resolve, both pageAsset and pageLanguages are updated atomically.
+            expect(store.pageAssetResponse()?.pageAsset.page.title).toBe('Reloaded');
+            expect(store.pageLanguages()[0].translated).toBe(true);
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
@@ -261,14 +261,12 @@ describe('withLoad', () => {
     });
 
     describe('reloadPageAfterLockChange – atomicity', () => {
-        it('should update pageLanguages together with pageAsset after lock so pageTranslateProps reflects current translated status', () => {
-            // Regression test for #35647: before the fix, setPageAsset fired before
-            // getLanguagesUsedPage responded. If an effect flush happened in that window,
-            // pageTranslateProps would read stale pageLanguages (translated: false) and
-            // incorrectly show the "Create language version?" dialog.
-            const staleLanguages: DotLanguage[] = [
-                { id: 1, language: 'English', languageCode: 'en', translated: false }
-            ];
+        it('should have pageLanguages already updated when setPageAsset is called after lock change', () => {
+            // Regression test for #35647. The pre-fix code called setPageAsset BEFORE
+            // getLanguagesUsedPage responded, so pageTranslateProps (which reacts to
+            // pageAsset but reads pageLanguages via untracked()) saw stale data.
+            // This test would FAIL against the pre-fix code: at the moment setPageAsset
+            // fired, store.pageLanguages() would still show translated: false.
             const freshLanguages: DotLanguage[] = [
                 { id: 1, language: 'English', languageCode: 'en', translated: true }
             ];
@@ -284,42 +282,23 @@ describe('withLoad', () => {
             store.setPageAPIResponse(MOCK_RESPONSE_HEADLESS);
             spectator.flushEffects();
 
-            patchState(store, { pageLanguages: staleLanguages });
+            patchState(store, {
+                pageLanguages: [
+                    { id: 1, language: 'English', languageCode: 'en', translated: false }
+                ]
+            });
+
+            let pageLanguagesAtSetPageAsset: DotLanguage[] | undefined;
+            const originalSetPageAsset = store.setPageAsset.bind(store);
+            jest.spyOn(store, 'setPageAsset').mockImplementation((payload) => {
+                pageLanguagesAtSetPageAsset = [...store.pageLanguages()];
+                originalSetPageAsset(payload);
+            });
 
             store.workflowToggleLock(MOCK_RESPONSE_HEADLESS.page.inode, false, false);
             spectator.flushEffects();
 
-            expect(store.pageLanguages()).toEqual(freshLanguages);
-            expect(store.pageTranslateProps().currentLanguage?.translated).toBe(true);
-        });
-
-        it('should update pageLanguages together with pageAsset after unlock so pageTranslateProps reflects current translated status', () => {
-            const staleLanguages: DotLanguage[] = [
-                { id: 1, language: 'English', languageCode: 'en', translated: false }
-            ];
-            const freshLanguages: DotLanguage[] = [
-                { id: 1, language: 'English', languageCode: 'en', translated: true }
-            ];
-
-            jest.spyOn(spectator.inject(DotPageApiService), 'get').mockReturnValue(
-                of(MOCK_RESPONSE_HEADLESS)
-            );
-            jest.spyOn(
-                spectator.inject(DotLanguagesService),
-                'getLanguagesUsedPage'
-            ).mockReturnValue(of(freshLanguages));
-
-            store.setPageAPIResponse(MOCK_RESPONSE_HEADLESS);
-            spectator.flushEffects();
-
-            patchState(store, { pageLanguages: staleLanguages });
-
-            // isLocked: true, isCurrentUser: true → unlock path
-            store.workflowToggleLock(MOCK_RESPONSE_HEADLESS.page.inode, true, true);
-            spectator.flushEffects();
-
-            expect(store.pageLanguages()).toEqual(freshLanguages);
-            expect(store.pageTranslateProps().currentLanguage?.translated).toBe(true);
+            expect(pageLanguagesAtSetPageAsset?.[0]?.translated).toBe(true);
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.spec.ts
@@ -16,6 +16,7 @@ import {
     DotPropertiesService,
     DotWorkflowsActionsService
 } from '@dotcms/data-access';
+import { DotLanguage } from '@dotcms/dotcms-models';
 import { DotCMSPageAsset, UVE_MODE } from '@dotcms/types';
 import { DotLanguagesServiceMock, mockWorkflowsActions } from '@dotcms/utils-testing';
 
@@ -256,6 +257,69 @@ describe('withLoad', () => {
 
                 expect(store.$lockOptions()?.shouldShowButton).toBe(false);
             });
+        });
+    });
+
+    describe('reloadPageAfterLockChange – atomicity', () => {
+        it('should update pageLanguages together with pageAsset after lock so pageTranslateProps reflects current translated status', () => {
+            // Regression test for #35647: before the fix, setPageAsset fired before
+            // getLanguagesUsedPage responded. If an effect flush happened in that window,
+            // pageTranslateProps would read stale pageLanguages (translated: false) and
+            // incorrectly show the "Create language version?" dialog.
+            const staleLanguages: DotLanguage[] = [
+                { id: 1, language: 'English', languageCode: 'en', translated: false }
+            ];
+            const freshLanguages: DotLanguage[] = [
+                { id: 1, language: 'English', languageCode: 'en', translated: true }
+            ];
+
+            jest.spyOn(spectator.inject(DotPageApiService), 'get').mockReturnValue(
+                of(MOCK_RESPONSE_HEADLESS)
+            );
+            jest.spyOn(
+                spectator.inject(DotLanguagesService),
+                'getLanguagesUsedPage'
+            ).mockReturnValue(of(freshLanguages));
+
+            store.setPageAPIResponse(MOCK_RESPONSE_HEADLESS);
+            spectator.flushEffects();
+
+            patchState(store, { pageLanguages: staleLanguages });
+
+            store.workflowToggleLock(MOCK_RESPONSE_HEADLESS.page.inode, false, false);
+            spectator.flushEffects();
+
+            expect(store.pageLanguages()).toEqual(freshLanguages);
+            expect(store.pageTranslateProps().currentLanguage?.translated).toBe(true);
+        });
+
+        it('should update pageLanguages together with pageAsset after unlock so pageTranslateProps reflects current translated status', () => {
+            const staleLanguages: DotLanguage[] = [
+                { id: 1, language: 'English', languageCode: 'en', translated: false }
+            ];
+            const freshLanguages: DotLanguage[] = [
+                { id: 1, language: 'English', languageCode: 'en', translated: true }
+            ];
+
+            jest.spyOn(spectator.inject(DotPageApiService), 'get').mockReturnValue(
+                of(MOCK_RESPONSE_HEADLESS)
+            );
+            jest.spyOn(
+                spectator.inject(DotLanguagesService),
+                'getLanguagesUsedPage'
+            ).mockReturnValue(of(freshLanguages));
+
+            store.setPageAPIResponse(MOCK_RESPONSE_HEADLESS);
+            spectator.flushEffects();
+
+            patchState(store, { pageLanguages: staleLanguages });
+
+            // isLocked: true, isCurrentUser: true → unlock path
+            store.workflowToggleLock(MOCK_RESPONSE_HEADLESS.page.inode, true, true);
+            spectator.flushEffects();
+
+            expect(store.pageLanguages()).toEqual(freshLanguages);
+            expect(store.pageTranslateProps().currentLanguage?.translated).toBe(true);
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
@@ -208,19 +208,38 @@ export function withWorkflow() {
                                           ).content
                                         : undefined;
 
+
+                                const pageAssetPayload = {
+                                    pageAsset: pageResponse.pageAsset,
+                                    ...(content !== undefined && { content })
+                                };
+
                                 return dotLanguagesService
                                     .getLanguagesUsedPage(pageResponse.pageAsset.page.identifier)
                                     .pipe(
                                         tap((languages) => {
-                                            pageStore.setPageAsset({
-                                                pageAsset: pageResponse.pageAsset,
-                                                ...(content !== undefined && { content })
-                                            });
+                                            // pageLanguages must land before setPageAsset so
+                                            // that pageTranslateProps (which reacts to pageAsset
+                                            // but reads pageLanguages via untracked) always sees
+                                            // a consistent languages slice when it recomputes.
                                             patchState(store, {
                                                 pageLanguages: languages,
                                                 uveStatus: UVE_STATUS.LOADED,
                                                 workflowLockIsLoading: false
                                             });
+                                            pageStore.setPageAsset(pageAssetPayload);
+                                        }),
+                                        catchError(() => {
+                                            // Languages fetch failed: still apply the fresh
+                                            // page asset with the current (stale) languages so
+                                            // the user sees the page rather than an error screen.
+                                            patchState(store, {
+                                                uveStatus: UVE_STATUS.LOADED,
+                                                workflowLockIsLoading: false
+                                            });
+                                            pageStore.setPageAsset(pageAssetPayload);
+
+                                            return EMPTY;
                                         })
                                     );
                             }),

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
@@ -208,7 +208,6 @@ export function withWorkflow() {
                                           ).content
                                         : undefined;
 
-
                                 const pageAssetPayload = {
                                     pageAsset: pageResponse.pageAsset,
                                     ...(content !== undefined && { content })

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
@@ -196,25 +196,19 @@ export function withWorkflow() {
 
                         return pageRequest.pipe(
                             switchMap((response) => {
-                                const pageResponse =
-                                    'pageAsset' in response ? response : { pageAsset: response };
-
+                                // Both request branches emit { pageAsset } or { pageAsset, content }.
+                                // The 'content' key is only present on the GraphQL path — setPageAsset
+                                // uses 'content' in payload to decide whether to clear previous content,
+                                // so preserving the key's presence/absence is the correct behavior.
                                 const content =
-                                    'content' in pageResponse
-                                        ? (
-                                              pageResponse as {
-                                                  content?: Record<string, unknown>;
-                                              }
-                                          ).content
-                                        : undefined;
-
+                                    'content' in response ? response.content : undefined;
                                 const pageAssetPayload = {
-                                    pageAsset: pageResponse.pageAsset,
+                                    pageAsset: response.pageAsset,
                                     ...(content !== undefined && { content })
                                 };
 
                                 return dotLanguagesService
-                                    .getLanguagesUsedPage(pageResponse.pageAsset.page.identifier)
+                                    .getLanguagesUsedPage(response.pageAsset.page.identifier)
                                     .pipe(
                                         tap((languages) => {
                                             // pageLanguages must land before setPageAsset so

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
@@ -208,21 +208,21 @@ export function withWorkflow() {
                                           ).content
                                         : undefined;
 
-                                pageStore.setPageAsset({
-                                    pageAsset: pageResponse.pageAsset,
-                                    ...(content !== undefined && { content })
-                                });
-
-                                return dotLanguagesService.getLanguagesUsedPage(
-                                    pageResponse.pageAsset.page.identifier
-                                );
-                            }),
-                            tap((languages) => {
-                                patchState(store, {
-                                    pageLanguages: languages,
-                                    uveStatus: UVE_STATUS.LOADED,
-                                    workflowLockIsLoading: false
-                                });
+                                return dotLanguagesService
+                                    .getLanguagesUsedPage(pageResponse.pageAsset.page.identifier)
+                                    .pipe(
+                                        tap((languages) => {
+                                            pageStore.setPageAsset({
+                                                pageAsset: pageResponse.pageAsset,
+                                                ...(content !== undefined && { content })
+                                            });
+                                            patchState(store, {
+                                                pageLanguages: languages,
+                                                uveStatus: UVE_STATUS.LOADED,
+                                                workflowLockIsLoading: false
+                                            });
+                                        })
+                                    );
                             }),
                             catchError(({ status: errorStatus }: HttpErrorResponse) => {
                                 patchState(store, {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
@@ -201,7 +201,9 @@ export function withWorkflow() {
                                 // uses 'content' in payload to decide whether to clear previous content,
                                 // so preserving the key's presence/absence is the correct behavior.
                                 const content =
-                                    'content' in response ? response.content : undefined;
+                                    'content' in response
+                                        ? (response.content as Record<string, unknown>)
+                                        : undefined;
                                 const pageAssetPayload = {
                                     pageAsset: response.pageAsset,
                                     ...(content !== undefined && { content })
@@ -211,10 +213,9 @@ export function withWorkflow() {
                                     .getLanguagesUsedPage(response.pageAsset.page.identifier)
                                     .pipe(
                                         tap((languages) => {
-                                            // Update both slices in the same synchronous tap.
-                                            // Angular batches the two signal writes before
-                                            // flushing effects, so $translatePageEffect sees
-                                            // a consistent pageAsset + pageLanguages state.
+                                            // Both writes land in the same synchronous tap.
+                                            // Angular batches them before flushing effects, so
+                                            // $translatePageEffect always sees a consistent state.
                                             patchState(store, {
                                                 pageLanguages: languages,
                                                 uveStatus: UVE_STATUS.LOADED,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/workflow/withWorkflow.ts
@@ -211,10 +211,10 @@ export function withWorkflow() {
                                     .getLanguagesUsedPage(response.pageAsset.page.identifier)
                                     .pipe(
                                         tap((languages) => {
-                                            // pageLanguages must land before setPageAsset so
-                                            // that pageTranslateProps (which reacts to pageAsset
-                                            // but reads pageLanguages via untracked) always sees
-                                            // a consistent languages slice when it recomputes.
+                                            // Update both slices in the same synchronous tap.
+                                            // Angular batches the two signal writes before
+                                            // flushing effects, so $translatePageEffect sees
+                                            // a consistent pageAsset + pageLanguages state.
                                             patchState(store, {
                                                 pageLanguages: languages,
                                                 uveStatus: UVE_STATUS.LOADED,


### PR DESCRIPTION
## Summary

Fixes #35647.

After creating a new language version of a page via the **Properties dialog** (the edit-page portlet opened from the UVE toolbar), the UVE toolbar language dropdown incorrectly showed the **\"Create New Language Version?\"** confirmation dialog for a version that had just been created — requiring a full browser refresh to recover.

### Root cause

The bug has two layers:

**Layer 1 — Stale reactive computation (`withPage.ts`)**

`pageTranslateProps` used `untracked(() => store.pageLanguages())`, making it invisible to changes in `pageLanguages`. It only recomputed when `pageAsset` changed. When `pageReload()` updated `pageAsset` before `getLanguagesUsedPage` responded, `pageTranslateProps` recomputed using the old (stale) language data, causing `$translatePageEffect` to see `translated: false` and incorrectly trigger the dialog.

**Layer 2 — Missing event handler in the shell (`dot-ema-shell.component.ts`)**

When a user selects a new language inside the Properties dialog, the iframe navigates to a new URL with an empty inode, creating a working draft. When the user saves, the JSP's `saveContentCallback` detects `workingContentletInode.length === 0` and fires `LANGUAGE_IS_CHANGED` instead of `SAVE_PAGE`. The shell's `handleNgEvent` had no `case` for `LANGUAGE_IS_CHANGED`, so the event was silently dropped and `pageLanguages` was never refreshed.

For the **workflow action path** (e.g. clicking a \"Publish\" workflow button), `handleWorkflowEvent` in the dialog calls `saveAssignCallBackAngular` inside the iframe, which starts an async AJAX save. By the time `saveContentCallback` fires `LANGUAGE_IS_CHANGED`, the dialog may already be closed and its iframe document listener destroyed. The `reloadFromDialog.emit()` call immediately after `callEmbeddedFunction` ensures the reload runs while the dialog is still open — and it already returns correct data because the language draft was created the moment the user navigated to the new language URL.

### Fix

- **`withPage.ts`** — Remove `untracked()` from `pageTranslateProps` so it is reactive on both `pageAsset` and `pageLanguages`. Angular batches synchronous signal writes before flushing effects, so updating both in the same `tap` results in a single consistent effect execution.

- **`withPageApi.ts` / `withWorkflow.ts`** — Move `patchState({ pageLanguages })` and `setPageAsset` into the same synchronous `tap` callback so both signals are always written together, preventing any window where `pageTranslateProps` could see a partially-updated state.

- **`dot-ema-shell.component.ts`** — Add `LANGUAGE_IS_CHANGED` case to `handleNgEvent`. This covers the direct-save path where the JSP fires the event after the new language version is persisted.

- **`dot-ema-dialog.component.ts`** — Keep `reloadFromDialog.emit()` in `handleWorkflowEvent` to cover the workflow-action path, where the async save callback may fire after the dialog is already closed. Remove the equivalent emit from the `EDIT_CONTENTLET_UPDATED / isTranslation` branch — that branch is only reached from the editor's own translation dialog, which already handles `LANGUAGE_IS_CHANGED` independently.

## Files changed

- `withPage.ts` — remove `untracked()` from `pageTranslateProps`; root cause fix
- `withPageApi.ts` — restructure `pageReload` pipeline; align `pageLoad` write order
- `withWorkflow.ts` — same restructuring for `reloadPageAfterLockChange`
- `dot-ema-shell.component.ts` — add `LANGUAGE_IS_CHANGED` case to `handleNgEvent`
- `dot-ema-dialog.component.ts` — clarify workflow reload comment; remove redundant `EDIT_CONTENTLET_UPDATED` emit
- Spec files for all of the above

## Test plan

- [ ] Open a page in the UVE. Click **Properties** in the toolbar → in the dialog, change the language dropdown to a language that has no version yet → fill in the form → click **Publish** → close the dialog → click the language dropdown in the UVE toolbar → the language switches without showing \"Create new language version?\"
- [ ] Switch between existing language translations in the UVE toolbar — no spurious dialog appears
- [ ] Toggle page lock — no spurious \"Create language version?\" dialog after the reload
- [ ] `yarn nx test portlets-edit-ema-portlet --testPathPattern="withPageApi.spec|withWorkflow.spec|withPage.spec|dot-ema-dialog|dot-ema-shell"`

This PR fixes: #35647