### PR TITLE
feat(agentic-tools): whitelist /api/v2/assets and refresh MCP spec

### DIFF
--- a/core-web/libs/agentic-tools/scripts/generate-spec.ts
+++ b/core-web/libs/agentic-tools/scripts/generate-spec.ts
@@ -24,7 +24,8 @@ const ALLOWED_PREFIXES = [
     '/api/v1/containers',
     '/api/v1/themes',
     '/api/v1/templates',
-    '/api/v1/content/_search'
+    '/api/v1/content/_search',
+    '/api/v2/assets'
 ];
 
 const EXCLUDED_PATTERNS = [

--- a/core-web/libs/agentic-tools/src/generated/spec.json
+++ b/core-web/libs/agentic-tools/src/generated/spec.json
@@ -3067,8 +3067,8 @@
         "/api/v1/page/{pageId}/content": {
             "post": {
                 "tags": ["Page"],
-                "summary": "Add or update content in page containers",
-                "description": "Updates all the contents in an HTML Page. Used to add or remove Contentlets from Containers. Takes a JSON array of container entries, each specifying a container ID, a unique UUID, and the list of contentlet identifiers. Duplicate container entries are merged automatically. Note: 'sortOrder' is required for each container entry but may not be present in the auto-generated schema.",
+                "summary": "Replace the content mapping of a page",
+                "description": "Replaces all container-to-contentlet assignments for the page (DEFAULT variant, or a named variant when 'variantName' is provided). This is a full replacement, not a patch: omitting a container slot removes its content. The body is a bare JSON array of container entries; each entry maps one container instance to its ordered list of contentlets. Duplicate entries are merged automatically. To build the payload, fetch GET /api/v1/page/json/{uri} first (faster than /render — no Velocity execution): use 'page.containers' for the path-based identifier and 'page.layout.body.rows[].columns[].containers[]' for the uuid of each slot.",
                 "operationId": "addContentToPage",
                 "parameters": [
                     {
@@ -3090,49 +3090,49 @@
                     }
                 ],
                 "requestBody": {
-                    "description": "Container entries with contentlet identifiers",
+                    "description": "Array of container entries. Full replacement: omitting a slot removes its content from the page.",
                     "content": {
                         "application/json": {
                             "schema": {
-                                "type": "object",
-                                "properties": {
-                                    "requestJson": {
-                                        "type": "string"
-                                    },
-                                    "containerEntries": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "personaTag": {
-                                                    "type": "string"
-                                                },
-                                                "contentIds": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "stylePropertiesMap": {
-                                                    "type": "object",
-                                                    "additionalProperties": {
-                                                        "type": "object",
-                                                        "additionalProperties": {
-                                                            "type": "object"
-                                                        }
-                                                    }
-                                                },
-                                                "containerId": {
-                                                    "type": "string"
-                                                },
-                                                "containerUUID": {
-                                                    "type": "string"
-                                                }
+                                "type": "array",
+                                "items": {
+                                    "required": ["contentletsId", "identifier", "uuid"],
+                                    "type": "object",
+                                    "properties": {
+                                        "identifier": {
+                                            "type": "string",
+                                            "description": "Container's path-based key, e.g. '//demo.dotcms.com/application/containers/default/'. Matches the keys in 'page.containers' returned by GET /api/v1/page/json/{uri} (or /render/{uri}). Not the database UUID.",
+                                            "example": "//demo.dotcms.com/application/containers/default/"
+                                        },
+                                        "uuid": {
+                                            "type": "string",
+                                            "description": "Slot instance identifier. Matches the 'uuid' in page.layout.body.rows[].columns[].containers[]. The same container can appear multiple times on a page with different UUIDs.",
+                                            "example": "10"
+                                        },
+                                        "contentletsId": {
+                                            "type": "array",
+                                            "description": "Ordered contentlet identifiers placed in this slot. An empty array clears the slot. This is a full replacement: omitted slots are removed from the page.",
+                                            "items": {
+                                                "type": "string",
+                                                "description": "Ordered contentlet identifiers placed in this slot. An empty array clears the slot. This is a full replacement: omitted slots are removed from the page."
                                             }
+                                        },
+                                        "personaTag": {
+                                            "type": "string",
+                                            "description": "Optional persona tag for personalized content variants.",
+                                            "nullable": true
                                         }
-                                    }
+                                    },
+                                    "description": "Single container slot assignment for a page."
                                 }
-                            }
+                            },
+                            "example": [
+                                {
+                                    "identifier": "//demo.dotcms.com/application/containers/default/",
+                                    "uuid": "10",
+                                    "contentletsId": ["7b33f0b474ba3b82c3a908b81dce5e2c"]
+                                }
+                            ]
                         }
                     },
                     "required": true
@@ -3146,6 +3146,9 @@
                     },
                     "400": {
                         "description": "Bad request or data exception"
+                    },
+                    "409": {
+                        "description": "Conflict — net content loss exceeds the configured threshold; refresh and retry"
                     }
                 }
             }
