### PR TITLE
chore(fd-36897): diagnostic logging for page content save path

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/PageRenderUtil.java
@@ -262,6 +262,7 @@ public class PageRenderUtil implements Serializable {
         final Set<String> personalizationsForPage = multiTreeAPI.getPersonalizationsForPage(htmlPage, currentVariantId);
         final List<ContainerRaw> rawContainers  = Lists.newArrayList();
         final String includeContentFor = this.getPersonaTagToIncludeContent(request, personalizationsForPage);
+        int fd36897UnresolvedForLanguage = 0; // [FD-36897] contentlets in multi_tree not resolvable for this render's language/variant
 
         for (final String containerId : pageContents.rowKeySet()) {
 
@@ -293,6 +294,7 @@ public class PageRenderUtil implements Serializable {
                     final Contentlet nonHydratedContentlet = getContentletByVariantFallback(currentVariantId, personalizedContentlet, timeMachineDate);
 
                     if (nonHydratedContentlet == null) {
+                        fd36897UnresolvedForLanguage++; // [FD-36897]
                         continue;
                     }
 
@@ -340,6 +342,12 @@ public class PageRenderUtil implements Serializable {
             }
 
             rawContainers.add(new ContainerRaw(container, containerStructures, contentMaps));
+        }
+
+        if (fd36897UnresolvedForLanguage > 0) {
+            Logger.warn(this, String.format(
+                    "[FD-36897] render SHORTFALL: pageId=%s lang=%s variant=%s live=%s unresolvedContentlets=%d (present in multi_tree but not resolvable for this language/variant -> missing from the editor model the next save will persist)",
+                    htmlPage.getIdentifier(), this.languageId, currentVariantId, live, fd36897UnresolvedForLanguage));
         }
 
         return rawContainers;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -200,8 +200,8 @@ public class PageResourceHelper implements Serializable {
             }
         }
         Logger.warn(this, String.format(
-                "[FD-36897] saveContent: pageId=%s lang=%d variant=%s containers=%d totalContentlets=%d entries=[%s]",
-                pageId, language.getId(), variantName,
+                "[FD-36897] saveContent: pageId=%s user=%s lang=%d variant=%s containers=%d totalContentlets=%d entries=[%s]",
+                pageId, (user != null ? user.getUserId() : "null"), language.getId(), variantName,
                 containerEntries.size(),
                 containerEntries.stream().mapToInt(e -> e.getContentIds().size()).sum(),
                 containerEntries.stream()

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/page/PageResourceHelper.java
@@ -199,6 +199,15 @@ public class PageResourceHelper implements Serializable {
                 multiTreesMap.computeIfAbsent(personalization, key -> new ArrayList<>());
             }
         }
+        Logger.warn(this, String.format(
+                "[FD-36897] saveContent: pageId=%s lang=%d variant=%s containers=%d totalContentlets=%d entries=[%s]",
+                pageId, language.getId(), variantName,
+                containerEntries.size(),
+                containerEntries.stream().mapToInt(e -> e.getContentIds().size()).sum(),
+                containerEntries.stream()
+                        .map(e -> e.getContainerId() + "(" + e.getContentIds().size() + ")")
+                        .collect(java.util.stream.Collectors.joining(", "))));
+
         for (final String personalization : multiTreesMap.keySet()) {
             multiTreeAPI.overridesMultitreesByPersonalization(pageId, personalization,
                     multiTreesMap.get(personalization), Optional.of(language.getId()),

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -697,6 +697,12 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
                 "Overriding MultiTrees: pageId -> %s personalization -> %s multiTrees-> %s ",
                 pageId, personalization, multiTrees));
 
+        Logger.warn(this, String.format(
+                "[FD-36897] overridesMT: pageId=%s personalization=%s variant=%s lang=%s multiTrees=%d",
+                pageId, personalization, variantId,
+                languageIdOpt.map(String::valueOf).orElse("none"),
+                multiTrees.size()));
+
         if (multiTrees == null) {
             throw new DotDataException("empty list passed in");
         }

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -697,15 +697,15 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
                 "Overriding MultiTrees: pageId -> %s personalization -> %s multiTrees-> %s ",
                 pageId, personalization, multiTrees));
 
+        if (multiTrees == null) {
+            throw new DotDataException("empty list passed in");
+        }
+
         Logger.warn(this, String.format(
                 "[FD-36897] overridesMT: pageId=%s personalization=%s variant=%s lang=%s multiTrees=%d",
                 pageId, personalization, variantId,
                 languageIdOpt.map(String::valueOf).orElse("none"),
                 multiTrees.size()));
-
-        if (multiTrees == null) {
-            throw new DotDataException("empty list passed in");
-        }
 
         Logger.debug(MultiTreeAPIImpl.class, ()->String.format("Saving page's content: %s", multiTrees));
         Set<String> originalContentletIds;

--- a/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/factories/MultiTreeAPIImpl.java
@@ -761,6 +761,23 @@ public class MultiTreeAPIImpl implements MultiTreeAPI {
                     .loadResult();
         }
 
+        // [FD-36897] Net-loss detector: originalContentletIds mirrors the DELETE's WHERE clause, so any
+        // id in it that is absent from the posted multiTrees is content this save is permanently dropping.
+        final Set<String> fd36897PostedChildIds = multiTrees.stream()
+                .map(MultiTree::getContentlet)
+                .collect(java.util.stream.Collectors.toSet());
+        final List<String> fd36897DroppedChildIds = originalContentletIds.stream()
+                .filter(id -> !fd36897PostedChildIds.contains(id))
+                .collect(java.util.stream.Collectors.toList());
+        if (!fd36897DroppedChildIds.isEmpty()) {
+            Logger.warn(this, String.format(
+                    "[FD-36897] overridesMT NET-LOSS: pageId=%s personalization=%s variant=%s lang=%s before=%d posted=%d dropped=%d ids=%s",
+                    pageId, personalization, variantId,
+                    languageIdOpt.map(String::valueOf).orElse("none"),
+                    originalContentletIds.size(), multiTrees.size(),
+                    fd36897DroppedChildIds.size(), fd36897DroppedChildIds));
+        }
+
         if (!multiTrees.isEmpty()) {
             copyMultiTree(pageId, multiTrees);
         }


### PR DESCRIPTION
## Summary

Temporary diagnostic build to investigate FD #36897 (page content wipe on save).

Adds `WARN`-level log lines tagged `[FD-36897]` to two locations in the page save path:

- **`PageResourceHelper.saveContent()`** — logs the number of containers and total contentlets received in the payload before the save runs
- **`MultiTreeAPIImpl.overridesMultitreesByPersonalization()`** — logs the `multiTrees` count and language at the point where the DELETE + re-insert executes

## What to look for in the logs

When the issue is reproduced, grep for `[FD-36897]`:

```
[FD-36897] saveContent: pageId=... lang=1 variant=DEFAULT containers=1 totalContentlets=1 entries=[container-id(1)]
[FD-36897] overridesMT:  pageId=... personalization=... variant=DEFAULT lang=1 multiTrees=1
```

- `containers=1 totalContentlets=1` when the page had many contentlets → payload arrived corrupt → **client-side bug**
- `containers` count correct → data loss happens inside the save → **server-side bug**

## Notes

- Branch is off `release-26.04.22-02` — intended for a targeted diagnostic deployment only
- These log lines must be removed before merging to any long-lived branch
- Do **not** merge to `main` or other release branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)