### PR TITLE
fix(block-editor): prevent block gutter and table handles from overlapping

### DIFF
--- a/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
+++ b/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
@@ -50,8 +50,16 @@
 }
 
 /* ─── Editor padding ────────────────────────────────────── */
+/*
+ * The left padding has to clear the left-margin furniture without it being clipped by
+ * `.editor-scroll-container` (whose `overflow-y: auto` forces `overflow-x: auto`, so it
+ * clips horizontally at x=0). Two things live in that left strip:
+ *   - the block gutter (~50px wide, pushed a further GUTTER_OFFSET=15px left), and
+ *   - the table row handle (protrudes 12px left of the table).
+ * 5rem (80px) keeps the gutter's left edge ~14px inside the clip boundary.
+ */
 :host ::ng-deep .tiptap {
-    padding: 2rem 4rem;
+    padding: 2rem 5rem;
 }
 
 /* ─── Scroll lock while overlays are open ───────────────── */
@@ -215,7 +223,7 @@
 :host ::ng-deep .tiptap td,
 :host ::ng-deep .tiptap th {
     border: 1px solid #e5e7eb;
-    padding: 4px 8px;
+    padding: 6px 10px;
     vertical-align: top;
     position: relative;
     min-width: 80px;

--- a/core-web/libs/new-block-editor/src/lib/editor/extensions/block-gutter.extension.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/extensions/block-gutter.extension.ts
@@ -1,4 +1,4 @@
-import { autoUpdate, computePosition, shift } from '@floating-ui/dom';
+import { autoUpdate, computePosition, offset, shift } from '@floating-ui/dom';
 
 import type { Editor } from '@tiptap/core';
 import { DragHandle, defaultComputePositionConfig } from '@tiptap/extension-drag-handle';
@@ -227,10 +227,21 @@ function ensureParentDragStartListener(
     registered.current = true;
 }
 
+/**
+ * Gap (px) the gutter keeps from the block's left edge.
+ *
+ * Tables render a row handle that protrudes 12px to the left of the table (it sits at
+ * `left: -12px` on the first-column cell — see `.dot-cell-handle--row` in
+ * editor.component.css). Without an offset the `left-start` gutter sits flush against the
+ * block edge and overlaps that handle. 15px clears the 12px protrusion with a 3px gap, and
+ * incidentally gives every block a little breathing room from its content.
+ */
+const GUTTER_OFFSET = 15;
+
 /** Must match `DragHandle.configure({ computePositionConfig })` so our updates align with TipTap. */
 const GUTTER_COMPUTE_POSITION_CONFIG = {
     ...defaultComputePositionConfig,
-    middleware: [shift({ padding: 8 })]
+    middleware: [offset(GUTTER_OFFSET), shift({ padding: 8 })]
 };
 
 /** Reads the hovered block's DOM and applies floating-ui's position to the wrapper. */


### PR DESCRIPTION
### Proposed Changes
Follow-up polish to the Block Editor table accessibility work (#35720).

* **Gutter ↔ table-handle overlap** — the block gutter (drag grip + `+` button) sat flush against the block's left edge and overlapped the table **row handle**, which protrudes 12px to the left of the table. The gutter is now pushed 15px further left via a floating-ui `offset` middleware, clearing the handle with a small gap.
* **Editor padding** — bumped the editor's horizontal padding `4rem → 5rem`. The scroll container uses `overflow-y: auto`, which per the CSS spec forces `overflow-x: auto` (a horizontal clip boundary at x=0). The extra left padding keeps the now-offset gutter inside that boundary so it isn't cut off.
* **Table cell padding** — nudged up `4px 8px → 6px 10px` for a touch more breathing room between the cell border and its content.

### Checklist
- [ ] Tests *(skipped per current `new-block-editor` convention — verified via `nx lint` + `tsc --noEmit`)*
- [x] Translations *(none — CSS / positioning only)*
- [x] Security Implications Contemplated *(none — presentational only)*

### Additional Info
CSS + gutter-positioning only; no schema, serialization, or behavior changes. `nx lint new-block-editor` and `tsc --noEmit` pass.

### Screenshots
_Before:_ the `+` button and the table row handle overlapped at the table's top-left corner.

_After:_

<!-- Drag the after-fix screenshot here -->

This PR relates to: #35720

This PR fixes: #35720