@@ -3600,6 +3603,83 @@
                     },
                     "404": {
                         "description": "Page not found"
+                    }
+                }
+            }
+        },
+        "/api/v1/page/_render-sources/{uri}": {
+            "get": {
+                "tags": ["Page"],
+                "summary": "Get render sources for a page",
+                "description": "Returns references only (path + identifier, no file content, no container code) mapping a rendered page to its source files. The page is identified by a URI path segment, exactly like `GET /api/v1/page/render/{uri}`.\n\nThe URI must be a plain path (e.g. `index`, `about/team`). To address a specific site, use the `host_id` query parameter.\n\nIncludes the page reference, theme VTL files, all containers referenced by the template (only content types actually placed under the applied persona/variant are included), and widget contentlets placed on the page.\n\n**Widget source field:**\nEach widget entry includes a `source` field:\n- `FILE` — the widget's Velocity lives in a file asset; `path` and `identifier` are populated. Retrieve the VTL content via `GET /api/v2/assets`.\n- `CODE` — the widget's Velocity is inline (in the content type's `widgetCode` field and/or the contentlet's own fields). No `path`/`identifier` are returned. Retrieve the content type definition via `GET /api/v1/contenttype/id/{contentTypeVar}` and the placed contentlet via `GET /api/v1/content/id/{contentletId}`.\n\n**Other source lookups:**\n- Theme folder files: `GET /api/v1/folder/sitename/{site}/uri/{uri}`\n- DB container code: `GET /api/v1/containers/working?containerId=<id>&includeContentType=true`\n- FILE container VTL content: `GET /api/v2/assets`",
+                "operationId": "getPageRenderSources",
+                "parameters": [
+                    {
+                        "name": "uri",
+                        "in": "path",
+                        "description": "Page URI path (e.g. 'index' or 'about/team'). Must be a plain path without an embedded host; use host_id to target a specific site.",
+                        "required": true,
+                        "schema": {
+                            "pattern": ".*",
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "host_id",
+                        "in": "query",
+                        "description": "Explicit host identifier; if omitted the default site is used",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "language_id",
+                        "in": "query",
+                        "description": "Language identifier; defaults to the default language",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "persona_id",
+                        "in": "query",
+                        "description": "Persona contentlet identifier for personalization lookup",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variantName",
+                        "in": "query",
+                        "description": "Variant name; defaults to DEFAULT",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "mode",
+                        "in": "query",
+                        "description": "Page mode: EDIT_MODE, PREVIEW_MODE, LIVE; defaults to PREVIEW_MODE",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Render sources retrieved successfully",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter (e.g. an unknown mode value)"
+                    },
+                    "403": {
+                        "description": "User does not have READ permission on the page"
+                    },
+                    "404": {
+                        "description": "Page not found, wrong language, or unknown host"
                     }
                 }
             }
@@ -10480,7 +10560,7 @@
             "put": {
                 "tags": ["Workflow"],
                 "summary": "Fire action by name (multipart form)",
-                "description": "Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by name, on a target contentlet. Uses a multipart form to transmit its data.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.",
+                "description": "Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by name, on a target contentlet. Uses a multipart form to transmit its data.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.\n\n**Block Editor (Story Block) fields:** send the value as an HTML or Markdown string — do not hand-author the underlying ProseMirror/JSON document. The value is stored as-is and converted to the Block Editor structure when the contentlet is opened in the editor. Example: `\"body\": \"<h2>Intro</h2><p>Hello <strong>world</strong>.</p>\"`.",
                 "operationId": "putFireActionByNameMultipart",
                 "parameters": [
                     {
@@ -10571,7 +10651,7 @@
             "put": {
                 "tags": ["Workflow"],
                 "summary": "Fire workflow action by name",
-                "description": "Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by name, on a target contentlet.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.",
+                "description": "Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by name, on a target contentlet.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.\n\n**Block Editor (Story Block) fields:** send the value as an HTML or Markdown string — do not hand-author the underlying ProseMirror/JSON document. The value is stored as-is and converted to the Block Editor structure when the contentlet is opened in the editor. Example: `\"body\": \"<h2>Intro</h2><p>Hello <strong>world</strong>.</p>\"`.",
                 "operationId": "putFireActionByName",
                 "parameters": [
                     {
@@ -10714,7 +10794,7 @@
             "put": {
                 "tags": ["Workflow"],
                 "summary": "Fire default action (multipart form)",
-                "description": "Fires a default [system action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) on target contentlet. Uses a multipart form to transmit its data.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.",
+                "description": "Fires a default [system action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) on target contentlet. Uses a multipart form to transmit its data.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.\n\n**Block Editor (Story Block) fields:** send the value as an HTML or Markdown string — do not hand-author the underlying ProseMirror/JSON document. The value is stored as-is and converted to the Block Editor structure when the contentlet is opened in the editor. Example: `\"body\": \"<h2>Intro</h2><p>Hello <strong>world</strong>.</p>\"`.",
                 "operationId": "putFireDefaultActionMultipart",
                 "parameters": [
                     {
@@ -10824,7 +10904,7 @@
             "put": {
                 "tags": ["Workflow"],
                 "summary": "Fire system action by name",
-                "description": "Fire a [default system action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) by name on a target contentlet.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**Request body** — wrap field values in a `contentlet` key:\n\n```json\n{\n  \"contentlet\": {\n    \"contentType\": \"<variable-or-inode>\",\n    \"title\": \"My New Item\",\n    \"...\": \"other field values\"\n  }\n}\n```\nField keys inside `contentlet` are the content type's field `variable` names (e.g., `title`, `body`, `image`). Unknown field names are silently dropped (a typo like `titel` will be ignored and may surface as a misleading 'title is required' error). Radio/Select/Checkbox values are not validated against the field's `values` list — out-of-range values are accepted as-is. Always verify spelling against `fields[].variable` from `GET /api/v1/contenttype/id/{idOrVar}`.\n\n**Validation error response shape:**\n\n```json\n{\n  \"entity\": \"\",\n  \"errors\": [{ \"errorCode\": \"required\", \"fieldName\": \"image\", \"message\": \"The field Image is required.\" }],\n  \"i18nMessagesMap\": {}, \"messages\": [], \"pagination\": null, \"permissions\": []\n}\n```\n`errorCode` values: `required`, `unknown`. `fieldName` is the field `variable` for field-specific errors, or `null` for content-level errors. Note: when the content type is not found, `message` returns the raw translation key `Workflow-does-not-exists-content-type` instead of translated text.\n\n**Binary and image fields** — These fields cannot receive raw file data or asset paths in the JSON body. Use one of the patterns below.\n\n**Pattern A — single-use file (works for all binary/image fields):**\n\n1. `POST /api/v1/temp` (multipart `file` part) OR `POST /api/v1/temp/byUrl` (JSON `{\"remoteUrl\":\"https://...\"}`) → use `tempFiles[0].id` (e.g. `\"temp_5311313004\"`) as the field value.\n2. Pass that ID in the contentlet body: `{\"contentlet\": {\"contentType\": \"ResortActivities\", \"image\": \"temp_5311313004\", ...}}`.\n\n**Pattern B — reusable shared asset (`ImmutableImageField` only):**\n\n1. Upload via `/temp`, create a dotAsset contentlet: `PUT .../fire/PUBLISH` with `{\"contentlet\": {\"contentType\": \"dotAsset\", \"asset\": \"temp_<id>\"}}`.\n2. Use the returned dotAsset `identifier` as the field value on any `ImmutableImageField`.\n\n| Field `clazz` | `temp_<id>` | dotAsset `identifier` |\n|---|---|---|\n| `ImmutableBinaryField` | ✅ | ❌ (returns 400 \\\"field is required\\\") |\n| `ImmutableImageField` | ✅ | ✅ |\n\nFind a field's `clazz` by calling `GET /api/v1/contenttype/id/{idOrVar}` and reading `fields[].clazz`.\n\n⚠️ **Known issue:** Firing `PUBLISH` on an archived contentlet (`archived: true`) does not validate the archived state and can produce an inconsistent `live: true, archived: true` tri-state. Always fire `UNARCHIVE` before `PUBLISH` on archived content.\n\n⚠️ **Multi-scheme content types:** When a content type has multiple workflow schemes attached, firing a system action only initializes the contentlet into the scheme whose `systemActionMappings` entry resolved the fire. Other attached schemes will not have a task for that contentlet, and firing their actions later will fail with 'Workflow Action is not available in the Workflow Step the content is currently in.' To exercise actions in those other schemes, fire by action ID via `PUT /api/v1/workflow/actions/{actionId}/fire` using an action mapped to the desired scheme.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.",
+                "description": "Fire a [default system action](https://www.dotcms.com/docs/latest/managing-workflows#DefaultActions) by name on a target contentlet.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**Request body** — wrap field values in a `contentlet` key:\n\n```json\n{\n  \"contentlet\": {\n    \"contentType\": \"<variable-or-inode>\",\n    \"title\": \"My New Item\",\n    \"...\": \"other field values\"\n  }\n}\n```\nField keys inside `contentlet` are the content type's field `variable` names (e.g., `title`, `body`, `image`). Unknown field names are silently dropped (a typo like `titel` will be ignored and may surface as a misleading 'title is required' error). Radio/Select/Checkbox values are not validated against the field's `values` list — out-of-range values are accepted as-is. Always verify spelling against `fields[].variable` from `GET /api/v1/contenttype/id/{idOrVar}`.\n\n**Validation error response shape:**\n\n```json\n{\n  \"entity\": \"\",\n  \"errors\": [{ \"errorCode\": \"required\", \"fieldName\": \"image\", \"message\": \"The field Image is required.\" }],\n  \"i18nMessagesMap\": {}, \"messages\": [], \"pagination\": null, \"permissions\": []\n}\n```\n`errorCode` values: `required`, `unknown`. `fieldName` is the field `variable` for field-specific errors, or `null` for content-level errors. Note: when the content type is not found, `message` returns the raw translation key `Workflow-does-not-exists-content-type` instead of translated text.\n\n**Binary and image fields** — These fields cannot receive raw file data or asset paths in the JSON body. Use one of the patterns below.\n\n**Pattern A — single-use file (works for all binary/image fields):**\n\n1. `POST /api/v1/temp` (multipart `file` part) OR `POST /api/v1/temp/byUrl` (JSON `{\"remoteUrl\":\"https://...\"}`) → use `tempFiles[0].id` (e.g. `\"temp_5311313004\"`) as the field value.\n2. Pass that ID in the contentlet body: `{\"contentlet\": {\"contentType\": \"ResortActivities\", \"image\": \"temp_5311313004\", ...}}`.\n\n**Pattern B — reusable shared asset (`ImmutableImageField` only):**\n\n1. Upload via `/temp`, create a dotAsset contentlet: `PUT .../fire/PUBLISH` with `{\"contentlet\": {\"contentType\": \"dotAsset\", \"asset\": \"temp_<id>\"}}`.\n2. Use the returned dotAsset `identifier` as the field value on any `ImmutableImageField`.\n\n| Field `clazz` | `temp_<id>` | dotAsset `identifier` |\n|---|---|---|\n| `ImmutableBinaryField` | ✅ | ❌ (returns 400 \\\"field is required\\\") |\n| `ImmutableImageField` | ✅ | ✅ |\n\nFind a field's `clazz` by calling `GET /api/v1/contenttype/id/{idOrVar}` and reading `fields[].clazz`.\n\n⚠️ **Known issue:** Firing `PUBLISH` on an archived contentlet (`archived: true`) does not validate the archived state and can produce an inconsistent `live: true, archived: true` tri-state. Always fire `UNARCHIVE` before `PUBLISH` on archived content.\n\n⚠️ **Multi-scheme content types:** When a content type has multiple workflow schemes attached, firing a system action only initializes the contentlet into the scheme whose `systemActionMappings` entry resolved the fire. Other attached schemes will not have a task for that contentlet, and firing their actions later will fail with 'Workflow Action is not available in the Workflow Step the content is currently in.' To exercise actions in those other schemes, fire by action ID via `PUT /api/v1/workflow/actions/{actionId}/fire` using an action mapped to the desired scheme.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.\n\n**Block Editor (Story Block) fields:** send the value as an HTML or Markdown string — do not hand-author the underlying ProseMirror/JSON document. The value is stored as-is and converted to the Block Editor structure when the contentlet is opened in the editor. Example: `\"body\": \"<h2>Intro</h2><p>Hello <strong>world</strong>.</p>\"`.",
                 "operationId": "putFireDefaultSystemAction",
                 "parameters": [
                     {
@@ -11278,7 +11358,7 @@
             "put": {
                 "tags": ["Workflow"],
                 "summary": "Fire action by ID (multipart form)",
-                "description": "Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by identifier, on a target contentlet. Uses a multipart form to transmit its data.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.",
+                "description": "Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by identifier, on a target contentlet. Uses a multipart form to transmit its data.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.\n\n**Block Editor (Story Block) fields:** send the value as an HTML or Markdown string — do not hand-author the underlying ProseMirror/JSON document. The value is stored as-is and converted to the Block Editor structure when the contentlet is opened in the editor. Example: `\"body\": \"<h2>Intro</h2><p>Hello <strong>world</strong>.</p>\"`.",
                 "operationId": "putFireActionByIdMultipart",
                 "parameters": [
                     {
@@ -11378,7 +11458,7 @@
             "put": {
                 "tags": ["Workflow"],
                 "summary": "Fire action by ID",
-                "description": "Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by identifier, on a target contentlet.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**Use this endpoint to fire actions that are not represented as `SystemAction` tokens** (`NEW`, `EDIT`, `PUBLISH`, etc.). The two most common are `Move` and `Copy` on the System Workflow scheme.\n\n**Move action** — relocates a contentlet to a new folder/host. Request body shape (note: `pathToMove` is a sibling of `contentlet`, **not** nested inside it):\n\n```json\n{\n  \"contentlet\": { \"identifier\": \"<contentlet-identifier>\" },\n  \"pathToMove\": \"//<siteHost>/<folderPath>\"\n}\n```\nAlternative shapes (`contentlet.host`+`contentlet.folder`, `contentlet.hostFolder`, `path` instead of `pathToMove`) all return `400 \"The host path is not valid: null\"`.\n\n**Copy action** — clones a contentlet. Fire with `?identifier=<source-id>` and an empty body (or `{\"contentlet\": {\"identifier\": \"<source-id>\"}}`). The Copy action id on the default System Workflow scheme is `963f6a04-5320-42e7-ab74-6d876d199946`; retrieve it for other environments via `GET /api/v1/workflow/schemes/{schemeId}/actions`. ⚠️ The response `entity` returns the **source** contentlet, not the newly-created copy — locate the copy via a follow-up `POST /api/content/_search` ordered by `modDate DESC`. The copy lands in `SYSTEM_HOST` / `SYSTEM_FOLDER`; destination hints (`pathToMove`, `host`, `folder`, `hostFolder`) are silently ignored. Fire the Move action afterwards to relocate.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.",
+                "description": "Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions), specified by identifier, on a target contentlet.\n\nReturns a map of the resultant contentlet, with an additional `AUTO_ASSIGN_WORKFLOW` property, which can be referenced by delegate services that handle automatically assigning workflow schemes to content with none.\n\n**Use this endpoint to fire actions that are not represented as `SystemAction` tokens** (`NEW`, `EDIT`, `PUBLISH`, etc.). The two most common are `Move` and `Copy` on the System Workflow scheme.\n\n**Move action** — relocates a contentlet to a new folder/host. Request body shape (note: `pathToMove` is a sibling of `contentlet`, **not** nested inside it):\n\n```json\n{\n  \"contentlet\": { \"identifier\": \"<contentlet-identifier>\" },\n  \"pathToMove\": \"//<siteHost>/<folderPath>\"\n}\n```\nAlternative shapes (`contentlet.host`+`contentlet.folder`, `contentlet.hostFolder`, `path` instead of `pathToMove`) all return `400 \"The host path is not valid: null\"`.\n\n**Copy action** — clones a contentlet. Fire with `?identifier=<source-id>` and an empty body (or `{\"contentlet\": {\"identifier\": \"<source-id>\"}}`). The Copy action id on the default System Workflow scheme is `963f6a04-5320-42e7-ab74-6d876d199946`; retrieve it for other environments via `GET /api/v1/workflow/schemes/{schemeId}/actions`. ⚠️ The response `entity` returns the **source** contentlet, not the newly-created copy — locate the copy via a follow-up `POST /api/content/_search` ordered by `modDate DESC`. The copy lands in `SYSTEM_HOST` / `SYSTEM_FOLDER`; destination hints (`pathToMove`, `host`, `folder`, `hostFolder`) are silently ignored. Fire the Move action afterwards to relocate.\n\n**When chaining workflow actions or reading state back immediately after firing, pass `indexPolicy=WAIT_FOR` on each call.** The default `DEFER` is asynchronous and can return stale index reads for several seconds, which can mimic server-side state bugs. For isolated one-off fires where nothing reads the result, leave the default.\n\n**Block Editor (Story Block) fields:** send the value as an HTML or Markdown string — do not hand-author the underlying ProseMirror/JSON document. The value is stored as-is and converted to the Block Editor structure when the contentlet is opened in the editor. Example: `\"body\": \"<h2>Intro</h2><p>Hello <strong>world</strong>.</p>\"`.",
                 "operationId": "putFireActionById",
                 "parameters": [
                     {
@@ -11533,19 +11613,26 @@
                     "content": {
                         "application/json": {
                             "schema": {
+                                "required": ["workflowActionId"],
                                 "type": "object",
                                 "properties": {
                                     "query": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "description": "Lucene query that selects the contentlets to act on. Mutually exclusive with 'contentletIds'.",
+                                        "example": "+contentType:webPageContent +languageId:1"
                                     },
                                     "contentletIds": {
                                         "type": "array",
+                                        "description": "Explicit list of contentlet identifiers to act on. Mutually exclusive with 'query'.",
                                         "items": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "description": "Explicit list of contentlet identifiers to act on. Mutually exclusive with 'query'."
                                         }
                                     },
                                     "workflowActionId": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "description": "The workflow action identifier (UUID) to fire. Discover via GET /api/v1/workflow/schemes/{schemeId}/actions or GET /api/v1/workflow/contentlet/{inode}/actions. Not the system action enum value (NEW, EDIT, PUBLISH, …).",
+                                        "example": "ceca4ee9-1b7b-4f21-a5f4-5d8e9b8b8a1d"
                                     },
                                     "additionalParams": {
                                         "type": "object",
@@ -11554,103 +11641,136 @@
                                                 "type": "object",
                                                 "properties": {
                                                     "whereToSend": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish environment identifier or name to receive the content."
                                                     },
                                                     "publishDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish date (yyyy-MM-dd)."
                                                     },
                                                     "publishTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish time (HH:mm)."
                                                     },
                                                     "expireDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire date (yyyy-MM-dd). Ignored when 'neverExpire' is true."
                                                     },
                                                     "expireTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire time (HH:mm). Ignored when 'neverExpire' is true."
                                                     },
                                                     "neverExpire": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "If 'true', the content does not expire. Overrides expireDate/expireTime."
                                                     },
                                                     "filterKey": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish filter key (defines what gets bundled with the content)."
                                                     },
                                                     "iWantTo": {
                                                         "type": "string",
                                                         "writeOnly": true
                                                     },
                                                     "timezoneId": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Timezone identifier (e.g. 'America/New_York') for publish/expire dates."
                                                     },
                                                     "iwantTo": {
                                                         "type": "string"
                                                     }
-                                                }
+                                                },
+                                                "description": "Push-publish settings applied when the resolved workflow action wires the Push Publish actionlet."
                                             },
                                             "assignComment": {
                                                 "type": "object",
                                                 "properties": {
                                                     "assign": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Identifier of the user or role to next receive the workflow task. Empty string keeps the existing assignee."
                                                     },
                                                     "comment": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Free-form comment recorded against the workflow task."
                                                     }
-                                                }
+                                                },
+                                                "description": "Assignee and comment to attach to the workflow task created when an action is fired."
                                             },
                                             "additionalParamsMap": {
                                                 "type": "object",
                                                 "additionalProperties": {
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "description": "Free-form map for actionlet-specific keys. Well-known keys: '_path_to_move' (String) — full target path including host, e.g. '//hostname/folder/path/'. Used by the Move actionlet when the resolved bulk action wires it. Silently ignored if no Move actionlet is in the resolved action.",
+                                                    "example": {
+                                                        "_path_to_move": "//demo.dotcms.com/destination/folder/"
+                                                    }
+                                                },
+                                                "description": "Free-form map for actionlet-specific keys. Well-known keys: '_path_to_move' (String) — full target path including host, e.g. '//hostname/folder/path/'. Used by the Move actionlet when the resolved bulk action wires it. Silently ignored if no Move actionlet is in the resolved action.",
+                                                "example": {
+                                                    "_path_to_move": "//demo.dotcms.com/destination/folder/"
                                                 }
                                             },
                                             "pushPublishBean": {
                                                 "type": "object",
                                                 "properties": {
                                                     "whereToSend": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish environment identifier or name to receive the content."
                                                     },
                                                     "publishDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish date (yyyy-MM-dd)."
                                                     },
                                                     "publishTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish time (HH:mm)."
                                                     },
                                                     "expireDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire date (yyyy-MM-dd). Ignored when 'neverExpire' is true."
                                                     },
                                                     "expireTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire time (HH:mm). Ignored when 'neverExpire' is true."
                                                     },
                                                     "neverExpire": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "If 'true', the content does not expire. Overrides expireDate/expireTime."
                                                     },
                                                     "filterKey": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish filter key (defines what gets bundled with the content)."
                                                     },
                                                     "iWantTo": {
                                                         "type": "string",
                                                         "writeOnly": true
                                                     },
                                                     "timezoneId": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Timezone identifier (e.g. 'America/New_York') for publish/expire dates."
                                                     },
                                                     "iwantTo": {
                                                         "type": "string"
                                                     }
-                                                }
+                                                },
+                                                "description": "Push-publish settings applied when the resolved workflow action wires the Push Publish actionlet."
                                             },
                                             "assignCommentBean": {
                                                 "type": "object",
                                                 "properties": {
                                                     "assign": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Identifier of the user or role to next receive the workflow task. Empty string keeps the existing assignee."
                                                     },
                                                     "comment": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Free-form comment recorded against the workflow task."
                                                     }
