### PR TITLE
ci(ai): upgrade auto-PR reviewer to DeepSeek R1 with configurable model variable

### DIFF
--- a/.github/prompts/gpt-auto-review.md
+++ b/.github/prompts/gpt-auto-review.md
@@ -24,6 +24,4 @@ Format each finding as:
 - 🔴 Critical / 🟠 High: blocking — these must be fixed before merge
 - 🟡 Medium: non-blocking — worth fixing but does not block merge
 
-**Carried-forward findings:** If prior review comments on this PR flagged issues that remain unresolved in the current diff, list them under a `## ⚠️ Unresolved from prior review` section with the original finding and current evidence that it still exists.
-
 If the PR is clean, say so in one sentence.

--- a/.github/prompts/gpt-auto-review.md
+++ b/.github/prompts/gpt-auto-review.md
@@ -2,6 +2,8 @@ You are reviewing a pull request for **dotCMS**, a Java/Angular headless CMS pla
 
 Review only what's in the diff. Be direct and specific — include file and line for every finding. Skip praise, summaries, and style nitpicks. Do not invent issues.
 
+**Only flag bugs introduced by this PR.** Do not flag pre-existing issues in unchanged code.
+
 Check for:
 1. **Bugs** — logic errors, null dereferences, off-by-one, missing edge cases, race conditions
 2. **Security** — SQL injection (`DotConnect + addParam()` required, never string concat), missing permission checks (`hasPermission` / `DotSecurityException`), sensitive data in logs, hardcoded secrets, unvalidated input in file paths or system calls
@@ -9,7 +11,15 @@ Check for:
 4. **Design** — wrong layer of concern, broken abstraction, unnecessary complexity
 5. **Test gaps** — meaningful new behavior with no test coverage
 
+**Non-speculative rule:** Only flag what you can prove from the diff and repository code. Do not flag based on assumptions about external systems, undocumented APIs, or behaviors you cannot verify. If a concern depends on uncertainty, include it as 🟡 Medium with explicit "Assumption:" and "What to verify:" lines — do not escalate its severity.
+
 Format each finding as:
 > **[🔴 Critical | 🟠 High | 🟡 Medium]** `path/to/file:line` — what's wrong and why it matters
+
+**Severity gating:**
+- 🔴 Critical / 🟠 High: blocking — these must be fixed before merge
+- 🟡 Medium: non-blocking — worth fixing but does not block merge
+
+**Carried-forward findings:** If prior review comments on this PR flagged issues that remain unresolved in the current diff, list them under a `## ⚠️ Unresolved from prior review` section with the original finding and current evidence that it still exists.
 
 If the PR is clean, say so in one sentence.

--- a/.github/prompts/gpt-auto-review.md
+++ b/.github/prompts/gpt-auto-review.md
@@ -18,7 +18,7 @@ Check for:
 **Non-speculative rule:** Only flag what you can prove from the diff and repository code. Do not flag based on assumptions about external systems, undocumented APIs, or behaviors you cannot verify. If a concern depends on uncertainty, include it as 🟡 Medium with explicit "Assumption:" and "What to verify:" lines — do not escalate its severity.
 
 Format each finding as:
-> **[🔴 Critical | 🟠 High | 🟡 Medium]** `path/to/file:line` — what's wrong and why it matters
+**[🔴 Critical | 🟠 High | 🟡 Medium]** `path/to/file:line` — what's wrong and why it matters
 
 **Severity gating:**
 - 🔴 Critical / 🟠 High: blocking — these must be fixed before merge

--- a/.github/prompts/gpt-auto-review.md
+++ b/.github/prompts/gpt-auto-review.md
@@ -10,6 +10,10 @@ Check for:
 3. **dotCMS conventions** — `Config.getStringProperty()` not `System.getProperty/getenv`; `Logger` not `System.out`; `APILocator`/`FactoryLocator` for service access; `@WrapInTransaction` on multi-step DB writes; add dependency versions to `bom/application/pom.xml` only (never `dotCMS/pom.xml`)
 4. **Design** — wrong layer of concern, broken abstraction, unnecessary complexity
 5. **Test gaps** — meaningful new behavior with no test coverage
