### PR TITLE
fix(opensearch): grant cluster:monitor/main to limited role for OS 3.x startup (#35922)

### DIFF
--- a/docker/docker-compose-examples/single-node-os-migration/opensearch.py
+++ b/docker/docker-compose-examples/single-node-os-migration/opensearch.py
@@ -79,6 +79,10 @@ class OpenSearchClient:
             "cluster:monitor/nodes/stats",
             "indices:data/read/scroll",
             "indices:data/read/scroll/clear",
+            # GET / — required by IndexStartupValidator's OS version/reachability
+            # probe (client.info()). Without it OS 3.x is misclassified as
+            # unreachable and dotCMS silently falls back to ES-only. See spike #35922.
+            "cluster:monitor/main",
         ]
         self.all_index_permissions = [
             "indices:monitor/stats",


### PR DESCRIPTION
## What

Adds `cluster:monitor/main` to the limited OpenSearch role's cluster action group in `opensearch.py` (the provisioning script for `dotcms-es-user` → `dotcms-role`).

## Why (spike #35922)

Spike #35922 validated dotCMS's **non-admin** OS user against **OpenSearch 3.4.0** using the `single-node-os-migration` stack. Finding:

- The role's `indices_all` action group already expands to the full **admin + read + write** action set on `cluster_<customer>*` indices on **both** OS 1.3 and OS 3.x — content write/read, mapping, scroll, forcemerge, cache-clear, delete-by-query all work. These were **not** real gaps.
- The **only** missing permission is **`cluster:monitor/main`** (`GET /`), required by `IndexStartupValidator.validateOSVersion()` which calls `client.info()` to read the OS version at startup.
- Without it, the limited user gets a `403 security_exception`, the validator's single `catch` block misclassifies a healthy OS 3.x cluster as *"not reachable"*, and dotCMS **silently halts the migration and falls back to ES-only** (phase reset 1 → 0).
- This is **not** an OS 3.x permission change — `GET /` returns `403` for the limited user on OS 1.3 too. It is a new dotCMS-side dependency introduced by the migration code.

## The change

```python
self.cluster_permissions = [
    "cluster:monitor/health",
    "indices:data/write/bulk",
    "cluster:monitor/state",
    "cluster:monitor/nodes/stats",
    "indices:data/read/scroll",
    "indices:data/read/scroll/clear",
    "cluster:monitor/main",   # <-- added: GET / for IndexStartupValidator
]
```

## Verification (end-to-end)

1. Re-provisioned OS 3.x with the patched script → `GET /` as the limited user now returns **200**.
2. Started dotCMS with `DOT_FEATURE_FLAG_OPEN_SEARCH_PHASE=3` (OS-only):
   - `IndexStartupValidator - OS version check passed: 3.4.0`
   - `Endpoint separation check passed`
   - OS-only index bootstrap (no ES index created).
3. REST smoke against the OS 3.x index:
   - `POST /api/content/_search` (`+live:true`) → `200`, results served from OS 3.x.
   - `POST /api/v1/workflow/actions/default/fire/PUBLISH` → content published; OS 3.x working index doc count `5 → 6`.
   - `POST /api/content/_search` (`+title:Smoke*`) → finds the new content (read from OS 3.x).

## Rollout note

This role is provisioned **per-customer**. The script change covers new provisioning automatically; **existing customer roles must be re-provisioned (or have the action group updated) before they advance past Phase 0**, or their startup validator will fail against OS 3.x.

## Follow-up (out of scope here)

Harden `IndexStartupValidator.validateOSVersion()` so a `403`/`security_exception` is distinguished from a genuine connectivity failure and logs the missing action name, instead of the opaque "not reachable" (tracked separately).

Full spike report and methodology: see issue #35922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35922