### PR TITLE
fix(urlmap): use configured detail page when not found on requesting site (#35268)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/cms/urlmap/URLMapAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotmarketing/cms/urlmap/URLMapAPIImpl.java
@@ -139,9 +139,10 @@ public class URLMapAPIImpl implements URLMapAPI {
             final Identifier myHostIdentifier = this.identifierAPI.find(currentHost, identifier.getPath());
             if (myHostIdentifier == null || !UtilMethods.isSet(myHostIdentifier.getId())) {
                 Logger.info(this.getClass(),
-                        "No valid detail page for Content Type '" + contentType.name()
-                                + "'. Looking for a detail page=" + identifier.getPath() + " on Site " + currentHost.getHostname());
-                return Optional.empty();
+                        "No detail page found at path '" + identifier.getPath()
+                                + "' on Site '" + currentHost.getHostname()
+                                + "'. Using configured detail page for Content Type '" + contentType.name() + "'.");
+                return Optional.of(identifier);
             }
 
             return Optional.of(myHostIdentifier);

--- a/dotcms-integration/src/test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/cms/urlmap/URLMapAPIImplTest.java
@@ -797,6 +797,56 @@ public class URLMapAPIImplTest {
 
     /**
      * methodToTest {@link URLMapAPIImpl#processURLMap(UrlMapContext)}
+     * Given Scenario: Content type is registered on siteA with a URL pattern; the configured detail
+     * page lives on a different host (globalHost). Content item is on siteA (same host as request).
+     * ExpectedResult: processURLMap resolves and returns the detail page from its configured host.
+     *
+     * @see <a href="https://github.com/dotCMS/core/issues/35268">#35268</a>
+     */
+    @Test
+    public void processURLMap_detailPageOnDifferentHost_shouldResolveWithConfiguredDetailPage()
+            throws DotDataException, DotSecurityException {
+
+        final Host siteA = new SiteDataGen().nextPersisted();
+        final Host globalHost = new SiteDataGen().nextPersisted();
+
+        final Template template = new TemplateDataGen().nextPersisted();
+        final Folder detailFolder = new FolderDataGen()
+                .name("detail-pages-" + System.currentTimeMillis())
+                .site(globalHost)
+                .nextPersisted();
+        final HTMLPageAsset globalDetailPage = new HTMLPageDataGen(detailFolder, template)
+                .pageURL("museum-detail")
+                .title("museum-detail")
+                .nextPersisted();
+
+        final String urlPattern = "/museum-" + System.currentTimeMillis() + "/{urlTitle}";
+
+        final ContentType museumType = getNewsLikeContentType(
+                "Museum" + System.currentTimeMillis(),
+                siteA,
+                globalDetailPage.getIdentifier(),
+                urlPattern);
+
+        final long langId = APILocator.getLanguageAPI().getDefaultLanguage().getId();
+        final Contentlet contentOnSiteA = ContentletDataGen.publish(
+                TestDataUtils.getNewsContent(true, langId, museumType.id(), siteA, new Date(), null));
+
+        final UrlMapContext context = getUrlMapContext(systemUser, siteA,
+                urlPattern.replace("{urlTitle}", contentOnSiteA.getStringProperty("urlTitle")),
+                PageMode.LIVE);
+
+        final Optional<URLMapInfo> result = urlMapAPI.processURLMap(context);
+
+        assertTrue("processURLMap should resolve when detail page is on a different host",
+                result.isPresent());
+        assertEquals(contentOnSiteA.getStringProperty("title"),
+                result.get().getContentlet().getName());
+        assertEquals(globalDetailPage.getURI(), result.get().getIdentifier().getURI());
+    }
+
+    /**
+     * methodToTest {@link URLMapAPIImpl#processURLMap(UrlMapContext)}
      * Given Scenario: Process a URL Map url when both the Content Type and Content exists but the field to Map is a
      * {@link com.dotcms.contenttype.model.field.DataTypes#FLOAT}
      * ExpectedResult: Should return a {@link URLMapInfo} wit the right content ans detail page


### PR DESCRIPTION
### Proposed Changes
* In `URLMapAPIImpl.getDetailPageUri()`, when the configured detail page lives on a different host (e.g. `//global/`) and no matching path exists on the requesting site, fall back to the configured identifier instead of returning `Optional.empty()`.

### Root Cause
The runtime URL map flow has two steps:
1. `buildContentQuery()` — finds the URL-mapped contentlet via ES, restricted to `+(conhost:<currentSite> OR conhost:SYSTEM_HOST)` ✅
2. `getDetailPageUri()` — resolves the rendering page from the content type's `detailPage` identifier

Step 2 correctly handles the case where the detail page is on the current host. When it isn't, it tries to find a page at the same path on the current host. If nothing is found (e.g. the page is on `//global/`), it was returning `Optional.empty()` → 404. The fix returns the configured identifier directly as a safe fallback.

Content host isolation is fully preserved — only step 1 determines which contentlet is returned, and that query is never modified.

This restores the targeted `getDetailPageUri()` fallback that was reverted in #35622 alongside the unsafe cross-site ES query change. The unsafe `buildContentQuery()` change is **not** reintroduced.

### Checklist
- [x] Tests — `processURLMap_detailPageOnDifferentHost_shouldResolveWithConfiguredDetailPage` added to `URLMapAPIImplTest`; existing cross-site bleed guard `processURLMap_mustNotReturnContentFromForeignHost_whenRequestingHostHasNoMatch` still passes
- [ ] Translations
- [x] Security Implications Contemplated — detail page is admin-configured (not user-supplied); content query host restriction unchanged

### Additional Info
- Regression of #35149 / follow-up to #35268
- Previous fix attempt (#35345) introduced multi-tenant content bleed (#35616) and was reverted (#35622). This fix addresses only the `getDetailPageUri()` path, not `buildContentQuery()`.
- All 20 `URLMapAPIImplTest` tests pass (1 pre-existing `@Ignore` skipped)

Closes #35268

This PR fixes: #35268