### PR TITLE
feat(push-publishing): add EndpointFailureDetail to static publish failure events (#35883)

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/AWSS3Publisher.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/AWSS3Publisher.java
@@ -21,6 +21,13 @@ import com.dotcms.publisher.environment.business.EnvironmentAPI;
 import com.dotcms.publisher.pusher.PushUtils;
 import com.dotcms.publisher.util.PusheableAsset;
 import com.dotcms.publishing.*;
+import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
+import com.dotcms.system.event.local.type.pushpublish.EndpointFailureDetail;
+import com.dotcms.system.event.local.type.pushpublish.FailureCategory;
+import com.dotcms.system.event.local.type.staticpublish.AllStaticPublishEndpointsFailureEvent;
+import com.dotcms.system.event.local.type.staticpublish.AllStaticPublishEndpointsSuccessEvent;
+import com.dotcms.system.event.local.type.staticpublish.SingleStaticPublishEndpointFailureEvent;
+import com.dotcms.system.event.local.type.staticpublish.SingleStaticPublishEndpointSuccessEvent;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
@@ -74,6 +81,7 @@ public class AWSS3Publisher extends Publisher {
     private final S3VanityAliasService vanityAliasService;
     private final ContentletAPI contentletAPI;
     private final LanguageAPI languageAPI;
+    private final LocalSystemEventsAPI localSystemEventsAPI = APILocator.getLocalSystemEventsAPI();
 
     /**
      * Class constructor.
@@ -260,6 +268,7 @@ public class AWSS3Publisher extends Publisher {
             //Increment numTries
             currentStatusHistory.addNumTries();
             int failedEnvironmentCounter = 0;
+            final List<EndpointFailureDetail> failureDetails = new ArrayList<>();
 
             for (Environment environment : environments) {
                 List<PublishingEndPoint> allEndpoints = this.publisherEndPointAPI.findSendingEndPointsByEnvironment(environment.getId());
@@ -312,6 +321,7 @@ public class AWSS3Publisher extends Publisher {
 					AWSS3EndPointPublisher endPointPublisher = getAWSS3EndPointPublisher(tokenProp,
                             secretProp, wsEndpoint, bucketRegion);
                     EndpointDetail detail = new EndpointDetail();
+                    EndpointFailureDetail endpointFailureDetail = null;
 
                     try {
                         endPointPublisher.checkConnectSuccessfully(bucketValidationName);
@@ -319,6 +329,7 @@ public class AWSS3Publisher extends Publisher {
                         String error = updateStatusFailedToSend(currentStatusHistory, environment, endpoint, detail);
                         failedEnvironment |= true;
                         Logger.error(this.getClass(), error);
+                        endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.CONNECTION_ERROR, e);
                     }
 
                     try {
@@ -382,6 +393,9 @@ public class AWSS3Publisher extends Publisher {
                                             String error = updateStatusFailedToSend(currentStatusHistory, environment, endpoint, detail);
                                             failedEnvironment |= true;
                                             Logger.error(this.getClass(), error, e);
+                                            if (endpointFailureDetail == null) {
+                                                endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.FILESYSTEM_ERROR, e);
+                                            }
                                         }
                                     }
                                     publishVanityAliasesForCanonicalFilesIfEnabled(endPointPublisher, endpoint,
@@ -405,6 +419,9 @@ public class AWSS3Publisher extends Publisher {
                         String error = 	"An error occurred for the endpoint "+ endpoint.getId() + " with address "+ endpoint.getAddress() + ".  Error: " + e.getMessage();
                         detail.setInfo(error);
                         failedEnvironment |= true;
+                        if (endpointFailureDetail == null) {
+                            endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.UNKNOWN, e);
+                        }
 
                         Logger.error(this.getClass(), error, e);
                         PushPublishLogger.log(this.getClass(), "Status Update: Failed to publish bundle");
@@ -423,6 +440,17 @@ public class AWSS3Publisher extends Publisher {
                     if (isHistoryEmpty || failedEnvironment) {
                         currentStatusHistory.addOrUpdateEndpoint(environment.getId(), endpoint.getId(), detail);
                     }
+
+                    if (detail.getStatus() == PublishAuditStatus.Status.SUCCESS.getCode()) {
+                        localSystemEventsAPI.asyncNotify(new SingleStaticPublishEndpointSuccessEvent(config, endpoint));
+                    } else {
+                        if (endpointFailureDetail == null) {
+                            endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.UNKNOWN, null);
+                        }
+                        failureDetails.add(endpointFailureDetail);
+                        localSystemEventsAPI.asyncNotify(new SingleStaticPublishEndpointFailureEvent(
+                                config.getAssets(), Collections.singletonList(endpointFailureDetail)));
+                    }
                 }
                 if(failedEnvironment) {
                     failedEnvironmentCounter++;
@@ -433,11 +461,14 @@ public class AWSS3Publisher extends Publisher {
                 //Updating Audit table
                 PushPublishLogger.log(this.getClass(), "Status Update: Bundle sent");
                 this.publishAuditAPI.updatePublishAuditStatus(config.getId(), PublishAuditStatus.Status.BUNDLE_SENT_SUCCESSFULLY, currentStatusHistory);
+                localSystemEventsAPI.asyncNotify(new AllStaticPublishEndpointsSuccessEvent(config));
             } else {
                 if(failedEnvironmentCounter == environments.size()) {
                     this.publishAuditAPI.updatePublishAuditStatus(config.getId(), PublishAuditStatus.Status.FAILED_TO_SEND_TO_ALL_GROUPS, currentStatusHistory);
+                    localSystemEventsAPI.asyncNotify(new AllStaticPublishEndpointsFailureEvent(config.getAssets(), failureDetails));
                 } else {
                     this.publishAuditAPI.updatePublishAuditStatus(config.getId(), PublishAuditStatus.Status.FAILED_TO_SEND_TO_SOME_GROUPS, currentStatusHistory);
+                    localSystemEventsAPI.asyncNotify(new SingleStaticPublishEndpointFailureEvent(config.getAssets(), failureDetails));
                 }
             }
 
@@ -455,6 +486,28 @@ public class AWSS3Publisher extends Publisher {
 
         return config;
     } // process.
+
+    private EndpointFailureDetail buildFailureDetail(
+            final Environment environment,
+            final PublishingEndPoint endpoint,
+            final EndpointDetail detail,
+            final FailureCategory category,
+            final Throwable throwable) {
+        final PublishAuditStatus.Status auditStatus =
+                PublishAuditStatus.getStatusObjectByCode(detail.getStatus());
+        return EndpointFailureDetail.builder()
+                .endpointId(endpoint.getId())
+                .endpointName(endpoint.getServerName() != null ? endpoint.getServerName().toString() : null)
+                .address(endpoint.getAddress())
+                .environmentId(environment.getId())
+                .environmentName(environment.getName())
+                .failureCategory(category)
+                .auditStatus(auditStatus)
+                .httpStatusCode(null)
+                .message(detail.getInfo())
+                .exceptionClass(throwable != null ? throwable.getClass().getName() : null)
+                .build();
+    }
 
     @NotNull
     private String updateStatusFailedToSend(PublishAuditHistory currentStatusHistory, Environment environment, PublishingEndPoint endpoint, EndpointDetail detail) throws DotDataException {

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/AWSS3Publisher.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/AWSS3Publisher.java
@@ -329,7 +329,7 @@ public class AWSS3Publisher extends Publisher {
                         String error = updateStatusFailedToSend(currentStatusHistory, environment, endpoint, detail);
                         failedEnvironment |= true;
                         Logger.error(this.getClass(), error);
-                        endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.CONNECTION_ERROR, e);
+                        endpointFailureDetail = buildStaticFailureDetail(environment, endpoint, detail, FailureCategory.CONNECTION_ERROR, e);
                     }
 
                     try {
@@ -394,7 +394,7 @@ public class AWSS3Publisher extends Publisher {
                                             failedEnvironment |= true;
                                             Logger.error(this.getClass(), error, e);
                                             if (endpointFailureDetail == null) {
-                                                endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.FILESYSTEM_ERROR, e);
+                                                endpointFailureDetail = buildStaticFailureDetail(environment, endpoint, detail, FailureCategory.FILESYSTEM_ERROR, e);
                                             }
                                         }
                                     }
@@ -420,7 +420,7 @@ public class AWSS3Publisher extends Publisher {
                         detail.setInfo(error);
                         failedEnvironment |= true;
                         if (endpointFailureDetail == null) {
-                            endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.UNKNOWN, e);
+                            endpointFailureDetail = buildStaticFailureDetail(environment, endpoint, detail, FailureCategory.UNKNOWN, e);
                         }
 
                         Logger.error(this.getClass(), error, e);
@@ -445,7 +445,7 @@ public class AWSS3Publisher extends Publisher {
                         localSystemEventsAPI.asyncNotify(new SingleStaticPublishEndpointSuccessEvent(config, endpoint));
                     } else {
                         if (endpointFailureDetail == null) {
-                            endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.UNKNOWN, null);
+                            endpointFailureDetail = buildStaticFailureDetail(environment, endpoint, detail, FailureCategory.UNKNOWN, null);
                         }
                         failureDetails.add(endpointFailureDetail);
                         localSystemEventsAPI.asyncNotify(new SingleStaticPublishEndpointFailureEvent(
@@ -486,28 +486,6 @@ public class AWSS3Publisher extends Publisher {
 
         return config;
     } // process.
-
-    private EndpointFailureDetail buildFailureDetail(
-            final Environment environment,
-            final PublishingEndPoint endpoint,
-            final EndpointDetail detail,
-            final FailureCategory category,
-            final Throwable throwable) {
-        final PublishAuditStatus.Status auditStatus =
-                PublishAuditStatus.getStatusObjectByCode(detail.getStatus());
-        return EndpointFailureDetail.builder()
-                .endpointId(endpoint.getId())
-                .endpointName(endpoint.getServerName() != null ? endpoint.getServerName().toString() : null)
-                .address(endpoint.getAddress())
-                .environmentId(environment.getId())
-                .environmentName(environment.getName())
-                .failureCategory(category)
-                .auditStatus(auditStatus)
-                .httpStatusCode(null)
-                .message(detail.getInfo())
-                .exceptionClass(throwable != null ? throwable.getClass().getName() : null)
-                .build();
-    }
 
     @NotNull
     private String updateStatusFailedToSend(PublishAuditHistory currentStatusHistory, Environment environment, PublishingEndPoint endpoint, EndpointDetail detail) throws DotDataException {

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisher.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisher.java
@@ -39,6 +39,8 @@ import com.dotcms.publishing.PublisherConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.ThreadContext;
 import com.dotcms.system.event.local.business.LocalSystemEventsAPI;
+import com.dotcms.system.event.local.type.pushpublish.EndpointFailureDetail;
+import com.dotcms.system.event.local.type.pushpublish.FailureCategory;
 import com.dotcms.system.event.local.type.staticpublish.AllStaticPublishEndpointsFailureEvent;
 import com.dotcms.system.event.local.type.staticpublish.AllStaticPublishEndpointsSuccessEvent;
 import com.dotcms.system.event.local.type.staticpublish.SingleStaticPublishEndpointFailureEvent;
@@ -145,11 +147,12 @@ public class StaticPublisher extends Publisher {
             currentStatusHistory = startStatusHistory();
 
             int failedEnvironmentCounter = 0;
+            final List<EndpointFailureDetail> allFailureDetails = new ArrayList<>();
 
             List<Environment> environments = environmentAPI.findEnvironmentsByBundleId(configId);
             for (Environment environment : environments) {
 
-                if (handleEnvironment(environment, currentStatusHistory)) {
+                if (handleEnvironment(environment, currentStatusHistory, allFailureDetails)) {
                     failedEnvironmentCounter++;
                 }
             }
@@ -170,14 +173,14 @@ public class StaticPublisher extends Publisher {
                         currentStatusHistory);
 
                     //Triggering static event listener when all endpoints failed during the process.
-                    localSystemEventsAPI.asyncNotify(new AllStaticPublishEndpointsFailureEvent(config.getAssets()));
+                    localSystemEventsAPI.asyncNotify(new AllStaticPublishEndpointsFailureEvent(config.getAssets(), allFailureDetails));
                 } else {
                     this.publishAuditAPI.updatePublishAuditStatus(config.getId(),
                         PublishAuditStatus.Status.FAILED_TO_SEND_TO_SOME_GROUPS,
                         currentStatusHistory);
 
                     //Triggering static event listener when at least one endpoint is successfully sent but others failed.
-                    localSystemEventsAPI.asyncNotify(new SingleStaticPublishEndpointFailureEvent(config.getAssets()));
+                    localSystemEventsAPI.asyncNotify(new SingleStaticPublishEndpointFailureEvent(config.getAssets(), allFailureDetails));
                 }
             }
 
@@ -205,7 +208,8 @@ public class StaticPublisher extends Publisher {
      * detail of the audit. If success, updates the audit with Success code.
      */
     private boolean handleEnvironment(Environment environment,
-                                      PublishAuditHistory currentStatusHistory)
+                                      PublishAuditHistory currentStatusHistory,
+                                      List<EndpointFailureDetail> allFailureDetails)
         throws DotDataException{
 
         EndpointDetail detail = new EndpointDetail();
@@ -213,6 +217,7 @@ public class StaticPublisher extends Publisher {
         boolean isHistoryEmpty = currentStatusHistory.getEndpointsMap().isEmpty();
 
         for (PublishingEndPoint endpoint : getStaticEndpointsByEnviroment(environment)) {
+            EndpointFailureDetail endpointFailureDetail = null;
             try {
                 handleEndpoint(endpoint);
             } catch (DotDataException | DotPublishingException e) {
@@ -226,6 +231,8 @@ public class StaticPublisher extends Publisher {
                         + endpoint.getAddress() + ".  Error: " + e.getMessage();
                 detail.setInfo(error);
                 hasEnvironmentFailed = true;
+                endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.FILESYSTEM_ERROR, e);
+                allFailureDetails.add(endpointFailureDetail);
 
                 Logger.error(this.getClass(), error, e);
                 PushPublishLogger.log(this.getClass(), "Status Update: Failed to publish bundle");
@@ -251,12 +258,37 @@ public class StaticPublisher extends Publisher {
                         .asyncNotify(new SingleStaticPublishEndpointSuccessEvent(config, endpoint));
             }else{
                 localSystemEventsAPI
-                        .asyncNotify(new SingleStaticPublishEndpointFailureEvent(config.getAssets()));
+                        .asyncNotify(new SingleStaticPublishEndpointFailureEvent(config.getAssets(),
+                                endpointFailureDetail != null
+                                        ? Collections.singletonList(endpointFailureDetail)
+                                        : Collections.emptyList()));
             }
         }
 
         return hasEnvironmentFailed;
     } //handleEnvironment.
+
+    private EndpointFailureDetail buildFailureDetail(
+            final Environment environment,
+            final PublishingEndPoint endpoint,
+            final EndpointDetail detail,
+            final FailureCategory category,
+            final Throwable throwable) {
+        final PublishAuditStatus.Status auditStatus =
+                PublishAuditStatus.getStatusObjectByCode(detail.getStatus());
+        return EndpointFailureDetail.builder()
+                .endpointId(endpoint.getId())
+                .endpointName(endpoint.getServerName() != null ? endpoint.getServerName().toString() : null)
+                .address(endpoint.getAddress())
+                .environmentId(environment.getId())
+                .environmentName(environment.getName())
+                .failureCategory(category)
+                .auditStatus(auditStatus)
+                .httpStatusCode(null)
+                .message(detail.getInfo())
+                .exceptionClass(throwable != null ? throwable.getClass().getName() : null)
+                .build();
+    }
 
     /**
      * Retrieves endpoint properties and build the publish-to folder path with that information.

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisher.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisher.java
@@ -231,7 +231,7 @@ public class StaticPublisher extends Publisher {
                         + endpoint.getAddress() + ".  Error: " + e.getMessage();
                 detail.setInfo(error);
                 hasEnvironmentFailed = true;
-                endpointFailureDetail = buildFailureDetail(environment, endpoint, detail, FailureCategory.FILESYSTEM_ERROR, e);
+                endpointFailureDetail = buildStaticFailureDetail(environment, endpoint, detail, FailureCategory.FILESYSTEM_ERROR, e);
                 allFailureDetails.add(endpointFailureDetail);
 
                 Logger.error(this.getClass(), error, e);
@@ -267,28 +267,6 @@ public class StaticPublisher extends Publisher {
 
         return hasEnvironmentFailed;
     } //handleEnvironment.
-
-    private EndpointFailureDetail buildFailureDetail(
-            final Environment environment,
-            final PublishingEndPoint endpoint,
-            final EndpointDetail detail,
-            final FailureCategory category,
-            final Throwable throwable) {
-        final PublishAuditStatus.Status auditStatus =
-                PublishAuditStatus.getStatusObjectByCode(detail.getStatus());
-        return EndpointFailureDetail.builder()
-                .endpointId(endpoint.getId())
-                .endpointName(endpoint.getServerName() != null ? endpoint.getServerName().toString() : null)
-                .address(endpoint.getAddress())
-                .environmentId(environment.getId())
-                .environmentName(environment.getName())
-                .failureCategory(category)
-                .auditStatus(auditStatus)
-                .httpStatusCode(null)
-                .message(detail.getInfo())
-                .exceptionClass(throwable != null ? throwable.getClass().getName() : null)
-                .build();
-    }
 
     /**
      * Retrieves endpoint properties and build the publish-to folder path with that information.

--- a/dotCMS/src/main/java/com/dotcms/publishing/Publisher.java
+++ b/dotCMS/src/main/java/com/dotcms/publishing/Publisher.java
@@ -1,8 +1,13 @@
 package com.dotcms.publishing;
 
 import com.dotcms.enterprise.publishing.staticpublishing.LanguageFolder;
+import com.dotcms.publisher.business.EndpointDetail;
+import com.dotcms.publisher.business.PublishAuditStatus;
 import com.dotcms.publisher.endpoint.bean.PublishingEndPoint;
+import com.dotcms.publisher.environment.bean.Environment;
 import com.dotcms.publisher.pusher.PushUtils;
+import com.dotcms.system.event.local.type.pushpublish.EndpointFailureDetail;
+import com.dotcms.system.event.local.type.pushpublish.FailureCategory;
 import com.dotcms.publishing.output.BundleOutput;
 import com.dotcms.publishing.output.DirectoryBundleOutput;
 import com.dotmarketing.beans.Host;
@@ -366,5 +371,31 @@ public abstract class Publisher implements IPublisher {
 
     public BundleOutput createBundleOutput() throws IOException {
         return new DirectoryBundleOutput(config);
+    }
+
+    /**
+     * Builds a per-endpoint failure detail for static push-publishing events.
+     * {@code httpStatusCode} is always {@code null} for static publishers (no HTTP call is made).
+     */
+    protected EndpointFailureDetail buildStaticFailureDetail(
+            final Environment environment,
+            final PublishingEndPoint endpoint,
+            final EndpointDetail detail,
+            final FailureCategory category,
+            final Throwable throwable) {
+        final PublishAuditStatus.Status auditStatus =
+                PublishAuditStatus.getStatusObjectByCode(detail.getStatus());
+        return EndpointFailureDetail.builder()
+                .endpointId(endpoint.getId())
+                .endpointName(endpoint.getServerName() != null ? endpoint.getServerName().toString() : null)
+                .address(endpoint.getAddress())
+                .environmentId(environment.getId())
+                .environmentName(environment.getName())
+                .failureCategory(category)
+                .auditStatus(auditStatus)
+                .httpStatusCode(null)
+                .message(detail.getInfo())
+                .exceptionClass(throwable != null ? throwable.getClass().getName() : null)
+                .build();
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/type/pushpublish/FailureCategory.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/type/pushpublish/FailureCategory.java
@@ -35,6 +35,12 @@ public enum FailureCategory {
     /** Bundle could not be built before sending. */
     BUNDLE_ERROR(false),
 
+    /** Filesystem I/O error writing the static bundle to disk (non-retryable). */
+    FILESYSTEM_ERROR(false),
+
+    /** Network or connection error reaching an S3 or similar static endpoint (retryable). */
+    CONNECTION_ERROR(true),
+
     /** Failure could not be classified. */
     UNKNOWN(false);
 

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/type/staticpublish/AllStaticPublishEndpointsFailureEvent.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/type/staticpublish/AllStaticPublishEndpointsFailureEvent.java
@@ -2,19 +2,43 @@ package com.dotcms.system.event.local.type.staticpublish;
 
 import com.dotcms.publisher.business.PublishQueueElement;
 import com.dotcms.system.event.local.type.publish.PublishEvent;
+import com.dotcms.system.event.local.type.pushpublish.EndpointFailureDetail;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 /**
- * Object used to represent an event to be triggered when all endpoints fail during static publishing
+ * Object used to represent an event to be triggered when all endpoints fail during static publishing.
+ *
+ * <p>Optionally carries per-endpoint {@link EndpointFailureDetail} entries so subscribers can
+ * distinguish filesystem and connection failures. Legacy single-arg constructor keeps working;
+ * {@link #getEndpointDetails()} returns an empty list when it is used.</p>
  *
  * @author Oscar Arrieta.
  */
 public class AllStaticPublishEndpointsFailureEvent extends PublishEvent {
 
+    private final List<EndpointFailureDetail> endpointDetails;
+
     public AllStaticPublishEndpointsFailureEvent(List<PublishQueueElement> publishQueueElements) {
+        this(publishQueueElements, Collections.emptyList());
+    }
+
+    public AllStaticPublishEndpointsFailureEvent(List<PublishQueueElement> publishQueueElements,
+                                                 List<EndpointFailureDetail> endpointDetails) {
         super(AllStaticPublishEndpointsFailureEvent.class.getCanonicalName(), publishQueueElements,
                 LocalDateTime.now());
+        this.endpointDetails = endpointDetails != null
+                ? List.copyOf(endpointDetails)
+                : Collections.emptyList();
+    }
+
+    /**
+     * Per-endpoint failure information. Never {@code null}; empty when the legacy
+     * single-argument constructor was used.
+     */
+    public List<EndpointFailureDetail> getEndpointDetails() {
+        return endpointDetails;
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/system/event/local/type/staticpublish/SingleStaticPublishEndpointFailureEvent.java
+++ b/dotCMS/src/main/java/com/dotcms/system/event/local/type/staticpublish/SingleStaticPublishEndpointFailureEvent.java
@@ -2,21 +2,44 @@ package com.dotcms.system.event.local.type.staticpublish;
 
 import com.dotcms.publisher.business.PublishQueueElement;
 import com.dotcms.system.event.local.type.publish.PublishEvent;
+import com.dotcms.system.event.local.type.pushpublish.EndpointFailureDetail;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 
 /**
- * Object used to represent an event to be triggered when an endpoint fails during static publishing
+ * Object used to represent an event to be triggered when an endpoint fails during static publishing.
+ *
+ * <p>Optionally carries per-endpoint {@link EndpointFailureDetail} entries so subscribers can
+ * distinguish filesystem and connection failures. Legacy single-arg constructor keeps working;
+ * {@link #getEndpointDetails()} returns an empty list when it is used.</p>
  *
  * @author Oscar Arrieta.
  */
 public class SingleStaticPublishEndpointFailureEvent extends PublishEvent {
 
-    public SingleStaticPublishEndpointFailureEvent(List<PublishQueueElement> publishQueueElements) {
+    private final List<EndpointFailureDetail> endpointDetails;
 
+    public SingleStaticPublishEndpointFailureEvent(List<PublishQueueElement> publishQueueElements) {
+        this(publishQueueElements, Collections.emptyList());
+    }
+
+    public SingleStaticPublishEndpointFailureEvent(List<PublishQueueElement> publishQueueElements,
+                                                   List<EndpointFailureDetail> endpointDetails) {
         super(SingleStaticPublishEndpointFailureEvent.class.getCanonicalName(), publishQueueElements,
                 LocalDateTime.now());
+        this.endpointDetails = endpointDetails != null
+                ? List.copyOf(endpointDetails)
+                : Collections.emptyList();
+    }
+
+    /**
+     * Per-endpoint failure information. Never {@code null}; empty when the legacy
+     * single-argument constructor was used.
+     */
+    public List<EndpointFailureDetail> getEndpointDetails() {
+        return endpointDetails;
     }
 
 }

--- a/dotCMS/src/test/java/com/dotcms/system/event/local/type/staticpublish/StaticPublishFailureEventsTest.java
+++ b/dotCMS/src/test/java/com/dotcms/system/event/local/type/staticpublish/StaticPublishFailureEventsTest.java
@@ -1,0 +1,132 @@
+package com.dotcms.system.event.local.type.staticpublish;
+
+import com.dotcms.publisher.business.PublishQueueElement;
+import com.dotcms.system.event.local.type.pushpublish.EndpointFailureDetail;
+import com.dotcms.system.event.local.type.pushpublish.FailureCategory;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Backward-compatibility and enrichment tests for the static-publish failure event classes.
+ *
+ * <p>Mirrors {@code PushPublishFailureEventsTest} for the static-publishing variants.</p>
+ */
+public class StaticPublishFailureEventsTest {
+
+    private static EndpointFailureDetail sampleDetail(final FailureCategory category) {
+        return EndpointFailureDetail.builder()
+                .endpointId("ep-1")
+                .endpointName("server-a")
+                .environmentId("env-1")
+                .failureCategory(category)
+                .message("error")
+                .build();
+    }
+
+    // ── AllStaticPublishEndpointsFailureEvent ──────────────────────────────────
+
+    @Test
+    public void allFailureEvent_legacyConstructor_returnsEmptyEndpointDetails() {
+        final AllStaticPublishEndpointsFailureEvent event =
+                new AllStaticPublishEndpointsFailureEvent(Collections.<PublishQueueElement>emptyList());
+        assertNotNull(event.getEndpointDetails());
+        assertTrue(event.getEndpointDetails().isEmpty());
+    }
+
+    @Test
+    public void allFailureEvent_newConstructor_carriesEndpointDetails() {
+        final List<EndpointFailureDetail> details = List.of(
+                sampleDetail(FailureCategory.FILESYSTEM_ERROR),
+                sampleDetail(FailureCategory.CONNECTION_ERROR));
+        final AllStaticPublishEndpointsFailureEvent event =
+                new AllStaticPublishEndpointsFailureEvent(Collections.<PublishQueueElement>emptyList(), details);
+        assertEquals(2, event.getEndpointDetails().size());
+        assertEquals(FailureCategory.FILESYSTEM_ERROR, event.getEndpointDetails().get(0).getFailureCategory());
+        assertEquals(FailureCategory.CONNECTION_ERROR, event.getEndpointDetails().get(1).getFailureCategory());
+    }
+
+    @Test
+    public void allFailureEvent_endpointDetailsList_isUnmodifiable() {
+        final AllStaticPublishEndpointsFailureEvent event = new AllStaticPublishEndpointsFailureEvent(
+                Collections.<PublishQueueElement>emptyList(),
+                List.of(sampleDetail(FailureCategory.FILESYSTEM_ERROR)));
+        try {
+            event.getEndpointDetails().clear();
+            fail("Expected UnsupportedOperationException — endpoint-details list must be immutable");
+        } catch (UnsupportedOperationException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void allFailureEvent_endpointDetailsList_isDefensivelyCopied() {
+        final List<EndpointFailureDetail> source = new ArrayList<>();
+        source.add(sampleDetail(FailureCategory.FILESYSTEM_ERROR));
+        final AllStaticPublishEndpointsFailureEvent event =
+                new AllStaticPublishEndpointsFailureEvent(Collections.<PublishQueueElement>emptyList(), source);
+
+        source.add(sampleDetail(FailureCategory.CONNECTION_ERROR));
+        source.clear();
+
+        assertEquals(1, event.getEndpointDetails().size());
+        assertEquals(FailureCategory.FILESYSTEM_ERROR, event.getEndpointDetails().get(0).getFailureCategory());
+    }
+
+    @Test
+    public void allFailureEvent_nullDetails_areCoercedToEmpty() {
+        final AllStaticPublishEndpointsFailureEvent event =
+                new AllStaticPublishEndpointsFailureEvent(Collections.<PublishQueueElement>emptyList(), null);
+        assertNotNull(event.getEndpointDetails());
+        assertTrue(event.getEndpointDetails().isEmpty());
+    }
+
+    // ── SingleStaticPublishEndpointFailureEvent ────────────────────────────────
+
+    @Test
+    public void singleFailureEvent_legacyConstructor_returnsEmptyEndpointDetails() {
+        final SingleStaticPublishEndpointFailureEvent event =
+                new SingleStaticPublishEndpointFailureEvent(Collections.<PublishQueueElement>emptyList());
+        assertNotNull(event.getEndpointDetails());
+        assertTrue(event.getEndpointDetails().isEmpty());
+    }
+
+    @Test
+    public void singleFailureEvent_newConstructor_carriesEndpointDetails() {
+        final List<EndpointFailureDetail> details = List.of(sampleDetail(FailureCategory.CONNECTION_ERROR));
+        final SingleStaticPublishEndpointFailureEvent event =
+                new SingleStaticPublishEndpointFailureEvent(
+                        Collections.<PublishQueueElement>emptyList(), details);
+        assertEquals(1, event.getEndpointDetails().size());
+        assertEquals(FailureCategory.CONNECTION_ERROR, event.getEndpointDetails().get(0).getFailureCategory());
+    }
+
+    @Test
+    public void singleFailureEvent_nullDetails_areCoercedToEmpty() {
+        final SingleStaticPublishEndpointFailureEvent event =
+                new SingleStaticPublishEndpointFailureEvent(
+                        Collections.<PublishQueueElement>emptyList(), null);
+        assertNotNull(event.getEndpointDetails());
+        assertTrue(event.getEndpointDetails().isEmpty());
+    }
+
+    // ── FailureCategory static-publishing variants ─────────────────────────────
+
+    @Test
+    public void filesystemError_isNotRetryable() {
+        assertFalse(FailureCategory.FILESYSTEM_ERROR.isRetryable());
+    }
+
+    @Test
+    public void connectionError_isRetryable() {
+        assertTrue(FailureCategory.CONNECTION_ERROR.isRetryable());
+    }
+}


### PR DESCRIPTION
## Summary

- Extends `AllStaticPublishEndpointsFailureEvent` and `SingleStaticPublishEndpointFailureEvent` with an optional `List<EndpointFailureDetail>` — one entry per failed endpoint — mirroring the pattern applied to dynamic PP in #35765 (issue #34356).
- `AWSS3Publisher` now fires all four static publish events (`AllStaticPublishEndpointsSuccessEvent`, `AllStaticPublishEndpointsFailureEvent`, `SingleStaticPublishEndpointSuccessEvent`, `SingleStaticPublishEndpointFailureEvent`); it previously emitted none, making S3 static publishing invisible to event subscribers.
- Adds `FILESYSTEM_ERROR` (non-retryable) and `CONNECTION_ERROR` (retryable) to `FailureCategory` for static-publishing failure classification.
- Legacy single-arg constructors preserved; `getEndpointDetails()` returns an empty immutable list when they are used — no breaking change for existing subscribers.

## Changes

| File | Change |
|------|--------|
| `AllStaticPublishEndpointsFailureEvent` | Overloaded constructor + `getEndpointDetails()` |
| `SingleStaticPublishEndpointFailureEvent` | Overloaded constructor + `getEndpointDetails()` |
| `FailureCategory` | Add `FILESYSTEM_ERROR`, `CONNECTION_ERROR` |
| `StaticPublisher` | `buildFailureDetail()` helper; enrich per-endpoint and process-level events |
| `AWSS3Publisher` | Inject `LocalSystemEventsAPI`; `buildFailureDetail()` helper; fire all four static events |
| `StaticPublishFailureEventsTest` *(new)* | 10 unit tests covering backward-compat, immutability, defensive copy, null coercion, retryability |

## Test plan

- [x] `StaticPublishFailureEventsTest` — 10 tests, all pass
- [x] `PushPublishFailureEventsTest` — 7 existing tests, no regressions
- [ ] Manual: trigger a static publish failure and verify `AllStaticPublishEndpointsFailureEvent` subscriber receives endpoint details
- [ ] Manual: trigger an S3 static publish and verify events are now emitted

Closes #35883

🤖 Generated with [Claude Code](https://claude.com/claude-code)