+6. **Error paths** — for each external call or state mutation in the diff, what actually happens when it fails? Is the failure caught, logged, surfaced, or silently swallowed?
+7. **Replay safety** — if this exact code runs twice (retry, double-click, redelivered queue message), does it double-charge, double-write, or corrupt state? New writes without idempotency guards are suspect.
+8. **Blast radius** — when this breaks, what breaks with it? Flag code paths where a single failure cascades to unrelated services, callers, or data.
+9. **Missing code** — the hardest check: what should be here but isn't? No timeout. No rollback. No cancellation. No error handler. No test for the failure case. Half the bugs are a correct line that was never written, not a wrong line that was.
 
 **Non-speculative rule:** Only flag what you can prove from the diff and repository code. Do not flag based on assumptions about external systems, undocumented APIs, or behaviors you cannot verify. If a concern depends on uncertainty, include it as 🟡 Medium with explicit "Assumption:" and "What to verify:" lines — do not escalate its severity.
 

--- a/.github/prompts/gpt-auto-review.md
+++ b/.github/prompts/gpt-auto-review.md
@@ -19,39 +19,41 @@ Check for:
 
 ## Output format
 
-Write the human-readable findings first (or "No issues found." if clean). Then, **at the very end of your response**, append this machine-data block on its own line (invisible in GitHub UI — used by the next review run to carry findings forward):
+Always use this exact structure (omit a section entirely if it has no entries):
 
-`<!-- dotcms-review-findings:[{"sev":"<severity emoji> <label>","loc":"path/file:line","desc":"<one-sentence description>"},...] -->`
+```
+#### New Issues
+- 🔴 Critical: `path/file:line` — what's wrong and why it matters
+- 🟠 High: `path/file:line` — what's wrong and why it matters
+- 🟡 Medium: `path/file:line` — what's wrong and why it matters
+
+#### Existing
+- 🟡 Medium: `path/file:line` — prior finding still present (unchanged or incomplete fix)
+
+#### Resolved
+- ✅ `path/file:line` — brief reason it's now fixed or no longer applicable
+```
+
+If the PR is clean with no prior findings, write: `No issues found.`
+
+**Severity gating:**
+- 🔴 Critical / 🟠 High: blocking — must be fixed before merge
+- 🟡 Medium: non-blocking — worth fixing but does not block merge
+
+At the very end of your response, on its own line, append this machine-data block (invisible in GitHub UI — used by the next run to carry findings forward):
+
+`<!-- dotcms-review-findings:[{"sev":"🔴 Critical","loc":"path/file:line","desc":"one sentence, no internal quotes"},...] -->`
 
 Rules for the machine-data line:
 - Always present — use `<!-- dotcms-review-findings:[] -->` when there are no findings
-- One line only, no newlines inside the JSON
-- Each object: `sev` = severity label (e.g. `"🔴 Critical"`), `loc` = `path/file:line`, `desc` = one sentence, no quotes that break JSON
-- Include ALL findings — new and carried
-
-Human-readable findings format:
-
-**[🔴 Critical | 🟠 High | 🟡 Medium]** `path/to/file:line` — what's wrong and why it matters
-
-**Severity gating:**
-- 🔴 Critical / 🟠 High: blocking — these must be fixed before merge
-- 🟡 Medium: non-blocking — worth fixing but does not block merge
+- One line, no newlines inside the JSON
+- Include ALL open findings — new and existing (not resolved ones)
 
 ## If a "Prior review findings" section is present
 
 A `## Prior review findings (recheck these)` section may appear at the end of this prompt. If it does:
 
-1. **Recheck each prior finding** against the current diff and codebase:
-   - Still present and unfixed → include in your findings with a **↩ Carried** prefix
-   - Fixed or no longer applicable → list under a **Resolved** section
-
-2. Check the diff for **new** issues not in the prior list.
-
-3. Structure your response as:
-   - New findings (new issues only)
-   - `**↩ Carried**` findings (prior issues still present)
-   - `**Resolved since last review:**` — `path/file:line` ✅ (one line each)
-
-The machine-data JSON comment must include ALL findings — both new and carried.
-
-If there are no prior findings, output findings directly (no sections needed).
+1. Check the diff for **new** issues not in the prior list → **New Issues** section
+2. **Recheck each prior finding** against the current diff:
+   - Still present → **Existing** section
+   - Fixed or no longer applicable → **Resolved** section

--- a/.github/prompts/gpt-auto-review.md
+++ b/.github/prompts/gpt-auto-review.md
@@ -19,13 +19,17 @@ Check for:
 
 ## Output format
 
-**First line of your response must always be this machine-data comment** (invisible in GitHub UI):
+Write the human-readable findings first (or "No issues found." if clean). Then, **at the very end of your response**, append this machine-data block on its own line (invisible in GitHub UI — used by the next review run to carry findings forward):
 
-`<!-- dotcms-review-findings:[{"sev":"<severity emoji> <label>","loc":"path/file:line","desc":"<one-line description>"},...] -->`
+`<!-- dotcms-review-findings:[{"sev":"<severity emoji> <label>","loc":"path/file:line","desc":"<one-sentence description>"},...] -->`
 
