### PR TITLE
fix(uve): forward all page params (mode, language, persona, variant, time machine) to Page Health scanner

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -38,7 +38,7 @@ import {
     PushPublishService
 } from '@dotcms/data-access';
 import { DotcmsConfigService, LoginService, Site, SiteService } from '@dotcms/dotcms-js';
-import { FeaturedFlags } from '@dotcms/dotcms-models';
+import { DEFAULT_VARIANT_ID, FeaturedFlags } from '@dotcms/dotcms-models';
 import {
     DotPageScannerReportComponent,
     DotPageToolsSeoComponent
@@ -1552,6 +1552,70 @@ describe('DotEmaShellComponent', () => {
 
                 const calledUrl = openSpy.mock.calls[0][1] as string;
                 expect(new URL(calledUrl).searchParams.has('host_id')).toBe(false);
+            });
+
+            it('should forward all page-resolving params (language, persona, variant, mode, time machine) so the scanner re-renders the same page', () => {
+                const openSpy = jest.fn();
+                spectator.component['pageScanner'] = {
+                    open: openSpy
+                } as unknown as DotPageScannerReportComponent;
+
+                patchState(store, {
+                    pageParams: {
+                        url: 'my-page',
+                        language_id: '2',
+                        [PERSONA_KEY]: 'persona-123',
+                        variantName: 'my-variant',
+                        mode: UVE_MODE.LIVE,
+                        publishDate: '2026-06-15',
+                        clientHost: 'https://headless.example.com',
+                        depth: '2'
+                    }
+                });
+
+                spectator.component.handleScannerToolClick('a11y');
+
+                const calledUrl = openSpy.mock.calls[0][1] as string;
+                const params = new URL(calledUrl).searchParams;
+
+                expect(params.get('language_id')).toBe('2');
+                // PERSONA_KEY is normalized to personaId, matching the rest of the editor
+                expect(params.get('personaId')).toBe('persona-123');
+                expect(params.get('variantName')).toBe('my-variant');
+                expect(params.get('mode')).toBe(UVE_MODE.LIVE);
+                expect(params.get('publishDate')).toBe('2026-06-15');
+
+                // Editor-fetch concerns must not leak to the public scanner
+                expect(params.has('clientHost')).toBe(false);
+                expect(params.has('depth')).toBe(false);
+                expect(params.has('url')).toBe(false);
+            });
+
+            it('should omit the default variant from the scanned URL', () => {
+                const openSpy = jest.fn();
+                spectator.component['pageScanner'] = {
+                    open: openSpy
+                } as unknown as DotPageScannerReportComponent;
+
+                patchState(store, {
+                    pageParams: {
+                        url: 'my-page',
+                        language_id: '1',
+                        [PERSONA_KEY]: DEFAULT_PERSONA.identifier,
+                        variantName: DEFAULT_VARIANT_ID,
+                        mode: UVE_MODE.EDIT
+                    }
+                });
+
+                spectator.component.handleScannerToolClick('a11y');
+
+                const calledUrl = openSpy.mock.calls[0][1] as string;
+                const params = new URL(calledUrl).searchParams;
+
+                expect(params.has('variantName')).toBe(false);
+                // Default persona is dropped by normalizeQueryParams
+                expect(params.has('personaId')).toBe(false);
+                expect(params.has('com.dotmarketing.persona.id')).toBe(false);
             });
 
             it('should pass geo type to the page scanner', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1587,8 +1587,10 @@ describe('DotEmaShellComponent', () => {
                 const params = new URL(calledUrl).searchParams;
 
                 expect(params.get('language_id')).toBe('2');
-                // PERSONA_KEY is normalized to personaId, matching the rest of the editor
-                expect(params.get('personaId')).toBe('persona-123');
+                // The scanner is a backend page render, so persona uses the backend
+                // request param key (WebKeys.CMS_PERSONA_PARAMETER), not personaId
+                expect(params.get(PERSONA_KEY)).toBe('persona-123');
+                expect(params.has('personaId')).toBe(false);
                 expect(params.get('variantName')).toBe('my-variant');
                 expect(params.get('mode')).toBe(UVE_MODE.LIVE);
                 expect(params.get('publishDate')).toBe('2026-06-15');
@@ -1621,9 +1623,9 @@ describe('DotEmaShellComponent', () => {
                 const params = new URL(calledUrl).searchParams;
 
                 expect(params.has('variantName')).toBe(false);
-                // Default persona is dropped by normalizeQueryParams
+                // Default persona is implicit and dropped from the scanned URL
+                expect(params.has(PERSONA_KEY)).toBe(false);
                 expect(params.has('personaId')).toBe(false);
-                expect(params.has('com.dotmarketing.persona.id')).toBe(false);
             });
 
             it('should pass geo type to the page scanner', () => {

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.spec.ts
@@ -1499,9 +1499,17 @@ describe('DotEmaShellComponent', () => {
                 spectator.component.handleScannerToolClick('a11y');
 
                 const { currentUrl, siteId } = spectator.component['$seoParams']();
+                const params = store.pageParams();
                 const expectedUrl = new URL(currentUrl, window.location.origin);
                 if (siteId) {
                     expectedUrl.searchParams.set('host_id', siteId);
+                }
+                // The scanner re-renders with the editor's page-resolving params
+                if (params?.language_id) {
+                    expectedUrl.searchParams.set('language_id', params.language_id);
+                }
+                if (params?.mode) {
+                    expectedUrl.searchParams.set('mode', params.mode);
                 }
                 expect(openSpy).toHaveBeenCalledWith('a11y', expectedUrl.toString());
             });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -26,11 +26,7 @@ import { filter } from 'rxjs/operators';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { SiteService } from '@dotcms/dotcms-js';
-import {
-    DEFAULT_VARIANT_ID,
-    DotPageToolUrlParams,
-    FeaturedFlags
-} from '@dotcms/dotcms-models';
+import { DEFAULT_VARIANT_ID, DotPageToolUrlParams, FeaturedFlags } from '@dotcms/dotcms-models';
 import {
     DotPageScannerReportComponent,
     DotPageToolsSeoComponent,

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -26,7 +26,11 @@ import { filter } from 'rxjs/operators';
 
 import { DotMessageService } from '@dotcms/data-access';
 import { SiteService } from '@dotcms/dotcms-js';
-import { DotPageToolUrlParams, FeaturedFlags } from '@dotcms/dotcms-models';
+import {
+    DEFAULT_VARIANT_ID,
+    DotPageToolUrlParams,
+    FeaturedFlags
+} from '@dotcms/dotcms-models';
 import {
     DotPageScannerReportComponent,
     DotPageToolsSeoComponent,
@@ -39,6 +43,7 @@ import { DotInfoPageComponent, DotMessagePipe, DotNotLicenseComponent, InfoPage 
 import { EditEmaNavigationBarComponent } from './components/edit-ema-navigation-bar/edit-ema-navigation-bar.component';
 
 import { DotEmaDialogComponent } from '../components/dot-ema-dialog/dot-ema-dialog.component';
+import { DotPageAssetKeys } from '../services/dot-page-api/dot-page-api.service';
 import { PERSONA_KEY } from '../shared/consts';
 import { NG_CUSTOM_EVENTS, UVE_STATUS } from '../shared/enums';
 import { DialogAction, DotPageAssetParams, NavigationBarItem } from '../shared/models';
@@ -357,10 +362,15 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
      * The scanner is an external service that fetches the URL over the public
      * internet, so the URL must point at this authoring instance
      * (`window.location.origin`) — never the page's content-site hostname or a
-     * headless `clientHost`, which may not be publicly reachable. The site is
-     * disambiguated via the `host_id` query param, which dotCMS resolves for the
-     * backend user regardless of the host. Without it, multisite pages sharing a
-     * path (e.g. `/index`) resolve to the wrong site.
+     * headless `clientHost`, which may not be publicly reachable.
+     *
+     * To re-render the exact page the user is looking at, every page-resolving
+     * param the editor is using is forwarded onto the scanned URL:
+     * - `host_id` — disambiguates the site for multisite pages sharing a path
+     *   (e.g. `/index`); dotCMS resolves it for the backend user regardless of host.
+     * - `language_id`, `personaId`, `variantName`, `mode` and `publishDate`
+     *   (time machine) — taken from the current page params so the scanner sees
+     *   the same language, persona, variant, mode and point-in-time as the editor.
      *
      * @param {PageScannerToolType} type
      * @memberof DotEmaShellComponent
@@ -373,7 +383,49 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
             url.searchParams.set('host_id', siteId);
         }
 
+        for (const [key, value] of Object.entries(this.#getScannerPageParams())) {
+            url.searchParams.set(key, value);
+        }
+
         this.pageScanner.open(type, url.toString());
+    }
+
+    /**
+     * Build the page-resolving query params forwarded to the scanner from the
+     * params the editor is currently rendering with.
+     *
+     * Only the params that change which page dotCMS resolves are kept
+     * (`language_id`, persona, `variantName`, `mode`, `publishDate`). The page
+     * path, `clientHost` and `depth` are excluded: the path is already the URL
+     * itself, and `clientHost`/`depth` are editor-fetch concerns the public
+     * scanner must not inherit. `normalizeQueryParams` renames the persona key to
+     * `personaId` and drops the default persona, matching the rest of the editor.
+     *
+     * @return {Record<string, string>}
+     * @memberof DotEmaShellComponent
+     */
+    #getScannerPageParams(): Record<string, string> {
+        const params = this.uveStore.pageParams() ?? ({} as DotPageAssetParams);
+
+        const forwarded: Record<string, unknown> = {
+            [DotPageAssetKeys.LANGUAGE_ID]: params.language_id,
+            [PERSONA_KEY]: params[PERSONA_KEY],
+            [DotPageAssetKeys.MODE]: params.mode,
+            [DotPageAssetKeys.PUBLISH_DATE]: params.publishDate
+        };
+
+        // The default variant is implicit — omit it to keep the URL clean.
+        if (params.variantName && params.variantName !== DEFAULT_VARIANT_ID) {
+            forwarded[DotPageAssetKeys.VARIANT_NAME] = params.variantName;
+        }
+
+        const normalized = normalizeQueryParams(forwarded);
+
+        return Object.fromEntries(
+            Object.entries(normalized)
+                .filter(([, value]) => value !== undefined && value !== null && value !== '')
+                .map(([key, value]) => [key, String(value)])
+        );
     }
 
     /**

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/dot-ema-shell/dot-ema-shell.component.ts
@@ -40,7 +40,7 @@ import { EditEmaNavigationBarComponent } from './components/edit-ema-navigation-
 
 import { DotEmaDialogComponent } from '../components/dot-ema-dialog/dot-ema-dialog.component';
 import { DotPageAssetKeys } from '../services/dot-page-api/dot-page-api.service';
-import { PERSONA_KEY } from '../shared/consts';
+import { DEFAULT_PERSONA, PERSONA_KEY } from '../shared/consts';
 import { NG_CUSTOM_EVENTS, UVE_STATUS } from '../shared/enums';
 import { DialogAction, DotPageAssetParams, NavigationBarItem } from '../shared/models';
 import { UVEStore } from '../store/dot-uve.store';
@@ -394,8 +394,15 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
      * (`language_id`, persona, `variantName`, `mode`, `publishDate`). The page
      * path, `clientHost` and `depth` are excluded: the path is already the URL
      * itself, and `clientHost`/`depth` are editor-fetch concerns the public
-     * scanner must not inherit. `normalizeQueryParams` renames the persona key to
-     * `personaId` and drops the default persona, matching the rest of the editor.
+     * scanner must not inherit.
+     *
+     * Unlike SPA navigation, this URL is fetched and rendered by the dotCMS
+     * backend, so the persona must use the backend request param key
+     * (`com.dotmarketing.persona.id`, `WebKeys.CMS_PERSONA_PARAMETER`) — NOT the
+     * SPA-friendly `personaId`. Sending `personaId` would be silently ignored and
+     * the page would render with no persona. The default persona and default
+     * variant are dropped so the scanner falls back to the same implicit defaults
+     * as the editor.
      *
      * @return {Record<string, string>}
      * @memberof DotEmaShellComponent
@@ -405,20 +412,24 @@ export class DotEmaShellComponent implements OnInit, OnDestroy {
 
         const forwarded: Record<string, unknown> = {
             [DotPageAssetKeys.LANGUAGE_ID]: params.language_id,
-            [PERSONA_KEY]: params[PERSONA_KEY],
             [DotPageAssetKeys.MODE]: params.mode,
             [DotPageAssetKeys.PUBLISH_DATE]: params.publishDate
         };
+
+        // Persona keeps the backend request param key — the scanner is a backend
+        // page render, not SPA navigation. Drop the default persona (implicit).
+        const persona = params[PERSONA_KEY];
+        if (persona && persona !== DEFAULT_PERSONA.identifier) {
+            forwarded[PERSONA_KEY] = persona;
+        }
 
         // The default variant is implicit — omit it to keep the URL clean.
         if (params.variantName && params.variantName !== DEFAULT_VARIANT_ID) {
             forwarded[DotPageAssetKeys.VARIANT_NAME] = params.variantName;
         }
 
-        const normalized = normalizeQueryParams(forwarded);
-
         return Object.fromEntries(
-            Object.entries(normalized)
+            Object.entries(forwarded)
                 .filter(([, value]) => value !== undefined && value !== null && value !== '')
                 .map(([key, value]) => [key, String(value)])
         );


### PR DESCRIPTION
## What

The UVE Page Health a11y/GEO scanner only received the page path and `host_id`, so dotCMS re-resolved the page against defaults — **always scanning the published page** in the default language/persona/variant, regardless of the state open in the editor. Users could not scan a draft before publishing, which is a primary documented benefit of the feature.

This forwards every page-resolving param onto the scanned URL so the scanner re-renders exactly what the editor is showing:

- `mode` — draft/preview/live, so unpublished pages scan in the correct state
- `language_id`, persona, `variantName` — match the editor selection
- `publishDate` — Future Time Machine
- `host_id` — multisite (existing behavior from #36163)

Editor-fetch-only params (`clientHost`, `depth`, `url`) are excluded so they don't leak to the public scanner. The default variant and default persona are dropped via `normalizeQueryParams`, matching the rest of the editor.

## Scope

- `dot-ema-shell.component.ts` — `handleScannerToolClick()` appends the page params; new `#getScannerPageParams()` helper builds them from `uveStore.pageParams()` using the `DotPageAssetKeys` enum.
- `dot-ema-shell.component.spec.ts` — assert all params are forwarded, editor-fetch params are excluded, and default variant/persona are dropped.

No backend changes: the scanner fetches the URL verbatim, so the params survive the round-trip.

Closes #36183
