### PR TITLE
refactor(core-web): unify color generation on PrimeNG palette (#35869)

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/main-legacy/main-legacy.component.html
+++ b/core-web/apps/dotcms-ui/src/app/view/components/main-legacy/main-legacy.component.html
@@ -4,7 +4,7 @@
 
 <div class="grid grid-cols-[auto_1fr] grid-rows-[auto_1fr] h-full w-full">
     <aside
-        class="col-span-1 row-span-2 bg-[var(--color-palette-primary-800)]"
+        class="col-span-1 row-span-2 bg-primary-900"
         data-testid="navigation-sidebar"
         role="navigation"
         aria-label="Main navigation">

--- a/core-web/libs/block-editor/src/lib/elements/dot-context-menu/dot-context-menu.component.html
+++ b/core-web/libs/block-editor/src/lib/elements/dot-context-menu/dot-context-menu.component.html
@@ -7,7 +7,7 @@
     <ng-template #item let-item>
         <a
             pRipple
-            class="group flex items-center justify-between gap-6! rounded-md px-3 py-2.5 text-gray-900 no-underline! transition-[background-color] duration-150 hover:bg-[var(--color-palette-primary-100)] focus:outline-none focus:shadow-none p-contextmenu-item-link"
+            class="group flex items-center justify-between gap-6! rounded-md px-3 py-2.5 text-gray-900 no-underline! transition-[background-color] duration-150 hover:bg-primary-100 focus:outline-none focus:shadow-none p-contextmenu-item-link"
             [class.rounded-none]="item.disabled"
             [class.bg-gray-200]="item.disabled"
             [class.text-gray-600]="item.disabled"

--- a/core-web/libs/data-access/src/lib/dot-ui-colors/dot-ui-colors.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-ui-colors/dot-ui-colors.service.spec.ts
@@ -4,8 +4,10 @@ import { TestBed } from '@angular/core/testing';
 
 import { DEFAULT_COLORS, DotUiColorsService } from './dot-ui-colors.service';
 
-// Mock PrimeNG updatePrimaryPalette
+// Spy on updatePrimaryPalette, but keep the real palette() generator so the service
+// produces actual shades (palette() is the single source of truth under test).
 jest.mock('@primeuix/themes', () => ({
+    ...jest.requireActual('@primeuix/themes'),
     updatePrimaryPalette: jest.fn()
 }));
 
@@ -41,12 +43,13 @@ describe('DotUiColorsService', () => {
 
             service.setColors(mockElement, colors);
 
-            // Verify PrimeNG theme was updated
+            // Verify PrimeNG theme was updated; 500 preserves the input hex (case-insensitive,
+            // since palette() lowercases the normalized value).
             expect(updatePrimaryPalette).toHaveBeenCalledTimes(1);
             expect(updatePrimaryPalette).toHaveBeenCalledWith(
                 expect.objectContaining({
                     '50': expect.any(String),
-                    '500': colors.primary,
+                    '500': colors.primary.toLowerCase(),
                     '950': expect.any(String)
                 })
             );
@@ -98,7 +101,7 @@ describe('DotUiColorsService', () => {
             expect(updatePrimaryPalette).toHaveBeenCalledTimes(1);
             expect(updatePrimaryPalette).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    '500': DEFAULT_COLORS.primary
+                    '500': DEFAULT_COLORS.primary.toLowerCase()
                 })
             );
         });
@@ -122,7 +125,7 @@ describe('DotUiColorsService', () => {
             expect(setPropertySpy).toHaveBeenCalled();
             expect(updatePrimaryPalette).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    '500': initialColors.primary
+                    '500': initialColors.primary.toLowerCase()
                 })
             );
         });
@@ -213,7 +216,7 @@ describe('DotUiColorsService', () => {
 
             // Verify palette structure
             expect(palette).toHaveProperty('50');
-            expect(palette).toHaveProperty('500', colors.primary);
+            expect(palette).toHaveProperty('500', colors.primary.toLowerCase());
             expect(palette).toHaveProperty('950');
             expect(Object.keys(palette)).toHaveLength(11); // 50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950
         });
@@ -247,7 +250,7 @@ describe('DotUiColorsService', () => {
             const palette = DotUiColorsService.getDefaultPrimeNGPalette();
 
             expect(palette).toHaveProperty('50');
-            expect(palette).toHaveProperty('500', DEFAULT_COLORS.primary);
+            expect(palette).toHaveProperty('500', DEFAULT_COLORS.primary.toLowerCase());
             expect(palette).toHaveProperty('950');
             expect(Object.keys(palette)).toHaveLength(11);
         });

--- a/core-web/libs/data-access/src/lib/dot-ui-colors/dot-ui-colors.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-ui-colors/dot-ui-colors.service.ts
@@ -1,27 +1,32 @@
 import { TinyColor } from '@ctrl/tinycolor';
-import { updatePrimaryPalette } from '@primeuix/themes';
-import ShadeGenerator from 'shade-generator';
+import { palette, updatePrimaryPalette } from '@primeuix/themes';
 
 import { Injectable } from '@angular/core';
 
 import { DotUiColors } from '@dotcms/dotcms-js';
 
