### PR TITLE
ci: bump upload/download-artifact to Node 24 majors

### DIFF
--- a/.github/actions/core-cicd/deployment/deploy-cli-npm/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-cli-npm/action.yml
@@ -55,7 +55,7 @@ runs:
 
     - name: 'Download all cli build artifacts.'
       id: download-cli-artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: cli-artifacts-*
         path: ${{ github.workspace }}/artifacts

--- a/.github/actions/core-cicd/deployment/deploy-docker/action.yml
+++ b/.github/actions/core-cicd/deployment/deploy-docker/action.yml
@@ -86,7 +86,7 @@ runs:
   using: "composite"
   steps:
     - name: Download Docker Build Context
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       if: inputs.build_run_id # Only download the artifact if a build run id is provided
       with:
         name: docker-build-context${{ inputs.artifact_suffix }}

--- a/.github/actions/core-cicd/maven-job/action.yml
+++ b/.github/actions/core-cicd/maven-job/action.yml
@@ -219,7 +219,7 @@ runs:
     - id: restore-artifact-maven-repo
       name: Restore Maven Build Repo
       if: ${{ inputs.artifacts-from != '' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         run-id: ${{ inputs.artifacts-from }}
         github-token: ${{ inputs.github-token }}
@@ -229,7 +229,7 @@ runs:
     - id: restore-artifact-docker-image
       name: Restore Docker Image
       if: ${{ inputs.needs-docker-image == 'true' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: docker-image${{ steps.artifact-suffix.outputs.suffix }}
         path: /tmp/docker-image
@@ -242,7 +242,7 @@ runs:
     - id: restore-artifact-classes
       name: Restore Classes
       if: ${{ inputs.restore-classes == 'true' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         run-id: ${{ inputs.artifacts-from }}
         github-token: ${{ inputs.github-token }}
@@ -300,7 +300,7 @@ runs:
     - id: persist-maven-repo
       name: Persist Maven Repo
       if: ${{ inputs.generate-artifacts == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: maven-repo${{ steps.artifact-suffix.outputs.suffix }}
         path: ~/.m2/repository
@@ -308,7 +308,7 @@ runs:
     - id: persist-docker-build-context
       name: Persist Docker Build Context
       if: ${{ inputs.generate-docker == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: docker-build-context${{ steps.artifact-suffix.outputs.suffix }}
         path: dotCMS/target/docker-build.tar
@@ -354,7 +354,7 @@ runs:
 
     - id: upload-docker-image
       name: Upload Docker Image as Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: ${{ inputs.generate-docker == 'true' }}
       with:
         name: docker-image${{ steps.artifact-suffix.outputs.suffix }}
@@ -363,7 +363,7 @@ runs:
     - id: persist-build-classes
       name: Persist Build Classes
       if: ${{ inputs.generate-artifacts == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-classes${{ steps.artifact-suffix.outputs.suffix }}
         path: |
@@ -413,7 +413,7 @@ runs:
     # ---------------------------- Generate Reports Artifacts ----------------------------
     - id: generate-build-reports-artifact
       name: Generate Build Reports Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: "build-reports-${{ inputs.stage-name }}"
@@ -424,7 +424,7 @@ runs:
 
     - id: create-test-reports-artifact
       name: Create Test Reports Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: always() && inputs.generates-test-results == 'true'
       with:
         name: "build-reports-test-${{ inputs.stage-name }}"

--- a/.github/actions/legacy-release/sbom-generator/action.yml
+++ b/.github/actions/legacy-release/sbom-generator/action.yml
@@ -49,7 +49,7 @@ runs:
         mv core/sbom-cyclonedx.json core/sbom-dotcms-${{ env.DOTCMS_VERSION }}.json
 
     - name: Upload SBOM to GitHub
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: sbom-dotcms-${{ env.DOTCMS_VERSION }}
         path: core/sbom-dotcms-${{ env.DOTCMS_VERSION }}.json

--- a/.github/workflows/cicd_comp_cli-native-build-phase.yml
+++ b/.github/workflows/cicd_comp_cli-native-build-phase.yml
@@ -107,7 +107,7 @@ jobs:
       # Upload the built distribution as an artifact
       - name: 'Upload built distribution'
         id: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: cli-artifacts-${{ matrix.platform }}
           path: |

--- a/.github/workflows/cicd_comp_finalize-phase.yml
+++ b/.github/workflows/cicd_comp_finalize-phase.yml
@@ -36,7 +36,7 @@ jobs:
       # Download build reports from previous steps
       - name: Download build reports
         id: download-artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: /tmp/build-step-reports
           pattern: build-reports-*
@@ -227,7 +227,7 @@ jobs:
           echo "aggregate_status=${AGGREGATE_STATUS}" >> $GITHUB_OUTPUT
       # Upload the final workflow data report as an artifact
       - name: Upload workflow data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: workflow-data
           path: ./workflow-data.json

--- a/.github/workflows/cicd_comp_release-phase.yml
+++ b/.github/workflows/cicd_comp_release-phase.yml
@@ -144,7 +144,7 @@ jobs:
           java-version: ${{ inputs.java-version }}
 
       - name: Restore Maven Repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: maven-repo${{ steps.java-suffix.outputs.suffix }}
           path: ~/.m2/repository
@@ -248,7 +248,7 @@ jobs:
           github_token: ${{ secrets.CI_MACHINE_TOKEN }}
 
       - name: Download SBOM Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ github.workspace }}/artifacts
           pattern: ${{ steps.sbom-generator.outputs.sbom-artifact }}

--- a/.github/workflows/cicd_comp_semgrep-phase.yml
+++ b/.github/workflows/cicd_comp_semgrep-phase.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Create Zip File
         run: find . -type f -name 'maven_dep_tree.txt' -exec zip -r dependency-tree.zip {} +
       - name: Upload Dependency Zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: dependency-tree
           path: dependency-tree.zip
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Download artifact from the previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: dependency-tree
       - name: Semgrep Scan

--- a/.github/workflows/cicd_manual_publish-starter.yml
+++ b/.github/workflows/cicd_manual_publish-starter.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: 'Upload artifacts'
         id: upload-artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ env.STARTER_TYPE }}-starter
           path: |
@@ -126,7 +126,7 @@ jobs:
           echo "::endgroup::"
           
       - name: 'Download artifacts'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           github-token: ${{ github.token }}
           name: ${{ env.STARTER_TYPE }}-starter

--- a/.github/workflows/cicd_release-cli.yml
+++ b/.github/workflows/cicd_release-cli.yml
@@ -165,7 +165,7 @@ jobs:
           echo "artifactsDir=${{ github.workspace }}/artifacts" >> "$GITHUB_ENV"
 
       - name: 'Download all build artifacts'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ github.workspace }}/artifacts
           pattern: cli-artifacts-*
@@ -207,7 +207,7 @@ jobs:
         run: pip install jinja2-cli
 
       - name: 'Download all build artifacts'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ github.workspace }}/artifacts
           pattern: cli-artifacts-*

--- a/.github/workflows/legacy-release_maven-release-process.yml
+++ b/.github/workflows/legacy-release_maven-release-process.yml
@@ -395,7 +395,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Download all build artifacts'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: ${{ github.workspace }}/artifacts
           pattern: ${{ steps.sbom-generator.outputs.sbom-artifact }}


### PR DESCRIPTION
## What

Bump the artifact actions to their first Node-24 majors, repo-wide.

Fixes #36087

| Action | From | To |
|---|---|---|
| `actions/upload-artifact` | v4 | **v6** |
| `actions/download-artifact` | v4 | **v7** |

Split out from #36086 because these are multi-major jumps (the artifact actions have breaking-API history), so they got a dedicated review.

## Why this is safe (reviewed)

- **Inputs are identical** across the bump — confirmed from each `action.yml`. The pipeline's `name`, `path`, `pattern`, `merge-multiple`, `retention-days`, `if-no-files-found` all still exist and behave the same.
- **download-artifact's only behavioral break (v5)** changes output paths *for downloads by `artifact-ids`*. Every download-artifact usage in this repo is by `name` or `pattern`/`merge-multiple` — **none uses `artifact-ids`** — so the upstream migration guide's "✅ no action needed" applies. Pinned to **v7** (not v8, whose "no longer unzips" change would matter).
- **Runner requirement**: v6/v7 need Actions Runner ≥ 2.327.1, satisfied by the hosted `ubuntu-24.04` runners.
- The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` smoke-test already proved the existing v4 artifact actions run on Node 24, so this isn't a cutover risk — it just clears the deprecation warning.

## Relationship to #36086

#36086 bumps the clean first-party actions (checkout/setup-node/setup-python/github-script/cache). Together with this PR, all first-party actions are on Node-24 majors. The two PRs touch different `@vN` lines and can merge in either order.
