### PR TITLE
fix(content-drive): upload-button flow drops the file in Chrome (#36279 follow-up)

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.spec.ts
@@ -956,6 +956,39 @@ describe('DotContentDriveShellComponent', () => {
             });
         });
 
+        it('should consume the file before resetting the input (live FileList)', () => {
+            // Regression: `input.files` is a LIVE FileList, so clearing `input.value` empties it.
+            // The component must consume the files BEFORE resetting the input; resetting first
+            // drops the selection and the upload silently no-ops (the real Chrome bug).
+            // jsdom doesn't model this, so we mock it faithfully: `.files` is one stable object
+            // that is emptied when `.value` is cleared.
+            uploadService.uploadFileByBaseType.mockReturnValue(of({} as DotCMSContentlet));
+            const file = createFile();
+            const fileInput = spectator.query('input[type="file"]') as HTMLInputElement;
+
+            const liveFiles: File[] = [file];
+            Object.defineProperty(fileInput, 'files', {
+                get: () => liveFiles as unknown as FileList,
+                configurable: true
+            });
+            Object.defineProperty(fileInput, 'value', {
+                get: () => (liveFiles.length ? 'C:\\fakepath\\test.png' : ''),
+                set: () => {
+                    liveFiles.length = 0; // clearing the input empties the live FileList
+                },
+                configurable: true
+            });
+
+            selectUploadType({ targetFolder: TARGET_FOLDER_DATA, baseType: 'FILEASSET' });
+            spectator.triggerEventHandler('input[type="file"]', 'change', { target: fileInput });
+
+            expect(uploadService.uploadFileByBaseType).toHaveBeenCalledWith(file, 'FILEASSET', {
+                hostFolder: TARGET_FOLDER_DATA.id,
+                indexPolicy: 'WAIT_FOR'
+            });
+            expect(fileInput.value).toBe(''); // still reset afterwards
+        });
+
         it('should not upload when the file picker is dismissed without files', () => {
             const fileInput = spectator.query('input[type="file"]') as HTMLInputElement;
 

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/dot-content-drive-shell/dot-content-drive-shell.component.ts
@@ -430,15 +430,16 @@ export class DotContentDriveShellComponent implements OnInit {
         const files = input.files;
         const selection = this.$activeSelection();
 
-        // Always reset so a cancelled/re-opened picker can't reuse a stale selection.
-        this.$activeSelection.set(undefined);
-        input.value = '';
-
-        if (!files || files.length === 0 || !selection) {
-            return;
+        // Consume the files BEFORE resetting the input: `input.files` is a live FileList, so
+        // `input.value = ''` empties it. Resetting first would drop the selection and the upload
+        // would never fire (the file is captured synchronously into FormData by resolveFilesUpload).
+        if (files && files.length > 0 && selection) {
+            this.resolveFilesUpload({ ...selection, files });
         }
 
-        this.resolveFilesUpload({ ...selection, files });
+        // Reset so a cancelled/re-opened picker can't reuse a stale selection.
+        this.$activeSelection.set(undefined);
+        input.value = '';
     }
 
     /**


### PR DESCRIPTION
## Proposed Changes

Follow-up to #36317 (merged). The Content Drive **Upload-button** flow silently dropped the selected file in Chrome — the OS picker opened, you chose a file, and nothing happened (no upload, no error).

### Root cause
`onFileChange` read `input.files` (a **live `FileList`**) but reset `input.value = ''` **before** the guard/consume. Clearing the input empties that same live `FileList`, so `files.length` was `0` by the time the code checked it → silent early-return, upload never fired. (The drag-and-drop flow was unaffected — it never goes through the file input.)

### Fix
Consume the files — fire `resolveFilesUpload`, which captures the `File` into `FormData` synchronously — **before** resetting the input.

```ts
if (files && files.length > 0 && selection) {
    this.resolveFilesUpload({ ...selection, files });
}
// reset only AFTER consuming
this.$activeSelection.set(undefined);
input.value = '';
```

## Checklist
- [x] Regression test added (`should consume the file before resetting the input (live FileList)`) that models the live-`FileList` semantics jsdom doesn't reproduce (the existing test stubbed `files` as a static array, which is why this slipped through).
- [x] **Verified red→green**: the test fails on the old reset-before-consume ordering and passes with the fix.
- [x] `portlets-content-drive` suite green (668 tests).

## Testing
1. In Content Drive (Chrome), click **Upload**, choose **Asset** or **File**, pick a file from the OS dialog → the asset is now created.
2. Drag-and-drop upload still works (unchanged path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36279

This PR fixes: #36279