### PR TITLE
fix(security): [release-25.07.10_lts] upgrade Bouncy Castle 1.70 → 1.84 (CVE-2025-14813)

### DIFF
--- a/bom/application/pom.xml
+++ b/bom/application/pom.xml
@@ -19,7 +19,7 @@
         <swagger.version>2.2.34</swagger.version>
         <bytebuddy.version>1.14.15</bytebuddy.version>
         <batik.version>1.17</batik.version>
-        <bouncy-castle.version>1.70</bouncy-castle.version>
+        <bouncy-castle.version>1.84</bouncy-castle.version>
         <awaitility.version>4.0.0</awaitility.version>
         <shedlock.version>4.33.0</shedlock.version>
         <jackson.version>2.17.2</jackson.version>
@@ -1124,12 +1124,12 @@
 
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-jdk15on</artifactId>
+                <artifactId>bcpkix-jdk18on</artifactId>
                 <version>${bouncy-castle.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.bouncycastle</groupId>
-                <artifactId>bcprov-jdk15on</artifactId>
+                <artifactId>bcprov-jdk18on</artifactId>
                 <version>${bouncy-castle.version}</version>
             </dependency>
 

--- a/dotCMS/pom.xml
+++ b/dotCMS/pom.xml
@@ -970,11 +970,11 @@
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
         </dependency>
 
 


### PR DESCRIPTION
Re-targets #35901 at the **canonical LTS branch** `release-25.07.10_lts`.

Fixes #35896

## Why this PR exists

The prior LTS backport PR (#35901) was merged into `dotcms/dotcms25.07.10_lts_v9_4f49576`, which @daniel.silva confirmed is **not** the branch that LTS 25.07.10 releases are cut from. Releases are tagged from `release-25.07.10_lts`. Verified by diffing — `release-25.07.10_lts` is still on BC `1.70` / `jdk15on` and missing the fix.

This PR applies the same byte-for-byte 5-line diff to the canonical branch via `git cherry-pick`.

## Diff (identical to #35897 commit `71bfbc5f7c`)

- `bom/application/pom.xml` — `<bouncy-castle.version>` 1.70 → 1.84 + artifactId rename `jdk15on` → `jdk18on`
- `dotCMS/pom.xml` — artifactId rename only

## Customer context

- CVE: https://nvd.nist.gov/vuln/detail/CVE-2025-14813 (Bouncy Castle GOSTCTR, CWE-327)
- Customer ticket: Freshdesk #37703
- Real exploit risk in dotCMS: near-zero (0 GOSTCTR references in the codebase). Upgrade is for scanner unblock + hygiene.

## Verification basis

- `main` PR #35897 ran the full 34-check CI matrix (JVM unit, Integration MainSuite 1a/1b/2a/2b/3a, OpenSearch upgrade, Karate, Playwright E2E, all Postman suites) — **34 pass / 0 fail**.
- This PR is a byte-for-byte cherry-pick. Identical input + identical diff = identical output.
- ⚠️ **Note on CI for LTS PRs**: PRs targeting LTS branches do not trigger the full `cicd_1-pr.yml` test matrix (only triggers on PRs to `main`/`master`). Same gap as #35901. Safety basis is the identical-diff main PR's full-suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35896