### PR TITLE
chore(ai-reviews): bump ai-workflows pin to v3.1.4

### DIFF
--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -85,7 +85,7 @@ jobs:
       id-token: write
       pull-requests: write
       issues: write
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.2
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.3
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}

--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -85,7 +85,7 @@ jobs:
       id-token: write
       pull-requests: write
       issues: write
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.3
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.4
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -82,7 +82,7 @@ jobs:
           )
         )
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.2
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.3
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
@@ -140,7 +140,7 @@ jobs:
     concurrency:
       group: claude-automatic-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.2
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.3
     with:
       model_id: openai.gpt-5.5
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -82,7 +82,7 @@ jobs:
           )
         )
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.3
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.4
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
@@ -140,7 +140,7 @@ jobs:
     concurrency:
       group: claude-automatic-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.3
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.4
     with:
       model_id: openai.gpt-5.5
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}


### PR DESCRIPTION
## Summary

Bumps the `dotCMS/ai-workflows` pin in the AI review workflows from `@v3.1.2` to **`@v3.1.4`** (orchestrator + backend reviewer). Supersedes the intermediate v3.1.3 bump — v3.1.4 includes everything in v3.1.3 plus the outcome-signaling improvements, so we go straight to it.

## What's in v3.1.3 + v3.1.4

**v3.1.3 — silent-failure fix ([ai-workflows#38](https://github.com/dotCMS/ai-workflows/pull/38)):** ~43% of GPT-5.5 reviews were posting "❌ Codex Review failed — job failed before producing output." Root cause: `max_output_tokens` caps reasoning+answer combined, so medium-effort GPT-5.5 sometimes spent the whole budget reasoning and returned `incomplete` with no text. Fix: budget 2048→8000, handle `response.incomplete`, retry once with a bigger budget + lighter reasoning.

**v3.1.4 — clear outcome signaling ([ai-workflows#39](https://github.com/dotCMS/ai-workflows/pull/39)):**
- Sticky header reflects the outcome: `🤖 Codex Review` / `⚠️ truncated` / `❌ no output` / `⏱️ canceled`
- The job **fails (red ✗ in checks)** when no review is produced — surfaces the outcome without gating merges (advisory review)
- Canceled / timed-out runs rewrite the sticky to `⏱️ Codex Review canceled` instead of leaving it stuck on `🔄 in progress`

## Validation

- v3.1.3 before/after e2e: steve-quarterly-planning #105 (@v3.1.2 failed, @v3.1.3 recovered)
- v3.1.4 signaling e2e: steve-quarterly-planning #106 (🤖+green confirmed; ⏱️ cancellation confirmed; retry makes the ❌ path a hardened safety net)

Closes: #36158