### PR TITLE
fix(contentlet): clear tag field when an empty value is sent (#35861)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ESContentletAPIImpl.java
@@ -7582,13 +7582,13 @@ public class ESContentletAPIImpl implements ContentletAPI {
                     "The contentlet's Content Type Inode must be set");
         }
 
-        if (value == null || !UtilMethods.isSet(value.toString())) {
-            contentlet.setProperty(field.getVelocityVarName(), null);
-            return;
-        }
-
         final com.dotcms.contenttype.model.field.Field newField = LegacyFieldTransformer.from(
                 field);
+
+        if (value == null || !UtilMethods.isSet(value.toString())) {
+            clearOrNullifyProperty(contentlet, newField, value);
+            return;
+        }
 
         FieldHandlerStrategyFactory.getInstance().get(newField).apply(contentlet, newField, value);
     }
@@ -7609,11 +7609,35 @@ public class ESContentletAPIImpl implements ContentletAPI {
         }
 
         if (value == null || !UtilMethods.isSet(value.toString())) {
-            contentlet.setProperty(field.variable(), null);
+            clearOrNullifyProperty(contentlet, field, value);
             return;
         }
 
         FieldHandlerStrategyFactory.getInstance().get(field).apply(contentlet, field, value);
+    }
+
+    /**
+     * Clears a field whose incoming value is null or empty. For most field types this nullifies the
+     * property (which removes the key from the contentlet map). For {@link TagField}s, however, an
+     * explicit empty string means "remove all tags": it is preserved as an empty string instead of
+     * being collapsed to null. Storing it as null would remove the key from the map, letting
+     * {@link Contentlet#setTags()} re-hydrate the previous version's tags during checkin and thus
+     * silently keep the old value (see issue #35861). Keeping the empty string makes the checkin tag
+     * logic ({@code prepareTags}/{@code relateTags}) wipe the {@code tag_inode} rows and prevents the
+     * re-hydration, while a genuinely null/absent value still leaves existing tags untouched
+     * (partial update).
+     *
+     * @param contentlet the contentlet being populated
+     * @param field      the (modern) field whose value is being cleared
+     * @param value      the incoming value (null or not-set)
+     */
+    private void clearOrNullifyProperty(final Contentlet contentlet,
+            final com.dotcms.contenttype.model.field.Field field, final Object value) {
+        if (field instanceof TagField && value != null) {
+            contentlet.setStringProperty(field.variable(), StringPool.BLANK);
+        } else {
+            contentlet.setProperty(field.variable(), null);
+        }
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
+++ b/dotCMS/src/main/java/com/dotmarketing/portlets/contentlet/model/Contentlet.java
@@ -1539,6 +1539,10 @@ public class Contentlet implements Serializable, Permissionable, Categorizable, 
 						final String fieldVarName = foundTagInode.getFieldVarName();
 
 						// if the map does not have already this field on the map so populate it. we do not want to override the eventual user values.
+						// INVARIANT (issue #35861): this containsKey guard is what lets a tag clear stick. When a tag field is
+						// cleared, ESContentletAPIImpl.clearOrNullifyProperty stores an empty string ("") rather than null so the
+						// key stays in the map; that blocks the re-hydration below from resurrecting the prior version's tags.
+						// Do not relax this guard (e.g. to also re-hydrate when the value is blank) without revisiting that fix.
 						if (!map.containsKey(fieldVarName)) {
 							StringBuilder contentletTagsBuilder = new StringBuilder();
 

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceIntegrationTest.java
@@ -46,6 +46,7 @@ import com.dotcms.contenttype.model.field.MultiSelectField;
 import com.dotcms.contenttype.model.field.RadioField;
 import com.dotcms.contenttype.model.field.RelationshipField;
 import com.dotcms.contenttype.model.field.SelectField;
+import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.field.TextAreaField;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.field.TimeField;
@@ -97,6 +98,7 @@ import com.dotmarketing.portlets.workflows.business.WorkflowAPI;
 import com.dotmarketing.portlets.workflows.business.WorkflowAPI.SystemAction;
 import com.dotmarketing.portlets.workflows.model.*;
 import com.dotmarketing.portlets.workflows.util.WorkflowImportExportUtil;
+import com.dotmarketing.tag.model.Tag;
 import com.dotmarketing.util.DateUtil;
 import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDGenerator;
@@ -1648,6 +1650,152 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         }
     }
 
