### PR TITLE
fix(uve): show content title instead of 'Details' in breadcrumb for detail pages

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1232,6 +1232,34 @@ describe('DotEmaShellComponent', () => {
                     })
                 );
             });
+
+            it('should fall back to page title and identifier when urlContentMap is absent', async () => {
+                jest.spyOn(dotPageApiService, 'get').mockReturnValue(
+                    of({
+                        ...MOCK_RESPONSE_HEADLESS,
+                        page: {
+                            ...MOCK_RESPONSE_HEADLESS.page,
+                            title: 'Page Title',
+                            identifier: 'page-id'
+                        },
+                        urlContentMap: null
+                    })
+                );
+
+                mockGlobalStore.addNewBreadcrumb.mockClear();
+                store.pageLoad(INITIAL_PAGE_PARAMS);
+                spectator.detectChanges();
+                await spectator.fixture.whenStable();
+                spectator.detectChanges();
+
+                expect(mockGlobalStore.addNewBreadcrumb).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        label: 'Page Title',
+                        id: 'page-id',
+                        url: expect.stringContaining('url=index')
+                    })
+                );
+            });
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -75,7 +75,8 @@ import {
     MOCK_RESPONSE_HEADLESS,
     PAGE_RESPONSE_BY_LANGUAGE_ID,
     PAGE_RESPONSE_URL_CONTENT_MAP,
-    PAYLOAD_MOCK
+    PAYLOAD_MOCK,
+    URL_CONTENT_MAP_MOCK
 } from '../shared/mocks';
 import { UVEStore } from '../store/dot-uve.store';
 
@@ -1084,7 +1085,7 @@ describe('DotEmaShellComponent', () => {
 
                 expect(mockGlobalStore.addNewBreadcrumb).toHaveBeenCalledWith(
                     expect.objectContaining({
-                        label: expect.any(String),
+                        label: 'hello world',
                         id: '123',
                         url: expect.stringContaining('url=index')
                     })
@@ -1196,6 +1197,38 @@ describe('DotEmaShellComponent', () => {
                         label: 'Page B',
                         id: '456',
                         url: expect.stringContaining('url=%2Fpage-b')
+                    })
+                );
+            });
+
+            it('should use urlContentMap title and identifier when present', async () => {
+                jest.spyOn(dotPageApiService, 'get').mockReturnValue(
+                    of({
+                        ...MOCK_RESPONSE_HEADLESS,
+                        page: {
+                            ...MOCK_RESPONSE_HEADLESS.page,
+                            title: 'Page Title',
+                            identifier: 'page-id'
+                        },
+                        urlContentMap: {
+                            ...URL_CONTENT_MAP_MOCK,
+                            title: 'Content Map Title',
+                            identifier: 'content-map-id'
+                        }
+                    })
+                );
+
+                mockGlobalStore.addNewBreadcrumb.mockClear();
+                store.pageLoad(INITIAL_PAGE_PARAMS);
+                spectator.detectChanges();
+                await spectator.fixture.whenStable();
+                spectator.detectChanges();
+
+                expect(mockGlobalStore.addNewBreadcrumb).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        label: 'Content Map Title',
+                        id: 'content-map-id',
+                        url: expect.stringContaining('url=index')
                     })
                 );
             });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -218,19 +218,18 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
     });
 
     readonly $updateBreadcrumb = signalMethod<DotCMSPage | null>((page) => {
-
         if (!page || !this.uveStore.pageParams()) return;
-
 
         const params = this.uveStore.pageFriendlyParams();
         const baseClientHost = this.#activatedRoute.snapshot.data?.uveConfig?.url;
         const cleanedParams = normalizeQueryParams(params, baseClientHost);
         const urlTree = this.#router.createUrlTree([], { queryParams: cleanedParams });
-        const label = this.uveStore.pageAsset()?.urlContentMap?.title ?? page.title;
-        const identifier =  this.uveStore.pageAsset()?.urlContentMap?.identifier ?? page.identifier;
+        const urlContentMap = this.uveStore.pageAsset()?.urlContentMap;
+        const label = urlContentMap?.title ?? page.title;
+        const identifier = urlContentMap?.identifier ?? page.identifier;
 
         this.#globalStore.addNewBreadcrumb({
-            label: label,
+            label,
             url: `/dotAdmin/#${urlTree.toString()}`,
             id: `${identifier}`
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -211,23 +211,28 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
 
     readonly $breadcrumbPage = computed<DotCMSPage | null>(() => {
         const page = this.uveStore.pageAsset()?.page;
+
         const status = this.uveStore.uveStatus();
 
         return page && status === UVE_STATUS.LOADED ? page : null;
     });
 
     readonly $updateBreadcrumb = signalMethod<DotCMSPage | null>((page) => {
+
         if (!page || !this.uveStore.pageParams()) return;
+
 
         const params = this.uveStore.pageFriendlyParams();
         const baseClientHost = this.#activatedRoute.snapshot.data?.uveConfig?.url;
         const cleanedParams = normalizeQueryParams(params, baseClientHost);
         const urlTree = this.#router.createUrlTree([], { queryParams: cleanedParams });
+        const label = this.uveStore.pageAsset()?.urlContentMap?.title ?? page.title;
+        const identifier =  this.uveStore.pageAsset()?.urlContentMap?.identifier ?? page.identifier;
 
         this.#globalStore.addNewBreadcrumb({
-            label: page.title,
+            label: label,
             url: `/dotAdmin/#${urlTree.toString()}`,
-            id: `${page.identifier}`
+            id: `${identifier}`
         });
     });
 