-                                                }
+                                                },
+                                                "description": "Assignee and comment to attach to the workflow task created when an action is fired."
                                             }
-                                        }
+                                        },
+                                        "description": "Action-specific parameters for bulk fire. Wraps push-publish settings, assign-and-comment metadata, and a free-form map for actionlet-specific keys."
                                     },
                                     "popupParamsBean": {
                                         "type": "object",
@@ -11659,105 +11779,139 @@
                                                 "type": "object",
                                                 "properties": {
                                                     "whereToSend": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish environment identifier or name to receive the content."
                                                     },
                                                     "publishDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish date (yyyy-MM-dd)."
                                                     },
                                                     "publishTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish time (HH:mm)."
                                                     },
                                                     "expireDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire date (yyyy-MM-dd). Ignored when 'neverExpire' is true."
                                                     },
                                                     "expireTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire time (HH:mm). Ignored when 'neverExpire' is true."
                                                     },
                                                     "neverExpire": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "If 'true', the content does not expire. Overrides expireDate/expireTime."
                                                     },
                                                     "filterKey": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish filter key (defines what gets bundled with the content)."
                                                     },
                                                     "iWantTo": {
                                                         "type": "string",
                                                         "writeOnly": true
                                                     },
                                                     "timezoneId": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Timezone identifier (e.g. 'America/New_York') for publish/expire dates."
                                                     },
                                                     "iwantTo": {
                                                         "type": "string"
                                                     }