+    /**
+     * Creates a custom contentType with a required text field and a tag field, associated with the
+     * out-of-the-box System and Document workflows.
+     *
+     * @return the created {@link ContentType}
+     * @throws Exception if the content type cannot be created
+     */
+    private ContentType createSampleContentTypeWithTagField() throws Exception {
+        final String ctPrefix = "TestContentTypeWithTag";
+        final String newContentTypeName = ctPrefix + System.currentTimeMillis();
+
+        // Create ContentType
+        ContentType contentType = createContentTypeAndAssignPermissions(newContentTypeName,
+                BaseContentType.CONTENT, PermissionAPI.PERMISSION_READ, adminRole.getId());
+        final WorkflowScheme systemWorkflow = workflowAPI.findSystemWorkflowScheme();
+        final WorkflowScheme documentWorkflow = workflowAPI.findSchemeByName(DM_WORKFLOW);
+
+        // Add a required Text field
+        final Field textField =
+                FieldBuilder.builder(TextField.class).name(REQUIRED_TEXT_FIELD_NAME)
+                        .variable(REQUIRED_TEXT_FIELD_NAME)
+                        .required(true)
+                        .contentTypeId(contentType.id()).dataType(DataTypes.TEXT).build();
+
+        // Add a Tag field
+        final Field tagField =
+                FieldBuilder.builder(TagField.class).name(TAG_FIELD_NAME)
+                        .variable(TAG_FIELD_NAME)
+                        .contentTypeId(contentType.id()).build();
+
+        contentType = contentTypeAPI.save(contentType, List.of(textField, tagField));
+
+        // Assign contentType to Workflows
+        workflowAPI.saveSchemeIdsForContentType(contentType,
+                Stream.of(
+                        systemWorkflow.getId(),
+                        documentWorkflow.getId()
+                ).collect(Collectors.toSet())
+        );
+
+        return contentType;
+    }
+
+    /**
+     * Method to test: {@link WorkflowResource#fireActionSinglePart(HttpServletRequest,
+     * HttpServletResponse, String, String, String, String, String, FireActionForm)}
+     * <p>
+     * Given Scenario: A contentlet of a content type that has a Tag field is saved/published with a
+     * tag value (e.g. {@code "new edit content"}). Then the Save/Publish workflow action is fired
+     * again over the same contentlet sending {@code "tags": ""} (an empty value) in the payload.
+     * <p>
+     * Expected Result: The tag must be cleared. After firing the action with an empty tags value
+     * the contentlet must have no tags associated to its tag field, and the returned contentlet must
+     * not echo back the stale tag value.
+     */
+    @Test
+    public void Test_Fire_Save_With_Tag_Then_Fire_Update_With_Empty_Tag_Clears_Tag()
+            throws Exception {
+        final String saveAndPublishActionId = "b9d89c80-3d88-4311-8365-187323c96436";
+        ContentType contentType = null;
+        try {
+            contentType = createSampleContentTypeWithTagField();
+            Contentlet brandNewContentlet = null;
+            try {
+                // 1) Save/Publish setting a tag value
+                final FireActionForm.Builder builder1 = new FireActionForm.Builder();
+                final Map<String, Object> contentletFormData = new HashMap<>();
+                contentletFormData.put("stInode", contentType.inode());
+                contentletFormData.put(REQUIRED_TEXT_FIELD_NAME, "value-1");
+                contentletFormData.put(TAG_FIELD_NAME, "new edit content");
+                contentletFormData.put("languageId", 1);
+                builder1.contentlet(contentletFormData);
+
+                final FireActionForm fireActionForm1 = new FireActionForm(builder1);
+                final Response response1 = workflowResource
+                        .fireActionSinglePart(getHttpRequest(), new EmptyHttpResponse(),
+                                saveAndPublishActionId, null, null,
+                                IndexPolicy.WAIT_FOR.name(), "-1", fireActionForm1);
+
+                assertEquals(Status.OK.getStatusCode(), response1.getStatus());
+                final ResponseEntityView fireEntityView1 = ResponseEntityView.class
+                        .cast(response1.getEntity());
+                brandNewContentlet = new Contentlet(Map.class.cast(fireEntityView1.getEntity()));
+                assertNotNull(brandNewContentlet.getInode());
+
+                // The tag must have been persisted
+                final List<Tag> savedTags = APILocator.getTagAPI()
+                        .getTagsByInodeAndFieldVarName(brandNewContentlet.getInode(),
+                                TAG_FIELD_NAME);
+                assertEquals("The tag should have been saved", 1, savedTags.size());
+                assertEquals("new edit content", savedTags.get(0).getTagName());
+
+                // 2) Fire the Save/Publish action again over the same contentlet, but now sending
+                // an empty tags value, which should clear the tag.
+                final FireActionForm.Builder builder2 = new FireActionForm.Builder();
+                final Map<String, Object> contentletFormData2 = new HashMap<>();
+                contentletFormData2.put("stInode", contentType.inode());
+                contentletFormData2.put(REQUIRED_TEXT_FIELD_NAME, "value-1");
+                contentletFormData2.put(TAG_FIELD_NAME, "");
+                contentletFormData2.put("languageId", 1);
+                builder2.contentlet(contentletFormData2);
+
+                final FireActionForm fireActionForm2 = new FireActionForm(builder2);
+                final Response response2 = workflowResource
+                        .fireActionSinglePart(getHttpRequest(), new EmptyHttpResponse(),
+                                saveAndPublishActionId, brandNewContentlet.getInode(), null,
+                                IndexPolicy.WAIT_FOR.name(), "-1", fireActionForm2);
+
+                assertEquals(Status.OK.getStatusCode(), response2.getStatus());
+                final ResponseEntityView fireEntityView2 = ResponseEntityView.class
+                        .cast(response2.getEntity());
+                final Contentlet updatedContentlet = new Contentlet(
+                        Map.class.cast(fireEntityView2.getEntity()));
+                assertNotNull(updatedContentlet);
+                assertEquals(brandNewContentlet.getIdentifier(),
+                        updatedContentlet.getIdentifier());
+
+                // 3) The tag must be cleared now (this is the bug: the old value is kept).
+                final List<Tag> updatedTags = APILocator.getTagAPI()
+                        .getTagsByInodeAndFieldVarName(updatedContentlet.getInode(),
+                                TAG_FIELD_NAME);
+                assertTrue(
+                        "Tags should be cleared when the action is fired with an empty tags value, "
+                                + "but the following tags were found: " + updatedTags,
+                        updatedTags.isEmpty());
+
+                // The returned contentlet must not echo back the stale tag value
+                final Object tagsValue = updatedContentlet.getMap().get(TAG_FIELD_NAME);
+                assertTrue(
+                        "The returned contentlet still shows the stale tag value: " + tagsValue,
+                        tagsValue == null
+                                || tagsValue.toString().isEmpty()
+                                || (tagsValue instanceof List && ((List) tagsValue).isEmpty()));
+
+            } finally {
+                if (null != brandNewContentlet) {
+                    contentletAPI.destroy(brandNewContentlet, APILocator.systemUser(), false);
+                }
+            }
+        } finally {
+            if (null != contentType) {
+                contentTypeAPI.delete(contentType);
+            }
+        }
+    }
+
     static ImmutableMap<Class, DataTypes> fieldTypesMetaDataMap = new ImmutableMap.Builder<Class, DataTypes>()
             //   .put(BinaryField.class, DataTypes.SYSTEM)
             //   .put(CategoryField.class, DataTypes.SYSTEM)
