### PR TITLE
fix(editor): JSP host-style isolation + image picker dialog overflow in block editor

### DIFF
--- a/core-web/libs/new-block-editor/src/lib/editor/components/toolbar/toolbar.component.html
+++ b/core-web/libs/new-block-editor/src/lib/editor/components/toolbar/toolbar.component.html
@@ -212,7 +212,7 @@
     data-testid="toolbar-edit-image"
     [disabled]="!state.isImageSelected()"
     [attr.aria-disabled]="!state.isImageSelected()"
-    [class]="btnClass(false)"
+    [class]="btnClass(popovers.isOpen('image-properties'))"
     (mousedown)="openImagePropertiesDialog($event)">
     <span aria-hidden="true" class="material-symbols-outlined">tune</span>
 </button>
@@ -369,7 +369,7 @@
             [tooltipPosition]="TOOLTIP_POSITION"
             [tooltipOptions]="overlayTooltipOptions()"
             [showDelay]="TOOLTIP_SHOW_DELAY"
-            [class]="btnClass(state.isLink())"
+            [class]="btnClass(state.isLink() || popovers.isOpen('link'))"
             (mousedown)="openLinkDialog($event)">
             <span aria-hidden="true" class="material-symbols-outlined">link</span>
         </button>
@@ -409,7 +409,7 @@
             [tooltipOptions]="overlayTooltipOptions()"
             [showDelay]="TOOLTIP_SHOW_DELAY"
             data-testid="toolbar-asset-by-url"
-            [class]="btnClass(false)"
+            [class]="btnClass(popovers.isOpen('asset-by-url'))"
             (mousedown)="openAssetByUrlDialog($event)">
             <span aria-hidden="true" class="material-symbols-outlined">media_link</span>
         </button>
@@ -422,7 +422,7 @@
             [tooltipPosition]="TOOLTIP_POSITION"
             [tooltipOptions]="overlayTooltipOptions()"
             [showDelay]="TOOLTIP_SHOW_DELAY"
-            [class]="btnClass(false)"
+            [class]="btnClass(popovers.isOpen('table'))"
             (mousedown)="openTableDialog($event)">
             <span aria-hidden="true" class="material-symbols-outlined">table</span>
         </button>
@@ -436,7 +436,7 @@
             data-testid="toolbar-table-properties"
             [disabled]="!state.isInTable()"
             [attr.aria-disabled]="!state.isInTable()"
-            [class]="btnClass(false)"
+            [class]="btnClass(popovers.isOpen('table-properties'))"
             (mousedown)="openTablePropertiesDialog($event)">
             <span aria-hidden="true" class="material-symbols-outlined">table_edit</span>
         </button>
@@ -455,7 +455,7 @@
             [tooltipPosition]="TOOLTIP_POSITION"
             [tooltipOptions]="overlayTooltipOptions()"
             [showDelay]="TOOLTIP_SHOW_DELAY"
-            [class]="btnClass(false)"
+            [class]="btnClass(popovers.isOpen('emoji'))"
             (mousedown)="openEmojiPicker($event)">
             <span aria-hidden="true" class="material-symbols-outlined">emoji_emotions</span>
         </button>

