### PR TITLE
fix(security): upgrade Bouncy Castle 1.81 → 1.84 (CVE-2025-14813)

### DIFF
--- a/independent-projects/core-plugins/tika-plugin/pom.xml
+++ b/independent-projects/core-plugins/tika-plugin/pom.xml
@@ -13,7 +13,7 @@
         <maven.bundle.version>5.1.8</maven.bundle.version>
         <osgi.core.version>8.0.0</osgi.core.version>
         <osgi.compendium.version>7.0.0</osgi.compendium.version>
-        <tika.version>3.2.2</tika.version>
+        <tika.version>3.3.1</tika.version>
         <skip.rewrite>true</skip.rewrite>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/osgi-base/system-bundles/pom.xml
+++ b/osgi-base/system-bundles/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
-        <tika.version>3.2.2</tika.version>
+        <tika.version>3.3.1</tika.version>
         <spifly.version>1.3.6</spifly.version>
         <asm.version>9.4</asm.version>
         <tika.plugin.bundle.version>2.7.0</tika.plugin.bundle.version>


### PR DESCRIPTION
Similar to #35897 but it's still in `com.dotcms.tika-25.07.10_lts_v12.jar`

Upgrade contains no breaking changes: https://dist.apache.org/repos/dist/release/tika/3.3.1/CHANGES-3.3.1.txt

Can be verified by running `./mvnw -pl :com.dotcms.tika -am dependency:tree -Dincludes=org.bouncycastle`

Before:
```
[INFO] --- dependency:3.6.0:tree (default-cli) @ com.dotcms.tika --- 
[INFO] com.dotcms.core.plugins:com.dotcms.tika:bundle:1.0.0-SNAPSHOT 
[INFO] \- org.apache.tika:tika-parsers-standard-package:jar:3.2.2:runtime
[INFO]    \- org.apache.tika:tika-parser-crypto-module:jar:3.2.2:runtime
[INFO]       +- org.bouncycastle:bcjmail-jdk18on:jar:1.81:runtime
[INFO]       |  \- org.bouncycastle:bcpkix-jdk18on:jar:1.81.1:runtime
[INFO]       |     \- org.bouncycastle:bcutil-jdk18on:jar:1.81.1:runtime
[INFO]       \- org.bouncycastle:bcprov-jdk18on:jar:1.81:runtime
```
After:
```
[INFO] --- dependency:3.6.0:tree (default-cli) @ com.dotcms.tika --- 
[INFO] com.dotcms.core.plugins:com.dotcms.tika:bundle:1.0.0-SNAPSHOT 
[INFO] \- org.apache.tika:tika-parsers-standard-package:jar:3.3.1:runtime
[INFO]    \- org.apache.tika:tika-parser-crypto-module:jar:3.3.1:runtime
[INFO]       +- org.bouncycastle:bcjmail-jdk18on:jar:1.84:runtime
[INFO]       |  \- org.bouncycastle:bcpkix-jdk18on:jar:1.84:runtime
[INFO]       |     \- org.bouncycastle:bcutil-jdk18on:jar:1.84:runtime
[INFO]       \- org.bouncycastle:bcprov-jdk18on:jar:1.84:runtime
```