@@ -1682,6 +1830,8 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
 
     private static final String REQUIRED_TEXT_FIELD_NAME = "requiredTextField";
     private static final String REQUIRED_TEXT_FIELD_VALUE = "This Value is Required";
+
+    private static final String TAG_FIELD_NAME = "tagField";
 
     private static final String NON_REQUIRED_TEXT_FIELD_NAME = "nonRequiredTextField";
     private static final String NON_REQUIRED_TEXT_FIELD_VALUE = "This Value isn't required";

--- a/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rest/api/v1/workflow/WorkflowResourceIntegrationTest.java
@@ -1796,6 +1796,120 @@ public class WorkflowResourceIntegrationTest extends BaseWorkflowIntegrationTest
         }
     }
 
+    /**
+     * Fires the System Workflow Save/Publish action over the given content type. When
+     * {@code includeTagKey} is true the {@code tagField} entry is added to the payload with
+     * {@code tagValue} (which may be a String, a List or {@code null}); when false the tag field key
+     * is omitted entirely (simulating a partial update that does not mention the field).
+     *
+     * @param contentType   the content type to fire against
+     * @param inode         the inode to update, or {@code null} to create a new contentlet
+     * @param tagValue      the value to set for the tag field (only used when {@code includeTagKey})
+     * @param includeTagKey whether the tag field key is present in the payload
+     * @return the contentlet returned by the fire action
+     */
+    private Contentlet fireSaveWithTagValue(final ContentType contentType, final String inode,
+            final Object tagValue, final boolean includeTagKey) throws Exception {
+        final String saveAndPublishActionId = "b9d89c80-3d88-4311-8365-187323c96436";
+        final FireActionForm.Builder builder = new FireActionForm.Builder();
+        final Map<String, Object> formData = new HashMap<>();
+        formData.put("stInode", contentType.inode());
+        formData.put(REQUIRED_TEXT_FIELD_NAME, "value-1");
+        if (includeTagKey) {
+            formData.put(TAG_FIELD_NAME, tagValue);
+        }
+        formData.put("languageId", 1);
+        builder.contentlet(formData);
+
+        final Response response = workflowResource.fireActionSinglePart(getHttpRequest(),
+                new EmptyHttpResponse(), saveAndPublishActionId, inode, null,
+                IndexPolicy.WAIT_FOR.name(), "-1", new FireActionForm(builder));
+        assertEquals(Status.OK.getStatusCode(), response.getStatus());
+        return new Contentlet(Map.class.cast(
+                ResponseEntityView.class.cast(response.getEntity()).getEntity()));
+    }
+
+    private List<Tag> tagsOf(final String inode) throws DotDataException {
+        return APILocator.getTagAPI().getTagsByInodeAndFieldVarName(inode, TAG_FIELD_NAME);
+    }
+
+    /**
+     * Method to test: {@link WorkflowResource#fireActionSinglePart(HttpServletRequest,
+     * HttpServletResponse, String, String, String, String, String, FireActionForm)}
+     * <p>
+     * Given Scenario: A contentlet with a tag value is updated firing the Save/Publish action with an
+     * explicit {@code "tags": null} in the payload.
+     * <p>
+     * Expected Result: The tags are LEFT UNCHANGED. A null value is a partial-update / no-op signal
+     * (only an explicit empty value clears tags), so the existing tag must survive. Guards the
+     * {@code ""} (wipe) vs {@code null} (no-op) distinction introduced by the fix for #35861.
+     */
+    @Test
+    public void Test_Fire_Update_With_Null_Tag_Preserves_Tag() throws Exception {
+        ContentType contentType = null;
+        try {
+            contentType = createSampleContentTypeWithTagField();
+            Contentlet contentlet = null;
+            try {
+                contentlet = fireSaveWithTagValue(contentType, null, "new edit content", true);
+                assertEquals(1, tagsOf(contentlet.getInode()).size());
+
+                final Contentlet updated = fireSaveWithTagValue(contentType,
+                        contentlet.getInode(), null, true);
+
+                final List<Tag> tags = tagsOf(updated.getInode());
+                assertEquals("A null tag value must leave existing tags unchanged", 1, tags.size());
+                assertEquals("new edit content", tags.get(0).getTagName());
+            } finally {
+                if (null != contentlet) {
+                    contentletAPI.destroy(contentlet, APILocator.systemUser(), false);
+                }
+            }
+        } finally {
+            if (null != contentType) {
+                contentTypeAPI.delete(contentType);
+            }
+        }
+    }
+
+    /**
+     * Method to test: {@link WorkflowResource#fireActionSinglePart(HttpServletRequest,
+     * HttpServletResponse, String, String, String, String, String, FireActionForm)}
+     * <p>
+     * Given Scenario: A contentlet with a tag value is updated firing the Save/Publish action with a
+     * payload that does NOT include the tag field key at all (a partial update of other fields).
+     * <p>
+     * Expected Result: The tags are LEFT UNCHANGED. Omitting the field must not wipe its tags.
+     */
+    @Test
+    public void Test_Fire_Update_Without_Tag_Key_Preserves_Tag() throws Exception {
+        ContentType contentType = null;
+        try {
+            contentType = createSampleContentTypeWithTagField();
+            Contentlet contentlet = null;
+            try {
+                contentlet = fireSaveWithTagValue(contentType, null, "new edit content", true);
+                assertEquals(1, tagsOf(contentlet.getInode()).size());
+
+                final Contentlet updated = fireSaveWithTagValue(contentType,
+                        contentlet.getInode(), null, false);
+
+                final List<Tag> tags = tagsOf(updated.getInode());
+                assertEquals("Omitting the tag field must leave existing tags unchanged",
+                        1, tags.size());
+                assertEquals("new edit content", tags.get(0).getTagName());
+            } finally {
+                if (null != contentlet) {
+                    contentletAPI.destroy(contentlet, APILocator.systemUser(), false);
+                }
+            }
+        } finally {
+            if (null != contentType) {
+                contentTypeAPI.delete(contentType);
+            }
+        }
+    }
+
     static ImmutableMap<Class, DataTypes> fieldTypesMetaDataMap = new ImmutableMap.Builder<Class, DataTypes>()
             //   .put(BinaryField.class, DataTypes.SYSTEM)
             //   .put(CategoryField.class, DataTypes.SYSTEM)

