### PR TITLE
fix(cluster): widen dot_cluster.cluster_id to varchar(255) (#36175)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260615AlterClusterIdLength.java
+++ b/dotCMS/src/main/java/com/dotmarketing/startup/runonce/Task260615AlterClusterIdLength.java
@@ -1,0 +1,34 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.startup.StartupTask;
+
+import java.sql.SQLException;
+
+/**
+ * Increases the size of the varchar column {@code cluster_id} in the {@code dot_cluster} table
+ * from 36 to 255 chars. Idempotent via {@link #forceRun()}.
+ *
+ * @since Jun 15th, 2026
+ */
+public class Task260615AlterClusterIdLength implements StartupTask {
+
+    @Override
+    public boolean forceRun() {
+        return !(new DotDatabaseMetaData().isColumnLengthExpected("dot_cluster",
+                "cluster_id", "255"));
+    }
+
+    @Override
+    public void executeUpgrade() throws DotDataException, DotRuntimeException {
+        final DotConnect dc = new DotConnect();
+        try {
+            dc.executeStatement("ALTER TABLE dot_cluster ALTER COLUMN cluster_id type varchar (255)");
+        } catch (SQLException e) {
+            throw new DotRuntimeException(e);
+        }
+    }
+}

--- a/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/TaskLocatorUtil.java
@@ -268,6 +268,7 @@ import com.dotmarketing.startup.runonce.Task260403SetPermissionReferenceUnlogged
 import com.dotmarketing.startup.runonce.Task260407AddBaseTypeColumnToIdentifier;
 import com.dotmarketing.startup.runonce.Task260506CreateS3VanityAliasTable;
 import com.dotmarketing.startup.runonce.Task260505AddPluginsPortletToMenu;
+import com.dotmarketing.startup.runonce.Task260615AlterClusterIdLength;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
@@ -610,6 +611,7 @@ public class TaskLocatorUtil {
         .add(Task260407AddBaseTypeColumnToIdentifier.class)
         .add(Task260506CreateS3VanityAliasTable.class)
         .add(Task260505AddPluginsPortletToMenu.class)
+        .add(Task260615AlterClusterIdLength.class)
         .build();
 
         return ret.stream().sorted(classNameComparator).collect(Collectors.toList());

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite3a.java
@@ -36,6 +36,7 @@ import com.dotmarketing.startup.runonce.Task260206AddUsagePortletToMenuTest;
 import com.dotmarketing.startup.runonce.Task260320AddPluginsPortletToMenuTest;
 import com.dotmarketing.startup.runonce.Task260407AddBaseTypeColumnToIdentifierTest;
 import com.dotmarketing.startup.runonce.Task260505AddPluginsPortletToMenuTest;
+import com.dotmarketing.startup.runonce.Task260615AlterClusterIdLengthTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
@@ -82,6 +83,7 @@ import org.junit.runners.Suite;
         Task260320AddPluginsPortletToMenuTest.class,
         Task260505AddPluginsPortletToMenuTest.class,
         Task260407AddBaseTypeColumnToIdentifierTest.class,
+        Task260615AlterClusterIdLengthTest.class,
         ImportContentletsActionSmokeTest.class,
 })
 

--- a/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260615AlterClusterIdLengthTest.java
+++ b/dotcms-integration/src/test/java/com/dotmarketing/startup/runonce/Task260615AlterClusterIdLengthTest.java
@@ -1,0 +1,51 @@
+package com.dotmarketing.startup.runonce;
+
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.common.db.DotDatabaseMetaData;
+import com.dotmarketing.exception.DotRuntimeException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies that {@link Task260615AlterClusterIdLength} widens {@code dot_cluster.cluster_id}
+ * to 255 chars and is idempotent.
+ */
+public class Task260615AlterClusterIdLengthTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    private void setLength(final String length) {
+        try {
+            new DotConnect().executeStatement(
+                    "ALTER TABLE dot_cluster ALTER COLUMN cluster_id type varchar (" + length + ")");
+        } catch (SQLException e) {
+            throw new DotRuntimeException(e);
+        }
+    }
+
+    @Test
+    public void test_executeUpgrade_widens_cluster_id() throws Exception {
+        final DotDatabaseMetaData meta = new DotDatabaseMetaData();
+        final Task260615AlterClusterIdLength task = new Task260615AlterClusterIdLength();
+
+        // Start narrow
+        setLength("36");
+        assertTrue("Task should run when column is not yet 255", task.forceRun());
+
+        task.executeUpgrade();
+        assertEquals("255", meta.getModifiedColumnLength("dot_cluster", "cluster_id").get("field_length"));
+
+        // Idempotent: already 255 -> no-op
+        assertFalse("Task should not re-run once column is 255", task.forceRun());
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #36175.

`dot_cluster.cluster_id` was `varchar(36)` (UUID-sized). This adds an idempotent run-once startup task that widens it to `varchar(255)`.

## Changes
- `Task260615AlterClusterIdLength` — `ALTER TABLE dot_cluster ALTER COLUMN cluster_id type varchar(255)`; idempotent via `forceRun()` → `isColumnLengthExpected(...,"255")`.
- Registered in `TaskLocatorUtil`.
- Integration test `Task260615AlterClusterIdLengthTest` — shrinks to 36, asserts `forceRun()`, runs, asserts 255, asserts `forceRun()` is now false.

## Notes
- Postgres FKs on `varchar` are length-agnostic, so the `cluster_server.cluster_id` FK is unaffected.

## Test
`./mvnw verify -pl :dotcms-integration -Dcoreit.test.skip=false -Dit.test=Task260615AlterClusterIdLengthTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36175