### PR TITLE
feat(content-drive): add FILEASSET base-type → content-type resolution (#36279)

### DIFF
--- a/core-web/libs/data-access/src/lib/dot-upload-file/dot-upload-file.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-upload-file/dot-upload-file.service.spec.ts
@@ -69,20 +69,53 @@ describe('DotUploadFileService', () => {
             );
         });
 
-        it('should fire the given content type when one is provided', () => {
-            dotWorkflowActionsFireService.newContentlet.mockReturnValueOnce(
+    });
+
+    describe('uploadFileByBaseType', () => {
+        it('should upload a file resolving the content type from the given base type', () => {
+            dotWorkflowActionsFireService.newContentletByBaseType.mockReturnValueOnce(
                 of({ entity: { identifier: 'test' } })
             );
 
             const file = new File([''], 'test.png', { type: 'image/png' });
 
-            spectator.service.uploadDotAsset(file, { hostFolder: '123' }, 'FileAsset').subscribe();
+            spectator.service.uploadFileByBaseType(file, 'FILEASSET').subscribe();
 
-            expect(dotWorkflowActionsFireService.newContentlet).toHaveBeenCalledWith(
-                'FileAsset',
+            expect(dotWorkflowActionsFireService.newContentletByBaseType).toHaveBeenCalledWith(
+                'FILEASSET',
                 expect.anything(),
                 expect.anything()
             );
+        });
+
+        it('should pass the base type and extra data through to the fire service', () => {
+            dotWorkflowActionsFireService.newContentletByBaseType.mockReturnValueOnce(
+                of({ entity: { identifier: 'test' } })
+            );
+
+            const file = new File([''], 'test.png', { type: 'image/png' });
+
+            spectator.service
+                .uploadFileByBaseType(file, 'DOTASSET', { hostFolder: '123' })
+                .subscribe();
+
+            expect(dotWorkflowActionsFireService.newContentletByBaseType).toHaveBeenCalledWith(
+                'DOTASSET',
+                expect.objectContaining({ hostFolder: '123' }),
+                expect.anything()
+            );
+        });
+
+        it('should not pass a contentType to the fire service', () => {
+            dotWorkflowActionsFireService.newContentletByBaseType.mockReturnValueOnce(
+                of({ entity: { identifier: 'test' } })
+            );
+
+            const file = new File([''], 'test.png', { type: 'image/png' });
+
+            spectator.service.uploadFileByBaseType(file, 'FILEASSET').subscribe();
+
+            expect(dotWorkflowActionsFireService.newContentlet).not.toHaveBeenCalled();
         });
     });
 });

--- a/core-web/libs/data-access/src/lib/dot-upload-file/dot-upload-file.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-upload-file/dot-upload-file.service.ts
@@ -107,29 +107,61 @@ export class DotUploadFileService {
      * @param file The file to be uploaded or the asset id.
      * @param extraData Additional data to be included in the contentlet object. This will be merged with
      * the base contentlet data in the request body.
-     * @param contentType The content type variable to create the contentlet as. Defaults to `dotAsset`;
-     * pass `FileAsset` (or another binary content type) to upload as a different type.
      * @returns An observable that resolves to the created contentlet.
      */
     uploadDotAsset(
         file: File | string,
-        extraData?: DotActionRequestOptions['data'],
-        contentType = 'dotAsset'
+        extraData?: DotActionRequestOptions['data']
     ): Observable<DotCMSContentlet> {
         if (file instanceof File) {
             const formData = new FormData();
             formData.append('file', file);
 
             return this.#workflowActionsFireService.newContentlet<DotCMSContentlet>(
-                contentType,
+                'dotAsset',
                 { file: file.name, ...extraData },
                 formData
             );
         }
 
-        return this.#workflowActionsFireService.newContentlet<DotCMSContentlet>(contentType, {
+        return this.#workflowActionsFireService.newContentlet<DotCMSContentlet>('dotAsset', {
             asset: file
         });
+    }
+
+    /**
+     * Uploads a file by resolving the content type from a base type instead of an explicit content
+     * type. The base type is sent to the backend, which resolves the matching content type for it
+     * (e.g. `FILEASSET` → File Asset, `DOTASSET` → dotAsset).
+     *
+     * @param file The file to be uploaded or the asset id.
+     * @param baseType The base type to create the contentlet as (e.g. `FILEASSET`, `DOTASSET`).
+     * @param extraData Additional data to be included in the contentlet object. This will be merged
+     * with the base contentlet data in the request body.
+     * @returns An observable that resolves to the created contentlet.
+     */
+    uploadFileByBaseType(
+        file: File | string,
+        baseType: string,
+        extraData?: DotActionRequestOptions['data']
+    ): Observable<DotCMSContentlet> {
+        if (file instanceof File) {
+            const formData = new FormData();
+            formData.append('file', file);
+
+            return this.#workflowActionsFireService.newContentletByBaseType<DotCMSContentlet>(
+                baseType,
+                { file: file.name, ...extraData },
+                formData
+            );
+        }
+
+        return this.#workflowActionsFireService.newContentletByBaseType<DotCMSContentlet>(
+            baseType,
+            {
+                asset: file
+            }
+        );
     }
 
     /**

--- a/core-web/libs/data-access/src/lib/dot-workflow-actions-fire/dot-workflow-actions-fire.service.spec.ts
+++ b/core-web/libs/data-access/src/lib/dot-workflow-actions-fire/dot-workflow-actions-fire.service.spec.ts
@@ -104,6 +104,66 @@ describe('DotWorkflowActionsFireService', () => {
         });
     });
 
+    it('should fire NEW with a baseType (no contentType) in the body', (done) => {
+        const mockResult = { name: 'test' };
+
+        const requestBody = {
+            contentlet: {
+                baseType: 'FILEASSET',
+                name: 'Test'
+            }
+        };
+
+        spectator.service
+            .newContentletByBaseType('FILEASSET', { name: 'Test' })
+            .subscribe((res) => {
+                expect(res).toEqual([mockResult]);
+                done();
+            });
+
+        const req = spectator.expectOne(
+            '/api/v1/workflow/actions/default/fire/NEW',
+            HttpMethod.PUT
+        );
+
+        expect(req.request.body).toEqual(requestBody);
+        expect(req.request.body.contentlet.contentType).toBeUndefined();
+        expect(req.request.headers).toEqual(defaultHeaders);
+
+        req.flush({ entity: [mockResult] });
+    });
+
+    it('should fire NEW with a baseType and FormData', (done) => {
+        const mockResult = { name: 'test' };
+        const file = new File(['hello'], 'hello.txt', { type: 'text/plain' });
+
+        const requestBody = {
+            contentlet: {
+                baseType: 'FILEASSET',
+                file: file.name
+            }
+        };
+
+        const formData = new FormData();
+        formData.append('file', file);
+
+        spectator.service
+            .newContentletByBaseType('FILEASSET', { file: file.name }, formData)
+            .subscribe((res) => {
+                expect(res).toEqual([mockResult]);
+                done();
+            });
+
+        const req = spectator.expectOne(
+            '/api/v1/workflow/actions/default/fire/NEW',
+            HttpMethod.PUT
+        );
+
+        expect(req.request.body.get('json')).toEqual(JSON.stringify(requestBody));
+
+        req.flush({ entity: [mockResult] });
+    });
+
     it('should EDIT and return the updated contentlet', (done) => {
         const mockResult = {
             inode: '123'

--- a/core-web/libs/data-access/src/lib/dot-workflow-actions-fire/dot-workflow-actions-fire.service.ts
+++ b/core-web/libs/data-access/src/lib/dot-workflow-actions-fire/dot-workflow-actions-fire.service.ts
@@ -138,6 +138,26 @@ export class DotWorkflowActionsFireService {
     }
 
     /**
+     * Fire a "NEW" action resolving the content type from a base type instead of an explicit
+     * content type. The base type is sent in the contentlet body (no `contentType`), so the
+     * backend resolves the matching content type for that base type (e.g. `FILEASSET`, `DOTASSET`).
+     *
+     * @template T
+     * @param {string} baseType the base type to resolve the content type from
+     * @param {{ [key: string]: string }} data
+     * @param {FormData} [formData]
+     * @returns Observable<T>
+     * @memberof DotWorkflowActionsFireService
+     */
+    newContentletByBaseType<T>(
+        baseType: string,
+        data: { [key: string]: string },
+        formData?: FormData
+    ): Observable<T> {
+        return this.request<T>({ data: { baseType, ...data }, action: ActionToFire.NEW, formData });
+    }
+
+    /**
      * Fire a "PUBLISH" action over the content type received with the specified data
      *
      * @template T

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-dialog-upload-selector/dot-content-drive-dialog-upload-selector.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-dialog-upload-selector/dot-content-drive-dialog-upload-selector.component.html
@@ -1,20 +1,20 @@
 <form class="form">
     <div class="flex flex-col gap-4 py-2">
-        @for (option of options; track option.contentType) {
+        @for (option of options; track option.baseType) {
             <label
                 class="flex cursor-pointer items-center gap-4 rounded-lg border p-4 transition-colors"
                 [class]="
-                    $selectedType() === option.contentType
+                    $selectedType() === option.baseType
                         ? 'border-primary bg-primary/5'
                         : 'border-gray-300 hover:border-primary'
                 "
-                [attr.data-testid]="'upload-selector-option-' + option.contentType">
+                [attr.data-testid]="'upload-selector-option-' + option.baseType">
                 <p-radiobutton
                     name="uploadType"
-                    [value]="option.contentType"
+                    [value]="option.baseType"
                     [ngModel]="$selectedType()"
                     (ngModelChange)="$selectedType.set($event)"
-                    [inputId]="option.contentType" />
+                    [inputId]="option.baseType" />
                 <span class="flex flex-col gap-1">
                     <span class="flex items-center gap-2">
                         <i

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-dialog-upload-selector/dot-content-drive-dialog-upload-selector.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-dialog-upload-selector/dot-content-drive-dialog-upload-selector.component.spec.ts
@@ -65,7 +65,7 @@ describe('DotContentDriveDialogUploadSelectorComponent', () => {
 
     const chooseFile = () => {
         const radios = spectator.debugElement.queryAll(By.css('p-radiobutton'));
-        spectator.triggerEventHandler(radios[1], 'ngModelChange', 'FileAsset');
+        spectator.triggerEventHandler(radios[1], 'ngModelChange', 'FILEASSET');
         spectator.detectChanges();
     };
 
@@ -76,13 +76,13 @@ describe('DotContentDriveDialogUploadSelectorComponent', () => {
 
     describe('rendering', () => {
         it('should render both upload options', () => {
-            expect(spectator.query(byTestId('upload-selector-option-dotAsset'))).toBeTruthy();
-            expect(spectator.query(byTestId('upload-selector-option-FileAsset'))).toBeTruthy();
+            expect(spectator.query(byTestId('upload-selector-option-DOTASSET'))).toBeTruthy();
+            expect(spectator.query(byTestId('upload-selector-option-FILEASSET'))).toBeTruthy();
         });
 
         it('should mark only the Asset option as recommended', () => {
             const recommended = spectator.queryAll(byTestId('upload-selector-recommended'));
-            const assetOption = spectator.query(byTestId('upload-selector-option-dotAsset'));
+            const assetOption = spectator.query(byTestId('upload-selector-option-DOTASSET'));
 
             expect(recommended.length).toBe(1);
             expect(
@@ -100,7 +100,7 @@ describe('DotContentDriveDialogUploadSelectorComponent', () => {
     });
 
     describe('selection', () => {
-        it('should emit the dotAsset selection with the folder and files when Continue is clicked', () => {
+        it('should emit the DOTASSET selection with the folder and files when Continue is clicked', () => {
             const files = { length: 0 } as FileList;
             spectator.setInput('files', files);
             spectator.detectChanges();
@@ -112,19 +112,19 @@ describe('DotContentDriveDialogUploadSelectorComponent', () => {
 
             expect(emitted).toEqual({
                 targetFolder: TARGET_FOLDER,
-                contentType: 'dotAsset',
+                baseType: 'DOTASSET',
                 files
             });
         });
 
-        it('should emit the FileAsset selection when File is chosen', () => {
+        it('should emit the FILEASSET selection when File is chosen', () => {
             let emitted: DotContentDriveUploadSelection | undefined;
             spectator.component.selectUploadType.subscribe((selection) => (emitted = selection));
 
             chooseFile();
             clickContinue();
 
-            expect(emitted?.contentType).toBe('FileAsset');
+            expect(emitted?.baseType).toBe('FILEASSET');
             expect(emitted?.targetFolder).toEqual(TARGET_FOLDER);
         });
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-dialog-upload-selector/dot-content-drive-dialog-upload-selector.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dialogs/dot-content-drive-dialog-upload-selector/dot-content-drive-dialog-upload-selector.component.ts
@@ -17,17 +17,17 @@ import { DotMessagePipe } from '@dotcms/ui';
 
 import { UPLOAD_SELECTOR_OPTIONS } from '../../../shared/constants';
 import {
-    DotContentDriveUploadContentType,
+    DotContentDriveUploadBaseType,
     DotContentDriveUploadSelection
 } from '../../../shared/models';
 import { DotContentDriveStore } from '../../../store/dot-content-drive.store';
 
 /**
  * Content Drive upload dialog body: lets the user choose whether the upload is created as an
- * Asset (`dotAsset`) or a File (`FileAsset`) before the upload runs.
+ * Asset (`DOTASSET`) or a File (`FILEASSET`) before the upload runs.
  *
  * On confirm it emits the full {@link DotContentDriveUploadSelection} (target folder + chosen
- * content type + the files, when already known) so the shell can trigger the upload directly.
+ * base type + the files, when already known) so the shell can trigger the upload directly.
  * Carrying the folder forward also feeds the future "remember preference per folder" feature
  * (epic #35436) without reshaping this contract.
  */
