### PR TITLE
fix(analytics): enable autoPageView by default (opt-out) in IIFE and React SDK

### DIFF
--- a/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts
@@ -115,7 +115,10 @@ export interface DotCMSAnalyticsConfig {
     logLevel?: LogLevel;
 
     /**
-     * Automatically track page views when set to true.
+     * Automatically track page views. Defaults to `true` (opt-out).
+     * Set explicitly to `false` to disable automatic page view tracking.
+     * Via the HTML `data-analytics-auto-page-view` attribute, only the literal string "false"
+     * disables it (any other value, including "", enables it).
      */
     autoPageView?: boolean;
 

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/utils/dot-analytics.utils.spec.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/utils/dot-analytics.utils.spec.ts
@@ -153,7 +153,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: 'https://analytics.dotcms.com',
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: 'test-key'
             });
         });
@@ -167,7 +167,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: 'https://analytics.dotcms.com',
                 debug: true,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: 'test-key'
             });
         });
@@ -217,7 +217,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: window.location.origin,
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: 'test-key'
             });
         });
@@ -231,7 +231,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: window.location.origin,
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: ''
             });
         });
@@ -252,12 +252,12 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: window.location.origin,
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: ''
             });
         });
 
-        it('should handle debug and autoPageView with non-true values', () => {
+        it('should disable autoPageView when attribute is "false" and keep debug false for non-true', () => {
             const script = document.querySelector('script[data-analytics-auth]');
             script?.setAttribute('data-analytics-debug', 'false');
             script?.setAttribute('data-analytics-auto-page-view', 'false');
@@ -269,6 +269,97 @@ describe('Analytics Utils', () => {
                 debug: false,
                 autoPageView: false,
                 siteAuth: 'test-key'
+            });
+        });
+
+        describe('autoPageView opt-out semantics', () => {
+            it('should default autoPageView to true when the attribute is missing', () => {
+                const result = getAnalyticsConfig();
+
+                expect(result.autoPageView).toBe(true);
+            });
+
+            it('should enable autoPageView when the attribute is an empty string', () => {
+                const script = document.querySelector('script[data-analytics-auth]');
+                script?.setAttribute('data-analytics-auto-page-view', '');
+
+                const result = getAnalyticsConfig();
+
+                expect(result.autoPageView).toBe(true);
+            });
+
+            it('should disable autoPageView only when the attribute is the literal string "false"', () => {
+                const script = document.querySelector('script[data-analytics-auth]');
+                script?.setAttribute('data-analytics-auto-page-view', 'false');
+
+                const result = getAnalyticsConfig();
+
+                expect(result.autoPageView).toBe(false);
+            });
+
+            it('should enable autoPageView when the attribute is "true"', () => {
+                const script = document.querySelector('script[data-analytics-auth]');
+                script?.setAttribute('data-analytics-auto-page-view', 'true');
+
+                const result = getAnalyticsConfig();
+
+                expect(result.autoPageView).toBe(true);
+            });
+
+            it('should enable autoPageView when the attribute is "0"', () => {
+                const script = document.querySelector('script[data-analytics-auth]');
+                script?.setAttribute('data-analytics-auto-page-view', '0');
+
+                const result = getAnalyticsConfig();
+
+                expect(result.autoPageView).toBe(true);
+            });
+
+            it('should enable autoPageView when the attribute is "no"', () => {
+                const script = document.querySelector('script[data-analytics-auth]');
+                script?.setAttribute('data-analytics-auto-page-view', 'no');
+
+                const result = getAnalyticsConfig();
+
+                expect(result.autoPageView).toBe(true);
+            });
+
+            it('should respect autoPageView false from JSON config when no attribute is present', () => {
+                const script = document.querySelector('script[data-analytics-auth]');
+                script?.setAttribute(
+                    'data-analytics-config',
+                    JSON.stringify({ autoPageView: false })
+                );
+
+                const result = getAnalyticsConfig();
+
+                expect(result.autoPageView).toBe(false);
+            });
+
+            it('should let attribute "false" override JSON config autoPageView true', () => {
+                const script = document.querySelector('script[data-analytics-auth]');
+                script?.setAttribute('data-analytics-auto-page-view', 'false');
+                script?.setAttribute(
+                    'data-analytics-config',
+                    JSON.stringify({ autoPageView: true })
+                );
+
+                const result = getAnalyticsConfig();
+
+                expect(result.autoPageView).toBe(false);
+            });
+
+            it('should let attribute presence (empty string) override JSON config autoPageView false', () => {
+                const script = document.querySelector('script[data-analytics-auth]');
+                script?.setAttribute('data-analytics-auto-page-view', '');
+                script?.setAttribute(
+                    'data-analytics-config',
+                    JSON.stringify({ autoPageView: false })
+                );
+
+                const result = getAnalyticsConfig();
+
+                expect(result.autoPageView).toBe(true);
             });
         });
 
@@ -286,7 +377,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: 'https://analytics.dotcms.com',
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: 'test-key',
                 queue: {
                     eventBatchSize: 5
@@ -308,7 +399,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: 'https://analytics.dotcms.com',
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: 'test-key',
                 queue: {
                     flushInterval: 2000
@@ -333,7 +424,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: 'https://analytics.dotcms.com',
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: 'test-key',
                 queue: {
                     eventBatchSize: 3,
@@ -357,7 +448,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: 'https://analytics.dotcms.com',
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: 'test-key'
             });
         });
@@ -376,7 +467,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: 'https://analytics.dotcms.com',
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: 'test-key'
             });
         });
