### PR TITLE
fix(rest-api): forward path params in ESIndexResource create/mod endpoints (#35635)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
+++ b/dotCMS/src/main/java/com/dotcms/rest/api/v1/index/ESIndexResource.java
@@ -55,6 +55,7 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.transform.ContentletToMapTransformer;
 import com.dotmarketing.util.Config;
 import com.dotmarketing.util.Logger;
+import com.dotmarketing.util.UtilMethods;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
@@ -264,9 +265,15 @@ public class ESIndexResource {
     @Produces("text/plain")
     public Response createIndex(@Context HttpServletRequest httpServletRequest, @Context final HttpServletResponse httpServletResponse, @PathParam("params") String params) {
         try {
-            InitDataObject init=auth(httpServletRequest, httpServletResponse);
+            InitDataObject init=auth(httpServletRequest, httpServletResponse, params);
 
-            int shards=Integer.parseInt(init.getParamsMap().get("shards"));
+            final String shardsParam = init.getParamsMap().get("shards");
+            if (!UtilMethods.isSet(shardsParam) || !Try.of(() -> Integer.parseInt(shardsParam)).isSuccess()) {
+                Logger.warn(this, "createIndex called with missing/invalid 'shards' param. URI: " + httpServletRequest.getRequestURI());
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity("Missing or invalid required 'shards' parameter").build();
+            }
+            final int shards = Integer.parseInt(shardsParam);
             boolean live = init.getParamsMap().containsKey("live") ? Boolean.parseBoolean(init.getParamsMap().get("live")) : false;
             String indexName = init.getParamsMap().get("index");
 
@@ -296,7 +303,7 @@ public class ESIndexResource {
     @Path("/clear/{params:.*}")
     public Response clearIndex(@Context HttpServletRequest httpServletRequest, @Context final HttpServletResponse httpServletResponse, @PathParam("params") String params) throws DotDataException, IOException {
 
-        InitDataObject init=auth(httpServletRequest,httpServletResponse);
+        InitDataObject init=auth(httpServletRequest,httpServletResponse, params);
         String indexName = this.indexHelper.getIndexNameOrAlias(init.getParamsMap(),"index","alias",this.indexAPI);
         return modIndex(httpServletRequest, httpServletResponse, indexName, IndexAction.CLEAR.name());
     }
@@ -404,7 +411,7 @@ public class ESIndexResource {
     @PUT
     @Path("/activate/{params:.*}")
     public Response activateIndex(@Context HttpServletRequest httpServletRequest, @Context final HttpServletResponse httpServletResponse, @PathParam("params") String params) throws DotDataException, IOException {
-        InitDataObject init=auth(httpServletRequest,httpServletResponse);
+        InitDataObject init=auth(httpServletRequest,httpServletResponse, params);
         String indexName = this.indexHelper.getIndexNameOrAlias(init.getParamsMap(),"index","alias",this.indexAPI);
         return modIndex(httpServletRequest, httpServletResponse, indexName, IndexAction.ACTIVATE.name());
     }
@@ -421,7 +428,7 @@ public class ESIndexResource {
     @PUT
     @Path("/deactivate/{params:.*}")
     public Response deactivateIndex(@Context HttpServletRequest httpServletRequest, @Context final HttpServletResponse httpServletResponse, @PathParam("params") String params) throws DotDataException, IOException {
-        InitDataObject init=auth(httpServletRequest,httpServletResponse);
+        InitDataObject init=auth(httpServletRequest,httpServletResponse, params);
         String indexName = this.indexHelper.getIndexNameOrAlias(init.getParamsMap(),"index","alias",this.indexAPI);
         return modIndex(httpServletRequest, httpServletResponse, indexName, IndexAction.DEACTIVATE.name());
     }
@@ -437,7 +444,7 @@ public class ESIndexResource {
     @PUT
     @Path("/close/{params:.*}")
     public Response closeIndex(@Context HttpServletRequest httpServletRequest,@Context final HttpServletResponse httpServletResponse, @PathParam("params") String params) throws DotDataException, IOException {
-        InitDataObject init=auth(httpServletRequest,httpServletResponse);
+        InitDataObject init=auth(httpServletRequest,httpServletResponse, params);
         String indexName = this.indexHelper.getIndexNameOrAlias(init.getParamsMap(),"index","alias",this.indexAPI);
         return modIndex(httpServletRequest, httpServletResponse, indexName, IndexAction.CLOSE.name());
     }
@@ -454,7 +461,7 @@ public class ESIndexResource {
     @Path("/open/{params:.*}")
     public Response openIndex(@Context HttpServletRequest httpServletRequest, @Context final HttpServletResponse httpServletResponse, @PathParam("params") String params) {
         try {
-            InitDataObject init=auth(httpServletRequest, httpServletResponse);
+            InitDataObject init=auth(httpServletRequest, httpServletResponse, params);
             String indexName = this.indexHelper.getIndexNameOrAlias(init.getParamsMap(),"index","alias",this.indexAPI);
             APILocator.getESIndexAPI().openIndex(indexName);
 


### PR DESCRIPTION
## Proposed Changes

Fixes the TC-005 blocker reported in #35635: `PUT /api/v1/esindex/create/{params:.*}` returned **HTTP 500** on every call, making it impossible for QA to validate the `threadSafeTimestampFormatter` thread-safety work.

> **Note on scope — deprecated endpoints.** All six endpoints touched here are `@Deprecated` and superseded by the modern routes (`PUT /api/v1/esindex/{indexName}?action=...`, which bind the index name via `@PathParam`/`@QueryParam` and are unaffected). They normally see no traffic. The issue surfaced only because the deprecated path-param endpoints are **still present in the codebase** and AI detected the latent defect while investigating TC-005 — `createIndex` in particular still 500s on every call. The fix restores correct behavior for these legacy endpoints with a minimal change; it does not revive or re-promote them.

### Root cause
`createIndex` captures the URL into `@PathParam("params") String params`, but invokes the **2-argument** `auth(request, response)` overload, which forwards `null` instead of `params` to `WebResource`. As a result `getParamsMap()` is built over `BLANK` and is always empty → `getParamsMap().get("shards")` is `null` → `Integer.parseInt(null)` throws `NumberFormatException` → HTTP 500. The captured `params` was effectively dead code.

The five sibling `@Deprecated` PUT endpoints (`clearIndex`, `activateIndex`, `deactivateIndex`, `closeIndex`, `openIndex`) share the identical defect — they read the index name from `getParamsMap()`, which always arrived empty, so they silently operated on a `null` index (returning 404 / erroring instead of acting).

### Fix
- `createIndex` and the five sibling endpoints now forward the captured `params` to the 3-arg `auth(request, response, params)` overload (the same pattern already used by `getActive`).
- `createIndex` now returns **HTTP 400** with a clear message when `shards` is missing or non-numeric, instead of an opaque 500.

## Issue
- #35635

## This PR fixes a defect

## How to test
Manual (TC-005):
```bash
seq 20 | xargs -P 20 -I{} curl -s -o /tmp/idx_{}.json -w "%{http_code}\n" \
  -u admin:admin -X PUT http://localhost:8082/api/v1/esindex/create/shards/1
```
Expected: 20× HTTP 200, 20 unique well-formed index names. A missing/invalid `shards` now yields HTTP 400 (not 500).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35635