### PR TITLE
build: make Java 25 the default, demote Java 21 to the variant

### DIFF
--- a/.github/workflows/cicd_8-manual-deploy.yml
+++ b/.github/workflows/cicd_8-manual-deploy.yml
@@ -82,7 +82,7 @@ on:
         required: false
         type: string
       java_version:
-        description: 'Override Java version (SDKMAN format, e.g., 25.0.2-ms). Leave empty to use default Java 21 from .sdkmanrc.'
+        description: 'Override Java version (SDKMAN format, e.g., 21.0.8-ms). Leave empty to use default Java 25 from .sdkmanrc.'
         required: false
         type: string
         default: ''

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # sets the SDKMAN_JAVA_VERSION for dotCMS
 # this is the version of java that will be used as the base image for the docker build
-java=21.0.8-ms
+java=25.0.2-ms

--- a/docker/java-base/Dockerfile
+++ b/docker/java-base/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:24.04 AS base-builder
 WORKDIR /srv
 
 # Defining default Java version, can be any java version provided by sdkman
-ARG SDKMAN_JAVA_VERSION="21.0.8-ms"
+ARG SDKMAN_JAVA_VERSION="25.0.2-ms"
 
 ENV JAVA_OUTPUT_DIR="/java"
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## What

Make **Java 25 the default** for all builds and for the published `dotcms/dotcms:latest` image, and demote **Java 21 to the parallel variant** (`…_java-21`).

This is a single source-of-truth change:

| File | Change |
|------|--------|
| `.sdkmanrc` | `java=21.0.8-ms` → `java=25.0.2-ms` |
| `docker/java-base/Dockerfile` | default `ARG SDKMAN_JAVA_VERSION` → `25.0.2-ms` (cosmetic; callers always pass the arg) |
| `cicd_8-manual-deploy.yml` | fix stale "default Java 21" doc string → "default Java 25" |

## Why this is all that's needed (no workflow tag-logic changes)

The `latest` tag is gated in `cicd_comp_deployment-phase.yml` on `inputs.latest && docker_suffix == ''`. The **primary** release build (`cicd_6-release.yml`) reads its Java version from `.sdkmanrc` and has an **empty suffix**, so once `.sdkmanrc` says Java 25, the primary build ships Java 25 and automatically wins `latest` (and, via `cicd_weekly-rolling-tags.yml`, `weekly`). The Java 21 build moves to the variant pathway (`cicd_7-release-java-variant.yml`) and ships under `…_java-21` + the floating `java-21` tag.

`dotcms/java-base:25.0.2-ms` already exists on Docker Hub (the Java 25 variant has been building against it), so the base-image path (`FROM dotcms/java-base:${SDKMAN_JAVA_VERSION}`) is already proven.

## ⚠️ Required companion change at merge time (repo variables, not in this PR)

Repo variables are GitHub settings, so they can't live in the PR. **At merge, flip them** so the variant builds Java 21 instead of Java 25:

```
RELEASE_JAVA_VARIANT_VERSION:  25.0.2-ms  →  21.0.8-ms
RELEASE_JAVA_VARIANT_SUFFIX:   java-25    →  java-21
```

If `.sdkmanrc` is merged but the vars are **not** flipped: the variant would also build Java 25 (duplicate of `latest`), and **no Java 21 image would be produced** — breaking consumers still pinned to Java 21. They must change together.

## Resulting tags after merge + var flip

- `dotcms/dotcms:latest`, `:weekly`, `:{version}` → **Java 25**
- `dotcms/dotcms:java-21`, `:{version}_java-21` → **Java 21** (transition support)

## Rollout

- **Draft for now.** Keep today's behavior (Java 21 default, Java 25 variant, `latest` = Java 21) for ~2–3 weeks.
- **Flip:** mark ready + merge **and** flip the two repo variables together.
- **Retire (end of July):** fully retire the Java 21 variant — disable the `cicd_7-release-java-variant.yml` trigger / unset the variant repo vars (separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)