--- a/core-web/libs/new-block-editor/src/lib/editor/components/toolbar/toolbar.component.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/components/toolbar/toolbar.component.ts
@@ -52,7 +52,7 @@ import type { ContentletEditEvent } from '../../extensions/nodes/contentlet/cont
 export class ToolbarComponent implements OnDestroy {
     protected readonly state = inject(EditorToolbarStore);
     protected readonly store = inject(EditorStore);
-    private readonly popovers = inject(EditorPopoverService);
+    protected readonly popovers = inject(EditorPopoverService);
     private readonly editorModal = inject(EditorModalService);
     private readonly contentletEditUrl = inject(ContentletEditUrlService);
     private readonly confirmationService = inject(ConfirmationService);

--- a/core-web/libs/new-block-editor/src/lib/editor/config.utils.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/config.utils.ts
@@ -52,7 +52,7 @@ export function buildBrowserSelectorConfig(opts: {
         resizable: false,
         modal: true,
         width: '90%',
-        style: { 'max-width': '1040px', overflow: 'auto' },
+        style: { 'max-width': '1040px', overflow: 'hidden' },
         contentStyle: { overflow: 'auto', height: 'min(45rem, 80vh)' },
         data: {
             mimeTypes: opts.mimeTypes,

--- a/core-web/libs/new-block-editor/src/lib/editor/config.utils.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/config.utils.ts
@@ -53,7 +53,7 @@ export function buildBrowserSelectorConfig(opts: {
         modal: true,
         width: '90%',
         style: { 'max-width': '1040px', overflow: 'hidden' },
-        contentStyle: { overflow: 'auto', height: 'min(45rem, 80vh)' },
+        contentStyle: { overflow: 'auto', 'min-height': 'min(45rem, 80vh)' },
         data: {
             mimeTypes: opts.mimeTypes,
             showLinks: false,

--- a/core-web/libs/new-block-editor/src/lib/editor/config.utils.ts
+++ b/core-web/libs/new-block-editor/src/lib/editor/config.utils.ts
@@ -52,8 +52,8 @@ export function buildBrowserSelectorConfig(opts: {
         resizable: false,
         modal: true,
         width: '90%',
-        style: { 'max-width': '1040px' },
-        contentStyle: { overflow: 'auto', 'min-height': '45rem' },
+        style: { 'max-width': '1040px', overflow: 'auto' },
+        contentStyle: { overflow: 'auto', height: 'min(45rem, 80vh)' },
         data: {
             mimeTypes: opts.mimeTypes,
             showLinks: false,

--- a/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
+++ b/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
@@ -16,7 +16,23 @@
    force font-size 0.875rem on many controls. Tailwind v4 emits prose +
    utilities inside @layer, so unlayered author CSS beats them regardless of
    specificity. These (unlayered) rules match that priority, then revert-layer
-   falls back to prose/utilities. */
+   falls back to prose/utilities.
+
+   PrimeNG widgets are excluded: PrimeNG's theme is injected UNLAYERED (no
+   `cssLayer` configured), so `.p-button` (0,1,0) already out-specifies JSP's
+   `button` (0,0,1) and wins on its own. It never needed this defense — and
+   reverting its padding/margin/font-size would roll back to Tailwind preflight
+   (0) and strip its design tokens. `[class~="p-component"]` is PrimeNG's host
+   marker on every widget root; the `, [class~="p-component"] *` also excludes
+   everything inside it (labels, icons, inner controls). A token match (`~=`)
+   avoids the `[class*="p-"]` trap of also matching Tailwind's `p-4` utility.
+
+   SPECIFICITY IS LOAD-BEARING: the exclusion is wrapped in `:where()` (which
+   contributes ZERO specificity) so the whole rule stays at (0,1,1) — high enough
+   to beat JSP's element selectors (0,0,1), but BELOW this file's own component
+   rules like `.tiptap { padding }` (0,2,0). Without `:where()`, each bare
+   `:not([class~=…])` would add (0,1,0), pushing the rule past our own styles and
+   reverting the editor's own padding/spacing to nothing. */
 :host(dotcms-block-editor) {
     display: block;
     font-family:
@@ -32,7 +48,9 @@
     color: #1f2937;
 }
 
-:host(dotcms-block-editor) ::ng-deep * {
+:host(dotcms-block-editor)
+    ::ng-deep
+    *:not(:where([class~='p-component'], [class~='p-component'] *)) {
     margin: revert-layer;
     padding: revert-layer;
     font-size: revert-layer;


### PR DESCRIPTION
## Block Editor (web component) styling fixes for JSP

Two independent visual defects in the **new Block Editor** (`@dotcms/new-block-editor`) when it runs as the `dotcms-block-editor` web component inside the legacy admin JSP. Found during the #35980 bug hunt.

### Proposed Changes

**1. JSP host-page styles breaking the editor chrome & PrimeNG components** (`editor.component.css`)
- The admin JSP (`dijit-dotcms/dotcms.css`) ships **unlayered** element resets (`button, input, p, td… { margin/padding: 0; font-size: 0.875rem }`). Because Tailwind is **layered**, unlayered JSP wins regardless of specificity — stripping spacing/typography from the editor.
- The existing defense reset every descendant with `revert-layer`, which over-reached: it also reverted **PrimeNG** components (to Tailwind preflight `0`, killing their design tokens) **and the editor's own component styles** (e.g. `.tiptap` padding).
- Fix: scope the reset to exclude PrimeNG widgets via `*:not(:where([class~='p-component'], [class~='p-component'] *))`.
  - PrimeNG's theme is injected **unlayered**, so `.p-button` (0,1,0) already beats JSP `button` (0,0,1) on its own — it never needed the defense.
  - The exclusion is wrapped in `:where()` (zero specificity) so the rule stays at `(0,1,1)`: **above** JSP element selectors `(0,0,1)` but **below** the editor's own component rules like `.tiptap { padding }` `(0,2,0)`. This is what keeps the editor's own spacing intact.

**2. Image/Video picker dialog overflows on short viewports** (`config.utils.ts`)
- `DotBrowserSelectorComponent` has a fixed-height root (`h-180` = 45rem) and the dialog also forced `min-height: 45rem`. On a short window the 45rem + header ran off the bottom of the screen and the action buttons became unreachable (`keepInViewport: false` left it unclamped).
- Fix: `contentStyle.height: min(45rem, 80vh)` + `overflow: auto`. Tall screens are unchanged (full 45rem, no scroll); short screens clamp to 80vh and scroll inside the viewport-bounded box. `min-height` was removed because CSS lets it win over `height` and would re-pin it to 45rem.

### Checklist
- [ ] Tests
- [ ] Translations — N/A (CSS/config only)
- [x] Security Implications Contemplated — none (presentation-only changes)

### Additional Info
- Scope: only the web-component path (`:host(dotcms-block-editor)`); the Angular host (`dot-block-editor`) is unaffected.
- Known follow-up: the picker dialog fix is scoped to the editor's config; the shared `DotBrowserSelectorComponent` (also used by file fields) still has the rigid `h-180` and likely the same overflow on short viewports. Deferred to avoid widening blast radius.

### Videos

https://github.com/user-attachments/assets/ac077668-cf52-4b36-85db-68e64678eb03


https://github.com/user-attachments/assets/555fbabf-fdc1-4a7a-b110-45aae8f3b78a



Related to #35980

This PR fixes: #35980