### PR TITLE
fix: add a go back button on the contents tab (#34749)

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/contentlet_actions_inc.jsp
@@ -20,6 +20,7 @@ if(user == null){
 }
 boolean isUserCMSAdmin = user.isAdmin();
 boolean isHost = ("Host".equals(structure.getVelocityVarName()));
+boolean isFromPublishingQueue = UtilMethods.isSet(referer) && referer.contains("publishing-queue");
 
 boolean isContLocked=(request.getParameter("sibbling") != null) ? false : contentlet.isLocked();
 WorkflowTask wfTask = APILocator.getWorkflowAPI().findTaskByContentlet(contentlet);
@@ -149,6 +150,14 @@ function jumpToContentType(){
 <%}%>
 
 <%--check permissions to display the save and publish button or not--%>
+
+<%if(isFromPublishingQueue) {%>
+<div class="content-edit-actions">
+    <a href="<%= referer %>">
+        &larr; <%= LanguageUtil.get(pageContext, "Back-to") %> <%= LanguageUtil.get(pageContext, "com.dotcms.repackage.javax.portlet.title.publishing-queue") %>
+    </a>
+</div>
+<%}%>
 
 <%if(!"edit-page".equals(request.getParameter("angularCurrentPortlet")) && UtilMethods.isSet(contentUrl)) {%>
    <div class="content-edit-actions" >


### PR DESCRIPTION
Added a go back button on the contents tab

<img width="776" height="1080" alt="image" src="https://github.com/user-attachments/assets/53b4ceb1-0e58-4c83-ad63-5d7a66553aed" />

This PR fixes: #36250

This PR fixes: #36250