### PR TITLE
feat(opensearch-migration): verbose, easy-to-locate startup logging with masked secrets

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -24,7 +24,7 @@ import com.dotcms.content.elasticsearch.util.MappingHelper;
 import com.dotcms.content.index.ContentletIndexOperations;
 import com.dotcms.content.index.IndexAPI;
 import com.dotcms.content.index.IndexAPIImpl;
-import com.dotcms.content.index.IndexStartupValidator;
+import com.dotcms.content.index.opensearch.IndexStartupValidator;
 import com.dotcms.content.index.IndexTag;
 import com.dotcms.content.index.PhaseRouter;
 import com.dotcms.content.index.VersionedIndices;

--- a/dotCMS/src/main/java/com/dotcms/content/index/IndexStartupValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/IndexStartupValidator.java
@@ -59,11 +59,14 @@ public class IndexStartupValidator {
     public static boolean validateIndexingConfig() {
         try {
             new IndexStartupValidator(CDIUtils.getBeanThrows(OSClientProvider.class)).validate();
+            Logger.info(IndexStartupValidator.class,
+                    "OpenSearch startup validation PASSED — connected to OS successfully; migration phase "
+                    + IndexConfigHelper.MigrationPhase.current().name() + " is active.");
             return true;
         } catch (DotRuntimeException e) {
             Logger.error(IndexStartupValidator.class,
-                    "OpenSearch configuration error — halting OS migration, dotCMS will fall back to ES-only: "
-                    + e.getMessage(), e);
+                    "OpenSearch startup validation FAILED — halting OS migration; dotCMS falls back to"
+                    + " ES-only (PHASE_0_MIGRATION_NOT_STARTED): " + e.getMessage(), e);
             return false;
         }
     }

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ConfigurableOpenSearchProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ConfigurableOpenSearchProvider.java
@@ -94,9 +94,13 @@ class ConfigurableOpenSearchProvider {
 
     /**
      * Resolves an {@link OSClientConfig} from dotCMS properties. Package-private and {@code static}
-     * so {@link IndexStartupValidator} (same package) can re-resolve the exact configuration the
-     * client is built from — for the startup banner — without exposing any configuration accessor
-     * outside this package or widening the {@link OSClientProvider} contract.
+     * so {@link IndexStartupValidator} (same package) can re-resolve the configuration from the same
+     * properties — for the startup banner and the endpoint-separation check — without exposing any
+     * configuration accessor outside this package or widening the {@link OSClientProvider} contract.
+     *
+     * <p>Resolution is deterministic from properties: the validator's re-resolution matches what the
+     * client is built with at startup. It is a re-resolution, not a readback of the live client's
+     * stored config; the two could only differ if properties changed without a client rebuild.</p>
      */
     static OSClientConfig configFromProperties() {
         Builder builder = OSClientConfig.builder();

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ConfigurableOpenSearchProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ConfigurableOpenSearchProvider.java
@@ -5,6 +5,7 @@ import com.dotcms.content.index.opensearch.ImmutableOSClientConfig.Builder;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.StringUtils;
 import com.dotmarketing.util.UtilMethods;
 import java.net.URI;
 import org.apache.hc.client5.http.auth.AuthScope;
@@ -112,13 +113,13 @@ class ConfigurableOpenSearchProvider {
 
         final String authSummary;
         if (config.jwtToken().isPresent()) {
-            authSummary = "JWT (token=" + maskSecret(config.jwtToken().get()) + ")";
+            authSummary = "JWT (token=" + StringUtils.maskSecret(config.jwtToken().get()) + ")";
         } else if (config.clientCertPath().isPresent() || config.clientKeyPath().isPresent()) {
             authSummary = "CERT (clientCert=" + config.clientCertPath().orElse("(not set)")
                     + ", clientKey=" + config.clientKeyPath().orElse("(not set)") + ")";
         } else if (config.username().isPresent() || config.password().isPresent()) {
             authSummary = "BASIC (user=" + config.username().orElse("(not set)")
-                    + ", password=" + maskSecret(config.password().orElse(null)) + ")";
+                    + ", password=" + StringUtils.maskSecret(config.password().orElse(null)) + ")";
         } else {
             authSummary = "NONE — connecting ANONYMOUSLY (no username/password/token resolved)";
         }
@@ -134,23 +135,6 @@ class ConfigurableOpenSearchProvider {
                 "  TLS CA cert       : " + config.caCertPath().orElse("(not set)"),
                 "  (connectivity + OS version are verified separately at startup)",
                 "================================================================="));
-    }
-
-    /**
-     * Masks a sensitive value for logging: returns a fixed-width mask plus the final character so
-     * the value can be sanity-checked against the source without exposing it
-     * (e.g. {@code "s3cret"} → {@code "****t"}). The fixed-width mask intentionally does not reveal
-     * the secret's real length. A single-character secret is masked entirely, and an unset value is
-     * rendered as {@code "(not set)"}.
-     */
-    private static String maskSecret(final String value) {
-        if (!UtilMethods.isSet(value)) {
-            return "(not set)";
-        }
-        if (value.length() == 1) {
-            return "****";
-        }
-        return "****" + value.charAt(value.length() - 1);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ConfigurableOpenSearchProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ConfigurableOpenSearchProvider.java
@@ -5,7 +5,6 @@ import com.dotcms.content.index.opensearch.ImmutableOSClientConfig.Builder;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
-import com.dotmarketing.util.StringUtils;
 import com.dotmarketing.util.UtilMethods;
 import java.net.URI;
 import org.apache.hc.client5.http.auth.AuthScope;
@@ -67,7 +66,7 @@ class ConfigurableOpenSearchProvider {
      */
     private void buildClient() {
         try {
-            OSClientConfig config = loadConfigurationFromProperties();
+            OSClientConfig config = configFromProperties();
             buildClient(config);
         } catch (Exception e) {
             Logger.error(this.getClass(), "Error building OpenSearch client from properties", e);
@@ -83,7 +82,10 @@ class ConfigurableOpenSearchProvider {
             transport = createTransport(config);
             client = new OpenSearchClient(transport);
 
-            logConfigSummary(config);
+            // The human-readable, masked configuration banner is logged once at startup by
+            // IndexStartupValidator (alongside the connection outcome). Here we keep only a quiet
+            // DEBUG line so runtime (re)builds remain observable without duplicating the banner.
+            Logger.debug(this.getClass(), "OpenSearch client built for endpoints: " + config.endpoints());
         } catch (Exception e) {
             Logger.error(this.getClass(), "Error building OpenSearch client", e);
             throw new DotRuntimeException("Failed to build OpenSearch client", e);
@@ -91,56 +93,12 @@ class ConfigurableOpenSearchProvider {
     }
 
     /**
-     * Emits an easy-to-locate, single-block summary of the OpenSearch migration parameters that
-     * were actually resolved for this client — migration phase, endpoints, the effective
-     * authentication mode, and the TLS flags. Sensitive values (password, JWT token) are masked
-     * via {@link #maskSecret(String)} so they are safe to leave in the logs.
-     *
-     * <p>Two things this banner makes explicit on purpose, because their absence was confusing
-     * during QA:</p>
-     * <ul>
-     *   <li>When no credentials are resolved (e.g. only an endpoint URL was provided) the auth mode
-     *       is reported as {@code NONE — connecting ANONYMOUSLY}. dotCMS will still connect if the
-     *       OpenSearch cluster does not enforce security, so this line is the signal that no
-     *       credentials were applied — it is not an error by itself.</li>
-     *   <li>Building the client does <strong>not</strong> open a connection. Reachability and the OS
-     *       version are verified separately at startup by {@code IndexStartupValidator}; that is
-     *       where a success/fallback outcome is logged.</li>
-     * </ul>
+     * Resolves an {@link OSClientConfig} from dotCMS properties. Package-private and {@code static}
+     * so {@link IndexStartupValidator} (same package) can re-resolve the exact configuration the
+     * client is built from — for the startup banner — without exposing any configuration accessor
+     * outside this package or widening the {@link OSClientProvider} contract.
      */
-    private void logConfigSummary(final OSClientConfig config) {
-        final String phase = IndexConfigHelper.MigrationPhase.current().name();
-
-        final String authSummary;
-        if (config.jwtToken().isPresent()) {
-            authSummary = "JWT (token=" + StringUtils.maskSecret(config.jwtToken().get()) + ")";
-        } else if (config.clientCertPath().isPresent() || config.clientKeyPath().isPresent()) {
-            authSummary = "CERT (clientCert=" + config.clientCertPath().orElse("(not set)")
-                    + ", clientKey=" + config.clientKeyPath().orElse("(not set)") + ")";
-        } else if (config.username().isPresent() || config.password().isPresent()) {
-            authSummary = "BASIC (user=" + config.username().orElse("(not set)")
-                    + ", password=" + StringUtils.maskSecret(config.password().orElse(null)) + ")";
-        } else {
-            authSummary = "NONE — connecting ANONYMOUSLY (no username/password/token resolved)";
-        }
-
-        Logger.info(this.getClass(), System.lineSeparator() + String.join(System.lineSeparator(),
-                "========== OpenSearch Migration — client configuration ==========",
-                "  Migration phase   : " + phase,
-                "  OS endpoints      : " + config.endpoints(),
-                "  Authentication    : " + authSummary,
-                "  TLS enabled       : " + config.tlsEnabled(),
-                "  TLS cert required : " + config.certRequired(),
-                "  TLS trust selfsign: " + config.trustSelfSigned(),
-                "  TLS CA cert       : " + config.caCertPath().orElse("(not set)"),
-                "  (connectivity + OS version are verified separately at startup)",
-                "================================================================="));
-    }
-
-    /**
-     * Load configuration from dotCMS properties
-     */
-    private OSClientConfig loadConfigurationFromProperties() {
+    static OSClientConfig configFromProperties() {
         Builder builder = OSClientConfig.builder();
 
         // Load endpoints
@@ -198,7 +156,7 @@ class ConfigurableOpenSearchProvider {
     /**
      * Get default endpoints if not configured
      */
-    private String[] getDefaultEndpoints() {
+    private static String[] getDefaultEndpoints() {
         String hostname = IndexConfigHelper.getString(OSIndexProperty.HOSTNAME, "localhost");
         String protocol = IndexConfigHelper.getString(OSIndexProperty.PROTOCOL, HTTPS_PROTOCOL);
         int port = IndexConfigHelper.getInt(OSIndexProperty.PORT, 9200);

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ConfigurableOpenSearchProvider.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/ConfigurableOpenSearchProvider.java
@@ -82,11 +82,75 @@ class ConfigurableOpenSearchProvider {
             transport = createTransport(config);
             client = new OpenSearchClient(transport);
 
-            Logger.info(this.getClass(), "OpenSearch client initialized successfully with endpoints: " + config.endpoints());
+            logConfigSummary(config);
         } catch (Exception e) {
             Logger.error(this.getClass(), "Error building OpenSearch client", e);
             throw new DotRuntimeException("Failed to build OpenSearch client", e);
         }
+    }
+
+    /**
+     * Emits an easy-to-locate, single-block summary of the OpenSearch migration parameters that
+     * were actually resolved for this client — migration phase, endpoints, the effective
+     * authentication mode, and the TLS flags. Sensitive values (password, JWT token) are masked
+     * via {@link #maskSecret(String)} so they are safe to leave in the logs.
+     *
+     * <p>Two things this banner makes explicit on purpose, because their absence was confusing
+     * during QA:</p>
+     * <ul>
+     *   <li>When no credentials are resolved (e.g. only an endpoint URL was provided) the auth mode
+     *       is reported as {@code NONE — connecting ANONYMOUSLY}. dotCMS will still connect if the
+     *       OpenSearch cluster does not enforce security, so this line is the signal that no
+     *       credentials were applied — it is not an error by itself.</li>
+     *   <li>Building the client does <strong>not</strong> open a connection. Reachability and the OS
+     *       version are verified separately at startup by {@code IndexStartupValidator}; that is
+     *       where a success/fallback outcome is logged.</li>
+     * </ul>
+     */
+    private void logConfigSummary(final OSClientConfig config) {
+        final String phase = IndexConfigHelper.MigrationPhase.current().name();
+
+        final String authSummary;
+        if (config.jwtToken().isPresent()) {
+            authSummary = "JWT (token=" + maskSecret(config.jwtToken().get()) + ")";
+        } else if (config.clientCertPath().isPresent() || config.clientKeyPath().isPresent()) {
+            authSummary = "CERT (clientCert=" + config.clientCertPath().orElse("(not set)")
+                    + ", clientKey=" + config.clientKeyPath().orElse("(not set)") + ")";
+        } else if (config.username().isPresent() || config.password().isPresent()) {
+            authSummary = "BASIC (user=" + config.username().orElse("(not set)")
+                    + ", password=" + maskSecret(config.password().orElse(null)) + ")";
+        } else {
+            authSummary = "NONE — connecting ANONYMOUSLY (no username/password/token resolved)";
+        }
+
+        Logger.info(this.getClass(), System.lineSeparator() + String.join(System.lineSeparator(),
+                "========== OpenSearch Migration — client configuration ==========",
+                "  Migration phase   : " + phase,
+                "  OS endpoints      : " + config.endpoints(),
+                "  Authentication    : " + authSummary,
+                "  TLS enabled       : " + config.tlsEnabled(),
+                "  TLS cert required : " + config.certRequired(),
+                "  TLS trust selfsign: " + config.trustSelfSigned(),
+                "  TLS CA cert       : " + config.caCertPath().orElse("(not set)"),
+                "  (connectivity + OS version are verified separately at startup)",
+                "================================================================="));
+    }
+
+    /**
+     * Masks a sensitive value for logging: returns a fixed-width mask plus the final character so
+     * the value can be sanity-checked against the source without exposing it
+     * (e.g. {@code "s3cret"} → {@code "****t"}). The fixed-width mask intentionally does not reveal
+     * the secret's real length. A single-character secret is masked entirely, and an unset value is
+     * rendered as {@code "(not set)"}.
+     */
+    private static String maskSecret(final String value) {
+        if (!UtilMethods.isSet(value)) {
+            return "(not set)";
+        }
+        if (value.length() == 1) {
+            return "****";
+        }
+        return "****" + value.charAt(value.length() - 1);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
@@ -63,7 +63,11 @@ public class IndexStartupValidator {
                     "OpenSearch startup validation PASSED — connected to OS successfully; migration phase "
                     + IndexConfigHelper.MigrationPhase.current().name() + " is active.");
             return true;
-        } catch (DotRuntimeException e) {
+        } catch (Exception e) {
+            // Catch broadly (not only DotRuntimeException): any failure here MUST funnel through
+            // this single FAILED-and-fallback path so the outcome is always logged and the caller
+            // reaches haltMigration()/Phase-3 abort, instead of an unexpected exception escaping to
+            // a generic FATAL that skips the ES-only fallback.
             Logger.error(IndexStartupValidator.class,
                     "OpenSearch startup validation FAILED — halting OS migration; dotCMS falls back to"
                     + " ES-only (PHASE_0_MIGRATION_NOT_STARTED): " + e.getMessage(), e);

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
@@ -1,11 +1,11 @@
-package com.dotcms.content.index;
+package com.dotcms.content.index.opensearch;
 
 import com.dotcms.cdi.CDIUtils;
-import com.dotcms.content.index.opensearch.OSClientProvider;
-import com.dotcms.content.index.opensearch.OSIndexProperty;
+import com.dotcms.content.index.IndexConfigHelper;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.StringUtils;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
@@ -74,10 +74,81 @@ public class IndexStartupValidator {
     /**
      * Runs all validations. Throws {@link DotRuntimeException} on the first failure
      * so the application startup is aborted with a clear error message.
+     *
+     * <p>Begins by logging an easy-to-locate banner with the resolved OpenSearch migration
+     * parameters (phase, endpoints, effective authentication mode, TLS), so the configuration and
+     * the success/fallback outcome appear together as a single startup story under one logger.</p>
      */
     public void validate() {
+        logConfigSummary(resolveConfig());
         validateOSVersion();
         validateEndpointSeparation();
+    }
+
+    // -------------------------------------------------------------------------
+    // Configuration summary banner
+    // -------------------------------------------------------------------------
+
+    /**
+     * Re-resolves the OpenSearch client configuration from properties using the same
+     * package-private resolution path the client itself is built from, so the banner reflects
+     * exactly what the client uses with no duplicated resolution logic. A resolution failure
+     * (e.g. an invalid/conflicting auth combination) is surfaced as a {@link DotRuntimeException}
+     * so it flows through the same uniform halt path as every other startup failure.
+     */
+    private OSClientConfig resolveConfig() {
+        try {
+            return ConfigurableOpenSearchProvider.configFromProperties();
+        } catch (Exception e) {
+            throw new DotRuntimeException("Invalid OpenSearch configuration: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Emits an easy-to-locate, single-block summary of the OpenSearch migration parameters that
+     * were resolved — migration phase, endpoints, the effective authentication mode, and the TLS
+     * flags. Sensitive values (password, JWT token) are masked via
+     * {@link StringUtils#maskSecret(String)} so the banner is safe to leave in the logs.
+     *
+     * <p>Two things this banner makes explicit on purpose, because their absence was confusing
+     * during QA:</p>
+     * <ul>
+     *   <li>When no credentials are resolved (e.g. only an endpoint URL was provided) the auth mode
+     *       is reported as {@code NONE — connecting ANONYMOUSLY}. dotCMS will still connect if the
+     *       OpenSearch cluster does not enforce security, so this line is the signal that no
+     *       credentials were applied — it is not an error by itself.</li>
+     *   <li>This banner reflects the resolved configuration; reachability and the OS version are
+     *       verified by the checks that follow — a printed config is not yet a confirmed
+     *       connection.</li>
+     * </ul>
+     */
+    private void logConfigSummary(final OSClientConfig config) {
+        final String phase = IndexConfigHelper.MigrationPhase.current().name();
+
+        final String authSummary;
+        if (config.jwtToken().isPresent()) {
+            authSummary = "JWT (token=" + StringUtils.maskSecret(config.jwtToken().get()) + ")";
+        } else if (config.clientCertPath().isPresent() || config.clientKeyPath().isPresent()) {
+            authSummary = "CERT (clientCert=" + config.clientCertPath().orElse("(not set)")
+                    + ", clientKey=" + config.clientKeyPath().orElse("(not set)") + ")";
+        } else if (config.username().isPresent() || config.password().isPresent()) {
+            authSummary = "BASIC (user=" + config.username().orElse("(not set)")
+                    + ", password=" + StringUtils.maskSecret(config.password().orElse(null)) + ")";
+        } else {
+            authSummary = "NONE — connecting ANONYMOUSLY (no username/password/token resolved)";
+        }
+
+        Logger.info(this, System.lineSeparator() + String.join(System.lineSeparator(),
+                "========== OpenSearch Migration — client configuration ==========",
+                "  Migration phase   : " + phase,
+                "  OS endpoints      : " + config.endpoints(),
+                "  Authentication    : " + authSummary,
+                "  TLS enabled       : " + config.tlsEnabled(),
+                "  TLS cert required : " + config.certRequired(),
+                "  TLS trust selfsign: " + config.trustSelfSigned(),
+                "  TLS CA cert       : " + config.caCertPath().orElse("(not set)"),
+                "  (connectivity + OS version are verified by the checks that follow)",
+                "================================================================="));
     }
 
     // -------------------------------------------------------------------------

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
@@ -80,9 +80,10 @@ public class IndexStartupValidator {
      * the success/fallback outcome appear together as a single startup story under one logger.</p>
      */
     public void validate() {
-        logConfigSummary(resolveConfig());
+        final OSClientConfig config = resolveConfig();
+        logConfigSummary(config);
         validateOSVersion();
-        validateEndpointSeparation();
+        validateEndpointSeparation(config);
     }
 
     // -------------------------------------------------------------------------
@@ -90,11 +91,18 @@ public class IndexStartupValidator {
     // -------------------------------------------------------------------------
 
     /**
-     * Re-resolves the OpenSearch client configuration from properties using the same
-     * package-private resolution path the client itself is built from, so the banner reflects
-     * exactly what the client uses with no duplicated resolution logic. A resolution failure
-     * (e.g. an invalid/conflicting auth combination) is surfaced as a {@link DotRuntimeException}
-     * so it flows through the same uniform halt path as every other startup failure.
+     * Re-resolves the OpenSearch configuration from properties through the same package-private
+     * resolution path the client is built from ({@link ConfigurableOpenSearchProvider#configFromProperties()}).
+     *
+     * <p><strong>This is a fresh re-resolution, not the live client's stored config.</strong> It is
+     * deterministic from the same properties, so at startup it matches what the client was built
+     * with; it would only diverge if properties changed at runtime without the client being rebuilt.
+     * The banner is therefore a faithful report of the resolved configuration, not a readback of the
+     * connected client's state.</p>
+     *
+     * <p>A resolution failure (e.g. an invalid/conflicting auth combination) is surfaced as a
+     * {@link DotRuntimeException} so it flows through the same uniform halt path as every other
+     * startup failure.</p>
      */
     private OSClientConfig resolveConfig() {
         try {
@@ -195,16 +203,20 @@ public class IndexStartupValidator {
      * Resolves the effective ES and OS endpoint sets and asserts they do not share
      * any {@code host:port} pair.
      *
-     * <p><strong>Best-effort:</strong> both sides are resolved from config strings through
-     * the same {@link #normalizeEndpoint} path, making the comparison consistent.
-     * Two configs that refer to the same host via different forms (e.g. {@code "127.0.0.1"}
-     * vs {@code "localhost"}) will not be detected as overlapping.</p>
+     * <p>The OS side comes from the already-resolved {@link OSClientConfig#endpoints()} (the very
+     * endpoints the client is built with), and the ES side is read from config; both are passed
+     * through the same {@link #normalizeEndpoint} path so the comparison is consistent.</p>
+     *
+     * <p><strong>Best-effort:</strong> two configs that refer to the same host via different forms
+     * (e.g. {@code "127.0.0.1"} vs {@code "localhost"}) will not be detected as overlapping.</p>
      *
      * @throws DotRuntimeException if at least one endpoint is common to both clients
      */
-    private void validateEndpointSeparation() {
+    private void validateEndpointSeparation(final OSClientConfig config) {
         final Set<String> esEndpoints = resolveESEndpoints();
-        final Set<String> osEndpoints = resolveOSEndpoints();
+        final Set<String> osEndpoints = config.endpoints().stream()
+                .map(IndexStartupValidator::normalizeEndpoint)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
 
         final Set<String> overlap = new LinkedHashSet<>(esEndpoints);
         overlap.retainAll(osEndpoints);
@@ -221,8 +233,8 @@ public class IndexStartupValidator {
     }
 
     /**
-     * Resolves ES endpoints from configuration, using the same normalisation path as
-     * {@link #resolveOSEndpoints()} so both sides can be compared consistently.
+     * Resolves ES endpoints from configuration, passing them through the same
+     * {@link #normalizeEndpoint} path used for the OS side so both can be compared consistently.
      *
      * <p>Reads {@code ES_ENDPOINTS} (full URL array) when present; otherwise synthesises
      * a single entry from {@code ES_HOSTNAME} / {@code ES_PORT}, defaulting to
@@ -237,29 +249,6 @@ public class IndexStartupValidator {
         }
         final String host = Config.getStringProperty("ES_HOSTNAME", "localhost");
         final int    port = Config.getIntProperty("ES_PORT", 9200);
-        return Set.of(host + ":" + port);
-    }
-
-    /**
-     * Resolves OS endpoints from configuration with the same fallback chain that
-     * {@link IndexConfigHelper} applies:
-     * {@code OS_ENDPOINTS} → {@code OS_HOSTNAME}/{@code OS_PORT} →
-     * {@code ES_HOSTNAME}/{@code ES_PORT} → {@code localhost:9200}.
-     *
-     * <p>Uses {@code OS_ENDPOINTS} (full URL array) when present; otherwise
-     * synthesises a single entry from the individual host/port/protocol properties.</p>
-     */
-    private Set<String> resolveOSEndpoints() {
-        final String[] rawEndpoints = Config.getStringArrayProperty("OS_ENDPOINTS", null);
-        if (rawEndpoints != null && rawEndpoints.length > 0) {
-            return Arrays.stream(rawEndpoints)
-                    .map(IndexStartupValidator::normalizeEndpoint)
-                    .collect(Collectors.toCollection(LinkedHashSet::new));
-        }
-
-        // Fall back to individual host/port properties (mirrors ConfigurableOpenSearchProvider)
-        final String host = IndexConfigHelper.getString(OSIndexProperty.HOSTNAME, "localhost");
-        final int    port = IndexConfigHelper.getInt(OSIndexProperty.PORT, 9200);
         return Set.of(host + ":" + port);
     }
 

--- a/dotCMS/src/main/java/com/dotmarketing/util/StringUtils.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/StringUtils.java
@@ -549,4 +549,26 @@ public class StringUtils {
         }
         return result;
     }
+
+    /**
+     * Masks a sensitive value for safe logging: returns a fixed-width mask plus the final
+     * character so the value can be sanity-checked against its source without exposing it
+     * (e.g. {@code "s3cret"} → {@code "****t"}).
+     *
+     * <p>The fixed-width mask intentionally does not reveal the secret's real length. A
+     * single-character secret is masked entirely so its only character is never leaked, and an
+     * unset (null/empty) value is rendered as {@code "(not set)"}.</p>
+     *
+     * @param value the sensitive value (password, token, etc.); may be {@code null}
+     * @return the masked representation, never {@code null}
+     */
+    public static String maskSecret(final String value) {
+        if (!UtilMethods.isSet(value)) {
+            return "(not set)";
+        }
+        if (value.length() == 1) {
+            return "****";
+        }
+        return "****" + value.charAt(value.length() - 1);
+    }
 }


### PR DESCRIPTION
## What & why

Make the ES→OpenSearch migration startup logging verbose and easy to locate so QA can follow the flow and immediately tell whether OS connected or the system fell back to ES.

### The problem
Testers couldn't follow the connection flow:
- A URL-only config (no user/pass) connected **silently** — credentials are only applied when *both* username and password are present, so against a security-disabled OS cluster dotCMS connected **anonymously** while the log just said `initialized successfully`.
- Building the `OpenSearchClient` doesn't open a connection; reachability/version are only checked later in `IndexStartupValidator`. "Configured" looked like "connected".

## Changes

### 1. One coherent startup banner, one logger
The configuration summary **and** the connection outcome are now logged together by `IndexStartupValidator`, as a single startup story:

```
========== OpenSearch Migration — client configuration ==========
  Migration phase   : PHASE_1_DUAL_WRITE_ES_READS
  OS endpoints      : [http://localhost:9201]
  Authentication    : NONE — connecting ANONYMOUSLY (no username/password/token resolved)
  TLS enabled       : false
  TLS cert required : false
  TLS trust selfsign: false
  TLS CA cert       : (not set)
  (connectivity + OS version are verified by the checks that follow)
=================================================================
OpenSearch startup validation PASSED — connected to OS successfully; migration phase PHASE_1_DUAL_WRITE_ES_READS is active.
```

- Effective auth mode: `BASIC` / `JWT` / `CERT` / `NONE` — with an explicit **anonymous** warning when no credentials resolve (the exact gap that confused QA).
- On failure: `OpenSearch startup validation FAILED — halting OS migration; dotCMS falls back to ES-only (PHASE_0_MIGRATION_NOT_STARTED): <reason>`.

### 2. Secret masking moved to `StringUtils`
`StringUtils.maskSecret(String)` — reusable, general-purpose: `****` + last char (`s3cret` → `****t`); a 1-char secret is fully masked; unset → `(not set)`; the mask never reveals the real length.

### 3. `IndexStartupValidator` moved into `com.dotcms.content.index.opensearch`
So the validator can re-resolve the exact same config the client is built from via a **package-private** `ConfigurableOpenSearchProvider.configFromProperties()` — **without** exposing any config accessor outside the package or widening the `OSClientProvider` CDI contract. The provider no longer logs the INFO banner; it keeps a quiet `DEBUG` line so runtime (re)builds stay observable without duplicating the banner.

### 4. Endpoint resolution unified + honest docs
- The endpoint-separation check now consumes the already-resolved `OSClientConfig.endpoints()` instead of its own `resolveOSEndpoints()` helper (removed) — one fewer independent config-read path. Behaviour preserved (same fallback chain, same `host:port` normalisation).
- Javadoc corrected: the banner is a **deterministic re-resolution from the same properties**, not a readback of the live client's stored config (documented the one case they could differ: runtime property change without a client rebuild).

## Design notes / conscious trade-offs
- **Re-resolution, not live readback**: the banner re-resolves config rather than reading the instance the live client holds. Deterministic at startup; documented. If a diagnostics endpoint ever needs the *live* client config, the provider should then store and expose the resolved `OSClientConfig`.
- **No ES classes changed** (migration design rule).

## Files
| File | Change |
|---|---|
| `IndexStartupValidator.java` | Moved to `…/opensearch`; owns the config + outcome banner; consumes resolved config for endpoint separation |
| `ConfigurableOpenSearchProvider.java` | `configFromProperties()` package-private static; DEBUG-only build line; banner removed |
| `StringUtils.java` | New reusable `maskSecret(String)` |
| `ContentletIndexAPIImpl.java` | Import update for the moved validator |

## Verification
`./mvnw compile -pl :dotcms-core -DskipTests` → **BUILD SUCCESS**.

Fixes #36233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36233