### PR TITLE
fix(dotAI): handle integer values in embedding JSON response

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/ai/api/EmbeddingsAPIImpl.java
@@ -496,8 +496,7 @@ class EmbeddingsAPIImpl implements EmbeddingsAPI {
         try {
             return (List<Float>) data.getJSONArray(AiKeys.EMBEDDING).stream().map(val -> {
 
-                final Double x = (Double) val;
-                return x.floatValue();
+                return ((Number) val).floatValue();
 
             }).collect(Collectors.toList());
         } catch (final JSONException e) {


### PR DESCRIPTION
## Problem

Semantic search and streaming chat fail with a `ClassCastException` when using Amazon Titan Embed Text V1:

```
class java.lang.Integer cannot be cast to class java.lang.Double
at com.dotcms.ai.api.EmbeddingsAPIImpl.lambda$getEmbeddingsFromJSON$0(EmbeddingsAPIImpl.java:499)
```

The embedding call succeeds (Bedrock returns the vector), but `getEmbeddingsFromJSON` was casting each JSON array element directly to `Double`. JSON parsers (Jackson/org.json) deserialize whole-number values like `0` as `Integer`, not `Double`. OpenAI always returns floats so this was never triggered before; Titan V1 vectors contain integer-valued components.

## Fix

Replace the direct `(Double)` cast with `((Number) val).floatValue()`, which handles `Integer`, `Double`, `Float`, and any other numeric type the JSON parser may return.

## Links

Fixes: [#35334](https://github.com/dotCMS/core/issues/35334)