### PR TITLE
fix(cache): harden lettuce Redis cache — cluster-scope, cache-stats, and codec defects (#36035)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/DotObjectCodec.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/DotObjectCodec.java
@@ -6,7 +6,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import com.dotmarketing.exception.DotRuntimeException;
+import java.nio.charset.StandardCharsets;
 import io.lettuce.core.codec.RedisCodec;
 
 /**
@@ -17,7 +17,7 @@ import io.lettuce.core.codec.RedisCodec;
  */
 public class DotObjectCodec<K,V> implements RedisCodec<K, V> {
 
-    private final Charset charset = Charset.forName("UTF-8");
+    private final Charset charset = StandardCharsets.UTF_8;
 
     @Override
     public K decodeKey(final ByteBuffer bytes) {
@@ -28,11 +28,18 @@ public class DotObjectCodec<K,V> implements RedisCodec<K, V> {
     @Override
     public V decodeValue(final ByteBuffer bytes) {
 
-        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.array()))){
-        
-            final Object o = in.readObject();
-            return  (V)o;
-        } catch(Exception e) {
+        try {
+            // copy exactly the readable region: bytes.array() ignores position/limit/arrayOffset and can
+            // read stale bytes when the buffer is a slice. (null buffer -> NPE -> DecodeException, as before.)
+            final byte[] data = new byte[bytes.remaining()];
+            bytes.get(data);
+
+            try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(data))) {
+
+                final Object o = in.readObject();
+                return (V) o;
+            }
+        } catch (Exception e) {
 
             throw new DecodeException(e);
         }

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
@@ -935,6 +935,12 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
 
         // Cache invalidation must not throw into callers (matches the other CacheProviders); a mid-scan
         // connection failure is logged and swallowed rather than propagated through remove()/removeAll().
+        //
+        // NOTE: a single pooled connection is held for the whole SCAN+UNLINK iteration. For a very large
+        // match (e.g. removeAll() over millions of keys) this occupies one pool slot for the duration. We
+        // deliberately do NOT release/reborrow between batches: under master-replica a SCAN cursor is bound
+        // to the node it started on and is not portable across connections/nodes. removeAll() is a rare
+        // full-flush operation and the default pool leaves other slots free for concurrent get/put/stats.
         try (StatefulRedisConnection<String, V> conn = this.getConn()) {
 
             if (this.isOpen(conn)) {

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
@@ -913,12 +913,16 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
 
         if (this.channelReferenceMap.containsKey(channel)) {
 
-            final List<String> channelUUIDList = channelReferenceMap.get(channel);
+            final List<String> channelUUIDList =
+                    channelReferenceMap.getOrDefault(channel, Collections.emptyList());
             for (final String channelUUID : channelUUIDList) {
                 final Tuple2<DotPubSubListener, StatefulRedisPubSubConnection<String, V>> channelRedisPubSubAsyncCommandsTuple =
                         channelStatefulRedisPubSubConnectionMap.get(channelUUID);
 
-                subscribers.add(channelRedisPubSubAsyncCommandsTuple._1());
+                // can be null if a concurrent unsubscribe removed the entry between the list snapshot and lookup
+                if (null != channelRedisPubSubAsyncCommandsTuple) {
+                    subscribers.add(channelRedisPubSubAsyncCommandsTuple._1());
+                }
             }
         }
 
@@ -935,32 +939,44 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
 
         // Cache invalidation must not throw into callers (matches the other CacheProviders); a mid-scan
         // connection failure is logged and swallowed rather than propagated through remove()/removeAll().
-        //
-        // NOTE: a single pooled connection is held for the whole SCAN+UNLINK iteration. For a very large
-        // match (e.g. removeAll() over millions of keys) this occupies one pool slot for the duration. We
-        // deliberately do NOT release/reborrow between batches: under master-replica a SCAN cursor is bound
-        // to the node it started on and is not portable across connections/nodes. removeAll() is a rare
-        // full-flush operation and the default pool leaves other slots free for concurrent get/put/stats.
         try (StatefulRedisConnection<String, V> conn = this.getConn()) {
 
             if (this.isOpen(conn)) {
 
-                // SCAN + UNLINK instead of a Lua KEYS+DEL: cluster-scoped (keyPrefix), non-blocking on the
-                // server, immune to the empty-match `del()` error, and not vulnerable to Lua string injection
-                final RedisCommands<String, V> syncCommand = conn.sync();
-                final ScanArgs scanArgs = ScanArgs.Builder
-                        .matches(this.keyPrefix() + pattern).limit(DELETE_SCAN_BATCH_SIZE);
-                KeyScanCursor<String> scanCursor = null;
-                do {
-                    scanCursor = scanCursor == null
-                            ? syncCommand.scan(scanArgs)
-                            : syncCommand.scan(scanCursor, scanArgs);
+                // SCAN is a read command. Under master-replica with REPLICA_PREFERRED it would run against a
+                // replica while UNLINK (a write) runs against the master, so keys on the master that have not
+                // yet replicated would be missed and survive the delete. Pin reads to the upstream (master) for
+                // this borrowed connection so SCAN and UNLINK target the same node, then restore the pool's
+                // default read routing before the connection goes back to the pool.
+                final boolean masterReplica = conn instanceof StatefulRedisMasterReplicaConnection;
+                if (masterReplica) {
+                    ((StatefulRedisMasterReplicaConnection) conn).setReadFrom(ReadFrom.UPSTREAM);
+                }
 
-                    final List<String> keys = scanCursor.getKeys();
-                    if (!keys.isEmpty()) {
-                        syncCommand.unlink(keys.toArray(new String[0]));
+                try {
+                    // SCAN + UNLINK instead of a Lua KEYS+DEL: cluster-scoped (keyPrefix), non-blocking on the
+                    // server, immune to the empty-match `del()` error, and not vulnerable to Lua string injection.
+                    // A single pooled connection is held for the whole iteration; removeAll() is a rare full
+                    // flush and the default pool leaves other slots free for concurrent get/put/stats.
+                    final RedisCommands<String, V> syncCommand = conn.sync();
+                    final ScanArgs scanArgs = ScanArgs.Builder
+                            .matches(this.keyPrefix() + pattern).limit(DELETE_SCAN_BATCH_SIZE);
+                    KeyScanCursor<String> scanCursor = null;
+                    do {
+                        scanCursor = scanCursor == null
+                                ? syncCommand.scan(scanArgs)
+                                : syncCommand.scan(scanCursor, scanArgs);
+
+                        final List<String> keys = scanCursor.getKeys();
+                        if (!keys.isEmpty()) {
+                            syncCommand.unlink(keys.toArray(new String[0]));
+                        }
+                    } while (!scanCursor.isFinished());
+                } finally {
+                    if (masterReplica) {
+                        ((StatefulRedisMasterReplicaConnection) conn).setReadFrom(ReadFrom.REPLICA_PREFERRED);
                     }
-                } while (!scanCursor.isFinished());
+                }
             }
         } catch (final Exception e) {
             Logger.warnAndDebug(MasterReplicaLettuceClient.class,

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -59,7 +60,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static com.liferay.util.StringPool.BLANK;
-import static io.lettuce.core.ScriptOutputType.STATUS;
 
 /**
  * Master replica implementation of redis cache. It works as a replicator when there is more than 1 URIs as part of the
@@ -90,6 +90,7 @@ import static io.lettuce.core.ScriptOutputType.STATUS;
  * @param <V> The Class representing the value stored in Redis. Usually an Object.
  * @author jsanca
  */
+@SuppressWarnings("deprecation") // implements deprecated (but retained) RedisClient methods
 public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
 
     public static final String REDIS_SESSION_ENABLED_PROP = "TOMCAT_REDIS_SESSION_ENABLED";
@@ -103,6 +104,7 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
 
     private static final String OK_RESPONSE = "OK";
     private static final String ERROR_RESPONSE = "ERROR";
+    private static final int DELETE_SCAN_BATCH_SIZE = 1000;
 
     private final List<RedisURI> redisUris = this.createRedisConnection();
     private final GenericObjectPool<StatefulRedisConnection<String, V>> pool;
@@ -209,7 +211,10 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
      */
     protected K unwrapKey(final String key) {
 
-        return  this.stringToKeyConverter.convert(key.replace(keyPrefix(), BLANK));
+        // strip only the leading cluster prefix; replace() would remove the prefix substring anywhere it occurs
+        final String prefix = keyPrefix();
+        final String unwrapped = key.startsWith(prefix) ? key.substring(prefix.length()) : key;
+        return this.stringToKeyConverter.convert(unwrapped);
     }
     /**
      * Returns a StatefulRedisConnection
@@ -342,8 +347,12 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
 
             if (this.isOpen(conn)) {
 
-                conn.sync().set(this.wrapKey(key), value,
-                        SetArgs.Builder.px(ttlMillis));
+                // px(-1) is an invalid Redis expire time; -1 means "persist without ttl"
+                if (ttlMillis == -1) {
+                    conn.sync().set(this.wrapKey(key), value);
+                } else {
+                    conn.sync().set(this.wrapKey(key), value, SetArgs.Builder.px(ttlMillis));
+                }
             }
         }
     }
@@ -511,7 +520,8 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
         try (StatefulRedisConnection<String,V> conn = this.getConn()) {
 
             if (this.isOpen(conn)) {
-                return conn.sync().del(ConversionUtils.INSTANCE.convertToArray(this.keyToStringConverter, String.class, keys));
+                // must wrap with the cluster prefix (like deleteNonBlocking) or stored keys never match
+                return conn.sync().del(ConversionUtils.INSTANCE.convertToArray(this::wrapKey, String.class, keys));
             }
         }
 
@@ -796,7 +806,11 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
                     Tuple.of(dotPubSubListener, conn);
 
             this.channelStatefulRedisPubSubConnectionMap.put(channelUUID, channelRedisPubSubAsyncCommandsTuple);
-            this.channelReferenceMap.computeIfAbsent(channel, key -> new ArrayList<>()).add(channelUUID);
+            // CopyOnWriteArrayList so concurrent subscribe/unsubscribe/getSubscribers don't race the plain list
+            this.channelReferenceMap.computeIfAbsent(channel, key -> new CopyOnWriteArrayList<>()).add(channelUUID);
+        } else if (null != conn) {
+            // avoid leaking the pub/sub connection when it could not be opened
+            Try.run(conn::close).onFailure(e -> Logger.debug(this, e.getMessage()));
         }
     }
 
@@ -919,12 +933,26 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
     @Override
     public void deleteFromPattern(final String pattern) {
 
-        try (StatefulRedisConnection<String,V> conn = this.getConn()) {
+        try (StatefulRedisConnection<String, V> conn = this.getConn()) {
 
             if (this.isOpen(conn)) {
 
-                conn.async().eval("return redis.call('del', unpack(redis.call('keys', '" + pattern + "')))",
-                        STATUS, new String[0]);
+                // SCAN + UNLINK instead of a Lua KEYS+DEL: cluster-scoped (keyPrefix), non-blocking on the
+                // server, immune to the empty-match `del()` error, and not vulnerable to Lua string injection
+                final RedisCommands<String, V> syncCommand = conn.sync();
+                final ScanArgs scanArgs = ScanArgs.Builder
+                        .matches(this.keyPrefix() + pattern).limit(DELETE_SCAN_BATCH_SIZE);
+                KeyScanCursor<String> scanCursor = null;
+                do {
+                    scanCursor = scanCursor == null
+                            ? syncCommand.scan(scanArgs)
+                            : syncCommand.scan(scanCursor, scanArgs);
+
+                    final List<String> keys = scanCursor.getKeys();
+                    if (!keys.isEmpty()) {
+                        syncCommand.unlink(keys.toArray(new String[0]));
+                    }
+                } while (!scanCursor.isFinished());
             }
         }
     }

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
@@ -976,6 +976,10 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
                             deleted += keys.size();
                         }
                     } while (!scanCursor.isFinished());
+
+                    final long removed = deleted;
+                    Logger.debug(MasterReplicaLettuceClient.class,
+                            () -> "deleteFromPattern '" + pattern + "' removed " + removed + " keys");
                 } finally {
                     if (masterReplica) {
                         ((StatefulRedisMasterReplicaConnection<String, V>) conn).setReadFrom(ReadFrom.REPLICA_PREFERRED);
@@ -1112,7 +1116,13 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
                 return defaultValue;
             }
         }
-        return Integer.parseInt(value);
+        final String numeric = value;
+        // tolerate a misconfigured (non-numeric) value instead of throwing NumberFormatException at startup
+        return Try.of(() -> Integer.parseInt(numeric.trim()))
+                .onFailure(e -> Logger.warn(MasterReplicaLettuceClient.class,
+                        "Non-numeric value '" + numeric + "' for '" + key + "'/'" + defaultKey
+                                + "', using default " + defaultValue))
+                .getOrElse(defaultValue);
     }
 
 }

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
@@ -861,7 +861,7 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
 
             if (successUnSubscription) {
                 channelUUIDList.remove(subscriberId);
-                if (channelUUIDList.size() == 0) {
+                if (channelUUIDList.isEmpty()) {
 
                     this.channelReferenceMap.remove(channel);
                 }
@@ -950,7 +950,7 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
                 // default read routing before the connection goes back to the pool.
                 final boolean masterReplica = conn instanceof StatefulRedisMasterReplicaConnection;
                 if (masterReplica) {
-                    ((StatefulRedisMasterReplicaConnection) conn).setReadFrom(ReadFrom.UPSTREAM);
+                    ((StatefulRedisMasterReplicaConnection<String, V>) conn).setReadFrom(ReadFrom.UPSTREAM);
                 }
 
                 try {
@@ -974,7 +974,7 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
                     } while (!scanCursor.isFinished());
                 } finally {
                     if (masterReplica) {
-                        ((StatefulRedisMasterReplicaConnection) conn).setReadFrom(ReadFrom.REPLICA_PREFERRED);
+                        ((StatefulRedisMasterReplicaConnection<String, V>) conn).setReadFrom(ReadFrom.REPLICA_PREFERRED);
                     }
                 }
             }

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
@@ -939,6 +939,9 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
 
         // Cache invalidation must not throw into callers (matches the other CacheProviders); a mid-scan
         // connection failure is logged and swallowed rather than propagated through remove()/removeAll().
+        // Track keys removed so a partial flush (e.g. a per-batch RedisCommandTimeoutException mid-iteration)
+        // is visible in the log instead of looking like a clean completion.
+        long deleted = 0;
         try (StatefulRedisConnection<String, V> conn = this.getConn()) {
 
             if (this.isOpen(conn)) {
@@ -970,6 +973,7 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
                         final List<String> keys = scanCursor.getKeys();
                         if (!keys.isEmpty()) {
                             syncCommand.unlink(keys.toArray(new String[0]));
+                            deleted += keys.size();
                         }
                     } while (!scanCursor.isFinished());
                 } finally {
@@ -980,7 +984,8 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
             }
         } catch (final Exception e) {
             Logger.warnAndDebug(MasterReplicaLettuceClient.class,
-                    "Unable to delete Redis keys for pattern '" + pattern + "': " + e.getMessage(), e);
+                    "Partial Redis delete for pattern '" + pattern + "' (" + deleted
+                            + " keys removed before failure): " + e.getMessage(), e);
         }
     }
 
@@ -1063,7 +1068,7 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
                                             codec,
                                             redisUris);
 
-                    ((StatefulRedisMasterReplicaConnection) connection).setReadFrom(ReadFrom.REPLICA_PREFERRED);
+                    ((StatefulRedisMasterReplicaConnection<String, V>) connection).setReadFrom(ReadFrom.REPLICA_PREFERRED);
                     if (timeout > 0) {
                         connection.setTimeout(Duration.ofMillis(timeout));
                     }

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/MasterReplicaLettuceClient.java
@@ -933,6 +933,8 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
     @Override
     public void deleteFromPattern(final String pattern) {
 
+        // Cache invalidation must not throw into callers (matches the other CacheProviders); a mid-scan
+        // connection failure is logged and swallowed rather than propagated through remove()/removeAll().
         try (StatefulRedisConnection<String, V> conn = this.getConn()) {
 
             if (this.isOpen(conn)) {
@@ -954,6 +956,9 @@ public class MasterReplicaLettuceClient<K, V> implements RedisClient<K, V> {
                     }
                 } while (!scanCursor.isFinished());
             }
+        } catch (final Exception e) {
+            Logger.warnAndDebug(MasterReplicaLettuceClient.class,
+                    "Unable to delete Redis keys for pattern '" + pattern + "': " + e.getMessage(), e);
         }
     }
 

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/NullLettuceClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/NullLettuceClient.java
@@ -1,13 +1,20 @@
 package com.dotcms.cache.lettuce;
 
 import io.lettuce.core.api.StatefulConnection;
+import org.apache.commons.lang3.concurrent.ConcurrentUtils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
+/**
+ * Null Object implementation of {@link RedisClient}: every operation is a no-op that returns a safe,
+ * non-null default. Used when Redis is unavailable/disabled so callers never NPE on Futures or collections.
+ */
+@SuppressWarnings("deprecation") // implements deprecated (but retained) RedisClient methods
 public class NullLettuceClient<K, V> implements RedisClient {
 
     @Override
@@ -32,7 +39,7 @@ public class NullLettuceClient<K, V> implements RedisClient {
 
     @Override
     public SetResult set(Object key, Object value) {
-        return null;
+        return SetResult.NO_CONN;
     }
 
     @Override
@@ -42,12 +49,12 @@ public class NullLettuceClient<K, V> implements RedisClient {
 
     @Override
     public Future<String> setAsync(Object key, Object value) {
-        return null;
+        return ConcurrentUtils.constantFuture("ERROR");
     }
 
     @Override
     public Future<String> setAsync(Object key, Object value, long ttlMillis) {
-        return null;
+        return ConcurrentUtils.constantFuture("ERROR");
     }
 
     @Override
@@ -57,12 +64,12 @@ public class NullLettuceClient<K, V> implements RedisClient {
 
     @Override
     public Future<Long> addAsyncMembers(Object key, Object... values) {
-        return null;
+        return ConcurrentUtils.constantFuture(0L);
     }
 
     @Override
     public SetResult setIfAbsent(Object key, Object value) {
-        return null;
+        return SetResult.NO_CONN;
     }
 
     @Override
@@ -77,7 +84,7 @@ public class NullLettuceClient<K, V> implements RedisClient {
 
     @Override
     public Set getMembers(Object key) {
-        return null;
+        return Collections.emptySet();
     }
 
     @Override
@@ -97,7 +104,7 @@ public class NullLettuceClient<K, V> implements RedisClient {
 
     @Override
     public Future<Long> deleteNonBlocking(Object... keys) {
-        return null;
+        return ConcurrentUtils.constantFuture(0L);
     }
 
     @Override
@@ -117,27 +124,27 @@ public class NullLettuceClient<K, V> implements RedisClient {
 
     @Override
     public Map getHash(Object key) {
-        return null;
+        return Collections.emptyMap();
     }
 
     @Override
     public Set fieldsHash(Object key) {
-        return null;
+        return Collections.emptySet();
     }
 
     @Override
     public List<Map.Entry> getHash(Object key, Object... fields) {
-        return null;
+        return Collections.emptyList();
     }
 
     @Override
     public SetResult setHash(Object key, Map map) {
-        return null;
+        return SetResult.NO_CONN;
     }
 
     @Override
     public SetResult setHash(Object key, Object field, Object value) {
-        return null;
+        return SetResult.NO_CONN;
     }
 
     @Override
@@ -157,12 +164,12 @@ public class NullLettuceClient<K, V> implements RedisClient {
 
     @Override
     public Future<Long> incrementOneAsync(Object key) {
-        return null;
+        return ConcurrentUtils.constantFuture(-1L);
     }
 
     @Override
     public Future<Long> incrementAsync(Object key, long amount) {
-        return null;
+        return ConcurrentUtils.constantFuture(-1L);
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisCache.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisCache.java
@@ -19,6 +19,7 @@ import java.text.NumberFormat;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -307,7 +308,8 @@ public class RedisCache extends CacheProvider {
     public Set<String> getGroups() {
 
         return this.getClient().getMembers(REDIS_GROUP_KEY).stream()
-                .map(k -> k.toString()).collect(Collectors.toSet());
+                .filter(Objects::nonNull)
+                .map(Object::toString).collect(Collectors.toSet());
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisCache.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisCache.java
@@ -250,6 +250,9 @@ public class RedisCache extends CacheProvider {
         // cluster-scoped by deleteFromPattern (keyPrefix); no leading "*" so we never touch other clusters' keys
         final String pattern = this.REDIS_PREFIX_KEY + "." + StringPool.STAR;
         this.getClient().deleteFromPattern(pattern);
+        // also clear the group registry SET; otherwise getGroups() (and getStats()) keep returning every group
+        // ever used after a full flush, growing unbounded and making stats do O(groups) pooled SCANs
+        this.getClient().deleteNonBlocking(REDIS_GROUP_KEY);
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisCache.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisCache.java
@@ -10,8 +10,6 @@ import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.annotations.VisibleForTesting;
 import com.liferay.util.StringPool;
-import io.lettuce.core.ScriptOutputType;
-import io.lettuce.core.api.StatefulRedisConnection;
 import io.vavr.Lazy;
 import io.vavr.control.Try;
 
@@ -46,8 +44,6 @@ import java.util.stream.Collectors;
 public class RedisCache extends CacheProvider {
 
     private static final long serialVersionUID = -855583393078878276L;
-
-    private static final Long ZERO = 0L;
 
     protected final String REDIS_GROUP_KEY;
     protected final String REDIS_PREFIX_KEY;
@@ -206,8 +202,7 @@ public class RedisCache extends CacheProvider {
     }
 
     private Object extractObject(final Object o) {
-        return o != null && o instanceof DotCloneable ?
-                this.extractObject(DotCloneable.class.cast(o)) : o;
+        return o instanceof DotCloneable cloneable ? this.extractObject(cloneable) : o;
     }
 
     private Object extractObject(final DotCloneable o) {
@@ -291,29 +286,20 @@ public class RedisCache extends CacheProvider {
 
         // Never throw: getStats() aggregates per-provider and a thrown exception here makes
         // CacheProviderAPIImpl.getStats() drop the entire Redis provider from the cache stats screen.
+        // Use the cluster-scoped, non-blocking SCAN (via scanKeys) rather than a blocking Lua KEYS eval;
+        // this also avoids the MasterReplicaLettuceClient downcast and any Lua string injection.
+        final long[] count = {0};
         try {
-            final RedisClient<String, Object> redisClient = this.getClient();
-            final String prefix = LettuceAdapter.getMasterReplicaLettuceClient(redisClient)
-                    .wrapKey(this.cacheKey(group) + StringPool.STAR);
-            final String script = "return #redis.pcall('keys', '" + prefix + "')";
-
-            try (StatefulRedisConnection<String, Object> conn =
-                         LettuceAdapter.getStatefulRedisConnection(redisClient)) {
-
-                // conn can be null when the pool fails to borrow a connection
-                if (null != conn && conn.isOpen()) {
-
-                    final Object keyCount = conn.sync().eval(script, ScriptOutputType.INTEGER, "0");
-                    return keyCount instanceof Long ? (Long) keyCount : ZERO;
-                }
-            }
+            final String matchesPattern = this.cacheKey(group) + StringPool.STAR;
+            this.getClient().scanKeys(matchesPattern, this.keyBatchingSize,
+                    keys -> count[0] += keys.size());
         } catch (final Exception e) {
 
             Logger.warnAndDebug(RedisCache.class,
                     "Unable to count Redis keys for group '" + group + "': " + e.getMessage(), e);
         }
 
-        return ZERO;
+        return count[0];
     }
 
 

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisCache.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisCache.java
@@ -18,7 +18,7 @@ import io.vavr.control.Try;
 import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.LinkedHashMap;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -229,19 +229,6 @@ public class RedisCache extends CacheProvider {
         }
     }
 
-    /**
-     * removes cache keys async and resets the get timer that reenables get functions
-     *
-     * @param keys
-     */
-    private void removeKeysRaw(final String... keys) {
-
-        if (UtilMethods.isSet(keys)) {
-
-            this.getClient().deleteNonBlocking(keys);
-        }
-    }
-
     @Override
     public void remove(final String group, final String key) {
 
@@ -254,21 +241,19 @@ public class RedisCache extends CacheProvider {
 
         if (!UtilMethods.isEmpty(group)) {
 
-            // todo: this should be a wildcard deletion instead of keys scan
-
-            final String prefix =  StringPool.STAR + cacheKey(group) + StringPool.STAR;
-            // Getting all the keys for the given groups
-            /*DotConcurrentFactory.getInstance().getSingleSubmitter
-                    (CacheWiper.class.getSimpleName()).submit(new CacheWiper(prefix));*/
-            this.getClient().deleteFromPattern(prefix);
+            // No leading "*": deleteFromPattern prepends the cluster prefix so the scan stays scoped to THIS
+            // client's keys. A leading "*" would match (and delete) other clusters' keys in a shared Redis space.
+            final String pattern = cacheKey(group) + StringPool.STAR;
+            this.getClient().deleteFromPattern(pattern);
         }
     }
 
     @Override
     public void removeAll() {
 
-        final String prefix = StringPool.STAR + this.REDIS_PREFIX_KEY + "." + StringPool.STAR;
-        this.getClient().deleteFromPattern(prefix);
+        // cluster-scoped by deleteFromPattern (keyPrefix); no leading "*" so we never touch other clusters' keys
+        final String pattern = this.REDIS_PREFIX_KEY + "." + StringPool.STAR;
+        this.getClient().deleteFromPattern(pattern);
     }
 
     @Override
@@ -277,9 +262,13 @@ public class RedisCache extends CacheProvider {
         final String prefix = this.cacheKey(group);
         final String matchesPattern = prefix + StringPool.STAR;
         final Set<String> keys = new LinkedHashSet<>();
-        this.getClient().scanKeys(matchesPattern, this.keyBatchingSize, //keys::addAll);
-                redisKeys -> redisKeys.stream().map(redisKey ->  // we remove the prefix in order to have the real key
-                        redisKey.replace(prefix, StringPool.BLANK)).forEach(keys::add));
+        this.getClient().scanKeys(matchesPattern, this.keyBatchingSize,
+                redisKeys -> redisKeys.stream()
+                        // strip only the leading group prefix to recover the real key (replace() is global)
+                        .map(redisKey -> redisKey.startsWith(prefix)
+                                ? redisKey.substring(prefix.length())
+                                : redisKey)
+                        .forEach(keys::add));
 
         return keys;
     }
@@ -300,21 +289,31 @@ public class RedisCache extends CacheProvider {
      */
     private long keyCount(final String group) {
 
-        final String prefix = LettuceAdapter.getMasterReplicaLettuceClient(this.getClient())
-                .wrapKey(this.cacheKey(group) + StringPool.STAR);
-        final String script = "return #redis.pcall('keys', '" + prefix + "')";
-        Object keyCount = ZERO;
+        // Never throw: getStats() aggregates per-provider and a thrown exception here makes
+        // CacheProviderAPIImpl.getStats() drop the entire Redis provider from the cache stats screen.
+        try {
+            final RedisClient<String, Object> redisClient = this.getClient();
+            final String prefix = LettuceAdapter.getMasterReplicaLettuceClient(redisClient)
+                    .wrapKey(this.cacheKey(group) + StringPool.STAR);
+            final String script = "return #redis.pcall('keys', '" + prefix + "')";
 
-        try (StatefulRedisConnection<String, Object> conn = LettuceAdapter.getStatefulRedisConnection(
-                this.getClient())) {
+            try (StatefulRedisConnection<String, Object> conn =
+                         LettuceAdapter.getStatefulRedisConnection(redisClient)) {
 
-            if (conn.isOpen()) {
+                // conn can be null when the pool fails to borrow a connection
+                if (null != conn && conn.isOpen()) {
 
-                keyCount = conn.sync().eval(script, ScriptOutputType.INTEGER, "0");
+                    final Object keyCount = conn.sync().eval(script, ScriptOutputType.INTEGER, "0");
+                    return keyCount instanceof Long ? (Long) keyCount : ZERO;
+                }
             }
+        } catch (final Exception e) {
+
+            Logger.warnAndDebug(RedisCache.class,
+                    "Unable to count Redis keys for group '" + group + "': " + e.getMessage(), e);
         }
 
-        return (Long) keyCount;
+        return ZERO;
     }
 
 
@@ -330,33 +329,17 @@ public class RedisCache extends CacheProvider {
 
         final CacheStats providerStats = new CacheStats();
         final CacheProviderStats cacheProviderStats = new CacheProviderStats(providerStats, getName());
-        String memoryStats = null;
-
-        try (StatefulRedisConnection<String, Object> conn =
-                     LettuceAdapter.getStatefulRedisConnection(this.getClient())) {
-
-            if (!conn.isOpen()) {
-
-                return cacheProviderStats;
-            }
-
-            memoryStats = conn.sync().info();
-        }
-
-        // Read the total memory usage
-        final Map<String, String> redis = getRedisProperties(memoryStats);
-
-        for (final Map.Entry<String, String> entry : redis.entrySet()) {
-
-            final CacheStats stats = new CacheStats();
-            stats.addStat(CacheStats.REGION, "redis: " + entry.getKey());
-            stats.addStat(CacheStats.REGION_SIZE, entry.getValue());
-            // ret.addStatRecord(stats);
-        }
 
         final NumberFormat nf = DecimalFormat.getInstance();
-        // Getting the list of groups
-        final Set<String> currentGroups = getGroups();
+        // Getting the list of groups. Guard against a throw: CacheProviderAPIImpl.getStats() drops the whole
+        // provider from the cache stats screen if getStats() throws, so the Redis region would vanish entirely.
+        Set<String> currentGroups;
+        try {
+            currentGroups = getGroups();
+        } catch (final Exception e) {
+            Logger.warnAndDebug(RedisCache.class, "Unable to list Redis groups: " + e.getMessage(), e);
+            currentGroups = Collections.emptySet();
+        }
 
         for (final String group : currentGroups) {
 
@@ -364,6 +347,16 @@ public class RedisCache extends CacheProvider {
             stats.addStat(CacheStats.REGION, "dotCMS: " + group);
             stats.addStat(CacheStats.REGION_SIZE, nf.format(keyCount(group)));
 
+            cacheProviderStats.addStatRecord(stats);
+        }
+
+        // Always emit at least one record; otherwise the cache stats screen renders an empty/blank table
+        // (no columns, no rows) for this provider. Mirrors CaffineCache's empty-groups fallback.
+        if (currentGroups.isEmpty()) {
+
+            final CacheStats stats = new CacheStats();
+            stats.addStat(CacheStats.REGION, "n/a");
+            stats.addStat(CacheStats.REGION_SIZE, 0);
             cacheProviderStats.addStatRecord(stats);
         }
 
@@ -376,32 +369,5 @@ public class RedisCache extends CacheProvider {
         Logger.info(this.getClass(), "*** Shutdown [" + getName() + "] .");
 
     }
-
-    /**
-     * Reads and parses the string report generated for the INFO Redis command in order to return any specific required
-     * property.
-     *
-     * @param redisReport
-     * @return Map
-     */
-    private Map<String, String> getRedisProperties(final String redisReport) {
-
-        final Map<String, String> map = new LinkedHashMap<>();
-        final String[] readLines = redisReport.split("\r\n");
-
-        for (final String readLine : readLines) {
-
-            final String[] lineValues = readLine.split(":", 2);
-
-            // First check if it is a property or a header
-            if (lineValues.length > 1) {
-
-                map.put(lineValues[0], lineValues[1]);
-            }
-        }
-
-        return map;
-    }
-
 
 }

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClient.java
@@ -364,8 +364,12 @@ public interface RedisClient<K, V> {
     }
 
     /**
-     * Deletes all entries that matches the pattern
-     * @param pattern String
+     * Deletes all entries whose key matches the given glob pattern.
+     * <p><b>Precondition:</b> {@code pattern} must NOT include the cluster key prefix — implementations
+     * prepend it internally (so callers pass a pattern relative to the prefix only). Passing an
+     * already-prefixed pattern would double-prefix and match nothing; omitting the prefix entirely could
+     * match other clusters' keys in a shared Redis space.
+     * @param pattern String glob pattern, relative to (without) the cluster key prefix
      */
     void deleteFromPattern(String pattern);
 }

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClient.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClient.java
@@ -57,6 +57,7 @@ public interface RedisClient<K, V> {
      * @param msg V
      * @return V
      */
+    @Deprecated
     V echo (final V msg);
 
     /**
@@ -99,6 +100,7 @@ public interface RedisClient<K, V> {
      * @param values V
      * @return long
      */
+    @Deprecated
     long addMembers (final K key, final V... values);
 
     /**
@@ -143,6 +145,7 @@ public interface RedisClient<K, V> {
      * @param key K
      * @return long
      */
+    @Deprecated
     long ttlMillis (final K key);
 
     /**
@@ -172,6 +175,7 @@ public interface RedisClient<K, V> {
      * @param keyBatchingSize {@link Integer} how many records do you want to fetch by iteration
      * @param keyConsumer {@link Consumer} consumer for each key
      */
+    @Deprecated
     void scanEachKey(final String matchesPattern, int keyBatchingSize, final Consumer<K> keyConsumer);
 
     /**
@@ -191,6 +195,7 @@ public interface RedisClient<K, V> {
      * @param field  K
      * @return boolean
      */
+    @Deprecated
     boolean existsHash (K key, K field);
 
     /**
@@ -199,6 +204,7 @@ public interface RedisClient<K, V> {
      * @param field K
      * @return V
      */
+    @Deprecated
     V getHash(K key, K field);
 
     /**
@@ -206,6 +212,7 @@ public interface RedisClient<K, V> {
      * @param key K
      * @return Map, field -> value
      */
+    @Deprecated
     Map<K, V> getHash(K key);
 
     /**
@@ -213,6 +220,7 @@ public interface RedisClient<K, V> {
      * @param key K
      * @return Set of K
      */
+    @Deprecated
     Set<K> fieldsHash (K key);
 
     /**
@@ -221,6 +229,7 @@ public interface RedisClient<K, V> {
      * @param fields  Array of K
      * @return List, K -> V
      */
+    @Deprecated
     List<Map.Entry<K, V>> getHash(K key, K... fields);
 
     /**
@@ -229,6 +238,7 @@ public interface RedisClient<K, V> {
      * @param map Map, field -> value
      * @return SetResult
      */
+    @Deprecated
     SetResult setHash(K key, Map<K, V> map);
 
     /**
@@ -238,6 +248,7 @@ public interface RedisClient<K, V> {
      * @param value V
      * @return SetResult
      */
+    @Deprecated
     SetResult setHash(K key, K field, V value);
 
     /**
@@ -246,6 +257,7 @@ public interface RedisClient<K, V> {
      * @param fields Array of K
      * @return long number of fields deleted (-1 if can not delete)
      */
+    @Deprecated
     long deleteHash(final K key, K... fields);
 
     ///// INCR
@@ -255,6 +267,7 @@ public interface RedisClient<K, V> {
      * @param key K
      * @return long current counter (if fail -1)
      */
+    @Deprecated
     long incrementOne(K key);
 
     /**
@@ -270,6 +283,7 @@ public interface RedisClient<K, V> {
      * @param key K
      * @return Future long current counter (if fail -1)
      */
+    @Deprecated
     Future<Long> incrementOneAsync (final K key);
 
     /**
@@ -278,6 +292,7 @@ public interface RedisClient<K, V> {
      * @param amount long
      * @return Future long current counter (if fail -1)
      */
+    @Deprecated
     Future<Long> incrementAsync (final K key, final long amount);
 
     /**
@@ -285,6 +300,7 @@ public interface RedisClient<K, V> {
      * @param key K
      * @return Long -1 if does not exists.
      */
+    @Deprecated
     long getIncrement (final K key);
 
     ////// Streams Pub/Sub

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClientFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClientFactory.java
@@ -24,6 +24,16 @@ public class RedisClientFactory {
         return getOrCreate(name, MasterReplicaLettuceClient::new);
     }
 
+    /**
+     * Returns the named client, creating it with the given codec on first use.
+     * <p><b>Note:</b> the {@code codec} is only applied when this is the first call for {@code name} AND no
+     * {@code LETTUCE_CLIENT_CLASS} override is configured. Clients are cached per name, so a later call with a
+     * different codec for an already-created name returns the existing client and the codec is ignored.
+     *
+     * @param name  the client name (cache key)
+     * @param codec the codec to use when the client is created for the first time
+     * @return the (possibly already-cached) client for {@code name}
+     */
     public static RedisClient<String, Object> getClient(final String name, final RedisCodec<String, Object> codec) {
 
         return getOrCreate(name, () -> new MasterReplicaLettuceClient<>(codec,

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClientFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClientFactory.java
@@ -3,11 +3,13 @@ package com.dotcms.cache.lettuce;
 import com.dotcms.enterprise.cluster.ClusterFactory;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.util.Config;
+import com.dotmarketing.util.Logger;
 import io.lettuce.core.codec.RedisCodec;
 import io.vavr.control.Try;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
 /**
  * Factory to provide clients for redis.
@@ -19,30 +21,18 @@ public class RedisClientFactory {
 
     public static RedisClient<String, Object> getClient(final String name) {
 
-        RedisClient<String, Object> redisClient = clientMap.get(name);
-        if (null == redisClient) {
-
-            synchronized (RedisClientFactory.class) {
-
-                redisClient = clientMap.get(name);
-
-                if (null == redisClient) {
-
-                    final String clazz = Config.getStringProperty("LETTUCE_CLIENT_CLASS",
-                            MasterReplicaLettuceClient.class.getCanonicalName());
-
-                    redisClient = Try.of(() -> (RedisClient) RedisClient.class.forName(clazz).newInstance())
-                            .getOrElse(new MasterReplicaLettuceClient<>());
-                    clientMap.put(name, redisClient);
-                }
-            }
-        }
-
-        return redisClient;
+        return getOrCreate(name, MasterReplicaLettuceClient::new);
     }
 
     public static RedisClient<String, Object> getClient(final String name, final RedisCodec<String, Object> codec) {
 
+        return getOrCreate(name, () -> new MasterReplicaLettuceClient<>(codec,
+                APILocator.getShortyAPI().shortify(ClusterFactory.getClusterId())));
+    }
+
+    private static RedisClient<String, Object> getOrCreate(final String name,
+            final Supplier<RedisClient<String, Object>> defaultClientSupplier) {
+
         RedisClient<String, Object> redisClient = clientMap.get(name);
         if (null == redisClient) {
 
@@ -55,9 +45,13 @@ public class RedisClientFactory {
                     final String clazz = Config.getStringProperty("LETTUCE_CLIENT_CLASS",
                             MasterReplicaLettuceClient.class.getCanonicalName());
 
-                    redisClient = Try.of(() -> (RedisClient) RedisClient.class.forName(clazz).newInstance())
-                            .getOrElse(new MasterReplicaLettuceClient<>(codec,
-                                    APILocator.getShortyAPI().shortify(ClusterFactory.getClusterId())));
+                    redisClient = Try.of(() ->
+                                    (RedisClient<String, Object>) Class.forName(clazz)
+                                            .getDeclaredConstructor().newInstance())
+                            .onFailure(e -> Logger.warnAndDebug(RedisClientFactory.class,
+                                    "Unable to instantiate LETTUCE_CLIENT_CLASS '" + clazz
+                                            + "', falling back to the default client: " + e.getMessage(), e))
+                            .getOrElseGet(e -> defaultClientSupplier.get());
                     clientMap.put(name, redisClient);
                 }
             }

--- a/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClientFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/cache/lettuce/RedisClientFactory.java
@@ -42,6 +42,9 @@ public class RedisClientFactory {
 
                 if (null == redisClient) {
 
+                    // NOTE: when LETTUCE_CLIENT_CLASS is set, the client is built via its no-arg constructor and
+                    // the defaultClientSupplier (including any custom codec) is NOT used. Clients are also cached
+                    // per name, so the first getClient(name, ...) call wins for that name regardless of codec.
                     final String clazz = Config.getStringProperty("LETTUCE_CLIENT_CLASS",
                             MasterReplicaLettuceClient.class.getCanonicalName());
 


### PR DESCRIPTION
Fixes #36035

I had RedisCache set up by default in the a cluster and found:
1) there was no Redis cache reporting in the backend
2) A full cache flush did not work - this is because it was actually trying to run a full flushall on redis without prefixing which our per-tenant namespaces did not allow.  Yea! Redis permissions and isolation worked!



I asked Claudio to fix (and simplify all the unnecessary abstractions) and here is what we got:

----------------------

## What

Hardens the Lettuce Redis cache (`com.dotcms.cache.lettuce`). Bug fixes only — the `RedisClient` interface is kept intact (generics + all methods); genuinely-unused methods are `@Deprecated` rather than removed.

## Fixes

- **Cross-cluster cache wipe (HIGH):** `RedisCache.remove(group)`/`removeAll()` built `*PREFIX*` patterns without the cluster id, matching/deleting other clusters' keys in a shared Redis space. `deleteFromPattern` now prepends `keyPrefix()` (consistent with `scanKeys`/`keyCount`); callers pass un-anchored patterns.
- **`deleteFromPattern` (HIGH):** replaced the Lua `KEYS`+`DEL` eval (blocking `KEYS`, errors on empty match, Lua-injectable) with `SCAN` + `UNLINK`.
- **Cache-stats region missing/blank (HIGH):** `getStats()`/`keyCount()` could throw on a null pooled connection; `CacheProviderAPIImpl.getStats()` drops any provider whose `getStats()` throws, so the Redis region vanished from the cache-stats screen. Both are now exception-proof, plus a `CaffineCache`-style empty-groups "n/a" fallback row.
- **`delete(K...)` (MED):** used `keyToStringConverter` instead of `wrapKey`, so it never matched stored keys. Now wraps like `deleteNonBlocking`.
- **Pub/sub (MED):** fixed connection leak when the connection can't be opened; subscriber lists are now `CopyOnWriteArrayList` for safe concurrent subscribe/unsubscribe.
- **Misc:** `DotObjectCodec.decodeValue` now reads `remaining()` into a copy instead of `bytes.array()` (which ignores position/limit/offset); `Charset.forName` → `StandardCharsets.UTF_8`; `unwrapKey`/`getKeys` strip only the leading prefix; sync `set(k,v,ttl)` guards `ttl == -1`; `RedisClientFactory` de-duplicated, `getDeclaredConstructor().newInstance()`, logs reflection failures; removed duplicate `removeKeysRaw` and the dead `getStats` INFO/`getRedisProperties` block; `NullLettuceClient` returns safe non-null defaults.

## Behavior notes for reviewers

- `remove(group)`/`removeAll()` are now **synchronous** (`SCAN`+`UNLINK`) rather than async fire-and-forget — this matches the Caffeine/H22 providers and avoids stale-read-after-remove. The one production caller is `RedisStoragePersistenceAPI.remove(...)`.
- `getClient(name, codec)` still ignores `codec` when reflection succeeds — pre-existing behavior, deliberately preserved.

## Testing

- `dotcms-core` compiles clean (`BUILD SUCCESS`, no warnings from the changed files).
- `DotObjectCodec` round-trip validated standalone against the built classes (encode/decode of key & value, `null` → `DecodeException`, and a **sliced-buffer** case that exercises the `bytes.array()` fix). The integration `DotObjectCodecTest` is Redis/Docker-gated and was not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)