### PR TITLE
fix(apps): export env-backed app secrets without aborting (#36179)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -974,14 +974,24 @@ public class AppsAPIImpl implements AppsAPI {
                 final Set<String> appKeysBySiteId = paramAppKeysBySite.get(siteId);
                 if (isSet(appKeysBySiteId)) {
                     for (final String appKey : appKeysBySiteId) {
-                        final Optional<AppSecrets> optional = getSecrets(appKey, site, user);
+                        // Resolve with the System Host tiers enabled so an app that is only counted
+                        // by `appKeysByHost` through a global env tier (e.g. System Host env) still
+                        // resolves here, instead of coming back empty and aborting the whole export.
+                        final Optional<AppSecrets> optional = getSecrets(appKey, true, site, user);
                         if (optional.isPresent()) {
                             final AppSecrets appSecrets = optional.get();
                             exportedSecrets
                                     .computeIfAbsent(siteId, list -> new LinkedList<>())
                                     .add(appSecrets);
                         } else {
-                            throw new IllegalArgumentException(String.format("Unable to find secret identified by key `%s` under site `%s` ",appKey, site.getIdentifier()));
+                            // Presence in the key listing does not guarantee an exportable blob:
+                            // env-backed apps are provisioned from the environment and are not
+                            // persisted, so they may legitimately resolve to nothing here. Skip
+                            // them rather than failing the export; the empty-result guard below
+                            // still catches the case where nothing at all could be collected.
+                            Logger.debug(AppsAPIImpl.class, () -> String.format(
+                                    "No exportable secret resolved for key `%s` under site `%s` ; skipping.",
+                                    appKey, site.getIdentifier()));
                         }
                     }
                 }

--- a/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/security/apps/AppsAPIImpl.java
@@ -989,7 +989,7 @@ public class AppsAPIImpl implements AppsAPI {
                             // persisted, so they may legitimately resolve to nothing here. Skip
                             // them rather than failing the export; the empty-result guard below
                             // still catches the case where nothing at all could be collected.
-                            Logger.debug(AppsAPIImpl.class, () -> String.format(
+                            Logger.warn(AppsAPIImpl.class, () -> String.format(
                                     "No exportable secret resolved for key `%s` under site `%s` ; skipping.",
                                     appKey, site.getIdentifier()));
                         }

--- a/dotcms-integration/src/test/java/com/dotcms/security/apps/AppsAPIImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/security/apps/AppsAPIImplTest.java
@@ -36,6 +36,7 @@ import com.dotmarketing.exception.DotDataValidationException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.exception.InvalidLicenseException;
 import com.dotmarketing.portlets.contentlet.business.HostAPI;
+import com.dotmarketing.util.Config;
 import com.dotmarketing.util.DateUtil;
 import com.dotmarketing.util.Logger;
 import com.google.common.collect.ImmutableMap;
@@ -1497,6 +1498,67 @@ public class AppsAPIImplTest {
            file.delete();
         }
 
+    }
+
+    /**
+     * Method to test {@link AppsAPIImpl#exportSecrets(Key, boolean, Map, User)} and
+     * {@link AppsAPIImpl#collectSecretsForExport(Map, User)} — regression for issue #36179.
+     * <p>
+     * Given scenario: An app is provisioned ONLY through a System Host environment variable
+     * (tier-3, {@code DOT_{APP_KEY}_SYSTEM_HOST_{PARAM}}) with no stored secret blob. The listing
+     * ({@code appKeysByHost}) counts such an app as present on every valid site, but export used to
+     * resolve it with {@code fallbackOnSystemHost = false}, which suppresses the System Host tiers —
+     * so {@code getSecrets} returned empty and the whole export aborted with an
+     * {@link IllegalArgumentException}.
+     * <p>
+     * Expected result: the export completes (the System Host tier participates in resolution) and an
+     * env-backed app with no exportable blob is skipped rather than failing the export.
+     */
+    @Test
+    public void Test_Export_App_Backed_Only_By_System_Host_Env_Does_Not_Abort()
+            throws DotDataException, IOException, AlreadyExistException, DotSecurityException, EncryptorException {
+        final User admin = TestUserUtils.getAdminUser();
+        final AppsAPI api = APILocator.getAppsAPI();
+        api.resetSecrets(admin);
+
+        // A regular (non-System) site: appKeysByHost will list the env-backed app for it.
+        final Host site = new SiteDataGen().nextPersisted();
+
+        final AppDescriptorDataGen dataGen = new AppDescriptorDataGen()
+                .stringParam("p1", false, true)
+                .stringParam("p2", false, true)
+                .withName("system-host-env-app-example")
+                .withDescription("system-host-env-app")
+                .withExtraParameters(false);
+        final File file = dataGen.nextPersistedDescriptor();
+        final String appKey = dataGen.getKey();
+
+        // Tier-3 (System Host env) value for a single param, with NO stored secret saved anywhere.
+        final String systemHostEnvKey =
+                AppsUtil.envVarName(appKey, AppsUtil.SYSTEM_HOST_ENV_SEGMENT, "p1");
+        final String originalEnvValue = Config.getStringProperty(systemHostEnvKey, null);
+        try {
+            api.createAppDescriptor(file, admin);
+            Config.setProperty(systemHostEnvKey, "env-secret-1");
+
+            // Sanity: the app is enumerated for the regular site purely via the System Host env tier.
+            assertTrue(api.appKeysByHost().getOrDefault(site.getIdentifier(), Set.of())
+                    .contains(appKey));
+
+            final String password = RandomStringUtils.randomAlphanumeric(32);
+            final Key securityKey = AppsUtil.generateKey(password);
+
+            // Export All. Before the fix this threw IllegalArgumentException
+            // ("Unable to find secret identified by key ... under site ...") for the regular site.
+            final Path exportSecretsFile = api.exportSecrets(securityKey, true, null, admin);
+            assertTrue(exportSecretsFile.toFile().exists());
+            assertTrue(exportSecretsFile.toFile().length() > 0);
+        } finally {
+            // Restore the env prop (descriptor removal already neutralizes tier-3, but keep it tidy).
+            Config.setProperty(systemHostEnvKey, originalEnvValue == null ? "" : originalEnvValue);
+            Try.run(() -> api.removeApp(appKey, admin, true));
+            file.delete();
+        }
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

Fixes #36179.

Exporting App secrets (`AppsAPIImpl.exportSecrets` with `exportAll = true`) aborted with `IllegalArgumentException: Unable to find secret identified by key '<appKey>' under site '<siteId>'` whenever an App was provisioned **only** through **System Host environment variables** (tier‑3, `DOT_{APP_KEY}_SYSTEM_HOST_{PARAM}`).

### Root cause

An asymmetry between enumeration and resolution in `collectSecretsForExport`:

| | Path | Behavior |
|---|---|---|
| **Enumerate** | `appKeysByHost()` → `hasGlobalEnvBackedSecrets()` | Counts the app as present on **every** site if it resolves from tier‑3 (System Host env) **or** tier‑4 (legacy env). |
| **Resolve** | `getSecrets(appKey, site, user)` | Uses `fallbackOnSystemHost = false`, which **suppresses tier‑3 and tier‑5** (System Host tiers). |

A System‑Host‑env‑only app is therefore listed for every site, but resolves to `Optional.empty()` for each — and the `else` branch threw, aborting the whole export. (Legacy tier‑4 was unaffected, since it is consulted even with `fallbackOnSystemHost = false`.)

### Fix

In `collectSecretsForExport`:

1. **Resolve with the System Host tiers enabled** — `getSecrets(appKey, true, site, user)` — so resolution matches what `appKeysByHost()` enumerated.
2. **Skip instead of throw** when an app key has no exportable blob: presence in the key listing does not guarantee a persistable secret (env‑backed values are not persisted and are not portable), so they are debug‑logged and skipped.

The existing empty‑result guard still fails a fully empty export, and the unknown‑**site** error is preserved.

## Checklist

- [x] Tests (Unit/Integration)? — see note below
- [x] Translations: NA
- [x] Security implications: handles secrets export; no secret values logged (debug log references key/site only).
- [x] Backwards compatibility: behavior change is strictly more permissive (no longer aborts on env‑backed apps); fully empty exports still error.

## Testing notes

Manual: register an app provisioned only via `DOT_{APP_KEY}_SYSTEM_HOST_{PARAM}`, add a non‑System site, and run Export All — export now completes instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
