### PR TITLE
perf(core): eliminate avoidable per-call allocation in hot logging/config paths

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/cost/LeakyTokenBucketImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/cost/LeakyTokenBucketImpl.java
@@ -52,19 +52,22 @@ public class LeakyTokenBucketImpl implements LeakyTokenBucket {
     }
 
 
+    // These run on every request-cost increment, so they return the values resolved at
+    // construction time rather than walking Config on each call. Config changes are picked
+    // up when the application-scoped bean is recreated.
     @Override
     public boolean isEnabled() {
-        return Config.getBooleanProperty("RATE_LIMIT_ENABLED", enabled);
+        return enabled;
     }
 
     @Override
     public long getMaximumBucketSize() {
-        return Config.getLongProperty("RATE_LIMIT_MAX_BUCKET_SIZE", maximumBucketSize);
+        return maximumBucketSize;
     }
 
     @Override
     public long getRefillPerSecond() {
-        return Config.getLongProperty("RATE_LIMIT_REFILL_PER_SECOND", refillPerSecond);
+        return refillPerSecond;
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/cost/LeakyTokenBucketImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/cost/LeakyTokenBucketImpl.java
@@ -3,10 +3,13 @@ package com.dotcms.cost;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Suppliers;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import javax.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
@@ -17,6 +20,14 @@ public class LeakyTokenBucketImpl implements LeakyTokenBucket {
     final long maximumBucketSize;
     final boolean enabled;
 
+    // These values are read on every request-cost increment, but a Config walk per call is an
+    // allocation hotspot. The TTL-memoized suppliers keep runtime overrides (system table /
+    // config refresh) working with at most CONFIG_REFRESH_SECONDS of staleness.
+    private static final long CONFIG_REFRESH_SECONDS = 30;
+    private final Supplier<Boolean> enabledSupplier;
+    private final Supplier<Long> refillPerSecondSupplier;
+    private final Supplier<Long> maximumBucketSizeSupplier;
+
     private final AtomicLong lastRefill = new AtomicLong(0);
     private final AtomicLong tokenCount = new AtomicLong(0);
     String REQUEST_COST_HEADER_TOKEN_MAX = "x-dotratelimit-toks-max";
@@ -26,6 +37,15 @@ public class LeakyTokenBucketImpl implements LeakyTokenBucket {
         this.enabled = enabled;
         this.maximumBucketSize = maximumBucketSize;
         this.refillPerSecond = refillPerSecond;
+        this.enabledSupplier = Suppliers.memoizeWithExpiration(
+                () -> Config.getBooleanProperty("RATE_LIMIT_ENABLED", enabled),
+                CONFIG_REFRESH_SECONDS, TimeUnit.SECONDS);
+        this.refillPerSecondSupplier = Suppliers.memoizeWithExpiration(
+                () -> Config.getLongProperty("RATE_LIMIT_REFILL_PER_SECOND", refillPerSecond),
+                CONFIG_REFRESH_SECONDS, TimeUnit.SECONDS);
+        this.maximumBucketSizeSupplier = Suppliers.memoizeWithExpiration(
+                () -> Config.getLongProperty("RATE_LIMIT_MAX_BUCKET_SIZE", maximumBucketSize),
+                CONFIG_REFRESH_SECONDS, TimeUnit.SECONDS);
 
         Logger.info(this.getClass(),
                 "Rate limiting enabled: " + enabled + ", refill per second: " + refillPerSecond + ", max bucket size: "
@@ -52,22 +72,19 @@ public class LeakyTokenBucketImpl implements LeakyTokenBucket {
     }
 
 
-    // These run on every request-cost increment, so they return the values resolved at
-    // construction time rather than walking Config on each call. Config changes are picked
-    // up when the application-scoped bean is recreated.
     @Override
     public boolean isEnabled() {
-        return enabled;
+        return enabledSupplier.get();
     }
 
     @Override
     public long getMaximumBucketSize() {
-        return maximumBucketSize;
+        return maximumBucketSizeSupplier.get();
     }
 
     @Override
     public long getRefillPerSecond() {
-        return refillPerSecond;
+        return refillPerSecondSupplier.get();
     }
 
     @Override

--- a/dotCMS/src/main/java/com/dotcms/cost/LeakyTokenBucketImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/cost/LeakyTokenBucketImpl.java
@@ -27,6 +27,7 @@ public class LeakyTokenBucketImpl implements LeakyTokenBucket {
     private final Supplier<Boolean> enabledSupplier;
     private final Supplier<Long> refillPerSecondSupplier;
     private final Supplier<Long> maximumBucketSizeSupplier;
+    private final Supplier<Boolean> addHeaderInfoSupplier;
 
     private final AtomicLong lastRefill = new AtomicLong(0);
     private final AtomicLong tokenCount = new AtomicLong(0);
@@ -34,18 +35,28 @@ public class LeakyTokenBucketImpl implements LeakyTokenBucket {
 
     @VisibleForTesting
     LeakyTokenBucketImpl(boolean enabled, long refillPerSecond, long maximumBucketSize) {
+        this(enabled, refillPerSecond, maximumBucketSize,
+                TimeUnit.SECONDS.toNanos(CONFIG_REFRESH_SECONDS));
+    }
+
+    @VisibleForTesting
+    LeakyTokenBucketImpl(boolean enabled, long refillPerSecond, long maximumBucketSize,
+            long configRefreshNanos) {
         this.enabled = enabled;
         this.maximumBucketSize = maximumBucketSize;
         this.refillPerSecond = refillPerSecond;
         this.enabledSupplier = Suppliers.memoizeWithExpiration(
                 () -> Config.getBooleanProperty("RATE_LIMIT_ENABLED", enabled),
-                CONFIG_REFRESH_SECONDS, TimeUnit.SECONDS);
+                configRefreshNanos, TimeUnit.NANOSECONDS);
         this.refillPerSecondSupplier = Suppliers.memoizeWithExpiration(
                 () -> Config.getLongProperty("RATE_LIMIT_REFILL_PER_SECOND", refillPerSecond),
-                CONFIG_REFRESH_SECONDS, TimeUnit.SECONDS);
+                configRefreshNanos, TimeUnit.NANOSECONDS);
         this.maximumBucketSizeSupplier = Suppliers.memoizeWithExpiration(
                 () -> Config.getLongProperty("RATE_LIMIT_MAX_BUCKET_SIZE", maximumBucketSize),
-                CONFIG_REFRESH_SECONDS, TimeUnit.SECONDS);
+                configRefreshNanos, TimeUnit.NANOSECONDS);
+        this.addHeaderInfoSupplier = Suppliers.memoizeWithExpiration(
+                () -> Config.getBooleanProperty("RATE_LIMIT_ADD_HEADER_INFO", true),
+                configRefreshNanos, TimeUnit.NANOSECONDS);
 
         Logger.info(this.getClass(),
                 "Rate limiting enabled: " + enabled + ", refill per second: " + refillPerSecond + ", max bucket size: "
@@ -64,7 +75,7 @@ public class LeakyTokenBucketImpl implements LeakyTokenBucket {
     @Override
     public Optional<Tuple2<String, String>> getHeaderInfo() {
 
-        if (!Config.getBooleanProperty("RATE_LIMIT_ADD_HEADER_INFO", true)) {
+        if (!addHeaderInfoSupplier.get()) {
             return Optional.empty();
         }
         return Optional.of(Tuple.of(REQUEST_COST_HEADER_TOKEN_MAX, getTokenCount() + "/" + getMaximumBucketSize()));
@@ -107,7 +118,7 @@ public class LeakyTokenBucketImpl implements LeakyTokenBucket {
             }
         }
 
-        Logger.debug(this.getClass(), "Request tokens available: " + currentCount);
+        Logger.debug(this, () -> "Request tokens available: " + currentCount);
         return true;
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/Config.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Config.java
@@ -557,7 +557,9 @@ public class Config {
 
             _refreshProperties();
 
-            Integer value = Try.of(() -> props.getInt(envKey)).getOrNull();
+            final Integer value =
+                    props.containsKey(envKey) ? Try.of(() -> props.getInt(envKey)).getOrNull()
+                            : null;
             if (value != null) {
                 return value;
             }
@@ -585,7 +587,9 @@ public class Config {
 
             _refreshProperties();
 
-            Long value = Try.of(() -> props.getLong(envKey)).getOrNull();
+            final Long value =
+                    props.containsKey(envKey) ? Try.of(() -> props.getLong(envKey)).getOrNull()
+                            : null;
             if (value != null) {
                 return value;
             }
@@ -617,7 +621,9 @@ public class Config {
 
             _refreshProperties();
 
-            Integer value = Try.of(() -> props.getInt(envKey(name))).getOrNull();
+            final Integer value =
+                    props.containsKey(envKey) ? Try.of(() -> props.getInt(envKey)).getOrNull()
+                            : null;
             if (value != null) {
                 return value;
             }
@@ -649,7 +655,9 @@ public class Config {
 
             _refreshProperties();
 
-            Float value = Try.of(() -> props.getFloat(envKey)).getOrNull();
+            final Float value =
+                    props.containsKey(envKey) ? Try.of(() -> props.getFloat(envKey)).getOrNull()
+                            : null;
             if (value != null) {
                 return value;
             }
@@ -682,7 +690,9 @@ public class Config {
 
             _refreshProperties();
 
-            Float value = Try.of(() -> props.getFloat(envKey)).getOrNull();
+            final Float value =
+                    props.containsKey(envKey) ? Try.of(() -> props.getFloat(envKey)).getOrNull()
+                            : null;
             if (value != null) {
                 return value;
             }
@@ -716,7 +726,9 @@ public class Config {
 
             _refreshProperties();
 
-            Boolean value = Try.of(() -> props.getBoolean(envKey)).getOrNull();
+            final Boolean value =
+                    props.containsKey(envKey) ? Try.of(() -> props.getBoolean(envKey)).getOrNull()
+                            : null;
             if (value != null) {
                 return value;
             }

--- a/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
@@ -68,15 +68,16 @@ public class Logger {
     }
 
     public static void info(Class clazz, final Supplier<String> message) {
-       
+        if (isInfoEnabled(clazz)) {
             info(clazz, message.get());
-        
+        }
     }
 
     public static void info(final Object ob, final Supplier<String> message) {
-
-            info(ob.getClass(), message.get());
-        
+        final Class<?> clazz = ob.getClass();
+        if (isInfoEnabled(clazz)) {
+            info(clazz, message.get());
+        }
     }
 
     public static void info(Object ob, String message) {
@@ -104,18 +105,23 @@ public class Logger {
     }
 
     public static void debug(final Object ob, final Supplier<String> message) {
-        debug(ob.getClass(), message.get());
-        
+        final Class<?> clazz = ob.getClass();
+        if (isDebugEnabled(clazz)) {
+            debug(clazz, message.get());
+        }
     }
 
     public static void debug(final String className, final Supplier<String> message) {
-        debug(className, message.get());
-        
+        if (isDebugEnabled(className)) {
+            debug(className, message.get());
+        }
     }
 
     public static void debug(final Object ob, final Throwable throwable, final Supplier<String> message) {
-        debug(ob.getClass(), message.get(), throwable);
-
+        final Class<?> clazz = ob.getClass();
+        if (isDebugEnabled(clazz)) {
+            debug(clazz, message.get(), throwable);
+        }
     }
 
     public static void debug(Object ob, String message) {
@@ -529,21 +535,28 @@ public class Logger {
         return isVelocityMessage(obj.getClass());
     }
 
+    /**
+     * Memoized per class name: this runs on every Class-keyed log call, and the lowercased
+     * name allocation showed up in allocation profiles.
+     */
+    private static final Cache<String, Boolean> velocityClassMap =
+                    Caffeine.newBuilder()
+                        .maximumSize(10000)
+                        .expireAfterAccess(6, TimeUnit.HOURS)
+                        .build();
+
     private static boolean isVelocityMessage(Class clazz) {
-        boolean ret = false;
-        if (clazz != null && clazz.getName() != null) {
-            String name = clazz.getName().toLowerCase();
-            ret = name.contains("velocity") || name.contains("viewtool");
-
-            if (!ret) {
-                ret = ViewTool.class.isAssignableFrom(clazz);
-            }
-            if (!ret) {
-                ret = VelocityServlet.class.isAssignableFrom(clazz);
-            }
+        if (clazz == null || clazz.getName() == null) {
+            return false;
         }
-        return ret;
+        return velocityClassMap.get(clazz.getName(), name -> computeIsVelocityMessage(clazz));
+    }
 
+    private static boolean computeIsVelocityMessage(final Class clazz) {
+        final String name = clazz.getName().toLowerCase();
+        return name.contains("velocity") || name.contains("viewtool")
+                || ViewTool.class.isAssignableFrom(clazz)
+                || VelocityServlet.class.isAssignableFrom(clazz);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/Logger.java
@@ -536,27 +536,22 @@ public class Logger {
     }
 
     /**
-     * Memoized per class name: this runs on every Class-keyed log call, and the lowercased
-     * name allocation showed up in allocation profiles.
+     * Memoized per class: this runs on every Class-keyed log call, and the lowercased name
+     * allocation showed up in allocation profiles. ClassValue lookups are allocation-free and
+     * entries are released with their class, so OSGi classloaders aren't pinned.
      */
-    private static final Cache<String, Boolean> velocityClassMap =
-                    Caffeine.newBuilder()
-                        .maximumSize(10000)
-                        .expireAfterAccess(6, TimeUnit.HOURS)
-                        .build();
+    private static final ClassValue<Boolean> velocityClassValue = new ClassValue<Boolean>() {
+        @Override
+        protected Boolean computeValue(final Class<?> type) {
+            final String name = type.getName().toLowerCase();
+            return name.contains("velocity") || name.contains("viewtool")
+                    || ViewTool.class.isAssignableFrom(type)
+                    || VelocityServlet.class.isAssignableFrom(type);
+        }
+    };
 
     private static boolean isVelocityMessage(Class clazz) {
-        if (clazz == null || clazz.getName() == null) {
-            return false;
-        }
-        return velocityClassMap.get(clazz.getName(), name -> computeIsVelocityMessage(clazz));
-    }
-
-    private static boolean computeIsVelocityMessage(final Class clazz) {
-        final String name = clazz.getName().toLowerCase();
-        return name.contains("velocity") || name.contains("viewtool")
-                || ViewTool.class.isAssignableFrom(clazz)
-                || VelocityServlet.class.isAssignableFrom(clazz);
+        return clazz != null && velocityClassValue.get(clazz);
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/cost/LeakyTokenBucketImplTest.java
+++ b/dotCMS/src/test/java/com/dotcms/cost/LeakyTokenBucketImplTest.java
@@ -5,11 +5,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.dotcms.UnitTestBase;
+import com.dotmarketing.util.Config;
+import java.lang.reflect.Field;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.configuration.MapConfiguration;
 import org.junit.Test;
 
 /**
@@ -17,6 +20,46 @@ import org.junit.Test;
  * draining, and concurrent access scenarios.
  */
 public class LeakyTokenBucketImplTest extends UnitTestBase {
+
+    /**
+     * Test: Runtime config overrides must reach a running bucket once the memoization TTL
+     * lapses, and reads within the TTL must serve the cached value. Pins the contract that the
+     * getters consult Config (not the constructor-captured fields), so rate limiting can be
+     * toggled at runtime without a restart.
+     */
+    @Test
+    public void test_runtimeConfigOverride_reachesRunningBucket() throws Exception {
+        final String key = "RATE_LIMIT_MAX_BUCKET_SIZE";
+        try {
+            // TTL of 1ns: every read consults Config
+            LeakyTokenBucket bucket = new LeakyTokenBucketImpl(true, 100, 1000, 1);
+            assertEquals(1000, bucket.getMaximumBucketSize());
+
+            Config.setProperty(key, 2000L);
+            assertEquals("runtime override must reach a running bucket",
+                    2000, bucket.getMaximumBucketSize());
+
+            // long TTL: the value is read once and cached
+            LeakyTokenBucket cached = new LeakyTokenBucketImpl(true, 100, 1000,
+                    TimeUnit.HOURS.toNanos(1));
+            assertEquals(2000, cached.getMaximumBucketSize());
+            Config.setProperty(key, 3000L);
+            assertEquals("reads within the TTL must not walk Config",
+                    2000, cached.getMaximumBucketSize());
+        } finally {
+            clearConfigProperty(key);
+        }
+    }
+
+    /**
+     * Config has no public removal API; clear via reflection so the leftover property cannot
+     * leak into the other tests in this class (their getters consult Config first).
+     */
+    private static void clearConfigProperty(final String key) throws Exception {
+        final Field propsField = Config.class.getDeclaredField("props");
+        propsField.setAccessible(true);
+        ((MapConfiguration) propsField.get(null)).clearProperty(key);
+    }
 
     /**
      * Test: New bucket should allow requests Expected: allow() returns true when bucket has tokens

--- a/dotCMS/src/test/java/com/dotmarketing/util/ConfigTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/ConfigTest.java
@@ -146,6 +146,28 @@ public class ConfigTest {
     }
 
     @Test
+    public void testing_notfound_long_returns_default() {
+        assertEquals(789L, Config.getLongProperty("no-property", 789L));
+    }
+
+    /**
+     * When the DOT_ env alias exists but its value is not parseable as the requested type, the
+     * getter must fall back to the default rather than propagate the conversion failure.
+     */
+    @Test
+    public void testing_unparseable_env_alias_falls_back_to_default() {
+        final String envAlias = "DOT_TESTING_UNPARSEABLE";
+        try {
+            Config.props.addProperty(envAlias, "not-a-number");
+            assertEquals(42L, Config.getLongProperty("TESTING_UNPARSEABLE", 42L));
+            assertEquals(42, Config.getIntProperty("TESTING_UNPARSEABLE", 42));
+            assertEquals(4.2f, Config.getFloatProperty("TESTING_UNPARSEABLE", 4.2f), 0.0);
+        } finally {
+            Config.props.clearProperty(envAlias);
+        }
+    }
+
+    @Test
     public void test_get_integer_from_env() {
         int value = Config.getIntProperty("no-property", -99);
         assertEquals(-99, value);

--- a/dotCMS/src/test/java/com/dotmarketing/util/LoggerTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/LoggerTest.java
@@ -1,0 +1,60 @@
+package com.dotmarketing.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.Test;
+
+public class LoggerTest {
+
+    /**
+     * The {@code Supplier} overloads exist so message building is skipped when the level is
+     * disabled. Verifies the supplier is only evaluated when debug logging is enabled.
+     */
+    @Test
+    public void debug_supplier_is_lazy() {
+        final String loggerName = LoggerTest.class.getName();
+        try {
+            Logger.setLevel(loggerName, "INFO");
+            final AtomicBoolean evaluated = new AtomicBoolean(false);
+            Logger.debug(this, () -> {
+                evaluated.set(true);
+                return "should not be built";
+            });
+            assertFalse("supplier must not be evaluated when debug is disabled", evaluated.get());
+
+            Logger.setLevel(loggerName, "DEBUG");
+            Logger.debug(this, () -> {
+                evaluated.set(true);
+                return "should be built";
+            });
+            assertTrue("supplier must be evaluated when debug is enabled", evaluated.get());
+        } finally {
+            Logger.setLevel(loggerName, "INFO");
+        }
+    }
+
+    @Test
+    public void info_supplier_is_lazy() {
+        final String loggerName = LoggerTest.class.getName();
+        try {
+            Logger.setLevel(loggerName, "WARN");
+            final AtomicBoolean evaluated = new AtomicBoolean(false);
+            Logger.info(this, () -> {
+                evaluated.set(true);
+                return "should not be built";
+            });
+            assertFalse("supplier must not be evaluated when info is disabled", evaluated.get());
+
+            Logger.setLevel(loggerName, "INFO");
+            Logger.info(this, () -> {
+                evaluated.set(true);
+                return "should be built";
+            });
+            assertTrue("supplier must be evaluated when info is enabled", evaluated.get());
+        } finally {
+            Logger.setLevel(loggerName, "INFO");
+        }
+    }
+}


### PR DESCRIPTION
### Proposed Changes
* **Logger lazy `Supplier` overloads are now actually lazy** — the three `debug(…, Supplier)` and two `info(…, Supplier)` overloads called `message.get()` unconditionally; they now check the level first. ~900 call sites use suppliers specifically to skip message building, including ones that did `reflectionToString` on Contentlets via `PermissionBitFactoryImpl` debug logging on the reindex path.
* **`Config` int/long/float/boolean getters no longer throw per read** — the `DOT_*` env-alias probe used commons-configuration's throwing 1-arg getter wrapped in vavr `Try`, so every read of a non-env-overridden key allocated and discarded a `NoSuchElementException` (with full stack trace). Applied the `containsKey` guard that `getBooleanProperty(name, default)` already had.
* **`Logger.isVelocityMessage` memoized via `ClassValue`** — previously allocated a lowercased class name on every Class-keyed log call; `ClassValue` lookups are allocation-free, keyed per actual Class (no FQN conflation across OSGi classloaders), and entries are released with their class.
* **`LeakyTokenBucketImpl` no longer walks Config per request-cost increment** — the four config reads (`enabled`, `refill`, `max bucket`, `add-header-info`) are TTL-memoized (30s). Runtime overrides via system table / config refresh still take effect within the TTL, preserved deliberately so rate limiting can be toggled during an incident; a test with an injectable TTL pins that contract.

### Why
Allocation profiling of a running instance (Pyroscope TLAB profiles under mixed REST/GraphQL/page-render load) attributed the `Throwable.fillInStackTrace`, `Method.copy`/`Field.copy`, and `StringLatin1.toLowerCase` allocation hotspots to these four spots; `Config.get*` subtrees alone were ~19% of sampled allocation in a mixed window (e.g. one full Config walk — exception included — per expired session via `ClickstreamListener`, per 250ms reindex-pause iteration, per request-cost increment). Expected effect is reduced allocation → less GC pressure, not a single-endpoint latency win.

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated (none — no input handling or auth paths touched; rate-limit values remain config-driven)

### Additional Info
New/extended unit tests: `LoggerTest` (suppliers not evaluated when level disabled), `LeakyTokenBucketImplTest` (runtime config override reaches a running bucket; reads within TTL stay cached), `ConfigTest` (`getLongProperty` missing-key default; env-alias-present-but-unparseable falls back to default for int/long/float). The deprecated no-default `Config` getters still throw `NoSuchElementException` for missing base keys — that documented contract is unchanged (and pinned by existing tests).

Closes #36145

This PR fixes: #36145