### PR TITLE
fix(push-publishing): remove fallback-rendered page artifacts on static un-publish (#35365)

### DIFF
--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticDependencyBundler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticDependencyBundler.java
@@ -23,6 +23,7 @@ import com.dotmarketing.beans.Identifier;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.business.IdentifierAPI;
 import com.dotmarketing.business.UserAPI;
+import com.dotmarketing.exception.DoesNotExistException;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
 import com.dotmarketing.portlets.contentlet.business.ContentletAPI;
@@ -31,8 +32,10 @@ import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.portlets.contentlet.model.ContentletVersionInfo;
 import com.dotmarketing.portlets.folders.business.FolderAPI;
 import com.dotmarketing.portlets.folders.model.Folder;
+import com.dotmarketing.portlets.htmlpageasset.model.IHTMLPage;
 import com.dotmarketing.portlets.languagesmanager.business.LanguageAPI;
 import com.dotmarketing.portlets.languagesmanager.model.Language;
+import com.dotmarketing.util.Logger;
 import com.dotmarketing.util.UUIDUtil;
 import com.dotmarketing.util.UtilMethods;
 import com.google.common.collect.Lists;
@@ -180,14 +183,19 @@ public class StaticDependencyBundler implements IBundler {
                     }
 
                     if (staticUnpublish && contentPath != null && h != null) {
-                        // A marker is only needed for languages where the content has NO live
-                        // version: live content is rendered by the content bundlers and removed by
-                        // the publisher's delete branch, so it needs no marker. The publish queue
-                        // does not track the asset language (PublisherAPIImpl hardcodes
-                        // language_id=1), so derive the languages from the content's own versions
-                        // rather than the bundle languages. See issue #35365.
+                        // Un-publish must remove every artifact Push Publish created. The publish
+                        // queue does not track the asset language (PublisherAPIImpl hardcodes
+                        // language_id=1), so derive the languages from the content itself:
+                        //  - HTML pages are published for every configured language they resolve in
+                        //    (directly or via default-language fallback), so mirror that — otherwise
+                        //    fallback-rendered artifacts in other languages are orphaned. See #35365.
+                        //  - Other content (file assets, URL-mapped) is published only where it has a
+                        //    real version, so the per-version languages are the right set.
+                        final Collection<String> markerLanguages = contentlet.isHTMLPage()
+                                ? pageMarkerLanguages(id, languages)
+                                : nonLiveLanguages(id.getId());
                         StaticUnpublishMarker.writeContentMarkers(config, output, h.getHostname(),
-                                nonLiveLanguages(id.getId()), contentPath);
+                                markerLanguages, contentPath);
                     }
                 }
             }
@@ -219,6 +227,40 @@ public class StaticDependencyBundler implements IBundler {
             }
         }
         return nonLive;
