### PR TITLE
fix(block-editor): keep body-portaled overlays above the fullscreen shell (#35980)

### DIFF
--- a/core-web/libs/new-block-editor/src/lib/editor/components/link-popover/link-popover.component.html
+++ b/core-web/libs/new-block-editor/src/lib/editor/components/link-popover/link-popover.component.html
@@ -24,6 +24,7 @@
                 <p-autoComplete
                     inputId="link-url"
                     appendTo="body"
+                    [overlayOptions]="overlayOptions"
                     optionLabel="url"
                     [size]="'small'"
                     [ngModel]="linkModel()"
@@ -156,6 +157,7 @@
                         <p-select
                             inputId="link-rel"
                             appendTo="body"
+                            [overlayOptions]="overlayOptions"
                             [size]="'small'"
                             [showClear]="true"
                             [options]="relOptions"

--- a/core-web/libs/new-block-editor/src/lib/editor/components/link-popover/link-popover.component.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/components/link-popover/link-popover.component.ts
@@ -32,6 +32,7 @@ import { DotContentSearchService } from '@dotcms/data-access';
 import { DotCMSContentlet } from '@dotcms/dotcms-models';
 import { DotMessagePipe } from '@dotcms/ui';
 
+import { FULLSCREEN_AWARE_OVERLAY_OPTIONS } from '../../config.utils';
 import { LINK_SELECTION_KEY } from '../../extensions/selection-preserve.extension';
 import { EditorPopoverService } from '../../services/editor-popover.service';
 import { EditorStore } from '../../store/editor.store';
@@ -88,6 +89,14 @@ export class LinkPopoverComponent {
     readonly #store = inject(EditorStore);
 
     protected readonly relOptions = REL_OPTIONS;
+
+    /**
+     * Overlay options for the URL `<p-autoComplete>` and rel `<p-select>` panels, both of which
+     * append to `document.body`. Lifts them above the fullscreen editor shell's `z-[9998]`
+     * backdrop so the suggestion/dropdown panels stay clickable in fullscreen.
+     * See {@link FULLSCREEN_AWARE_OVERLAY_OPTIONS}.
+     */
+    protected readonly overlayOptions = FULLSCREEN_AWARE_OVERLAY_OPTIONS;
 
     /** AutoComplete instance — used to force-hide the overlay when an external URL is typed. */
     protected readonly autoComplete = viewChild<AutoComplete>(AutoComplete);

--- a/core-web/libs/new-block-editor/src/lib/editor/components/table-popover/table-handle-popover.component.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/components/table-popover/table-handle-popover.component.ts
@@ -19,6 +19,7 @@ import { Editor } from '@tiptap/core';
 import { DotMessageService } from '@dotcms/data-access';
 import { DotMessagePipe } from '@dotcms/ui';
 
+import { FULLSCREEN_AWARE_OVERLAY_OPTIONS } from '../../config.utils';
 import { EditorPopoverService } from '../../services/editor-popover.service';
 import { EditorPopoverComponent } from '../editor-popover/editor-popover.component';
 
@@ -93,6 +94,7 @@ interface ActionEntry {
                         <p-select
                             inputId="tbl-col-scope"
                             appendTo="body"
+                            [overlayOptions]="overlayOptions"
                             styleClass="popover-field__select"
                             [size]="'small'"
                             [options]="scopeOptions"
@@ -124,6 +126,13 @@ export class TableHandlePopoverComponent implements OnDestroy {
     private readonly dotMessageService = inject(DotMessageService);
 
     protected readonly POPOVER_IDS = ['table-column', 'table-row', 'table-selection'] as const;
+
+    /**
+     * Overlay options for the header-scope `<p-select>` panel, which appends to `document.body`.
+     * Lifts it above the fullscreen editor shell's `z-[9998]` backdrop so the dropdown stays
+     * clickable in fullscreen. See {@link FULLSCREEN_AWARE_OVERLAY_OPTIONS}.
+     */
+    protected readonly overlayOptions = FULLSCREEN_AWARE_OVERLAY_OPTIONS;
 
     // ── Action lists ─────────────────────────────────────────────────────────
     // Plain lists of action keys per variant. The actual config lives in `ACTIONS` below.

--- a/core-web/libs/new-block-editor/src/lib/editor/components/toolbar/toolbar.component.html
+++ b/core-web/libs/new-block-editor/src/lib/editor/components/toolbar/toolbar.component.html
@@ -35,6 +35,7 @@
 <p-select
     inputId="toolbar-block-type"
     appendTo="body"
+    [overlayOptions]="overlayOptions"
     [size]="'small'"
     [options]="blockTypeOptions()"
     [ngModel]="blockTypeValue()"

--- a/core-web/libs/new-block-editor/src/lib/editor/components/toolbar/toolbar.component.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/components/toolbar/toolbar.component.ts
@@ -22,6 +22,10 @@ import { DotMessagePipe } from '@dotcms/ui';
 
 import { EditorToolbarStore } from './editor-toolbar.store';
 
+import {
+    FULLSCREEN_AWARE_OVERLAY_OPTIONS,
+    OVERLAY_ABOVE_FULLSCREEN_Z_INDEX
+} from '../../config.utils';
 import { BLOCK_TARGET_KEY } from '../../extensions/selection-preserve.extension';
 import { ContentletEditUrlService } from '../../services/contentlet-edit-url.service';
 import { EditorModalService } from '../../services/editor-modal.service';
@@ -68,8 +72,19 @@ export class ToolbarComponent implements OnDestroy {
      */
     protected readonly overlayTooltipOptions = computed(
         (): TooltipOptions =>
-            this.isFullscreen() ? { tooltipZIndex: '10050' } : { tooltipZIndex: 'auto' }
+            this.isFullscreen()
+                ? { tooltipZIndex: `${OVERLAY_ABOVE_FULLSCREEN_Z_INDEX}` }
+                : { tooltipZIndex: 'auto' }
     );
+
+    /**
+     * Overlay options for the block-type `<p-select>` panel, which appends to `document.body`.
+     * Like the tooltips above, its default base z-index (≈1000) would be painted under the
+     * fullscreen shell's `z-[9998]` backdrop, leaving the dropdown invisible/unclickable in
+     * fullscreen. An open dropdown anchored to its trigger should sit on top in either mode, so
+     * it is lifted unconditionally — the single rule every body-portaled editor overlay follows.
+     */
+    protected readonly overlayOptions = FULLSCREEN_AWARE_OVERLAY_OPTIONS;
 
     readonly fullscreenToggle = output<void>();
     readonly contentletEdit = output<ContentletEditEvent>();

--- a/core-web/libs/new-block-editor/src/lib/editor/config.utils.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/config.utils.ts
@@ -1,4 +1,26 @@
+import { OverlayOptions } from 'primeng/api';
 import { DynamicDialogConfig } from 'primeng/dynamicdialog';
+
+/**
+ * Base z-index for every body-portaled overlay the editor opens (PrimeNG `DialogService`
+ * modals and `<p-select>` / `<p-autoComplete>` panels). The fullscreen editor shell renders
+ * its backdrop at `z-[9998]` (see `editor.component.ts`), so overlays appended to
+ * `document.body` with PrimeNG's default base (≈1000) get painted *under* the fullscreen
+ * overlay and become unreachable. Lifting the base above the shell keeps them clickable.
+ * Matches the toolbar's tooltip override (`overlayTooltipOptions`), which uses the same value.
+ */
+export const OVERLAY_ABOVE_FULLSCREEN_Z_INDEX = 10050;
+
+/**
+ * Shared `overlayOptions` for the editor's `<p-select>` / `<p-autoComplete>` controls.
+ * PrimeNG 21 exposes overlay z-index through `overlayOptions` (not a `baseZIndex` input), so
+ * every body-portaled dropdown panel binds this to clear the fullscreen shell's backdrop.
+ * `appendTo` is left to each control's own input (which takes precedence over this).
+ */
+export const FULLSCREEN_AWARE_OVERLAY_OPTIONS: OverlayOptions = {
+    autoZIndex: true,
+    baseZIndex: OVERLAY_ABOVE_FULLSCREEN_Z_INDEX
+};
 
 /**
  * Shared centered-modal configuration for editor dialogs that mount
@@ -19,6 +41,8 @@ export function buildBrowserSelectorConfig(opts: {
     return {
         header: opts.header,
         appendTo: 'body',
+        // Modal picker must clear the fullscreen editor shell's `z-[9998]` backdrop.
+        baseZIndex: OVERLAY_ABOVE_FULLSCREEN_Z_INDEX,
         closeOnEscape: true,
         closable: true,
         dismissableMask: true,

--- a/core-web/libs/new-block-editor/src/lib/editor/extensions/nodes/code-block/code-block.component.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/extensions/nodes/code-block/code-block.component.ts
@@ -5,6 +5,8 @@ import { FormsModule } from '@angular/forms';
 
 import { Select, SelectChangeEvent } from 'primeng/select';
 
+import { FULLSCREEN_AWARE_OVERLAY_OPTIONS } from '../../../config.utils';
+
 interface LanguageOption {
     label: string;
     value: string;
@@ -22,6 +24,7 @@ interface LanguageOption {
                 filter="true"
                 class="code-block__lang"
                 appendTo="body"
+                [overlayOptions]="overlayOptions"
                 optionLabel="label"
                 optionValue="value"
                 placeholder="Select Code Language"
@@ -33,6 +36,13 @@ interface LanguageOption {
     `
 })
 export class DotCodeBlockNodeViewComponent extends AngularNodeViewComponent {
+    /**
+     * The language `<p-select>` panel appends to `document.body`; lift its base z-index above
+     * the fullscreen editor shell's `z-[9998]` backdrop so the dropdown stays clickable in
+     * fullscreen. See {@link FULLSCREEN_AWARE_OVERLAY_OPTIONS}.
+     */
+    protected readonly overlayOptions = FULLSCREEN_AWARE_OVERLAY_OPTIONS;
+
     /** Empty string maps to the "auto" option; lowlight will auto-detect. */
     protected readonly currentLanguage = computed(
         () => (this.node().attrs['language'] as string | null) ?? ''

--- a/core-web/libs/new-block-editor/src/lib/editor/services/editor-modal.service.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/services/editor-modal.service.ts
@@ -9,7 +9,7 @@ import { DotCMSContentlet, DotGeneratedAIImage } from '@dotcms/dotcms-models';
 import { DotAIImagePromptComponent, DotBrowserSelectorComponent } from '@dotcms/ui';
 
 import { AiContentDialogComponent } from '../components/ai-content-dialog/ai-content-dialog.component';
-import { buildBrowserSelectorConfig } from '../config.utils';
+import { OVERLAY_ABOVE_FULLSCREEN_Z_INDEX, buildBrowserSelectorConfig } from '../config.utils';
 import { insertDotImageFromContentlet, insertDotVideoFromContentlet } from '../editor.utils';
 
 /**
@@ -111,6 +111,8 @@ export class EditorModalService implements OnDestroy {
         this.aiImageDialogRef = this.dialogService.open(DotAIImagePromptComponent, {
             header: this.dotMessageService.get('block-editor.extension.ai-image.dialog-title'),
             appendTo: 'body',
+            // Modal must clear the fullscreen editor shell's `z-[9998]` backdrop.
+            baseZIndex: OVERLAY_ABOVE_FULLSCREEN_Z_INDEX,
             closeOnEscape: true,
             closable: true,
             dismissableMask: true,
@@ -154,6 +156,8 @@ export class EditorModalService implements OnDestroy {
         this.aiContentDialogRef = this.dialogService.open(AiContentDialogComponent, {
             header: this.dotMessageService.get('dot.block.editor.dialog.ai-content.header'),
             appendTo: 'body',
+            // Modal must clear the fullscreen editor shell's `z-[9998]` backdrop.
+            baseZIndex: OVERLAY_ABOVE_FULLSCREEN_Z_INDEX,
             closeOnEscape: true,
             closable: true,
             // Match the original embedded behavior — clicking outside should NOT discard


### PR DESCRIPTION
QA follow-up for #35980 (see [this QA comment](https://github.com/dotCMS/core/issues/35980#issuecomment-4672387422)) on the new TipTap block editor (`libs/new-block-editor`).

### Problem

The fullscreen editor shell renders its backdrop at `z-[9998]` (`editor.component.ts`). PrimeNG overlays that append to `document.body` — `DialogService` modals and `<p-select>` / `<p-autoComplete>` panels — get PrimeNG's default base z-index (~1000), so in fullscreen they were painted **under** the shell and were invisible/unclickable.

QA reported the **block-type dropdown** and the **image/video pickers**. Sweeping the lib for every body-portaled overlay surfaced the same latent defect in several more.

### Proposed Changes

Lift every body-portaled overlay above the fullscreen shell, reusing the value the toolbar's existing tooltip override (`overlayTooltipOptions`) already uses for this exact reason. A single shared constant lives in `config.utils.ts`.

* **`DialogService` modals** — image picker, video picker (`buildBrowserSelectorConfig`), AI image, AI content — seed `baseZIndex`.
* **`<p-select>` / `<p-autoComplete>` panels** — bind a shared `overlayOptions` (`{ autoZIndex, baseZIndex }`). PrimeNG 21 exposes overlay z-index through `overlayOptions`, not a `baseZIndex` input. Covers:
  - toolbar block-type select (reported)
  - code-block language select
  - link popover URL autocomplete + rel select
  - table handle header-scope select

### Verification

Runtime-verified in the standalone harness (`nx serve dotcms-block-editor`): in fullscreen the block-type panel now renders at z-index **11052** (> 9998) and is fully clickable. `nx lint new-block-editor` and `nx build dotcms-block-editor` both pass.

### Note on the second QA item ("table-properties language keys not showing")

Not a code defect. The popover references valid keys via `| dm`, and those keys exist in `Language.properties`. The three affected entries are the `*.placeholder` keys **added in #36042** — they were simply not yet in the deployed/cached message bundle at QA time (confirmed: the running backend still served the old `add-caption` key and none of the new `.placeholder` keys). A fresh build/deploy picks them up; no frontend change applies.

### Checklist
- [x] Translations — none added; existing keys verified present.
- [x] Security Implications Contemplated — none; UI-only z-index changes, no new inputs reach the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35980

This PR fixes: #35980