-                                                }
+                                                },
+                                                "description": "Push-publish settings applied when the resolved workflow action wires the Push Publish actionlet."
                                             },
                                             "assignComment": {
                                                 "type": "object",
                                                 "properties": {
                                                     "assign": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Identifier of the user or role to next receive the workflow task. Empty string keeps the existing assignee."
                                                     },
                                                     "comment": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Free-form comment recorded against the workflow task."
                                                     }
-                                                }
+                                                },
+                                                "description": "Assignee and comment to attach to the workflow task created when an action is fired."
                                             },
                                             "additionalParamsMap": {
                                                 "type": "object",
                                                 "additionalProperties": {
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "description": "Free-form map for actionlet-specific keys. Well-known keys: '_path_to_move' (String) — full target path including host, e.g. '//hostname/folder/path/'. Used by the Move actionlet when the resolved bulk action wires it. Silently ignored if no Move actionlet is in the resolved action.",
+                                                    "example": {
+                                                        "_path_to_move": "//demo.dotcms.com/destination/folder/"
+                                                    }
+                                                },
+                                                "description": "Free-form map for actionlet-specific keys. Well-known keys: '_path_to_move' (String) — full target path including host, e.g. '//hostname/folder/path/'. Used by the Move actionlet when the resolved bulk action wires it. Silently ignored if no Move actionlet is in the resolved action.",
+                                                "example": {
+                                                    "_path_to_move": "//demo.dotcms.com/destination/folder/"
                                                 }
                                             },
                                             "pushPublishBean": {
                                                 "type": "object",
                                                 "properties": {
                                                     "whereToSend": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish environment identifier or name to receive the content."
                                                     },
                                                     "publishDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish date (yyyy-MM-dd)."
                                                     },
                                                     "publishTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish time (HH:mm)."
                                                     },
                                                     "expireDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire date (yyyy-MM-dd). Ignored when 'neverExpire' is true."
                                                     },
                                                     "expireTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire time (HH:mm). Ignored when 'neverExpire' is true."
                                                     },
                                                     "neverExpire": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "If 'true', the content does not expire. Overrides expireDate/expireTime."
                                                     },
                                                     "filterKey": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish filter key (defines what gets bundled with the content)."
                                                     },
                                                     "iWantTo": {
                                                         "type": "string",
                                                         "writeOnly": true
                                                     },
                                                     "timezoneId": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Timezone identifier (e.g. 'America/New_York') for publish/expire dates."
                                                     },
                                                     "iwantTo": {
                                                         "type": "string"
                                                     }