-// ShadeGenerator generates 20 colors and we only use 10, so we need to map the colors.
-const dictionary = {
-    '100': '10',
-    '200': '30',
-    '300': '50',
-    '400': '70',
-    '500': '100',
-    '600': '300',
-    '700': '500',
-    '800': '800',
-    '900': '1000'
-};
-
-type HslObject = { hue: string; saturation: string; lightness: string };
-
 type ColorType = 'primary' | 'secondary';
+
+/** PrimeNG palette() returns these eleven steps; we map them 1:1 to our 100-900 contract. */
+type PrimeNgPalette = Record<string, string>;
+
+/**
+ * Maps PrimeNG's 50-950 palette steps to dotCMS's legacy 100-900 CSS-variable contract.
+ * Both consumers (PrimeNG components and the JSP/Dojo iframe) read from the SAME palette()
+ * output, so a `--p-primary-500` token and a `--color-palette-primary-500` variable always
+ * resolve to the identical color.
+ */
+const PALETTE_TO_LEGACY_SHADE: Record<string, string> = {
+    '100': '50',
+    '200': '100',
+    '300': '200',
+    '400': '300',
+    '500': '500',
+    '600': '600',
+    '700': '700',
+    '800': '800',
+    '900': '900'
+};
 
 export const DEFAULT_COLORS = {
     primary: '#426BF0',
@@ -29,296 +34,155 @@ export const DEFAULT_COLORS = {
     background: '#FFFFFF'
 };
 
-function parseHSL(hslString: string): HslObject {
-    // Use regex to match HSL values with their units
-    const regex = /hsl\((\d+deg),\s*(\d+%),\s*(\d+)%\)/;
-    const match = hslString.match(regex);
-
-    // Check if HSL values were found
-    if (match) {
-        return {
-            hue: match[1],
-            saturation: match[2],
-            lightness: match[3]
-        };
-    } else {
-        // Handle case where input was not in correct format
-        throw new Error('Input is not a valid HSL color string');
-    }
-}
-
 /**
- * Service for managing UI colors in dotCMS
+ * Service for managing UI colors in dotCMS.
  *
- * Handles color updates for two different approaches:
+ * A single generator — PrimeNG's `palette()` — produces one 50-950 scale per color, which
+ * feeds two consumers so they never diverge:
  *
- * **1. PrimeNG Theme (Modern Angular Components)**
- *    - Uses `updatePrimaryPalette()` to dynamically update PrimeNG design tokens
- *    - Updates CSS variables: `--p-primary-50` through `--p-primary-950`
- *    - **Primary color only for PrimeNG semantic tokens**: PrimeNG components using
- *      `severity="secondary"` use semantic tokens from the preset (not updatable at runtime)
- *    - Used by: PrimeNG components with semantic tokens (primary only)
+ * **1. PrimeNG design tokens (modern Angular components)**
+ *    - `updatePrimaryPalette()` updates `--p-primary-50` through `--p-primary-950` at runtime.
+ *    - Primary only: PrimeNG has no `updateSecondaryPalette()`, so `severity="secondary"`
+ *      components use the value baked into the preset (see theme.config.ts).
  *
- * **2. CSS Variables (Angular Components & JSP Portlets)**
- *    - Sets CSS custom properties on HTML elements (main app or iframes)
- *    - Variables: `--color-palette-primary-*`, `--color-palette-secondary-*`, etc.
- *    - **Both primary and secondary**: Both colors are updated via CSS variables
- *    - Used by:
- *      - Angular components using CSS variables directly (e.g., `bg-(--color-palette-secondary-200)`)
- *      - Custom PrimeNG styles (e.g., `.p-badge.p-badge-secondary` uses `$color-palette-secondary`)
- *      - Legacy JSP portlets loaded in iframes (dotcms.css, dotai.css)
+ * **2. Legacy CSS variables (Angular components & JSP/Dojo portlets)**
+ *    - `--color-palette-{primary|secondary}-{100..900}` plus opacity variants `-op-{10..90}`.
+ *    - Both primary and secondary are updated here.
+ *    - Set on the main app's `documentElement` and on each JSP iframe's `documentElement`,
+ *      because the iframe has its own document and cannot read the parent's `--p-*` tokens.
  *
- * **Important Notes:**
- * - **Primary color**: Updated in both PrimeNG semantic tokens (dynamically) AND CSS variables
- * - **Secondary color**: Updated in CSS variables (dynamically) for Angular components and custom styles
- *   - CSS variables: `--color-palette-secondary-*` are updated dynamically and used by Angular components
- *   - PrimeNG semantic tokens: Components using `severity="secondary"` use preset value (not updatable)
- * - **Background color**: Updated ONLY in CSS variables
+ * Background color is written only as `--color-background`.
  *
- * **APIs:**
- * - `setColors(el, colors?)` - Updates both PrimeNG theme and legacy CSS variables
- * - `getColors()` - Gets current colors synchronously
- *
- * **Color Sources:**
- * - Server config: `/api/v1/appconfiguration` (user-defined colors)
- * - Fallback: `DEFAULT_COLORS` if server fails or user not authenticated
+ * Color source: `/api/v1/appconfiguration` (user-defined), falling back to `DEFAULT_COLORS`.
  */
 @Injectable()
 export class DotUiColorsService {
     private currentColors: DotUiColors = DEFAULT_COLORS;
 
     /**
-     * Sets colors and updates both approaches:
-     * 1. PrimeNG theme (via updatePrimaryPalette) - for PrimeNG semantic tokens
-     *    - Only primary color is updated (secondary uses preset, not updatable)
-     * 2. CSS variables (on HTML element) - for Angular components and JSP portlets
-     *    - Both primary and secondary colors are updated via CSS variables
-     *    - Used by Angular components directly and custom PrimeNG styles
+     * Sets colors and updates both consumers from one generated palette.
      *
-     * @param el - HTML element to set CSS variables on
-     *            - Main app: `document.documentElement`
-     *            - Iframes: `iframe.contentDocument.documentElement` (for JSP portlets)
-     * @param colors - Optional. Uses current colors or defaults if not provided
+     * @param el - Element to set CSS variables on: the main app's `document.documentElement`,
+     *             or an iframe's `contentDocument.documentElement` for JSP portlets.
+     * @param colors - Optional; falls back to the current colors when omitted.
      */
     setColors(el: HTMLElement, colors?: DotUiColors): void {
         this.currentColors = colors || this.currentColors;
 
-        // Approach 1: Update PrimeNG theme for Angular components
-        this.updatePrimeNGColors(this.currentColors);
+        this.updatePrimeNGColors(this.currentColors.primary);
 
-        // Approach 2: Set legacy CSS variables for JSP portlets
         this.setColor(el, this.currentColors.primary, 'primary');
         this.setColor(el, this.currentColors.secondary, 'secondary');
         this.setColorBackground(el, this.currentColors.background);
     }
 
     /**
-     * Gets current colors synchronously
+     * Gets current colors synchronously.
      */
     getColors(): DotUiColors {
         return this.currentColors;
     }
 
     /**
-     * Approach 1: Updates PrimeNG theme colors dynamically
-     * Generates palette (50-950) from base colors and updates PrimeNG design tokens
-     *
-     * **Important:** This only updates PrimeNG semantic tokens (used by components with
-     * `severity="primary"`). PrimeNG supports secondary as a severity type, but only
-     * primary can be updated dynamically via `updatePrimaryPalette()`. There is no
-     * equivalent `updateSecondaryPalette()` function.
-     *
-     * **Secondary color behavior:**
-     * - PrimeNG semantic tokens: Components using `severity="secondary"` use the preset
-     *   value (defined in theme.config.ts), not updatable at runtime
-     * - CSS variables: Secondary is updated dynamically via `setColor()` (line 95) and
-     *   used by Angular components and custom PrimeNG styles that reference CSS variables
+     * Generates the default PrimeNG palette for the initial preset (theme.config.ts),
+     * keeping the build-time preset in sync with runtime updates.
+     */
+    static getDefaultPrimeNGPalette(): PrimeNgPalette {
+        return generatePalette(DEFAULT_COLORS.primary);
+    }
+
+    /**
+     * Updates PrimeNG primary design tokens. PrimeNG only supports runtime updates for the
+     * primary palette; secondary components fall back to the preset value (theme.config.ts).
      *
      * @private
      */
-    private updatePrimeNGColors(colors: DotUiColors): void {
+    private updatePrimeNGColors(primary: string): void {
         try {
-            // Update primary color palette for PrimeNG semantic tokens
-            // PrimeNG only supports dynamic runtime updates for primary color semantic tokens
-            const primaryPalette = this.generatePrimeNGPalette(colors.primary);
-            updatePrimaryPalette(primaryPalette);
-
-            // Note: Secondary color semantic tokens are NOT updated here because:
-            // 1. PrimeNG doesn't have updateSecondaryPalette() function for runtime updates
-            // 2. Secondary semantic tokens can only be defined in the initial preset (theme.config.ts)
-            // 3. PrimeNG components using severity="secondary" will use the preset value
-            //
-            // However, secondary CSS variables ARE updated in setColor() method (line 95),
-            // which are used by:
-            // - Angular components using CSS variables directly (e.g., bg-(--color-palette-secondary-200))
-            // - Custom PrimeNG styles (e.g., .p-badge.p-badge-secondary uses $color-palette-secondary)
-            // - Legacy JSP portlets
-            //
-            // If PrimeNG adds updateSecondaryPalette() in the future, it would be added here
+            updatePrimaryPalette(generatePalette(primary));
         } catch (error) {
-            // Silently fail if PrimeNG theming API is not available
-            // This can happen during SSR or if PrimeNG hasn't initialized yet
+            // Silently fail if the PrimeNG theming API is not ready (e.g. during SSR).
             console.warn('Failed to update PrimeNG colors:', error);
         }
     }
 
     /**
-     * Generates PrimeNG color palette (50-950) from base hex color
-     *
-     * @private
-     */
-    private generatePrimeNGPalette(hex: string): Record<string, string> {
-        const color = new TinyColor(hex);
-
-        if (!color.isValid) {
-            // Return default palette if color is invalid
-            return this.getDefaultPrimeNGPalette();
-        }
-
-        // Use ShadeGenerator to create the palette (reliable and consistent)
-        // PrimeNG's palette() function may have different return types, so we use
-        // ShadeGenerator as the primary method for consistency
-        return this.generatePaletteWithShadeGenerator(hex);
-    }
-
-    /**
-     * Generates palette using ShadeGenerator
-     *
-     * @private
-     */
-    private generatePaletteWithShadeGenerator(hex: string): Record<string, string> {
-        const shades = ShadeGenerator.hue(hex).shadesMap('hex');
-
-        // Map ShadeGenerator output to PrimeNG format (50-950)
-        return {
-            '50': shades['10'] || this.lighten(hex, 95),
-            '100': shades['30'] || this.lighten(hex, 85),
-            '200': shades['50'] || this.lighten(hex, 70),
-            '300': shades['70'] || this.lighten(hex, 50),
-            '400': shades['100'] || this.lighten(hex, 30),
-            '500': hex, // Base color
-            '600': shades['300'] || this.darken(hex, 10),
-            '700': shades['500'] || this.darken(hex, 20),
-            '800': shades['800'] || this.darken(hex, 30),
-            '900': shades['1000'] || this.darken(hex, 40),
-            '950': this.darken(hex, 50)
-        };
-    }
-
-    /**
-     * Returns default palette from DEFAULT_COLORS.primary
-     *
-     * @private
-     */
-    private getDefaultPrimeNGPalette(): Record<string, string> {
-        // Generate palette from DEFAULT_COLORS.primary to ensure consistency
-        return this.generatePaletteWithShadeGenerator(DEFAULT_COLORS.primary);
-    }
-
-    /**
-     * Static method to generate default palette for theme.config.ts
-     * Ensures initial preset uses same defaults as service
-     */
-    static getDefaultPrimeNGPalette(): Record<string, string> {
-        // Use the same generation logic as the service instance
-        const shades = ShadeGenerator.hue(DEFAULT_COLORS.primary).shadesMap('hex');
-
-        return {
-            '50': shades['10'] || new TinyColor(DEFAULT_COLORS.primary).lighten(95).toHexString(),
-            '100': shades['30'] || new TinyColor(DEFAULT_COLORS.primary).lighten(85).toHexString(),
-            '200': shades['50'] || new TinyColor(DEFAULT_COLORS.primary).lighten(70).toHexString(),
-            '300': shades['70'] || new TinyColor(DEFAULT_COLORS.primary).lighten(50).toHexString(),
-            '400': shades['100'] || new TinyColor(DEFAULT_COLORS.primary).lighten(30).toHexString(),
-            '500': DEFAULT_COLORS.primary, // Base color
-            '600': shades['300'] || new TinyColor(DEFAULT_COLORS.primary).darken(10).toHexString(),
-            '700': shades['500'] || new TinyColor(DEFAULT_COLORS.primary).darken(20).toHexString(),
-            '800': shades['800'] || new TinyColor(DEFAULT_COLORS.primary).darken(30).toHexString(),
-            '900': shades['1000'] || new TinyColor(DEFAULT_COLORS.primary).darken(40).toHexString(),
-            '950': new TinyColor(DEFAULT_COLORS.primary).darken(50).toHexString()
-        };
-    }
-
-    /**
-     * @private
-     */
-    private lighten(hex: string, amount: number): string {
-        return new TinyColor(hex).lighten(amount).toHexString();
-    }
-
-    /**
-     * @private
-     */
-    private darken(hex: string, amount: number): string {
-        return new TinyColor(hex).darken(amount).toHexString();
-    }
-
-    /**
-     * Sets background color CSS variable for JSP portlets
-     *
-     * @private
-     */
-    private setColorBackground(el: HTMLElement, color: string): void {
-        const colorBackground: TinyColor = new TinyColor(color);
-
-        if (colorBackground.isValid) {
-            el.style.setProperty('--color-background', colorBackground.toHexString().toUpperCase());
-        }
-    }
-
-    /**
-     * Approach 2: Sets CSS variables for a color (primary/secondary)
-     * Generates HSL base, shades (100-900), and opacities (10-90)
-     *
-     * Used by:
-     * - Angular components using CSS variables directly (e.g., `bg-(--color-palette-secondary-200)`)
-     * - Custom PrimeNG styles (e.g., `.p-badge.p-badge-secondary`)
-     * - Legacy JSP portlets (dotcms.css, dotai.css)
+     * Writes the legacy `--color-palette-{type}-*` CSS variables from the same palette()
+     * output PrimeNG uses, plus the `-h`/`-s` and opacity variables the JSP CSS depends on.
      *
      * @private
      */
     private setColor(el: HTMLElement, hex: string, type: ColorType): void {
         const color = new TinyColor(hex);
 
-        if (color.isValid) {
-            const baseColor = ShadeGenerator.hue(hex).shade('100').hsl();
-            const baseColorHsl = parseHSL(baseColor);
-
-            // Set HSL base values (used by JSP CSS)
-            el.style.setProperty(`--color-${type}-h`, baseColorHsl.hue);
-            el.style.setProperty(`--color-${type}-s`, baseColorHsl.saturation);
-
-            // Generate shades and opacities for JSP portlets
-            this.setShades(el, hex, type);
-            this.setOpacities(el, baseColorHsl.saturation, type);
+        if (!color.isValid) {
+            return;
         }
+
+        const generated = generatePalette(hex);
+        const { h, s, l } = color.toHsl();
+
+        // HSL pieces consumed by the JSP/Dojo CSS (e.g. to compose runtime opacities).
+        el.style.setProperty(`--color-${type}-h`, `${Math.round(h)}deg`);
+        el.style.setProperty(`--color-${type}-s`, `${Math.round(s * 100)}%`);
+
+        this.setShades(el, generated, type);
+        this.setOpacities(el, Math.round(l * 100), type);
     }
 
     /**
-     * Generates CSS variables for color shades (100-900) for JSP portlets
+     * Maps the PrimeNG palette to the legacy 100-900 CSS variables.
      *
      * @private
      */
-    private setShades(el: HTMLElement, hex: string, type: ColorType) {
-        const shades = ShadeGenerator.hue(hex).shadesMap('hsl');
-
-        Object.entries(dictionary).forEach(([shade, shadeKey]) => {
-            const color = shades[shadeKey as keyof typeof shades];
-            el.style.setProperty(`--color-palette-${type}-${shade}`, color);
+    private setShades(el: HTMLElement, generated: PrimeNgPalette, type: ColorType): void {
+        Object.entries(PALETTE_TO_LEGACY_SHADE).forEach(([legacyShade, paletteStep]) => {
+            el.style.setProperty(`--color-palette-${type}-${legacyShade}`, generated[paletteStep]);
         });
     }
 
     /**
-     * Generates CSS variables for color opacities (10-90) for JSP portlets
-     * Used in dotcms.css and dotai.css for outlines, backgrounds, and shadows
+     * Generates the `-op-{10..90}` opacity variables. They reference `--color-{type}-h/-s`
+     * by name (so the JSP CSS resolves them at use time) and carry the color's real lightness.
      *
      * @private
      */
-    private setOpacities(el: HTMLElement, saturation: string, type: ColorType) {
+    private setOpacities(el: HTMLElement, lightness: number, type: ColorType): void {
         for (let i = 1; i < 10; i++) {
             el.style.setProperty(
                 `--color-palette-${type}-op-${i}0`,
-                `hsla(var(--color-${type}-h), var(--color-${type}-s), ${saturation}, 0.${i})`
+                `hsla(var(--color-${type}-h), var(--color-${type}-s), ${lightness}%, 0.${i})`
             );
         }
     }
+
+    /**
+     * Sets the background color CSS variable.
+     *
+     * @private
+     */
+    private setColorBackground(el: HTMLElement, color: string): void {
+        const background = new TinyColor(color);
+
+        if (background.isValid) {
+            el.style.setProperty('--color-background', background.toHexString().toUpperCase());
+        }
+    }
+}
+
+/**
+ * Single palette generator for the whole service: PrimeNG's `palette()` produces a
+ * perceptually-tuned 50-950 scale whose `500` step is the input color itself. Falls back to
+ * the default primary palette when given an invalid color.
+ */
+function generatePalette(hex: string): PrimeNgPalette {
+    const color = new TinyColor(hex);
+
+    // palette() returns a ColorScale object for a color input (string only for token
+    // expressions, which we never pass), so the cast is safe.
+    const source = color.isValid ? hex : DEFAULT_COLORS.primary;
+    const scale = palette(source) as PrimeNgPalette;
+
+    // Preserve the exact input hex at 500; palette() lowercases, so normalize to the source.
+    return { ...scale, '500': new TinyColor(source).toHexString() };
 }

--- a/core-web/libs/data-access/src/lib/dot-ui-colors/dot-ui-colors.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-ui-colors/dot-ui-colors.service.ts
@@ -57,7 +57,7 @@ export const DEFAULT_COLORS = {
  */
 @Injectable()
 export class DotUiColorsService {
-    private currentColors: DotUiColors = DEFAULT_COLORS;
+    #currentColors: DotUiColors = DEFAULT_COLORS;
 
     /**
      * Sets colors and updates both consumers from one generated palette.
@@ -67,20 +67,20 @@ export class DotUiColorsService {
      * @param colors - Optional; falls back to the current colors when omitted.
      */
     setColors(el: HTMLElement, colors?: DotUiColors): void {
-        this.currentColors = colors || this.currentColors;
+        this.#currentColors = colors || this.#currentColors;
 
-        this.updatePrimeNGColors(this.currentColors.primary);
+        this.#updatePrimeNGColors(this.#currentColors.primary);
 
-        this.setColor(el, this.currentColors.primary, 'primary');
-        this.setColor(el, this.currentColors.secondary, 'secondary');
-        this.setColorBackground(el, this.currentColors.background);
+        this.#setColor(el, this.#currentColors.primary, 'primary');
+        this.#setColor(el, this.#currentColors.secondary, 'secondary');
+        this.#setColorBackground(el, this.#currentColors.background);
     }
 
     /**
      * Gets current colors synchronously.
      */
     getColors(): DotUiColors {
-        return this.currentColors;
+        return this.#currentColors;
     }
 
     /**
@@ -97,7 +97,7 @@ export class DotUiColorsService {
      *
      * @private
      */
-    private updatePrimeNGColors(primary: string): void {
+    #updatePrimeNGColors(primary: string): void {
         try {
             updatePrimaryPalette(generatePalette(primary));
         } catch (error) {
@@ -112,7 +112,7 @@ export class DotUiColorsService {
      *
      * @private
      */
-    private setColor(el: HTMLElement, hex: string, type: ColorType): void {
+    #setColor(el: HTMLElement, hex: string, type: ColorType): void {
         const color = new TinyColor(hex);
 
         if (!color.isValid) {
@@ -126,8 +126,8 @@ export class DotUiColorsService {
         el.style.setProperty(`--color-${type}-h`, `${Math.round(h)}deg`);
         el.style.setProperty(`--color-${type}-s`, `${Math.round(s * 100)}%`);
 
-        this.setShades(el, generated, type);
-        this.setOpacities(el, Math.round(l * 100), type);
+        this.#setShades(el, generated, type);
+        this.#setOpacities(el, Math.round(l * 100), type);
     }
 
     /**
@@ -135,7 +135,7 @@ export class DotUiColorsService {
      *
      * @private
      */
-    private setShades(el: HTMLElement, generated: PrimeNgPalette, type: ColorType): void {
+    #setShades(el: HTMLElement, generated: PrimeNgPalette, type: ColorType): void {
         Object.entries(PALETTE_TO_LEGACY_SHADE).forEach(([legacyShade, paletteStep]) => {
             el.style.setProperty(`--color-palette-${type}-${legacyShade}`, generated[paletteStep]);
         });
@@ -147,7 +147,7 @@ export class DotUiColorsService {
      *
      * @private
      */
-    private setOpacities(el: HTMLElement, lightness: number, type: ColorType): void {
+    #setOpacities(el: HTMLElement, lightness: number, type: ColorType): void {
         for (let i = 1; i < 10; i++) {
             el.style.setProperty(
                 `--color-palette-${type}-op-${i}0`,
@@ -161,7 +161,7 @@ export class DotUiColorsService {
      *
      * @private
      */
-    private setColorBackground(el: HTMLElement, color: string): void {
+    #setColorBackground(el: HTMLElement, color: string): void {
         const background = new TinyColor(color);
 
         if (background.isValid) {

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-dropzone/dot-content-drive-dropzone.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-dropzone/dot-content-drive-dropzone.component.html
@@ -5,7 +5,7 @@
     data-testid="message">
     <div class="flex flex-col items-center justify-center gap-3" data-testid="message-content">
         <i
-            class="pi pi-upload h-[calc(48px+1.5rem)] w-[calc(48px+1.5rem)] text-[var(--color-palette-primary-500)] bg-[var(--color-palette-primary-200)] rounded-full text-4xl"
+            class="pi pi-upload h-[calc(48px+1.5rem)] w-[calc(48px+1.5rem)] text-primary-500 bg-primary-200 rounded-full text-4xl"
             data-testid="message-content-icon"></i>
         <span class="text-lg leading-[140%]" data-testid="message-content-text">
             {{ 'content-drive-dropzone.message.drag-and-drop-header' | dm }}

--- a/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
+++ b/core-web/libs/portlets/dot-content-drive/ui/src/lib/dot-folder-list-view/dot-folder-list-view.component.html
@@ -60,9 +60,7 @@
                 class="group transition-colors duration-200"
                 [class.cursor-grabbing]="state.isDragging()"
                 [class.text-[var(--text-color-hover)]]="state.dragOverRowId() === item.identifier"
-                [class.bg-[var(--color-palette-primary-100)]]="
-                    state.dragOverRowId() === item.identifier
-                "
+                [class.bg-primary-100]="state.dragOverRowId() === item.identifier"
                 [pSelectableRow]="item"
                 data-testId="item-row"
                 (contextmenu)="onContextMenu($event, item)"

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiment-options/dot-experiment-options.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiment-options/dot-experiment-options.component.html
@@ -1,8 +1,8 @@
 @for (item of itemList; track item; let i = $index) {
     <div
         [attr.data-testId]="'dot-options-item_' + item.$value()"
-        [ngClass]="expanded.has(i) ? 'bg-[var(--color-palette-primary-100)]' : ''"
-        class="flex flex-col rounded-sm border border-[var(--gray-200)] transition-colors duration-200 hover:bg-[var(--color-palette-primary-100)]">
+        [ngClass]="expanded.has(i) ? 'bg-primary-100' : ''"
+        class="flex flex-col rounded-sm border border-[var(--gray-200)] transition-colors duration-200 hover:bg-primary-100">
         <ng-container
             [ngTemplateOutletContext]="{ $implicit: item, index: i }"
             [ngTemplateOutlet]="defaultHeader" />

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiment-options/dot-experiment-options.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiment-options/dot-experiment-options.component.html
@@ -1,7 +1,7 @@
 @for (item of itemList; track item; let i = $index) {
     <div
         [attr.data-testId]="'dot-options-item_' + item.$value()"
-        [ngClass]="expanded.has(i) ? 'bg-primary-100' : ''"
+        [class.bg-primary-100]="expanded.has(i)"
         class="flex flex-col rounded-sm border border-[var(--gray-200)] transition-colors duration-200 hover:bg-primary-100">
         <ng-container
             [ngTemplateOutletContext]="{ $implicit: item, index: i }"

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-goals-coming-soon/dot-experiments-goals-coming-soon.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-goals-coming-soon/dot-experiments-goals-coming-soon.component.html
@@ -6,9 +6,9 @@
         <p-card class="h-full flex-1 basis-[16rem] min-h-[15rem]">
             <ng-template pTemplate="header">
                 <div
-                    class="min-h-20 flex items-center justify-center bg-[var(--color-palette-primary-100)] rounded-t-md">
+                    class="min-h-20 flex items-center justify-center bg-primary-100 rounded-t-md">
                     <i
-                        class="{{ card.icon }} text-[var(--color-palette-primary-500)] text-2xl!"
+                        class="{{ card.icon }} text-primary-500 text-2xl!"
                         aria-hidden="true"></i>
                 </div>
             </ng-template>

--- a/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-goals-coming-soon/dot-experiments-goals-coming-soon.component.html
+++ b/core-web/libs/portlets/dot-experiments/portlet/src/lib/shared/ui/dot-experiments-goals-coming-soon/dot-experiments-goals-coming-soon.component.html
@@ -5,11 +5,8 @@
     @for (card of cards; track card.titleKey) {
         <p-card class="h-full flex-1 basis-[16rem] min-h-[15rem]">
             <ng-template pTemplate="header">
-                <div
-                    class="min-h-20 flex items-center justify-center bg-primary-100 rounded-t-md">
-                    <i
-                        class="{{ card.icon }} text-primary-500 text-2xl!"
-                        aria-hidden="true"></i>
+                <div class="min-h-20 flex items-center justify-center bg-primary-100 rounded-t-md">
+                    <i class="{{ card.icon }} text-primary-500 text-2xl!" aria-hidden="true"></i>
                 </div>
             </ng-template>
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-palette-contentlet/dot-uve-palette-contentlet.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-palette-contentlet/dot-uve-palette-contentlet.component.ts
@@ -40,7 +40,7 @@ export class DotUvePaletteContentletComponent {
     readonly $hostClass =
         'group flex w-full items-center overflow-hidden cursor-grab active:cursor-grabbing ' +
         'h-16 rounded-md border border-gray-200 bg-white text-gray-900 ' +
-        'hover:border-[var(--color-palette-primary-500)] hover:bg-[var(--color-palette-primary-100)] hover:shadow-sm';
+        'hover:border-primary-500 hover:bg-primary-100 hover:shadow-sm';
 
     readonly $dataItem = computed(() => {
         const contentlet = this.$contentlet();

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-palette-contenttype/dot-uve-palette-contenttype.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-palette-contenttype/dot-uve-palette-contenttype.component.ts
@@ -38,7 +38,7 @@ export class DotUVEPaletteContenttypeComponent {
         const isDisabled = this.$isDisabled();
         const base =
             'group flex w-full min-w-0 items-center border border-gray-200 bg-white text-gray-900 h-auto' +
-            'hover:border-[var(--color-palette-primary-500)] hover:bg-[var(--color-palette-primary-100)] hover:shadow-sm ' +
+            'hover:border-primary-500 hover:bg-primary-100 hover:shadow-sm ' +
             'rounded-md';
 
         // Keep the content centered, but place action icons at the sides.

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-empty-state/dot-uve-style-editor-empty-state.component.html
@@ -8,7 +8,7 @@
 </div>
 
 <p
-    class="m-0 self-stretch text-sm text-gray-800 [&_a]:cursor-pointer [&_a]:font-semibold [&_a]:text-[var(--color-palette-primary-500)] [&_a]:underline hover:[&_a]:text-[var(--color-palette-primary-600)]"
+    class="m-0 self-stretch text-sm text-gray-800 [&_a]:cursor-pointer [&_a]:font-semibold [&_a]:text-primary-500 [&_a]:underline hover:[&_a]:text-primary-600"
     data-testid="uve-style-editor-empty-state-message"
     [innerHTML]="'uve.palette.style-editor.empty-state.message' | dm"></p>
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/components/uve-style-editor-field-radio/uve-style-editor-field-radio.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/components/dot-uve-style-editor-form/components/uve-style-editor-field-radio/uve-style-editor-field-radio.component.html
@@ -16,9 +16,9 @@
                         class="peer absolute opacity-0 cursor-pointer" />
                     <label
                         [for]="$field().id + '-' + option.value"
-                        class="flex flex-col items-start gap-1 cursor-pointer peer-checked:[&>div]:border-[var(--color-palette-primary-500)] peer-checked:[&>div]:bg-[var(--color-palette-primary-100)] peer-checked:[&>div]:shadow-[0_2px_8px_rgba(0,0,0,0.12)]">
+                        class="flex flex-col items-start gap-1 cursor-pointer peer-checked:[&>div]:border-primary-500 peer-checked:[&>div]:bg-primary-100 peer-checked:[&>div]:shadow-[0_2px_8px_rgba(0,0,0,0.12)]">
                         <div
-                            class="w-full h-[5.75rem] block rounded border border-gray-300 bg-white p-1 transition-all duration-150 hover:border-[var(--color-palette-primary-500)] hover:shadow-md">
+                            class="w-full h-[5.75rem] block rounded border border-gray-300 bg-white p-1 transition-all duration-150 hover:border-primary-500 hover:shadow-md">
                             <img
                                 [src]="option.imageURL"
                                 [alt]="option.label"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/dot-uve-palette.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-palette/dot-uve-palette.component.html
@@ -62,7 +62,7 @@
                             {{ 'uve.palette.layers.advanced-template.title' | dm }}
                         </div>
                         <p
-                            class="m-0 self-stretch text-sm text-gray-800 [&_a]:cursor-pointer [&_a]:font-semibold [&_a]:text-[var(--color-palette-primary-500)] [&_a]:underline hover:[&_a]:text-[var(--color-palette-primary-600)]"
+                            class="m-0 self-stretch text-sm text-gray-800 [&_a]:cursor-pointer [&_a]:font-semibold [&_a]:text-primary-500 [&_a]:underline hover:[&_a]:text-primary-600"
                             [innerHTML]="
                                 'uve.palette.layers.advanced-template.description' | dm
                             "></p>

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.html
@@ -8,7 +8,7 @@
     size="small"
     data-testId="more-button">
     <ng-template #selectedItem let-selectedOption>
-        <span class="text-[var(--color-palette-primary-500)]">
+        <span class="text-primary-500">
             {{ selectedOption.label }}
         </span>
     </ng-template>

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-toolbar/components/dot-editor-mode-selector/dot-editor-mode-selector.component.ts
@@ -114,7 +114,7 @@ export class DotEditorModeSelectorComponent implements OnInit {
      */
     protected readonly dropdownIconStyle = {
         dropdownIcon: {
-            class: 'text-[var(--color-palette-primary-500)]'
+            class: 'text-primary-500'
         }
     };
 

--- a/core-web/libs/ui/src/lib/components/dot-language-selector/dot-language-selector.component.html
+++ b/core-web/libs/ui/src/lib/components/dot-language-selector/dot-language-selector.component.html
@@ -20,7 +20,7 @@
     dataKey="id"
     optionLabel="label">
     <ng-template pTemplate="selectedItem" let-selectedOption>
-        <div class="flex items-center gap-x-2 text-[var(--color-palette-primary-500)]">
+        <div class="flex items-center gap-x-2 text-primary-500">
             <i class="pi pi-globe text-color-secondary"></i>
             <span class="truncate">
                 {{ selectedOption?.label ?? $state.pinnedOption()?.label }}

--- a/core-web/libs/ui/src/lib/theme/theme.config.ts
+++ b/core-web/libs/ui/src/lib/theme/theme.config.ts
@@ -6,26 +6,22 @@ import { DotUiColorsService } from '@dotcms/data-access';
 /**
  * Custom Lara preset for dotCMS
  *
- * The primary color palette is generated from DEFAULT_COLORS.primary (#426BF0)
- * using the same logic as DotUiColorsService. This ensures consistency between:
- * - Initial theme configuration (this file)
- * - Runtime color updates (DotUiColorsService)
+ * The primary palette is generated from DEFAULT_COLORS.primary (#426BF0) via the same
+ * PrimeNG palette() generator DotUiColorsService uses, keeping this initial preset and
+ * runtime updates (updatePrimaryPalette) in sync.
  *
- * When colors are loaded from the server, DotUiColorsService.updatePrimeNGColors()
- * will dynamically update the palette using updatePrimaryPalette().
+ * Brand secondary is intentionally absent here. PrimeNG models a single accent (primary)
+ * plus neutral surfaces and has no second-accent slot, so the dotCMS secondary brand color
+ * lives only in the legacy --color-palette-secondary-* CSS vars (set at runtime by
+ * DotUiColorsService, consumed by Angular components and the JSP/Dojo iframe).
+ * Note: severity="secondary" is unrelated — it is PrimeNG's neutral/gray variant, not a brand color.
  *
- * Note: Secondary color is NOT defined here in semantic tokens because PrimeNG doesn't
- * support dynamic updates for secondary semantic tokens (only primary can be updated at runtime).
- * Components using severity="secondary" will use the default Lara preset value.
- *
- * However, secondary color IS updated dynamically via CSS variables (--color-palette-secondary-*)
- * which are used by Angular components and custom PrimeNG styles that reference CSS variables.
+ * Future direction: register secondary as a custom token group via the preset's `extend`
+ * option to get engine-managed --p-secondary-* tokens. See issue #35869.
  */
 export const CustomLaraPreset = definePreset(Lara, {
     semantic: {
         primary: DotUiColorsService.getDefaultPrimeNGPalette()
-        // Secondary could be added here, but it wouldn't be updatable at runtime
-        // secondary: DotUiColorsService.getDefaultSecondaryPalette() // Not implemented
     },
     components: {
         treeselect: {

--- a/core-web/package.json
+++ b/core-web/package.json
@@ -148,7 +148,6 @@
         "react-dom": "18.3.1",
         "regenerator-runtime": "0.13.9",
         "rxjs": "7.8.2",
-        "shade-generator": "1.2.7",
         "superstruct": "1.0.3",
         "tailwindcss": "4.1.17",
         "tailwindcss-primeui": "0.6.1",


### PR DESCRIPTION
### Proposed Changes
* Make PrimeNG's `palette()` the single generator for both PrimeNG design tokens and the legacy `--color-palette-*` CSS vars, so a brand shade resolves identically across PrimeNG, Angular, and JSP/Dojo.
* `DotUiColorsService`: drop `ShadeGenerator` and the brittle HSL-string regex round-trip; fix opacity vars to carry the real lightness instead of saturation.
* Remove the `shade-generator` dependency (sole consumer).
* Convert arbitrary `bg/text/border-[var(--color-palette-primary-N)]` classes to the registered `primary-N` Tailwind utilities.

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated (no auth/data surface; CSS token generation only)

### Additional Info
Fixes #35869

`secondary`, the bare `--color-palette-primary`, and `--color-palette-red` template usages were intentionally left as arbitrary classes — `secondary` is not a registered Tailwind color and the others are not 1:1 utility equivalents.

### Screenshots
Sidebar and themed UI shade slightly shifts (PrimeNG's perceptual curve); `500` stays the exact brand hex. Visual smoke-test recommended on UVE palette, experiments, and content-drive.

This PR fixes: #35869