### PR TITLE
fix(sdk-client): omit `undefined` optional params from `page.get() graphql.variables`

### DIFF
--- a/core-web/libs/sdk/client/src/lib/client/page/page-api.spec.ts
+++ b/core-web/libs/sdk/client/src/lib/client/page/page-api.spec.ts
@@ -169,13 +169,26 @@ describe('PageClient', () => {
                         mode: 'LIVE',
                         languageId: '1',
                         fireRules: false,
-                        siteId: 'test-site',
-                        personaId: undefined,
-                        publishDate: undefined,
-                        variantName: undefined
+                        siteId: 'test-site'
                     }
                 }
             });
+        });
+
+        // Regression: https://github.com/dotCMS/core/issues/36108
+        // The returned response must be JSON-serializable so consumers like Next.js Pages Router
+        // can return it from getServerSideProps/getStaticProps without throwing on `undefined`.
+        it('returns a JSON-serializable response with no undefined values in graphql.variables', async () => {
+            const pageClient = new PageClient(validConfig, requestOptions, new FetchHttpClient());
+
+            const result = await pageClient.get('/graphql-page');
+
+            const variables = result.graphql.variables;
+            expect(Object.values(variables).some((value) => value === undefined)).toBe(false);
+
+            // Round-trips without losing data and without throwing on undefined values.
+            expect(() => JSON.stringify(result.graphql.variables)).not.toThrow();
+            expect(JSON.parse(JSON.stringify(variables))).toEqual(variables);
         });
 
         it('should print graphql errors', async () => {
@@ -355,10 +368,7 @@ describe('PageClient', () => {
                         mode: 'LIVE',
                         languageId: '1',
                         fireRules: false,
-                        siteId: 'test-site',
-                        personaId: undefined,
-                        publishDate: undefined,
-                        variantName: undefined
+                        siteId: 'test-site'
                     });
                 }
             }
@@ -591,7 +601,6 @@ describe('PageClient', () => {
                         fireRules: false,
                         siteId: 'test-site',
                         personaId: 'test-persona',
-                        publishDate: undefined,
                         variantName: 'test-variant',
                         customVar: 'customValue'
                     });
@@ -920,10 +929,7 @@ describe('PageClient', () => {
                     mode: 'LIVE',
                     languageId: '1',
                     fireRules: false,
-                    siteId: 'test-site',
-                    personaId: undefined,
-                    publishDate: undefined,
-                    variantName: undefined
+                    siteId: 'test-site'
                 });
             });
 
@@ -1051,6 +1057,23 @@ describe('PageClient', () => {
                 await pageClient.get('/already-slash');
 
                 expect(getRequestBody().variables.url).toBe('/already-slash');
+            });
+
+            // Regression: https://github.com/dotCMS/core/issues/36108
+            // Optional params left undefined must be omitted from the variables object so the
+            // returned page response is JSON-serializable (Next.js Pages Router throws otherwise).
+            it('omits optional params left undefined instead of sending undefined values', async () => {
+                const pageClient = new PageClient(
+                    validConfig,
+                    requestOptions,
+                    new FetchHttpClient()
+                );
+                await pageClient.get('/home');
+
+                const vars = getRequestBody().variables;
+                expect(vars).not.toHaveProperty('personaId');
+                expect(vars).not.toHaveProperty('publishDate');
+                expect(vars).not.toHaveProperty('variantName');
             });
         });
 

--- a/core-web/libs/sdk/client/src/lib/client/page/page-api.ts
+++ b/core-web/libs/sdk/client/src/lib/client/page/page-api.ts
@@ -13,7 +13,13 @@ import {
     UVE_MODE
 } from '@dotcms/types';
 
-import { buildPageQuery, buildQuery, fetchGraphQL, mapContentResponse } from './utils';
+import {
+    buildPageQuery,
+    buildQuery,
+    fetchGraphQL,
+    mapContentResponse,
+    removeUndefinedValues
+} from './utils';
 
 import { graphqlToPageEntity } from '../../utils';
 import { BaseApiClient } from '../base/api/base-api';
@@ -144,24 +150,25 @@ export class PageClient extends BaseApiClient {
         });
 
         const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
