### PR TITLE
fix(analytics): align relative date-range window with upstream to fix +1 day chart shift

### DIFF
--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.spec.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.spec.ts
@@ -10,6 +10,7 @@ import {
     extractPageViews,
     extractSessions,
     extractTopPageValue,
+    fillMissingApiDates,
     fillMissingDates,
     getDateRange,
     getPreviousPeriod,
@@ -593,20 +594,21 @@ describe('Analytics Data Utils', () => {
         });
 
         describe('success cases', () => {
-            it('should return last 7 days range correctly', () => {
+            it('should return last 7 complete days ending yesterday', () => {
                 const result = getDateRange('last7days');
                 const [startDate, endDate] = result;
 
-                expect(format(startDate, 'yyyy-MM-dd HH:mm:ss')).toEqual('2024-01-09 00:00:00');
-                expect(format(endDate, 'yyyy-MM-dd HH:mm:ss')).toEqual('2024-01-15 23:59:59');
+                // Today (2024-01-15) is excluded; range is the 7 complete days ending yesterday
+                expect(format(startDate, 'yyyy-MM-dd HH:mm:ss')).toEqual('2024-01-08 00:00:00');
+                expect(format(endDate, 'yyyy-MM-dd HH:mm:ss')).toEqual('2024-01-14 23:59:59');
             });
 
-            it('should return last 30 days range correctly', () => {
+            it('should return last 30 complete days ending yesterday', () => {
                 const result = getDateRange('last30days');
                 const [startDate, endDate] = result;
 
-                expect(format(startDate, 'yyyy-MM-dd HH:mm:ss')).toEqual('2023-12-17 00:00:00');
-                expect(format(endDate, 'yyyy-MM-dd HH:mm:ss')).toEqual('2024-01-15 23:59:59');
+                expect(format(startDate, 'yyyy-MM-dd HH:mm:ss')).toEqual('2023-12-16 00:00:00');
+                expect(format(endDate, 'yyyy-MM-dd HH:mm:ss')).toEqual('2024-01-14 23:59:59');
             });
 
             it('should handle custom date range array correctly', () => {
@@ -627,6 +629,54 @@ describe('Analytics Data Utils', () => {
         });
     });
 
+    describe('fillMissingApiDates + transformPageViewTimeLineData (relative range regression)', () => {
+        beforeEach(() => {
+            jest.useFakeTimers();
+            // Reproduces the reported bug: today = Jun 10, API returns Jun 03 … Jun 09.
+            jest.setSystemTime(new Date('2026-06-10T12:00:00.000'));
+        });
+
+        afterEach(() => {
+            jest.useRealTimers();
+        });
+
+        it('keeps the earliest day and does not append today for a last7days range', () => {
+            // Sparse API rows for the 7 complete days ending yesterday (Jun 03 … Jun 09).
+            const apiData: TotalEventsByDayData[] = [
+                { day: '2026-06-03', totalEvents: 993 },
+                { day: '2026-06-04', totalEvents: 1136 },
+                { day: '2026-06-05', totalEvents: 1558 },
+                { day: '2026-06-06', totalEvents: 718 },
+                { day: '2026-06-07', totalEvents: 721 },
+                { day: '2026-06-08', totalEvents: 1107 },
+                { day: '2026-06-09', totalEvents: 2424 }
+            ];
+
+            const filled = fillMissingApiDates(apiData, 'last7days', 'day', (date) => ({
+                day: format(date, 'yyyy-MM-dd'),
+                totalEvents: 0
+            }));
+
+            // Window must match the API data exactly: Jun 03 … Jun 09 — no Jun 10 (today) bucket.
+            expect(filled.map((item) => item.day)).toEqual([
+                '2026-06-03',
+                '2026-06-04',
+                '2026-06-05',
+                '2026-06-06',
+                '2026-06-07',
+                '2026-06-08',
+                '2026-06-09'
+            ]);
+            // Earliest real day is retained with its value (previously dropped).
+            expect(filled[0]).toEqual({ day: '2026-06-03', totalEvents: 993 });
+
+            const chart = transformPageViewTimeLineData(filled);
+            expect(chart.labels?.[0]).toBe('Jun 03');
+            expect(chart.labels?.[chart.labels.length - 1]).toBe('Jun 09');
+            expect(chart.datasets[0].data).toEqual([993, 1136, 1558, 718, 721, 1107, 2424]);
+        });
+    });
+
     describe('getPreviousPeriod', () => {
         it('should return previous period of same length for custom date range', () => {
             const result = getPreviousPeriod(['2026-02-01', '2026-02-06']);
@@ -643,9 +693,9 @@ describe('Analytics Data Utils', () => {
             jest.setSystemTime(new Date('2024-01-15T12:00:00.000Z'));
             const result = getPreviousPeriod('last7days');
             jest.useRealTimers();
-            // last7days: Jan 9 - Jan 15 (7 days). Previous: Jan 2 - Jan 8
-            expect(result[0]).toBe('2024-01-02');
-            expect(result[1]).toBe('2024-01-08');
+            // last7days: Jan 8 - Jan 14 (7 complete days ending yesterday). Previous: Jan 1 - Jan 7
+            expect(result[0]).toBe('2024-01-01');
+            expect(result[1]).toBe('2024-01-07');
         });
     });
 

--- a/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.ts
+++ b/core-web/libs/portlets/dot-analytics/data-access/src/lib/utils/data/analytics-data.utils.ts
@@ -674,18 +674,18 @@ export const getDateRange = (timeRange: TimeRangeInput): [Date, Date] => {
         return [startDate, endDate];
     }
 
+    // Relative ranges resolve to whole, completed days ending YESTERDAY — today is still in
+    // progress and is excluded. Mirrors the upstream `last_7_days` / `last_30_days` semantics
+    // used by toApiRangeParams, so the client-side fill window lines up exactly with the data
+    // the API returns (otherwise chart labels drift +1 day and today shows as an empty bucket).
+    const yesterday = endOfDay(subDays(today, 1));
+
     switch (timeRange) {
-        case TIME_RANGE_OPTIONS.last7days: {
-            const sevenDaysAgo = subDays(today, 6);
+        case TIME_RANGE_OPTIONS.last7days:
+            return [startOfDay(subDays(today, 7)), yesterday];
 
-            return [startOfDay(sevenDaysAgo), endOfDay(today)];
-        }
-
-        case TIME_RANGE_OPTIONS.last30days: {
-            const thirtyDaysAgo = subDays(today, 29);
-
-            return [startOfDay(thirtyDaysAgo), endOfDay(today)];
-        }
+        case TIME_RANGE_OPTIONS.last30days:
+            return [startOfDay(subDays(today, 30)), yesterday];
 
         default:
             return [startOfDay(today), endOfDay(today)];


### PR DESCRIPTION
Relative presets (last7days/last30days) were resolved by two functions that disagreed by one day. toApiRangeParams sends range=last_N_days, which the upstream resolves to the N complete days ending yesterday, while the client-side getDateRange (used by fillMissingApiDates to build the X-axis window) computed N days ending today. The fill loop therefore dropped the earliest real day and appended today as an empty 0 bucket, shifting every label +1 day.

Fix getDateRange's relative-preset branches to end at end-of-yesterday, matching the upstream "complete days" semantics. This single shared function corrects all day-series charts (pageviews timeline, conversion trend, visitors-vs-converting) and aligns getPreviousPeriod's comparison window. Custom date-array ranges were already correct and are unchanged.

Update getDateRange/getPreviousPeriod expectations and add an end-to-end regression test reproducing the reported scenario.

fixes: #35988 

This PR fixes: #35988