### PR TITLE
feat(ai-reviews): bump ai-workflows to v3.1.5 + switch auto-review to DeepSeek V3.2

### DIFF
--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -85,7 +85,7 @@ jobs:
       id-token: write
       pull-requests: write
       issues: write
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.4
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -127,11 +127,16 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   # Automatic PR reviews (no @claude mention)
-  # Uses GPT-5.5 via AWS Bedrock Mantle for model diversity — Claude writes code here,
-  # GPT reviews it so training/weighting biases from one model family don't carry into
-  # the review. Interactive @claude sessions remain on Anthropic Claude (job above).
-  # Prompt lives in .github/prompts/gpt-auto-review.md — edit it there, not here.
-  gpt-automatic-review:
+  # Uses DeepSeek V3.2 via AWS Bedrock (Converse API, generic-bedrock route) for model
+  # diversity — Claude writes code here, a non-Claude model reviews it so training/weighting
+  # biases from one model family don't carry into the review. Interactive @claude sessions
+  # remain on Anthropic Claude (job above). Prompt lives in .github/prompts/gpt-auto-review.md.
+  #
+  # Was openai.gpt-5.5 (Bedrock Mantle), but as of 2026-06-15 gpt-5.5 is failing on mantle
+  # in both regions ("Engine not found"; AWS-side — see ext-aws-tam thread). DeepSeek V3.2 is
+  # healthy on bedrock-runtime and keeps the reviews running. Switch back to a mantle model by
+  # setting model_id to an openai.* id once AWS restores it.
+  ai-automatic-review:
     needs: [security-check, load-gpt-prompt]
     # load-gpt-prompt enforces all the PR/no-mention conditions; if it was skipped
     # or failed this job is skipped too.
@@ -142,10 +147,11 @@ jobs:
       cancel-in-progress: true
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
     with:
-      model_id: openai.gpt-5.5
+      # deepseek.* is not anthropic/openai, so the orchestrator routes it to the
+      # bedrock-generic (Converse) executor. reasoning_effort has no effect on that path.
+      model_id: deepseek.v3.2
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: automatic
-      reasoning_effort: medium
       prompt: ${{ needs.load-gpt-prompt.outputs.prompt }}
       timeout_minutes: 20
       runner: ubuntu-latest

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -82,7 +82,7 @@ jobs:
           )
         )
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.4
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
@@ -140,7 +140,7 @@ jobs:
     concurrency:
       group: claude-automatic-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.4
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
     with:
       model_id: openai.gpt-5.5
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}


### PR DESCRIPTION
Two changes to get automatic PR reviews working again and keep them legible:

## 1. Switch automatic reviewer GPT-5.5 → DeepSeek V3.2
`openai.gpt-5.5` is failing on Bedrock Mantle in **both** us-east-1 and us-east-2 as of 2026-06-15 (`invalid_prompt: 404 Not Found: Engine not found` — AWS-side; the alias *and* its `-2026-04-23` snapshot both 404 while still listed in `/v1/models`). Raised with our AWS TAM.

`deepseek.v3.2` is healthy on **bedrock-runtime** (Converse) and is still a non-Claude reviewer, so it preserves the model-diversity rationale (Claude writes the code, a different family reviews it). `deepseek.*` routes to the existing `bedrock-generic` (Converse) executor — **no IAM or ai-workflows change** needed (`BedrockInvokeReviewModels` already allows `bedrock:Converse` on `foundation-model/deepseek.*`).

- Renamed `gpt-automatic-review` → `ai-automatic-review` (model-agnostic); dropped `reasoning_effort` (mantle-only).
- Interactive `@claude` and the backend reviewer stay on Anthropic Claude.
- Validated e2e on steve-quarterly-planning #108 (routed to bedrock-generic, posted a real review catching all planted bugs).

## 2. Bump pin v3.1.4 → v3.1.5
[ai-workflows#40](https://github.com/dotCMS/ai-workflows/pull/40): surfaces the actual failure reason on `response.failed` (e.g. `server_error` / `Engine not found`) in the sticky + job log instead of a generic "failed before producing output", and retries once on transient failures. This is exactly what made the gpt-5.5 outage diagnosable.

Switch back to a mantle model by setting `model_id` to an `openai.*` id once AWS restores gpt-5.5.

Closes: #36181