### PR TITLE
fix(apps): count env-locked secret as present in required-param warning (#35982)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/ContainerLoader.java
@@ -447,7 +447,15 @@ public class ContainerLoader implements DotLoader {
         try {
 
             final Host host = WebAPILocator.getHostWebAPI().getCurrentHost();
-            return UtilMethods.isSet(host) && ContentAnalyticsUtil.isContentTrackingEnabled(host);
+            if (!UtilMethods.isSet(host)) {
+                Logger.debug(this, () -> "Analytics tracking disabled: no current host resolved from request");
+                return false;
+            }
+            final boolean enabled = ContentAnalyticsUtil.isContentTrackingEnabled(host);
+            Logger.debug(this, () -> String.format(
+                    "Analytics tracking for host '%s' (id '%s'): enabled=%s",
+                    host.getHostname(), host.getIdentifier(), enabled));
+            return enabled;
         } catch (final DotDataException | DotSecurityException e) {
             Logger.warn(this, "Could not check Content Analytics app for current host: " + e.getMessage());
             return false;

--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/analytics/content/util/ContentAnalyticsUtil.java
@@ -318,18 +318,32 @@ public class ContentAnalyticsUtil {
      * @return true if analytics content tracking is active for the site
      */
     public static boolean isContentTrackingEnabled(final Host currentSite) {
+        final String siteId = null != currentSite ? currentSite.getIdentifier() : "null";
         final Map<String, Secret> secrets = getAppSecrets(currentSite);
         if (secrets.isEmpty()) {
+            Logger.debug(ContentAnalyticsUtil.class, () -> String.format(
+                    "Content tracking disabled for site '%s': Content Analytics app has no secrets configured",
+                    siteId));
             return false;
         }
         final Secret siteAuth = secrets.get("siteAuth");
         if (siteAuth == null || !UtilMethods.isSet(siteAuth.getString())) {
+            Logger.debug(ContentAnalyticsUtil.class, () -> String.format(
+                    "Content tracking disabled for site '%s': 'siteAuth' is missing or blank (fromEnv=%s)",
+                    siteId, null != siteAuth && siteAuth.isFromEnv()));
             return false;
         }
         final Secret contentImpression = secrets.get("contentImpression");
         final Secret contentClick = secrets.get("contentClick");
-        return (contentImpression != null && Boolean.parseBoolean(contentImpression.getString()))
-                || (contentClick != null && Boolean.parseBoolean(contentClick.getString()));
+        final boolean impressionEnabled =
+                contentImpression != null && Boolean.parseBoolean(contentImpression.getString());
+        final boolean clickEnabled =
+                contentClick != null && Boolean.parseBoolean(contentClick.getString());
+        final boolean enabled = impressionEnabled || clickEnabled;
+        Logger.debug(ContentAnalyticsUtil.class, () -> String.format(
+                "Content tracking for site '%s': enabled=%s (contentImpression=%s, contentClick=%s)",
+                siteId, enabled, impressionEnabled, clickEnabled));
+        return enabled;
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -842,8 +842,10 @@ public class AppsAPIImpl implements AppsAPI {
     private boolean isRequiredWithNoDefaultValue(final ParamDescriptor descriptor, final Secret secret ){
         //Verify we have a param marked required and no default Value
         final boolean isRequiredWithNoDefaultParam = (descriptor.isRequired() && isEmpty(descriptor.getValue()));
-        //Verify the secret is empty
-        final boolean isSecretWithEmptyValue = (null == secret || isNotSet(secret.getValue()));
+        //Verify the secret is empty. An env-locked (tier-1) value lives in envVarValue, not value, so
+        // honor hasEnvVarValue() — otherwise an env-provisioned required param is wrongly flagged missing.
+        final boolean isSecretWithEmptyValue =
+                (null == secret || (!secret.hasEnvVarValue() && isNotSet(secret.getValue())));
         return isRequiredWithNoDefaultParam && isSecretWithEmptyValue;
     }
 

--- a/dotCMS/src/test/java/com/dotcms/security/apps/AppsAPIImplHostEnvProvisioningTest.java
+++ b/dotCMS/src/test/java/com/dotcms/security/apps/AppsAPIImplHostEnvProvisioningTest.java
@@ -15,6 +15,7 @@ import com.dotmarketing.business.LayoutAPI;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
 import com.dotmarketing.util.Config;
 import com.liferay.portal.model.User;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.After;
@@ -39,14 +40,22 @@ public class AppsAPIImplHostEnvProvisioningTest {
     private static final String HOST_ID = "48190c8c-42c4-46af-8d1a-0cd5db894797";
     private static final String PARAM_NAME = "clientId";
     private static final String ENV_VALUE = "the-client-id";
+    // A required param with no descriptor default — mirrors Content Analytics' "siteAuth".
+    private static final String REQUIRED_PARAM = "siteAuth";
+    private static final String REQUIRED_ENV_VALUE = "my-site-auth-key";
 
     private String envVarName() {
         return AppsUtil.envVarName(APP_KEY, HOST_NAME, PARAM_NAME);
     }
 
+    private String requiredEnvVarName() {
+        return AppsUtil.envVarName(APP_KEY, HOST_NAME, REQUIRED_PARAM);
+    }
+
     @After
     public void cleanup() {
         Config.setProperty(envVarName(), null);
+        Config.setProperty(requiredEnvVarName(), null);
     }
 
     private AppsAPIImpl newApiWithNoStoredBlob() {
@@ -123,5 +132,124 @@ public class AppsAPIImplHostEnvProvisioningTest {
         final Optional<AppSecrets> resolved = api.getSecrets(APP_KEY, false, host, adminUser());
 
         assertFalse("Expected empty when neither stored blob nor env var resolve", resolved.isPresent());
+    }
+
+    /**
+     * Builds an API whose descriptor declares a required, no-default param ({@code siteAuth}) plus an
+     * optional one ({@code clientId}). The store reports no blob, but {@code containsKey} returns true
+     * so {@code filterSitesForAppKey} short-circuits without hitting {@code APILocator.systemUser()}.
+     */
+    /**
+     * A descriptor declaring a required, no-default param ({@code siteAuth}) plus an optional one
+     * ({@code clientId}) — the shape that exercises the missing-value warning.
+     */
+    private AppDescriptor requiredParamDescriptor() {
+        // Required, no-default param — the condition under which the missing-value warning fires.
+        final ParamDescriptor requiredParam = mock(ParamDescriptor.class);
+        when(requiredParam.isRequired()).thenReturn(true);
+        when(requiredParam.getValue()).thenReturn(null);
+        when(requiredParam.getType()).thenReturn(Type.STRING);
+        when(requiredParam.isHidden()).thenReturn(false);
+
+        // Optional param used to keep AppSecrets non-empty in the missing-value control case.
+        final ParamDescriptor optionalParam = mock(ParamDescriptor.class);
+        when(optionalParam.isRequired()).thenReturn(false);
+        when(optionalParam.getType()).thenReturn(Type.STRING);
+        when(optionalParam.isHidden()).thenReturn(false);
+
+        final AppDescriptor appDescriptor = mock(AppDescriptor.class);
+        when(appDescriptor.getKey()).thenReturn(APP_KEY);
+        when(appDescriptor.getParams())
+                .thenReturn(Map.of(REQUIRED_PARAM, requiredParam, PARAM_NAME, optionalParam));
+        return appDescriptor;
+    }
+
+    /**
+     * Builds an API wired to the given descriptor. The store reports no blob, but {@code containsKey}
+     * returns true so {@code filterSitesForAppKey} short-circuits without hitting
+     * {@code APILocator.systemUser()}.
+     */
+    private AppsAPIImpl newApiFor(final AppDescriptor appDescriptor) {
+        final LayoutAPI layoutAPI = mock(LayoutAPI.class);
+        final HostAPI hostAPI = mock(HostAPI.class);
+        final SecretsStore secretsStore = mock(SecretsStore.class);
+        final AppsCache appsCache = mock(AppsCache.class);
+        final LocalSystemEventsAPI localSystemEventsAPI = mock(LocalSystemEventsAPI.class);
+        final AppDescriptorHelper appDescriptorHelper = mock(AppDescriptorHelper.class);
+        final LicenseValiditySupplier licenseValiditySupplier = new LicenseValiditySupplier() {
+            @Override
+            public boolean hasValidLicense() {
+                return true;
+            }
+        };
+
+        // No stored blob, but report the site as configured so computeSecretWarnings proceeds without
+        // the env-detection path that would call APILocator.systemUser().
+        when(secretsStore.getValue(anyString())).thenReturn(Optional.empty());
+        when(secretsStore.containsKey(anyString())).thenReturn(true);
+        when(appsCache.getAppDescriptorsMap(any()))
+                .thenReturn(Map.of(APP_KEY.toLowerCase(), appDescriptor));
+
+        return new AppsAPIImpl(layoutAPI, hostAPI, secretsStore, appsCache,
+                localSystemEventsAPI, appDescriptorHelper, licenseValiditySupplier);
+    }
+
+    private Host hostMock() {
+        final Host host = mock(Host.class);
+        when(host.getIdentifier()).thenReturn(HOST_ID);
+        when(host.getHostname()).thenReturn(HOST_NAME);
+        return host;
+    }
+
+    /**
+     * Regression for the tier-1 env-locked secret being wrongly reported as missing.
+     * <p>
+     * A required, no-default param provisioned through the host-specific env var keeps its value in
+     * {@code envVarValue} (not {@code value}), so the warning check must honor {@code hasEnvVarValue()}.
+     * Before the fix, {@code computeSecretWarnings} flagged {@code siteAuth} as
+     * "required, missing value" even though the env var supplied it.
+     * <p>
+     * Given: no stored blob and the host-specific env var set for the required param.
+     * Expected: no warning is produced for that param.
+     */
+    @Test
+    public void test_no_warning_when_required_param_provisioned_via_host_env() throws Exception {
+        Config.setProperty(requiredEnvVarName(), REQUIRED_ENV_VALUE);
+
+        final AppDescriptor descriptor = requiredParamDescriptor();
+        final AppsAPIImpl api = newApiFor(descriptor);
+        final Host host = hostMock();
+
+        final Map<String, List<String>> warnings =
+                api.computeSecretWarnings(descriptor, host, adminUser());
+
+        assertFalse("Env-provisioned required param must not be flagged as missing",
+                warnings.containsKey(REQUIRED_PARAM));
+        assertTrue("Expected no warnings at all for a fully provisioned required param",
+                warnings.isEmpty());
+    }
+
+    /**
+     * Control: the missing-value warning must still fire for a genuinely unprovisioned required param.
+     * <p>
+     * Given: the optional param is env-backed (so AppSecrets is present) but the required {@code siteAuth}
+     * has no env var and no stored value.
+     * Expected: a warning is produced for {@code siteAuth} only.
+     */
+    @Test
+    public void test_warning_present_when_required_param_missing() throws Exception {
+        // Only the optional param is provisioned; the required one is left unset.
+        Config.setProperty(envVarName(), ENV_VALUE);
+        Config.setProperty(requiredEnvVarName(), null);
+
+        final AppDescriptor descriptor = requiredParamDescriptor();
+        final AppsAPIImpl api = newApiFor(descriptor);
+        final Host host = hostMock();
+
+        final Map<String, List<String>> warnings =
+                api.computeSecretWarnings(descriptor, host, adminUser());
+
+        assertTrue("A required param with no value must still warn", warnings.containsKey(REQUIRED_PARAM));
+        assertFalse("The provisioned optional param must not warn", warnings.containsKey(PARAM_NAME));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #35982. A **required** app-secret param (declared `required: true` with no default `value`) provisioned through a **host-specific (tier-1) environment variable** was wrongly flagged as *"required, missing value"*, even though the value resolved correctly at read time. This made env-provisioned apps — most visibly **Content Analytics `siteAuth`** — appear misconfigured (false warning badge + non-zero `secretsWithWarnings`).

## Root cause

Tier-1 env-locked secrets store their value in `envVarValue`, not `value`. `AppsAPIImpl.isRequiredWithNoDefaultValue(...)` checked emptiness via `secret.getValue()`, which is `null` for an env-locked secret, so the param looked empty. Introduced with the env-var / Kubernetes secret provisioning work (#35860 / #35859).

## Changes

- **`AppsAPIImpl.isRequiredWithNoDefaultValue`** — honor `secret.hasEnvVarValue()` when determining emptiness, so an env-provisioned required param is treated as present.
- **`AppsAPIImplHostEnvProvisioningTest`** — regression coverage:
  - `test_no_warning_when_required_param_provisioned_via_host_env` — env-provisioned required param produces **no** warning (fails before the fix).
  - `test_warning_present_when_required_param_missing` — a genuinely unprovisioned required param **still** warns (no regression).
- **Debug logging** (`chore`, no behavior change) — `ContentAnalyticsUtil.isContentTrackingEnabled` and `ContainerLoader.isAnalyticsTrackingEnabled` now log why tracking is enabled/disabled, making the "I set the env var but tracking is off" case self-diagnosing.

## Test plan

- [x] New unit tests green: `AppsAPIImplHostEnvProvisioningTest` (4 tests, 0 failures)
- [x] `dotcms-core` compiles
- [ ] CI

## Reproduction

```
DOT_DOTCONTENTANALYTICS_CONFIG_DEMO_DOTCMS_COM_SITEAUTH=my-site-auth-key
```
Before: Content Analytics on `demo.dotcms.com` shows a missing-value warning despite the env var. After: no warning, `secretsWithWarnings = 0`, field locked with `fromEnv: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35982