-        const requestVariables: Record<string, unknown> = {
+        // Strip `undefined` values from the variables. They are returned verbatim on the response
+        // and `undefined` breaks JSON serialization for consumers like Next.js Pages Router
+        // (getServerSideProps/getStaticProps throw on it). Any param can be `undefined` — the
+        // optional ones (personaId/publishDate/variantName) by default, or any param if a caller
+        // passes it explicitly. The GraphQL request is unaffected since these variables are
+        // nullable and JSON.stringify already drops undefined keys.
+        const requestVariables: Record<string, unknown> = removeUndefinedValues({
             // The url is expected to have a leading slash to comply on VanityURL Matching, some frameworks like Angular will not add the leading slash
             url: normalizedUrl,
             // Translate the UVE_MODE key ('EDIT' | 'PREVIEW' | ...) to the value the backend PageMode enum expects ('EDIT_MODE' | 'PREVIEW_MODE' | ...)
             mode: UVE_MODE[mode],
             languageId,
+            personaId,
             fireRules,
+            publishDate,
             siteId,
-            // Only include optional params when defined. Spreading `undefined` would leave
-            // `undefined` values in `requestVariables`, which is returned verbatim on the response
-            // and breaks JSON serialization for consumers like Next.js Pages Router
-            // (getServerSideProps/getStaticProps). The GraphQL request itself is unaffected since
-            // these variables are nullable and JSON.stringify already drops undefined keys.
-            ...(personaId !== undefined && { personaId }),
-            ...(publishDate !== undefined && { publishDate }),
-            ...(variantName !== undefined && { variantName }),
+            variantName,
             ...variables
-        };
+        });
 
         const requestHeaders = this.requestOptions.headers;
         const requestBody = JSON.stringify({ query: completeQuery, variables: requestVariables });

--- a/core-web/libs/sdk/client/src/lib/client/page/page-api.ts
+++ b/core-web/libs/sdk/client/src/lib/client/page/page-api.ts
@@ -149,18 +149,10 @@ export class PageClient extends BaseApiClient {
             verbose
         });
 
