### PR TITLE
fix(content-type): decode dollar sign in Story Block JSON on read (#35782)

### DIFF
--- a/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/UtilMethods.java
@@ -1520,7 +1520,8 @@ public class UtilMethods {
 
     public static String escapeHTMLCodeFromJSON(String json) {
         json = json.replace("&#58;",":")
-                .replace("&#44;",",");
+                .replace("&#44;",",")
+                .replace("&#36;","$");
         return json;
     }
 

--- a/dotCMS/src/test/java/com/dotmarketing/util/UtilMethodsTest.java
+++ b/dotCMS/src/test/java/com/dotmarketing/util/UtilMethodsTest.java
@@ -694,4 +694,22 @@ public class UtilMethodsTest extends UnitTestBase {
       final String invalidBase64 = "This is not a valid base64 string!";
       UtilMethods.base64Decode(invalidBase64);
    }
+
+   /**
+    * Method to test: {@link UtilMethods#escapeHTMLCodeFromJSON(String)}
+    * Given Scenario: A contentlet JSON value (e.g. a Story Block field) where {@code $}, {@code :} and
+    *                 {@code ,} have been stored as their decimal HTML numeric entities.
+    * Expected Result: The entities are decoded back to the literal characters so consumers such as the
+    *                  Block Editor display {@code $50} instead of {@code &#36;50} (issue #35782).
+    */
+   @Test
+   public void test_escapeHTMLCodeFromJSON_decodes_dollar_colon_and_comma() {
+      final String encoded = "{\"text\":\"The application fee is &#36;50, see http&#58;//x.com\"}";
+      final String decoded = UtilMethods.escapeHTMLCodeFromJSON(encoded);
+
+      assertEquals("{\"text\":\"The application fee is $50, see http://x.com\"}", decoded);
+      assertFalse(decoded.contains("&#36;"));
+      assertFalse(decoded.contains("&#58;"));
+      assertFalse(decoded.contains("&#44;"));
+   }
 }


### PR DESCRIPTION
### Proposed Changes
* `UtilMethods.escapeHTMLCodeFromJSON(...)` now also decodes the decimal HTML numeric entity `&#36;` back to a literal `$`, alongside the existing `&#58;`→`:` and `&#44;`→`,` decoding.
* Added a unit test in `UtilMethodsTest` locking in `$` decoding (plus the existing `:`/`,` behavior).

### Additional Info
A `$` typed into a Block Editor (Story Block) field was persisted in `contentlet_as_json` as its decimal HTML numeric entity `&#36;` (same family as the `&#58;`/`&#44;` case from #25903 / #28020). On every content read, `ContentletTransformer.transform()` passes the whole JSON through `escapeHTMLCodeFromJSON`, which only reversed `:` and `,` — so `&#36;` survived into the value handed to the editor.

The symptom was editor-only: the browser HTML parser renders `&#36;` as `$` (front-end output looked correct), but the ProseMirror/TipTap editor displays the raw text node `&#36;50` literally on reopen. The shared read path (`ContentletTransformer` → `StoryBlockViewStrategy`) is why both the legacy and new editors were affected.

Fixing at this universal read boundary is what the issue investigation recommended ("fix at the read/transform boundary so all API consumers — not just the editor — receive the correct `$`"), and it self-heals content that was already saved with `&#36;` — no DB migration required.

> Note: `#` has the identical sister-bug potential (`&#35;`) since `$` and `#` are both Velocity-special. The issue's acceptance criteria is `$`-only, so `#` was intentionally left out of scope.

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated (read-side decode only; no change to validation/storage of incoming content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35782

This PR fixes: #35782