### PR TITLE
fix(edit-content): enable enhanced locale selector by default in sidebar

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.ts
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/dot-edit-content-sidebar.component.ts
@@ -81,9 +81,9 @@ export class DotEditContentSidebarComponent {
     readonly $isLocaleSelectorV2 = toSignal(
         this.#dotPropertiesService.getFeatureFlagWithDefault(
             FeaturedFlags.FEATURE_FLAG_LOCALE_SELECTOR_V2,
-            false
+            true
         ),
-        { initialValue: false }
+        { initialValue: true }
     );
     readonly $identifier = this.$store.getCurrentContentIdentifier;
     readonly $formValues = this.$store.formValues;

--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -874,7 +874,7 @@ FEATURE_FLAG_NEW_BLOCK_EDITOR=false
 FEATURE_FLAG_REPORT_ISSUE_ENABLED=false
 
 ## Enhanced locale selector v2 in the edit-content sidebar
-FEATURE_FLAG_LOCALE_SELECTOR_V2=false
+FEATURE_FLAG_LOCALE_SELECTOR_V2=true
 
 STARTER_BUILD_VERSION=${starter.deploy.version}
 


### PR DESCRIPTION
## Summary

- Enables `FEATURE_FLAG_LOCALE_SELECTOR_V2` by default in `dotmarketing-config.properties`
- Updates default value in `DotEditContentSidebarComponent` to `true` so the enhanced locale selector is active before the feature flag resolves

## Changes

| File | Change |
|------|--------|
| `dotmarketing-config.properties` | `FEATURE_FLAG_LOCALE_SELECTOR_V2=false` → `true` |
| `dot-edit-content-sidebar.component.ts` | Default and initial value changed from `false` → `true` |

## Test plan

- [ ] Open the Edit Content sidebar — the enhanced locale selector (v2) should render by default
- [ ] Verify the feature flag can still override the behavior when explicitly set to `false`
- [ ] Smoke test locale switching in the sidebar with the new selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35889

This PR fixes: #35889