### PR TITLE
feat(edit-content): add placeholder to Tags field empty state

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/components/tag-field/tag-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/components/tag-field/tag-field.component.html
@@ -19,6 +19,7 @@
     [minLength]="AUTO_COMPLETE_MIN_LENGTH"
     [delay]="AUTO_COMPLETE_DELAY"
     [disabled]="$isDisabled()"
+    [placeholder]="'edit.content.form.field.tags.placeholder' | dm"
     (ngModelChange)="onTagsChange($event)"
     (completeMethod)="onSearch($event)"
     (keydown.enter)="onEnterKey($event)">

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/components/tag-field/tag-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/components/tag-field/tag-field.component.ts
@@ -19,6 +19,8 @@ import { AutoComplete, AutoCompleteCompleteEvent, AutoCompleteModule } from 'pri
 
 import { catchError, skip, switchMap } from 'rxjs/operators';
 
+import { DotMessagePipe } from '@dotcms/ui';
+
 import { DotEditContentService } from '../../../../services/dot-edit-content.service';
 import { BaseControlValueAccessor } from '../../../shared/base-control-value-accesor';
 
@@ -35,7 +37,7 @@ export const AUTO_COMPLETE_UNIQUE = true;
  */
 @Component({
     selector: 'dot-tag-field',
-    imports: [AutoCompleteModule, FormsModule, ReactiveFormsModule],
+    imports: [AutoCompleteModule, FormsModule, ReactiveFormsModule, DotMessagePipe],
     templateUrl: './tag-field.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     providers: [

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/dot-edit-content-tag-field.component.spec.ts
@@ -15,8 +15,13 @@ import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import { AutoComplete } from 'primeng/autocomplete';
 
+import { DotMessageService } from '@dotcms/data-access';
 import { DotCMSContentlet, DotCMSContentTypeField } from '@dotcms/dotcms-models';
-import { createFakeContentlet, createFakeTagField } from '@dotcms/utils-testing';
+import {
+    createFakeContentlet,
+    createFakeTagField,
+    MockDotMessageService
+} from '@dotcms/utils-testing';
 
 import {
     AUTO_COMPLETE_DELAY,
@@ -54,7 +59,15 @@ describe('DotEditContentTagFieldComponent', () => {
         host: MockFormComponent,
         imports: [ReactiveFormsModule],
         detectChanges: false,
-        providers: [mockProvider(DotEditContentService)]
+        providers: [
+            mockProvider(DotEditContentService),
+            {
+                provide: DotMessageService,
+                useValue: new MockDotMessageService({
+                    'edit.content.form.field.tags.placeholder': 'Search tags or type to create one.'
+                })
+            }
+        ]
     });
 
     describe('Component Configuration', () => {
@@ -93,6 +106,10 @@ describe('DotEditContentTagFieldComponent', () => {
             expect(autocomplete.unique).toBe(AUTO_COMPLETE_UNIQUE);
             expect(autocomplete.minLength).toBe(AUTO_COMPLETE_MIN_LENGTH);
             expect(autocomplete.delay).toBe(AUTO_COMPLETE_DELAY);
+        });
+
+        it('should display placeholder text on the autocomplete input', () => {
+            expect(autocomplete.placeholder).toBe('Search tags or type to create one.');
         });
 
         it('should be connected to form control', () => {

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -7073,6 +7073,7 @@ analytics.engagement.platforms.empty=No data for the selected period.
 com.dotcms.repackage.javax.portlet.title.analytics-dashboard=Analytics Dashboard
 edit.content.form.field.calendar.never.expires=Never Expires
 edit.content.form.field.required=This field is mandatory
+edit.content.form.field.tags.placeholder=Search tags or type to create one.
 uniquefields.notification.duplicatevalues.title=Duplicate Unique Values
 uniquefields.notification.duplicatevalues.message=dotCMS found several Contentlets with the same unique field value. Please go to the Maintenance > Log Files portlet, select and download the 'unique_field_data_conflicts.log' file which provides the information you need to manually fix them.
 


### PR DESCRIPTION
## Summary

- The Tags field in the new Edit Contentlet had no placeholder, leaving users with no hint that the field supports both searching existing tags and typing to create new ones.
- Added the placeholder text `Search tags or type to create one.` to the PrimeNG AutoComplete input, delivered via the `dm` i18n pipe consistent with existing field patterns in the codebase.

Closes #36194


## Acceptance Criteria

- [ ] **AC1 — Empty state:** When the Tags field contains zero tags and the input is untouched, the input element displays the placeholder text `Search tags or type to create one.`
- [ ] **AC2 — Exact text match:** The placeholder string is exactly `Search tags or type to create one.` — same capitalisation, spacing, and trailing period, with no leading/trailing whitespace.
- [ ] **AC3 — Typing hides placeholder:** Once the user focuses the Tags input and begins typing, the placeholder is no longer visible (standard HTML placeholder behavior).
- [ ] **AC4 — Tag present hides placeholder:** When one or more tags have been added to the field, the placeholder is not visible regardless of whether the input is focused or blurred.
- [ ] **AC5 — Placeholder returns on clear:** If all tags are removed and the input is emptied, the placeholder reappears.
- [ ] **AC6 — Scope:** The placeholder appears only in the new Edit Contentlet Tags field; no other Tags field instances (legacy portlets, standalone tag pickers) are affected.

## Test Plan

- [ ] Open the new Edit Contentlet for any content type that has a Tags field
- [ ] Verify the Tags input shows `Search tags or type to create one.` when empty
- [ ] Start typing — verify the placeholder disappears
- [ ] Add a tag — verify the placeholder is not visible
- [ ] Remove all tags — verify the placeholder reappears

## Visual Changes

> **Screenshots/GIFs needed:** This PR includes frontend changes. Please attach visual evidence before marking as ready for review.
>
> - [ ] Before screenshot (empty Tags field with no placeholder)
> - [ ] After screenshot (empty Tags field showing the placeholder)

## Notes

- `DotMessagePipe` must be imported in `DotTagFieldComponent` independently — as a standalone component it does not inherit its parent's imports. The parent `DotEditContentTagFieldComponent` already had `DotMessagePipe`, but standalone components require their own declaration.
- AC3, AC4, AC5 rely on native HTML `placeholder` attribute behavior — no custom logic was needed.

This PR fixes: #36194