### PR TITLE
fix(ai-review): stop models wrapping the review in a code block

### DIFF
--- a/.github/prompts/gpt-auto-review.md
+++ b/.github/prompts/gpt-auto-review.md
@@ -19,9 +19,8 @@ Check for:
 
 ## Output format
 
-Always use this exact structure (omit a section entirely if it has no entries):
+Respond with raw GitHub-flavored markdown directly in your reply. Do **not** wrap the whole response in a code block or triple backticks — the sections below are the literal output, not an example to fence. Use this exact structure (omit a section entirely if it has no entries):
 
-```
 #### New Issues
 - 🔴 Critical: `path/file:line` — what's wrong and why it matters
 - 🟠 High: `path/file:line` — what's wrong and why it matters
@@ -32,7 +31,6 @@ Always use this exact structure (omit a section entirely if it has no entries):
 
 #### Resolved
 - ✅ `path/file:line` — brief reason it's now fixed or no longer applicable
-```
 
 If the PR is clean with no prior findings, write: `No issues found.`
 


### PR DESCRIPTION
## Problem
The Qwen reviewer rendered its entire review inside a fenced code block — see [example on #36076](https://github.com/dotCMS/core/pull/36076#issuecomment-4785492100). The `## Output format` section of `gpt-auto-review.md` showed the expected structure *inside* triple backticks as an example, and the model copied that fence literally around its whole output, so it rendered as raw text instead of markdown.

## Fix
Remove the example fence and add an explicit instruction to reply in raw GitHub-flavored markdown, not wrapped in a code block. Model-agnostic — no change for models that were already formatting correctly (Opus, R1, etc.).

Fixes: #36131

🤖 Generated with [Claude Code](https://claude.com/claude-code)