### PR TITLE
chore(report-issue): remove FEATURE_FLAG_REPORT_ISSUE_ENABLED from config

### DIFF
--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -870,9 +870,6 @@ FEATURE_FLAG_UVE_LEGACY_SCRIPT_INJECTION=false
 ## New TipTap-v3 Block Editor (rollback safety: legacy editor renders by default)
 FEATURE_FLAG_NEW_BLOCK_EDITOR=false
 
-## Report Issue entry in the toolbar user menu (opt-in)
-FEATURE_FLAG_REPORT_ISSUE_ENABLED=false
-
 ## Enhanced locale selector v2 in the edit-content sidebar
 FEATURE_FLAG_LOCALE_SELECTOR_V2=true
 


### PR DESCRIPTION
## What

Removes the `FEATURE_FLAG_REPORT_ISSUE_ENABLED` default from `dotmarketing-config.properties`. The "Report an Issue" feature (#35717) is launched, so the gating flag default is no longer needed.

## Changes

- `dotCMS/src/main/resources/dotmarketing-config.properties` — drop the `FEATURE_FLAG_REPORT_ISSUE_ENABLED=false` line (and its comment)

Fixes #36216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36216