### PR TITLE
fix: add a go back button on the contents tab (#34749)

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
@@ -20,6 +20,7 @@ if(user == null){
 }
 boolean isUserCMSAdmin = user.isAdmin();
 boolean isHost = ("Host".equals(structure.getVelocityVarName()));
+boolean isFromPublishingQueue = UtilMethods.isSet(referer) && referer.contains("publishing-queue");
 
 boolean isContLocked=(request.getParameter("sibbling") != null) ? false : contentlet.isLocked();
 WorkflowTask wfTask = APILocator.getWorkflowAPI().findTaskByContentlet(contentlet);
@@ -149,6 +150,14 @@ function jumpToContentType(){
 <%}%>
 
 <%--check permissions to display the save and publish button or not--%>
+
+<%if(isFromPublishingQueue) {%>
+<div class="content-edit-actions">
+    <a href="<%= referer %>">
+        &larr; <%= LanguageUtil.get(pageContext, "Back-to") %> <%= LanguageUtil.get(pageContext, "com.dotcms.repackage.javax.portlet.title.publishing-queue") %>
+    </a>
+</div>
+<%}%>
 
 <%if(!"edit-page".equals(request.getParameter("angularCurrentPortlet")) && UtilMethods.isSet(contentUrl)) {%>
    <div class="content-edit-actions" >


### PR DESCRIPTION
Added a go back button on the contents tab

<img width="388" height="540" alt="Captura de pantalla 2026-06-19 a la(s) 3 48 33 p  m" src="https://github.com/user-attachments/assets/46de1343-fe4b-49bd-b00f-bfcda92d263e" />

This PR fixes: #34749
