### PR TITLE
fix(uve): focus the clicked inline-edit field on multi-page content (#36099)

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.spec.ts
@@ -8,6 +8,7 @@ import { MessageService } from 'primeng/api';
 import { DotMessageService, DotWorkflowActionsFireService } from '@dotcms/data-access';
 import { DEFAULT_VARIANT_ID } from '@dotcms/dotcms-models';
 import { DotCMSUVEAction } from '@dotcms/types';
+import { __DOTCMS_UVE_EVENT__ } from '@dotcms/types/internal';
 import { DotCopyContentModalService } from '@dotcms/ui';
 
 import { DotUveActionsHandlerService } from './dot-uve-actions-handler.service';
@@ -15,6 +16,8 @@ import { DotUveActionsHandlerService } from './dot-uve-actions-handler.service';
 import { UpdatedContentlet } from '../../edit-ema-editor/components/ema-page-dropzone/types';
 import { EDITOR_STATE, UVE_STATUS } from '../../shared/enums';
 import { UVEStore } from '../../store/dot-uve.store';
+import { PageType } from '../../store/models';
+import { InlineEditService } from '../inline-edit/inline-edit.service';
 
 const MOCK_UPDATED_CONTENTLET: UpdatedContentlet = {
     dataset: {
@@ -630,5 +633,142 @@ describe('DotUveActionsHandlerService – CLIENT_READY', () => {
 
         expect(mockStore.setCustomClient).not.toHaveBeenCalled();
         expect(mockStore.pageReload).not.toHaveBeenCalled();
+    });
+});
+
+describe('DotUveActionsHandlerService – COPY_CONTENTLET_INLINE_EDITING (field switching)', () => {
+    let spectator: SpectatorService<DotUveActionsHandlerService>;
+    let service: DotUveActionsHandlerService;
+
+    const INODE = 'contentlet-123';
+    const HOST = 'http://localhost';
+
+    const createService = createServiceFactory({
+        service: DotUveActionsHandlerService,
+        providers: [
+            mockProvider(DotWorkflowActionsFireService),
+            mockProvider(DotMessageService),
+            mockProvider(MessageService),
+            mockProvider(DotCopyContentModalService),
+            {
+                provide: UVEStore,
+                useValue: buildMockStore()
+            }
+        ]
+    });
+
+    // Store already in INLINE_EDITING with `INODE` as the contentlet under edit.
+    const buildInlineEditingStore = (pageType: PageType) => ({
+        ...buildMockStore(),
+        editorState: signal(EDITOR_STATE.INLINE_EDITING),
+        editorContentArea: signal({
+            payload: { contentlet: { inode: INODE }, container: { identifier: 'container-1' } }
+        }),
+        pageType: signal(pageType),
+        getCurrentTreeNode: jest.fn().mockReturnValue({})
+    });
+
+    const buildDataset = (inode: string) => ({
+        dataset: { inode, fieldName: 'body', mode: 'minimal', language: '1' }
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        spectator = createService();
+        service = spectator.service;
+    });
+
+    it('should move focus to the clicked field without re-opening the copy dialog when switching fields on the same contentlet (headless)', () => {
+        const mockStore = buildInlineEditingStore(PageType.HEADLESS);
+        const copyModal = spectator.inject(DotCopyContentModalService);
+        const contentWindow = { postMessage: jest.fn() } as unknown as Window;
+
+        service.handleAction(
+            {
+                action: DotCMSUVEAction.COPY_CONTENTLET_INLINE_EDITING,
+                payload: buildDataset(INODE)
+            },
+            {
+                uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                dialog: null,
+                inlineEditingService: null,
+                contentWindow,
+                host: HOST,
+                onCopyContent: jest.fn()
+            }
+        );
+
+        expect(copyModal.open).not.toHaveBeenCalled();
+        expect(contentWindow.postMessage).toHaveBeenCalledWith(
+            {
+                name: __DOTCMS_UVE_EVENT__.UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS,
+                payload: {
+                    oldInode: INODE,
+                    inode: INODE,
+                    fieldName: 'body',
+                    mode: 'minimal',
+                    language: '1'
+                }
+            },
+            HOST
+        );
+    });
+
+    it('should re-init the inline editor on the clicked field when switching fields on the same contentlet (traditional)', () => {
+        const mockStore = buildInlineEditingStore(PageType.TRADITIONAL);
+        const copyModal = spectator.inject(DotCopyContentModalService);
+        const inlineEditingService = {
+            setTargetInlineMCEDataset: jest.fn(),
+            initEditor: jest.fn()
+        } as unknown as InlineEditService;
+
+        service.handleAction(
+            {
+                action: DotCMSUVEAction.COPY_CONTENTLET_INLINE_EDITING,
+                payload: buildDataset(INODE)
+            },
+            {
+                uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                dialog: null,
+                inlineEditingService,
+                contentWindow: null,
+                host: HOST,
+                onCopyContent: jest.fn()
+            }
+        );
+
+        expect(copyModal.open).not.toHaveBeenCalled();
+        expect(inlineEditingService.setTargetInlineMCEDataset).toHaveBeenCalledWith({
+            oldInode: INODE,
+            inode: INODE,
+            fieldName: 'body',
+            mode: 'minimal',
+            language: '1'
+        });
+        expect(inlineEditingService.initEditor).toHaveBeenCalled();
+    });
+
+    it('should ignore the click when already inline-editing a different contentlet', () => {
+        const mockStore = buildInlineEditingStore(PageType.HEADLESS);
+        const copyModal = spectator.inject(DotCopyContentModalService);
+        const contentWindow = { postMessage: jest.fn() } as unknown as Window;
+
+        service.handleAction(
+            {
+                action: DotCMSUVEAction.COPY_CONTENTLET_INLINE_EDITING,
+                payload: buildDataset('a-different-inode')
+            },
+            {
+                uveStore: mockStore as unknown as InstanceType<typeof UVEStore>,
+                dialog: null,
+                inlineEditingService: null,
+                contentWindow,
+                host: HOST,
+                onCopyContent: jest.fn()
+            }
+        );
+
+        expect(copyModal.open).not.toHaveBeenCalled();
+        expect(contentWindow.postMessage).not.toHaveBeenCalled();
     });
 });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-uve-actions-handler/dot-uve-actions-handler.service.ts
@@ -147,12 +147,55 @@ export class DotUveActionsHandlerService {
             [DotCMSUVEAction.COPY_CONTENTLET_INLINE_EDITING]: (payload: {
                 dataset: InlineEditingContentletDataset;
             }) => {
+                const contentArea = uveStore.editorContentArea();
+                const { contentlet, container } = contentArea.payload;
+
+                // Move focus to an inline field that has already cleared (or does
+                // not need) the copy/edit decision: headless via postMessage,
+                // traditional via TinyMCE init.
+                const focusInlineField = (data: {
+                    oldInode: string;
+                    inode: string;
+                    fieldName: string;
+                    mode: string;
+                    language: string;
+                }) => {
+                    if (uveStore.pageType() === PageType.HEADLESS) {
+                        contentWindow?.postMessage(
+                            {
+                                name: __DOTCMS_UVE_EVENT__.UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS,
+                                payload: data
+                            },
+                            host
+                        );
+
+                        return;
+                    }
+
+                    inlineEditingService.setTargetInlineMCEDataset(data);
+                    inlineEditingService.initEditor();
+                };
+
                 if (uveStore.editorState() === EDITOR_STATE.INLINE_EDITING) {
+                    // Already inline-editing. When the click targets another field
+                    // on the SAME contentlet, the copy/edit decision was already
+                    // made for it — just move focus to the new field instead of
+                    // re-opening the dialog. Without this the guard silently drops
+                    // the click and the user cannot edit any other field on a
+                    // content that has many inline-editable fields.
+                    if (contentlet?.inode === payload.dataset.inode) {
+                        focusInlineField({
+                            oldInode: payload.dataset.inode,
+                            inode: payload.dataset.inode,
+                            fieldName: payload.dataset.fieldName,
+                            mode: payload.dataset.mode,
+                            language: payload.dataset.language
+                        });
+                    }
+
                     return;
                 }
 
-                const contentArea = uveStore.editorContentArea();
-                const { contentlet, container } = contentArea.payload;
                 const currentTreeNode = uveStore.getCurrentTreeNode(container, contentlet);
 
                 this.dotCopyContentModalService

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-editable-text/dotcms-editable-text.component.spec.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-editable-text/dotcms-editable-text.component.spec.ts
@@ -261,20 +261,38 @@ describe('DotCMSEditableTextComponent', () => {
                     focusSpy = jest.spyOn(spectator.component.editorComponent.editor, 'focus');
                 });
 
-                it("should focus on the editor when the message is 'uve-copy-contentlet-inline-editing-success'", () => {
+                it("should focus on the editor when the message is 'uve-copy-contentlet-inline-editing-success' and the field name matches", () => {
                     window.dispatchEvent(
                         new MessageEvent('message', {
                             data: {
                                 name: __DOTCMS_UVE_EVENT__.UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS,
                                 payload: {
                                     oldInode: dotcmsContentletMock.inode,
-                                    inode: dotcmsContentletMock.inode
+                                    inode: dotcmsContentletMock.inode,
+                                    fieldName: 'title'
                                 }
                             }
                         })
                     );
                     spectator.detectChanges();
                     expect(focusSpy).toHaveBeenCalled();
+                });
+
+                it('should not focus on the editor when the inode matches but the field name is for another field', () => {
+                    window.dispatchEvent(
+                        new MessageEvent('message', {
+                            data: {
+                                name: __DOTCMS_UVE_EVENT__.UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS,
+                                payload: {
+                                    oldInode: dotcmsContentletMock.inode,
+                                    inode: dotcmsContentletMock.inode,
+                                    fieldName: 'anotherField'
+                                }
+                            }
+                        })
+                    );
+                    spectator.detectChanges();
+                    expect(focusSpy).not.toHaveBeenCalled();
                 });
 
                 it("should not focus on the editor when the message is not 'uve-copy-contentlet-inline-editing-success'", () => {

--- a/core-web/libs/sdk/angular/src/lib/components/dotcms-editable-text/dotcms-editable-text.component.ts
+++ b/core-web/libs/sdk/angular/src/lib/components/dotcms-editable-text/dotcms-editable-text.component.ts
@@ -158,10 +158,14 @@ export class DotCMSEditableTextComponent<T extends DotCMSBasicContentlet>
             return;
         }
 
-        const { oldInode, inode } = payload;
+        const { oldInode, inode, fieldName } = payload;
         const currentInode = this.contentlet.inode;
+        const matchesInode = currentInode === oldInode || currentInode === inode;
 
-        if (currentInode === oldInode || currentInode === inode) {
+        // Match the field too: a contentlet's fields all share one inode, so an
+        // inode-only check focuses every editable field on the contentlet (the
+        // last one wins) instead of the one the user clicked.
+        if (matchesInode && fieldName === this.fieldName) {
             this.editorComponent.editor.focus();
 
             return;

--- a/core-web/libs/sdk/react/src/lib/next/__test__/components/DotCMSEditableText.test.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/__test__/components/DotCMSEditableText.test.tsx
@@ -216,19 +216,36 @@ describe('DotCMSEditableText', () => {
                     focusSpy = jest.spyOn(TINYMCE_EDITOR_MOCK, 'focus');
                 });
 
-                it("should focus on the editor when the message is 'UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS'", () => {
+                it("should focus on the editor when the message is 'UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS' and the field name matches", () => {
                     window.dispatchEvent(
                         new MessageEvent('message', {
                             data: {
                                 name: __DOTCMS_UVE_EVENT__.UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS,
                                 payload: {
                                     oldInode: MOCK_CONTENTLET['inode'],
-                                    inode: '456'
+                                    inode: '456',
+                                    fieldName: 'title'
                                 }
                             }
                         })
                     );
                     expect(focusSpy).toHaveBeenCalled();
+                });
+
+                it('should not focus on the editor when the inode matches but the field name is for another field', () => {
+                    window.dispatchEvent(
+                        new MessageEvent('message', {
+                            data: {
+                                name: __DOTCMS_UVE_EVENT__.UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS,
+                                payload: {
+                                    oldInode: MOCK_CONTENTLET['inode'],
+                                    inode: '456',
+                                    fieldName: 'anotherField'
+                                }
+                            }
+                        })
+                    );
+                    expect(focusSpy).not.toHaveBeenCalled();
                 });
 
                 it("should not focus on the editor when the message is not 'UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS'", () => {

--- a/core-web/libs/sdk/react/src/lib/next/components/DotCMSEditableText/DotCMSEditableText.tsx
+++ b/core-web/libs/sdk/react/src/lib/next/components/DotCMSEditableText/DotCMSEditableText.tsx
@@ -97,9 +97,14 @@ export function DotCMSEditableText<T extends DotCMSBasicContentlet>({
                 return;
             }
 
-            const { oldInode, inode } = payload;
+            const { oldInode, inode, fieldName: focusedFieldName } = payload;
             const currentInode = contentlet.inode;
-            const shouldFocus = currentInode === oldInode || currentInode === inode;
+            const matchesInode = currentInode === oldInode || currentInode === inode;
+
+            // Match the field too: a contentlet's fields all share one inode, so an
+            // inode-only check focuses every editable field on the contentlet (the
+            // last one wins) instead of the one the user clicked.
+            const shouldFocus = matchesInode && focusedFieldName === fieldName;
 
             if (shouldFocus) {
                 editorRef.current?.focus();
@@ -111,7 +116,7 @@ export function DotCMSEditableText<T extends DotCMSBasicContentlet>({
         return () => {
             window.removeEventListener('message', onMessage);
         };
-    }, [contentlet?.inode]);
+    }, [contentlet?.inode, fieldName]);
 
     const onMouseDown = (event: MouseEvent) => {
         const { onNumberOfPages = 1 } = contentlet;


### PR DESCRIPTION
## Proposed Changes

Fixes #36099 — inline editing on the SDK could not reliably edit a content item that lives on multiple pages and has many inline-editable fields.

Two root causes, fixed together:

1. **Wrong field gets focused.** The SDK editable-text components (`@dotcms/react` and `@dotcms/angular`) matched the `UVE_COPY_CONTENTLET_INLINE_EDITING_SUCCESS` focus event by **inode only**. Every field on a contentlet shares one inode, so the broadcast focused *all* of them and the last one won — not the field the user clicked. Now they also match `fieldName` (already present in the payload).

2. **Cannot switch to another field.** Once "Edit all" is chosen the editor enters `INLINE_EDITING`, and that state never clears while the user stays on the same contentlet (by design — see `withEditor.setContentletArea`). The `COPY_CONTENTLET_INLINE_EDITING` handler then dropped every subsequent click via its re-entrancy guard, so other fields on the same content became unreachable. Now a click on **another field of the same contentlet** moves focus to it (headless → `postMessage`, traditional → TinyMCE re-init) **without re-opening the copy/edit dialog**. Clicks on a *different* contentlet are still ignored.

https://github.com/user-attachments/assets/dc5f0bcd-e392-4143-90e8-0f852aa5d026



## Files

| File | Change |
|---|---|
| `libs/sdk/react/.../DotCMSEditableText.tsx` | Focus only when `fieldName` matches; add `fieldName` to effect deps |
| `libs/sdk/angular/.../dotcms-editable-text.component.ts` | Focus only when `fieldName` matches |
| `libs/portlets/edit-ema/.../dot-uve-actions-handler.service.ts` | Same-contentlet field switch focuses the new field without re-prompting |

## Testing

- **Unit tests added** for all three files:
  - SDK (both): focus fires on matching `fieldName`, not on a different field with the same inode.
  - Actions handler: same-contentlet switch focuses the clicked field (headless + traditional) without re-opening the dialog; a different-contentlet click is ignored.
- `sdk-angular` (220), `sdk-react` (121), `portlets-edit-ema-portlet` (1445) suites pass.

### Manual verification
On a headless page with a multi-page content that has several `DotCMSEditableText` fields, in the UVE:
1. Click a field → choose "Edit all" → the **clicked** field is focused.
2. Click another field on the same content → focus moves to it, **no** dialog re-prompt.
3. Every field is now editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36099