### PR TITLE
fix: open dialog when clicking on content on pending bundles (#36250)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublishQueueElementTransformer.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublishQueueElementTransformer.java
@@ -30,6 +30,7 @@ public class PublishQueueElementTransformer {
     public static final String TITLE_KEY = "title";
     public static final String INODE_KEY = "inode";
     public static final String CONTENT_TYPE_NAME_KEY = "content_type_name";
+    public static final String CONTENT_TYPE_VARIABLE_KEY = "content_type_variable";
     public static final String LANGUAGE_CODE_KEY = "language_code";
     public static final String COUNTRY_CODE_KEY = "country_code";
     public static final String OPERATION_KEY = "operation";
@@ -156,6 +157,7 @@ public class PublishQueueElementTransformer {
                         TITLE_KEY, contentlet.getTitle(),
                         INODE_KEY, contentlet.getInode(),
                         CONTENT_TYPE_NAME_KEY, contentlet.getContentType().name(),
+                        CONTENT_TYPE_VARIABLE_KEY, contentlet.getContentType().variable(),
                         HTML_PAGE_KEY, contentlet.isHTMLPage()
                     ) : Map.of(TITLE_KEY, id, INODE_KEY, id));
         } catch (DotSecurityException | DotDataException e) {

--- a/dotCMS/src/main/java/com/dotcms/publisher/business/PublishQueueElementTransformer.java
+++ b/dotCMS/src/main/java/com/dotcms/publisher/business/PublishQueueElementTransformer.java
@@ -1,5 +1,6 @@
 package com.dotcms.publisher.business;
 
+import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.publisher.util.PusheableAsset;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
@@ -152,12 +153,16 @@ public class PublishQueueElementTransformer {
             contentlet = PublishAuditUtil.getInstance()
                     .findContentletByIdentifier(id);
 
+            final ContentType contentType = UtilMethods.isSet(contentlet) ? contentlet.getContentType() : null;
+            final String contentTypeName = contentType != null ? contentType.name() : StringPool.BLANK;
+            final String contentTypeVariable = contentType != null ? contentType.variable() : StringPool.BLANK;
+
             return new HashMap<>(UtilMethods.isSet(contentlet) ?
                     Map.of(
                         TITLE_KEY, contentlet.getTitle(),
                         INODE_KEY, contentlet.getInode(),
-                        CONTENT_TYPE_NAME_KEY, contentlet.getContentType().name(),
-                        CONTENT_TYPE_VARIABLE_KEY, contentlet.getContentType().variable(),
+                        CONTENT_TYPE_NAME_KEY, contentTypeName,
+                        CONTENT_TYPE_VARIABLE_KEY, contentTypeVariable,
                         HTML_PAGE_KEY, contentlet.isHTMLPage()
                     ) : Map.of(TITLE_KEY, id, INODE_KEY, id));
         } catch (DotSecurityException | DotDataException e) {

--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_queue_list.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/publishing/view_publish_queue_list.jsp
@@ -115,6 +115,17 @@
 
 <script type="text/javascript">
 
+	function openContentEditor(inode, contentType) {
+		var customEvent = document.createEvent("CustomEvent");
+		customEvent.initCustomEvent("ng-event", false, false, {
+			name: "edit-contentlet",
+			data: {
+				inode: inode,
+				contentType: contentType
+			}
+		});
+		document.dispatchEvent(customEvent);
+	}
 
 	dojo.require("dijit.Tooltip");
 
@@ -322,8 +333,10 @@
 
 							final Object structureObject = asset.get(PublishQueueElementTransformer.CONTENT_TYPE_NAME_KEY);
 							structureName =  UtilMethods.isSet(structureObject) ? structureObject.toString() : StringPool.BLANK;
+							final Object contentTypeVariableObject = asset.get(PublishQueueElementTransformer.CONTENT_TYPE_VARIABLE_KEY);
+							final String contentTypeVariable = UtilMethods.isSet(contentTypeVariableObject) ? contentTypeVariableObject.toString() : StringPool.BLANK;
                         %>
-						    <a href="/c/portal/layout?p_l_id=<%=layoutId %>&p_p_id=<%=PortletID.CONTENT%>&p_p_action=1&p_p_state=maximized&p_p_mode=view&_<%=PortletID.CONTENT%>_struts_action=/ext/contentlet/edit_contentlet&_<%=PortletID.CONTENT%>_cmd=edit&inode=<%=inode %>&referer=<%=referer %>">
+						    <a href="javascript:void(0)" onclick="openContentEditor('<%=inode%>', '<%=contentTypeVariable%>')">
 						        <%=StringEscapeUtils.escapeHtml(title)%>
                             </a>
 						<% } else {


### PR DESCRIPTION
Open edit content dialog to improve navigation on the pending bundle tab.

 

https://github.com/user-attachments/assets/3cace579-d1e7-4b34-b5ab-a2ad02bffffe


This PR fixes: #36250

This PR fixes: #36250