### PR TITLE
POC: Azure Foundry image support via dedicated azure_foundry provider

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureFoundryModelProviderStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureFoundryModelProviderStrategy.java
@@ -1,0 +1,65 @@
+package com.dotcms.ai.client.langchain4j;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.image.ImageModel;
+import dev.langchain4j.model.openaiofficial.OpenAiOfficialImageModel;
+
+import java.time.Duration;
+
+class AzureFoundryModelProviderStrategy implements ModelProviderStrategy {
+
+    @Override
+    public String providerName() {
+        return "azure_foundry";
+    }
+
+    @Override
+    public ChatModel buildChatModel(final ProviderConfig config, final String modelType) {
+        throw new UnsupportedOperationException(
+                "azure_foundry only supports image models; use azure_openai for chat and embeddings");
+    }
+
+    @Override
+    public StreamingChatModel buildStreamingChatModel(final ProviderConfig config, final String modelType) {
+        throw new UnsupportedOperationException(
+                "azure_foundry only supports image models; use azure_openai for chat and embeddings");
+    }
+
+    @Override
+    public EmbeddingModel buildEmbeddingModel(final ProviderConfig config, final String modelType) {
+        throw new UnsupportedOperationException(
+                "azure_foundry only supports image models; use azure_openai for chat and embeddings");
+    }
+
+    @Override
+    public ImageModel buildImageModel(final ProviderConfig config, final String modelType) {
+        validate(config, modelType);
+        final OpenAiOfficialImageModel.Builder builder = OpenAiOfficialImageModel.builder()
+                .baseUrl(config.endpoint())
+                .apiKey(config.apiKey())
+                .modelName(deploymentName(config));
+        if (config.size() != null) builder.size(config.size());
+        if (config.timeout() != null) builder.timeout(Duration.ofSeconds(config.timeout()));
+        if (config.maxRetries() != null) builder.maxRetries(config.maxRetries());
+        return builder.build();
+    }
+
+    private void validate(final ProviderConfig config, final String modelType) {
+        ModelProviderStrategy.requireNonBlank(config.apiKey(), "apiKey", modelType);
+        ModelProviderStrategy.requireNonBlank(config.endpoint(), "endpoint", modelType);
+        if ((config.model() == null || config.model().isBlank())
+                && (config.deploymentName() == null || config.deploymentName().isBlank())) {
+            throw new IllegalArgumentException(
+                    "providerConfig." + modelType + ": either 'model' or 'deploymentName' is required for azure_foundry");
+        }
+    }
+
+    private static String deploymentName(final ProviderConfig config) {
+        return config.deploymentName() != null && !config.deploymentName().isBlank()
+                ? config.deploymentName()
+                : config.model();
+    }
+
+}

--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/LangChain4jModelFactory.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/LangChain4jModelFactory.java
@@ -14,14 +14,16 @@ import java.util.List;
  * To add a new provider, create a class that implements {@link ModelProviderStrategy}
  * and add an instance to {@link #STRATEGIES}. No other class needs to change.
  *
- * <p>Supported providers: {@code openai}, {@code azure_openai}, {@code vertex_ai}
- * <p>Note: {@code vertex_ai} supports chat only; embeddings and image are not available via LangChain4J.
+ * <p>Supported providers: {@code openai}, {@code azure_openai}, {@code azure_foundry}, {@code vertex_ai}
+ * <p>Note: {@code vertex_ai} supports chat only; {@code azure_foundry} supports image only;
+ * embeddings and image are not available for {@code vertex_ai} via LangChain4J.
  */
 public class LangChain4jModelFactory {
 
     static final List<ModelProviderStrategy> STRATEGIES = List.of(
             new OpenAiModelProviderStrategy(),
             new AzureOpenAiModelProviderStrategy(),
+            new AzureFoundryModelProviderStrategy(),
             new VertexAiModelProviderStrategy()
     );
 


### PR DESCRIPTION
## POC — Option 2: New `azure_foundry` provider

Adds `AzureFoundryModelProviderStrategy` — a dedicated provider for image generation on Azure AI Foundry. Chat and embeddings remain on `azure_openai`; the image section uses the new provider.

**Config:**
```json
{
  "chat":   { "provider": "azure_openai", ... },
  "embeddings": { "provider": "azure_openai", ... },
  "image":  {
    "provider": "azure_foundry",
    "endpoint": "https://<resource>.services.ai.azure.com/openai/v1/",
    "apiKey": "...",
    "model": "gpt-image-2"
  }
}
```

**Trade-off:** Explicit and clean separation of concerns, but requires the user to know which provider to use for which capability.

---
*Draft POC for comparison. See also: `poc/azure-foundry-auto-detect`, `poc/azure-foundry-flag`.*