### PR TITLE
Update tomcat-redis-session-manager version to 2.0

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -1591,7 +1591,7 @@
             <dependency>
                 <groupId>com.dotcms</groupId>
                 <artifactId>tomcat-redis-session-manager</artifactId>
-                <version>1.5</version>
+                <version>2.0</version>
                 <scope>provided</scope>
             </dependency>
 


### PR DESCRIPTION
Fixes possible Redis session key collision (and ships several other reliability fixes) by bumping the `tomcat-redis-session-manager` dependency from **1.5 → 2.0**.

ref: #35874

### Proposed Changes
* Bump `tomcat-redis-session-manager` from `1.5` to `2.0` in `bom/application/pom.xml`.

This single version bump pulls in everything shipped upstream between 1.5 and 2.0:

* **v1.6 — Redis key collision fix (the issue this PR closes):** Adds a `:sessions:` delimiter after the cluster-ID prefix when building Redis session keys, so clusters whose IDs share leading characters (e.g. `prod` vs `prod2`) can no longer collide on the same Redis instance. Delimiter is appended once at init with a guard against double-appending.
* **v1.7 — Locking performance fix:** Replaces manager-level save synchronization with striped, session-ID-based locking so concurrent sessions no longer serialize on a single monitor.
* **v1.8 — NPE & encoding fixes:** Fixes a NullPointerException in the Sentinel configuration check and replaces platform-dependent string encoding with explicit UTF-8 (`StandardCharsets.UTF_8`) across all Redis key operations.
* **v2.0 — Redis Sentinel high availability:** Wires up previously-unused Sentinel configuration to enable automatic master discovery and failover, with correct fallback to a standalone connection when Sentinel is not (or is blank-)configured.

### Checklist
- [ ] Tests
- [ ] Translations
- [x] Security Implications Contemplated (add notes if applicable)

### Additional Info
**Redis Tenant Isolation Overlap Convo:**
https://github.com/dotCMS/ovh-k8s-cluster/pull/302#issuecomment-4582968037


The collision fix prefixes Redis keys with the cluster ID followed by a fixed delimiter, so a key becomes `${cluster_id}:sessions:${key}`. Upstream changes were reviewed and released across PRs #12–#15 in `dotCMS/tomcat-redis-session-manager`; v2.0 artifacts are published to JFrog Artifactory at https://repo.dotcms.com/artifactory/libs-release-local/.

This PR fixes: #35874