@@ -46,26 +46,26 @@ export class DotContentDriveDialogUploadSelectorComponent {
     /** Files to upload — present for the drag-and-drop flow, absent for the Upload-button flow. */
     $files = input<FileList | undefined>(undefined, { alias: 'files' });
 
-    /** Emits the chosen content type plus the upload context when the user confirms. */
+    /** Emits the chosen base type plus the upload context when the user confirms. */
     selectUploadType = output<DotContentDriveUploadSelection>();
 
     protected readonly options = UPLOAD_SELECTOR_OPTIONS;
 
-    /** Currently selected content type variable. Defaults to the first (recommended) option. */
-    protected readonly $selectedType = signal<DotContentDriveUploadContentType>(
-        UPLOAD_SELECTOR_OPTIONS[0].contentType
+    /** Currently selected base type. Defaults to the first (recommended) option. */
+    protected readonly $selectedType = signal<DotContentDriveUploadBaseType>(
+        UPLOAD_SELECTOR_OPTIONS[0].baseType
     );
     protected readonly $canContinue = computed(() => !!this.$selectedType());
 
     protected onContinue(): void {
-        const contentType = this.$selectedType();
-        if (!contentType) {
+        const baseType = this.$selectedType();
+        if (!baseType) {
             return;
         }
 
         this.selectUploadType.emit({
             targetFolder: this.$targetFolder(),
-            contentType,
+            baseType,
             files: this.$files()
         });
     }

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
@@ -107,7 +107,7 @@ describe('DotContentDriveShellComponent', () => {
                 getFolders: jest.fn().mockReturnValue(of([]))
             }),
             mockProvider(DotUploadFileService, {
-                uploadDotAsset: jest.fn().mockReturnValue(of({}))
+                uploadFileByBaseType: jest.fn().mockReturnValue(of({}))
             }),
             provideHttpClient(),
             mockProvider(DotMessageService, {
@@ -702,7 +702,7 @@ describe('DotContentDriveShellComponent', () => {
                 header: expect.any(String),
                 payload: { targetFolder: TARGET_FOLDER_DATA }
             });
-            expect(uploadService.uploadDotAsset).not.toHaveBeenCalled();
+            expect(uploadService.uploadFileByBaseType).not.toHaveBeenCalled();
         });
 
         it('should open the upload selector carrying the files when the dropzone emits uploadFiles', () => {
@@ -719,7 +719,7 @@ describe('DotContentDriveShellComponent', () => {
                 header: expect.any(String),
                 payload: { targetFolder: TARGET_FOLDER_DATA, files }
             });
-            expect(uploadService.uploadDotAsset).not.toHaveBeenCalled();
+            expect(uploadService.uploadFileByBaseType).not.toHaveBeenCalled();
         });
 
         it('should open the upload selector carrying the files when the sidebar emits uploadFiles', () => {
@@ -736,7 +736,7 @@ describe('DotContentDriveShellComponent', () => {
                 header: expect.any(String),
                 payload: { targetFolder: TARGET_FOLDER_DATA, files }
             });
-            expect(uploadService.uploadDotAsset).not.toHaveBeenCalled();
+            expect(uploadService.uploadFileByBaseType).not.toHaveBeenCalled();
         });
 
         it('should render the upload selector dialog body when the dialog type is UPLOAD_SELECTOR', () => {
@@ -757,64 +757,79 @@ describe('DotContentDriveShellComponent', () => {
         });
 
         it('should upload the file as dotAsset when Asset is selected', () => {
-            uploadService.uploadDotAsset.mockReturnValue(of({} as DotCMSContentlet));
+            uploadService.uploadFileByBaseType.mockReturnValue(of({} as DotCMSContentlet));
             const file = createFile();
 
             selectUploadType({
                 targetFolder: TARGET_FOLDER_DATA,
                 files: createFileList([file]),
-                contentType: 'dotAsset'
+                baseType: 'DOTASSET'
             });
 
-            expect(uploadService.uploadDotAsset).toHaveBeenCalledWith(
-                file,
-                { hostFolder: TARGET_FOLDER_DATA.id, indexPolicy: 'WAIT_FOR' },
-                'dotAsset'
-            );
+            expect(uploadService.uploadFileByBaseType).toHaveBeenCalledWith(file, 'DOTASSET', {
+                hostFolder: TARGET_FOLDER_DATA.id,
+                indexPolicy: 'WAIT_FOR'
+            });
         });
 
         it('should upload the file as FileAsset when File is selected', () => {
-            uploadService.uploadDotAsset.mockReturnValue(of({} as DotCMSContentlet));
+            uploadService.uploadFileByBaseType.mockReturnValue(of({} as DotCMSContentlet));
             const file = createFile();
 
             selectUploadType({
                 targetFolder: TARGET_FOLDER_DATA,
                 files: createFileList([file]),
-                contentType: 'FileAsset'
+                baseType: 'FILEASSET'
             });
 
-            expect(uploadService.uploadDotAsset).toHaveBeenCalledWith(
-                file,
-                { hostFolder: TARGET_FOLDER_DATA.id, indexPolicy: 'WAIT_FOR' },
-                'FileAsset'
-            );
+            expect(uploadService.uploadFileByBaseType).toHaveBeenCalledWith(file, 'FILEASSET', {
+                hostFolder: TARGET_FOLDER_DATA.id,
+                indexPolicy: 'WAIT_FOR'
+            });
         });
 
-        it('should upload to the site root when no folder is selected', () => {
-            uploadService.uploadDotAsset.mockReturnValue(of({} as DotCMSContentlet));
+        it('should upload to the current site root when no folder is selected', () => {
+            uploadService.uploadFileByBaseType.mockReturnValue(of({} as DotCMSContentlet));
+            store.currentSite.mockReturnValue(MOCK_SITES[0]);
             const file = createFile();
 
             selectUploadType({
                 targetFolder: undefined,
                 files: createFileList([file]),
-                contentType: 'dotAsset'
+                baseType: 'DOTASSET'
             });
 
-            expect(uploadService.uploadDotAsset).toHaveBeenCalledWith(
-                file,
-                { hostFolder: '', indexPolicy: 'WAIT_FOR' },
-                'dotAsset'
-            );
+            expect(uploadService.uploadFileByBaseType).toHaveBeenCalledWith(file, 'DOTASSET', {
+                hostFolder: MOCK_SITES[0].identifier,
+                indexPolicy: 'WAIT_FOR'
+            });
+        });
+
+        it('should fall back to empty hostFolder when no folder and no current site', () => {
+            uploadService.uploadFileByBaseType.mockReturnValue(of({} as DotCMSContentlet));
+            store.currentSite.mockReturnValue(undefined);
+            const file = createFile();
+
+            selectUploadType({
+                targetFolder: undefined,
+                files: createFileList([file]),
+                baseType: 'FILEASSET'
+            });
+
+            expect(uploadService.uploadFileByBaseType).toHaveBeenCalledWith(file, 'FILEASSET', {
+                hostFolder: '',
+                indexPolicy: 'WAIT_FOR'
+            });
         });
 
         it('should show the info message when the upload starts', () => {
-            uploadService.uploadDotAsset.mockReturnValue(of({} as DotCMSContentlet));
+            uploadService.uploadFileByBaseType.mockReturnValue(of({} as DotCMSContentlet));
             const addSpy = jest.spyOn(messageService, 'add');
 
             selectUploadType({
                 targetFolder: TARGET_FOLDER_DATA,
                 files: createFileList([createFile()]),
-                contentType: 'dotAsset'
+                baseType: 'DOTASSET'
             });
 
             expect(addSpy).toHaveBeenCalledWith({
@@ -825,7 +840,7 @@ describe('DotContentDriveShellComponent', () => {
         });
 
         it('should show a success message after a successful upload', () => {
-            uploadService.uploadDotAsset.mockReturnValue(
+            uploadService.uploadFileByBaseType.mockReturnValue(
                 of({ title: 'test.jpg', contentType: 'image/jpeg' } as DotCMSContentlet)
             );
             const addSpy = jest.spyOn(messageService, 'add');
@@ -833,7 +848,7 @@ describe('DotContentDriveShellComponent', () => {
             selectUploadType({
                 targetFolder: TARGET_FOLDER_DATA,
                 files: createFileList([createFile()]),
-                contentType: 'dotAsset'
+                baseType: 'DOTASSET'
             });
 
             expect(addSpy).toHaveBeenCalledWith({
@@ -845,7 +860,7 @@ describe('DotContentDriveShellComponent', () => {
         });
 
         it('should show an error message on upload failure', () => {
-            uploadService.uploadDotAsset.mockReturnValue(
+            uploadService.uploadFileByBaseType.mockReturnValue(
                 throwError(() => new Error('Upload failed'))
             );
             const addSpy = jest.spyOn(messageService, 'add');
@@ -853,7 +868,7 @@ describe('DotContentDriveShellComponent', () => {
             selectUploadType({
                 targetFolder: TARGET_FOLDER_DATA,
                 files: createFileList([createFile()]),
-                contentType: 'dotAsset'
+                baseType: 'DOTASSET'
             });
 
             expect(addSpy).toHaveBeenCalledWith({
@@ -865,7 +880,7 @@ describe('DotContentDriveShellComponent', () => {
         });
 
         it('should show the server error message on failure with an errors payload', () => {
-            uploadService.uploadDotAsset.mockReturnValue(
+            uploadService.uploadFileByBaseType.mockReturnValue(
                 throwError(() => ({ error: { errors: [{ message: 'Upload failed' }] } }))
             );
             const addSpy = jest.spyOn(messageService, 'add');
@@ -873,7 +888,7 @@ describe('DotContentDriveShellComponent', () => {
             selectUploadType({
                 targetFolder: TARGET_FOLDER_DATA,
                 files: createFileList([createFile()]),
-                contentType: 'dotAsset'
+                baseType: 'DOTASSET'
             });
 
             expect(addSpy).toHaveBeenCalledWith({
@@ -885,7 +900,7 @@ describe('DotContentDriveShellComponent', () => {
         });
 
         it('should warn and upload only the first file when multiple files are selected', () => {
-            uploadService.uploadDotAsset.mockReturnValue(of({} as DotCMSContentlet));
+            uploadService.uploadFileByBaseType.mockReturnValue(of({} as DotCMSContentlet));
             const addSpy = jest.spyOn(messageService, 'add');
             const file1 = createFile('test1.jpg');
             const file2 = createFile('test2.jpg');
@@ -893,7 +908,7 @@ describe('DotContentDriveShellComponent', () => {
             selectUploadType({
                 targetFolder: TARGET_FOLDER_DATA,
                 files: createFileList([file1, file2]),
-                contentType: 'dotAsset'
+                baseType: 'DOTASSET'
             });
 
             expect(addSpy).toHaveBeenCalledWith({
@@ -902,12 +917,11 @@ describe('DotContentDriveShellComponent', () => {
                 detail: expect.any(String),
                 life: WARNING_MESSAGE_LIFE
             });
-            expect(uploadService.uploadDotAsset).toHaveBeenCalledTimes(1);
-            expect(uploadService.uploadDotAsset).toHaveBeenCalledWith(
-                file1,
-                { hostFolder: TARGET_FOLDER_DATA.id, indexPolicy: 'WAIT_FOR' },
-                'dotAsset'
-            );
+            expect(uploadService.uploadFileByBaseType).toHaveBeenCalledTimes(1);
+            expect(uploadService.uploadFileByBaseType).toHaveBeenCalledWith(file1, 'DOTASSET', {
+                hostFolder: TARGET_FOLDER_DATA.id,
+                indexPolicy: 'WAIT_FOR'
+            });
         });
     });
 
@@ -917,17 +931,17 @@ describe('DotContentDriveShellComponent', () => {
         });
 
         it('should open the file picker after a type is chosen, then upload with that type', () => {
-            uploadService.uploadDotAsset.mockReturnValue(of({} as DotCMSContentlet));
+            uploadService.uploadFileByBaseType.mockReturnValue(of({} as DotCMSContentlet));
             const file = createFile();
 
             const fileInput = spectator.query('input[type="file"]') as HTMLInputElement;
             const clickSpy = jest.spyOn(fileInput, 'click');
 
             // Button flow: dialog opens with NO files in the payload.
-            selectUploadType({ targetFolder: TARGET_FOLDER_DATA, contentType: 'FileAsset' });
+            selectUploadType({ targetFolder: TARGET_FOLDER_DATA, baseType: 'FILEASSET' });
 
             expect(clickSpy).toHaveBeenCalled();
-            expect(uploadService.uploadDotAsset).not.toHaveBeenCalled();
+            expect(uploadService.uploadFileByBaseType).not.toHaveBeenCalled();
 
             Object.defineProperty(fileInput, 'files', {
                 value: [file],
@@ -936,17 +950,16 @@ describe('DotContentDriveShellComponent', () => {
             });
             spectator.triggerEventHandler('input[type="file"]', 'change', { target: fileInput });
 
-            expect(uploadService.uploadDotAsset).toHaveBeenCalledWith(
-                file,
-                { hostFolder: TARGET_FOLDER_DATA.id, indexPolicy: 'WAIT_FOR' },
-                'FileAsset'
-            );
+            expect(uploadService.uploadFileByBaseType).toHaveBeenCalledWith(file, 'FILEASSET', {
+                hostFolder: TARGET_FOLDER_DATA.id,
+                indexPolicy: 'WAIT_FOR'
+            });
         });
 
         it('should not upload when the file picker is dismissed without files', () => {
             const fileInput = spectator.query('input[type="file"]') as HTMLInputElement;
 
-            selectUploadType({ targetFolder: TARGET_FOLDER_DATA, contentType: 'dotAsset' });
+            selectUploadType({ targetFolder: TARGET_FOLDER_DATA, baseType: 'DOTASSET' });
 
             Object.defineProperty(fileInput, 'files', {
                 value: [],
@@ -955,7 +968,7 @@ describe('DotContentDriveShellComponent', () => {
             });
             spectator.triggerEventHandler('input[type="file"]', 'change', { target: fileInput });
 
-            expect(uploadService.uploadDotAsset).not.toHaveBeenCalled();
+            expect(uploadService.uploadFileByBaseType).not.toHaveBeenCalled();
         });
     });
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
@@ -463,19 +463,19 @@ export class DotContentDriveShellComponent implements OnInit {
     protected resolveFilesUpload({
         files,
         targetFolder,
-        contentType
+        baseType
     }: DotContentDriveUploadSelection) {
         if (!files?.length) {
             return;
         }
 
         if (files.length > 1) {
-            this.uploadFiles({ files, targetFolder, contentType });
+            this.uploadFiles({ files, targetFolder, baseType });
 
             return;
         }
 
-        this.uploadFile({ files, targetFolder, contentType });
+        this.uploadFile({ files, targetFolder, baseType });
     }
 
     /**
@@ -485,7 +485,7 @@ export class DotContentDriveShellComponent implements OnInit {
      * @param {DotContentDriveUploadSelection} selection
      * @memberof DotContentDriveShellComponent
      */
-    protected uploadFiles({ files, targetFolder, contentType }: DotContentDriveUploadSelection) {
+    protected uploadFiles({ files, targetFolder, baseType }: DotContentDriveUploadSelection) {
         this.#messageService.add({
             severity: 'warn',
             summary: this.#dotMessageService.get('content-drive.work-in-progress'),
@@ -493,14 +493,14 @@ export class DotContentDriveShellComponent implements OnInit {
             life: WARNING_MESSAGE_LIFE
         });
 
-        this.uploadFile({ files, targetFolder, contentType });
+        this.uploadFile({ files, targetFolder, baseType });
     }
 
     /**
      * Uploads a file to the content drive
      * @param selection The chosen content type, target folder and files to upload
      */
-    protected uploadFile({ files, targetFolder, contentType }: DotContentDriveUploadSelection) {
+    protected uploadFile({ files, targetFolder, baseType }: DotContentDriveUploadSelection) {
         if (!files?.length) {
             return;
         }
@@ -511,31 +511,30 @@ export class DotContentDriveShellComponent implements OnInit {
             detail: this.#dotMessageService.get('content-drive.file-upload-in-progress-detail')
         });
 
-        this.uploadDotAsset(files[0], targetFolder, contentType);
+        this.uploadByBaseType(files[0], baseType, targetFolder);
     }
 
     /**
-     * Uploads a file to the content drive as the given content type (`dotAsset` or `FileAsset`).
+     * Uploads a file to the content drive resolving the content type from the given base type
+     * (`DOTASSET` for Assets, `FILEASSET` for Files).
      *
      * @protected
      * @param {File} file
+     * @param {string} baseType
      * @param {DotFolderTreeNodeData} [hostFolder]
-     * @param {string} [contentType]
      * @memberof DotContentDriveShellComponent
      */
-    protected uploadDotAsset(file: File, hostFolder?: DotFolderTreeNodeData, contentType?: string) {
+    protected uploadByBaseType(file: File, baseType: string, hostFolder?: DotFolderTreeNodeData) {
         this.#fileService
-            .uploadDotAsset(
-                file,
-                {
-                    hostFolder: hostFolder?.id ?? '',
-                    indexPolicy: 'WAIT_FOR'
-                },
-                contentType
-            )
+            .uploadFileByBaseType(file, baseType, {
+                // A folder id carries its site; at the site root (no folder) fall back to the
+                // current site identifier so the upload lands on the site being browsed, not the
+                // backend default host.
+                hostFolder: hostFolder?.id ?? this.#store.currentSite()?.identifier ?? '',
+                indexPolicy: 'WAIT_FOR'
+            })
             .subscribe({
-                // `contentType` here is the created contentlet's resolved type (from the response),
-                // distinct from the requested `contentType` parameter above.
+                // `contentType` here is the created contentlet's resolved type (from the response).
                 next: ({ title, contentType: uploadedContentType }) => {
                     this.#messageService.add({
                         severity: 'success',

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/constants.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/constants.ts
@@ -85,19 +85,20 @@ export const DIALOG_TYPE = {
 export const DEFAULT_FILE_ASSET_TYPES = [{ id: 'FileAsset', name: 'File' }];
 
 /**
- * Options shown in the upload-type selector dialog. `contentType` is the content type variable
- * fired to the upload endpoint: `dotAsset` for Assets, `FileAsset` for Files.
+ * Options shown in the upload-type selector dialog. `baseType` is the base type fired to the
+ * upload endpoint, which the backend resolves to the matching content type: `DOTASSET` for Assets,
+ * `FILEASSET` for Files.
  */
 export const UPLOAD_SELECTOR_OPTIONS = [
     {
-        contentType: 'dotAsset',
+        baseType: DotCMSBaseTypesContentTypes.DOTASSET,
         icon: 'image',
         labelKey: 'content-drive.dialog.upload-selector.asset',
         descriptionKey: 'content-drive.dialog.upload-selector.asset.description',
         recommended: true
     },
     {
-        contentType: 'FileAsset',
+        baseType: DotCMSBaseTypesContentTypes.FILEASSET,
         icon: 'code_blocks',
         labelKey: 'content-drive.dialog.upload-selector.file',
         descriptionKey: 'content-drive.dialog.upload-selector.file.description',

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/models.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/shared/models.ts
@@ -10,11 +10,11 @@ import { DotUVEPaletteListTypes } from '@dotcms/portlets/dot-ema/ui';
 import { DIALOG_TYPE, UPLOAD_SELECTOR_OPTIONS } from './constants';
 
 /**
- * Content type variables the upload selector can produce, derived from the selector options so the
- * type and the rendered choices never drift apart.
+ * Base types the upload selector can produce, derived from the selector options so the type and the
+ * rendered choices never drift apart.
  */
-export type DotContentDriveUploadContentType =
-    (typeof UPLOAD_SELECTOR_OPTIONS)[number]['contentType'];
+export type DotContentDriveUploadBaseType =
+    (typeof UPLOAD_SELECTOR_OPTIONS)[number]['baseType'];
 
 /**
  * The status of the content drive.
@@ -120,7 +120,7 @@ export interface DotContentDriveUploadSelectorPayload {
  * `targetFolder` is omitted when nothing is selected (uploads to the site root).
  */
 export interface DotContentDriveUploadSelection {
-    contentType: DotContentDriveUploadContentType;
+    baseType: DotContentDriveUploadBaseType;
     targetFolder?: DotFolderTreeNodeData;
     files?: FileList;
 }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/BaseTypeMimeTypeMatcher.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/BaseTypeMimeTypeMatcher.java
@@ -1,0 +1,167 @@
+package com.dotcms.contenttype.business;
+
+import com.dotcms.contenttype.model.field.BinaryField;
+import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.field.FieldVariable;
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.util.MimeTypeUtils;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.util.UtilMethods;
+import com.liferay.portal.model.User;
+import com.liferay.util.StringPool;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Reusable matcher that, given a mime type, resolves the best-matching {@link ContentType} among
+ * the content types of a given {@link BaseContentType}. The match is done by comparing the mime
+ * type against the "accept" ({@link BinaryField#ALLOWED_FILE_TYPES}) field variable of the
+ * content type's binary field.
+ *
+ * <p>This is the algorithm originally embedded in {@code DotAssetAPIImpl} for the
+ * {@link BaseContentType#DOTASSET} base type, extracted here so it can be reused for other binary
+ * base types (e.g. {@link BaseContentType#FILEASSET}) without duplicating the logic.</p>
+ *
+ * <p>Matches are evaluated in priority order: exact mime type wins over a partial wildcard
+ * (e.g. {@code application/*}) which wins over a total wildcard ({@code *}{@code /}{@code *} or no
+ * "accept" restriction); within each tier, content types on the current site win over content
+ * types on the system host. A binary field with no "accept" field variable is treated as the total
+ * wildcard, so a content type that accepts everything resolves as the catch-all when nothing
+ * stricter matches.</p>
+ *
+ * @author dotCMS
+ */
+public class BaseTypeMimeTypeMatcher {
+
+    /**
+     * Resolves the best-matching content type of the given base type for the supplied mime type.
+     *
+     * @param mimeType       the mime type to match
+     * @param currentHost    the current site; content types on this site or on the system host are considered
+     * @param user           the user used to look up the content types
+     * @param baseContentType the base type whose content types are searched
+     * @param binaryFieldVar  the variable name of the binary field that holds the "accept" field variable
+     * @return Optional of the matching content type, empty if none matches
+     */
+    public Optional<ContentType> match(final String mimeType, final Host currentHost, final User user,
+                                       final BaseContentType baseContentType, final String binaryFieldVar)
+            throws DotDataException, DotSecurityException {
+
+        final List<ContentType> contentTypes = APILocator.getContentTypeAPI(user).findByType(baseContentType);
+
+        if (UtilMethods.isSet(contentTypes)) {
+
+            // Stores the content type indexed by mimetypes, on each index stores the subsets
+            // 0:Exact/on Site, 1:Exact/SYSTEM_HOST, 2:Partial Wildcard/on Site, 3:Partial Wildcard/SYSTEM_HOST,
+            // 4:Total Wildcard (or null)/on Site, 5:Total Wildcard (or null)/SYSTEM_HOST
+            final Map<String, ContentType>[] mimeTypeMappingArray = new Map[6];
+
+            contentTypes.stream()
+                    .filter(contentType -> isSystemHostOrCurrentHost(contentType, currentHost))
+                    .map(contentType -> mapToContentTypeMimeType(contentType, binaryFieldVar))
+                    .forEach(contentTypeMimeType -> {
+
+                        for (final String mimeTypeItem : contentTypeMimeType.mimeTypeFieldVariables) {
+
+                            if (DotAssetAPI.ALL_MIME_TYPE.equals(mimeTypeItem)) {
+
+                                this.getMap(mimeTypeMappingArray, contentTypeMimeType.systemHost ? 5 : 4).put(mimeTypeItem, contentTypeMimeType.contentType);
+                            } else if (mimeTypeItem.endsWith(DotAssetAPI.PARTIAL_MIME_TYPE)) {
+
+                                this.getMap(mimeTypeMappingArray, contentTypeMimeType.systemHost ? 3 : 2).put(mimeTypeItem, contentTypeMimeType.contentType);
+                            } else {
+
+                                this.getMap(mimeTypeMappingArray, contentTypeMimeType.systemHost ? 1 : 0).put(mimeTypeItem, contentTypeMimeType.contentType);
+                            }
+                        }
+                    });
+
+            return findContentType(mimeType, mimeTypeMappingArray);
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<ContentType> findContentType(final String mimeType,
+                                                  final Map<String, ContentType>... mimeTypeMappingArray) {
+
+        for (final Map<String, ContentType> mimeTypeContentTypeMap : mimeTypeMappingArray) {
+
+            if (null != mimeTypeContentTypeMap) {
+                for (final Map.Entry<String, ContentType> entry : mimeTypeContentTypeMap.entrySet()) {
+
+                    if (MimeTypeUtils.match(entry.getKey(), mimeType)) {
+
+                        return Optional.ofNullable(entry.getValue());
+                    }
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Map<String, ContentType> getMap(final Map<String, ContentType>[] mimeTypeMappingArray, final int index) {
+
+        if (null == mimeTypeMappingArray[index]) {
+
+            mimeTypeMappingArray[index] = new HashMap<>();
+        }
+
+        return mimeTypeMappingArray[index];
+    }
+
+    private ContentTypeMimeType mapToContentTypeMimeType(final ContentType contentType, final String binaryFieldVar) {
+
+        final String systemHostId          = APILocator.systemHost().getIdentifier();
+        final String contentTypeHostId     = contentType.host();
+        final boolean isSystemHost         = null == contentTypeHostId || contentTypeHostId.equals(systemHostId);
+        final Map<String, Field>  fieldMap = contentType.fieldMap();
+        String [] mimeTypeFieldVariables   = new String [] { DotAssetAPI.ALL_MIME_TYPE };
+        final List<FieldVariable> fieldVariables = fieldMap.containsKey(binaryFieldVar)?
+                fieldMap.get(binaryFieldVar).fieldVariables(): Collections.emptyList();
+
+        if (UtilMethods.isSet(fieldVariables)) {
+
+            final Optional<FieldVariable> fieldVariableOpt = fieldVariables.stream().filter(fieldVariable ->
+                    BinaryField.ALLOWED_FILE_TYPES.equalsIgnoreCase(fieldVariable.key())).findFirst();
+
+            if (fieldVariableOpt.isPresent() && UtilMethods.isSet(fieldVariableOpt.get().value())) {
+
+                mimeTypeFieldVariables = fieldVariableOpt.get().value().split(StringPool.COMMA);
+            }
+        }
+
+        return new ContentTypeMimeType(mimeTypeFieldVariables, contentType, isSystemHost);
+    }
+
+    private boolean isSystemHostOrCurrentHost (final ContentType contentType, final Host currentHost) {
+
+        final String contentTypeHostId = contentType.host();
+        final String systemHostId      = APILocator.systemHost().getIdentifier();
+        return null == contentTypeHostId ||
+                contentTypeHostId.equals(currentHost.getIdentifier()) || contentTypeHostId.equals(systemHostId);
+    }
+
+    private static class ContentTypeMimeType {
+
+        private final boolean systemHost;
+        private final String [] mimeTypeFieldVariables;
+        private final ContentType contentType;
+
+        public ContentTypeMimeType(final String [] mimeTypeFieldVariables,
+                                   final ContentType contentType, final boolean systemHost) {
+            this.mimeTypeFieldVariables = mimeTypeFieldVariables;
+            this.contentType = contentType;
+            this.systemHost  = systemHost;
+        }
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/BaseTypeToContentTypeStrategyResolver.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/BaseTypeToContentTypeStrategyResolver.java
@@ -1,19 +1,8 @@
 package com.dotcms.contenttype.business;
 
 import com.dotcms.contenttype.model.type.BaseContentType;
-import com.dotcms.contenttype.model.type.ContentType;
-import com.dotcms.contenttype.model.type.DotAssetContentType;
-import com.dotcms.rest.api.v1.temp.DotTempFile;
-import com.dotmarketing.beans.Host;
-import com.dotmarketing.business.APILocator;
-import com.dotmarketing.exception.DotDataException;
-import com.dotmarketing.exception.DotSecurityException;
 import com.google.common.collect.ImmutableMap;
-import com.liferay.portal.model.User;
 
-import java.io.File;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -31,7 +20,8 @@ public class BaseTypeToContentTypeStrategyResolver {
         final ImmutableMap.Builder<BaseContentType, BaseTypeToContentTypeStrategy> builder =
                 new ImmutableMap.Builder<>();
 
-        builder.put(BaseContentType.DOTASSET, new DotAssetBaseTypeToContentTypeStrategyImpl());
+        builder.put(BaseContentType.DOTASSET,  new DotAssetBaseTypeToContentTypeStrategyImpl());
+        builder.put(BaseContentType.FILEASSET, new FileAssetBaseTypeToContentTypeStrategyImpl());
 
         return builder.build();
     }
@@ -44,8 +34,13 @@ public class BaseTypeToContentTypeStrategyResolver {
             final ImmutableMap.Builder<BaseContentType, BaseTypeToContentTypeStrategy> builder =
                     new ImmutableMap.Builder<>();
 
-            builder.putAll(this.strategiesMap);
-            builder.put(BaseContentType.DOTASSET, strategy);
+            // keep every existing mapping except the one being (re)subscribed, then register the new strategy
+            this.strategiesMap.forEach((key, value) -> {
+                if (!key.equals(baseContentType)) {
+                    builder.put(key, value);
+                }
+            });
+            builder.put(baseContentType, strategy);
 
             this.strategiesMap = builder.build();
         }
@@ -77,59 +72,5 @@ public class BaseTypeToContentTypeStrategyResolver {
                 Optional.of(this.strategiesMap.get(baseContentType)):
                 Optional.empty();
     }
-    /////////////
-    private class DotAssetBaseTypeToContentTypeStrategyImpl  implements BaseTypeToContentTypeStrategy {
-
-        @Override
-        public Optional<ContentType> apply(final BaseContentType baseContentType, final Map<String, Object> contextMap) {
-
-            final User user              = (User)contextMap.get("user");
-            final Host currentHost       = (Host)contextMap.get("host");
-            final List<File> binaryFiles = (List<File>) contextMap.getOrDefault("binaryFiles", Collections.emptyList());
-            final Map<String, Object> contentletMap = (Map<String, Object>) contextMap.get("contentletMap");
-            final List<String>        accessingList = (List<String>)contextMap.get("accessingList");
-
-            final File file = this.getBinary(binaryFiles, contentletMap, accessingList);
-            if (null != file && file.exists() && file.canRead()) {
-
-                try {
-
-                    return APILocator.getDotAssetAPI().tryMatch(file, currentHost, user);
-                } catch (DotDataException | DotSecurityException e) {
-                    return Optional.empty();
-                }
-            }
-
-            return Optional.empty();
-        }
-
-        private File getBinary (final List<File> binaryFiles, final Map<String, Object> contentletMap,
-                                final List<String> accessingList) {
-
-            File file = null;
-            if (contentletMap.containsKey(DotAssetContentType.ASSET_FIELD_VAR)) {
-
-                final Object assetValue = contentletMap.get(DotAssetContentType.ASSET_FIELD_VAR);
-                if (assetValue instanceof  File) {
-
-                    file = (File)assetValue;
-                } else {
-
-                    final Optional<DotTempFile>  tempFile = APILocator.getTempFileAPI()
-                            .getTempFile(accessingList, assetValue.toString()); // lets try by temporal file id.
-                    if (tempFile.isPresent()) {
-
-                        file = tempFile.get().file;
-                    }
-                }
-            } else if (!binaryFiles.isEmpty()) {
-
-                file = binaryFiles.get(0); // we try with the first one, on dotAsset is only one.
-            }
-
-            return file;
-        }
-    } // DotAssetBaseTypeToContentTypeStrategyImpl.
-
 
 }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/DotAssetAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/DotAssetAPIImpl.java
@@ -1,25 +1,15 @@
 package com.dotcms.contenttype.business;
 
-import com.dotcms.contenttype.model.field.BinaryField;
-import com.dotcms.contenttype.model.field.Field;
-import com.dotcms.contenttype.model.field.FieldVariable;
 import com.dotcms.contenttype.model.type.BaseContentType;
 import com.dotcms.contenttype.model.type.ContentType;
 import com.dotcms.contenttype.model.type.DotAssetContentType;
-import com.dotcms.util.MimeTypeUtils;
 import com.dotmarketing.beans.Host;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.exception.DotSecurityException;
-import com.dotmarketing.util.UtilMethods;
 import com.liferay.portal.model.User;
-import com.liferay.util.StringPool;
 
 import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -27,6 +17,8 @@ import java.util.Optional;
  * @author jsanca
  */
 public class DotAssetAPIImpl implements DotAssetAPI {
+
+    private final BaseTypeMimeTypeMatcher mimeTypeMatcher = new BaseTypeMimeTypeMatcher();
 
     @Override
     public Optional<ContentType> tryMatch(final File file,final  Host currentHost,final  User user) throws DotDataException, DotSecurityException {
@@ -37,113 +29,7 @@ public class DotAssetAPIImpl implements DotAssetAPI {
     @Override
     public Optional<ContentType> tryMatch(final String mimeType, final Host currentHost, final User user) throws DotSecurityException, DotDataException {
 
-        final List<ContentType> dotAssetContentTypes = APILocator.getContentTypeAPI(user).findByType(BaseContentType.DOTASSET);
-
-        if (UtilMethods.isSet(dotAssetContentTypes)) {
-
-            // Stores the content type indexed by mimetypes, on each index stores the subsets
-            // 0:Exact/on Site, 1:Exact/SYSTEM_HOST, 2:Partial Wildcard/on Site, 3:Partial Wildcard/SYSTEM_HOST,
-            // 4:Total Wildcard (or null)/on Site, 5:Total Wildcard (or null)/SYSTEM_HOST
-            final Map<String, ContentType>[] mimeTypeMappingArray = new Map [6];
-
-            dotAssetContentTypes.stream()
-                    .filter(contentType -> isSystemHostOrCurrentHost(contentType, currentHost)) // remove the ones that are not system host or current host
-                    .map(this::mapToContentTypeMimeType).forEach(contentTypeMimeType -> {
-
-                for (final String mimeTypeItem : contentTypeMimeType.mimeTypeFieldVariables) {
-
-                    if (ALL_MIME_TYPE.equals(mimeTypeItem)) {
-
-                        this.getMap(mimeTypeMappingArray, contentTypeMimeType.systemHost?5:4).put(mimeTypeItem, contentTypeMimeType.contentType);
-                    } else if (mimeTypeItem.endsWith(PARTIAL_MIME_TYPE)) {
-
-                        this.getMap(mimeTypeMappingArray, contentTypeMimeType.systemHost?3:2).put(mimeTypeItem, contentTypeMimeType.contentType);
-                    } else {
-
-                        this.getMap(mimeTypeMappingArray, contentTypeMimeType.systemHost?1:0).put(mimeTypeItem, contentTypeMimeType.contentType);
-                    }
-                }
-            });
-
-            return findDotAssetContentType (mimeType, mimeTypeMappingArray);
-        }
-
-        return Optional.empty();
-    }
-
-    private Optional<ContentType> findDotAssetContentType(final String mimeType,
-                                                          final Map<String, ContentType>... mimeTypeMappingArray) {
-
-        for (final Map<String, ContentType> mimeTypeContentTypeMap : mimeTypeMappingArray) {
-
-            if (null != mimeTypeContentTypeMap) {
-                for (final Map.Entry<String, ContentType> entry : mimeTypeContentTypeMap.entrySet()) {
-
-                    if (MimeTypeUtils.match(entry.getKey(), mimeType)) {
-
-                        return Optional.ofNullable(entry.getValue());
-                    }
-                }
-            }
-        }
-
-        return Optional.empty();
-    }
-
-    private Map<String, ContentType> getMap(final Map<String, ContentType>[] mimeTypeMappingArray, final int index) {
-
-        if (null == mimeTypeMappingArray[index]) {
-
-            mimeTypeMappingArray[index] = new HashMap<>();
-        }
-
-        return mimeTypeMappingArray[index];
-    }
-
-    private ContentTypeMimeType mapToContentTypeMimeType(final ContentType contentType) {
-
-        final String systemHostId          = APILocator.systemHost().getIdentifier();
-        final String contentTypeHostId     = contentType.host();
-        final boolean isSystemHost         = null == contentTypeHostId || contentTypeHostId.equals(systemHostId);
-        final Map<String, Field>  fieldMap = contentType.fieldMap();
-        String [] mimeTypeFieldVariables   = new String [] { ALL_MIME_TYPE };
-        final List<FieldVariable> fieldVariables = fieldMap.containsKey(DotAssetContentType.ASSET_FIELD_VAR)?
-                fieldMap.get(DotAssetContentType.ASSET_FIELD_VAR).fieldVariables(): Collections.emptyList();
-
-        if (UtilMethods.isSet(fieldVariables)) {
-
-            final Optional<FieldVariable> fieldVariableOpt = fieldVariables.stream().filter(fieldVariable ->
-                    BinaryField.ALLOWED_FILE_TYPES.equalsIgnoreCase(fieldVariable.key())).findFirst();
-
-            if (fieldVariableOpt.isPresent() && UtilMethods.isSet(fieldVariableOpt.get().value())) {
-
-                mimeTypeFieldVariables = fieldVariableOpt.get().value().split(StringPool.COMMA);
-            }
-        }
-
-        return new ContentTypeMimeType(mimeTypeFieldVariables, contentType, isSystemHost);
-    }
-
-    private boolean isSystemHostOrCurrentHost (final ContentType contentType, final Host currentHost) {
-
-        final String contentTypeHostId = contentType.host();
-        final String systemHostId      = APILocator.systemHost().getIdentifier();
-        return null == contentTypeHostId ||
-                contentTypeHostId.equals(currentHost.getIdentifier()) || contentTypeHostId.equals(systemHostId);
-
-    }
-
-    private class ContentTypeMimeType {
-
-        private final boolean systemHost;
-        private final String [] mimeTypeFieldVariables;
-        private final ContentType contentType;
-
-        public ContentTypeMimeType(final String [] mimeTypeFieldVariables,
-                                   final ContentType contentType, final boolean systemHost) {
-            this.mimeTypeFieldVariables = mimeTypeFieldVariables;
-            this.contentType = contentType;
-            this.systemHost  = systemHost;
-        }
+        return this.mimeTypeMatcher.match(mimeType, currentHost, user,
+                BaseContentType.DOTASSET, DotAssetContentType.ASSET_FIELD_VAR);
     }
 }

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/DotAssetBaseTypeToContentTypeStrategyImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/DotAssetBaseTypeToContentTypeStrategyImpl.java
@@ -1,0 +1,77 @@
+package com.dotcms.contenttype.business;
+
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.DotAssetContentType;
+import com.dotcms.rest.api.v1.temp.DotTempFile;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.liferay.portal.model.User;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves the {@link ContentType} for the {@link BaseContentType#DOTASSET} base type by matching
+ * the uploaded binary's mime type against the dotAsset content types via
+ * {@link DotAssetAPI#tryMatch(File, Host, User)}.
+ *
+ * @author jsanca
+ */
+public class DotAssetBaseTypeToContentTypeStrategyImpl implements BaseTypeToContentTypeStrategy {
+
+    @Override
+    public Optional<ContentType> apply(final BaseContentType baseContentType, final Map<String, Object> contextMap) {
+
+        final User user              = (User)contextMap.get("user");
+        final Host currentHost       = (Host)contextMap.get("host");
+        final List<File> binaryFiles = (List<File>) contextMap.getOrDefault("binaryFiles", Collections.emptyList());
+        final Map<String, Object> contentletMap = (Map<String, Object>) contextMap.get("contentletMap");
+        final List<String>        accessingList = (List<String>)contextMap.get("accessingList");
+
+        final File file = this.getBinary(binaryFiles, contentletMap, accessingList);
+        if (null != file && file.exists() && file.canRead()) {
+
+            try {
+
+                return APILocator.getDotAssetAPI().tryMatch(file, currentHost, user);
+            } catch (DotDataException | DotSecurityException e) {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private File getBinary (final List<File> binaryFiles, final Map<String, Object> contentletMap,
+                            final List<String> accessingList) {
+
+        File file = null;
+        if (contentletMap.containsKey(DotAssetContentType.ASSET_FIELD_VAR)) {
+
+            final Object assetValue = contentletMap.get(DotAssetContentType.ASSET_FIELD_VAR);
+            if (assetValue instanceof  File) {
+
+                file = (File)assetValue;
+            } else {
+
+                final Optional<DotTempFile>  tempFile = APILocator.getTempFileAPI()
+                        .getTempFile(accessingList, assetValue.toString()); // lets try by temporal file id.
+                if (tempFile.isPresent()) {
+
+                    file = tempFile.get().file;
+                }
+            }
+        } else if (!binaryFiles.isEmpty()) {
+
+            file = binaryFiles.get(0); // we try with the first one, on dotAsset is only one.
+        }
+
+        return file;
+    }
+}

--- a/dotCMS/src/main/java/com/dotcms/contenttype/business/FileAssetBaseTypeToContentTypeStrategyImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/contenttype/business/FileAssetBaseTypeToContentTypeStrategyImpl.java
@@ -1,0 +1,97 @@
+package com.dotcms.contenttype.business;
+
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.FileAssetContentType;
+import com.dotcms.rest.api.v1.temp.DotTempFile;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
+import com.dotmarketing.util.Logger;
+import com.liferay.portal.model.User;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Resolves the {@link ContentType} for the {@link BaseContentType#FILEASSET} base type.
+ *
+ * <p>Mirrors {@link DotAssetBaseTypeToContentTypeStrategyImpl}: it matches the uploaded binary's
+ * mime type against the "accept" field variable of the File Asset content types (via
+ * {@link BaseTypeMimeTypeMatcher}). When no content type matches by mime type, it falls back to the
+ * system default {@code FileAsset} content type so a File Asset upload never fails to resolve a
+ * content type. In practice the default {@code FileAsset} (which has no "accept" restriction) is
+ * already resolved by the matcher as the total-wildcard catch-all.</p>
+ *
+ * @author dotCMS
+ */
+public class FileAssetBaseTypeToContentTypeStrategyImpl implements BaseTypeToContentTypeStrategy {
+
+    private final BaseTypeMimeTypeMatcher mimeTypeMatcher = new BaseTypeMimeTypeMatcher();
+
+    @Override
+    public Optional<ContentType> apply(final BaseContentType baseContentType, final Map<String, Object> contextMap) {
+
+        final User user              = (User)contextMap.get("user");
+        final Host currentHost       = (Host)contextMap.get("host");
+        final List<File> binaryFiles = (List<File>) contextMap.getOrDefault("binaryFiles", Collections.emptyList());
+        final Map<String, Object> contentletMap = (Map<String, Object>) contextMap.get("contentletMap");
+        final List<String>        accessingList = (List<String>)contextMap.get("accessingList");
+
+        try {
+
+            final File file = this.getBinary(binaryFiles, contentletMap, accessingList);
+            if (null != file && file.exists() && file.canRead()) {
+
+                final String mimeType = APILocator.getFileAssetAPI().getMimeType(file);
+                final Optional<ContentType> matched = this.mimeTypeMatcher.match(mimeType, currentHost, user,
+                        BaseContentType.FILEASSET, FileAssetContentType.FILEASSET_FILEASSET_FIELD_VAR);
+
+                if (matched.isPresent()) {
+
+                    return matched;
+                }
+            }
+
+            // Safety fallback: the system default File Asset content type.
+            return Optional.ofNullable(APILocator.getContentTypeAPI(user)
+                    .find(FileAssetAPI.DEFAULT_FILE_ASSET_STRUCTURE_VELOCITY_VAR_NAME));
+        } catch (DotDataException | DotSecurityException e) {
+
+            Logger.debug(this, () -> "Could not resolve a FILEASSET content type: " + e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private File getBinary (final List<File> binaryFiles, final Map<String, Object> contentletMap,
+                            final List<String> accessingList) {
+
+        File file = null;
+        if (contentletMap.containsKey(FileAssetContentType.FILEASSET_FILEASSET_FIELD_VAR)) {
+
+            final Object assetValue = contentletMap.get(FileAssetContentType.FILEASSET_FILEASSET_FIELD_VAR);
+            if (assetValue instanceof File) {
+
+                file = (File)assetValue;
+            } else {
+
+                final Optional<DotTempFile> tempFile = APILocator.getTempFileAPI()
+                        .getTempFile(accessingList, assetValue.toString()); // lets try by temporal file id.
+                if (tempFile.isPresent()) {
+
+                    file = tempFile.get().file;
+                }
+            }
+        } else if (!binaryFiles.isEmpty()) {
+
+            file = binaryFiles.get(0); // upload path puts the binary here (only one file per file asset).
+        }
+
+        return file;
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/contenttype/business/BaseTypeToContentTypeStrategyResolverTest.java
+++ b/dotCMS/src/test/java/com/dotcms/contenttype/business/BaseTypeToContentTypeStrategyResolverTest.java
@@ -1,0 +1,74 @@
+package com.dotcms.contenttype.business;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import com.dotcms.UnitTestBase;
+import com.dotcms.contenttype.model.type.BaseContentType;
+import java.util.Optional;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link BaseTypeToContentTypeStrategyResolver}.
+ *
+ * Covers the {@code subscribe(...)} regression (it used to ignore its {@code baseContentType}
+ * argument and always register under {@link BaseContentType#DOTASSET}) and the registration of
+ * the default {@code FILEASSET} strategy.
+ */
+public class BaseTypeToContentTypeStrategyResolverTest extends UnitTestBase {
+
+    /**
+     * Method to test: {@link BaseTypeToContentTypeStrategyResolver#subscribe(BaseContentType, BaseTypeToContentTypeStrategy)}
+     * Given Scenario: A strategy is subscribed under {@link BaseContentType#FILEASSET}.
+     * Expected Result: {@code get(FILEASSET)} returns exactly that strategy, and the DOTASSET
+     * default strategy is left untouched.
+     */
+    @Test
+    public void test_subscribe_registers_strategy_under_the_passed_base_type() {
+
+        final BaseTypeToContentTypeStrategyResolver resolver = new BaseTypeToContentTypeStrategyResolver();
+        final BaseTypeToContentTypeStrategy dotAssetDefault =
+                resolver.get(BaseContentType.DOTASSET).orElse(null);
+        final BaseTypeToContentTypeStrategy customStrategy =
+                (baseContentType, contextMap) -> Optional.empty();
+
+        resolver.subscribe(BaseContentType.FILEASSET, customStrategy);
+
+        final Optional<BaseTypeToContentTypeStrategy> result = resolver.get(BaseContentType.FILEASSET);
+        assertTrue("FILEASSET strategy should be registered under FILEASSET", result.isPresent());
+        assertSame("subscribe must register under the passed base type", customStrategy, result.get());
+        assertSame("DOTASSET strategy must not be overwritten by subscribing FILEASSET",
+                dotAssetDefault, resolver.get(BaseContentType.DOTASSET).orElse(null));
+    }
+
+    /**
+     * Method to test: {@link BaseTypeToContentTypeStrategyResolver#get(BaseContentType)}
+     * Given Scenario: A freshly built resolver with its default strategies.
+     * Expected Result: Both DOTASSET and FILEASSET resolution strategies are registered by default.
+     */
+    @Test
+    public void test_default_strategies_include_dotasset_and_fileasset() {
+
+        final BaseTypeToContentTypeStrategyResolver resolver = new BaseTypeToContentTypeStrategyResolver();
+
+        assertTrue("DOTASSET strategy must be registered by default",
+                resolver.get(BaseContentType.DOTASSET).isPresent());
+        assertTrue("FILEASSET strategy must be registered by default",
+                resolver.get(BaseContentType.FILEASSET).isPresent());
+    }
+
+    /**
+     * Method to test: {@link BaseTypeToContentTypeStrategyResolver#get(BaseContentType)}
+     * Given Scenario: A base type with no registered strategy.
+     * Expected Result: An empty Optional is returned.
+     */
+    @Test
+    public void test_get_returns_empty_for_unregistered_base_type() {
+
+        final BaseTypeToContentTypeStrategyResolver resolver = new BaseTypeToContentTypeStrategyResolver();
+
+        assertFalse(resolver.get(BaseContentType.WIDGET).isPresent());
+    }
+
+}

--- a/dotcms-integration/src/test/java/com/dotcms/contenttype/business/FileAssetBaseTypeToContentTypeStrategyImplTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/contenttype/business/FileAssetBaseTypeToContentTypeStrategyImplTest.java
@@ -1,0 +1,169 @@
+package com.dotcms.contenttype.business;
+
+import com.dotcms.IntegrationTestBase;
+import com.dotcms.contenttype.model.field.BinaryField;
+import com.dotcms.contenttype.model.field.Field;
+import com.dotcms.contenttype.model.field.FieldVariable;
+import com.dotcms.contenttype.model.field.ImmutableFieldVariable;
+import com.dotcms.contenttype.model.type.BaseContentType;
+import com.dotcms.contenttype.model.type.ContentType;
+import com.dotcms.contenttype.model.type.ContentTypeBuilder;
+import com.dotcms.contenttype.model.type.FileAssetContentType;
+import com.dotcms.mock.request.MockAttributeRequest;
+import com.dotcms.mock.request.MockHeaderRequest;
+import com.dotcms.mock.request.MockHttpRequestIntegrationTest;
+import com.dotcms.mock.request.MockSessionRequest;
+import com.dotcms.rest.api.v1.temp.DotTempFile;
+import com.dotcms.util.IntegrationTestInitService;
+import com.dotmarketing.beans.Host;
+import com.dotmarketing.business.APILocator;
+import com.dotmarketing.exception.DotDataException;
+import com.dotmarketing.exception.DotSecurityException;
+import com.dotmarketing.portlets.fileassets.business.FileAssetAPI;
+import com.dotmarketing.portlets.folders.business.FolderAPI;
+import com.dotmarketing.util.FileUtil;
+import com.dotmarketing.util.UUIDGenerator;
+import com.liferay.portal.util.WebKeys;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Integration test for {@link FileAssetBaseTypeToContentTypeStrategyImpl}, the strategy that
+ * resolves a {@link BaseContentType#FILEASSET} content type from an uploaded binary. Mirrors
+ * {@link DotAssetBaseTypeToContentTypeStrategyImplTest}.
+ */
+public class FileAssetBaseTypeToContentTypeStrategyImplTest extends IntegrationTestBase {
+
+    @BeforeClass
+    public static void prepare() throws Exception {
+        //Setting web app environment
+        IntegrationTestInitService.getInstance().init();
+    }
+
+    private MockHeaderRequest mockRequest() {
+        final MockHeaderRequest request = new MockHeaderRequest(
+                new MockSessionRequest(new MockAttributeRequest(
+                        new MockHttpRequestIntegrationTest("localhost", "/").request()).request()).request());
+        request.setHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString("admin@dotcms.com:admin".getBytes()));
+        request.setHeader("User-Agent", "Fake-Agent");
+        request.setHeader("Host", "localhost");
+        request.setHeader("Origin", "localhost");
+        request.setAttribute(WebKeys.USER, APILocator.systemUser());
+        return request;
+    }
+
+    private DotTempFile createTextTempFile(final MockHeaderRequest request) throws Exception {
+        final File file = FileUtil.createTemporaryFile("test", "txt");
+        try (final FileWriter fileWriter = new FileWriter(file)) {
+            fileWriter.write("This is a test temporal file");
+        }
+        return APILocator.getTempFileAPI().createTempFile(
+                "test" + System.currentTimeMillis(), request, com.liferay.util.FileUtil.createInputStream(file));
+    }
+
+    /**
+     * Method to test: {@link FileAssetBaseTypeToContentTypeStrategyImpl#apply(BaseContentType, Map)}
+     * Given Scenario: A File Asset content type whose "accept" field variable is {@code text/plain}
+     *                 exists, and a temporal text file is uploaded with only {@code baseType: FILEASSET}.
+     * Expected Result: The strategy resolves to that specific File Asset content type by mime type.
+     */
+    @Test
+    public void test_apply_matches_specific_fileasset_by_mimetype() throws Exception {
+
+        final String variable = "testFileAsset" + System.currentTimeMillis();
+        final ContentType fileAssetContentType = APILocator.getContentTypeAPI(APILocator.systemUser()).save(
+                ContentTypeBuilder.builder(FileAssetContentType.class).folder(FolderAPI.SYSTEM_FOLDER)
+                        .host(Host.SYSTEM_HOST).name(variable)
+                        .owner(APILocator.systemUser().getUserId()).build());
+
+        final Map<String, Field> fieldMap = fileAssetContentType.fieldMap();
+        Field binaryField = fieldMap.get(FileAssetContentType.FILEASSET_FILEASSET_FIELD_VAR);
+        final FieldVariable allowFileTypes = ImmutableFieldVariable.builder().key(BinaryField.ALLOWED_FILE_TYPES)
+                .value("text/plain").fieldId(binaryField.id()).build();
+        binaryField.constructFieldVariables(Arrays.asList(allowFileTypes));
+
+        APILocator.getContentTypeAPI(APILocator.systemUser()).save(fileAssetContentType);
+        APILocator.getContentTypeFieldAPI().save(binaryField, APILocator.systemUser());
+        APILocator.getContentTypeFieldAPI().save(allowFileTypes, APILocator.systemUser());
+
+        final Optional<BaseTypeToContentTypeStrategy> strategy =
+                BaseTypeToContentTypeStrategyResolver.getInstance().get(BaseContentType.FILEASSET);
+        Assert.assertTrue("A FILEASSET strategy must be registered", strategy.isPresent());
+
+        final MockHeaderRequest request = this.mockRequest();
+        final DotTempFile dotTempFile = this.createTextTempFile(request);
+        final String sessionId = UUIDGenerator.generateUuid();
+
+        // contentlet map without content type, only FILEASSET baseType + the temporal file
+        final Map<String, Object> map = Map.of("baseType", "FILEASSET", "fileAsset", dotTempFile.id);
+        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
+
+        final Optional<ContentType> contentTypeOpt = strategy.get().apply(BaseContentType.FILEASSET,
+                Map.of("user", APILocator.systemUser(), "host", defaultHost,
+                        "contentletMap", map, "accessingList", Arrays.asList(APILocator.systemUser().getUserId(),
+                                APILocator.getTempFileAPI().getRequestFingerprint(request), sessionId)));
+
+        Assert.assertTrue(contentTypeOpt.isPresent());
+        Assert.assertEquals(variable.toLowerCase(), contentTypeOpt.get().variable().toLowerCase());
+        Assert.assertEquals(BaseContentType.FILEASSET, contentTypeOpt.get().baseType());
+    }
+
+    /**
+     * Method to test: {@link FileAssetBaseTypeToContentTypeStrategyImpl#apply(BaseContentType, Map)}
+     * Given Scenario: No File Asset content type targets the uploaded file's mime type specifically;
+     *                 a binary is uploaded with only {@code baseType: FILEASSET}.
+     * Expected Result: The strategy resolves to a File Asset content type — the system default
+     *                  {@code FileAsset} (matched as the total-wildcard catch-all / safety fallback).
+     */
+    @Test
+    public void test_apply_resolves_default_fileasset_when_no_specific_match() throws Exception {
+
+        final Optional<BaseTypeToContentTypeStrategy> strategy =
+                BaseTypeToContentTypeStrategyResolver.getInstance().get(BaseContentType.FILEASSET);
+        Assert.assertTrue("A FILEASSET strategy must be registered", strategy.isPresent());
+
+        final MockHeaderRequest request = this.mockRequest();
+        final DotTempFile dotTempFile = this.createTextTempFile(request);
+        final String sessionId = UUIDGenerator.generateUuid();
+
+        final Map<String, Object> map = Map.of("baseType", "FILEASSET", "fileAsset", dotTempFile.id);
+        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
+
+        final Optional<ContentType> contentTypeOpt = strategy.get().apply(BaseContentType.FILEASSET,
+                Map.of("user", APILocator.systemUser(), "host", defaultHost,
+                        "contentletMap", map, "accessingList", Arrays.asList(APILocator.systemUser().getUserId(),
+                                APILocator.getTempFileAPI().getRequestFingerprint(request), sessionId)));
+
+        Assert.assertTrue("A FILEASSET content type must always be resolved", contentTypeOpt.isPresent());
+        Assert.assertEquals(BaseContentType.FILEASSET, contentTypeOpt.get().baseType());
+    }
+
+    /**
+     * Method to test: {@link DotAssetAPI#tryMatch(String, Host, com.liferay.portal.model.User)} via the
+     * extracted {@link BaseTypeMimeTypeMatcher}.
+     * Given Scenario: The dotAsset mime matching is now delegated to the shared matcher.
+     * Expected Result: The default {@code FileAsset} content type is resolvable directly, confirming the
+     *                  shared matcher works for the FILEASSET base type as it does for DOTASSET.
+     */
+    @Test
+    public void test_matcher_resolves_default_fileasset_for_any_mimetype() throws DotDataException, DotSecurityException {
+
+        final Host defaultHost = APILocator.getHostAPI().findDefaultHost(APILocator.systemUser(), false);
+        final Optional<ContentType> matched = new BaseTypeMimeTypeMatcher().match(
+                "application/octet-stream", defaultHost, APILocator.systemUser(),
+                BaseContentType.FILEASSET, FileAssetContentType.FILEASSET_FILEASSET_FIELD_VAR);
+
+        Assert.assertTrue(matched.isPresent());
+        Assert.assertEquals(BaseContentType.FILEASSET, matched.get().baseType());
+        Assert.assertEquals(FileAssetAPI.DEFAULT_FILE_ASSET_STRUCTURE_VELOCITY_VAR_NAME.toLowerCase(),
+                matched.get().variable().toLowerCase());
+    }
+}


### PR DESCRIPTION
Content Drive's upload dialog lets users pick Asset vs File, which are
semantically base types. Previously only DOTASSET could be resolved from a
base type on the backend, so firing the NEW workflow action with
baseType: FILEASSET failed with "content type or base type is not set or is
invalid". This adds the missing FILEASSET resolution and switches the
frontend to send the base type.

Backend:
- Extract the dotAsset mime-matching algorithm into a reusable
  BaseTypeMimeTypeMatcher (parameterized by base type + binary field var);
  DotAssetAPIImpl.tryMatch now delegates to it (DOTASSET behavior unchanged).
- Move DotAssetBaseTypeToContentTypeStrategyImpl out of the resolver into its
  own class and add FileAssetBaseTypeToContentTypeStrategyImpl, which
  mime-matches FILEASSET content types and falls back to the default FileAsset.
- Register both strategies; fix BaseTypeToContentTypeStrategyResolver.subscribe
  which ignored its baseContentType arg and always registered under DOTASSET.

Frontend:
- Revert uploadDotAsset to its original 2-arg form; add uploadFileByBaseType
  (DotUploadFileService) and newContentletByBaseType (DotWorkflowActionsFireService)
  which send baseType instead of contentType.
- Content Drive now emits DOTASSET/FILEASSET and routes uploads through the new
  method; root-level uploads carry the current site identifier so they land on
  the browsed site, not the default host.

Tests: resolver unit test (subscribe regression + FILEASSET registration),
FileAsset strategy integration test, and frontend specs for the new methods,
base-type selection, and current-site root upload.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