+    }
+
+    /**
+     * For an HTML page, resolves the languages in which Push Publish would have created an artifact:
+     * each configured bundle language in which the page resolves directly or via default-language
+     * fallback. This mirrors {@link com.dotcms.enterprise.publishing.bundlers.HTMLPageAsContentBundler},
+     * which renders a file per configured language via {@code findByIdLanguageFallback}. Un-publish
+     * must remove every such artifact — including the fallback-rendered ones for languages the page
+     * has no direct version in, which would otherwise be orphaned on the endpoint. See issue #35365.
+     *
+     * @param identifier      the page identifier
+     * @param configLanguages the bundle's configured languages (ids as strings)
+     * @return the language ids (as strings) in which the page is published
+     */
+    private Collection<String> pageMarkerLanguages(final Identifier identifier,
+            final Set<String> configLanguages) throws DotDataException, DotSecurityException {
+        final Set<String> langs = new LinkedHashSet<>();
+        for (final String languageId : configLanguages) {
+            try {
+                // live=false: at un-publish time the live version is already gone, but the (now
+                // working) version still resolves through the same fallback Push Publish used.
+                final IHTMLPage page = APILocator.getHTMLPageAssetAPI().findByIdLanguageFallback(
+                        identifier, Long.parseLong(languageId), false, systemUser, false);
+                if (page != null) {
+                    langs.add(languageId);
+                }
+            } catch (final DoesNotExistException e) {
+                // The page is not published in this language (no direct version and no fallback)
+                // -> Push Publish created nothing here, so there is nothing to remove.
+                Logger.debug(StaticDependencyBundler.class, () -> "Page " + identifier.getId()
+                        + " does not resolve in language " + languageId + "; no un-publish marker.");
+            }
+        }
+        return langs;
     }
 
     @Override

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticDependencyBundler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticDependencyBundler.java
@@ -244,12 +244,25 @@ public class StaticDependencyBundler implements IBundler {
     private Collection<String> pageMarkerLanguages(final Identifier identifier,
             final Set<String> configLanguages) throws DotDataException, DotSecurityException {
         final Set<String> langs = new LinkedHashSet<>();
+        if (identifier == null || configLanguages == null) {
+            return langs;
+        }
         for (final String languageId : configLanguages) {
+            // Bundle languages are language ids; guard against any non-numeric value so a bad entry
+            // skips that language rather than aborting the whole bundle with NumberFormatException.
+            final long langId;
+            try {
+                langId = Long.parseLong(languageId);
+            } catch (final NumberFormatException e) {
+                Logger.warn(StaticDependencyBundler.class,
+                        "Skipping non-numeric bundle language id: " + languageId);
+                continue;
+            }
             try {
                 // live=false: at un-publish time the live version is already gone, but the (now
                 // working) version still resolves through the same fallback Push Publish used.
                 final IHTMLPage page = APILocator.getHTMLPageAssetAPI().findByIdLanguageFallback(
-                        identifier, Long.parseLong(languageId), false, systemUser, false);
+                        identifier, langId, false, systemUser, false);
                 if (page != null) {
                     langs.add(languageId);
                 }

--- a/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticDependencyBundler.java
+++ b/dotCMS/src/enterprise/java/com/dotcms/enterprise/publishing/staticpublishing/StaticDependencyBundler.java
@@ -255,7 +255,7 @@ public class StaticDependencyBundler implements IBundler {
                 langId = Long.parseLong(languageId);
             } catch (final NumberFormatException e) {
                 Logger.warn(StaticDependencyBundler.class,
-                        "Skipping non-numeric bundle language id: " + languageId);
+                        () -> "Skipping non-numeric bundle language id: " + languageId);
                 continue;
             }
             try {

--- a/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTest.java
@@ -62,6 +62,7 @@ import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherI
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getLivePage;
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getLivePageInOneLangAndWorkingInAnother;
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getLivePageWithDifferentLang;
+import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getWorkingPageInDefaultLangConfiguredForFallbackLang;
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getLivePageWithDifferentLangIncludingJustOne;
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getPageWithCSS;
 import static com.dotcms.enterprise.publishing.staticpublishing.StaticPublisherIntegrationTestHelper.getPageWithImage;
@@ -157,7 +158,8 @@ public class StaticPublisherIntegrationTest {
 
        final TestCase[] testCasesWitLangFilter = {
                getLivePageWithDifferentLangIncludingJustOne(),
-                getLiveFileAssetDifferentLangIncludingJustOneg()
+                getLiveFileAssetDifferentLangIncludingJustOneg(),
+                getWorkingPageInDefaultLangConfiguredForFallbackLang()
         };
 
        final List<TestCase> testCaseWithEmptyLang = Arrays.stream(testCasesWithoutLangFilter)

--- a/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTestHelper.java
+++ b/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTestHelper.java
@@ -794,6 +794,36 @@ public class StaticPublisherIntegrationTestHelper {
         return testCase;
     }
 
+    /**
+     * QA repro for issue #35365: a page whose only real version is in the DEFAULT language, with the
+     * bundle configured for an additional language. Push Publish renders the page in BOTH languages
+     * — the additional one via default-language fallback ({@code findByIdLanguageFallback}) — so the
+     * artifact exists on the static endpoint for both. Push Remove must therefore remove BOTH
+     * language artifacts, not only the default-language one. The page has no live version (working
+     * only, i.e. already unpublished), so removal is driven entirely by /live/ markers.
+     */
+    public static TestCase getWorkingPageInDefaultLangConfiguredForFallbackLang()
+            throws WebAssetException, DotDataException, DotSecurityException {
+        final Language defaultLanguage = APILocator.getLanguageAPI().getDefaultLanguage();
+        final PageWithDependencies workingPage = new PageWithDependenciesBuilder()
+                .language(defaultLanguage)
+                .build();
+
+        // A second language with NO real version of this page; Push Publish renders it via
+        // default-language fallback, so its artifact also exists on the endpoint.
+        final Language fallbackLanguage = new LanguageDataGen().nextPersisted();
+
+        final Map<String, String> assetsMap = getAssetsMap(workingPage.page);
+
+        final TestCase testCase = new TestCase(workingPage.page, new ArrayList<>(),
+                list(defaultLanguage, fallbackLanguage), assetsMap);
+        // Both the default-language and the fallback-language artifacts must be removed.
+        testCase.unPublishExpected = list(
+                new FileExpected(getPageFilePath(workingPage, defaultLanguage), null, true),
+                new FileExpected(getPageFilePath(workingPage, fallbackLanguage), null, true));
+        return testCase;
+    }
+
     private static Contentlet createNewVersionInDifferentLang(final Contentlet contentlet,
             final Language language, final Map<String, String> fieldValues) throws DotDataException, DotSecurityException {
 

--- a/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTestHelper.java
+++ b/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTestHelper.java
@@ -1,5 +1,7 @@
 package com.dotcms.enterprise.publishing.staticpublishing;
 
+import static org.junit.Assert.assertNotEquals;
+
 import com.dotcms.contenttype.model.field.Field;
 import com.dotcms.contenttype.model.field.TextField;
 import com.dotcms.contenttype.model.type.ContentType;
@@ -810,8 +812,11 @@ public class StaticPublisherIntegrationTestHelper {
                 .build();
 
         // A second language with NO real version of this page; Push Publish renders it via
-        // default-language fallback, so its artifact also exists on the endpoint.
+        // default-language fallback, so its artifact also exists on the endpoint. It must be a
+        // distinct language for the fallback scenario to be exercised.
         final Language fallbackLanguage = new LanguageDataGen().nextPersisted();
+        assertNotEquals("fallback language must differ from the default language",
+                defaultLanguage.getId(), fallbackLanguage.getId());
 
         final Map<String, String> assetsMap = getAssetsMap(workingPage.page);
 

--- a/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTestHelper.java
+++ b/dotcms-integration/src/test/java/com/dotcms/enterprise/publishing/staticpublishing/StaticPublisherIntegrationTestHelper.java
@@ -805,7 +805,7 @@ public class StaticPublisherIntegrationTestHelper {
      * only, i.e. already unpublished), so removal is driven entirely by /live/ markers.
      */
     public static TestCase getWorkingPageInDefaultLangConfiguredForFallbackLang()
-            throws WebAssetException, DotDataException, DotSecurityException {
+            throws DotDataException, DotSecurityException {
         final Language defaultLanguage = APILocator.getLanguageAPI().getDefaultLanguage();
         final PageWithDependencies workingPage = new PageWithDependenciesBuilder()
                 .language(defaultLanguage)


### PR DESCRIPTION
## What

QA follow-up for #35365 (PR #36193). Static **Push Remove** of a page removed only the **default-language** artifact from the static endpoint (e.g. S3); other-language copies were left orphaned.

## Root cause — publish/un-publish language asymmetry

- **Publish:** `HTMLPageAsContentBundler` renders a file for **every configured bundle language** via `findByIdLanguageFallback(...)` (default-language fallback). So a page with a real version only in the default language is still published to S3 for *every* configured language (the others fall back to the default content). → *"Push Publish always creates a page on other languages."*
- **Un-publish (before this PR):** `StaticDependencyBundler` derived marker languages from `findContentletVersionInfos(identifier)` — **only languages with a real version**. The fallback-rendered copies have no real version, so they were never marked for removal. → *"Push Remove only removes the current language."*

This was never caught because every existing test page is built in a *fresh, non-default* language, so default-language fallback never triggers — no test created a page in the default language.

## Fix

`StaticDependencyBundler` now mirrors the page bundler: for **HTML pages**, it marks every configured language in which the page **resolves** (directly or via default-language fallback), using the same `findByIdLanguageFallback` call. Removal is therefore symmetric with publish, and fallback-rendered artifacts are removed.

**Scope:** page-specific. File assets and URL-mapped content are published per-language by *real version* (no fallback), so they keep the per-version-language behavior unchanged.

## Testing

- New integration case `getWorkingPageInDefaultLangConfiguredForFallbackLang` reproduces the QA scenario (page real-version only in default language, bundle configured for an extra language). It **fails before the fix** (`expected:<2> but was:<1>`) and **passes after**.
- Full `StaticPublisherIntegrationTest`: **76/76 green** (verified locally against PostgreSQL + OpenSearch). Unit tests green.

## Related

Still tracked separately: an enhancement to let static push-remove of *working (non-live)* content remove only specific language versions rather than all (pending product direction).

Refs: #35365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35365