### PR TITLE
fix(edit-content): clear date, datetime and time fields on calendar clear

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/components/calendar-field/calendar-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/components/calendar-field/calendar-field.component.html
@@ -12,6 +12,8 @@
     [timeOnly]="fieldTypeConfig.timeOnly"
     [showTime]="fieldTypeConfig.showTime"
     (onSelect)="onCalendarChange($event)"
+    (onClearClick)="onCalendarChange(null)"
+    (onClear)="onCalendarChange(null)"
     [id]="'calendar-id-' + field.variable"
     [inputId]="field.variable"
     [attr.data-testid]="'calendar-input-' + field.variable"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.spec.ts
@@ -692,6 +692,87 @@ describe('DotEditContentCalendarFieldComponent', () => {
         });
     });
 
+    describe('Clearing the field', () => {
+        // Seeded timestamp representing an existing, persisted value.
+        const EXISTING_TIMESTAMP = 1701380400000;
+
+        // Base field mock WITHOUT a defaultValue so clearing does not re-push a value
+        // through handleChangeValue when the control transitions to null.
+        const fieldWithoutDefault = { ...DATE_FIELD_MOCK, defaultValue: undefined };
+
+        const buildSeededHost = (field: DotCMSContentTypeField) =>
+            createHost(
+                `<form [formGroup]="formGroup">
+                    <dot-edit-content-calendar-field [field]="field" [contentlet]="contentlet" [utcTimezone]="utcTimezone" [contentType]="contentType" />
+                </form>`,
+                {
+                    hostProps: {
+                        formGroup: new FormGroup({
+                            [field.variable]: new FormControl(EXISTING_TIMESTAMP)
+                        }),
+                        field,
+                        utcTimezone: MOCK_TIMEZONE,
+                        contentType: CONTENT_TYPE_WITHOUT_EXPIRE,
+                        contentlet: createFakeContentlet({
+                            [field.variable]: EXISTING_TIMESTAMP
+                        })
+                    }
+                }
+            );
+
+        it.each([
+            ['DATE', FIELD_TYPES.DATE],
+            ['DATE_AND_TIME', FIELD_TYPES.DATE_AND_TIME],
+            ['TIME', FIELD_TYPES.TIME]
+        ])(
+            'should clear the parent form value via onClearClick for %s field',
+            (_label, fieldType) => {
+                const field = { ...fieldWithoutDefault, fieldType };
+                spectator = buildSeededHost(field);
+                spectator.detectChanges();
+
+                const formGroup = spectator.hostComponent.formGroup;
+                expect(formGroup.get(field.variable)?.value).toBe(EXISTING_TIMESTAMP);
+
+                spectator.triggerEventHandler(DatePicker, 'onClearClick', {});
+                spectator.detectChanges();
+
+                expect(formGroup.get(field.variable)?.value).toBeNull();
+            }
+        );
+
+        it('should clear the parent form value via onClear (X icon path) for an expire date field', () => {
+            const field = { ...fieldWithoutDefault, fieldType: FIELD_TYPES.DATE_AND_TIME };
+            spectator = createHost(
+                `<form [formGroup]="formGroup">
+                    <dot-edit-content-calendar-field [field]="field" [contentlet]="contentlet" [utcTimezone]="utcTimezone" [contentType]="contentType" />
+                </form>`,
+                {
+                    hostProps: {
+                        formGroup: new FormGroup({
+                            [field.variable]: new FormControl(EXISTING_TIMESTAMP)
+                        }),
+                        field,
+                        utcTimezone: MOCK_TIMEZONE,
+                        contentType: CONTENT_TYPE_WITH_EXPIRE,
+                        contentlet: createFakeContentlet({
+                            [field.variable]: EXISTING_TIMESTAMP
+                        })
+                    }
+                }
+            );
+            spectator.detectChanges();
+
+            const formGroup = spectator.hostComponent.formGroup;
+            expect(formGroup.get(field.variable)?.value).toBe(EXISTING_TIMESTAMP);
+
+            spectator.triggerEventHandler(DatePicker, 'onClear', {});
+            spectator.detectChanges();
+
+            expect(formGroup.get(field.variable)?.value).toBeNull();
+        });
+    });
+
     describe('Accessibility', () => {
         it('should set correct aria-label from field name', () => {
             const fieldWithName = { ...DATE_FIELD_MOCK, name: 'Event Date' };


### PR DESCRIPTION
## Summary

In the new Angular content editor, **Date / DateTime / Time** fields did not clear. The calendar component (`DotCalendarFieldComponent`) is a `ControlValueAccessor` that only propagated values to the parent contentlet form via its `onCalendarChange()` method — and that method was wired **only** to PrimeNG's `(onSelect)` event.

PrimeNG's clear actions emit different events:
- the button-bar **Clear** (shown on every calendar field via `[showButtonBar]="true"`) emits `(onClearClick)`
- the `showClear` X icon (expire-date fields) emits `(onClear)`

Neither was handled, so clicking Clear nulled the internal display control but never called the CVA `onChange(null)`. The stale timestamp was submitted on save and the field repopulated with the old value afterward.

**Fix:** wire `(onClearClick)` and `(onClear)` to the existing `onCalendarChange(null)` path, so clearing propagates `null` to the form for DATE, DATE_AND_TIME and TIME fields. No component logic change was needed — `onCalendarChange(null)` already nulls the control, calls `onChange(null)` and `onTouched()`.

## Related issue

Related to #35861. The Tag-field part of that issue was already fixed in #35873; this PR addresses the **Date/DateTime/Time** follow-up reported in the issue comments + screen recording.

## Acceptance criteria

- [x] Date / DateTime / Time fields propagate an empty value to the form when cleared (frontend)
- [ ] End-to-end round-trip confirmed (clear → save → reload stays empty) — see Test plan
- [ ] Manual QA of other field types (Text, TextArea, Binary, HostFolder…) per AC2

## Test plan

- **Unit:** added a `Clearing the field` regression block (DATE / DATE_AND_TIME / TIME via `onClearClick`, plus an expire-date case via `onClear`) asserting the parent form control becomes `null`. `edit-content`: 1870 passed / 28 skipped / 0 failures; `lint` 0 errors.
- **E2E (required before this issue is closed):** on a running instance — create a contentlet with date/datetime/time values and publish; clear each field via the button-bar **Clear**; publish; **reload** the contentlet and confirm the fields stay empty; verify the fire request payload sends `null` for the cleared fields.
- **Backend caveat:** #35873's clear logic special-cases only `TagField`; for date fields it nullifies the property (removes the key from the contentlet map). If reload still shows old values despite the payload sending `null`, a separate **backend** follow-up is required (clear date/datetime/time on explicit null, analogous to #35873).

## Changed files

- `core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/components/calendar-field/calendar-field.component.html` — added `(onClearClick)` / `(onClear)` bindings
- `core-web/libs/edit-content/src/lib/fields/dot-edit-content-calendar-field/dot-edit-content-calendar-field.component.spec.ts` — regression tests

This PR fixes: #35861