--- a/dotcms-integration/src/test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/portlets/contentlet/business/ContentletAPITest.java
@@ -36,6 +36,7 @@ import com.dotcms.contenttype.model.field.JSONField;
 import com.dotcms.contenttype.model.field.KeyValueField;
 import com.dotcms.contenttype.model.field.RadioField;
 import com.dotcms.contenttype.model.field.RelationshipField;
+import com.dotcms.contenttype.model.field.TagField;
 import com.dotcms.contenttype.model.field.TextAreaField;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.BaseContentType;
@@ -2053,6 +2054,158 @@ public class ContentletAPITest extends ContentletBaseTest {
 
         //Validations
         assertTrue(value2.isEmpty());
+    }
+
+    private static final String TAG_CLEARING_FIELD_VAR = "tags";
+
+    /**
+     * Creates a content type with a {@code title} text field and a single {@code tags}
+     * {@link TagField}. Helper for the tag-clearing tests below (GitHub issue #35861).
+     */
+    private ContentType createContentTypeWithTagField() {
+        final List<com.dotcms.contenttype.model.field.Field> fields = new ArrayList<>();
+        fields.add(new FieldDataGen().velocityVarName("title").next());
+        fields.add(new FieldDataGen().type(TagField.class)
+                .velocityVarName(TAG_CLEARING_FIELD_VAR).next());
+        return new ContentTypeDataGen().fields(fields).nextPersisted();
+    }
+
+    /**
+     * Creates and checks in a contentlet of the given type with the given tag value.
+     */
+    private Contentlet createContentletWithTag(final ContentType contentType, final String tagValue)
+            throws Exception {
+        final Contentlet contentlet = new Contentlet();
+        contentlet.setContentTypeId(contentType.id());
+        contentlet.setHost(defaultHost.getIdentifier());
+        contentlet.setLanguageId(languageAPI.getDefaultLanguage().getId());
+        contentlet.setStringProperty("title", "Test " + System.currentTimeMillis());
+        contentlet.setStringProperty(TAG_CLEARING_FIELD_VAR, tagValue);
+        contentlet.setIndexPolicy(IndexPolicy.FORCE);
+        return contentletAPI.checkin(contentlet, user, false);
+    }
+
+    private com.dotcms.contenttype.model.field.Field tagClearingField(final ContentType contentType) {
+        final Optional<com.dotcms.contenttype.model.field.Field> field = contentType.fields().stream()
+                .filter(f -> TAG_CLEARING_FIELD_VAR.equals(f.variable())).findFirst();
+        assertTrue("The content type must have the tag field", field.isPresent());
+        return field.get();
+    }
+
+    private List<Tag> tagsOf(final String inode) throws DotDataException {
+        return tagAPI.getTagsByInodeAndFieldVarName(inode, TAG_CLEARING_FIELD_VAR);
+    }
+
+    /**
+     * Method to test: {@link ContentletAPI#setContentletProperty(Contentlet, Field, Object)} +
+     * {@link ContentletAPI#checkin(Contentlet, User, boolean)}.
+     * <p>
+     * Given Scenario: A contentlet has a tag value. It is updated through
+     * {@code setContentletProperty(tagField, "")} — the field setter the REST/form populator uses —
+     * and checked in.
+     * <p>
+     * Expected Result: The tag is cleared (no {@code tag_inode} rows for the new inode and the
+     * reloaded contentlet does not echo the old value). Regression guard documenting that, at the
+     * {@link ContentletAPI} boundary, clearing a tag field works correctly — the GitHub issue #35861
+     * defect lives in the workflow/REST merge layer (see {@code WorkflowResourceIntegrationTest}),
+     * not here.
+     */
+    @Test
+    public void setContentletProperty_emptyStringOnTagField_thenCheckin_clearsTags() throws Exception {
+        ContentType contentType = null;
+        try {
+            contentType = createContentTypeWithTagField();
+            final Contentlet saved = createContentletWithTag(contentType, "new edit content");
+            assertEquals("The tag should have been saved", 1, tagsOf(saved.getInode()).size());
+
+            final Contentlet working = contentletAPI.checkout(saved.getInode(), user, false);
+            contentletAPI.setContentletProperty(working, tagClearingField(contentType), "");
+            working.setIndexPolicy(IndexPolicy.FORCE);
+            final Contentlet updated = contentletAPI.checkin(working, user, false);
+
+            assertTrue("tag_inode should be empty after clearing via setContentletProperty, found: "
+                            + tagsOf(updated.getInode()),
+                    tagsOf(updated.getInode()).isEmpty());
+
+            final Contentlet reloaded = contentletAPI.findContentletByIdentifier(
+                    updated.getIdentifier(), false, updated.getLanguageId(), user, false);
+            final String reloadedTag = reloaded.getStringProperty(TAG_CLEARING_FIELD_VAR);
+            assertTrue("Reloaded contentlet still shows the stale tag value: " + reloadedTag,
+                    !UtilMethods.isSet(reloadedTag));
+        } finally {
+            if (null != contentType) {
+                ContentTypeDataGen.remove(contentType);
+            }
+        }
+    }
+
+    /**
+     * Method to test: {@link Contentlet#setStringProperty(String, String)} +
+     * {@link ContentletAPI#checkin(Contentlet, User, boolean)}.
+     * <p>
+     * Given Scenario: A contentlet has a tag value, then the tag field is set to the empty string
+     * directly on the contentlet (the direct-API path) and checked in.
+     * <p>
+     * Expected Result: Tags are cleared. Characterization/regression guard — this path already works
+     * today and must keep working (GitHub issue #35861).
+     */
+    @Test
+    public void setStringProperty_emptyStringOnTagField_thenCheckin_clearsTags() throws Exception {
+        ContentType contentType = null;
+        try {
+            contentType = createContentTypeWithTagField();
+            final Contentlet saved = createContentletWithTag(contentType, "new edit content");
+            assertEquals(1, tagsOf(saved.getInode()).size());
+
+            final Contentlet working = contentletAPI.checkout(saved.getInode(), user, false);
+            working.setStringProperty(TAG_CLEARING_FIELD_VAR, "");
+            working.setIndexPolicy(IndexPolicy.FORCE);
+            final Contentlet updated = contentletAPI.checkin(working, user, false);
+
+            assertTrue("tag_inode should be empty after clearing via setStringProperty",
+                    tagsOf(updated.getInode()).isEmpty());
+        } finally {
+            if (null != contentType) {
+                ContentTypeDataGen.remove(contentType);
+            }
+        }
+    }
+
+    /**
+     * Method to test: {@link ContentletAPI#checkin(Contentlet, User, boolean)} when the tag field
+     * value is not present in the contentlet map.
+     * <p>
+     * Given Scenario: A contentlet has a tag value; it is checked out and the tag property is set to
+     * {@code null} before checkin (a new version).
+     * <p>
+     * Expected Result: The new version has NO tags. This characterizes the key architectural fact
+     * behind GitHub issue #35861: at the {@link ContentletAPI} layer tag persistence is driven
+     * entirely by the tag field value in the contentlet map — there is no automatic carry-over of a
+     * prior version's tags. Consequently "preserve tags on a partial update" is a concern of the
+     * workflow/REST merge layer (which re-populates the loaded value), not of checkin; and that same
+     * merge layer is where the #35861 defect lives (it keeps the stale value when the user clears it).
+     */
+    @Test
+    public void checkin_newVersionWithoutTagValueInMap_doesNotCarryOverTags() throws Exception {
+        ContentType contentType = null;
+        try {
+            contentType = createContentTypeWithTagField();
+            final Contentlet saved = createContentletWithTag(contentType, "new edit content");
+            assertEquals(1, tagsOf(saved.getInode()).size());
+
+            final Contentlet working = contentletAPI.checkout(saved.getInode(), user, false);
+            working.setProperty(TAG_CLEARING_FIELD_VAR, null);
+            working.setIndexPolicy(IndexPolicy.FORCE);
+            final Contentlet updated = contentletAPI.checkin(working, user, false);
+
+            assertTrue("Checkin must not carry over a prior version's tags when the tag field value "
+                            + "is absent from the map, found: " + tagsOf(updated.getInode()),
+                    tagsOf(updated.getInode()).isEmpty());
+        } finally {
+            if (null != contentType) {
+                ContentTypeDataGen.remove(contentType);
+            }
+        }
     }
 
     /**

--- a/dotcms-integration/src/test/java/com/dotmarketing/tag/business/TagAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/tag/business/TagAPITest.java
@@ -613,6 +613,21 @@ public class TagAPITest extends IntegrationTestBase {
 	}
 
 	/**
+	 * Destroys the contentlet with the given inode (best-effort). Destroying the contentlet also
+	 * removes its tag_inode relations, so it is enough to clean up the deletion tests below.
+	 */
+	private void destroyContentletByInode(final String inode) {
+		try {
+			final Contentlet contentlet = conAPI.find(inode, testUser, false);
+			if (contentlet != null) {
+				conAPI.destroy(contentlet, testUser, false);
+			}
+		} catch (Exception e) {
+			Logger.warn(this, "Unable to destroy contentlet " + inode + ": " + e.getMessage());
+		}
+	}
+
+	/**
 	 * Test the deleteTagInodesByInodeAndFieldVarName method of the tagAPI: it must remove only the
 	 * tag relations of the matching inode, leaving other inodes' relations (under the same field var
 	 * name) intact.
@@ -638,8 +653,8 @@ public class TagAPITest extends IntegrationTestBase {
 			assertFalse("inodeB tag relations must remain untouched",
 					tagAPI.getTagsByInodeAndFieldVarName(inodeB, WIKI_TAG_VARNAME).isEmpty());
 		} finally {
-			tagAPI.deleteTagInodesByInode(inodeA);
-			tagAPI.deleteTagInodesByInode(inodeB);
+			destroyContentletByInode(inodeA);
+			destroyContentletByInode(inodeB);
 		}
 	}
 
@@ -651,20 +666,24 @@ public class TagAPITest extends IntegrationTestBase {
 	@Test
 	public void deleteTagInodesByInode_removesAllForInode() throws Exception {
 		final String inode = createWikiContentletInode("DelByInode");
-		final String stamp = UtilMethods.dateToHTMLDate(new Date(), "MMddyyyyHHmmss");
-		final String tagName1 = "testapidelinode1" + stamp;
-		final String tagName2 = "testapidelinode2" + stamp;
-		tagAPI.getTagAndCreate(tagName1, testUser.getUserId(), defaultHostId);
-		tagAPI.getTagAndCreate(tagName2, testUser.getUserId(), defaultHostId);
-		tagAPI.addContentletTagInode(tagName1, inode, defaultHostId, WIKI_TAG_VARNAME);
-		tagAPI.addContentletTagInode(tagName2, inode, defaultHostId, WIKI_TAG_VARNAME);
+		try {
+			final String stamp = UtilMethods.dateToHTMLDate(new Date(), "MMddyyyyHHmmss");
+			final String tagName1 = "testapidelinode1" + stamp;
+			final String tagName2 = "testapidelinode2" + stamp;
+			tagAPI.getTagAndCreate(tagName1, testUser.getUserId(), defaultHostId);
+			tagAPI.getTagAndCreate(tagName2, testUser.getUserId(), defaultHostId);
+			tagAPI.addContentletTagInode(tagName1, inode, defaultHostId, WIKI_TAG_VARNAME);
+			tagAPI.addContentletTagInode(tagName2, inode, defaultHostId, WIKI_TAG_VARNAME);
 
-		assertEquals(2, tagAPI.getTagInodesByInode(inode).size());
+			assertEquals(2, tagAPI.getTagInodesByInode(inode).size());
 
-		tagAPI.deleteTagInodesByInode(inode);
+			tagAPI.deleteTagInodesByInode(inode);
 
-		assertTrue("All tag relations for the inode should be removed",
-				tagAPI.getTagInodesByInode(inode).isEmpty());
+			assertTrue("All tag relations for the inode should be removed",
+					tagAPI.getTagInodesByInode(inode).isEmpty());
+		} finally {
+			destroyContentletByInode(inode);
+		}
 	}
 
 	/**

--- a/dotcms-integration/src/test/java/com/dotmarketing/tag/business/TagAPITest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/tag/business/TagAPITest.java
@@ -592,6 +592,82 @@ public class TagAPITest extends IntegrationTestBase {
 	}
 
 	/**
+	 * Creates, checks in and publishes a Wiki-like contentlet, returning its inode. Helper for the
+	 * tag-inode deletion tests below.
+	 */
+	private String createWikiContentletInode(final String nameSuffix) throws Exception {
+		Contentlet contentAsset = new Contentlet();
+		final ContentType contentType = TestDataUtils.getWikiLikeContentType();
+		contentAsset.setContentTypeId(contentType.id());
+		contentAsset.setHost(defaultHostId);
+		contentAsset.setProperty(WIKI_SYSPUBLISHDATE_VARNAME, new Date());
+		final String name = "testtagapi" + nameSuffix + UtilMethods.dateToHTMLDate(new Date(), "MMddyyyyHHmmss");
+		contentAsset.setProperty(WIKI_TITLE_VARNAME, name);
+		contentAsset.setProperty(WIKI_URL_VARNAME, name);
+		contentAsset.setProperty(WIKI_BYLINEL_VARNAME, "test");
+		contentAsset.setProperty(WIKI_STORY_VARNAME, "test");
+		contentAsset.setLanguageId(langAPI.getDefaultLanguage().getId());
+		contentAsset = conAPI.checkin(contentAsset, testUser, false);
+		APILocator.getContentletAPI().publish(contentAsset, testUser, false);
+		return contentAsset.getInode();
+	}
+
+	/**
+	 * Test the deleteTagInodesByInodeAndFieldVarName method of the tagAPI: it must remove only the
+	 * tag relations of the matching inode, leaving other inodes' relations (under the same field var
+	 * name) intact.
+	 * @throws Exception
+	 */
+	@Test
+	public void deleteTagInodesByInodeAndFieldVarName_removesOnlyMatchingInode() throws Exception {
+		final String inodeA = createWikiContentletInode("DelByFieldA");
+		final String inodeB = createWikiContentletInode("DelByFieldB");
+		try {
+			final String tagName = "testapidelfield" + UtilMethods.dateToHTMLDate(new Date(), "MMddyyyyHHmmss");
+			tagAPI.getTagAndCreate(tagName, testUser.getUserId(), defaultHostId);
+			tagAPI.addContentletTagInode(tagName, inodeA, defaultHostId, WIKI_TAG_VARNAME);
+			tagAPI.addContentletTagInode(tagName, inodeB, defaultHostId, WIKI_TAG_VARNAME);
+
+			assertFalse(tagAPI.getTagsByInodeAndFieldVarName(inodeA, WIKI_TAG_VARNAME).isEmpty());
+			assertFalse(tagAPI.getTagsByInodeAndFieldVarName(inodeB, WIKI_TAG_VARNAME).isEmpty());
+
+			tagAPI.deleteTagInodesByInodeAndFieldVarName(inodeA, WIKI_TAG_VARNAME);
+
+			assertTrue("inodeA tag relations should be removed",
+					tagAPI.getTagsByInodeAndFieldVarName(inodeA, WIKI_TAG_VARNAME).isEmpty());
+			assertFalse("inodeB tag relations must remain untouched",
+					tagAPI.getTagsByInodeAndFieldVarName(inodeB, WIKI_TAG_VARNAME).isEmpty());
+		} finally {
+			tagAPI.deleteTagInodesByInode(inodeA);
+			tagAPI.deleteTagInodesByInode(inodeB);
+		}
+	}
+
+	/**
+	 * Test the deleteTagInodesByInode method of the tagAPI: it must remove every tag relation for the
+	 * given inode.
+	 * @throws Exception
+	 */
+	@Test
+	public void deleteTagInodesByInode_removesAllForInode() throws Exception {
+		final String inode = createWikiContentletInode("DelByInode");
+		final String stamp = UtilMethods.dateToHTMLDate(new Date(), "MMddyyyyHHmmss");
+		final String tagName1 = "testapidelinode1" + stamp;
+		final String tagName2 = "testapidelinode2" + stamp;
+		tagAPI.getTagAndCreate(tagName1, testUser.getUserId(), defaultHostId);
+		tagAPI.getTagAndCreate(tagName2, testUser.getUserId(), defaultHostId);
+		tagAPI.addContentletTagInode(tagName1, inode, defaultHostId, WIKI_TAG_VARNAME);
+		tagAPI.addContentletTagInode(tagName2, inode, defaultHostId, WIKI_TAG_VARNAME);
+
+		assertEquals(2, tagAPI.getTagInodesByInode(inode).size());
+
+		tagAPI.deleteTagInodesByInode(inode);
+
+		assertTrue("All tag relations for the inode should be removed",
+				tagAPI.getTagInodesByInode(inode).isEmpty());
+	}
+
+	/**
 	 * Test the removeTagRelationAndTagWhenPossible method of the tagAPI
 	 * @throws Exception
 	 */


