### PR TITLE
ci(java): stop auto-building the java-25 release variant

### DIFF
--- a/.github/workflows/cicd_7-release-java-variant.yml
+++ b/.github/workflows/cicd_7-release-java-variant.yml
@@ -24,7 +24,7 @@
 # Java version for the same release are prevented via concurrency groups.
 #
 # Configuration:
-# Set repository variables for automatic parallel builds:
+# Repository variables provide defaults when the dispatch inputs are left empty:
 #   RELEASE_JAVA_VARIANT_VERSION: Java version in SDKMAN format (e.g., 25.0.2-ms)
 #   RELEASE_JAVA_VARIANT_SUFFIX: Artifact suffix without separator (e.g., java-25-ms)
 #
@@ -45,7 +45,7 @@ on:
         required: true
         type: string
       java_version:
-        description: 'Java version to build (SDKMAN format, e.g., 25.0.2-ms). Leave empty to use the RELEASE_JAVA_VARIANT_VERSION repository variable (same as push-triggered builds).'
+        description: 'Java version to build (SDKMAN format, e.g., 25.0.2-ms). Leave empty to use the RELEASE_JAVA_VARIANT_VERSION repository variable.'
         required: false
         type: string
         default: ''
@@ -58,7 +58,10 @@ on:
 # Prevent duplicate runs for the same release branch AND Java version
 # Different Java versions can run in parallel, but duplicate builds of the same version are prevented
 concurrency:
-  group: release-java-variant-${{ github.ref_name }}-${{ github.event_name == 'workflow_dispatch' && inputs.java_version || vars.RELEASE_JAVA_VARIANT_VERSION }}
+  # Key on the release_branch input, not github.ref_name: with workflow_dispatch the
+  # ref is the branch the workflow was dispatched from (usually main), which would
+  # collapse all dispatches into one group and cancel in-flight builds for other releases.
+  group: release-java-variant-${{ inputs.release_branch }}-${{ inputs.java_version || vars.RELEASE_JAVA_VARIANT_VERSION }}
   cancel-in-progress: true
 
 jobs:
@@ -74,11 +77,8 @@ jobs:
       - name: Parse Version from Branch
         id: parse
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            branch="${{ inputs.release_branch }}"
-          else
-            branch="${{ github.ref_name }}"
-          fi
+          # workflow_dispatch is the only trigger; the release branch always comes from the input
+          branch="${{ inputs.release_branch }}"
 
           # Extract version from release-{version} branch name
           if [[ ! ${branch} =~ ^release- ]]; then

--- a/.github/workflows/cicd_7-release-java-variant.yml
+++ b/.github/workflows/cicd_7-release-java-variant.yml
@@ -33,9 +33,6 @@ name: '-7 Release Java Variant'
 run-name: "Release Java Variant - ${{ github.event_name == 'workflow_dispatch' && inputs.release_branch || github.ref_name }}${{ inputs.java_version && format(' [{0}]', inputs.java_version) || '' }}"
 
 on:
-  # NOTE: Automatic trigger on release-* branches has been removed.
-  # Java 25 is now the default build (see #33865), so the previously
-  # auto-built java-25 variant is redundant with the primary release image.
   # This workflow is now manual-only and can be repurposed for other variants
   # (e.g. a future java-11 build) via workflow_dispatch or repository variables.
   workflow_dispatch:

--- a/.github/workflows/cicd_7-release-java-variant.yml
+++ b/.github/workflows/cicd_7-release-java-variant.yml
@@ -1,14 +1,16 @@
 #
 # Release Java Variant Workflow
 #
-# This workflow builds alternate Java versions for a release, running in parallel
-# with the primary release workflow. It triggers automatically when the primary
-# release workflow creates a release branch.
+# This workflow builds alternate Java versions for a release. It is MANUAL-ONLY
+# (workflow_dispatch); the automatic trigger on release-* branches was removed
+# once Java 25 became the default build (see #33865), making the parallel
+# java-25 variant redundant with the primary release image.
 #
 # Architecture:
-# When the primary release workflow (cicd_6-release.yml) creates a release branch,
-# this workflow automatically triggers and runs in parallel. Both workflows build
-# from the SAME release branch and commit, ensuring identical source code.
+# Dispatch this workflow against a release branch/tag to build an alternate Java
+# variant from the SAME release source. Both the primary release and this variant
+# build from identical source code, differing only in Java version and artifact
+# suffix.
 #
 # This variant workflow:
 # - Uses alternate Java version for compilation (e.g., Java 25 vs Java 21)
@@ -31,9 +33,11 @@ name: '-7 Release Java Variant'
 run-name: "Release Java Variant - ${{ github.event_name == 'workflow_dispatch' && inputs.release_branch || github.ref_name }}${{ inputs.java_version && format(' [{0}]', inputs.java_version) || '' }}"
 
 on:
-  push:
-    branches:
-      - 'release-*'
+  # NOTE: Automatic trigger on release-* branches has been removed.
+  # Java 25 is now the default build (see #33865), so the previously
+  # auto-built java-25 variant is redundant with the primary release image.
+  # This workflow is now manual-only and can be repurposed for other variants
+  # (e.g. a future java-11 build) via workflow_dispatch or repository variables.
   workflow_dispatch:
     inputs:
       release_branch:


### PR DESCRIPTION
## What

Now that Java 25 is the default build (#33865 / companion PR #35914), the parallel **java-25 variant** image that `cicd_7-release-java-variant.yml` builds on every release is redundant with the primary release image (`dotcms/dotcms:latest`, `:trunk`, `:<version>`).

This removes the automatic `push: release-*` trigger so the java-25 variant is no longer built on release.

## Details

- `cicd_7` is the **only** workflow that auto-builds a Java variant (verified: trunk/nightly/release/manual-deploy only build a variant when a human passes `java-version` explicitly).
- The workflow is **kept as manual-only** (`workflow_dispatch`) rather than deleted, so it can be repurposed for a future **java-11 variant** (the planned follow-up to preserve the old default for users not yet on JVM 25).
- Header comment updated to reflect manual-only operation.

## Reviewer notes

- The repository variables `RELEASE_JAVA_VARIANT_VERSION=25.0.2-ms` and `RELEASE_JAVA_VARIANT_SUFFIX=java-25` are **left untouched** (they're live repo settings, not in-tree). They simply go dormant. ⚠️ Consequence: a *manual* `workflow_dispatch` of `cicd_7` with no inputs would still build a **java-25** image from those vars. That's acceptable for a deliberate manual run; the java-11 follow-up PR will repoint these vars.
- Depends on / pairs with #35914 (which makes Java 25 the default).

Refs #33865

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #33865