### PR TITLE
fix(global-store): load site/user reactively from auth state

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/services/dot-page-actions.service.spec.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/services/dot-page-actions.service.spec.ts
@@ -1,7 +1,6 @@
 import { createServiceFactory, SpectatorService } from '@ngneat/spectator/jest';
 import { of, throwError } from 'rxjs';
 
-import { signal } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
 
 import { DialogService } from 'primeng/dynamicdialog';
@@ -27,7 +26,6 @@ import {
     PermissionsType,
     UserPermissions
 } from '@dotcms/dotcms-models';
-import { GlobalStore } from '@dotcms/store';
 
 import { DotPageActionsService } from './dot-page-actions.service';
 import { DotPageListService } from './dot-page-list.service';
@@ -150,7 +148,6 @@ describe('DotPageActionsService', () => {
     let mockPushPublishDialogService: jest.Mocked<DotPushPublishDialogService>;
     let mockCurrentUserService: jest.Mocked<DotCurrentUserService>;
     let mockPushPublishService: jest.Mocked<PushPublishService>;
-    let mockGlobalStore: { loggedUser: ReturnType<typeof signal> };
     let mockPagesStore: PagesStoreMock;
     let mockDotPageListService: jest.Mocked<Pick<DotPageListService, 'getFavoritePageByURL'>>;
 
@@ -199,16 +196,13 @@ describe('DotPageActionsService', () => {
         } as unknown as jest.Mocked<DotPushPublishDialogService>;
 
         mockCurrentUserService = {
+            getCurrentUser: jest.fn().mockReturnValue(of(MOCK_USER)),
             getUserPermissions: jest.fn().mockReturnValue(of(MOCK_PERMISSIONS))
         } as unknown as jest.Mocked<DotCurrentUserService>;
 
         mockPushPublishService = {
             getEnvironments: jest.fn().mockReturnValue(of(MOCK_ENVIRONMENTS))
         } as unknown as jest.Mocked<PushPublishService>;
-
-        mockGlobalStore = {
-            loggedUser: signal(MOCK_USER)
-        };
 
         mockPagesStore = {
             getFavoritePages: jest.fn()
@@ -240,7 +234,6 @@ describe('DotPageActionsService', () => {
                 { provide: DotPushPublishDialogService, useValue: mockPushPublishDialogService },
                 { provide: DotCurrentUserService, useValue: mockCurrentUserService },
                 { provide: PushPublishService, useValue: mockPushPublishService },
-                { provide: GlobalStore, useValue: mockGlobalStore },
                 { provide: DotCMSPagesStore, useValue: mockPagesStore },
                 { provide: DotPageListService, useValue: mockDotPageListService }
             ]

--- a/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/services/dot-page-actions.service.ts
+++ b/core-web/apps/dotcms-ui/src/app/portlets/dot-pages/services/dot-page-actions.service.ts
@@ -5,7 +5,7 @@ import { inject, Injectable, signal } from '@angular/core';
 import { MenuItem } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 
-import { map, take } from 'rxjs/operators';
+import { map, switchMap, take } from 'rxjs/operators';
 
 import {
     DotCurrentUserService,
@@ -30,7 +30,6 @@ import {
     UserPermissions
 } from '@dotcms/dotcms-models';
 import { DotFavoritePageComponent } from '@dotcms/portlets/dot-ema/ui';
-import { GlobalStore } from '@dotcms/store';
 import { generateDotFavoritePageUrl } from '@dotcms/utils';
 
 import { DotPageListService } from './dot-page-list.service';
@@ -77,7 +76,6 @@ export class DotPageActionsService {
     readonly #dotPushPublishDialogService = inject(DotPushPublishDialogService);
     readonly #dotCurrentUser = inject(DotCurrentUserService);
     readonly #pushPublishService = inject(PushPublishService);
-    readonly #globalStore = inject(GlobalStore);
     readonly #dotCMSPagesStore = inject(DotCMSPagesStore);
     readonly #dotPageListService = inject(DotPageListService);
 
@@ -373,17 +371,27 @@ export class DotPageActionsService {
     /**
      * Fetches logged-user permissions once and caches them in signals.
      *
+     * We resolve the current user via `getCurrentUser()` rather than reading the `GlobalStore`
+     * `loggedUser` signal synchronously: this service is constructed during navigation (e.g. right
+     * after login from /starter) before the store has finished loading the user, so the signal can
+     * still be `null` at construction time. Sourcing the userId from the request avoids that race.
+     *
      * We intentionally `take(1)` because this service is used for menu building only; permissions are
      * expected to be stable for the session, and reactivity is not required here.
      */
     #initUserPermissions(): void {
         this.#dotCurrentUser
-            .getUserPermissions(
-                this.#globalStore.loggedUser().userId,
-                [UserPermissions.READ, UserPermissions.WRITE],
-                [PermissionsType.CONTENTLETS, PermissionsType.HTMLPAGES]
+            .getCurrentUser()
+            .pipe(
+                take(1),
+                switchMap(({ userId }) =>
+                    this.#dotCurrentUser.getUserPermissions(
+                        userId,
+                        [UserPermissions.READ, UserPermissions.WRITE],
+                        [PermissionsType.CONTENTLETS, PermissionsType.HTMLPAGES]
+                    )
+                )
             )
-            .pipe(take(1))
             .subscribe({
                 next: (permissions: DotPermissionsType) => {
                     this.#contentletsPermissions.set(permissions['CONTENTLETS'] as DotPermissions);

--- a/core-web/libs/global-store/src/lib/features/with-site/with-site.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/with-site/with-site.feature.ts
@@ -143,8 +143,10 @@ export function withSite() {
                 // (`provideAppInitializer`), before the session cookie is valid, so a one-shot
                 // load would fire pre-auth and never retry after the SPA login navigation —
                 // leaving the site selector empty until a manual refresh. `watchUser()` fires
-                // immediately when a session already exists (refresh) and on every login,
-                // mirroring the legacy SiteService behavior. See `withUser` for full rationale.
+                // when `auth$` emits: on refresh once the AuthGuard resolves auth via
+                // `loadAuth()`, and on every login via `setAuth()` (it only fires synchronously
+                // if auth was already set before the store initialized). Mirrors the legacy
+                // SiteService behavior. See `withUser` for full rationale.
                 loginService.watchUser(() => store.loadCurrentSite());
                 store.syncSiteOnSwitchEvent();
             }

--- a/core-web/libs/global-store/src/lib/features/with-site/with-site.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/with-site/with-site.feature.ts
@@ -16,6 +16,7 @@ import { computed, inject } from '@angular/core';
 import { switchMap, tap } from 'rxjs/operators';
 
 import { DotSiteService } from '@dotcms/data-access';
+import { LoginService } from '@dotcms/dotcms-js';
 import { DotSite } from '@dotcms/dotcms-models';
 
 /**
@@ -134,11 +135,19 @@ export function withSite() {
                 )
             )
         })),
-        withHooks({
-            onInit(store) {
-                store.loadCurrentSite();
+        withHooks((store) => ({
+            onInit() {
+                const loginService = inject(LoginService);
+                // Load the current site reactively from the authentication state instead of
+                // a one-shot bootstrap load. The GlobalStore is created at app startup
+                // (`provideAppInitializer`), before the session cookie is valid, so a one-shot
+                // load would fire pre-auth and never retry after the SPA login navigation —
+                // leaving the site selector empty until a manual refresh. `watchUser()` fires
+                // immediately when a session already exists (refresh) and on every login,
+                // mirroring the legacy SiteService behavior. See `withUser` for full rationale.
+                loginService.watchUser(() => store.loadCurrentSite());
                 store.syncSiteOnSwitchEvent();
             }
-        })
+        }))
     );
 }

--- a/core-web/libs/global-store/src/lib/features/with-site/with-site.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/with-site/with-site.feature.ts
@@ -13,7 +13,7 @@ import { Observable, pipe } from 'rxjs';
 
 import { computed, inject } from '@angular/core';
 
-import { switchMap, tap } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
 
 import { DotSiteService } from '@dotcms/data-access';
 import { LoginService } from '@dotcms/dotcms-js';
@@ -142,12 +142,20 @@ export function withSite() {
                 // a one-shot bootstrap load. The GlobalStore is created at app startup
                 // (`provideAppInitializer`), before the session cookie is valid, so a one-shot
                 // load would fire pre-auth and never retry after the SPA login navigation —
-                // leaving the site selector empty until a manual refresh. `watchUser()` fires
-                // when `auth$` emits: on refresh once the AuthGuard resolves auth via
-                // `loadAuth()`, and on every login via `setAuth()` (it only fires synchronously
-                // if auth was already set before the store initialized). Mirrors the legacy
-                // SiteService behavior. See `withUser` for full rationale.
-                loginService.watchUser(() => store.loadCurrentSite());
+                // leaving the site selector empty until a manual refresh. We seed the stream
+                // with the current auth (`startWith`) for an already-established session, then
+                // react to `auth$`: on refresh once the AuthGuard resolves auth via
+                // `loadAuth()`, and on every login via `setAuth()`. Keying on `user.userId`
+                // with `distinctUntilChanged()` avoids a redundant reload on re-emissions that
+                // don't change the user (e.g. login-as). See `withUser` for full rationale.
+                loginService.auth$
+                    .pipe(
+                        startWith(loginService.auth),
+                        map((auth) => auth?.user?.userId ?? null),
+                        filter((userId): userId is string => !!userId),
+                        distinctUntilChanged()
+                    )
+                    .subscribe(() => store.loadCurrentSite());
                 store.syncSiteOnSwitchEvent();
             }
         }))

--- a/core-web/libs/global-store/src/lib/features/with-site/with-site.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/with-site/with-site.feature.ts
@@ -11,7 +11,8 @@ import {
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { Observable, pipe } from 'rxjs';
 
-import { computed, inject } from '@angular/core';
+import { computed, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { distinctUntilChanged, filter, map, startWith, switchMap, tap } from 'rxjs/operators';
 
@@ -138,6 +139,7 @@ export function withSite() {
         withHooks((store) => ({
             onInit() {
                 const loginService = inject(LoginService);
+                const destroyRef = inject(DestroyRef);
                 // Load the current site reactively from the authentication state instead of
                 // a one-shot bootstrap load. The GlobalStore is created at app startup
                 // (`provideAppInitializer`), before the session cookie is valid, so a one-shot
@@ -153,7 +155,11 @@ export function withSite() {
                         startWith(loginService.auth),
                         map((auth) => auth?.user?.userId ?? null),
                         filter((userId): userId is string => !!userId),
-                        distinctUntilChanged()
+                        distinctUntilChanged(),
+                        // Tie the subscription to the store's lifecycle so it is torn down if
+                        // the store is ever destroyed (e.g. if this feature is reused in a
+                        // non-root, scoped store). Harmless for the current root singleton.
+                        takeUntilDestroyed(destroyRef)
                     )
                     .subscribe(() => store.loadCurrentSite());
                 store.syncSiteOnSwitchEvent();

--- a/core-web/libs/global-store/src/lib/features/with-user/with-user.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/with-user/with-user.feature.ts
@@ -87,11 +87,14 @@ export function withUser() {
              * because login navigates via the SPA router (no full page reload), the user
              * would stay `null` until a manual refresh.
              *
-             * `loginService.watchUser()` fires the callback immediately when a session
-             * already exists (e.g. on refresh, once the AuthGuard resolves auth via
-             * `loadAuth()`) and again on every login, so the user is loaded for both the
-             * initial login and subsequent re-logins. This mirrors the reactive pattern the
-             * legacy `SiteService` used (`loginService.watchUser(() => this.loadCurrentSite())`).
+             * `loginService.watchUser()` fires the callback synchronously only if auth was
+             * already established before the store initialized; otherwise it fires when
+             * `auth$` emits. In practice that means: on a hard refresh it fires once the
+             * AuthGuard resolves auth via `loadAuth()` (the store subscribes at bootstrap,
+             * before the guard runs), and on every login it fires when `setAuth()` emits — so
+             * the user is loaded for the initial login and subsequent re-logins alike. This
+             * mirrors the reactive pattern the legacy `SiteService` used
+             * (`loginService.watchUser(() => this.loadCurrentSite())`).
              */
             onInit() {
                 const loginService = inject(LoginService);

--- a/core-web/libs/global-store/src/lib/features/with-user/with-user.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/with-user/with-user.feature.ts
@@ -3,7 +3,8 @@ import { patchState, signalStoreFeature, withHooks, withMethods, withState } fro
 import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { pipe } from 'rxjs';
 
-import { inject } from '@angular/core';
+import { DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { distinctUntilChanged, filter, map, startWith, switchMap } from 'rxjs/operators';
 
@@ -98,12 +99,17 @@ export function withUser() {
              */
             onInit() {
                 const loginService = inject(LoginService);
+                const destroyRef = inject(DestroyRef);
                 loginService.auth$
                     .pipe(
                         startWith(loginService.auth),
                         map((auth) => auth?.user?.userId ?? null),
                         filter((userId): userId is string => !!userId),
-                        distinctUntilChanged()
+                        distinctUntilChanged(),
+                        // Tie the subscription to the store's lifecycle so it is torn down if
+                        // the store is ever destroyed (e.g. if this feature is reused in a
+                        // non-root, scoped store). Harmless for the current root singleton.
+                        takeUntilDestroyed(destroyRef)
                     )
                     .subscribe(() => store.loadLoggedUser());
             }

--- a/core-web/libs/global-store/src/lib/features/with-user/with-user.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/with-user/with-user.feature.ts
@@ -5,7 +5,7 @@ import { pipe } from 'rxjs';
 
 import { inject } from '@angular/core';
 
-import { switchMap } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, startWith, switchMap } from 'rxjs/operators';
 
 import { DotCurrentUserService } from '@dotcms/data-access';
 import { LoginService } from '@dotcms/dotcms-js';
@@ -87,18 +87,25 @@ export function withUser() {
              * because login navigates via the SPA router (no full page reload), the user
              * would stay `null` until a manual refresh.
              *
-             * `loginService.watchUser()` fires the callback synchronously only if auth was
-             * already established before the store initialized; otherwise it fires when
-             * `auth$` emits. In practice that means: on a hard refresh it fires once the
-             * AuthGuard resolves auth via `loadAuth()` (the store subscribes at bootstrap,
-             * before the guard runs), and on every login it fires when `setAuth()` emits — so
-             * the user is loaded for the initial login and subsequent re-logins alike. This
-             * mirrors the reactive pattern the legacy `SiteService` used
-             * (`loginService.watchUser(() => this.loadCurrentSite())`).
+             * Instead we react to `loginService.auth$`: `startWith(loginService.auth)` seeds
+             * the stream with the current auth (already-established session, e.g. lazy store
+             * init after login), then `auth$` delivers future logins. On a hard refresh the
+             * emission comes once the AuthGuard resolves auth via `loadAuth()` → `setAuth()`
+             * (the store subscribes at bootstrap, before the guard runs); on login it comes
+             * from `setAuth()`. We key on `user.userId` and `distinctUntilChanged()` so
+             * re-emissions that don't change the user (e.g. login-as, which only sets
+             * `loginAsUser`) don't trigger a redundant reload.
              */
             onInit() {
                 const loginService = inject(LoginService);
-                loginService.watchUser(() => store.loadLoggedUser());
+                loginService.auth$
+                    .pipe(
+                        startWith(loginService.auth),
+                        map((auth) => auth?.user?.userId ?? null),
+                        filter((userId): userId is string => !!userId),
+                        distinctUntilChanged()
+                    )
+                    .subscribe(() => store.loadLoggedUser());
             }
         }))
     );

--- a/core-web/libs/global-store/src/lib/features/with-user/with-user.feature.ts
+++ b/core-web/libs/global-store/src/lib/features/with-user/with-user.feature.ts
@@ -8,6 +8,7 @@ import { inject } from '@angular/core';
 import { switchMap } from 'rxjs/operators';
 
 import { DotCurrentUserService } from '@dotcms/data-access';
+import { LoginService } from '@dotcms/dotcms-js';
 import { DotCurrentUser } from '@dotcms/dotcms-models';
 
 /**
@@ -75,14 +76,27 @@ export function withUser() {
                 )
             )
         })),
-        withHooks({
+        withHooks((store) => ({
             /**
-             * Automatically loads the current user when the feature is initialized.
+             * Reactively (re)loads the current user from the authentication state.
+             *
+             * Why not a one-shot load here:
+             * The GlobalStore is instantiated at app bootstrap (`provideAppInitializer`),
+             * before the session cookie is valid (e.g. while on the login page). A one-shot
+             * load in `onInit` would therefore fire pre-auth, fail, and never retry — and
+             * because login navigates via the SPA router (no full page reload), the user
+             * would stay `null` until a manual refresh.
+             *
+             * `loginService.watchUser()` fires the callback immediately when a session
+             * already exists (e.g. on refresh, once the AuthGuard resolves auth via
+             * `loadAuth()`) and again on every login, so the user is loaded for both the
+             * initial login and subsequent re-logins. This mirrors the reactive pattern the
+             * legacy `SiteService` used (`loginService.watchUser(() => this.loadCurrentSite())`).
              */
-            onInit(store) {
-                // Auto-load current user on feature initialization
-                store.loadLoggedUser();
+            onInit() {
+                const loginService = inject(LoginService);
+                loginService.watchUser(() => store.loadLoggedUser());
             }
-        })
+        }))
     );
 }

--- a/core-web/libs/global-store/src/lib/store.spec.ts
+++ b/core-web/libs/global-store/src/lib/store.spec.ts
@@ -1,5 +1,5 @@
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
-import { Subject, of } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 
 import {
     DotCurrentUserService,
@@ -59,6 +59,10 @@ describe('GlobalStore', () => {
         // captures the correct subject by the time onInit subscribes to SWITCH_SITE.
         switchSiteSubject = new Subject<DotSite>();
         authCallbacks = [];
+        // Reset shared mock call counts each test so assertions don't depend on test order.
+        // clearAllMocks() clears recorded calls but preserves the mockReturnValue / jest.fn
+        // implementations declared in createServiceFactory.
+        jest.clearAllMocks();
         spectator = createService();
         store = spectator.service;
     });
@@ -98,8 +102,6 @@ describe('GlobalStore', () => {
 
         it('should reload state on every auth notification (e.g. re-login)', () => {
             const siteService = spectator.inject(DotSiteService);
-            // Reset call count: the getCurrentSite mock instance is shared across tests.
-            siteService.getCurrentSite.mockClear();
             siteService.getCurrentSite.mockReturnValue(of(mockSiteEntity));
 
             authCallbacks.forEach((cb) => cb());
@@ -107,6 +109,25 @@ describe('GlobalStore', () => {
 
             // getCurrentSite fires once per notification (2 notifications here).
             expect(siteService.getCurrentSite).toHaveBeenCalledTimes(2);
+        });
+
+        it('should keep loggedUser null when getCurrentUser fails after auth fires', () => {
+            const userService = spectator.inject(DotCurrentUserService);
+            userService.getCurrentUser.mockReturnValue(throwError(() => new Error('401')));
+
+            authCallbacks.forEach((cb) => cb());
+
+            // The pre-auth/failed-load scenario must degrade gracefully, not crash the store.
+            expect(store.loggedUser()).toBeNull();
+        });
+
+        it('should keep siteDetails null when getCurrentSite fails after auth fires', () => {
+            const siteService = spectator.inject(DotSiteService);
+            siteService.getCurrentSite.mockReturnValue(throwError(() => new Error('500')));
+
+            authCallbacks.forEach((cb) => cb());
+
+            expect(store.siteDetails()).toBeNull();
         });
     });
 

--- a/core-web/libs/global-store/src/lib/store.spec.ts
+++ b/core-web/libs/global-store/src/lib/store.spec.ts
@@ -7,25 +7,41 @@ import {
     DotSiteService,
     DotSystemConfigService
 } from '@dotcms/data-access';
-import { DotSite } from '@dotcms/dotcms-models';
+import { LoginService } from '@dotcms/dotcms-js';
+import { DotCurrentUser, DotSite } from '@dotcms/dotcms-models';
 
 import { GlobalStore } from './store';
 import { mockSiteEntity } from './store.mock';
+
+const mockCurrentUser = {
+    userId: 'user-123',
+    email: 'john@example.com'
+} as DotCurrentUser;
 
 describe('GlobalStore', () => {
     let spectator: SpectatorService<InstanceType<typeof GlobalStore>>;
     let store: InstanceType<typeof GlobalStore>;
     let switchSiteSubject: Subject<DotSite>;
+    // Callbacks registered via LoginService.watchUser() by the site/user features on init.
+    // Invoking them simulates the LoginService notifying that a user is authenticated.
+    let authCallbacks: Array<() => void>;
 
     const createService = createServiceFactory({
         service: GlobalStore,
         providers: [
-            mockProvider(DotCurrentUserService),
+            mockProvider(DotCurrentUserService, {
+                getCurrentUser: jest.fn().mockReturnValue(of(mockCurrentUser))
+            }),
             mockProvider(DotSiteService, {
                 getCurrentSite: jest.fn().mockReturnValue(of(null)),
                 switchSite: jest.fn().mockReturnValue(of({} as DotSite))
             }),
             mockProvider(DotSystemConfigService),
+            // watchUser captures the callback instead of firing it, so tests control exactly
+            // when the "user authenticated" signal happens (no implicit load at store init).
+            mockProvider(LoginService, {
+                watchUser: jest.fn((fn: () => void) => authCallbacks.push(fn))
+            }),
             mockProvider(DotEventsSocket, {
                 connect: () => of({}),
                 status$: () => new Subject(),
@@ -42,6 +58,7 @@ describe('GlobalStore', () => {
         // switchSiteSubject is assigned before createService() so the on() closure
         // captures the correct subject by the time onInit subscribes to SWITCH_SITE.
         switchSiteSubject = new Subject<DotSite>();
+        authCallbacks = [];
         spectator = createService();
         store = spectator.service;
     });
@@ -50,6 +67,46 @@ describe('GlobalStore', () => {
         it('should initialize with expected default values', () => {
             expect(store.siteDetails()).toBeNull();
             expect(store.currentSiteId()).toBeNull();
+        });
+
+        it('should NOT load site or user before the user is authenticated', () => {
+            const siteService = spectator.inject(DotSiteService);
+            const userService = spectator.inject(DotCurrentUserService);
+
+            // watchUser() has registered callbacks but they have not fired yet.
+            expect(siteService.getCurrentSite).not.toHaveBeenCalled();
+            expect(userService.getCurrentUser).not.toHaveBeenCalled();
+            expect(store.siteDetails()).toBeNull();
+            expect(store.loggedUser()).toBeNull();
+        });
+    });
+
+    describe('auth-reactive loading', () => {
+        it('should load the current site and user when the auth state becomes a logged-in user', () => {
+            const siteService = spectator.inject(DotSiteService);
+            const userService = spectator.inject(DotCurrentUserService);
+            siteService.getCurrentSite.mockReturnValue(of(mockSiteEntity));
+
+            // Simulate LoginService notifying subscribers that a user is authenticated.
+            authCallbacks.forEach((cb) => cb());
+
+            expect(siteService.getCurrentSite).toHaveBeenCalled();
+            expect(userService.getCurrentUser).toHaveBeenCalled();
+            expect(store.siteDetails()).toEqual(mockSiteEntity);
+            expect(store.loggedUser()).toEqual(mockCurrentUser);
+        });
+
+        it('should reload state on every auth notification (e.g. re-login)', () => {
+            const siteService = spectator.inject(DotSiteService);
+            // Reset call count: the getCurrentSite mock instance is shared across tests.
+            siteService.getCurrentSite.mockClear();
+            siteService.getCurrentSite.mockReturnValue(of(mockSiteEntity));
+
+            authCallbacks.forEach((cb) => cb());
+            authCallbacks.forEach((cb) => cb());
+
+            // getCurrentSite fires once per notification (2 notifications here).
+            expect(siteService.getCurrentSite).toHaveBeenCalledTimes(2);
         });
     });
 

--- a/core-web/libs/global-store/src/lib/store.spec.ts
+++ b/core-web/libs/global-store/src/lib/store.spec.ts
@@ -1,5 +1,5 @@
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
-import { Subject, of, throwError } from 'rxjs';
+import { defer, Subject, of, throwError } from 'rxjs';
 
 import {
     DotCurrentUserService,
@@ -7,7 +7,7 @@ import {
     DotSiteService,
     DotSystemConfigService
 } from '@dotcms/data-access';
-import { LoginService } from '@dotcms/dotcms-js';
+import { Auth, LoginService } from '@dotcms/dotcms-js';
 import { DotCurrentUser, DotSite } from '@dotcms/dotcms-models';
 
 import { GlobalStore } from './store';
@@ -18,13 +18,16 @@ const mockCurrentUser = {
     email: 'john@example.com'
 } as DotCurrentUser;
 
+// Minimal Auth payload; the features only read `auth.user.userId` to key the reactive load.
+const authForUser = (userId: string): Auth => ({ user: { userId } }) as unknown as Auth;
+
 describe('GlobalStore', () => {
     let spectator: SpectatorService<InstanceType<typeof GlobalStore>>;
     let store: InstanceType<typeof GlobalStore>;
     let switchSiteSubject: Subject<DotSite>;
-    // Callbacks registered via LoginService.watchUser() by the site/user features on init.
-    // Invoking them simulates the LoginService notifying that a user is authenticated.
-    let authCallbacks: Array<() => void>;
+    // Auth stream the site/user features subscribe to. Emitting on it simulates the
+    // LoginService notifying that the authenticated user changed (login / re-login).
+    let authSubject: Subject<Auth>;
 
     const createService = createServiceFactory({
         service: GlobalStore,
@@ -37,10 +40,11 @@ describe('GlobalStore', () => {
                 switchSite: jest.fn().mockReturnValue(of({} as DotSite))
             }),
             mockProvider(DotSystemConfigService),
-            // watchUser captures the callback instead of firing it, so tests control exactly
-            // when the "user authenticated" signal happens (no implicit load at store init).
+            // No session at init (`auth` null); the deferred `auth$` resolves to the current
+            // per-test subject so tests control exactly when an authenticated user is signalled.
             mockProvider(LoginService, {
-                watchUser: jest.fn((fn: () => void) => authCallbacks.push(fn))
+                auth: null as unknown as Auth,
+                auth$: defer(() => authSubject)
             }),
             mockProvider(DotEventsSocket, {
                 connect: () => of({}),
@@ -58,7 +62,7 @@ describe('GlobalStore', () => {
         // switchSiteSubject is assigned before createService() so the on() closure
         // captures the correct subject by the time onInit subscribes to SWITCH_SITE.
         switchSiteSubject = new Subject<DotSite>();
-        authCallbacks = [];
+        authSubject = new Subject<Auth>();
         // Reset shared mock call counts each test so assertions don't depend on test order.
         // clearAllMocks() clears recorded calls but preserves the mockReturnValue / jest.fn
         // implementations declared in createServiceFactory.
@@ -77,7 +81,7 @@ describe('GlobalStore', () => {
             const siteService = spectator.inject(DotSiteService);
             const userService = spectator.inject(DotCurrentUserService);
 
-            // watchUser() has registered callbacks but they have not fired yet.
+            // The store subscribed to auth$ but no authenticated user has been emitted yet.
             expect(siteService.getCurrentSite).not.toHaveBeenCalled();
             expect(userService.getCurrentUser).not.toHaveBeenCalled();
             expect(store.siteDetails()).toBeNull();
@@ -86,13 +90,12 @@ describe('GlobalStore', () => {
     });
 
     describe('auth-reactive loading', () => {
-        it('should load the current site and user when the auth state becomes a logged-in user', () => {
+        it('should load the current site and user when a user authenticates', () => {
             const siteService = spectator.inject(DotSiteService);
             const userService = spectator.inject(DotCurrentUserService);
             siteService.getCurrentSite.mockReturnValue(of(mockSiteEntity));
 
-            // Simulate LoginService notifying subscribers that a user is authenticated.
-            authCallbacks.forEach((cb) => cb());
+            authSubject.next(authForUser('user-123'));
 
             expect(siteService.getCurrentSite).toHaveBeenCalled();
             expect(userService.getCurrentUser).toHaveBeenCalled();
@@ -100,14 +103,24 @@ describe('GlobalStore', () => {
             expect(store.loggedUser()).toEqual(mockCurrentUser);
         });
 
-        it('should reload state on every auth notification (e.g. re-login)', () => {
+        it('should NOT reload when the same user is re-emitted (e.g. login-as)', () => {
             const siteService = spectator.inject(DotSiteService);
             siteService.getCurrentSite.mockReturnValue(of(mockSiteEntity));
 
-            authCallbacks.forEach((cb) => cb());
-            authCallbacks.forEach((cb) => cb());
+            authSubject.next(authForUser('user-123'));
+            authSubject.next(authForUser('user-123'));
 
-            // getCurrentSite fires once per notification (2 notifications here).
+            // distinctUntilChanged on userId collapses the duplicate emission.
+            expect(siteService.getCurrentSite).toHaveBeenCalledTimes(1);
+        });
+
+        it('should reload when a different user authenticates (re-login)', () => {
+            const siteService = spectator.inject(DotSiteService);
+            siteService.getCurrentSite.mockReturnValue(of(mockSiteEntity));
+
+            authSubject.next(authForUser('user-123'));
+            authSubject.next(authForUser('user-456'));
+
             expect(siteService.getCurrentSite).toHaveBeenCalledTimes(2);
         });
 
@@ -115,7 +128,7 @@ describe('GlobalStore', () => {
             const userService = spectator.inject(DotCurrentUserService);
             userService.getCurrentUser.mockReturnValue(throwError(() => new Error('401')));
 
-            authCallbacks.forEach((cb) => cb());
+            authSubject.next(authForUser('user-123'));
 
             // The pre-auth/failed-load scenario must degrade gracefully, not crash the store.
             expect(store.loggedUser()).toBeNull();
@@ -125,7 +138,7 @@ describe('GlobalStore', () => {
             const siteService = spectator.inject(DotSiteService);
             siteService.getCurrentSite.mockReturnValue(throwError(() => new Error('500')));
 
-            authCallbacks.forEach((cb) => cb());
+            authSubject.next(authForUser('user-123'));
 
             expect(store.siteDetails()).toBeNull();
         });


### PR DESCRIPTION
## What

Make `GlobalStore` load the current site and user **reactively from the authentication state** instead of a one-shot load at app bootstrap.

Fixes #36189

## Why

`GlobalStore` (`providedIn: 'root'`) is instantiated at app bootstrap via `provideAppInitializer` (`DotAppLifecycleEffect` injects it) — **before the session cookie is valid** (e.g. while on the login page). Its feature `onInit` hooks ran a one-shot load (`withSite.loadCurrentSite()`, `withUser.loadLoggedUser()`) that fired pre-auth, got a `401`, logged a `console.warn`, and **never retried**.

Because login navigates through the SPA router (`router.navigate(['/'])`, no full page reload), nothing re-triggered the loads. Result: after an initial login the header showed **"Select a site"** and Pages crashed with `Cannot read properties of null (reading 'userId')`. A manual refresh recreated the store with a valid session, masking the bug.

## How

- **`withSite` / `withUser`**: load reactively via `loginService.watchUser(() => store.loadX())`. `watchUser()` fires immediately when a session already exists (refresh, once `AuthGuard` resolves auth via `loadAuth()`) and again on every login — covering initial login, refresh and re-login uniformly. This mirrors the reactive pattern the legacy `SiteService` already used (`loginService.watchUser(() => this.loadCurrentSite())`), which the modern store had dropped.
- **`DotPageActionsService`**: resolve `userId` via `getCurrentUser()` instead of reading the `GlobalStore.loggedUser()` signal synchronously at construction time (defensive — reading a store signal synchronously in a constructor is inherently racy).
- **`store.spec`**: mock `LoginService` and add coverage for the auth-reactive load behavior (no load before auth; load on auth notification; reload on re-login).

## Testing

- `nx test global-store` — 177 passing (incl. new auth-reactive cases)
- `nx test dotcms-ui` — passing (incl. `dot-page-actions`, `main-legacy`)
- `nx lint global-store dotcms-ui` — passing (Nx module boundaries OK: `global-store → @dotcms/dotcms-js` already used by `withWebSocket`)

### Manual

1. Log in to the backend, land on `/starter`, **do not refresh**.
2. Header site selector shows the current site (not "Select a site").
3. Open Pages — no `userId` null error; menus build with correct permissions.
