### PR TITLE
chore(ci): migrate AI auto-review off sticky_namespace hack to use_sticky_comment: false

### DIFF
--- a/.github/workflows/ai_claude-orchestrator.yml
+++ b/.github/workflows/ai_claude-orchestrator.yml
@@ -177,8 +177,12 @@ jobs:
       bedrock_role_arn: ${{ vars.BEDROCK_ROLE_ARN }}
       trigger_mode: automatic
       prompt: ${{ needs.load-gpt-prompt.outputs.prompt }}
-      # Each push gets a unique SHA → unique sticky marker → new comment instead of overwrite.
-      sticky_namespace: ${{ github.sha }}
+      # Non-sticky: each commit gets its own review comment (fresh per push) instead of one
+      # auto-updating comment, preserving the full feedback→change→feedback history. Supersedes
+      # the old `sticky_namespace: ${{ github.sha }}` hack — the orchestrator now scopes the
+      # marker by head SHA itself (and includes the model id, so it's collision-safe across
+      # models). Requires ai-workflows >= v3.1.8. Set to true (or remove) for one rolling comment.
+      use_sticky_comment: false
       timeout_minutes: 20
       runner: ubuntu-latest
       enable_mention_detection: false


### PR DESCRIPTION
## Proposal

Replace the `sticky_namespace: ${{ github.sha }}` workaround in the `ai-automatic-review` job with the first-class `use_sticky_comment: false` input (dotCMS/ai-workflows v3.1.8, already on the pinned `@v3`).

```diff
-      # Each push gets a unique SHA → unique sticky marker → new comment instead of overwrite.
-      sticky_namespace: ${{ github.sha }}
+      use_sticky_comment: false
```

## Why

Day-to-day behavior is **equivalent** — both produce a fresh review comment per commit with the in-progress placeholder reconciled to final. This isn't a behavior change for the common path; it's a clarity + correctness cleanup:

- **`sticky_namespace` is the wrong tool.** Its purpose is to separate *different review jobs* on one PR. Overloading it with the commit SHA to defeat stickiness is a hack; `use_sticky_comment: false` says what we actually mean.
- **More correct on re-runs.** The hack keys on `github.sha` (the PR *merge* commit, which changes when `main` advances even if the PR head doesn't), so re-running a review after a base move posts a duplicate comment for the same code. The flag keys on the PR **head** SHA → updates in place.
- **Collision-safe for multi-model review (the main motivator).** We're moving toward multiple review models. The flag's marker includes the **model id** (`...:<model>:<sha>`), so each model gets its own comment lane. The hack's marker is just the SHA, so two models reviewing the same commit would clobber each other's comment. (If we instead decide each model should share one lane, that's a deliberate choice we can make then — the point is the flag gives us the safe default.)

## Verification

E2E-tested on the DeepSeek R1 (bedrock-generic) path in `core-workflow-test` (throwaway PR, now closed): two commits → two distinct final review comments, each in-progress placeholder reconciled in place, zero orphans.

## Related (not fixed here)

A cancelled review run can still strand a "🔄 in progress" comment under this job's `cancel-in-progress: true` concurrency — that's an upstream gap in the bedrock-generic executor, fixed separately in dotCMS/ai-workflows#50. It affects the hack and the flag equally, so it's orthogonal to this migration.

Closes: #36301

🤖 Generated with [Claude Code](https://claude.com/claude-code)