-                                                }
+                                                },
+                                                "description": "Push-publish settings applied when the resolved workflow action wires the Push Publish actionlet."
                                             },
                                             "assignCommentBean": {
                                                 "type": "object",
                                                 "properties": {
                                                     "assign": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Identifier of the user or role to next receive the workflow task. Empty string keeps the existing assignee."
                                                     },
                                                     "comment": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Free-form comment recorded against the workflow task."
                                                     }
-                                                }
+                                                },
+                                                "description": "Assignee and comment to attach to the workflow task created when an action is fired."
                                             }
-                                        }
+                                        },
+                                        "description": "Action-specific parameters for bulk fire. Wraps push-publish settings, assign-and-comment metadata, and a free-form map for actionlet-specific keys."
                                     }
-                                }
+                                },
+                                "description": "Request body for PUT /api/v1/workflow/contentlet/actions/bulk/fire. Either 'query' OR 'contentletIds' must be supplied (not both). 'workflowActionId' is required and must belong to the workflow scheme that owns the input contentlets — otherwise the contentlets are skipped and the response returns a non-empty 'skippedCount' with a 'skipReason'. To bypass scheme checks (e.g. for System Workflow actions like Move on content from a non-system scheme), use PUT /api/v1/workflow/actions/{actionId}/fire instead."
                             }
                         }
                     },
