### PR TITLE
fix(uve) #35926: don't reuse the previous page's client GraphQL request on headless navigation

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.spec.ts
@@ -536,3 +536,99 @@ describe('DotUveActionsHandlerService – REGISTER_STYLE_SCHEMAS', () => {
         expect(setStyleSchemas).toHaveBeenCalledWith(mockSchemas);
     });
 });
+
+describe('DotUveActionsHandlerService – CLIENT_READY', () => {
+    let spectator: SpectatorService<DotUveActionsHandlerService>;
+    let service: DotUveActionsHandlerService;
+
+    const createService = createServiceFactory({
+        service: DotUveActionsHandlerService,
+        providers: [
+            mockProvider(DotWorkflowActionsFireService),
+            mockProvider(DotMessageService),
+            mockProvider(MessageService),
+            mockProvider(DotCopyContentModalService),
+            {
+                provide: UVEStore,
+                useValue: buildMockStore()
+            }
+        ]
+    });
+
+    const buildClientReadyStore = (isClientReady: boolean) => ({
+        ...buildMockStore(),
+        isClientReady: jest.fn().mockReturnValue(isClientReady),
+        setCustomClient: jest.fn(),
+        setIsClientReady: jest.fn()
+    });
+
+    const CLIENT_READY_PAYLOAD = {
+        graphql: {
+            query: '{ page { url } }',
+            variables: { url: '/page-two', depth: '1' }
+        }
+    };
+
+    const buildDeps = (mockStore: ReturnType<typeof buildClientReadyStore>) => ({
+        uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+        dialog: null,
+        inlineEditingService: null,
+        contentWindow: null,
+        host: 'http://localhost',
+        onCopyContent: jest.fn()
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        spectator = createService();
+        service = spectator.service;
+    });
+
+    it('should install the client request and reload when the client is not ready', () => {
+        const mockStore = buildClientReadyStore(false);
+
+        service.handleAction(
+            { action: DotCMSUVEAction.CLIENT_READY, payload: CLIENT_READY_PAYLOAD },
+            buildDeps(mockStore)
+        );
+
+        expect(mockStore.setCustomClient).toHaveBeenCalledWith({
+            query: CLIENT_READY_PAYLOAD.graphql.query,
+            variables: CLIENT_READY_PAYLOAD.graphql.variables
+        });
+        expect(mockStore.pageReload).toHaveBeenCalled();
+        expect(mockStore.setIsClientReady).toHaveBeenCalledWith(true);
+    });
+
+    it('should refresh the stored client request without reloading when already ready', () => {
+        // Client-side navigation: the new page's CLIENT_READY arrives while the
+        // editor is still initialized for the previous page. The config must be
+        // refreshed (so the upcoming NAVIGATION_UPDATE pageLoad uses the new
+        // page's query/variables) but no reload should fire.
+        const mockStore = buildClientReadyStore(true);
+
+        service.handleAction(
+            { action: DotCMSUVEAction.CLIENT_READY, payload: CLIENT_READY_PAYLOAD },
+            buildDeps(mockStore)
+        );
+
+        expect(mockStore.setCustomClient).toHaveBeenCalledWith({
+            query: CLIENT_READY_PAYLOAD.graphql.query,
+            variables: CLIENT_READY_PAYLOAD.graphql.variables
+        });
+        expect(mockStore.pageReload).not.toHaveBeenCalled();
+        expect(mockStore.setIsClientReady).not.toHaveBeenCalled();
+    });
+
+    it('should not install a client request when the payload has no graphql query', () => {
+        const mockStore = buildClientReadyStore(true);
+
+        service.handleAction(
+            { action: DotCMSUVEAction.CLIENT_READY, payload: {} },
+            buildDeps(mockStore)
+        );
+
+        expect(mockStore.setCustomClient).not.toHaveBeenCalled();
+        expect(mockStore.pageReload).not.toHaveBeenCalled();
+    });
+});

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.ts
@@ -257,18 +257,26 @@ export class DotUveActionsHandlerService {
             }) => {
                 const isClientReady = uveStore.isClientReady();
 
-                if (isClientReady) {
-                    return;
-                }
-
                 const { graphql, params } = devConfig || {};
                 const { query, variables } = graphql || {};
 
+                // Always refresh the stored client request — it is page-scoped.
+                // When the app re-announces itself on a client-side route change,
+                // the new page's CLIENT_READY arrives right before its
+                // NAVIGATION_UPDATE; installing the config here lets the upcoming
+                // pageLoad fetch the new page with its own query/variables instead
+                // of the previous page's.
                 if (query) {
                     uveStore.setCustomClient({
                         query,
                         variables: (variables ?? {}) as Record<string, string>
                     });
+                }
+
+                if (isClientReady) {
+                    // Already initialized: don't reload. The navigation (if any)
+                    // drives the fetch; a duplicate CLIENT_READY is a no-op.
+                    return;
                 }
 
                 const pageParams = convertClientParamsToPageParams(params);

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/dot-uve.store.ts
@@ -145,6 +145,7 @@ export const UVEStore = signalStore(
             // Client configuration
             resetClientConfiguration: () => store.resetClientConfiguration(),
             markPageLoading: () => store.markPageLoading(),
+            resetRequestMetadata: () => store.resetRequestMetadata(),
 
             // Request metadata
             requestMetadata: () => store.requestMetadata(),

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
@@ -35,7 +35,10 @@ const pageParamsBase = {
     mode: UVE_MODE.EDIT
 };
 
-const graphqlRequest = {
+// Deliberately omits a `url` variable: exercises the legacy-client branch where
+// pageLoad assumes the stored request belongs to the page currently loaded
+// (falls back to comparing against the previous pageParams.url).
+const graphqlRequestWithoutUrl = {
     query: '{ page { url } }',
     variables: { depth: '1', language_id: '1' }
 };
@@ -151,8 +154,8 @@ describe('withPageApi', () => {
         });
 
         it('should use getGraphQLPage when requestMetadata is set', () => {
-            store.setCustomClient(graphqlRequest);
-            expect(store.requestMetadata()).toEqual(graphqlRequest);
+            store.setCustomClient(graphqlRequestWithoutUrl);
+            expect(store.requestMetadata()).toEqual(graphqlRequestWithoutUrl);
 
             store.pageLoad({ language_id: '2' });
             spectator.flushEffects();
@@ -183,7 +186,7 @@ describe('withPageApi', () => {
         });
 
         it('should set page asset with content when GraphQL response includes content', () => {
-            store.setCustomClient(graphqlRequest);
+            store.setCustomClient(graphqlRequestWithoutUrl);
 
             store.pageLoad({});
             spectator.flushEffects();
@@ -195,11 +198,30 @@ describe('withPageApi', () => {
 
         it('should drop the stored client request and use get() when navigating to a different page', () => {
             // Page One's CLIENT_READY installed its GraphQL request
-            store.setCustomClient(graphqlRequest);
-            expect(store.requestMetadata()).toEqual(graphqlRequest);
+            store.setCustomClient(graphqlRequestWithoutUrl);
+            expect(store.requestMetadata()).toEqual(graphqlRequestWithoutUrl);
 
             // The stored request belongs to the current page ('test-url'):
             // navigating to another page must NOT reuse its query/variables
+            store.pageLoad({ url: 'another-page' });
+            spectator.flushEffects();
+
+            expect(store.requestMetadata()).toBeNull();
+            expect(getGraphQLPageSpy).not.toHaveBeenCalled();
+            expect(getSpy).toHaveBeenCalledWith(expect.objectContaining({ url: 'another-page' }));
+            expect(store.uveStatus()).toBe(UVE_STATUS.LOADED);
+        });
+
+        it('should drop a stored request explicitly captured for another page (NAVIGATION_UPDATE before CLIENT_READY)', () => {
+            // The stored request declares the page it belongs to via its own
+            // url variable (current page, '/test-url'). If NAVIGATION_UPDATE
+            // arrives before the new page's CLIENT_READY, pageLoad must not
+            // reuse it — it falls back to the standard Page API (first-load flow)
+            store.setCustomClient({
+                query: 'query',
+                variables: { url: '/test-url', depth: '1' }
+            });
+
             store.pageLoad({ url: 'another-page' });
             spectator.flushEffects();
 
@@ -231,20 +253,20 @@ describe('withPageApi', () => {
         });
 
         it('should keep the stored client request when navigating to the same page (other params)', () => {
-            store.setCustomClient(graphqlRequest);
+            store.setCustomClient(graphqlRequestWithoutUrl);
 
             // Same pathname, leading-slash variant — still the same page
             store.pageLoad({ url: '/test-url', language_id: '2' });
             spectator.flushEffects();
 
-            expect(store.requestMetadata()).toEqual(graphqlRequest);
+            expect(store.requestMetadata()).toEqual(graphqlRequestWithoutUrl);
             expect(getGraphQLPageSpy).toHaveBeenCalled();
             expect(getSpy).not.toHaveBeenCalled();
         });
 
         it('should drop the stored client request when there are no previous pageParams', () => {
             patchState(store, { pageParams: null });
-            store.setCustomClient(graphqlRequest);
+            store.setCustomClient(graphqlRequestWithoutUrl);
 
             // Fresh load (e.g. shell re-created after leaving the portlet):
             // stale metadata from a previous visit must not leak into the new page
@@ -406,7 +428,7 @@ describe('withPageApi', () => {
         });
 
         it('should call getGraphQLPage when reloading with GraphQL metadata', () => {
-            store.setCustomClient(graphqlRequest);
+            store.setCustomClient(graphqlRequestWithoutUrl);
             store.setPageAsset({ pageAsset: MOCK_RESPONSE_HEADLESS });
             jest.clearAllMocks();
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.spec.ts
@@ -50,6 +50,7 @@ function buildTestStore() {
             withPageApi({
                 resetClientConfiguration: () => store.resetClientConfiguration(),
                 markPageLoading: () => store.markPageLoading(),
+                resetRequestMetadata: () => store.resetRequestMetadata(),
                 requestMetadata: () => store.requestMetadata(),
                 $requestWithParams: store.$requestWithParams,
                 setPageAsset: (payload) => store.setPageAsset(payload),
@@ -190,6 +191,69 @@ describe('withPageApi', () => {
             const response = store.pageAssetResponse();
             expect(response?.pageAsset).toEqual(MOCK_RESPONSE_HEADLESS);
             expect(response?.content).toEqual({ source: 'graphql' });
+        });
+
+        it('should drop the stored client request and use get() when navigating to a different page', () => {
+            // Page One's CLIENT_READY installed its GraphQL request
+            store.setCustomClient(graphqlRequest);
+            expect(store.requestMetadata()).toEqual(graphqlRequest);
+
+            // The stored request belongs to the current page ('test-url'):
+            // navigating to another page must NOT reuse its query/variables
+            store.pageLoad({ url: 'another-page' });
+            spectator.flushEffects();
+
+            expect(store.requestMetadata()).toBeNull();
+            expect(getGraphQLPageSpy).not.toHaveBeenCalled();
+            expect(getSpy).toHaveBeenCalledWith(expect.objectContaining({ url: 'another-page' }));
+            expect(store.uveStatus()).toBe(UVE_STATUS.LOADED);
+        });
+
+        it('should keep the stored client request when it was captured for the target page', () => {
+            // Client-side navigation: the new page's CLIENT_READY already
+            // installed its own request (variables.url points to the target)
+            store.setCustomClient({
+                query: 'query',
+                variables: { url: '/another-page', depth: '1' }
+            });
+
+            store.pageLoad({ url: 'another-page' });
+            spectator.flushEffects();
+
+            expect(store.requestMetadata()).not.toBeNull();
+            expect(getGraphQLPageSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    variables: expect.objectContaining({ url: 'another-page' })
+                })
+            );
+            expect(getSpy).not.toHaveBeenCalled();
+            expect(store.uveStatus()).toBe(UVE_STATUS.LOADED);
+        });
+
+        it('should keep the stored client request when navigating to the same page (other params)', () => {
+            store.setCustomClient(graphqlRequest);
+
+            // Same pathname, leading-slash variant — still the same page
+            store.pageLoad({ url: '/test-url', language_id: '2' });
+            spectator.flushEffects();
+
+            expect(store.requestMetadata()).toEqual(graphqlRequest);
+            expect(getGraphQLPageSpy).toHaveBeenCalled();
+            expect(getSpy).not.toHaveBeenCalled();
+        });
+
+        it('should drop the stored client request when there are no previous pageParams', () => {
+            patchState(store, { pageParams: null });
+            store.setCustomClient(graphqlRequest);
+
+            // Fresh load (e.g. shell re-created after leaving the portlet):
+            // stale metadata from a previous visit must not leak into the new page
+            store.pageLoad({ ...pageParamsBase, url: 'fresh-page' });
+            spectator.flushEffects();
+
+            expect(store.requestMetadata()).toBeNull();
+            expect(getGraphQLPageSpy).not.toHaveBeenCalled();
+            expect(getSpy).toHaveBeenCalled();
         });
 
         it('should reset editorSelected when loading a new page', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page-api/withPageApi.ts
@@ -26,7 +26,7 @@ import {
     PageContainer,
     SaveStylePropertiesPayload
 } from '../../../shared/models';
-import { getIframeAccessMode, isForwardOrPage } from '../../../utils';
+import { compareUrlPaths, getIframeAccessMode, isForwardOrPage } from '../../../utils';
 import { PageType, UVEState } from '../../models';
 import { PageSnapshot } from '../page/withPage';
 
@@ -60,6 +60,8 @@ export interface WithPageApiDeps {
     resetClientConfiguration: () => void;
     /** Reset readiness + history but keep current pageAssetResponse. */
     markPageLoading: () => void;
+    /** Drop the stored client GraphQL request (belongs to the page being left). */
+    resetRequestMetadata: () => void;
 
     // Request metadata
     requestMetadata: () => { query: string; variables: Record<string, string> } | null;
@@ -153,6 +155,31 @@ export function withPageApi(deps: WithPageApiDeps) {
                             };
                         }),
                         tap((pageParams) => {
+                            // The stored client GraphQL request (sent by the headless
+                            // app's CLIENT_READY) is page-scoped: its variables carry
+                            // the URL it was captured for. Keep it only when it belongs
+                            // to the page being loaded — same-page param changes
+                            // (language/persona/mode) or a client-side navigation whose
+                            // CLIENT_READY already refreshed it. Otherwise drop it so
+                            // this page loads through the standard Page API (same as a
+                            // first load) until its own CLIENT_READY installs fresh
+                            // metadata. Reusing another page's request (stale variables
+                            // like publishDate or custom vars) can resolve to NOT_FOUND
+                            // and strand the editor on the previous page.
+                            // Requests without a url variable are assumed to belong to
+                            // the page currently loaded in the editor.
+                            const metadataUrl =
+                                deps.requestMetadata()?.variables?.['url'] ??
+                                store.pageParams()?.url;
+                            const belongsToTargetPage =
+                                !!metadataUrl &&
+                                !!pageParams.url &&
+                                compareUrlPaths(metadataUrl, pageParams.url);
+
+                            if (!belongsToTargetPage) {
+                                deps.resetRequestMetadata();
+                            }
+
                             // Don't fully reset — that would null
                             // `pageAssetResponse` and unmount the editor
                             // chrome (toolbars, sidebars, navigation,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page/withPage.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page/withPage.spec.ts
@@ -86,7 +86,8 @@ describe('withPage', () => {
         /**
          * resetClientConfiguration clears page asset and ready state but intentionally
          * preserves requestMetadata so headless/GraphQL clients keep their query across
-         * pageLoad cycles (see withPageApi / shell behavior).
+         * pageLoad cycles. Cross-page staleness is handled in withPageApi's pageLoad,
+         * which drops the stored request when it belongs to another page.
          */
         it('should reset page asset and ready state but preserve requestMetadata', () => {
             const graphql = {
@@ -114,6 +115,27 @@ describe('withPage', () => {
             expect(store.requestMetadata()).toEqual(graphql);
             expect(store.isClientReady()).toBe(false);
             expect(store.pageAssetResponse()).toBeNull();
+        });
+
+        it('should drop only the stored client request via resetRequestMetadata', () => {
+            const graphql = {
+                query: 'test',
+                variables: {}
+            };
+            store.setCustomClient(graphql);
+            store.setIsClientReady(true);
+            store.setPageAsset({
+                pageAsset: { page: { identifier: 'p1' } } as Parameters<
+                    typeof store.setPageAsset
+                >[0]['pageAsset']
+            });
+
+            store.resetRequestMetadata();
+
+            expect(store.requestMetadata()).toBeNull();
+            // Everything else stays untouched
+            expect(store.isClientReady()).toBe(true);
+            expect(store.pageAssetResponse()).not.toBeNull();
         });
     });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page/withPage.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/store/features/page/withPage.ts
@@ -83,6 +83,14 @@ export interface WithPageMethods extends PageComputed {
         query: string;
         variables: Record<string, string>;
     }) => void;
+    /**
+     * Drops the stored client GraphQL request (CLIENT_READY config).
+     * Called on cross-page navigation: the stored query/variables belong
+     * to the page being left, so the next page must be fetched through
+     * the standard Page API until its own CLIENT_READY installs fresh
+     * request metadata.
+     */
+    resetRequestMetadata: () => void;
     /** Updates page asset (and optionally content). Omit content to merge; include content to replace. */
     setPageAsset: (payload: {
         pageAsset: DotCMSPageAsset;
@@ -150,6 +158,9 @@ export function withPage() {
                             variables
                         }
                     });
+                },
+                resetRequestMetadata: () => {
+                    patchState(store, { requestMetadata: null });
                 },
                 setPageAsset: (payload) => {
                     const current = store.pageAssetResponse();


### PR DESCRIPTION


https://github.com/user-attachments/assets/f1d6a520-53a4-4c7b-9dc1-a94e78383794



This PR fixes #35926

### Problem

In headless mode, opening "Page One" in UVE and then navigating to "Page Two" could fail: the fetch for Page Two errored out and the editor bounced back to Page One, getting stuck on it. Traditional pages were not affected.

### Root cause

When a headless app boots inside UVE, the SDK sends `CLIENT_READY` with the page's GraphQL request (query + **variables**: `url`, `languageId`, `publishDate`, `siteId`, custom vars, etc.). UVE stores it as `requestMetadata` and prefers it for every subsequent page fetch.

Two recent refactors broke the lifecycle of that stored request:

1. **#34173 (Real-Time Canvas)** renamed `graphql` → `requestMetadata`. The old `resetClientConfiguration()` reset the whole client state (including the stored query); the new implementation no longer cleared it.
2. **#35539 (explicit iframe sizing)** changed `pageLoad` to call `markPageLoading()` instead of `resetClientConfiguration()` (intentionally, to keep the editor chrome mounted during navigation). `markPageLoading()` only resets `isClientReady` + history — `requestMetadata` survives every navigation.

On top of that, the `CLIENT_READY` handler early-returned when `isClientReady` was already `true`. During a client-side route change inside the headless app, the SDK sends `CLIENT_READY` (for the new page) **before** `NAVIGATION_UPDATE` — so the new page's request was **discarded** while the editor was still marked ready for the previous page.

**Failure chain:** navigate to Page Two → `pageLoad` fetches it via GraphQL using **Page One's stored query/variables** → the query can resolve to `page: null` (stale variables) → `graphqlToPageEntity` returns `null` → `const { vanityUrl } = pageAsset` throws → `uveStatus: ERROR` with no HTTP status (no error UI). Since `markPageLoading()` keeps the previous `pageAssetResponse`, `$iframeURL` still derives from **Page One** → the iframe reloads Page One → the app re-announces `updateNavigation('/page-one')` → UVE loads Page One again. That's the "falls back to the last page" behavior.

### Proposed Changes

* **`dot-uve-actions-handler.service.ts` (`CLIENT_READY`)** — the stored client request is now refreshed on every `CLIENT_READY` (it is page-scoped data). When the client is already ready, only the config is updated — no `pageReload` is fired, so no extra request happens. This means that by the time a client-side navigation's `NAVIGATION_UPDATE` triggers `pageLoad`, the store already holds the **target page's** query/variables and the fetch goes through GraphQL with the correct config.
* **`withPageApi.ts` (`pageLoad`)** — before fetching, the store now checks whether the stored request **belongs to the target page** by comparing the request's own `variables.url` against the navigation target (`compareUrlPaths`, so leading-slash variants match). Requests without a `url` variable are assumed to belong to the currently loaded page (preserves legacy-client behavior).
  * Belongs to the target → GraphQL fetch, same as today.
  * Belongs to another page (e.g. navigation from the toolbar / Pages portlet, where no `CLIENT_READY` for the target exists yet) → the stale request is dropped and the page loads through the standard Page API — which is exactly the first-load flow — until the page's own `CLIENT_READY` installs fresh metadata.
* **`withPage.ts`** — new `resetRequestMetadata()` method (drops only the stored client request), wired into `withPageApi` deps in `dot-uve.store.ts`.

### What deliberately did NOT change

| Flow | Behavior |
|---|---|
| Same-page param changes (language / persona / mode) | Unchanged — GraphQL with the stored request, as today |
| Page reload / save / style editor | Unchanged |
| Traditional pages | Unchanged (they never use `requestMetadata`) |
| Request count on navigation | Unchanged — same number of editor-side fetches as today, only the *config* used is corrected |
| `resetClientConfiguration()` | Untouched (currently has no production callers; left out of scope on purpose) |

**Known constraint (legacy clients):** a custom GraphQL client that omits the `url` variable from its `CLIENT_READY` request is assumed to belong to the page currently loaded in the editor. On cross-page navigation its stored request is dropped and the page loads through the standard Page API until the client re-announces itself — this matches the pre-#34173 behavior, where the stored request was reset on every `pageLoad`. The SDK (`@dotcms/client`) always sends `url`, so this only affects hand-rolled clients.

### Checklist
- [x] Tests
- [ ] Translations (N/A — no user-facing text)
- [x] Security Implications Contemplated (no new attack surface: `CLIENT_READY` could already overwrite the stored request before the editor was ready; messages still come from the same UVE iframe channel)

### Additional Info

**Tests added:**
* `withPageApi.spec.ts`: navigating to a different page drops the stale request and uses the Page API; a request captured *for* the target page is kept (client-side navigation); same-page param changes keep the request; a fresh load with no previous `pageParams` drops stale metadata surviving from a prior visit (the store lives at the route level and outlives the shell).
* `dot-uve-actions-handler.service.spec.ts`: new `CLIENT_READY` suite — installs config + reloads when not ready; refreshes config **without** reloading when already ready; no-ops without a graphql query.
* `withPage.spec.ts`: `resetRequestMetadata()` drops only the stored request.

Full `portlets-edit-ema-portlet` suite: 70 suites / 1418 passing. Lint clean.

**Assumption worth knowing:** the client-side navigation path relies on the SDK sending `CLIENT_READY` before `NAVIGATION_UPDATE` (both are emitted in that order from the same effect in `useEditableDotCMSPage` / `DotCMSEditablePageService.listen`). If that order ever changes, behavior degrades safely to the Page API path (first-load flow), not to a failure.

**Follow-ups (separate issues recommended):**
1. Make the `CLIENT_READY` payload carry an explicit page identity (typed in `@dotcms/types`) instead of inferring ownership from `variables.url` — removes the implicit contract between the editor store and the SDK's GraphQL variable naming.
2. `@dotcms/client` regression in `page.get()`: `UVE_MODE[mode]` returns `undefined` when apps forward the raw `mode=EDIT_MODE` URL param (string enums have no reverse mapping), silently falling back to LIVE — unpublished pages 404 inside the editor.
3. No E2E covers "navigate between two headless pages in UVE" — both refactors that introduced this regression passed CI.

This PR fixes: #35926