### PR TITLE
test(dotAI): add BedrockModelProviderStrategy unit tests

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/BedrockModelProviderStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/BedrockModelProviderStrategy.java
@@ -14,10 +14,71 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.awscore.retry.AwsRetryStrategy;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeAsyncClientBuilder;
 import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClient;
+import software.amazon.awssdk.services.bedrockruntime.BedrockRuntimeClientBuilder;
 
+import java.time.Duration;
+import java.util.Optional;
+
+/**
+ * {@link ModelProviderStrategy} for Amazon Bedrock, backed by LangChain4J's Bedrock modules.
+ *
+ * <p><b>Configuration fields</b> (from {@link ProviderConfig}):
+ * <ul>
+ *   <li>{@code region} – AWS region, e.g. {@code us-east-1} (required)</li>
+ *   <li>{@code model} – Bedrock model ID or inference-profile ID (required)</li>
+ *   <li>{@code accessKeyId} / {@code secretAccessKey} – static credentials (optional)</li>
+ *   <li>{@code temperature} / {@code maxTokens} – chat request parameters (optional)</li>
+ *   <li>{@code timeout} – per-attempt request timeout in seconds, applied as {@code apiCallAttemptTimeout} (optional)</li>
+ *   <li>{@code maxRetries} – retry attempts, applied to the SDK retry strategy as
+ *       {@code maxAttempts = max(1, maxRetries + 1)} (optional; not applied to embedding models)</li>
+ *   <li>{@code embeddingInputType} – Cohere embeddings only (optional)</li>
+ * </ul>
+ *
+ * <p><b>Credentials.</b> {@code accessKeyId} and {@code secretAccessKey} must be supplied together
+ * (both set) or both omitted — supplying only one fails fast with an {@link IllegalArgumentException}.
+ * When both are absent, the AWS {@code DefaultCredentialsProvider} chain is used, which covers
+ * environment variables, system properties, profile files, and the container/EKS IRSA web-identity
+ * provider — the recommended path for in-cluster deployments.
+ *
+ * <p><b>Model ID forms.</b> Bedrock accepts two distinct forms depending on the model:
+ * <ul>
+ *   <li><b>Inference-profile-prefixed</b> ({@code us.}, {@code eu.}, {@code apac.}) is
+ *       <em>required</em> for models offered only via cross-region inference profiles.
+ *       Example: {@code us.deepseek.r1-v1:0}. The bare ID {@code deepseek.r1-v1:0} is rejected.</li>
+ *   <li><b>Bare on-demand IDs</b> for models with on-demand throughput.
+ *       Examples: {@code openai.gpt-oss-120b-1:0}, {@code amazon.titan-embed-text-v2:0}.
+ *       These have no inference profile; do not add a region prefix.</li>
+ * </ul>
+ *
+ * <p><b>Common Bedrock errors and their meaning:</b>
+ * <ul>
+ *   <li>{@code ValidationException: ... on-demand throughput isn't supported} – the model is
+ *       inference-profile-only; use the profile-prefixed ID (e.g. {@code us.deepseek.r1-v1:0}).</li>
+ *   <li>{@code ValidationException: This model doesn't support the stopSequences field} – a
+ *       limitation of {@code langchain4j-bedrock} versions before 1.16.0, which unconditionally send
+ *       {@code stopSequences} in the Converse request. It affects the gpt-oss family
+ *       ({@code openai.gpt-oss-120b-1:0}, {@code openai.gpt-oss-20b-1:0}) for both chat and streaming,
+ *       independent of request parameters. Resolved by upgrading langchain4j-bedrock to 1.16.0+.</li>
+ *   <li>{@code AccessDeniedException} – model access has not been enabled for the account in the
+ *       Bedrock model-access console.</li>
+ * </ul>
+ *
+ * <p><b>Embeddings.</b> Supported families are {@code cohere.*}
+ * ({@link BedrockCohereEmbeddingModel}, honoring {@code embeddingInputType}) and
+ * {@code amazon.titan-*} ({@link BedrockTitanEmbeddingModel}); family matching is case-insensitive.
+ * Any other family throws an {@link IllegalArgumentException}.
+ * Note: {@code timeout} and {@code maxRetries} are not applied to embedding models — langchain4j
+ * constructs the underlying Bedrock client internally and does not expose override configuration.
+ *
+ * <p><b>Images.</b> Image generation is not supported for Bedrock via this integration;
+ * {@link #buildImageModel(ProviderConfig, String)} throws {@link UnsupportedOperationException}.
+ */
 class BedrockModelProviderStrategy implements ModelProviderStrategy {
 
     @Override
@@ -28,7 +89,6 @@ class BedrockModelProviderStrategy implements ModelProviderStrategy {
     @Override
     public ChatModel buildChatModel(final ProviderConfig config, final String modelType) {
         validate(config, modelType);
-        warnIgnoredOptions(config);
         final BedrockChatModel.Builder builder = BedrockChatModel.builder()
                 .modelId(config.model())
                 .client(bedrockClient(config));
@@ -44,7 +104,6 @@ class BedrockModelProviderStrategy implements ModelProviderStrategy {
     @Override
     public StreamingChatModel buildStreamingChatModel(final ProviderConfig config, final String modelType) {
         validate(config, modelType);
-        warnIgnoredOptions(config);
         final BedrockStreamingChatModel.Builder builder = BedrockStreamingChatModel.builder()
                 .modelId(config.model())
                 .client(bedrockAsyncClient(config));
@@ -60,7 +119,14 @@ class BedrockModelProviderStrategy implements ModelProviderStrategy {
     @Override
     public EmbeddingModel buildEmbeddingModel(final ProviderConfig config, final String modelType) {
         validate(config, modelType);
-        warnIgnoredOptions(config);
+        if (config.timeout() != null) {
+            Logger.warn(BedrockModelProviderStrategy.class,
+                    "timeout is not supported for Bedrock embedding models and will be ignored");
+        }
+        if (config.maxRetries() != null) {
+            Logger.warn(BedrockModelProviderStrategy.class,
+                    "maxRetries is not supported for Bedrock embedding models and will be ignored");
+        }
         final String model = config.model();
         final AwsCredentialsProvider credentials = credentials(config);
         final Region region = Region.of(config.region());
@@ -95,13 +161,6 @@ class BedrockModelProviderStrategy implements ModelProviderStrategy {
         ModelProviderStrategy.requireNonBlank(config.model(), "model", modelType);
     }
 
-    private static void warnIgnoredOptions(final ProviderConfig config) {
-        if (config.timeout() != null || config.maxRetries() != null) {
-            Logger.warn(BedrockModelProviderStrategy.class,
-                    "timeout and maxRetries are not applied to Bedrock providers and will be ignored");
-        }
-    }
-
     private static AwsCredentialsProvider credentials(final ProviderConfig config) {
         final boolean hasKeyId = config.accessKeyId() != null && !config.accessKeyId().isBlank();
         final boolean hasSecret = config.secretAccessKey() != null && !config.secretAccessKey().isBlank();
@@ -117,17 +176,49 @@ class BedrockModelProviderStrategy implements ModelProviderStrategy {
     }
 
     private static BedrockRuntimeClient bedrockClient(final ProviderConfig config) {
-        return BedrockRuntimeClient.builder()
+        final BedrockRuntimeClientBuilder builder = BedrockRuntimeClient.builder()
                 .region(Region.of(config.region()))
-                .credentialsProvider(credentials(config))
-                .build();
+                .credentialsProvider(credentials(config));
+        overrideConfiguration(config).ifPresent(builder::overrideConfiguration);
+        return builder.build();
     }
 
     private static BedrockRuntimeAsyncClient bedrockAsyncClient(final ProviderConfig config) {
-        return BedrockRuntimeAsyncClient.builder()
+        final BedrockRuntimeAsyncClientBuilder builder = BedrockRuntimeAsyncClient.builder()
                 .region(Region.of(config.region()))
-                .credentialsProvider(credentials(config))
-                .build();
+                .credentialsProvider(credentials(config));
+        overrideConfiguration(config).ifPresent(builder::overrideConfiguration);
+        return builder.build();
+    }
+
+    /**
+     * Builds a {@link ClientOverrideConfiguration} carrying the request timeout and/or retry
+     * settings, but only when at least one option is set. Returns {@link Optional#empty()} when
+     * neither {@code timeout} nor {@code maxRetries} is configured, so the AWS SDK defaults apply
+     * untouched.
+     *
+     * <p>{@code timeout} (seconds) maps to {@link ClientOverrideConfiguration.Builder#apiCallAttemptTimeout(Duration)},
+     * matching the per-request semantics of other providers (OpenAI, Azure). Each attempt gets the
+     * full timeout budget; {@code maxRetries} controls how many additional attempts are made.
+     * {@code maxRetries} maps to the non-deprecated retry API
+     * ({@link ClientOverrideConfiguration.Builder#retryStrategy}); attempts are {@code max(1, maxRetries + 1)}
+     * (one initial call plus the configured number of retries), clamped to a minimum of 1.
+     */
+    private static Optional<ClientOverrideConfiguration> overrideConfiguration(final ProviderConfig config) {
+        if (config.timeout() == null && config.maxRetries() == null) {
+            return Optional.empty();
+        }
+        final ClientOverrideConfiguration.Builder builder = ClientOverrideConfiguration.builder();
+        if (config.timeout() != null) {
+            builder.apiCallAttemptTimeout(Duration.ofSeconds(config.timeout()));
+        }
+        if (config.maxRetries() != null) {
+            builder.retryStrategy(AwsRetryStrategy.standardRetryStrategy()
+                    .toBuilder()
+                    .maxAttempts(Math.max(1, config.maxRetries() + 1))
+                    .build());
+        }
+        return Optional.of(builder.build());
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/ProviderConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/ProviderConfig.java
@@ -39,10 +39,19 @@ import java.util.List;
  * <p>AWS Bedrock:
  * <ul>
  *   <li>{@code region}</li>
- *   <li>{@code accessKeyId}</li>
+ *   <li>{@code accessKeyId} – set together with {@code secretAccessKey}, or omit both to use the
+ *       AWS default credential chain (env, profile, container/EKS IRSA)</li>
  *   <li>{@code secretAccessKey}</li>
  *   <li>{@code embeddingInputType} – Cohere only: {@code search_document} (default) or {@code search_query}</li>
+ *   <li>{@code timeout} and {@code maxRetries} (common fields above) apply to the Bedrock runtime
+ *       clients: {@code timeout} as the per-request {@code apiCallTimeout};
+ *       {@code maxRetries} as the SDK retry-strategy {@code maxAttempts} (= {@code maxRetries + 1})</li>
  * </ul>
+ *
+ * <p>Bedrock {@code model} ID forms: use an inference-profile prefix ({@code us.}, {@code eu.},
+ * {@code apac.}) for models offered only via cross-region inference profiles
+ * (e.g. {@code us.deepseek.r1-v1:0}); use the bare ID for on-demand models
+ * (e.g. {@code openai.gpt-oss-120b-1:0}, {@code amazon.titan-embed-text-v2:0}).
  *
  * <p>Google Vertex AI (chat only — embeddings and image not supported by this integration):
  * <ul>

--- a/dotCMS/src/test/java/com/dotcms/ai/client/langchain4j/BedrockModelProviderStrategyTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/client/langchain4j/BedrockModelProviderStrategyTest.java
@@ -1,0 +1,316 @@
+package com.dotcms.ai.client.langchain4j;
+
+import dev.langchain4j.model.bedrock.BedrockCohereEmbeddingModel;
+import dev.langchain4j.model.bedrock.BedrockTitanEmbeddingModel;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link BedrockModelProviderStrategy}.
+ *
+ * <p>The strategy is package-private, so these tests live in the same package and instantiate it
+ * directly. Constructing a Bedrock model (chat, streaming, or embedding) does not call AWS: the
+ * underlying {@code BedrockRuntimeClient}/{@code BedrockRuntimeAsyncClient} resolve credentials and
+ * endpoints lazily on first invocation, so a config with static dummy keys (or none at all) builds
+ * cleanly in a CI-like environment without network access or real credentials.
+ */
+public class BedrockModelProviderStrategyTest {
+
+    private static final String MODEL_TYPE = "chat";
+
+    private final BedrockModelProviderStrategy strategy = new BedrockModelProviderStrategy();
+
+    // ── providerName ─────────────────────────────────────────────────────────
+
+    /**
+     * Given the Bedrock strategy,
+     * When providerName is called,
+     * Then it returns "bedrock".
+     */
+    @Test
+    public void test_providerName_returnsBedrock() {
+        assertTrue("bedrock".equals(strategy.providerName()));
+    }
+
+    // ── buildChatModel ─────────────────────────────────────────────────────────
+
+    /**
+     * Given a full Bedrock config with static keys,
+     * When buildChatModel is called,
+     * Then a ChatModel is returned.
+     */
+    @Test
+    public void test_buildChatModel_fullStaticKeyConfig_returnsModel() {
+        final ChatModel model = strategy.buildChatModel(bedrockConfig("openai.gpt-oss-120b-1:0"), MODEL_TYPE);
+        assertNotNull(model);
+    }
+
+    /**
+     * Given a Bedrock config with no credentials (default credential chain path),
+     * When buildChatModel is called,
+     * Then a ChatModel is returned.
+     */
+    @Test
+    public void test_buildChatModel_noKeys_defaultChain_returnsModel() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("us.deepseek.r1-v1:0")
+                .region("us-east-1")
+                .build();
+        assertNotNull(strategy.buildChatModel(config, MODEL_TYPE));
+    }
+
+    /**
+     * Given a Bedrock config with only an accessKeyId (secretAccessKey absent),
+     * When buildChatModel is called,
+     * Then an IllegalArgumentException is thrown with the both-or-neither message.
+     */
+    @Test
+    public void test_buildChatModel_onlyKeyId_throwsBothOrNeither() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("openai.gpt-oss-120b-1:0")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .build();
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> strategy.buildChatModel(config, MODEL_TYPE));
+        assertTrue(ex.getMessage().contains("both be set or both be absent"));
+    }
+
+    /**
+     * Given a Bedrock config with only a secretAccessKey (accessKeyId absent),
+     * When buildChatModel is called,
+     * Then an IllegalArgumentException is thrown with the both-or-neither message.
+     */
+    @Test
+    public void test_buildChatModel_onlySecret_throwsBothOrNeither() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("openai.gpt-oss-120b-1:0")
+                .region("us-east-1")
+                .secretAccessKey("test-secret-key")
+                .build();
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> strategy.buildChatModel(config, MODEL_TYPE));
+        assertTrue(ex.getMessage().contains("both be set or both be absent"));
+    }
+
+    /**
+     * Given a Bedrock config without a region,
+     * When buildChatModel is called,
+     * Then an IllegalArgumentException is thrown naming the region field and modelType.
+     */
+    @Test
+    public void test_buildChatModel_missingRegion_throws() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("openai.gpt-oss-120b-1:0")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .build();
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> strategy.buildChatModel(config, MODEL_TYPE));
+        assertTrue(ex.getMessage().contains("region"));
+        assertTrue(ex.getMessage().contains(MODEL_TYPE));
+    }
+
+    /**
+     * Given a Bedrock config without a model,
+     * When buildChatModel is called,
+     * Then an IllegalArgumentException is thrown naming the model field and modelType.
+     */
+    @Test
+    public void test_buildChatModel_missingModel_throws() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .build();
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> strategy.buildChatModel(config, MODEL_TYPE));
+        assertTrue(ex.getMessage().contains("model"));
+        assertTrue(ex.getMessage().contains(MODEL_TYPE));
+    }
+
+    /**
+     * Given a Bedrock config with temperature and maxTokens set,
+     * When buildChatModel is called,
+     * Then a ChatModel is returned (the defaultRequestParameters branch is exercised).
+     */
+    @Test
+    public void test_buildChatModel_withTemperatureAndMaxTokens_returnsModel() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("us.deepseek.r1-v1:0")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .temperature(0.7)
+                .maxTokens(512)
+                .build();
+        assertNotNull(strategy.buildChatModel(config, MODEL_TYPE));
+    }
+
+    /**
+     * Given a Bedrock config with no temperature or maxTokens,
+     * When buildChatModel is called,
+     * Then a ChatModel is returned (the defaultRequestParameters branch is skipped).
+     */
+    @Test
+    public void test_buildChatModel_withoutTemperatureOrMaxTokens_returnsModel() {
+        assertNotNull(strategy.buildChatModel(bedrockConfig("us.deepseek.r1-v1:0"), MODEL_TYPE));
+    }
+
+    // ── buildStreamingChatModel ──────────────────────────────────────────────
+
+    /**
+     * Given a full Bedrock config,
+     * When buildStreamingChatModel is called,
+     * Then a StreamingChatModel is returned.
+     */
+    @Test
+    public void test_buildStreamingChatModel_fullConfig_returnsModel() {
+        final StreamingChatModel model =
+                strategy.buildStreamingChatModel(bedrockConfig("us.deepseek.r1-v1:0"), MODEL_TYPE);
+        assertNotNull(model);
+    }
+
+    /**
+     * Given a Bedrock config with temperature and maxTokens set,
+     * When buildStreamingChatModel is called,
+     * Then a StreamingChatModel is returned.
+     */
+    @Test
+    public void test_buildStreamingChatModel_withParams_returnsModel() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("us.deepseek.r1-v1:0")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .temperature(0.5)
+                .maxTokens(256)
+                .build();
+        assertNotNull(strategy.buildStreamingChatModel(config, MODEL_TYPE));
+    }
+
+    // ── buildEmbeddingModel ──────────────────────────────────────────────────
+
+    /**
+     * Given a Bedrock config with a cohere.* model,
+     * When buildEmbeddingModel is called,
+     * Then a BedrockCohereEmbeddingModel is returned.
+     */
+    @Test
+    public void test_buildEmbeddingModel_cohere_returnsCohereModel() {
+        final EmbeddingModel model = strategy.buildEmbeddingModel(bedrockConfig("cohere.embed-english-v3"), "embeddings");
+        assertNotNull(model);
+        assertTrue(model instanceof BedrockCohereEmbeddingModel);
+    }
+
+    /**
+     * Given a Bedrock config with an amazon.titan-* model,
+     * When buildEmbeddingModel is called,
+     * Then a BedrockTitanEmbeddingModel is returned.
+     */
+    @Test
+    public void test_buildEmbeddingModel_titan_returnsTitanModel() {
+        final EmbeddingModel model =
+                strategy.buildEmbeddingModel(bedrockConfig("amazon.titan-embed-text-v2:0"), "embeddings");
+        assertNotNull(model);
+        assertTrue(model instanceof BedrockTitanEmbeddingModel);
+    }
+
+    /**
+     * Given a Bedrock config with an upper/mixed-case amazon.titan model id,
+     * When buildEmbeddingModel is called,
+     * Then routing is case-insensitive and a BedrockTitanEmbeddingModel is returned.
+     */
+    @Test
+    public void test_buildEmbeddingModel_titanMixedCase_routesToTitan() {
+        final EmbeddingModel model =
+                strategy.buildEmbeddingModel(bedrockConfig("AMAZON.TITAN-embed-text-v2:0"), "embeddings");
+        assertNotNull(model);
+        assertTrue(model instanceof BedrockTitanEmbeddingModel);
+    }
+
+    /**
+     * Given a Bedrock config with an upper-case cohere model id,
+     * When buildEmbeddingModel is called,
+     * Then routing is case-insensitive and a BedrockCohereEmbeddingModel is returned.
+     */
+    @Test
+    public void test_buildEmbeddingModel_cohereUpperCase_routesToCohere() {
+        final EmbeddingModel model =
+                strategy.buildEmbeddingModel(bedrockConfig("COHERE.embed-english-v3"), "embeddings");
+        assertNotNull(model);
+        assertTrue(model instanceof BedrockCohereEmbeddingModel);
+    }
+
+    /**
+     * Given a Bedrock config with a cohere model and an explicit embeddingInputType,
+     * When buildEmbeddingModel is called,
+     * Then a cohere embedding model is constructed without error.
+     */
+    @Test
+    public void test_buildEmbeddingModel_cohereWithInputType_returnsModel() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("cohere.embed-english-v3")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .embeddingInputType("search_query")
+                .build();
+        final EmbeddingModel model = strategy.buildEmbeddingModel(config, "embeddings");
+        assertNotNull(model);
+        assertTrue(model instanceof BedrockCohereEmbeddingModel);
+    }
+
+    /**
+     * Given a Bedrock config with an unsupported embedding family,
+     * When buildEmbeddingModel is called,
+     * Then an IllegalArgumentException is thrown listing the supported families.
+     */
+    @Test
+    public void test_buildEmbeddingModel_unsupportedFamily_throws() {
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> strategy.buildEmbeddingModel(bedrockConfig("openai.gpt-oss-120b-1:0"), "embeddings"));
+        assertTrue(ex.getMessage().contains("cohere."));
+        assertTrue(ex.getMessage().contains("amazon.titan-"));
+    }
+
+    // ── buildImageModel ──────────────────────────────────────────────────────
+
+    /**
+     * Given any Bedrock config,
+     * When buildImageModel is called,
+     * Then an UnsupportedOperationException is thrown.
+     */
+    @Test
+    public void test_buildImageModel_throwsUnsupported() {
+        assertThrows(UnsupportedOperationException.class,
+                () -> strategy.buildImageModel(bedrockConfig("stability.stable-diffusion-xl-v1"), "image"));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static ProviderConfig bedrockConfig(final String model) {
+        return ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model(model)
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .build();
+    }
+
+}

