### PR TITLE
fix(plugins): keep focus on search input in Exported Packages (#36214)

### DIFF
--- a/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.spec.ts
+++ b/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.spec.ts
@@ -159,8 +159,7 @@ describe('DotPluginsExtraPackagesComponent', () => {
     });
 
     describe('search', () => {
-        const PACKAGES_TEXT =
-            'com.example.foo\ncom.example.bar\norg.example.baz\ncom.example.qux';
+        const PACKAGES_TEXT = 'com.example.foo\ncom.example.bar\norg.example.baz\ncom.example.qux';
 
         function searchInput(): HTMLInputElement | null {
             const host = spectator.query(byTestId('plugins-extra-packages-search'));

--- a/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.spec.ts
+++ b/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.spec.ts
@@ -8,7 +8,10 @@ import { DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { DotHttpErrorManagerService, DotMessageService, DotOsgiService } from '@dotcms/data-access';
 
-import { DotPluginsExtraPackagesComponent } from './dot-plugins-extra-packages.component';
+import {
+    DotPluginsExtraPackagesComponent,
+    SEARCH_DEBOUNCE_MS
+} from './dot-plugins-extra-packages.component';
 
 describe('DotPluginsExtraPackagesComponent', () => {
     let spectator: Spectator<DotPluginsExtraPackagesComponent>;
@@ -156,13 +159,15 @@ describe('DotPluginsExtraPackagesComponent', () => {
     });
 
     describe('search', () => {
-        const SEARCH_DEBOUNCE_MS = 500;
         const PACKAGES_TEXT =
             'com.example.foo\ncom.example.bar\norg.example.baz\ncom.example.qux';
 
-        function searchInput(): HTMLInputElement {
-            const el = spectator.query(byTestId('plugins-extra-packages-search'));
-            return el as HTMLInputElement;
+        function searchInput(): HTMLInputElement | null {
+            const host = spectator.query(byTestId('plugins-extra-packages-search'));
+            if (!host) return null;
+            return host instanceof HTMLInputElement
+                ? host
+                : host.querySelector<HTMLInputElement>('input');
         }
 
         beforeEach(() => {
@@ -171,7 +176,7 @@ describe('DotPluginsExtraPackagesComponent', () => {
         });
 
         it('should keep focus on the search input after typing (debounced)', fakeAsync(() => {
-            const input = searchInput();
+            const input = searchInput()!;
             const textarea = nativeTextarea()!;
             expect(input).toBeTruthy();
             expect(textarea).toBeTruthy();
@@ -188,7 +193,7 @@ describe('DotPluginsExtraPackagesComponent', () => {
         }));
 
         it('should pre-select the first match on the textarea while typing without focusing it', fakeAsync(() => {
-            const input = searchInput();
+            const input = searchInput()!;
             const textarea = nativeTextarea()!;
 
             input.focus();
@@ -203,7 +208,7 @@ describe('DotPluginsExtraPackagesComponent', () => {
         }));
 
         it('should move focus to the textarea on next-match navigation', fakeAsync(() => {
-            const input = searchInput();
+            const input = searchInput()!;
             const textarea = nativeTextarea()!;
 
             input.focus();
@@ -221,7 +226,7 @@ describe('DotPluginsExtraPackagesComponent', () => {
         }));
 
         it('should move focus to the textarea on prev-match navigation', fakeAsync(() => {
-            const input = searchInput();
+            const input = searchInput()!;
             const textarea = nativeTextarea()!;
 
             input.focus();
@@ -236,7 +241,7 @@ describe('DotPluginsExtraPackagesComponent', () => {
         }));
 
         it('should leave focus untouched when the query has no matches', fakeAsync(() => {
-            const input = searchInput();
+            const input = searchInput()!;
 
             input.focus();
             spectator.typeInElement('does-not-exist', input);

--- a/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.spec.ts
+++ b/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.spec.ts
@@ -1,6 +1,8 @@
 import { byTestId, createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { Observable, of } from 'rxjs';
 
+import { fakeAsync, tick } from '@angular/core/testing';
+
 import { ConfirmationService } from 'primeng/api';
 import { DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -151,6 +153,99 @@ describe('DotPluginsExtraPackagesComponent', () => {
         it('should render confirm dialog host for reset flow', () => {
             expect(spectator.query('p-confirmdialog')).toExist();
         });
+    });
+
+    describe('search', () => {
+        const SEARCH_DEBOUNCE_MS = 500;
+        const PACKAGES_TEXT =
+            'com.example.foo\ncom.example.bar\norg.example.baz\ncom.example.qux';
+
+        function searchInput(): HTMLInputElement {
+            const el = spectator.query(byTestId('plugins-extra-packages-search'));
+            return el as HTMLInputElement;
+        }
+
+        beforeEach(() => {
+            component.extraPackages.set(PACKAGES_TEXT);
+            spectator.detectChanges();
+        });
+
+        it('should keep focus on the search input after typing (debounced)', fakeAsync(() => {
+            const input = searchInput();
+            const textarea = nativeTextarea()!;
+            expect(input).toBeTruthy();
+            expect(textarea).toBeTruthy();
+
+            input.focus();
+            expect(document.activeElement).toBe(input);
+
+            spectator.typeInElement('com', input);
+            tick(SEARCH_DEBOUNCE_MS);
+            spectator.detectChanges();
+
+            expect(component.matchCount()).toBe(3);
+            expect(document.activeElement).toBe(input);
+        }));
+
+        it('should pre-select the first match on the textarea while typing without focusing it', fakeAsync(() => {
+            const input = searchInput();
+            const textarea = nativeTextarea()!;
+
+            input.focus();
+            spectator.typeInElement('com', input);
+            tick(SEARCH_DEBOUNCE_MS);
+            spectator.detectChanges();
+
+            expect(document.activeElement).toBe(input);
+            const firstStart = component.matchPositions()[0];
+            expect(textarea.selectionStart).toBe(firstStart);
+            expect(textarea.selectionEnd).toBe(firstStart + 'com'.length);
+        }));
+
+        it('should move focus to the textarea on next-match navigation', fakeAsync(() => {
+            const input = searchInput();
+            const textarea = nativeTextarea()!;
+
+            input.focus();
+            spectator.typeInElement('com', input);
+            tick(SEARCH_DEBOUNCE_MS);
+            spectator.detectChanges();
+
+            component.nextMatch();
+
+            expect(document.activeElement).toBe(textarea);
+            expect(component.currentMatchIndex()).toBe(1);
+            const secondStart = component.matchPositions()[1];
+            expect(textarea.selectionStart).toBe(secondStart);
+            expect(textarea.selectionEnd).toBe(secondStart + 'com'.length);
+        }));
+
+        it('should move focus to the textarea on prev-match navigation', fakeAsync(() => {
+            const input = searchInput();
+            const textarea = nativeTextarea()!;
+
+            input.focus();
+            spectator.typeInElement('com', input);
+            tick(SEARCH_DEBOUNCE_MS);
+            spectator.detectChanges();
+
+            component.prevMatch();
+
+            expect(document.activeElement).toBe(textarea);
+            expect(component.currentMatchIndex()).toBe(component.matchCount() - 1);
+        }));
+
+        it('should leave focus untouched when the query has no matches', fakeAsync(() => {
+            const input = searchInput();
+
+            input.focus();
+            spectator.typeInElement('does-not-exist', input);
+            tick(SEARCH_DEBOUNCE_MS);
+            spectator.detectChanges();
+
+            expect(component.matchCount()).toBe(0);
+            expect(document.activeElement).toBe(input);
+        }));
     });
 
     describe('save', () => {

--- a/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.ts
+++ b/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.ts
@@ -115,13 +115,13 @@ export class DotPluginsExtraPackagesComponent {
     nextMatch(): void {
         const next = (this.currentMatchIndex() + 1) % this.matchCount();
         this.currentMatchIndex.set(next);
-        this.#scrollToMatch(next);
+        this.#scrollToMatch(next, { focus: true });
     }
 
     prevMatch(): void {
         const prev = (this.currentMatchIndex() - 1 + this.matchCount()) % this.matchCount();
         this.currentMatchIndex.set(prev);
-        this.#scrollToMatch(prev);
+        this.#scrollToMatch(prev, { focus: true });
     }
 
     save(): void {
@@ -180,8 +180,12 @@ export class DotPluginsExtraPackagesComponent {
             });
     }
 
-    /** Focuses the textarea, selects the match at `index`, and scrolls to center it. */
-    #scrollToMatch(index: number): void {
+    /**
+     * Selects the match at `index` and scrolls to center it. Focus is only moved to the
+     * textarea when `focus: true` is passed (explicit ▲/▼ navigation); the search-as-you-type
+     * path must leave focus on the search input so further keystrokes don't edit the textarea.
+     */
+    #scrollToMatch(index: number, { focus = false }: { focus?: boolean } = {}): void {
         const positions = this.matchPositions();
         const textarea = this.textareaRef()?.nativeElement;
         if (!textarea || positions.length === 0) return;
@@ -189,7 +193,7 @@ export class DotPluginsExtraPackagesComponent {
         const start = positions[index];
         const end = start + this.searchQuery().length;
 
-        textarea.focus();
+        if (focus) textarea.focus();
         textarea.setSelectionRange(start, end);
         textarea.scrollTop = this.#scrollTopForChar(textarea, start);
     }

--- a/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.ts
+++ b/core-web/libs/portlets/dot-plugins/src/lib/dot-plugins-extra-packages/dot-plugins-extra-packages.component.ts
@@ -35,7 +35,7 @@ import { DotMessagePipe } from '@dotcms/ui';
 export const EXTRA_PACKAGES_RESET_RESULT = 'restart' as const;
 
 /** Debounce delay (ms) before scrolling to a match while the user is typing. */
-const SEARCH_DEBOUNCE_MS = 500;
+export const SEARCH_DEBOUNCE_MS = 500;
 
 @Component({
     selector: 'dot-plugins-extra-packages',


### PR DESCRIPTION
## Summary

- The **Plugins → Exported Packages** search field was silently moving focus to the editable package-list `<textarea>` ~500 ms after typing (the debounce). Any keystrokes after the debounce fired went into the textarea instead of the search box — and the textarea is the live exported-packages config, so unnoticed edits can corrupt it (a known cause of OSGi plugin-load failures).
- `#scrollToMatch()` in `dot-plugins-extra-packages.component.ts` was calling `textarea.focus()` unconditionally. That call is needed for the explicit ▲/▼ next/prev navigation but not for the search-as-you-type path.
- This PR adds an opt-in `{ focus }` flag to `#scrollToMatch`. The debounced typing path now leaves focus on the search input; only `nextMatch()` / `prevMatch()` pass `focus: true`. The selection range is still set during typing so the match becomes visible the moment the user navigates with ▲/▼.

Fixes #36214

## Acceptance criteria

- [x] Typing in the Exported Packages search field does not move focus out of the search input
- [x] The matched text is still scrolled into view
- [x] Focus moves to the textarea only on explicit ▲/▼ (next/prev) match navigation
- [x] Regression tests cover the search-as-you-type focus behavior

## Test plan

- [ ] Manual QA: open **Plugins → Exported Packages**, type in the search box, confirm focus stays in the input and that ▲/▼ still navigates and selects matches in the textarea


This PR fixes: #36214