### PR TITLE
fix(editor): render list markers in block editor web component

### DIFF
--- a/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
+++ b/core-web/libs/new-block-editor/src/lib/editor/editor.component.css
@@ -133,6 +133,63 @@
     margin-top: 2.5rem;
 }
 
+/* ─── Lists ─────────────────────────────────────────────── */
+/* Self-contained list rendering. We do NOT rely on the host page's Tailwind
+   Typography (`prose`) for markers: Tailwind's preflight resets
+   `ol, ul, menu { list-style: none }` in `@layer base`, and depending on the
+   consuming app's layer order that can beat `prose` (it does in the
+   `dotcms-block-editor` web-component build, where lists rendered with no
+   bullets/numbers). These rules are unlayered component CSS, so they win over
+   any layered Tailwind reset regardless of host. `padding-left` is required for
+   the markers to be visible (`list-style-position: outside` paints them in the
+   indent); it also out-specifies the host-style `revert-layer` defense (0,1,1),
+   which would otherwise strip the list's padding and clip the markers. */
+:host ::ng-deep .tiptap ul,
+:host ::ng-deep .tiptap ol {
+    padding-left: 1.625rem;
+    margin: 0;
+}
+
+:host ::ng-deep .tiptap ul {
+    list-style: disc;
+}
+
+:host ::ng-deep .tiptap ol {
+    list-style: decimal;
+}
+
+/* Nested markers cycle so depth stays legible */
+:host ::ng-deep .tiptap ul ul {
+    list-style: circle;
+}
+
+:host ::ng-deep .tiptap ul ul ul {
+    list-style: square;
+}
+
+/* `list-style: inherit` is load-bearing: the admin JSP ships an unlayered
+   `li { list-style: none }` that sets the property *directly on the <li>*,
+   overriding the value `list-style-type` would otherwise inherit from the
+   <ul>/<ol> above. Forcing the li to inherit re-derives the correct marker
+   (disc / decimal / circle / square) from its list parent. `.tiptap li`
+   (0,2,1) out-specifies the JSP's `li` (0,0,1). */
+:host ::ng-deep .tiptap li {
+    margin: 0.25rem 0;
+    list-style: inherit;
+}
+
+/* Markers default to Tailwind prose's light-gray bullet/counter color; match
+   them to the editor's text color so they read as part of the content. */
+:host ::ng-deep .tiptap li::marker {
+    color: currentColor;
+}
+
+/* TipTap wraps list-item content in a <p>; collapse its prose margins so the
+   marker stays vertically aligned with the first line of text. */
+:host ::ng-deep .tiptap li > p {
+    margin: 0;
+}
+
 /* ─── Figures / Images ──────────────────────────────────── */
 :host ::ng-deep .ProseMirror figure {
     display: block;


### PR DESCRIPTION
## Block Editor: list markers not rendering in the web component

Bullet and ordered lists rendered **without markers** (no bullets/numbers) in the new Block Editor when it runs as the `dotcms-block-editor` web component. Follow-up to #36235, found during the #35980 bug hunt.

### Root cause

The editor was relying on the host page's Tailwind `prose` to render list markers — a fragile dependency for a web component meant to drop into arbitrary host pages. Two host-cascade effects defeated it:

1. **Tailwind preflight** resets `ol, ul, menu { list-style: none }` in `@layer base`. In the web-component build's layer order this **beats `prose`**, so `<ul>`/`<ol>` lost their markers.
2. The admin **JSP** additionally ships an unlayered `li { list-style: none }` set *directly on the `<li>`*, overriding the `list-style-type` the `<li>` would otherwise inherit from its list parent. On top of that, prose colors `li::marker` a light gray.

### Proposed Changes

Add **self-contained, unlayered** list CSS to `editor.component.css` so markers render regardless of the host's Tailwind/prose setup (same pattern the file already uses for tables/code/figures):

- `ul → disc`, `ol → decimal`, with `padding-left` so the markers are visible (`list-style-position: outside` paints them in the indent).
- Nested-marker cycling: `disc → circle → square`.
- `li { list-style: inherit }` — re-derives the marker from the list parent, defeating the JSP's `li { list-style: none }`. `.tiptap li` (0,2,1) out-specifies JSP's `li` (0,0,1).
- `li::marker { color: currentColor }` — markers match the editor text instead of prose's gray.
- Tight `li` / `li > p` spacing so markers align with the first line of text.

### Checklist
- [ ] Tests — N/A (no specs in `new-block-editor`; verified via build + manual)
- [ ] Translations — N/A (CSS only)
- [x] Security Implications Contemplated — none (presentation-only)

### Additional Info
- Scope: editor content lists (`.tiptap ul/ol/li`); unlayered so it wins over layered Tailwind resets in **both** the web-component (`dotcms-block-editor`) and Angular (`dot-block-editor`) hosts.
- Production build passes (`nx run dotcms-block-editor:build --configuration=production`); the bundle-budget line is a pre-existing warning unrelated to this change.

### Video

https://github.com/user-attachments/assets/31387ee8-5d23-4041-b79e-3f4c92c3ad42

Related to #35980

This PR fixes: #35980