### PR TITLE
chore(ci): track ai-workflows @v3 floating tag

### DIFF
--- a/.github/workflows/ai_claude-backend-reviewer.yml
+++ b/.github/workflows/ai_claude-backend-reviewer.yml
@@ -85,7 +85,7 @@ jobs:
       id-token: write
       pull-requests: write
       issues: write
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}

--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -82,7 +82,7 @@ jobs:
           )
         )
       )
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
@@ -168,7 +168,7 @@ jobs:
     concurrency:
       group: claude-automatic-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
       # Routes to bedrock-generic (Converse) executor for non-Anthropic/OpenAI models.
       # Set REVIEW_MODEL_ID in GitHub repo variables (Settings → Variables → Actions).

--- a/.github/workflows/ai_claude-rollback-safety.yml
+++ b/.github/workflows/ai_claude-rollback-safety.yml
@@ -86,7 +86,7 @@ jobs:
       id-token: write
       pull-requests: write
       issues: write
-    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3.1.5
+    uses: dotCMS/ai-workflows/.github/workflows/claude-orchestrator.yml@v3
     with:
       model_id: ${{ vars.BEDROCK_MODEL_ID }}
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}


### PR DESCRIPTION
This PR fixes  #36285

## What

Pin the `ai-workflows` orchestrator to the floating major tag **`@v3`** (currently v3.1.6) instead of an exact patch tag, across all 4 references in 3 workflows. Consumers now auto-pick up `v3.x` releases without a per-release bump PR.

## Why `@v3` and not `@main`/SHA

The Bedrock OIDC trust (`GitHubActions-BedrockCodeReview`, IaC #7833) requires `job_workflow_ref` to match **`refs/tags/*`**. A branch or commit SHA is denied at `configure-aws-credentials` (`AssumeRoleWithWebIdentity` fails). `@v3` is a tag (`refs/tags/v3`), so it satisfies the trust while still floating to the latest v3.x.

## What v3.1.6 brings

Configurable `max_output_tokens` orchestrator input and the bedrock-generic default raised `2048` -> `32000`. Core routes `us.deepseek.r1-v1:0` (a reasoning model) through that path, where reasoning tokens count against the same budget — the old 2048 cap truncated reviews mid-thought. Completes the budget side of the R1 reviewer upgrade in #36285.

## Files

- `.github/workflows/ai_claude-rollback-safety.yml`
- `.github/workflows/ai_claude-orchestrator.yml` (2 refs)
- `.github/workflows/ai_claude-backend-reviewer.yml`

## Validation

v3.1.6 was validated end-to-end against the real DeepSeek R1 model in `dotCMS/steve-quarterly-planning` #109 (now closed): correct routing to the bedrock-generic path, sticky comment posted, all planted bugs caught, `maxTokens=32000` accepted by R1 with no truncation.

Release: https://github.com/dotCMS/ai-workflows/releases/tag/v3.1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