-Use `[]` when there are no findings. Each object: `sev` = severity label (e.g. `"🔴 Critical"`), `loc` = file and line, `desc` = one-sentence description. No newlines inside the JSON.
+Rules for the machine-data line:
+- Always present — use `<!-- dotcms-review-findings:[] -->` when there are no findings
+- One line only, no newlines inside the JSON
+- Each object: `sev` = severity label (e.g. `"🔴 Critical"`), `loc` = `path/file:line`, `desc` = one sentence, no quotes that break JSON
+- Include ALL findings — new and carried
 
-Then the human-readable findings:
+Human-readable findings format:
 
 **[🔴 Critical | 🟠 High | 🟡 Medium]** `path/to/file:line` — what's wrong and why it matters
 

--- a/.github/prompts/gpt-auto-review.md
+++ b/.github/prompts/gpt-auto-review.md
@@ -17,11 +17,37 @@ Check for:
 
 **Non-speculative rule:** Only flag what you can prove from the diff and repository code. Do not flag based on assumptions about external systems, undocumented APIs, or behaviors you cannot verify. If a concern depends on uncertainty, include it as 🟡 Medium with explicit "Assumption:" and "What to verify:" lines — do not escalate its severity.
 
-Format each finding as:
+## Output format
+
+**First line of your response must always be this machine-data comment** (invisible in GitHub UI):
+
+`<!-- dotcms-review-findings:[{"sev":"<severity emoji> <label>","loc":"path/file:line","desc":"<one-line description>"},...] -->`
+
+Use `[]` when there are no findings. Each object: `sev` = severity label (e.g. `"🔴 Critical"`), `loc` = file and line, `desc` = one-sentence description. No newlines inside the JSON.
+
+Then the human-readable findings:
+
 **[🔴 Critical | 🟠 High | 🟡 Medium]** `path/to/file:line` — what's wrong and why it matters
 
 **Severity gating:**
 - 🔴 Critical / 🟠 High: blocking — these must be fixed before merge
 - 🟡 Medium: non-blocking — worth fixing but does not block merge
 
-If the PR is clean, say so in one sentence.
+## If a "Prior review findings" section is present
+
+A `## Prior review findings (recheck these)` section may appear at the end of this prompt. If it does:
+
+1. **Recheck each prior finding** against the current diff and codebase:
+   - Still present and unfixed → include in your findings with a **↩ Carried** prefix
+   - Fixed or no longer applicable → list under a **Resolved** section
+
+2. Check the diff for **new** issues not in the prior list.
+
+3. Structure your response as:
+   - New findings (new issues only)
+   - `**↩ Carried**` findings (prior issues still present)
+   - `**Resolved since last review:**` — `path/file:line` ✅ (one line each)
+
+The machine-data JSON comment must include ALL findings — both new and carried.
+
+If there are no prior findings, output findings directly (no sections needed).

--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -217,9 +217,8 @@ jobs:
 
         Write findings to /tmp/dotcms_review_body.md using this format.
         The FIRST LINE must always be exactly: <!-- dotcms-backend-review -->
-        This marker is invisible in GitHub's rendered markdown and is used to find
-        and update this specific comment on future pushes without touching any other
-        bot comment on the PR.
+        This marker is invisible in GitHub's rendered markdown and identifies this
+        as a dotCMS backend review comment.
 
         <!-- dotcms-backend-review -->
         ## 🔍 dotCMS Backend Review
@@ -240,23 +239,14 @@ jobs:
         - 🟡 You can ask me to handle mechanical fixes inline: `@claude fix <issue description> in <File.java>`
         - Every new push triggers a fresh review automatically
 
-        Then post it using the marker to find and update the existing review comment,
-        or create a new one if none exists yet:
+        Then post it as a new comment (each push gets its own comment for a historical record):
 
-          COMMENT_ID=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-            --jq '[.[] | select(.body | startswith("<!-- dotcms-backend-review -->"))] | last | .id // empty')
-
-          if [ -n "$COMMENT_ID" ]; then
-            jq -n --rawfile body /tmp/dotcms_review_body.md '{"body": $body}' \
-              | gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID -X PATCH --input -
-          else
-            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/dotcms_review_body.md
-          fi
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/dotcms_review_body.md
 
         If ALL agents returned NO_FINDINGS, write this to /tmp/dotcms_review_body.md instead:
           <!-- dotcms-backend-review -->
           ✅ **dotCMS Backend Review**: no issues found.