### PR DESCRIPTION
## Problem

When navigating to detail pages (e.g. blog posts, products, activities), the UVE breadcrumb was always displaying the generic page title instead of the actual content name — so users would see something like **"Details"** rather than **"Ecotourism in Costa Rica"** or **"French Polynesia: Everything You Need to Know"**.

This happened because the breadcrumb was built exclusively from `page.title`, which reflects the page template title, not the content being displayed.


Before 

<img width="1536" height="650" alt="Screenshot 2026-06-03 at 3 15 14 PM" src="https://github.com/user-attachments/assets/eb0d74c5-cd5b-420d-a385-1e66e8245623" />

<img width="1536" height="696" alt="Screenshot 2026-06-03 at 3 14 54 PM" src="https://github.com/user-attachments/assets/86314b1b-7a15-4395-8ef6-7ad71e8eddda" />

<img width="1569" height="854" alt="Screenshot 2026-06-03 at 3 14 14 PM" src="https://github.com/user-attachments/assets/05ce4db0-a080-4c63-a4b7-6201633a7702" />


Now
<img width="1539" height="675" alt="Screenshot 2026-06-03 at 3 14 58 PM" src="https://github.com/user-attachments/assets/7a4aa215-7746-439b-a96a-0483ab841cee" />

<img width="1536" height="806" alt="Screenshot 2026-06-03 at 3 14 43 PM" src="https://github.com/user-attachments/assets/e78dff57-ebb9-440f-8236-4558b69f867a" />

<img width="1504" height="640" alt="Screenshot 2026-06-03 at 3 15 19 PM" src="https://github.com/user-attachments/assets/47fb73a5-2aa2-499c-81dd-98bf03ddfd27" />

## Solution

When a `urlContentMap` is present (the mapped content for detail/listing pages), the breadcrumb now uses:

- `urlContentMap.title` as the label → shows the actual content name
- `urlContentMap.identifier` as the breadcrumb ID → correctly identifies the content entry

Falls back to `page.title` / `page.identifier` when no `urlContentMap` is available (e.g. regular pages).

## Changes

- `DotEmaShellComponent.$updateBreadcrumb` — reads `urlContentMap.title` and `urlContentMap.identifier` with fallback to `page` values
- Added test case to verify `urlContentMap` values take precedence over page values

## Related

Closes #35807

This PR fixes: #35807