@@ -11795,26 +11949,33 @@
             "put": {
                 "tags": ["Workflow"],
                 "summary": "Perform workflow actions on bulk content",
-                "description": "This operation allows you to specify a multiple content items (either by query or a list of identifiers), a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) to perform on them, and additional parameters as needed by the selected action.\n\n⚠️ **Important contract notes:**\n\n- `contentletIds` despite its name expects **inodes**, not identifiers. Passing identifiers results in a silent no-op with no error.\n- `additionalParams` must be present, even when empty (`{}`). Omitting it returns a `500` NPE.\n- The endpoint is **not step-aware**: if the action is not valid in a contentlet's current step, the input is dropped silently (no `fails[]` entry). Verify post-fire state via `POST /api/content/_search`.\n- `PUT /api/v1/workflow/contentlet/actions/bulk/fire` and `POST /api/v1/workflow/contentlet/actions/_bulkfire` behave identically; `_bulkfire` streams via SSE.\n- For batches larger than a few contentlets, the synchronous response can exceed common client timeouts (e.g. ~15 s for the MCP sandbox). The server-side work typically completes; verify with `_search`.",
+                "description": "Fires a [workflow action](https://www.dotcms.com/docs/latest/managing-workflows#Actions) on multiple contentlets identified either by a Lucene 'query' or an explicit 'contentletIds' list. If both are supplied, 'query' wins and 'contentletIds' is ignored.\n\n**Scheme association is enforced.** Contentlets whose workflow scheme does not own the supplied 'workflowActionId' are skipped — they are not processed and are counted in 'skippedCount' on the response, with a 'skipReason' explaining the mismatch. When *every* input contentlet is skipped, the endpoint returns 422. To bypass scheme association checks (e.g. for System Workflow actions like Move on content from a custom scheme), use PUT /api/v1/workflow/actions/{actionId}/fire instead.\n\n⚠️ **Important contract notes:**\n\n- `contentletIds` despite its name expects **inodes**, not identifiers. Passing identifiers results in a silent no-op with no error.\n- `additionalParams` must be present, even when empty (`{}`). Omitting it returns a `500` NPE.\n- The endpoint is **not step-aware**: if the action is not valid in a contentlet's current step, the input is dropped silently (no `fails[]` entry). Verify post-fire state via `POST /api/content/_search`.\n- `PUT /api/v1/workflow/contentlet/actions/bulk/fire` and `POST /api/v1/workflow/contentlet/actions/_bulkfire` behave identically; `_bulkfire` streams via SSE.\n- For batches larger than a few contentlets, the synchronous response can exceed common client timeouts (e.g. ~15 s for the MCP sandbox). The server-side work typically completes; verify with `_search`.",
                 "operationId": "putBulkActionsFire",
                 "requestBody": {
-                    "description": "Body consists of a JSON object with the following possible properties:\n\n| Property | Type | Description |\n|-|-|-|\n| `contentletIds` | List of Strings | A list of contentlet **inodes** (not identifiers, despite the property name). |\n| `query` | String | [Lucene query](https://www.dotcms.com/docs/latest/content-search-syntax#Lucene); uses all matching contentlets. |\n| `workflowActionId` | String | The identifier of the workflow action to be performed on the selected content. |\n| `additionalParams` | Object | Further parameters and properties are conveyed here, depending on the particulars of the selected action.<br><br>For a complete list of possible parameters, refer to the various keys listed in `GET /workflow/actionlets`. |\n\nIf both `contentletIds` and `query` properties are present, the operation will use the query and disregard the identifier list.",
+                    "description": "See FireBulkActionsForm for full field-level docs. Either 'query' OR 'contentletIds' is required (not both); 'contentletIds' is a list of contentlet **inodes** (not identifiers, despite the property name). 'workflowActionId' must be a workflow action UUID — discover via GET /api/v1/workflow/schemes/{schemeId}/actions or GET /api/v1/workflow/contentlet/{inode}/actions. To pass a target path to a Move actionlet, set 'additionalParams.additionalParamsMap._path_to_move'.",
                     "content": {
                         "application/json": {
                             "schema": {
+                                "required": ["workflowActionId"],
                                 "type": "object",
                                 "properties": {
                                     "query": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "description": "Lucene query that selects the contentlets to act on. Mutually exclusive with 'contentletIds'.",
+                                        "example": "+contentType:webPageContent +languageId:1"
                                     },
                                     "contentletIds": {
                                         "type": "array",
+                                        "description": "Explicit list of contentlet identifiers to act on. Mutually exclusive with 'query'.",
                                         "items": {
-                                            "type": "string"
+                                            "type": "string",
+                                            "description": "Explicit list of contentlet identifiers to act on. Mutually exclusive with 'query'."
                                         }
                                     },
                                     "workflowActionId": {
-                                        "type": "string"
+                                        "type": "string",
+                                        "description": "The workflow action identifier (UUID) to fire. Discover via GET /api/v1/workflow/schemes/{schemeId}/actions or GET /api/v1/workflow/contentlet/{inode}/actions. Not the system action enum value (NEW, EDIT, PUBLISH, …).",
+                                        "example": "ceca4ee9-1b7b-4f21-a5f4-5d8e9b8b8a1d"
                                     },
                                     "additionalParams": {
                                         "type": "object",
@@ -11823,103 +11984,136 @@
                                                 "type": "object",
                                                 "properties": {
                                                     "whereToSend": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish environment identifier or name to receive the content."
                                                     },
                                                     "publishDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish date (yyyy-MM-dd)."
                                                     },
                                                     "publishTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish time (HH:mm)."
                                                     },
                                                     "expireDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire date (yyyy-MM-dd). Ignored when 'neverExpire' is true."
                                                     },
                                                     "expireTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire time (HH:mm). Ignored when 'neverExpire' is true."
                                                     },
                                                     "neverExpire": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "If 'true', the content does not expire. Overrides expireDate/expireTime."
                                                     },
                                                     "filterKey": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish filter key (defines what gets bundled with the content)."
                                                     },
                                                     "iWantTo": {
                                                         "type": "string",
                                                         "writeOnly": true
                                                     },
                                                     "timezoneId": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Timezone identifier (e.g. 'America/New_York') for publish/expire dates."
                                                     },
                                                     "iwantTo": {
                                                         "type": "string"
                                                     }
-                                                }
+                                                },
+                                                "description": "Push-publish settings applied when the resolved workflow action wires the Push Publish actionlet."
                                             },
                                             "assignComment": {
                                                 "type": "object",
                                                 "properties": {
                                                     "assign": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Identifier of the user or role to next receive the workflow task. Empty string keeps the existing assignee."
                                                     },
                                                     "comment": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Free-form comment recorded against the workflow task."
                                                     }
-                                                }
+                                                },
+                                                "description": "Assignee and comment to attach to the workflow task created when an action is fired."
                                             },
                                             "additionalParamsMap": {
                                                 "type": "object",
                                                 "additionalProperties": {
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "description": "Free-form map for actionlet-specific keys. Well-known keys: '_path_to_move' (String) — full target path including host, e.g. '//hostname/folder/path/'. Used by the Move actionlet when the resolved bulk action wires it. Silently ignored if no Move actionlet is in the resolved action.",
+                                                    "example": {
+                                                        "_path_to_move": "//demo.dotcms.com/destination/folder/"
+                                                    }
+                                                },
+                                                "description": "Free-form map for actionlet-specific keys. Well-known keys: '_path_to_move' (String) — full target path including host, e.g. '//hostname/folder/path/'. Used by the Move actionlet when the resolved bulk action wires it. Silently ignored if no Move actionlet is in the resolved action.",
+                                                "example": {
+                                                    "_path_to_move": "//demo.dotcms.com/destination/folder/"
                                                 }
                                             },
                                             "pushPublishBean": {
                                                 "type": "object",
                                                 "properties": {
                                                     "whereToSend": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish environment identifier or name to receive the content."
                                                     },
                                                     "publishDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish date (yyyy-MM-dd)."
                                                     },
                                                     "publishTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish time (HH:mm)."
                                                     },
                                                     "expireDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire date (yyyy-MM-dd). Ignored when 'neverExpire' is true."
                                                     },
                                                     "expireTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire time (HH:mm). Ignored when 'neverExpire' is true."
                                                     },
                                                     "neverExpire": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "If 'true', the content does not expire. Overrides expireDate/expireTime."
                                                     },
                                                     "filterKey": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish filter key (defines what gets bundled with the content)."
                                                     },
                                                     "iWantTo": {
                                                         "type": "string",
                                                         "writeOnly": true
                                                     },
                                                     "timezoneId": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Timezone identifier (e.g. 'America/New_York') for publish/expire dates."
                                                     },
                                                     "iwantTo": {
                                                         "type": "string"
                                                     }