-        Then follow the same find-and-update-or-create logic above.
+        Then post it the same way.
 
         ## STEP 6 — Submit a formal GitHub review
 

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -153,6 +153,8 @@ jobs:
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: automatic
       prompt: ${{ needs.load-gpt-prompt.outputs.prompt }}
+      # Each push gets a unique SHA → unique sticky marker → new comment instead of overwrite.
+      sticky_namespace: ${{ github.sha }}
       timeout_minutes: 20
       runner: ubuntu-latest
       enable_mention_detection: false

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -127,15 +127,14 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   # Automatic PR reviews (no @claude mention)
-  # Uses DeepSeek V3.2 via AWS Bedrock (Converse API, generic-bedrock route) for model
+  # Uses DeepSeek R1 via AWS Bedrock (Converse API, generic-bedrock route) for model
   # diversity — Claude writes code here, a non-Claude model reviews it so training/weighting
   # biases from one model family don't carry into the review. Interactive @claude sessions
   # remain on Anthropic Claude (job above). Prompt lives in .github/prompts/gpt-auto-review.md.
   #
   # Was openai.gpt-5.5 (Bedrock Mantle), but as of 2026-06-15 gpt-5.5 is failing on mantle
-  # in both regions ("Engine not found"; AWS-side — see ext-aws-tam thread). DeepSeek V3.2 is
-  # healthy on bedrock-runtime and keeps the reviews running. Switch back to a mantle model by
-  # setting model_id to an openai.* id once AWS restores it.
+  # in both regions ("Engine not found"; AWS-side). Switched to DeepSeek R1 (reasoning model)
+  # which produces higher-quality code review findings than V3.2.
   ai-automatic-review:
     needs: [security-check, load-gpt-prompt]
     # load-gpt-prompt enforces all the PR/no-mention conditions; if it was skipped
@@ -147,9 +146,10 @@ jobs:
       cancel-in-progress: true
     uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
     with:
-      # deepseek.* is not anthropic/openai, so the orchestrator routes it to the
-      # bedrock-generic (Converse) executor. reasoning_effort has no effect on that path.
-      model_id: deepseek.v3.2
+      # Routes to bedrock-generic (Converse) executor for non-Anthropic/OpenAI models.
+      # Set REVIEW_MODEL_ID in GitHub repo variables (Settings → Variables → Actions).
+      # Current value: deepseek.r1-v1:0 (reasoning model, better for catching subtle bugs).
+      model_id: ${{ vars.REVIEW_MODEL_ID || 'deepseek.r1-v1:0' }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: automatic
       prompt: ${{ needs.load-gpt-prompt.outputs.prompt }}

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -136,8 +136,10 @@ jobs:
             | head -1)
 
           if [ -n "$PRIOR_FINDINGS" ]; then
-            # Format the JSON array as a readable list for the model
-            PRIOR_LIST=$(echo "$PRIOR_FINDINGS" | jq -r '.[] | "- **[\(.sev)]** `\(.loc)` — \(.desc)"')
+            # Cap at 15 findings and truncate desc to 150 chars to bound prompt size
+            # and prevent prompt injection via model-generated content in prior reviews.
+            PRIOR_LIST=$(echo "$PRIOR_FINDINGS" \
+              | jq -r '.[0:15][] | "- **[\(.sev)]** `\(.loc)` — \(.desc | .[0:150])"')
             printf '\n\n---\n\n## Prior review findings (recheck these)\n\n%s\n' "$PRIOR_LIST" >> /tmp/full_prompt.md
           fi
 

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -148,8 +148,8 @@ jobs:
     with:
       # Routes to bedrock-generic (Converse) executor for non-Anthropic/OpenAI models.
       # Set REVIEW_MODEL_ID in GitHub repo variables (Settings → Variables → Actions).
-      # Current value: deepseek.r1-v1:0 (reasoning model, better for catching subtle bugs).
-      model_id: ${{ vars.REVIEW_MODEL_ID || 'deepseek.r1-v1:0' }}
+      # R1 requires the cross-region inference profile id (us.deepseek.r1-v1:0), not the bare model id.
+      model_id: ${{ vars.REVIEW_MODEL_ID || 'us.deepseek.r1-v1:0' }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: automatic
       prompt: ${{ needs.load-gpt-prompt.outputs.prompt }}

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -130,16 +130,16 @@ jobs:
           # Extract structured findings from the most recent prior AI review comment.
           # Findings are stored as a JSON array in a hidden HTML comment at the top of each review.
           PRIOR_FINDINGS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            | jq -r '[.[] | select(.body | test("^<!-- dotcms-review-findings:"))] | sort_by(.created_at) | last | .body // empty' \
-            | grep '^<!-- dotcms-review-findings:' \
-            | sed 's/<!-- dotcms-review-findings:\(.*\) -->/\1/' \
+            | jq -r '[.[] | select(.body | test("<!-- dotcms-review-findings:"))] | sort_by(.created_at) | last | .body // empty' \
+            | grep '<!-- dotcms-review-findings:' \
+            | sed 's/.*<!-- dotcms-review-findings:\(.*\) -->.*/\1/' \
             | head -1)
 
           if [ -n "$PRIOR_FINDINGS" ]; then
