### PR TITLE
chore(fd-36897): diagnostic logging forcontent-wipe investigation

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -199,6 +199,15 @@ public class PageResourceHelper implements Serializable {
                 multiTreesMap.computeIfAbsent(personalization, key -> new ArrayList<>());
             }
         }
+        Logger.warn(this, String.format(
+                "[FD-36897] saveContent: pageId=%s lang=%d variant=%s containers=%d totalContentlets=%d entries=[%s]",
+                pageId, language.getId(), variantName,
+                containerEntries.size(),
+                containerEntries.stream().mapToInt(e -> e.getContentIds().size()).sum(),
+                containerEntries.stream()
+                        .map(e -> e.getContainerId() + "(" + e.getContentIds().size() + ")")
+                        .collect(java.util.stream.Collectors.joining(", "))));
+
         for (final String personalization : multiTreesMap.keySet()) {
             multiTreeAPI.overridesMultitreesByPersonalization(pageId, personalization,
                     multiTreesMap.get(personalization), Optional.of(language.getId()),

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -697,6 +697,12 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
                 "Overriding MultiTrees: pageId -> %s personalization -> %s multiTrees-> %s ",
                 pageId, personalization, multiTrees));
 
+        Logger.warn(this, String.format(
+                "[FD-36897] overridesMT: pageId=%s personalization=%s variant=%s lang=%s multiTrees=%d",
+                pageId, personalization, variantId,
+                languageIdOpt.map(String::valueOf).orElse("none"),
+                multiTrees.size()));
+
         if (multiTrees == null) {
             throw new DotDataException("empty list passed in");
         }


### PR DESCRIPTION
## Summary

Temporary diagnostic build for FD #36897

Adds `WARN`-level log lines tagged `[FD-36897]` to two locations in the page save path:

- **`PageResourceHelper.saveContent()`** — logs the number of containers and total contentlets received in the payload before the save runs
- **`MultiTreeAPIImpl.overridesMultitreesByPersonalization()`** — logs the `multiTrees` count and language at the point where the page-wide DELETE + re-insert executes

## What to look for in the logs

When the customer reproduces the wipe, grep for `[FD-36897]` in the server logs:

```
[FD-36897] saveContent: pageId=... lang=1 variant=DEFAULT containers=1 totalContentlets=1 entries=[container-id(1)]
[FD-36897] overridesMT:  pageId=... personalization=... variant=DEFAULT lang=1 multiTrees=1
```

- If `containers=1 totalContentlets=1` when the page had 10+ contentlets → payload is already corrupt on arrival → **client-side (Angular) bug**
- If `containers` count is correct → data loss happens inside the save operation → **server-side bug**

## Notes

- This branch is off `release-26.04.22-02` — intended for a targeted customer deployment only
- These log lines must be removed before merging to any long-lived branch
- Do NOT merge to `main` or other release branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)