### PR TITLE
DO NOT MERGE - test: force Node 24 on all github actions smoke-test

### DIFF
--- a/.github/workflows/cicd_1-pr.yml
+++ b/.github/workflows/cicd_1-pr.yml
@@ -37,6 +37,11 @@ concurrency:
   # Cancel any in-progress runs for the same branch/PR to prevent delays from changes during build
   cancel-in-progress: true
 
+env:
+  # TEMP smoke-test (Node 24 migration): force all JS actions onto Node 24 ahead of the
+  # 2026-06-16 default switch, to surface incompatibilities. DO NOT MERGE.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Initialize the PR check process
   initialize:

--- a/.github/workflows/cicd_comp_build-phase.yml
+++ b/.github/workflows/cicd_comp_build-phase.yml
@@ -59,6 +59,11 @@ on:
         type: string
         default: ''
 
+env:
+  # TEMP smoke-test (Node 24 migration): force all JS actions onto Node 24 ahead of the
+  # 2026-06-16 default switch, to surface incompatibilities. DO NOT MERGE.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # Initial JDK Build
   # This job performs a basic build and install with Maven without running tests.

--- a/.github/workflows/cicd_comp_finalize-phase.yml
+++ b/.github/workflows/cicd_comp_finalize-phase.yml
@@ -25,6 +25,11 @@ on:
       aggregate_status:
         value: ${{ jobs.prepare-report-data.outputs.aggregate_status }}
 
+env:
+  # TEMP smoke-test (Node 24 migration): force all JS actions onto Node 24 ahead of the
+  # 2026-06-16 default switch, to surface incompatibilities. DO NOT MERGE.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   prepare-report-data:
     name: Prepare Report Data

--- a/.github/workflows/cicd_comp_initialize-phase.yml
+++ b/.github/workflows/cicd_comp_initialize-phase.yml
@@ -51,6 +51,11 @@ on:
       changes:
         value: ${{ jobs.changes.outputs.changes }}
 
+env:
+  # TEMP smoke-test (Node 24 migration): force all JS actions onto Node 24 ahead of the
+  # 2026-06-16 default switch, to surface incompatibilities. DO NOT MERGE.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   # This job is used as a required check to indicate that the workflow has started and is running
   initialize:

--- a/.github/workflows/cicd_comp_pr-area-labeler.yml
+++ b/.github/workflows/cicd_comp_pr-area-labeler.yml
@@ -21,6 +21,11 @@ on:
         type: string
         required: true
 
+env:
+  # TEMP smoke-test (Node 24 migration): force all JS actions onto Node 24 ahead of the
+  # 2026-06-16 default switch, to surface incompatibilities. DO NOT MERGE.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   apply-labels:
     name: Apply Area Labels

--- a/.github/workflows/cicd_comp_pr-notifier.yml
+++ b/.github/workflows/cicd_comp_pr-notifier.yml
@@ -18,6 +18,11 @@ on:
         description: 'Slack bot token'
         required: true
 
+env:
+  # TEMP smoke-test (Node 24 migration): force all JS actions onto Node 24 ahead of the
+  # 2026-06-16 default switch, to surface incompatibilities. DO NOT MERGE.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   message-resolver:
     name: Resolve Message

--- a/.github/workflows/cicd_comp_semgrep-phase.yml
+++ b/.github/workflows/cicd_comp_semgrep-phase.yml
@@ -20,6 +20,11 @@ on:
       SEMGREP_APP_TOKEN:
         required: true
 
+env:
+  # TEMP smoke-test (Node 24 migration): force all JS actions onto Node 24 ahead of the
+  # 2026-06-16 default switch, to surface incompatibilities. DO NOT MERGE.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   buildmavenDepTree:
     name: Semgrep Dep Tree

--- a/.github/workflows/cicd_comp_test-phase.yml
+++ b/.github/workflows/cicd_comp_test-phase.yml
@@ -70,6 +70,9 @@ on:
         required: true
 
 env:
+  # TEMP smoke-test (Node 24 migration): force all JS actions onto Node 24 ahead of the
+  # 2026-06-16 default switch, to surface incompatibilities. DO NOT MERGE.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id || github.run_id }}
 
 jobs:


### PR DESCRIPTION
This PR exists to **smoke-test the Node 24 runtime** across the PR pipeline ahead of GitHub's forced cutover on **2026-06-16**. It changes **no action versions** — it sets `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` so every JS action (incl. third-party) runs on Node 24, surfacing any breakage now.

### What this validates
`actions/checkout@v4`, `setup-node`, `setup-java`, `github-script`, `upload/download-artifact`, `cache`, `dorny/paths-filter`, `docker/*`, `aws-actions/*`, etc. — all running on Node 24 instead of 20.

### Why the env is in 8 files, not 1
Workflow-level `env` does **not** propagate into reusable (`uses:`) workflows. The orchestrator (`cicd_1-pr.yml`) has no direct steps, so the env had to be added to each `cicd_comp_*` phase that actually runs actions.

### How to read the result
- ✅ **All green** → the pipeline is Node-24-safe; the durable version-bump sweep can follow at a normal pace.
- ❌ **A job fails** → note which action/version; that's the one needing a version bump (or `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` as a temporary opt-out after 6/16).

The `backend` path filter includes `cicd_comp_*.yml`, so this PR runs the full build + integration/postman/karate/jvm/CLI fan-out — a real exercise, not a no-op.

**Next step after reading the run:** open the actual fix PR bumping action versions, then close this one.