@@ -398,7 +489,7 @@ describe('Analytics Utils', () => {
             expect(result).toEqual({
                 server: 'https://analytics.dotcms.com',
                 debug: false,
-                autoPageView: false,
+                autoPageView: true,
                 siteAuth: 'test-key',
                 queue: {
                     eventBatchSize: 10

--- a/core-web/libs/sdk/analytics/src/lib/core/shared/utils/dot-analytics.utils.ts
+++ b/core-web/libs/sdk/analytics/src/lib/core/shared/utils/dot-analytics.utils.ts
@@ -287,7 +287,9 @@ export interface AnalyticsConfigResult {
  * Always returns a config (with defaults if needed).
  *
  * - If no data-analytics-server attribute is found, uses the current domain as the server endpoint
- * - Both debug and autoPageView default to false (must be explicitly set to "true")
+ * - debug defaults to false (opt-in: must be explicitly set to "true")
+ * - autoPageView defaults to true (opt-out: only the literal string "false" disables it via
+ *   `data-analytics-auto-page-view="false"`)
  *
  * @returns The analytics configuration object
  */
@@ -335,7 +337,7 @@ export const getAnalyticsConfig = (): DotCMSAnalyticsConfig => {
             // 1. Default fallback values
             server: window.location.origin,
             debug: false,
-            autoPageView: false,
+            autoPageView: true,
             siteAuth: '',
 
             // 2. Advanced config (JSON)
@@ -344,7 +346,9 @@ export const getAnalyticsConfig = (): DotCMSAnalyticsConfig => {
             // 3. Explicit attributes (highest priority)
             ...(serverAttr && { server: serverAttr }),
             ...(debugAttr && { debug: debugAttr === 'true' }),
-            ...(autoPageViewAttr && { autoPageView: autoPageViewAttr === 'true' }),
+            // autoPageView is opt-out: presence of the attribute overrides JSON config; only the
+            // literal string "false" disables it (any other value, including "", enables it)
+            ...(autoPageViewAttr !== null && { autoPageView: autoPageViewAttr !== 'false' }),
             ...(siteAuthAttr && { siteAuth: siteAuthAttr }),
             ...(impressionsAttr && { impressions: impressionsAttr === 'true' }),
             ...(clicksAttr && { clicks: clicksAttr === 'true' })
@@ -357,7 +361,7 @@ export const getAnalyticsConfig = (): DotCMSAnalyticsConfig => {
     return {
         server: window.location.origin,
         debug: false,
-        autoPageView: false,
+        autoPageView: true,
         siteAuth: ''
     };
 };

--- a/core-web/libs/sdk/analytics/src/lib/react/components/DotContentAnalytics.tsx
+++ b/core-web/libs/sdk/analytics/src/lib/react/components/DotContentAnalytics.tsx
@@ -17,9 +17,9 @@ function DotContentAnalyticsTracker({
     const analytics = useMemo(() => initializeAnalytics(config), [config]);
     const debug = Boolean(config.debug);
 
-    if (analytics) {
-        useRouterTracker(analytics, debug);
-    }
+    // autoPageView is opt-out: undefined/true enables tracking, only explicit false disables it.
+    // The hook is called unconditionally (analytics may be null; the hook handles that internally).
+    useRouterTracker(analytics, debug, config.autoPageView !== false);
 
     return null;
 }

--- a/core-web/libs/sdk/analytics/src/lib/react/hook/useRouteTracker.spec.tsx
+++ b/core-web/libs/sdk/analytics/src/lib/react/hook/useRouteTracker.spec.tsx
@@ -76,4 +76,40 @@ describe('useRouterTracker', () => {
         mockUsePathname.mockReturnValue('/new-path');
         expect(mockAnalytics.pageView).toHaveBeenCalledTimes(1);
     });
+
+    it('should not track when enabled is false, even after a route change', () => {
+        const { rerender } = renderHook(() => useRouterTracker(mockAnalytics, false, false));
+        expect(mockAnalytics.pageView).not.toHaveBeenCalled();
+
+        // Simulate path change
+        mockUsePathname.mockReturnValue('/new-path');
+        rerender();
+
+        expect(mockAnalytics.pageView).not.toHaveBeenCalled();
+    });
+
+    it('should track on render and unique route changes when enabled is explicitly true', () => {
+        const { rerender } = renderHook(() => useRouterTracker(mockAnalytics, false, true));
+        expect(mockAnalytics.pageView).toHaveBeenCalledTimes(1);
+
+        // Unique route change
+        mockUsePathname.mockReturnValue('/new-path');
+        rerender();
+        expect(mockAnalytics.pageView).toHaveBeenCalledTimes(2);
+
+        // Same route, no additional pageView
+        mockUsePathname.mockReturnValue('/new-path');
+        rerender();
+        expect(mockAnalytics.pageView).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not crash and not track when enabled is false and analytics is null', () => {
+        const { rerender } = renderHook(() => useRouterTracker(null, false, false));
+        expect(mockAnalytics.pageView).not.toHaveBeenCalled();
+
+        mockUsePathname.mockReturnValue('/new-path');
+        rerender();
+
+        expect(mockAnalytics.pageView).not.toHaveBeenCalled();
+    });
 });

--- a/core-web/libs/sdk/analytics/src/lib/react/hook/useRouterTracker.ts
+++ b/core-web/libs/sdk/analytics/src/lib/react/hook/useRouterTracker.ts
@@ -19,14 +19,16 @@ const computeNextKey = (
  *
  * @param analytics Analytics singleton instance; if null, does nothing
  * @param debug When true, logs which tracking path is used
+ * @param enabled When false, tracking is disabled even if analytics is present (defaults to true)
  */
-export function useRouterTracker(analytics: DotCMSAnalytics | null, debug = false) {
+export function useRouterTracker(analytics: DotCMSAnalytics | null, debug = false, enabled = true) {
     const lastKeyRef = useRef<string | null>(null);
 
     const pathname = usePathname();
     const searchParams = useSearchParams();
 
     useEffect(() => {
+        if (!enabled) return;
         if (!analytics) return;
 
         const fireIfChanged = (key: string) => {
@@ -40,5 +42,5 @@ export function useRouterTracker(analytics: DotCMSAnalytics | null, debug = fals
             console.info('DotCMS Analytics [React]: using Next.js App Router tracking');
         }
         fireIfChanged(computeNextKey(pathname, searchParams));
-    }, [analytics, pathname, searchParams, debug]);
+    }, [analytics, pathname, searchParams, debug, enabled]);
 }


### PR DESCRIPTION
## Summary

The `@dotcms/analytics` SDK now tracks page views out-of-the-box across all delivery modes. Previously the IIFE required explicit opt-in (`data-analytics-auto-page-view="true"`), server-rendered pages with a missing `autoPageView` app secret silently lost page views (empty attribute fell back to `false`), and the React `<DotContentAnalytics>` component ignored the `autoPageView` flag entirely.

<img width="2416" height="1258" alt="CleanShot 2026-06-09 at 17 19 56@2x" src="https://github.com/user-attachments/assets/a989b71a-7a43-4f96-8b66-594039907110" />


Closes #36090

### Changes

- **`getAnalyticsConfig()`** (`dot-analytics.utils.ts`): default flipped to `autoPageView: true` in both return paths (script found / not found). Attribute parsing changed from a truthy guard (`attr && attr === 'true'`) to a presence check with opt-out semantics: `attr !== null && attr !== 'false'`. Only the literal string `"false"` disables; `""`, `"true"`, `"0"`, `"no"` all enable. Attribute presence still beats `data-analytics-config` JSON; JSON `{"autoPageView": false}` still disables when no attribute is present. `debug`/`impressions`/`clicks` keep their opt-in semantics.
- **`useRouterTracker`**: new optional `enabled` param (default `true`); when `false` the effect exits early while all hooks still run unconditionally. `enabled` added to the dependency array. Non-breaking — the hook is not part of the public API surface and the param is optional.
- **`DotContentAnalytics.tsx`**: removed the `if (analytics) { useRouterTracker(...) }` rules-of-hooks violation; the hook is now called unconditionally with `enabled = config.autoPageView !== false` (undefined/true → tracking on, explicit `false` → off).
- **JSDoc** updated in `getAnalyticsConfig()` and `library.model.ts` to document the opt-out default.
- **No Java changes** — `AnalyticsWebAPIImpl` / `analytics_head.html` already render the secret verbatim; the SDK-side opt-out semantics align the traditional injection path automatically (a missing secret renders `data-analytics-auto-page-view=""`, which now resolves to enabled, matching the app config contract "defaults to true").

### Acceptance Criteria

#### IIFE (standalone script)
- [x] Missing `data-analytics-auto-page-view` attribute → auto page view enabled, `pageview` fires on DOM ready
- [x] `data-analytics-auto-page-view="false"` → disabled (existing "Auto page view is disabled" warning preserved)
- [x] Any value other than the literal `"false"` (`"true"`, `"no"`, `"0"`, `""`) → enabled
- [x] `autoPageView: false` via `data-analytics-config` JSON disables; explicit attribute takes precedence over JSON
- [x] Both default-config return paths of `getAnalyticsConfig()` default to `true`

#### Traditional (server-rendered, auto-injected script)
- [x] Missing app secret (attribute renders `""`) → enabled, matching the app config contract
- [x] Admin sets Enable Auto Page Views = off (attribute `"false"`) → disabled
- [x] Secret stored as `true` → enabled (current behavior preserved)
- [ ] End-to-end verification against a dotCMS-rendered LIVE page (manual check — no Java changes)

#### React / Next.js
- [x] `config.autoPageView` undefined or `true` → page views tracked on App Router route changes
- [x] `config.autoPageView: false` → no automatic page views; manual `pageView()` via `useContentAnalytics` unaffected
- [x] `useRouterTracker` invoked unconditionally at top level; enable/disable passed as data

#### Docs & types
- [x] JSDoc updated in `getAnalyticsConfig()` and `library.model.ts`
- [x] Unit tests added for missing attribute, `"false"`, invalid values, JSON config override (IIFE), and `autoPageView: false` (React tracker)

### Test plan

- `yarn nx lint sdk-analytics` — clean
- `yarn nx test sdk-analytics` — 15 suites, 314 tests passing
- New unit tests: full attribute-value matrix (missing/`""`/`"false"`/`"true"`/`"0"`/`"no"`), JSON-vs-attribute precedence in both directions, and `enabled` behavior of `useRouterTracker` (false blocks tracking incl. after route changes; null-analytics safety)
- Remaining manual step: verify a `pageview` event fires on a dotCMS-rendered LIVE page using the auto-injected script with no explicit attribute (AC above left unchecked)

### Notes for reviewers

- **Intentional behavior change**: existing IIFE installations without the attribute will start sending automatic pageviews after upgrading — this is the desired out-of-the-box behavior (see issue).
- The `"false"` comparison is intentionally case-sensitive (literal string match) per the issue's AC; the server-side injection always renders lowercase `true`/`false` from the app secret.

### Changed files

- `core-web/libs/sdk/analytics/src/lib/core/shared/utils/dot-analytics.utils.ts`
- `core-web/libs/sdk/analytics/src/lib/core/shared/utils/dot-analytics.utils.spec.ts`
- `core-web/libs/sdk/analytics/src/lib/core/shared/models/library.model.ts`
- `core-web/libs/sdk/analytics/src/lib/react/components/DotContentAnalytics.tsx`
- `core-web/libs/sdk/analytics/src/lib/react/hook/useRouterTracker.ts`
- `core-web/libs/sdk/analytics/src/lib/react/hook/useRouteTracker.spec.tsx`

This PR fixes: #36090