### PR TITLE
fix(angular-ssr): remove invalid "public" property from vercel.json

### DIFF
--- a/examples/angular-ssr/vercel.json
+++ b/examples/angular-ssr/vercel.json
@@ -1,6 +1,5 @@
 {
   "version": 2,
-  "public": true,
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## What

Removes the invalid `"public": true` property from `examples/angular-ssr/vercel.json`.

## Why

Vercel's current `vercel.json` schema no longer accepts a top-level `public` property. Deployments of the angular-ssr example fail at build time with:

> The `vercel.json` schema validation failed with the following message: should NOT have additional property `public`

## Fix

Dropped the single offending line. The remaining `rewrites` and `functions` config is unchanged and schema-valid.

Fixes #36211

🤖 Generated with [Claude Code](https://claude.com/claude-code)