### PR TITLE
Update cicd_6-release.yml

### DIFF
--- a/.github/workflows/cicd_6-release.yml
+++ b/.github/workflows/cicd_6-release.yml
@@ -49,6 +49,11 @@ on:
         type: boolean
         default: true
         required: false
+      update_latest:
+        description: 'Update the "latest" Docker tag (disable for back-patches of older release lines)'
+        type: boolean
+        default: true
+        required: false
       notify_slack:
         description: 'Notify Slack'
         type: boolean
@@ -134,7 +139,7 @@ jobs:
       tag-identifier: ${{ needs.release-prepare.outputs.release_version }}
       omit-environment-prefix: true
       artifact-run-id: ${{ github.run_id }}
-      latest: ${{ needs.release-prepare.outputs.is_latest == 'true' && github.ref_name == 'main' }}
+      latest: ${{ needs.release-prepare.outputs.is_latest == 'true' && github.ref_name == 'main' && github.event.inputs.update_latest == 'true' }}
       deploy-cli: true
       deploy-dev-image: true
       publish-npm-cli: false


### PR DESCRIPTION
## Add `update_latest` toggle to the Release workflow

### Summary

Adds an optional `update_latest` boolean input to the `-6 Release Process` workflow (`cicd_6-release.yml`) so an operator can cut a release **without moving the Docker `latest` tag**. This is needed for back-patching older release lines (e.g. publishing `26.04.22-04` while the current line is `26.06.x`), where letting `latest` regress to the older patch is undesirable.

### Background

The `latest` Docker tag was previously derived solely from the version-string format (`is_latest`) AND the run being on `main`:

```yaml
latest: ${{ needs.release-prepare.outputs.is_latest == 'true' && github.ref_name == 'main' }}
```

Because a standard version like `26.04.22-04` matches the "latest-eligible" regex (`^\d{2}.\d{2}.\d{2}-\d{1,2}$`), `is_latest` is `true` — so a back-patch of an old line, cut from `main`, would **move `latest` backward**. There was no way to suppress this short of editing the workflow.

### Changes

- **New input** `update_latest` (boolean, default `true`) — preserves existing behavior unless explicitly disabled. Described as: *Update the "latest" Docker tag (disable for back-patches of older release lines).*
- **Gated the `latest` flag** on the new input, ANDed onto the existing conditions:

```yaml
latest: ${{ needs.release-prepare.outputs.is_latest == 'true' && github.ref_name == 'main' && github.event.inputs.update_latest == 'true' }}
```

The `is_latest` (version-format) and `github.ref_name == 'main'` (defense-in-depth) guards are intentionally **kept**:
- `is_latest` keeps LTS releases (`_lts_v##`) automatically excluded from `latest`, so the default `true` value can't accidentally tag an LTS build.
- `github.ref_name == 'main'` is redundant with the existing `verify-branch` guard but retained as harmless defense-in-depth, consistent with #35919.

### Expected behavior

| Scenario | `update_latest` | Version | Branch | `latest` tagged? |
|---|---|---|---|---|
| Normal release (unchanged) | `true` (default) | `26.06.04-01` | `main` | ✅ Yes |
| **Back-patch of older line** | **`false`** | `26.04.22-04` | `main` | ❌ **No** |
| LTS release | any | `26.04.22_lts_v1` | `main` | ❌ No (format guard) |
| Back-patch with box left checked | `true` | `26.04.22-04` | `main` | ⚠️ Yes — operator must uncheck for back-patches |

### How to use for the `26.04.22-04` back-patch

Dispatch `-6 Release Process` from `main` with:
- `release_version = 26.04.22-04`
- `release_commit =` the patch commit on the `26.04.22` line
- **`update_latest` unchecked**

The release builds, tags, and deploys normally; `latest` stays pointed at the current `26.06.x` release.

### Testing

- `actionlint` passes clean on `cicd_6-release.yml`.
- No changes to job graph, `needs:` chains, or the `verify-branch` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
