### PR TITLE
fix(edit-content): make WYSIWYG Insert Image dialog dismissable (#35898)

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.spec.ts
@@ -128,6 +128,9 @@ describe('DotWysiwygPluginService', () => {
                 width: '800px',
                 height: '500px',
                 contentStyle: { padding: 0 },
+                closable: true,
+                closeOnEscape: true,
+                dismissableMask: true,
                 data: {
                     assetType: 'image'
                 }
@@ -140,6 +143,24 @@ describe('DotWysiwygPluginService', () => {
             expect(spyEditorInserContent).toHaveBeenCalledWith(
                 formatDotImageNode(MOCK_IMAGE_URL_PATTERN, EMPTY_CONTENTLET)
             );
+        });
+
+        it('should NOT insert content when the dialog is closed without selecting an image', () => {
+            const spyDialog = jest.spyOn(dialogService, 'open').mockReturnValue({
+                onClose: of(undefined)
+            } as DynamicDialogRef);
+
+            const spyEditorInserContent = jest.spyOn(editor, 'insertContent');
+
+            spectator.service.initializePlugins(editor);
+
+            const button = editor.ui.registry.getAll().buttons['dotAddImage'];
+
+            // Simulate the button click that opens the dialog
+            button.onAction();
+
+            expect(spyDialog).toHaveBeenCalled();
+            expect(spyEditorInserContent).not.toHaveBeenCalled();
         });
 
         it('should upload the image when dropped', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.spec.ts
@@ -50,6 +50,8 @@ class MockEditor {
     };
 
     insertContent = jest.fn();
+
+    focus = jest.fn();
 }
 
 const MOCK_IMAGE_URL_PATTERN = '/dA/{shortyId}/{name}?language_id={languageId}';
@@ -143,6 +145,8 @@ describe('DotWysiwygPluginService', () => {
             expect(spyEditorInserContent).toHaveBeenCalledWith(
                 formatDotImageNode(MOCK_IMAGE_URL_PATTERN, EMPTY_CONTENTLET)
             );
+            // Focus returns to the editor after inserting an image
+            expect(editor.focus).toHaveBeenCalled();
         });
 
         it('should NOT insert content when the dialog is closed without selecting an image', () => {
@@ -161,6 +165,9 @@ describe('DotWysiwygPluginService', () => {
 
             expect(spyDialog).toHaveBeenCalled();
             expect(spyEditorInserContent).not.toHaveBeenCalled();
+            // AC5: focus still returns to the editor when the dialog is dismissed
+            // without selecting an image (X, Esc or overlay mask)
+            expect(editor.focus).toHaveBeenCalled();
         });
 
         it('should upload the image when dropped', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.ts
@@ -80,6 +80,9 @@ export class DotWysiwygPluginService {
                 width: '800px',
                 height: '500px',
                 contentStyle: { padding: 0 },
+                closable: true,
+                closeOnEscape: true,
+                dismissableMask: true,
                 data: {
                     assetType: 'image'
                 }

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.ts
@@ -88,11 +88,15 @@ export class DotWysiwygPluginService {
                 }
             });
 
-            ref.onClose
-                .pipe(filter((asset) => !!asset))
-                .subscribe((asset: DotCMSContentlet) =>
-                    editor.insertContent(formatDotImageNode(this.IMAGE_URL_PATTERN, asset))
-                );
+            ref.onClose.subscribe((asset: DotCMSContentlet) => {
+                if (asset) {
+                    editor.insertContent(formatDotImageNode(this.IMAGE_URL_PATTERN, asset));
+                }
+
+                // Return focus to the editor on every close (insert or dismiss via
+                // X, Esc or overlay mask) so the user is never left without focus.
+                editor.focus();
+            });
         });
     }
 

--- a/core-web/libs/ui/src/lib/components/dot-asset-search/components/dot-asset-card-list/dot-asset-card-list.component.ts
+++ b/core-web/libs/ui/src/lib/components/dot-asset-search/components/dot-asset-card-list/dot-asset-card-list.component.ts
@@ -25,6 +25,7 @@ const squarePlus =
     selector: 'dot-asset-card-list',
     templateUrl: './dot-asset-card-list.component.html',
     styleUrls: ['./dot-asset-card-list.component.scss'],
+    host: { class: 'px-4' },
     imports: [
         ScrollerModule,
         DotAssetCardComponent,


### PR DESCRIPTION
## Summary

The **Insert Image** dialog opened from a **WYSIWYG field** in the New Edit Content experience had no way to be dismissed — no close (X) icon, no Esc-key support, and clicking the overlay mask did nothing. Users were trapped in the dialog and could only escape by selecting an image (then deleting it).

This adds the three PrimeNG `DynamicDialog` dismissal flags to the `dialogService.open(DotAssetSearchDialogComponent, …)` call in `DotWysiwygPluginService.dotImageDialog()`:

```ts
closable: true,        // renders the X icon in the header
closeOnEscape: true,   // Esc dismisses the dialog
dismissableMask: true, // overlay-mask click dismisses the dialog
```

In PrimeNG 21.1.3 these `DynamicDialogConfig` options all default to `false`, so the dialog previously rendered with no close affordances. This follows the project convention in `core-web/CLAUDE.md` ("All dialogs must have `closable: true` and `closeOnEscape: true`") and mirrors the sibling block-editor asset picker (`new-block-editor/src/lib/editor/config.utils.ts`), which already sets all three flags. No changes were needed to `DotAssetSearchDialogComponent` itself.

The `onClose` subscription was also reworked: instead of the previous `filter((asset) => !!asset)` (which produced no callback at all on dismissal), it now subscribes unconditionally — inserting content only when an asset is selected, and calling `editor.focus()` on **every** close path so focus reliably returns to the editor (AC5) without depending on PrimeNG/TinyMCE default focus behavior.

Additionally, a small UI tweak adds `host: { class: 'px-4' }` (Tailwind, 1rem left/right) to the shared `DotAssetCardListComponent`, giving the asset list horizontal breathing room. Note this component is also consumed by the block-editor asset picker, so the gutter change applies there too.

Closes #35898

## Acceptance Criteria

- [x] AC1 — Insert Image dialog displays a close (X) icon in the header (`closable: true`; verified against PrimeNG 21.1.3 source where the default is `false`)
- [x] AC2 — Clicking the X dismisses the dialog without inserting an image (`onClose` only inserts when an asset is selected; covered by the negative-path unit test)
- [x] AC3 — Pressing Esc dismisses the dialog without inserting an image (`closeOnEscape: true`)
- [x] AC4 — Clicking outside (overlay mask) dismisses the dialog without inserting an image (`dismissableMask: true`) — *intentional scope addition beyond the original issue ACs, justified by the reported behavior in the issue video*
- [x] AC5 — After dismissal, keyboard focus returns to the WYSIWYG editor (`editor.focus()` is now called on every close path; asserted in both the insert and dismiss unit tests)
- [x] AC6 — After dismissal, the editor content is unchanged (insertion is gated on a selected asset; covered by the negative-path unit test)

> AC7 from the original issue (cancel in-progress upload on close) was determined **out of scope**: this dialog is browse-only. Disk uploads use a separate drag-and-drop path (`handleImageDrop`).

## Test Plan

- `yarn nx lint edit-content` → 0 errors (pre-existing warnings only, in unrelated files)
- `yarn nx test edit-content` → 1867 passed, 0 failures
- `yarn nx lint ui` / `yarn nx test ui` → 0 errors, all green (covers the `dot-asset-card-list` change)
- Unit test `should open the dialog when the button is clicked` — asserts the full `dialogConfig` (including the three new flags) **and** that `editor.focus()` is called after insertion.
- Unit test `should NOT insert content when the dialog is closed without selecting an image` — mocks `onClose` emitting `undefined`, asserts `editor.insertContent` is **not** called **and** `editor.focus()` **is** called (AC5 on the dismiss path).

## Changed Files

- `core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.ts`
- `core-web/libs/edit-content/src/lib/fields/dot-edit-content-wysiwyg-field/dot-wysiwyg-plugin/dot-wysiwyg-plugin.service.spec.ts`
- `core-web/libs/ui/src/lib/components/dot-asset-search/components/dot-asset-card-list/dot-asset-card-list.component.ts`

## Demo

https://github.com/user-attachments/assets/da2813c3-625c-482f-88c9-1be01ee2bcf9

This PR fixes: #35898