### PR TITLE
fix(security): [LTS 25.07.10] upgrade Bouncy Castle 1.70 → 1.84 (CVE-2025-14813)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -19,7 +19,7 @@
         <swagger.version>2.2.34</swagger.version>
         <bytebuddy.version>1.18.1</bytebuddy.version>
         <batik.version>1.17</batik.version>
-        <bouncy-castle.version>1.70</bouncy-castle.version>
+        <bouncy-castle.version>1.84</bouncy-castle.version>
         <awaitility.version>4.0.0</awaitility.version>
         <shedlock.version>4.33.0</shedlock.version>
         <jackson.version>2.17.2</jackson.version>
@@ -1170,12 +1170,12 @@
 
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncy-castle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncy-castle.version}</version>
             </dependency>
 

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -1004,11 +1004,11 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
 
 


### PR DESCRIPTION
LTS 25.07.10 backport of #35897.

Fixes #35896

## Summary

Cherry-pick of the BC 1.70 → 1.84 upgrade from `main` (PR #35897), targeted at the `dotcms/dotcms25.07.10_lts_v9_4f49576` LTS branch.

Same 5-line diff: version bump in `bom/application/pom.xml` + 4 `bcpkix`/`bcprov` artifactId renames (`jdk15on` → `jdk18on`) across the BOM and `dotCMS/pom.xml`.

## Status: Draft

Held as draft until #35897 merges on `main`. Once that lands, will flip to ready-for-review.

## ⚠️ Reviewer note on CI coverage

**No PR-time integration tests run on this PR.** `.github/workflows/cicd_1-pr.yml` (the full PR test matrix: JVM unit, Integration MainSuite, Postman, Karate, Playwright E2E, etc.) only triggers on PRs targeting `main`/`master` — PRs targeting LTS branches like `dotcms/dotcms25.07.10_lts_v9_*` don't match its filter, and no other workflow fills the gap. This is a repo-wide CI policy, not specific to this PR.

The 26 checks that did run and passed are all lightweight: link-issue, security-check, semgrep, claude reviews, Vercel previews. **No backend tests ran.**

**Why this is still safe to merge:**

1. This PR's diff is a byte-for-byte `git cherry-pick` of commit `71bfbc5f7c` from #35897. No merge conflicts. No auto-resolution.
2. PR #35897 (`main`) ran the full 34-check suite — **34 pass, 0 fail** — covering: JVM unit tests, Integration MainSuite 1a/1b/2a/2b/3a, OpenSearch upgrade suite, Karate, Playwright E2E, and all Postman suites.
3. The LTS branch was on the same BC 1.70 starting state as `main`. Identical input + identical diff = identical output.

The reviewer here is approving on the strength of `main`'s CI, not this PR's CI. Flagging explicitly so this isn't a silent assumption.

## Context

- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-14813 (Bouncy Castle GOSTCTR, CWE-327)
- Customer ticket: Freshdesk #37703 (deployment scanner blocking dotCMS Docker image on this CVE)
- Real exploit risk in dotCMS: near-zero (0 GOSTCTR references in the codebase). Upgrade unblocks the customer scanner and gets us off a 3-year-old crypto release.

## Verification

Local sanity matches the main PR (same diff applied cleanly to the LTS branch via `git cherry-pick`).

- [x] Cherry-pick clean, identical diff
- [x] 26 lightweight CI checks pass on this PR (security-check, semgrep, claude reviews)
- [ ] #35897 merged to `main`
- [ ] Flip from draft to ready-for-review
- [ ] LTS patch release tagged
- [ ] Update Freshdesk #37703 with patched LTS build link

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35896