-                                                }
+                                                },
+                                                "description": "Push-publish settings applied when the resolved workflow action wires the Push Publish actionlet."
                                             },
                                             "assignCommentBean": {
                                                 "type": "object",
                                                 "properties": {
                                                     "assign": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Identifier of the user or role to next receive the workflow task. Empty string keeps the existing assignee."
                                                     },
                                                     "comment": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Free-form comment recorded against the workflow task."
                                                     }
-                                                }
+                                                },
+                                                "description": "Assignee and comment to attach to the workflow task created when an action is fired."
                                             }
-                                        }
+                                        },
+                                        "description": "Action-specific parameters for bulk fire. Wraps push-publish settings, assign-and-comment metadata, and a free-form map for actionlet-specific keys."
                                     },
                                     "popupParamsBean": {
                                         "type": "object",
@@ -11928,105 +12122,139 @@
                                                 "type": "object",
                                                 "properties": {
                                                     "whereToSend": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish environment identifier or name to receive the content."
                                                     },
                                                     "publishDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish date (yyyy-MM-dd)."
                                                     },
                                                     "publishTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish time (HH:mm)."
                                                     },
                                                     "expireDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire date (yyyy-MM-dd). Ignored when 'neverExpire' is true."
                                                     },
                                                     "expireTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire time (HH:mm). Ignored when 'neverExpire' is true."
                                                     },
                                                     "neverExpire": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "If 'true', the content does not expire. Overrides expireDate/expireTime."
                                                     },
                                                     "filterKey": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish filter key (defines what gets bundled with the content)."
                                                     },
                                                     "iWantTo": {
                                                         "type": "string",
                                                         "writeOnly": true
                                                     },
                                                     "timezoneId": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Timezone identifier (e.g. 'America/New_York') for publish/expire dates."
                                                     },
                                                     "iwantTo": {
                                                         "type": "string"
                                                     }
-                                                }
+                                                },
+                                                "description": "Push-publish settings applied when the resolved workflow action wires the Push Publish actionlet."
                                             },
                                             "assignComment": {
                                                 "type": "object",
                                                 "properties": {
                                                     "assign": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Identifier of the user or role to next receive the workflow task. Empty string keeps the existing assignee."
                                                     },
                                                     "comment": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Free-form comment recorded against the workflow task."
                                                     }
-                                                }
+                                                },
+                                                "description": "Assignee and comment to attach to the workflow task created when an action is fired."
                                             },
                                             "additionalParamsMap": {
                                                 "type": "object",
                                                 "additionalProperties": {
-                                                    "type": "object"
+                                                    "type": "object",
+                                                    "description": "Free-form map for actionlet-specific keys. Well-known keys: '_path_to_move' (String) — full target path including host, e.g. '//hostname/folder/path/'. Used by the Move actionlet when the resolved bulk action wires it. Silently ignored if no Move actionlet is in the resolved action.",
+                                                    "example": {
+                                                        "_path_to_move": "//demo.dotcms.com/destination/folder/"
+                                                    }
+                                                },
+                                                "description": "Free-form map for actionlet-specific keys. Well-known keys: '_path_to_move' (String) — full target path including host, e.g. '//hostname/folder/path/'. Used by the Move actionlet when the resolved bulk action wires it. Silently ignored if no Move actionlet is in the resolved action.",
+                                                "example": {
+                                                    "_path_to_move": "//demo.dotcms.com/destination/folder/"
                                                 }
                                             },
                                             "pushPublishBean": {
                                                 "type": "object",
                                                 "properties": {
                                                     "whereToSend": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish environment identifier or name to receive the content."
                                                     },
                                                     "publishDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish date (yyyy-MM-dd)."
                                                     },
                                                     "publishTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Publish time (HH:mm)."
                                                     },
                                                     "expireDate": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire date (yyyy-MM-dd). Ignored when 'neverExpire' is true."
                                                     },
                                                     "expireTime": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Expire time (HH:mm). Ignored when 'neverExpire' is true."
                                                     },
                                                     "neverExpire": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "If 'true', the content does not expire. Overrides expireDate/expireTime."
                                                     },
                                                     "filterKey": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Push-publish filter key (defines what gets bundled with the content)."
                                                     },
                                                     "iWantTo": {
                                                         "type": "string",
                                                         "writeOnly": true
                                                     },
                                                     "timezoneId": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Timezone identifier (e.g. 'America/New_York') for publish/expire dates."
                                                     },
                                                     "iwantTo": {
                                                         "type": "string"
                                                     }
-                                                }
+                                                },
+                                                "description": "Push-publish settings applied when the resolved workflow action wires the Push Publish actionlet."
                                             },
                                             "assignCommentBean": {
                                                 "type": "object",
                                                 "properties": {
                                                     "assign": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Identifier of the user or role to next receive the workflow task. Empty string keeps the existing assignee."
                                                     },
                                                     "comment": {
-                                                        "type": "string"
+                                                        "type": "string",
+                                                        "description": "Free-form comment recorded against the workflow task."
                                                     }
-                                                }
+                                                },
+                                                "description": "Assignee and comment to attach to the workflow task created when an action is fired."
                                             }
-                                        }
+                                        },
+                                        "description": "Action-specific parameters for bulk fire. Wraps push-publish settings, assign-and-comment metadata, and a free-form map for actionlet-specific keys."
                                     }
-                                }
+                                },
+                                "description": "Request body for PUT /api/v1/workflow/contentlet/actions/bulk/fire. Either 'query' OR 'contentletIds' must be supplied (not both). 'workflowActionId' is required and must belong to the workflow scheme that owns the input contentlets — otherwise the contentlets are skipped and the response returns a non-empty 'skippedCount' with a 'skipReason'. To bypass scheme checks (e.g. for System Workflow actions like Move on content from a non-system scheme), use PUT /api/v1/workflow/actions/{actionId}/fire instead."
                             }
                         }
                     },