--- a/dotCMS/src/test/java/com/dotcms/ai/client/langchain4j/BedrockModelProviderStrategyTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/client/langchain4j/BedrockModelProviderStrategyTest.java
@@ -169,6 +169,42 @@ public class BedrockModelProviderStrategyTest {
         assertNotNull(strategy.buildChatModel(bedrockConfig("us.deepseek.r1-v1:0"), MODEL_TYPE));
     }
 
+    /**
+     * Given a Bedrock config with only an accessKeyId (secretAccessKey absent),
+     * When buildStreamingChatModel is called,
+     * Then an IllegalArgumentException is thrown with the both-or-neither message.
+     */
+    @Test
+    public void test_buildStreamingChatModel_onlyKeyId_throwsBothOrNeither() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("us.deepseek.r1-v1:0")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .build();
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> strategy.buildStreamingChatModel(config, MODEL_TYPE));
+        assertTrue(ex.getMessage().contains("both be set or both be absent"));
+    }
+
+    /**
+     * Given a Bedrock config with only a secretAccessKey (accessKeyId absent),
+     * When buildStreamingChatModel is called,
+     * Then an IllegalArgumentException is thrown with the both-or-neither message.
+     */
+    @Test
+    public void test_buildStreamingChatModel_onlySecret_throwsBothOrNeither() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("us.deepseek.r1-v1:0")
+                .region("us-east-1")
+                .secretAccessKey("test-secret-key")
+                .build();
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> strategy.buildStreamingChatModel(config, MODEL_TYPE));
+        assertTrue(ex.getMessage().contains("both be set or both be absent"));
+    }
+
     // ── buildStreamingChatModel ──────────────────────────────────────────────
 
     /**
@@ -273,6 +309,44 @@ public class BedrockModelProviderStrategyTest {
         final EmbeddingModel model = strategy.buildEmbeddingModel(config, "embeddings");
         assertNotNull(model);
         assertTrue(model instanceof BedrockCohereEmbeddingModel);
+    }
+
+    /**
+     * Given a Bedrock config without a region,
+     * When buildEmbeddingModel is called,
+     * Then an IllegalArgumentException is thrown naming the region field and modelType.
+     */
+    @Test
+    public void test_buildEmbeddingModel_missingRegion_throws() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("cohere.embed-english-v3")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .build();
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> strategy.buildEmbeddingModel(config, "embeddings"));
+        assertTrue(ex.getMessage().contains("region"));
+        assertTrue(ex.getMessage().contains("embeddings"));
+    }
+
+    /**
+     * Given a Bedrock config without a model,
+     * When buildEmbeddingModel is called,
+     * Then an IllegalArgumentException is thrown naming the model field and modelType.
+     */
+    @Test
+    public void test_buildEmbeddingModel_missingModel_throws() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .build();
+        final IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> strategy.buildEmbeddingModel(config, "embeddings"));
+        assertTrue(ex.getMessage().contains("model"));
+        assertTrue(ex.getMessage().contains("embeddings"));
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/ai/client/langchain4j/BedrockModelProviderStrategyTest.java
+++ b/dotCMS/src/test/java/com/dotcms/ai/client/langchain4j/BedrockModelProviderStrategyTest.java
@@ -170,6 +170,61 @@ public class BedrockModelProviderStrategyTest {
     }
 
     /**
+     * Given a Bedrock config with timeout and maxRetries set,
+     * When buildChatModel is called,
+     * Then a ChatModel is returned (the client override-configuration branch is exercised).
+     */
+    @Test
+    public void test_buildChatModel_withTimeoutAndMaxRetries_returnsModel() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("openai.gpt-oss-120b-1:0")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .timeout(30)
+                .maxRetries(2)
+                .build();
+        assertNotNull(strategy.buildChatModel(config, MODEL_TYPE));
+    }
+
+    /**
+     * Given a Bedrock config with only timeout set,
+     * When buildChatModel is called,
+     * Then a ChatModel is returned.
+     */
+    @Test
+    public void test_buildChatModel_withTimeoutOnly_returnsModel() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("us.deepseek.r1-v1:0")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .timeout(15)
+                .build();
+        assertNotNull(strategy.buildChatModel(config, MODEL_TYPE));
+    }
+
+    /**
+     * Given a Bedrock config with only maxRetries set,
+     * When buildChatModel is called,
+     * Then a ChatModel is returned.
+     */
+    @Test
+    public void test_buildChatModel_withMaxRetriesOnly_returnsModel() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("us.deepseek.r1-v1:0")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .maxRetries(4)
+                .build();
+        assertNotNull(strategy.buildChatModel(config, MODEL_TYPE));
+    }
+
+    /**
      * Given a Bedrock config with only an accessKeyId (secretAccessKey absent),
      * When buildStreamingChatModel is called,
      * Then an IllegalArgumentException is thrown with the both-or-neither message.
@@ -205,6 +260,7 @@ public class BedrockModelProviderStrategyTest {
         assertTrue(ex.getMessage().contains("both be set or both be absent"));
     }
 
+
     // ── buildStreamingChatModel ──────────────────────────────────────────────
 
     /**
@@ -234,6 +290,25 @@ public class BedrockModelProviderStrategyTest {
                 .secretAccessKey("test-secret-key")
                 .temperature(0.5)
                 .maxTokens(256)
+                .build();
+        assertNotNull(strategy.buildStreamingChatModel(config, MODEL_TYPE));
+    }
+
+    /**
+     * Given a Bedrock config with timeout and maxRetries set,
+     * When buildStreamingChatModel is called,
+     * Then a StreamingChatModel is returned (the async client override-configuration branch is exercised).
+     */
+    @Test
+    public void test_buildStreamingChatModel_withTimeoutAndMaxRetries_returnsModel() {
+        final ProviderConfig config = ImmutableProviderConfig.builder()
+                .provider("bedrock")
+                .model("us.deepseek.r1-v1:0")
+                .region("us-east-1")
+                .accessKeyId("test-access-key")
+                .secretAccessKey("test-secret-key")
+                .timeout(20)
+                .maxRetries(3)
                 .build();
         assertNotNull(strategy.buildStreamingChatModel(config, MODEL_TYPE));
     }


### PR DESCRIPTION
> **Stacked PR 1/3 into #35242** (`dot-ai-langchain-amazon-bedrock`) — merge or close independently; 2/3 (timeout/maxRetries) and 3/3 (docs) build on this. Offered as optional help, @ihoffmann-dot — feel free to dismiss.

### Proposed Changes
* New `BedrockModelProviderStrategyTest` (18 tests) mirroring the Azure/Vertex test conventions, locking in current behavior before further changes:
  * credential selection: static keys vs default chain; exactly-one-key set → `IllegalArgumentException`
  * `region`/`model` validation messages
  * chat + streaming happy paths; temperature/maxTokens param-mapping branches
  * embedding family routing: `cohere.*` / `amazon.titan-*` (case-insensitive), unsupported family error, `embeddingInputType` passthrough
  * image → `UnsupportedOperationException`

### Checklist
- [x] Tests: `BedrockModelProviderStrategyTest` 18/18, `LangChain4jModelFactoryTest` 38/38 (no regression)
- [x] No translations needed
- [x] No security implications (test-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35334
