### PR TITLE
fix(uve): scan correct site in Page Health a11y/GEO reports on multisite

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1500,7 +1500,9 @@ describe('DotEmaShellComponent', () => {
 
                 const { currentUrl, siteId } = spectator.component['$seoParams']();
                 const expectedUrl = new URL(currentUrl, window.location.origin);
-                expectedUrl.searchParams.set('host_id', siteId);
+                if (siteId) {
+                    expectedUrl.searchParams.set('host_id', siteId);
+                }
                 expect(openSpy).toHaveBeenCalledWith('a11y', expectedUrl.toString());
             });
 
@@ -1521,12 +1523,35 @@ describe('DotEmaShellComponent', () => {
                 spectator.component['pageScanner'] = {
                     open: openSpy
                 } as unknown as DotPageScannerReportComponent;
+                jest.spyOn(spectator.component, '$seoParams' as never).mockReturnValue({
+                    currentUrl: '/my-page',
+                    requestHostName: 'https://content-site.example.com',
+                    siteId: 'site-b-identifier',
+                    languageId: 1
+                } as never);
 
                 spectator.component.handleScannerToolClick('a11y');
 
-                const { siteId } = spectator.component['$seoParams']();
                 const calledUrl = openSpy.mock.calls[0][1] as string;
-                expect(new URL(calledUrl).searchParams.get('host_id')).toBe(siteId);
+                expect(new URL(calledUrl).searchParams.get('host_id')).toBe('site-b-identifier');
+            });
+
+            it('should omit host_id when the page has no site identifier', () => {
+                const openSpy = jest.fn();
+                spectator.component['pageScanner'] = {
+                    open: openSpy
+                } as unknown as DotPageScannerReportComponent;
+                jest.spyOn(spectator.component, '$seoParams' as never).mockReturnValue({
+                    currentUrl: '/my-page',
+                    requestHostName: 'https://content-site.example.com',
+                    siteId: undefined,
+                    languageId: 1
+                } as never);
+
+                spectator.component.handleScannerToolClick('a11y');
+
+                const calledUrl = openSpy.mock.calls[0][1] as string;
+                expect(new URL(calledUrl).searchParams.has('host_id')).toBe(false);
             });
 
             it('should pass geo type to the page scanner', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1498,8 +1498,23 @@ describe('DotEmaShellComponent', () => {
 
                 spectator.component.handleScannerToolClick('a11y');
 
-                const { requestHostName, currentUrl } = spectator.component['$seoParams']();
-                expect(openSpy).toHaveBeenCalledWith('a11y', `${requestHostName}${currentUrl}`);
+                const { requestHostName, currentUrl, siteId } = spectator.component['$seoParams']();
+                const expectedUrl = new URL(`${requestHostName}${currentUrl}`);
+                expectedUrl.searchParams.set('host_id', siteId);
+                expect(openSpy).toHaveBeenCalledWith('a11y', expectedUrl.toString());
+            });
+
+            it('should append the page site host_id so the scanner resolves the correct site on multisite', () => {
+                const openSpy = jest.fn();
+                spectator.component['pageScanner'] = {
+                    open: openSpy
+                } as unknown as DotPageScannerReportComponent;
+
+                spectator.component.handleScannerToolClick('a11y');
+
+                const { siteId } = spectator.component['$seoParams']();
+                const calledUrl = openSpy.mock.calls[0][1] as string;
+                expect(new URL(calledUrl).searchParams.get('host_id')).toBe(siteId);
             });
 
             it('should pass geo type to the page scanner', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1498,10 +1498,22 @@ describe('DotEmaShellComponent', () => {
 
                 spectator.component.handleScannerToolClick('a11y');
 
-                const { requestHostName, currentUrl, siteId } = spectator.component['$seoParams']();
-                const expectedUrl = new URL(`${requestHostName}${currentUrl}`);
+                const { currentUrl, siteId } = spectator.component['$seoParams']();
+                const expectedUrl = new URL(currentUrl, window.location.origin);
                 expectedUrl.searchParams.set('host_id', siteId);
                 expect(openSpy).toHaveBeenCalledWith('a11y', expectedUrl.toString());
+            });
+
+            it('should scan the authoring instance origin, not the page content host', () => {
+                const openSpy = jest.fn();
+                spectator.component['pageScanner'] = {
+                    open: openSpy
+                } as unknown as DotPageScannerReportComponent;
+
+                spectator.component.handleScannerToolClick('a11y');
+
+                const calledUrl = openSpy.mock.calls[0][1] as string;
+                expect(new URL(calledUrl).origin).toBe(window.location.origin);
             });
 
             it('should append the page site host_id so the scanner resolves the correct site on multisite', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -354,13 +354,23 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
      * Handle scanner tool click from the page tools panel.
      * Opens the page scanner report dialog with the selected tool type.
      *
+     * The `host_id` query param is appended so the scanner resolves the page's
+     * own site when it renders back into dotCMS. Without it dotCMS falls back to
+     * the host derived from the request — wrong on multisite instances where
+     * different sites share the same path (e.g. `/index`).
+     *
      * @param {PageScannerToolType} type
      * @memberof DotEmaShellComponent
      */
     handleScannerToolClick(type: PageScannerToolType): void {
-        const { currentUrl, requestHostName } = this.$seoParams();
-        const pageUrl = `${requestHostName}${currentUrl ?? '/'}`;
-        this.pageScanner.open(type, pageUrl);
+        const { currentUrl, requestHostName, siteId } = this.$seoParams();
+        const url = new URL(`${requestHostName}${currentUrl ?? '/'}`);
+
+        if (siteId) {
+            url.searchParams.set('host_id', siteId);
+        }
+
+        this.pageScanner.open(type, url.toString());
     }
 
     /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -354,17 +354,20 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
      * Handle scanner tool click from the page tools panel.
      * Opens the page scanner report dialog with the selected tool type.
      *
-     * The `host_id` query param is appended so the scanner resolves the page's
-     * own site when it renders back into dotCMS. Without it dotCMS falls back to
-     * the host derived from the request — wrong on multisite instances where
-     * different sites share the same path (e.g. `/index`).
+     * The scanner is an external service that fetches the URL over the public
+     * internet, so the URL must point at this authoring instance
+     * (`window.location.origin`) — never the page's content-site hostname or a
+     * headless `clientHost`, which may not be publicly reachable. The site is
+     * disambiguated via the `host_id` query param, which dotCMS resolves for the
+     * backend user regardless of the host. Without it, multisite pages sharing a
+     * path (e.g. `/index`) resolve to the wrong site.
      *
      * @param {PageScannerToolType} type
      * @memberof DotEmaShellComponent
      */
     handleScannerToolClick(type: PageScannerToolType): void {
-        const { currentUrl, requestHostName, siteId } = this.$seoParams();
-        const url = new URL(`${requestHostName}${currentUrl ?? '/'}`);
+        const { currentUrl, siteId } = this.$seoParams();
+        const url = new URL(currentUrl ?? '/', window.location.origin);
 
         if (siteId) {
             url.searchParams.set('host_id', siteId);


### PR DESCRIPTION


https://github.com/user-attachments/assets/48b7f092-a64b-4409-b87e-2cfc9dab5397



## What

The Page Health a11y and GEO reports in UVE scanned the wrong site on multisite instances. Only the page path was sent to the scanner, so when multiple sites share a path (e.g. `/index`) dotCMS resolved the page against the request-derived site instead of the site open in the editor — and in headless/UVE the request host maps to no dotCMS site at all.

This appends `host_id=<siteId>` (the page's own `pageAsset.site.identifier`, already computed in `$seoParams()`) to the URL passed to the scanner. dotCMS honors `host_id` to resolve the current site for backend users (`HostWebApiImpl.getCurrentHost`), so the scanner now re-renders the correct page.

## Scope

- `dot-ema-shell.component.ts` — `handleScannerToolClick()` builds the scanner URL with `host_id` via the `URL` API (preserves existing query params, omits when no siteId).
- `dot-ema-shell.component.spec.ts` — updated expectation + added a multisite assertion.

No backend changes needed: the scanner fetches the URL verbatim, so the param survives the round-trip.

Closes #36162
