### PR TITLE
feat(health): add OSGi bundle startup validation health check (#35806)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/health/checks/OsgiBundlesHealthCheck.java
+++ b/dotCMS/src/main/java/com/dotcms/health/checks/OsgiBundlesHealthCheck.java
@@ -1,0 +1,249 @@
+package com.dotcms.health.checks;
+
+import com.dotcms.health.config.HealthCheckConfig.HealthCheckMode;
+import com.dotcms.health.model.HealthStatus;
+import com.dotcms.health.util.HealthCheckBase;
+import com.dotmarketing.util.Config;
+import org.apache.felix.framework.OSGIUtil;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Readiness probe that fails if any installed OSGi plugin has not reached
+ * {@link Bundle#ACTIVE} state after a configurable grace period. Blocks new
+ * deployments from receiving traffic when a previously-working plugin has
+ * regressed in the new image.
+ *
+ * <p>OSGi bundles install asynchronously, so this check honors a grace window
+ * (default 5 minutes) that begins when {@code OSGIUtil.initializeFramework()}
+ * completes. During the grace window the check reports {@code UP} so the
+ * probe does not flap while bundles are still starting.</p>
+ *
+ * <p>Not registered as a liveness check: a failed plugin should block the
+ * rollout, not restart-loop the pod.</p>
+ *
+ * Configuration (env-var form in parentheses):
+ * <ul>
+ *   <li>{@code health.check.osgi-bundles.mode} ({@code DOT_HEALTH_CHECK_OSGI_BUNDLES_MODE}) —
+ *       PRODUCTION (default), MONITOR_MODE, DISABLED</li>
+ *   <li>{@code health.check.osgi-bundles.grace.period.ms}
+ *       ({@code DOT_HEALTH_CHECK_OSGI_BUNDLES_GRACE_PERIOD_MS}) — grace window in ms (default 300000)</li>
+ *   <li>{@code health.check.osgi-bundles.required.bundles}
+ *       ({@code DOT_HEALTH_CHECK_OSGI_BUNDLES_REQUIRED_BUNDLES}) — optional CSV of symbolic names that
+ *       MUST be present and ACTIVE; if empty, every non-system, non-fragment bundle is required</li>
+ * </ul>
+ */
+public class OsgiBundlesHealthCheck extends HealthCheckBase {
+
+    private static final String CHECK_NAME = "osgi-bundles";
+    private static final long DEFAULT_GRACE_PERIOD_MS = 300_000L; // 5 minutes
+
+    @Override
+    public String getName() {
+        return CHECK_NAME;
+    }
+
+    @Override
+    protected CheckResult performCheck() {
+        final long initAt = osgiInitCompletedAt();
+        if (initAt == 0L) {
+            return new CheckResult(true, 0L,
+                    "OSGi framework not yet initialized; deferring bundle check");
+        }
+
+        final long gracePeriodMs = gracePeriodMs();
+        final long elapsed = System.currentTimeMillis() - initAt;
+        final boolean withinGrace = elapsed < gracePeriodMs;
+
+        final Bundle[] bundles = bundles();
+        if (bundles == null) {
+            return new CheckResult(true, 0L,
+                    "OSGi bundle list not yet available; deferring bundle check");
+        }
+
+        final Set<String> required = requiredBundleNames();
+        final List<Bundle> candidates = candidates(bundles, required);
+        final List<Bundle> notActive = candidates.stream()
+                .filter(b -> b.getState() != Bundle.ACTIVE)
+                .collect(Collectors.toList());
+
+        if (!required.isEmpty()) {
+            final Set<String> present = candidates.stream()
+                    .map(Bundle::getSymbolicName)
+                    .collect(Collectors.toSet());
+            final List<String> missing = required.stream()
+                    .filter(name -> !present.contains(name))
+                    .sorted()
+                    .collect(Collectors.toList());
+            if (!missing.isEmpty() && !withinGrace) {
+                return new CheckResult(false, 0L,
+                        "Required OSGi bundles missing after " + elapsed + "ms: "
+                                + String.join(", ", missing));
+            }
+        }
+
+        if (notActive.isEmpty()) {
+            return new CheckResult(true, 0L,
+                    "All " + candidates.size() + " OSGi bundle(s) ACTIVE");
+        }
+
+        if (withinGrace) {
+            return new CheckResult(true, 0L,
+                    notActive.size() + " of " + candidates.size()
+                            + " OSGi bundle(s) still starting (" + elapsed + "ms of "
+                            + gracePeriodMs + "ms grace)");
+        }
+
+        return new CheckResult(false, 0L,
+                "OSGi bundle(s) did not reach ACTIVE within " + gracePeriodMs + "ms: "
+                        + describe(notActive));
+    }
+
+    private static String describe(final List<Bundle> bundles) {
+        return bundles.stream()
+                .map(b -> b.getSymbolicName() + "[" + stateName(b.getState()) + "]")
+                .collect(Collectors.joining(", "));
+    }
+
+    private static String stateName(final int state) {
+        switch (state) {
+            case Bundle.UNINSTALLED: return "UNINSTALLED";
+            case Bundle.INSTALLED:   return "INSTALLED";
+            case Bundle.RESOLVED:    return "RESOLVED";
+            case Bundle.STARTING:    return "STARTING";
+            case Bundle.STOPPING:    return "STOPPING";
+            case Bundle.ACTIVE:      return "ACTIVE";
+            default: return "UNKNOWN(" + state + ")";
+        }
+    }
+
+    /**
+     * Plugin candidates: every non-system, non-fragment bundle. When a required-bundles
+     * list is configured we narrow to just that set (intersected with non-fragment).
+     */
+    private static List<Bundle> candidates(final Bundle[] bundles, final Set<String> required) {
+        final List<Bundle> out = new ArrayList<>();
+        for (final Bundle bundle : bundles) {
+            if (bundle.getBundleId() == 0L) {
+                continue; // system bundle
+            }
+            if (isFragment(bundle)) {
+                continue; // fragments never reach ACTIVE
+            }
+            if (!required.isEmpty() && !required.contains(bundle.getSymbolicName())) {
+                continue;
+            }
+            out.add(bundle);
+        }
+        return out;
+    }
+
+    private static boolean isFragment(final Bundle bundle) {
+        return bundle.getHeaders().get(Constants.FRAGMENT_HOST) != null;
+    }
+
+    // Package-private hooks for unit tests; production code reads the real OSGIUtil.
+
+    long osgiInitCompletedAt() {
+        return OSGIUtil.getInstance().getOsgiInitCompletedAt();
+    }
+
+    Bundle[] bundles() {
+        try {
+            return OSGIUtil.getInstance().getBundles();
+        } catch (final Exception e) {
+            return null;
+        }
+    }
+
+    long gracePeriodMs() {
+        return Config.getLongProperty(
+                "health.check.osgi-bundles.grace.period.ms", DEFAULT_GRACE_PERIOD_MS);
+    }
+
+    Set<String> requiredBundleNames() {
+        final String csv = Config.getStringProperty(
+                "health.check.osgi-bundles.required.bundles", "");
+        if (csv == null || csv.trim().isEmpty()) {
+            return Collections.emptySet();
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isLivenessCheck() {
+        return false;
+    }
+
+    @Override
+    public boolean isReadinessCheck() {
+        return getMode() != HealthCheckMode.DISABLED;
+    }
+
+    @Override
+    public int getOrder() {
+        return 50;
+    }
+
+    @Override
+    public String getDescription() {
+        return String.format(
+                "Fails readiness if any installed OSGi plugin is not ACTIVE after the grace period (Mode: %s, grace: %dms)",
+                getMode().name(), gracePeriodMs());
+    }
+
+    @Override
+    protected Map<String, Object> buildStructuredData(final CheckResult result,
+                                                      final HealthStatus originalStatus,
+                                                      final HealthStatus finalStatus,
+                                                      final HealthCheckMode mode) {
+        final Map<String, Object> data = new HashMap<>();
+        final long initAt = osgiInitCompletedAt();
+        data.put("osgiInitCompleted", initAt != 0L);
+        if (initAt != 0L) {
+            data.put("elapsedSinceInitMs", System.currentTimeMillis() - initAt);
+        }
+        data.put("gracePeriodMs", gracePeriodMs());
+
+        final Bundle[] bundles = bundles();
+        if (bundles != null) {
+            final Set<String> required = requiredBundleNames();
+            final List<Bundle> candidates = candidates(bundles, required);
+            data.put("totalBundles", candidates.size());
+            final Map<String, Long> byState = candidates.stream()
+                    .collect(Collectors.groupingBy(b -> stateName(b.getState()),
+                            Collectors.counting()));
+            data.put("bundlesByState", byState);
+
+            final List<Map<String, Object>> failing = candidates.stream()
+                    .filter(b -> b.getState() != Bundle.ACTIVE)
+                    .map(b -> {
+                        final Map<String, Object> m = new HashMap<>();
+                        m.put("symbolicName", b.getSymbolicName());
+                        m.put("state", stateName(b.getState()));
+                        m.put("location", b.getLocation());
+                        return m;
+                    })
+                    .collect(Collectors.toList());
+            if (!failing.isEmpty()) {
+                data.put("notActiveBundles", failing);
+            }
+            if (!required.isEmpty()) {
+                data.put("requiredBundles", required);
+            }
+        }
+        return data;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/health/servlet/HealthProbeServlet.java
+++ b/dotCMS/src/main/java/com/dotcms/health/servlet/HealthProbeServlet.java
@@ -3,6 +3,7 @@ package com.dotcms.health.servlet;
 import com.dotcms.health.checks.ApplicationHealthCheck;
 import com.dotcms.health.checks.CdiInitializationHealthCheck;
 import com.dotcms.health.checks.GarbageCollectionHealthCheck;
+import com.dotcms.health.checks.OsgiBundlesHealthCheck;
 import com.dotcms.health.checks.ServletContainerHealthCheck;
 import com.dotcms.health.checks.ShutdownHealthCheck;
 import com.dotcms.health.checks.SystemHealthCheck;
@@ -200,7 +201,11 @@ public class HealthProbeServlet extends AbstractManagementServlet {
             // Shutdown status check - readiness only (fails when shutdown begins to stop new traffic)
             ShutdownHealthCheck shutdownCheck = new ShutdownHealthCheck();
             healthStateManager.registerHealthCheck(shutdownCheck);
-            
+
+            // OSGi bundle start check - readiness only (fails rollout if a plugin does not reach ACTIVE)
+            OsgiBundlesHealthCheck osgiBundlesCheck = new OsgiBundlesHealthCheck();
+            healthStateManager.registerHealthCheck(osgiBundlesCheck);
+
             Logger.info(this, "Core health checks registered successfully");
         } catch (Exception e) {
             Logger.error(this, "Failed to register core health checks", e);

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/monitor/MonitorHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/system/monitor/MonitorHelper.java
@@ -1,16 +1,14 @@
 package com.dotcms.rest.api.v1.system.monitor;
 
-import com.dotcms.content.index.domain.ClusterStats;
 import com.dotcms.exception.ExceptionUtil;
+import com.dotcms.health.api.HealthService;
 import com.dotcms.http.CircuitBreakerUrl;
 import com.dotcms.rest.api.v1.analytics.content.util.ContentAnalyticsUtil;
 import com.dotcms.rest.api.v1.analytics.event.EventAnalyticsProxyHelper;
 import com.dotcms.util.HttpRequestDataUtil;
 import com.dotcms.util.network.IPUtils;
 import com.dotmarketing.beans.Host;
-import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.web.WebAPILocator;
-import com.dotmarketing.common.db.DotConnect;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.ConfigUtils;
 import com.dotmarketing.util.Logger;
@@ -23,6 +21,7 @@ import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import io.vavr.control.Try;
 
+import javax.enterprise.inject.spi.CDI;
 import javax.servlet.http.HttpServletRequest;
 import java.io.File;
 import java.io.OutputStream;
@@ -251,31 +250,42 @@ class MonitorHelper {
     }
 
     /**
-     * Determines if the database server is healthy by executing a simple query.
+     * Looks up the unified {@link HealthService} via CDI. A request only reaches this helper
+     * through the Jersey REST stack, which runs after CDI is up — so if this lookup fails the
+     * application is not healthy and the caller should treat the subsystem as DOWN.
+     */
+    HealthService healthService() {
+        return CDI.current().select(HealthService.class).get();
+    }
+
+    /**
+     * Determines if the database server is healthy by delegating to the unified health system
+     * so the legacy monitor endpoint and {@code /readyz} return the same answer.
      *
      * @return If the database server is healthy, returns {@code true}.
      */
     boolean isDBHealthy()  {
-            return Try.of(()->
-                            new DotConnect().setSQL("SELECT 1 as count")
-                    .loadInt("count"))
-                    .onFailure(e->Logger.warnAndDebug(MonitorHelper.class, "unable to connect to db:" + e.getMessage(),e))
-                    .getOrElse(0) > 0;
+        try {
+            return healthService().isDatabaseHealthy();
+        } catch (final Exception e) {
+            Logger.warnAndDebug(MonitorHelper.class,
+                    "unable to query health service for DB: " + ExceptionUtil.getErrorMessage(e), e);
+            return false;
+        }
     }
 
     /**
-     * Determines if dotCMS can connect to Elasticsearch by checking the ES Server cluster
-     * statistics. If they're available, it means dotCMS can connect to ES.
+     * Determines if dotCMS can connect to Elasticsearch by delegating to the unified health
+     * system (same probe as {@code /readyz}).
      *
      * @return If dotCMS can connect to Elasticsearch, returns {@code true}.
      */
     boolean canConnectToES() {
         try {
-            final ClusterStats stats = APILocator.getESIndexAPI().getClusterStats();
-            return stats != null && stats.clusterName() != null;
+            return healthService().isSearchServiceHealthy();
         } catch (final Exception e) {
             Logger.warnAndDebug(this.getClass(),
-                    "Unable to connect to ES: " + ExceptionUtil.getErrorMessage(e), e);
+                    "unable to query health service for ES: " + ExceptionUtil.getErrorMessage(e), e);
             return false;
         }
     }
@@ -297,16 +307,17 @@ class MonitorHelper {
 
 
     /**
-     * Determines if the cache is healthy by checking if the SYSTEM_HOST identifier is available.
+     * Determines if the cache is healthy by delegating to the unified health system (same probe
+     * as {@code /readyz}).
      *
      * @return If the cache is healthy, returns {@code true}.
      */
     boolean isCacheHealthy()  {
         try {
-            APILocator.getIdentifierAPI().find(Host.SYSTEM_HOST);
-            return UtilMethods.isSet(APILocator.getIdentifierAPI().find(Host.SYSTEM_HOST).getId());
+            return healthService().isHealthCheckUp("cache");
         } catch (final Exception e){
-            Logger.warnAndDebug(this.getClass(), "unable to find SYSTEM_HOST: " + e.getMessage(), e);
+            Logger.warnAndDebug(this.getClass(),
+                    "unable to query health service for cache: " + ExceptionUtil.getErrorMessage(e), e);
             return false;
         }
     }

--- a/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
+++ b/dotCMS/src/main/java/org/apache/felix/framework/OSGIUtil.java
@@ -136,6 +136,9 @@ public class OSGIUtil {
     private Framework felixFramework;
     private String felixExtraPackagesFile;
     private WorkflowAPIOsgiService workflowOsgiService;
+    // Epoch millis at which initializeFramework() last completed. 0 means OSGI has not finished initializing.
+    // Read by health checks to compute the bundle-start grace period.
+    private volatile long osgiInitCompletedAt = 0L;
 
     //List of jar prefixes of the jars to be included in the osgi-extra.conf file
     public final List<String> portletIDsStopped = Collections.synchronizedList(new ArrayList<>());
@@ -403,8 +406,13 @@ public class OSGIUtil {
         System.setProperty(WebKeys.OSGI_ENABLED, Boolean.TRUE.toString());
         System.setProperty(WebKeys.DOTCMS_STARTUP_TIME_OSGI,
                 String.valueOf(System.currentTimeMillis() - start));
+        osgiInitCompletedAt = System.currentTimeMillis();
 
         return felixFramework;
+    }
+
+    public long getOsgiInitCompletedAt() {
+        return osgiInitCompletedAt;
     }
 
     private void startWatchingUploadFolder(final String uploadFolder) {
@@ -828,6 +836,7 @@ public class OSGIUtil {
             Logger.warn(this, "Error while stopping felix!", e);
         }finally {
             felixFramework=null;
+            osgiInitCompletedAt = 0L;
         }
     }
 

--- a/dotCMS/src/test/java/com/dotcms/health/checks/OsgiBundlesHealthCheckTest.java
+++ b/dotCMS/src/test/java/com/dotcms/health/checks/OsgiBundlesHealthCheckTest.java
@@ -1,0 +1,202 @@
+package com.dotcms.health.checks;
+
+import com.dotcms.health.model.HealthCheckResult;
+import com.dotcms.health.model.HealthStatus;
+import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Constants;
+
+import java.util.Collections;
+import java.util.Hashtable;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OsgiBundlesHealthCheckTest {
+
+    private static final long GRACE_MS = 60_000L;
+
+    @Test
+    public void preInit_reportsUp_withDeferredMessage() {
+        final TestableCheck check = new TestableCheck()
+                .withInitAt(0L)
+                .withBundles(new Bundle[] { bundle("plugin-a", Bundle.ACTIVE, false) });
+
+        final HealthCheckResult result = check.check();
+
+        assertEquals(HealthStatus.UP, result.status());
+        assertTrue(result.message().orElse(""),result.message().orElse("").contains("not yet initialized"));
+    }
+
+    @Test
+    public void withinGrace_bundleNotActive_reportsUp() {
+        final long now = System.currentTimeMillis();
+        final TestableCheck check = new TestableCheck()
+                .withInitAt(now - 1_000L) // 1s elapsed; well inside 60s grace
+                .withBundles(new Bundle[] {
+                        systemBundle(),
+                        bundle("plugin-a", Bundle.STARTING, false)
+                });
+
+        final HealthCheckResult result = check.check();
+
+        assertEquals(HealthStatus.UP, result.status());
+        assertTrue(result.message().orElse(""),result.message().orElse("").contains("still starting"));
+    }
+
+    @Test
+    public void afterGrace_bundleNotActive_reportsDown() {
+        final long now = System.currentTimeMillis();
+        final TestableCheck check = new TestableCheck()
+                .withInitAt(now - (GRACE_MS + 5_000L)) // past grace
+                .withBundles(new Bundle[] {
+                        systemBundle(),
+                        bundle("plugin-a", Bundle.ACTIVE, false),
+                        bundle("plugin-b", Bundle.RESOLVED, false)
+                });
+
+        final HealthCheckResult result = check.check();
+
+        assertEquals(HealthStatus.DOWN, result.status());
+        assertTrue(result.message().orElse(""),result.message().orElse("").contains("plugin-b"));
+        assertTrue(result.message().orElse(""),result.message().orElse("").contains("RESOLVED"));
+    }
+
+    @Test
+    public void afterGrace_allActive_reportsUp() {
+        final long now = System.currentTimeMillis();
+        final TestableCheck check = new TestableCheck()
+                .withInitAt(now - (GRACE_MS + 5_000L))
+                .withBundles(new Bundle[] {
+                        systemBundle(),
+                        bundle("plugin-a", Bundle.ACTIVE, false),
+                        bundle("plugin-b", Bundle.ACTIVE, false)
+                });
+
+        final HealthCheckResult result = check.check();
+
+        assertEquals(HealthStatus.UP, result.status());
+        assertTrue(result.message().orElse(""),result.message().orElse("").contains("ACTIVE"));
+    }
+
+    @Test
+    public void fragmentBundle_isIgnored_evenWhenResolved() {
+        final long now = System.currentTimeMillis();
+        final TestableCheck check = new TestableCheck()
+                .withInitAt(now - (GRACE_MS + 5_000L))
+                .withBundles(new Bundle[] {
+                        systemBundle(),
+                        bundle("plugin-a", Bundle.ACTIVE, false),
+                        bundle("plugin-fragment", Bundle.RESOLVED, true) // fragments never go ACTIVE
+                });
+
+        final HealthCheckResult result = check.check();
+
+        assertEquals(HealthStatus.UP, result.status());
+    }
+
+    @Test
+    public void requiredBundles_missing_afterGrace_reportsDown() {
+        final long now = System.currentTimeMillis();
+        final TestableCheck check = new TestableCheck()
+                .withInitAt(now - (GRACE_MS + 5_000L))
+                .withRequired(Collections.singleton("plugin-required"))
+                .withBundles(new Bundle[] {
+                        systemBundle(),
+                        bundle("plugin-a", Bundle.ACTIVE, false)
+                });
+
+        final HealthCheckResult result = check.check();
+
+        assertEquals(HealthStatus.DOWN, result.status());
+        assertTrue(result.message().orElse(""),result.message().orElse("").contains("plugin-required"));
+        assertTrue(result.message().orElse(""),result.message().orElse("").contains("missing"));
+    }
+
+    @Test
+    public void name_isStable() {
+        assertEquals("osgi-bundles", new OsgiBundlesHealthCheck().getName());
+    }
+
+    @Test
+    public void readiness_yes_liveness_no() {
+        final OsgiBundlesHealthCheck check = new OsgiBundlesHealthCheck();
+        assertTrue(check.isReadinessCheck());
+        assertEquals(false, check.isLivenessCheck());
+    }
+
+    @Test
+    public void description_includesGracePeriod() {
+        final String description = new TestableCheck().getDescription();
+        assertNotNull(description);
+        assertTrue(description, description.contains("grace"));
+    }
+
+    private static Bundle systemBundle() {
+        final Bundle b = mock(Bundle.class);
+        when(b.getBundleId()).thenReturn(0L);
+        when(b.getSymbolicName()).thenReturn("org.apache.felix.framework");
+        when(b.getState()).thenReturn(Bundle.ACTIVE);
+        when(b.getHeaders()).thenReturn(new Hashtable<>());
+        return b;
+    }
+
+    private static Bundle bundle(final String symbolicName, final int state, final boolean fragment) {
+        final Bundle b = mock(Bundle.class);
+        when(b.getBundleId()).thenReturn(1L);
+        when(b.getSymbolicName()).thenReturn(symbolicName);
+        when(b.getState()).thenReturn(state);
+        when(b.getLocation()).thenReturn("file:" + symbolicName + ".jar");
+        final Hashtable<String, String> headers = new Hashtable<>();
+        if (fragment) {
+            headers.put(Constants.FRAGMENT_HOST, "host.bundle");
+        }
+        when(b.getHeaders()).thenReturn(headers);
+        return b;
+    }
+
+    private static final class TestableCheck extends OsgiBundlesHealthCheck {
+        private long initAt;
+        private Bundle[] bundles = new Bundle[0];
+        private Set<String> required = Collections.emptySet();
+
+        TestableCheck withInitAt(final long ts) {
+            this.initAt = ts;
+            return this;
+        }
+
+        TestableCheck withBundles(final Bundle[] bundles) {
+            this.bundles = bundles;
+            return this;
+        }
+
+        TestableCheck withRequired(final Set<String> required) {
+            this.required = required;
+            return this;
+        }
+
+        @Override
+        long osgiInitCompletedAt() {
+            return initAt;
+        }
+
+        @Override
+        Bundle[] bundles() {
+            return bundles;
+        }
+
+        @Override
+        long gracePeriodMs() {
+            return GRACE_MS;
+        }
+
+        @Override
+        Set<String> requiredBundleNames() {
+            return required;
+        }
+    }
+}


### PR DESCRIPTION
Add OsgiBundlesHealthCheck that fails readiness when configured OSGi
plugins do not start, preventing deployment cutover on plugin failure.
Track OSGi init timestamp in OSGIUtil and register the check in
HealthProbeServlet. Consolidate MonitorHelper to delegate DB,
Elasticsearch, and cache checks to the unified HealthService.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

This PR fixes: #35806
