### PR TITLE
fix(dot-edit-content-sidebar-locales-selector): remove justify-center from selectButton to fix tab gap in enhanced view

### DIFF
--- a/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-locales/dot-edit-content-sidebar-locales-selector/dot-edit-content-sidebar-locales-selector.component.html
+++ b/core-web/libs/edit-content/src/lib/components/dot-edit-content-sidebar/components/dot-edit-content-sidebar-locales/dot-edit-content-sidebar-locales-selector/dot-edit-content-sidebar-locales-selector.component.html
@@ -90,8 +90,9 @@
         <!-- Tabs + Search header -->
         <div class="flex flex-col gap-2 rounded-t-xl bg-surface-100 p-2">
             <!-- SelectButton tabs -->
+
             <p-selectButton
-                styleClass="justify-center  mx-auto!"
+                styleClass="mx-auto"
                 [ngModel]="$activeTab()"
                 (ngModelChange)="setTab($event)"
                 [options]="tabDefs"
@@ -99,7 +100,7 @@
                 data-testid="locale-tabs">
                 <ng-template pTemplate="item" let-item>
                     <div
-                        class="flex items-center justify-center gap-1"
+                        class="flex items-center justify-center gap-2.5"
                         [attr.data-testid]="'tab-' + item.value">
                         <span class="text-sm">{{ item.label | dm }}</span>
                         <p-badge


### PR DESCRIPTION
## Summary

- Removes `justify-center mx-auto!` `styleClass` from `p-selectButton` in the locales selector enhanced view (>5 locales)
- The `justify-center` class was applied to the SelectButton's root flex container, causing unexpected gaps between the tab buttons
- Replaced with `mx-auto` to center the button group without affecting its internal flex layout

Closes #35889

## Test plan

- [ ] Add more than 5 languages in dotCMS
- [ ] Open the content editor sidebar and expand the Locales section
- [ ] Verify the All / Translated / Pending tabs render without gaps between them
- [ ] Verify the tabs are centered horizontally within the header area

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35889