@@ -12034,7 +12262,7 @@
                 },
                 "responses": {
                     "200": {
-                        "description": "Success",
+                        "description": "Success — at least one contentlet processed.",
                         "content": {
                             "application/json": {}
                         }
@@ -12053,6 +12281,9 @@
                     },
                     "415": {
                         "description": "Unsupported Media Type"
+                    },
+                    "422": {
+                        "description": "Whole batch skipped — none of the input contentlets are on a workflow scheme that owns the supplied 'workflowActionId'."
                     },
                     "500": {
                         "description": "Internal Server Error"
@@ -12528,16 +12759,10 @@
                                                         "hasUnarchiveActionlet": {
                                                             "type": "boolean"
                                                         },
-                                                        "hasDeleteActionlet": {
-                                                            "type": "boolean"
-                                                        },
                                                         "hasDestroyActionlet": {
                                                             "type": "boolean"
                                                         },
                                                         "hasCommentActionlet": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "hasResetActionlet": {
                                                             "type": "boolean"
                                                         },
                                                         "hasMoveActionletHasPathActionlet": {
@@ -12547,6 +12772,12 @@
                                                             "type": "boolean"
                                                         },
                                                         "hasSaveActionlet": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "hasDeleteActionlet": {
+                                                            "type": "boolean"
+                                                        },
+                                                        "hasResetActionlet": {
                                                             "type": "boolean"
                                                         }
                                                     }
@@ -12802,16 +13033,10 @@
                                                                 "hasUnarchiveActionlet": {
                                                                     "type": "boolean"
                                                                 },
-                                                                "hasDeleteActionlet": {
-                                                                    "type": "boolean"
-                                                                },
                                                                 "hasDestroyActionlet": {
                                                                     "type": "boolean"
                                                                 },
                                                                 "hasCommentActionlet": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "hasResetActionlet": {
                                                                     "type": "boolean"
                                                                 },
                                                                 "hasMoveActionletHasPathActionlet": {
@@ -12821,6 +13046,12 @@
                                                                     "type": "boolean"
                                                                 },
                                                                 "hasSaveActionlet": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "hasDeleteActionlet": {
+                                                                    "type": "boolean"
+                                                                },
+                                                                "hasResetActionlet": {
                                                                     "type": "boolean"
                                                                 }
                                                             }
@@ -13287,6 +13518,266 @@
                     },
                     "500": {
                         "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/api/v2/assets/{identifier}": {
+            "get": {
+                "tags": ["File Assets"],
+                "summary": "Get raw file-asset content by identifier",
+                "description": "Streams the raw bytes of a file asset addressed by its dotCMS identifier (UUID). Returns the working version in the site default language by default. READ permission is enforced — 403 is returned when the user lacks permission.",
+                "operationId": "getFileAssetById",
+                "parameters": [
+                    {
+                        "name": "identifier",
+                        "in": "path",
+                        "description": "Asset identifier (UUID)",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "48190c8c-42c4-46af-8d1a-0cd5db894797"
+                    },
+                    {
+                        "name": "language",
+                        "in": "query",
+                        "description": "Language tag (e.g. en-US). Defaults to site default language.",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "en-US"
+                    },
+                    {
+                        "name": "version",
+                        "in": "query",
+                        "description": "Asset version to retrieve. Accepted values: working (default), live.",
+                        "schema": {
+                            "type": "string",
+                            "enum": ["working", "live"],
+                            "default": "working"
+                        },
+                        "example": "working"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw file bytes streamed with resolved MIME type and Content-Disposition header",
+                        "content": {
+                            "application/octet-stream": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request — unknown language tag or version value",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized — authentication required",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — user does not have READ permission on this asset",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found — identifier not found, not a file asset, or language version unavailable",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v2/assets": {
+            "get": {
+                "tags": ["File Assets"],
+                "summary": "Get raw file-asset content by path",
+                "description": "Streams the raw bytes of a file asset addressed by a host-qualified path (//hostname/path/file.ext).  Returns the working version by default; use version=live for the published version.  Responds with 404 when the asset or language version does not exist, 400 when the path points at a folder.",
+                "operationId": "getFileAssetByPath",
+                "parameters": [
+                    {
+                        "name": "path",
+                        "in": "query",
+                        "description": "Host-qualified asset path, e.g. //demo.dotcms.com/application/foo.vtl",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "//demo.dotcms.com/application/containers/default/banner.vtl"
+                    },
+                    {
+                        "name": "language",
+                        "in": "query",
+                        "description": "Language tag (e.g. en-US). Defaults to site default language.",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "en-US"
+                    },
+                    {
+                        "name": "version",
+                        "in": "query",
+                        "description": "Asset version to retrieve. Accepted values: working (default), live.",
+                        "schema": {
+                            "type": "string",
+                            "enum": ["working", "live"],
+                            "default": "working"
+                        },
+                        "example": "working"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Raw file bytes streamed with resolved MIME type and Content-Disposition header",
+                        "content": {
+                            "application/octet-stream": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request — path is missing, ambiguous, points at a folder, or unknown language/version value",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized — authentication required",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — insufficient read permissions",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found — host, path, or language version does not exist",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v2/assets/publish": {
+            "put": {
+                "tags": ["File Assets"],
+                "summary": "Publish file asset (working + live)",
+                "description": "Creates or updates a file asset at the given host-qualified path and immediately publishes it (promotes to live). Submit via multipart/form-data with fields: file (binary), path (//host/folder/file.ext), language (optional).",
+                "operationId": "publishFileAsset",
+                "requestBody": {
+                    "description": "Multipart form with fields: file (binary content, required), path (host-qualified asset path including filename, required), language (language tag, optional — defaults to site default)",
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "description": "Multipart form. See endpoint description for fields.",
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Asset saved and published successfully",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request — missing file part, zero-byte file, unknown language, or invalid path",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized — authentication required",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — insufficient permissions on target folder",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found — unknown host in path",
+                        "content": {
+                            "application/json": {}
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v2/assets/save": {
+            "put": {
+                "tags": ["File Assets"],
+                "summary": "Save file asset (working version)",
+                "description": "Creates or updates a file asset at the given host-qualified path. Only the working version is affected — the live version is NOT changed. Submit via multipart/form-data with fields: file (binary), path (//host/folder/file.ext), language (optional).",
+                "operationId": "saveFileAsset",
+                "requestBody": {
+                    "description": "Multipart form with fields: file (binary content, required), path (host-qualified asset path including filename, required), language (language tag, optional — defaults to site default)",
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "type": "object",
+                                "description": "Multipart form. See endpoint description for fields.",
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Asset saved successfully as working version",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request — missing file part, zero-byte file, unknown language, or invalid path",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized — authentication required",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden — insufficient permissions on target folder",
+                        "content": {
+                            "application/json": {}
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found — unknown host in path",
+                        "content": {
+                            "application/json": {}
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Exposes two newly-added REST endpoints through the agentic-tools MCP server.

- Added `/api/v2/assets` to `ALLOWED_PREFIXES` in `generate-spec.ts` — covers the new file-asset endpoints from #36112 (`/api/v2/assets`, `/{identifier}`, `/save`, `/publish`).
- `GET /api/v1/page/_render-sources/{uri}` from #36102 is already covered by the existing `/api/v1/page` prefix — no whitelist change needed.
- Regenerated `src/generated/spec.json` against a local instance that includes both PRs.

All 5 new paths are present in the regenerated spec:

```
/api/v2/assets
/api/v2/assets/publish
/api/v2/assets/save
/api/v2/assets/{identifier}
/api/v1/page/_render-sources/{uri}
```

The large `spec.json` diff is expected — regenerating from a live instance refreshes the whole file, not just the new paths.

Closes #36198

🤖 Generated with [Claude Code](https://claude.com/claude-code)