### PR TITLE
fix(analytics) #34401: emit closing contentlet div in LIVE mode when tracking enabled

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
@@ -331,7 +331,10 @@ public class ContainerLoader implements DotLoader {
 
                 velocityCodeBuilder.append("#set($HAVE_A_VERSION=($CONTENT_INODE != ''))");
 
-                if (mode == PageMode.EDIT_MODE || (mode == PageMode.LIVE && isAnalyticsTrackingEnabled())) {
+                final boolean trackingWrapperEnabled =
+                        mode == PageMode.EDIT_MODE || (mode == PageMode.LIVE && isAnalyticsTrackingEnabled());
+
+                if (trackingWrapperEnabled) {
                     velocityCodeBuilder.append("<div")
                         .append(" class=\"dotcms-contentlet\"")
                         .append(" data-dot-object=")
@@ -403,7 +406,7 @@ public class ContainerLoader implements DotLoader {
                 velocityCodeBuilder.append("#end");
 
                // end content dot-data-content
-                if (mode == PageMode.EDIT_MODE || (mode == PageMode.LIVE && isAnalyticsTrackingEnabled())) {
+                if (trackingWrapperEnabled) {
                     velocityCodeBuilder.append("</div>");
                 }
 

--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
@@ -403,7 +403,7 @@ public class ContainerLoader implements DotLoader {
                 velocityCodeBuilder.append("#end");
 
                // end content dot-data-content
-                if (mode == PageMode.EDIT_MODE) {
+                if (mode == PageMode.EDIT_MODE || (mode == PageMode.LIVE && isAnalyticsTrackingEnabled())) {
                     velocityCodeBuilder.append("</div>");
                 }
 


### PR DESCRIPTION
## Proposed Changes

Fixes the unbalanced `dotcms-contentlet` wrapper `<div>` on live traditional pages.

The opening wrapper div (`ContainerLoader.java:334`) is already emitted in `LIVE` mode when content analytics tracking is enabled:

```java
if (mode == PageMode.EDIT_MODE || (mode == PageMode.LIVE && isAnalyticsTrackingEnabled())) {
```

…but the matching closing `</div>` (`ContainerLoader.java:406`) was only emitted in `EDIT_MODE`. This left the wrapper div unclosed on live traditional pages, breaking the markup that **Content Impression** events depend on.

This change aligns the closing-tag condition with the opening-tag condition so the wrapper is balanced whenever analytics tracking is active.

## This fixes #34401

Ensures Content Impression events work in Traditional Implementations.

This PR fixes: #34401