-            # Cap at 15 findings and truncate desc to 150 chars to bound prompt size
+            # Cap at 15 findings and truncate desc to 300 chars to bound prompt size
             # and prevent prompt injection via model-generated content in prior reviews.
             PRIOR_LIST=$(echo "$PRIOR_FINDINGS" \
-              | jq -r '.[0:15][] | "- **[\(.sev)]** `\(.loc)` — \(.desc | .[0:150])"')
+              | jq -r '.[0:15][] | "- **[\(.sev)]** `\(.loc)` — \(.desc | .[0:300])"')
             printf '\n\n---\n\n## Prior review findings (recheck these)\n\n%s\n' "$PRIOR_LIST" >> /tmp/full_prompt.md
           fi
 

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -114,16 +114,38 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: read
     outputs:
-      prompt: ${{ steps.read.outputs.prompt }}
+      prompt: ${{ steps.build.outputs.prompt }}
     steps:
       - uses: actions/checkout@v4
-      - id: read
+      - id: build
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
         run: |
+          cp .github/prompts/gpt-auto-review.md /tmp/full_prompt.md
+
+          # Extract structured findings from the most recent prior AI review comment.
+          # Findings are stored as a JSON array in a hidden HTML comment at the top of each review.
+          PRIOR_FINDINGS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            | jq -r '[.[] | select(.body | test("^<!-- dotcms-review-findings:"))] | sort_by(.created_at) | last | .body // empty' \
+            | grep '^<!-- dotcms-review-findings:' \
+            | sed 's/<!-- dotcms-review-findings:\(.*\) -->/\1/' \
+            | head -1)
+
+          if [ -n "$PRIOR_FINDINGS" ]; then
+            # Format the JSON array as a readable list for the model
+            PRIOR_LIST=$(echo "$PRIOR_FINDINGS" | jq -r '.[] | "- **[\(.sev)]** `\(.loc)` — \(.desc)"')
+            printf '\n\n---\n\n## Prior review findings (recheck these)\n\n%s\n' "$PRIOR_LIST" >> /tmp/full_prompt.md
+          fi
+
+          DELIM="PROMPT_$(openssl rand -hex 8)"
           {
-            echo 'prompt<<PROMPT_EOF'
-            cat .github/prompts/gpt-auto-review.md
-            echo 'PROMPT_EOF'
+            echo "prompt<<${DELIM}"
+            cat /tmp/full_prompt.md
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 
   # Automatic PR reviews (no @claude mention)

--- a/.github/workflows/ai_claude-rollback-safety.yml
+++ b/.github/workflows/ai_claude-rollback-safety.yml
@@ -129,5 +129,3 @@ jobs:
       timeout_minutes: 15
       runner: ubuntu-latest
       enable_mention_detection: false
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/ai_claude-rollback-safety.yml
+++ b/.github/workflows/ai_claude-rollback-safety.yml
@@ -86,7 +86,7 @@ jobs:
       id-token: write
       pull-requests: write
       issues: write
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.0.0
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}


### PR DESCRIPTION
Closes #36285

## Summary

- Upgrades automatic PR reviewer from `deepseek.v3.2` → `us.deepseek.r1-v1:0` (R1 reasoning model via cross-region inference profile — higher-quality findings)
- Model now configurable via `REVIEW_MODEL_ID` GitHub repo variable (fallback: `us.deepseek.r1-v1:0`)
- Backend reviewer posts a new comment per push (historical record instead of sticky overwrite)
- Bumps rollback-safety workflow `ai-workflows@v3.0.0` → `v3.1.5` (picks up prompt-injection security fix from v3.1.2)
- Strengthens auto-review prompt: non-speculative rule, severity gating, error path / replay safety / blast radius / missing-code checks

## Setup after merge

**Settings → Secrets and variables → Actions → Variables → New repository variable**

| Variable | Value |
|----------|-------|
| `REVIEW_MODEL_ID` | `us.deepseek.r1-v1:0` |

Use the cross-region inference profile ID format (`us.*`), not the bare model ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36285