-        const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
-        // Strip `undefined` values from the variables. They are returned verbatim on the response
-        // and `undefined` breaks JSON serialization for consumers like Next.js Pages Router
-        // (getServerSideProps/getStaticProps throw on it). Any param can be `undefined` — the
-        // optional ones (personaId/publishDate/variantName) by default, or any param if a caller
-        // passes it explicitly. The GraphQL request is unaffected since these variables are
-        // nullable and JSON.stringify already drops undefined keys.
+        const newURL = url.startsWith('/') ? url : `/${url}`;
         const requestVariables: Record<string, unknown> = removeUndefinedValues({
-            // The url is expected to have a leading slash to comply on VanityURL Matching, some frameworks like Angular will not add the leading slash
-            url: normalizedUrl,
-            // Translate the UVE_MODE key ('EDIT' | 'PREVIEW' | ...) to the value the backend PageMode enum expects ('EDIT_MODE' | 'PREVIEW_MODE' | ...)
-            mode: UVE_MODE[mode],
+            url: newURL,
+            mode: UVE_MODE[mode], // Translate the UVE_MODE key ('EDIT' | 'PREVIEW' | ...) to the value the backend PageMode enum expects ('EDIT_MODE' | 'PREVIEW_MODE' | ...)
             languageId,
             personaId,
             fireRules,
@@ -187,14 +179,11 @@ export class PageClient extends BaseApiClient {
                     .filter((error: { extensions?: { code?: string } }) => !error.extensions?.code)
                     .forEach((error: { message: string }) => {
                         if (verbose) {
-                            logVerboseError(normalizedUrl, error.message, {
+                            logVerboseError(newURL, error.message, {
                                 variables: requestVariables
                             });
                         } else {
-                            consola.error(
-                                `[DotCMS GraphQL Error] ${normalizedUrl}: `,
-                                error.message
-                            );
+                            consola.error(`[DotCMS GraphQL Error] ${newURL}: `, error.message);
                         }
                     });
             }
@@ -234,19 +223,19 @@ export class PageClient extends BaseApiClient {
                         (code === 'NOT_FOUND' ? 404 : code === 'PERMISSION_DENIED' ? 403 : 400);
                     const message =
                         code === 'NOT_FOUND'
-                            ? `Page '${normalizedUrl}' was not found`
+                            ? `Page '${newURL}' was not found`
                             : code === 'PERMISSION_DENIED'
-                              ? `Permission denied: you do not have access to page '${normalizedUrl}'. Verify the page permissions in dotCMS and that the auth token has sufficient access.`
-                              : `Page '${normalizedUrl}' could not be loaded (${code})`;
+                              ? `Permission denied: you do not have access to page '${newURL}'. Verify the page permissions in dotCMS and that the auth token has sufficient access.`
+                              : `Page '${newURL}' could not be loaded (${code})`;
 
                     if (verbose) {
-                        logVerboseError(normalizedUrl, message, {
+                        logVerboseError(newURL, message, {
                             status,
                             code,
                             variables: requestVariables
                         });
                     } else {
-                        consola.error(`[DotCMS GraphQL Error] ${normalizedUrl}: `, message);
+                        consola.error(`[DotCMS GraphQL Error] ${newURL}: `, message);
                     }
 
                     throw new DotErrorPage(message, status, code, undefined, {
@@ -265,13 +254,13 @@ export class PageClient extends BaseApiClient {
 
             if (!pageResponse) {
                 throw new DotErrorPage(
-                    `Page '${normalizedUrl}' was not found`,
+                    `Page '${newURL}' was not found`,
                     404,
                     'NOT_FOUND',
                     new DotHttpError({
                         status: 404,
                         statusText: 'Not Found',
-                        message: `Page '${normalizedUrl}' was not found`,
+                        message: `Page '${newURL}' was not found`,
                         data: response.errors
                     }),
                     { query: completeQuery, variables: requestVariables }
@@ -298,7 +287,7 @@ export class PageClient extends BaseApiClient {
 
             if (error instanceof DotHttpError) {
                 throw new DotErrorPage(
-                    `Page request failed for URL '${normalizedUrl}': ${error.message}`,
+                    `Page request failed for URL '${newURL}': ${error.message}`,
                     error.status,
                     'UNKNOWN',
                     error,
@@ -307,7 +296,7 @@ export class PageClient extends BaseApiClient {
             }
 
             throw new DotErrorPage(
-                `Page request failed for URL '${normalizedUrl}': ${error instanceof Error ? error.message : 'Unknown error'}`,
+                `Page request failed for URL '${newURL}': ${error instanceof Error ? error.message : 'Unknown error'}`,
                 500,
                 'UNKNOWN',
                 undefined,

--- a/core-web/libs/sdk/client/src/lib/client/page/page-api.ts
+++ b/core-web/libs/sdk/client/src/lib/client/page/page-api.ts
@@ -150,11 +150,16 @@ export class PageClient extends BaseApiClient {
             // Translate the UVE_MODE key ('EDIT' | 'PREVIEW' | ...) to the value the backend PageMode enum expects ('EDIT_MODE' | 'PREVIEW_MODE' | ...)
             mode: UVE_MODE[mode],
             languageId,
-            personaId,
             fireRules,
-            publishDate,
             siteId,
-            variantName,
+            // Only include optional params when defined. Spreading `undefined` would leave
+            // `undefined` values in `requestVariables`, which is returned verbatim on the response
+            // and breaks JSON serialization for consumers like Next.js Pages Router
+            // (getServerSideProps/getStaticProps). The GraphQL request itself is unaffected since
+            // these variables are nullable and JSON.stringify already drops undefined keys.
+            ...(personaId !== undefined && { personaId }),
+            ...(publishDate !== undefined && { publishDate }),
+            ...(variantName !== undefined && { variantName }),
             ...variables
         };
 

--- a/core-web/libs/sdk/client/src/lib/client/page/utils.spec.ts
+++ b/core-web/libs/sdk/client/src/lib/client/page/utils.spec.ts
@@ -1,4 +1,4 @@
-import { buildPageQuery, buildQuery, mapContentResponse } from './utils';
+import { buildPageQuery, buildQuery, mapContentResponse, removeUndefinedValues } from './utils';
 
 describe('buildPageQuery()', () => {
     it('generates a query containing the PageContent operation', () => {
@@ -122,5 +122,36 @@ describe('mapContentResponse()', () => {
 
     it('returns an empty object when keys array is empty', () => {
         expect(mapContentResponse({ blogs: [] }, [])).toEqual({});
+    });
+});
+
+describe('removeUndefinedValues()', () => {
+    it('removes keys whose value is undefined', () => {
+        const result = removeUndefinedValues({ a: 1, b: undefined, c: 'x' });
+        expect(result).toEqual({ a: 1, c: 'x' });
+        expect(result).not.toHaveProperty('b');
+    });
+
+    it('preserves null and other falsy values', () => {
+        expect(removeUndefinedValues({ a: null, b: 0, c: '', d: false })).toEqual({
+            a: null,
+            b: 0,
+            c: '',
+            d: false
+        });
+    });
+
+    it('returns an empty object when all values are undefined', () => {
+        expect(removeUndefinedValues({ a: undefined, b: undefined })).toEqual({});
+    });
+
+    it('returns an equivalent object when nothing is undefined', () => {
+        const input = { a: 1, b: 'x' };
+        expect(removeUndefinedValues(input)).toEqual(input);
+    });
+
+    it('produces a JSON-serializable object', () => {
+        const result = removeUndefinedValues({ a: 1, b: undefined });
+        expect(JSON.parse(JSON.stringify(result))).toEqual(result);
     });
 });

--- a/core-web/libs/sdk/client/src/lib/client/page/utils.ts
+++ b/core-web/libs/sdk/client/src/lib/client/page/utils.ts
@@ -275,12 +275,8 @@ export function mapContentResponse(
  * @param {Record<string, unknown>} object - Source object to clean
  * @returns {Record<string, unknown>} New object without `undefined` values
  */
-export function removeUndefinedValues(
-    object: Record<string, unknown>
-): Record<string, unknown> {
-    return Object.fromEntries(
-        Object.entries(object).filter(([, value]) => value !== undefined)
-    );
+export function removeUndefinedValues(object: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries(Object.entries(object).filter(([, value]) => value !== undefined));
 }
 
 /**

--- a/core-web/libs/sdk/client/src/lib/client/page/utils.ts
+++ b/core-web/libs/sdk/client/src/lib/client/page/utils.ts
@@ -266,6 +266,24 @@ export function mapContentResponse(
 }
 
 /**
+ * Returns a shallow copy of the object with every key whose value is `undefined` removed.
+ *
+ * `undefined` is not valid JSON, so keeping such keys breaks consumers that serialize the value
+ * (e.g. Next.js Pages Router `getServerSideProps`/`getStaticProps`). `null` and other falsy values
+ * are preserved since they serialize fine.
+ *
+ * @param {Record<string, unknown>} object - Source object to clean
+ * @returns {Record<string, unknown>} New object without `undefined` values
+ */
+export function removeUndefinedValues(
+    object: Record<string, unknown>
+): Record<string, unknown> {
+    return Object.fromEntries(
+        Object.entries(object).filter(([, value]) => value !== undefined)
+    );
+}
+
+/**
  * Executes a GraphQL query against the DotCMS API.
  *
  * @param {Object} options - Options for the fetch request


### PR DESCRIPTION
## Proposed Changes

Fixes #36108

`client.page.get()` returned `undefined` values inside `graphql.variables`, breaking **Next.js Pages Router** apps that return the page response from `getServerSideProps`/`getStaticProps` (JSON has no representation for `undefined`).

### Root cause

In `core-web/libs/sdk/client/src/lib/client/page/page-api.ts`, the optional request params `personaId`, `publishDate`, and `variantName` were destructured without defaults and spread verbatim into `requestVariables`. That object is returned on the response, so the `undefined` values surfaced to consumers.

### Fix

Only include the optional params (`personaId`, `publishDate`, `variantName`) in `requestVariables` when they are actually defined. The GraphQL **request** is unaffected — these variables are nullable and `JSON.stringify` already drops `undefined` keys — so the only observable change is that the **returned** `graphql.variables` object is now JSON-serializable.

### Tests

- Updated existing assertions that expected `personaId/publishDate/variantName: undefined`.
- Added a regression test asserting `graphql.variables` contains no `undefined` values and round-trips through `JSON.parse(JSON.stringify(...))`.
- Added a request-contract test asserting undefined optional params are omitted from the request variables.

All 280 `sdk-client` tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36108