### PR TITLE
perf(velocity): remove avoidable per-render allocations in template engine hot path

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/VelocityResourceKey.java
+++ b/dotCMS/src/main/java/com/dotcms/rendering/velocity/services/VelocityResourceKey.java
@@ -20,12 +20,16 @@ import org.apache.velocity.runtime.resource.ResourceManager;
 import java.io.Serializable;
 import java.io.StringWriter;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 public class VelocityResourceKey implements Serializable {
 
     private static final char RESOURCE_TEMPLATE = ResourceManager.RESOURCE_TEMPLATE + '0';
     private static final String HOST_INDICATOR = "///";
     private static final long serialVersionUID = 1L;
+    // Compiled once: String.split("[/\\.]") would compile this character-class regex on every
+    // construction, and a VelocityResourceKey is built on every Velocity cache get (per render).
+    private static final Pattern PATH_SPLIT = Pattern.compile("[/.]");
 
     public final String path, language, id1, id2, cacheKey, variant;
     public final VelocityType type;
@@ -76,7 +80,7 @@ public class VelocityResourceKey implements Serializable {
 
         path = cleanKey(filePath);
 
-        final String[] pathArry = path.split("[/\\.]", 0);
+        final String[] pathArry = PATH_SPLIT.split(path, 0);
 
         this.mode = PageMode.get(pathArry[1]);
 

--- a/dotCMS/src/main/java/org/apache/velocity/runtime/parser/node/ASTMethod.java
+++ b/dotCMS/src/main/java/org/apache/velocity/runtime/parser/node/ASTMethod.java
@@ -140,7 +140,7 @@ public class ASTMethod extends SimpleNode
          *  at execution time.  There can be no in-node caching,
          *  but if we are careful, we can do it in the context.
          */
-        Object [] params = new Object[paramCount];
+        Object [] params = paramCount > 0 ? new Object[paramCount] : ArrayUtils.EMPTY_OBJECT_ARRAY;
 
           /*
            * sadly, we do need recalc the values of the args, as this can

--- a/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
+++ b/dotcms-integration/src/test/java/com/dotcms/MainSuite1b.java
@@ -44,6 +44,7 @@ import org.junit.runners.Suite.SuiteClasses;
         com.dotcms.contenttype.model.field.layout.FieldLayoutTest.class,
         com.dotcms.workflow.helper.TestSystemActionMappingsHandlerMerger.class,
         com.dotcms.concurrent.lock.DotKeyLockManagerTest.class,
+        com.dotcms.rendering.velocity.ASTMethodTest.class,
         com.dotcms.rendering.velocity.VelocityMacroCacheTest.class,
         com.dotcms.rendering.velocity.VelocityUtilTest.class,
         com.dotcms.rendering.velocity.viewtools.navigation.NavToolTest.class,

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/ASTMethodTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/ASTMethodTest.java
@@ -1,0 +1,83 @@
+package com.dotcms.rendering.velocity;
+
+import com.dotcms.rendering.velocity.util.VelocityUtil;
+import com.dotcms.util.IntegrationTestInitService;
+import org.apache.velocity.context.Context;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Renders method calls through Velocity to lock in the behavior of
+ * {@link org.apache.velocity.runtime.parser.node.ASTMethod} after the zero-arg
+ * allocation optimization (zero-arg calls reuse the shared empty {@code Object[]}
+ * instead of allocating {@code new Object[0]} on every render).
+ *
+ * <p>The point of these tests is behavior-preservation: zero-arg, single-arg and
+ * multi-arg invocations must still resolve and render identically, and repeated
+ * invocation of a cached executor must stay correct.</p>
+ */
+public class ASTMethodTest {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    /**
+     * Zero-arg method calls exercise the shared {@code ArrayUtils.EMPTY_OBJECT_ARRAY}
+     * path. They must still resolve and render correctly.
+     */
+    @Test
+    public void zero_arg_method_calls_render_correctly() throws Exception {
+        final Context ctx = VelocityUtil.getBasicContext();
+        ctx.put("str", "Hello World");
+
+        Assert.assertEquals("HELLO WORLD", VelocityUtil.eval("$str.toUpperCase()", ctx).trim());
+        Assert.assertEquals("hello world", VelocityUtil.eval("$str.toLowerCase()", ctx).trim());
+        Assert.assertEquals("11", VelocityUtil.eval("$str.length()", ctx).trim());
+    }
+
+    /**
+     * Method calls with arguments still allocate their {@code Object[]} and must
+     * resolve/render correctly (the optimization only short-circuits the zero-arg case).
+     */
+    @Test
+    public void method_calls_with_args_render_correctly() throws Exception {
+        final Context ctx = VelocityUtil.getBasicContext();
+        ctx.put("str", "Hello World");
+
+        Assert.assertEquals("Hello", VelocityUtil.eval("$str.substring(0, 5)", ctx).trim());
+        Assert.assertEquals("true", VelocityUtil.eval("$str.startsWith(\"Hello\")", ctx).trim());
+        Assert.assertEquals("Jello World", VelocityUtil.eval("$str.replace(\"H\", \"J\")", ctx).trim());
+    }
+
+    /**
+     * The resolved executor is cached per node/class; repeatedly invoking a zero-arg
+     * method against the shared empty array must remain stable (no cross-call corruption).
+     */
+    @Test
+    public void repeated_zero_arg_invocation_is_stable() throws Exception {
+        final Context ctx = VelocityUtil.getBasicContext();
+        ctx.put("str", "abc");
+
+        for (int i = 0; i < 100; i++) {
+            Assert.assertEquals("ABC", VelocityUtil.eval("$str.toUpperCase()", ctx).trim());
+        }
+    }
+
+    /**
+     * Mixing zero-arg and arg calls in a single template render must not let the
+     * shared empty array leak into the arg path (guards the re-entrancy concern).
+     */
+    @Test
+    public void mixed_zero_arg_and_arg_calls_in_one_render() throws Exception {
+        final Context ctx = VelocityUtil.getBasicContext();
+        ctx.put("str", "Hello World");
+
+        // nested: a zero-arg call feeding an arg-bearing call, plus another zero-arg
+        final String out = VelocityUtil.eval(
+                "$str.toUpperCase().substring(0, $str.indexOf(\" \"))", ctx).trim();
+        Assert.assertEquals("HELLO", out);
+    }
+}

--- a/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/services/VelocityResourceKeyTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/rendering/velocity/services/VelocityResourceKeyTest.java
@@ -104,4 +104,25 @@ public class VelocityResourceKeyTest {
         Assert.assertEquals("/PREVIEW_MODE/5a125bb6-4950-429a-9cfc-f1a9c8d90aa8_2.contentlet", velocityResourceKey.cacheKey);
     }
 
+    /**
+     * A page key whose variant name itself contains underscores must still split the
+     * path correctly and re-join the variant. This locks in the behavior of the
+     * precompiled {@code [/.]} path split and the underscore-based variant join.
+     */
+    @Test
+    public void velocityResourceKey_constructor_page_variant_with_underscores_test() throws DotDataException {
+
+        final String path = VelocityResourceKey.getHTMLPageFilePath(
+                "abc-123", PageMode.LIVE, 1, "my_variant_name");
+        final VelocityResourceKey velocityResourceKey = new VelocityResourceKey(path);
+
+        Assert.assertEquals("abc-123", velocityResourceKey.id1);
+        Assert.assertEquals("1", velocityResourceKey.language);
+        Assert.assertEquals("my_variant_name", velocityResourceKey.variant);
+        Assert.assertNull(velocityResourceKey.id2);
+        Assert.assertEquals(PageMode.LIVE, velocityResourceKey.mode);
+        Assert.assertEquals(VelocityType.HTMLPAGE, velocityResourceKey.type);
+        Assert.assertEquals(path, velocityResourceKey.cacheKey);
+    }
+
 }


### PR DESCRIPTION
Fixes #36201

## What

Two behavior-identical optimizations in the Velocity rendering hot path, surfaced while evaluating whether the [reflex "ast.walk 220x" optimizations](https://reflex.dev/blog/why-ast-walk-when-you-can-ast-sprint/) applied to our forked Velocity engine. The tree-walk itself (`SimpleNode.render`) is already optimal; these are the two genuine wins.

### 1. `VelocityResourceKey` — precompile the path-split regex
`VelocityResourceKey` is built on every Velocity resource-cache `get()` (per page/template/container/contentlet/field lookup — dozens to hundreds per page render). Its constructor used `path.split("[/\\.]", 0)`; a character-class regex does **not** hit `String.split`'s single-char fast path, so it recompiled the `Pattern` every call. Hoisted to a `static final Pattern`.

### 2. `ASTMethod` — reuse the shared empty array for zero-arg calls
`ASTMethod.execute()` allocated `new Object[0]` for every zero-arg method call (`$x.toUpperCase()`, `$foo.size()`, …). Now reuses `ArrayUtils.EMPTY_OBJECT_ARRAY`, mirroring the existing `paramClasses` zero-arg optimization one line below.

## Tests
- **New** `ASTMethodTest` — renders zero-arg, single/multi-arg, repeated, and mixed/nested method calls through Velocity (locks in behavior; guards the empty-array re-entrancy concern). Registered in `MainSuite1b`.
- **Extended** `VelocityResourceKeyTest` — adds a variant-name-with-underscores case covering the path split + variant join.

## Deliberately out of scope
- **Arg-array pooling** — unsafe; method calls are re-entrant (`$a.foo($b.bar())`).
- **`StringWriter` per interpolated literal** — speculative; JIT typically lock-elides the synchronized buffer, and the interpolation kludge is fragile.
- **MethodHandle invocation caching** — redundant on Java 25; core reflection is MethodHandle-backed since JDK 18 (JEP 416), and executors are already cached per node/class.

## Risk
Low. No schema, API, or behavioral changes — pure hot-path micro-optimization. Safe to rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36201