### PR DESCRIPTION
## Problem

When a contentlet has tags and the user clears them (saves with an empty Tag field), the tags are **not cleared** — the old value reappears in the persisted state and the API response.

Reproduction (REST/workflow):
1. Content Type with a Text field and a Tag field.
2. Create a contentlet, set a tag (e.g. `"new edit content"`), save/publish.
3. Fire a workflow save action with `"tags": ""` in the payload (`PUT /api/v1/workflow/actions/{actionId}/fire?indexPolicy=WAIT_FOR&inode={inode}`).
4. The response still shows the old tag value.

## Root cause

The REST/workflow merge calls `setContentletProperty(contentlet, tagField, "")`. Both overloads collapsed an empty value to `null`, and `ContentletHashMap.put(key, null)` **removes** the key from the contentlet map.

Because the fire path builds a fresh `new Contentlet()` (`loadedTags=false`) that is copied several times during checkin (copies that drop the `NULL_PROPERTIES` marker), `Contentlet.setTags()` then **re-hydrates** the `tags` field from the previous version's `tag_inode` rows. `prepareTags` re-relates the resurrected value, so the "cleared" tags survive on the new version.

The direct-API path (`setProperty("tag", "")`) already worked because it stores the empty string rather than nulling the key.

## Fix

Route both `setContentletProperty` overloads through a new `clearOrNullifyProperty(...)` helper in `ESContentletAPIImpl`:

