### PR TITLE
POC: Azure Foundry image support via foundry flag in ProviderConfig

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureOpenAiModelProviderStrategy.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/AzureOpenAiModelProviderStrategy.java
@@ -63,18 +63,19 @@ class AzureOpenAiModelProviderStrategy implements ModelProviderStrategy {
         return builder.build();
     }
 
-    /**
-     * Builds an image model using the official OpenAI Java SDK with Microsoft Foundry (Azure)
-     * support, which provides access to gpt-image-1 and other modern image models.
-     *
-     * <p>The legacy {@code AzureOpenAiImageModel} only supported dall-e-3, which was deprecated
-     * by Azure in June 2025. This implementation uses {@code OpenAiOfficialImageModel} with
-     * {@code isMicrosoftFoundry(true)}, which routes through the official OpenAI SDK and
-     * supports gpt-image-1 on Azure.
-     */
     @Override
     public ImageModel buildImageModel(final ProviderConfig config, final String modelType) {
         validate(config, modelType);
+        if (config.foundry()) {
+            final OpenAiOfficialImageModel.Builder builder = OpenAiOfficialImageModel.builder()
+                    .baseUrl(config.endpoint())
+                    .apiKey(config.apiKey())
+                    .modelName(deploymentName(config));
+            if (config.size() != null) builder.size(config.size());
+            if (config.timeout() != null) builder.timeout(Duration.ofSeconds(config.timeout()));
+            if (config.maxRetries() != null) builder.maxRetries(config.maxRetries());
+            return builder.build();
+        }
         final OpenAiOfficialImageModel.Builder builder = OpenAiOfficialImageModel.builder()
                 .isMicrosoftFoundry(true)
                 .baseUrl(config.endpoint())

--- a/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/ProviderConfig.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/client/langchain4j/ProviderConfig.java
@@ -112,4 +112,7 @@ public interface ProviderConfig {
      */
     @Value.Redacted @Nullable String credentialsJson();
 
+    @Value.Default
+    default boolean foundry() { return false; }
+
 }


### PR DESCRIPTION
## POC — Option 3: `foundry` flag on `ProviderConfig`

Adds a `foundry: boolean` field (default `false`) to `ProviderConfig`. When `true`, `azure_openai` skips the `isMicrosoftFoundry` routing and builds a plain OpenAI-style image client — compatible with Azure AI Foundry endpoints.

**Config:**
```json
{
  "provider": "azure_openai",
  "foundry": true,
  "endpoint": "https://<resource>.services.ai.azure.com/openai/v1/",
  "apiKey": "...",
  "model": "gpt-image-2"
}
```

**Trade-off:** Explicit, backward-compatible (existing configs unaffected), single provider for all Azure cases. Adds one config field.

---
*Draft POC for comparison. See also: `poc/azure-foundry-auto-detect`, `poc/azure-foundry-provider`.*