- For a `TagField`, an explicit empty string is **preserved as `""`** instead of being collapsed to `null`. A concrete `""` survives the copy chain, blocks `setTags()` re-hydration (`map.containsKey` stays `true`), and makes `prepareTags`/`relateTags` wipe the `tag_inode` rows.
- A genuinely `null`/absent value still nullifies the property, so existing tags are left untouched on partial updates.

Single production file changed: `ESContentletAPIImpl.java`.

## Tests

New integration coverage (no production behavior assumed beyond the observable contract):

- `WorkflowResourceIntegrationTest#Test_Fire_Save_With_Tag_Then_Fire_Update_With_Empty_Tag_Clears_Tag` — fires the workflow save action with an empty tag value and asserts the tags are cleared (the bug repro; now passes).
- `ContentletAPITest` — `setContentletProperty`/`setStringProperty` empty-string clear semantics and the new-version no-carry-over behavior.
- `TagAPITest` — direct coverage for `deleteTagInodesByInodeAndFieldVarName` and `deleteTagInodesByInode`.

### Verification

| Test | Result |
|------|--------|
| `WorkflowResourceIntegrationTest` repro | ✅ pass (was failing pre-fix) |
| `ContentletAPITest` (full class) | ✅ 183 run, 0 failures, 0 errors |
| `TagAPITest` C1/C2 | ✅ pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes: #35861

This PR fixes: #35861