### PR TITLE
fix(maintenance): import DEFAULT variant so experiment starter restore works (#36337)

### DIFF
--- a/docker/dev-env/README.md
+++ b/docker/dev-env/README.md
@@ -72,7 +72,7 @@ docker run --rm \
 --pull always \
 -p 8443:8443 \
 -v $PWD/data:/data \
--e DOTCMS_STARTER_URL=https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20250613/starter-20250613.zip \
+-e DOTCMS_STARTER_URL=https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip \
 dotcms/dotcms-dev:nightly
 
 ```

--- a/docker/docker-compose-examples/cluster-mode/README.md
+++ b/docker/docker-compose-examples/cluster-mode/README.md
@@ -23,7 +23,7 @@ The license pack must contain at least two licenses (one for each node in the cl
 3. A custom starter can be set through this line (uncomment and change the starter url accordingly):
 
 ```
-#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20250722/starter-20250722.zip'
+#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
 ```
 
 #### Deploying nodes:

--- a/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/cluster-mode/docker-compose-node-1.yml
@@ -44,7 +44,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/cluster-mode/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/cluster-mode/docker-compose-node-2.yml
@@ -21,7 +21,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-production'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     volumes:
       #- {local_data_path}:/data/shared
       #- {license_local_path}/license.zip:/data/shared/assets/license.zip

--- a/docker/docker-compose-examples/load-db-dump/README.md
+++ b/docker/docker-compose-examples/load-db-dump/README.md
@@ -33,7 +33,7 @@ dotCMS loads the SQL dump via the `DB_LOAD_DUMP_SQL` environment variable, which
 2. A custom starter can be set by uncommenting and updating this line (note: normally not needed when loading from a dump):
 
    ```yaml
-   #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+   #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
    ```
 
 3. HTTPS is optional. To enable it, uncomment the SSL cert env vars and the `certs` volume mount (a cert can be created with the [mkcert](https://github.com/FiloSottile/mkcert) tool):

--- a/docker/docker-compose-examples/load-db-dump/docker-compose.yml
+++ b/docker/docker-compose-examples/load-db-dump/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       GLOWROOT_WEB_UI_ENABLED: 'true' # Enable glowroot web ui on localhost.  do not use in production
       #CMS_SSL_CERTIFICATE_FILE: '/certs/localhost.pem'    # Can create cert with mkcert tool
       #CMS_SSL_CERTIFICATE_KEY_FILE: '/certs/localhost-key.pem'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - db
       - opensearch      

--- a/docker/docker-compose-examples/push-publish/README.md
+++ b/docker/docker-compose-examples/push-publish/README.md
@@ -31,7 +31,7 @@ To reference the receiver service (`dotcms-receiver`), use the `HTTP` protocol w
 3. A custom starter can be set through this line (uncomment and change the starter URL accordingly):
 
    ```yaml
-   #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20250722/starter-20250722.zip'
+   #"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
    ```
 
 ### Deploying Nodes

--- a/docker/docker-compose-examples/push-publish/docker-compose.yml
+++ b/docker/docker-compose-examples/push-publish/docker-compose.yml
@@ -50,7 +50,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch-sender:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-sender'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - opensearch-sender
       - db-sender
@@ -115,7 +115,7 @@ services:
         DOT_ES_ENDPOINTS: 'https://opensearch-receiver:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
         DOT_DOTCMS_CLUSTER_ID:  'dotcms-receiver'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - opensearch-receiver
       - db-receiver

--- a/docker/docker-compose-examples/single-node-debug-mode/README.md
+++ b/docker/docker-compose-examples/single-node-debug-mode/README.md
@@ -21,7 +21,7 @@ A single instance of dotcms running on port 8080. Database: postgres. Debug mode
 3. A custom starter can be set through this line (uncomment and change the starter url accordingly):
 
 ```
-#CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20250722/starter-20250722.zip'
+#CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
 ```
 
 #### Run an example:

--- a/docker/docker-compose-examples/single-node-debug-mode/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-debug-mode/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       DOT_ES_ENDPOINTS: 'https://opensearch:9200'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-production'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - db
       - opensearch      

--- a/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-demo-site/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       DOT_ES_ENDPOINTS: 'https://opensearch:9200'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-production'
-      CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+      CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - db
       - opensearch

--- a/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node-os-migration/docker-compose.yml
@@ -225,7 +225,7 @@ services:
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-os-migration'
       GLOWROOT_ENABLED: 'true'
       GLOWROOT_WEB_UI_ENABLED: 'true'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260211/starter-20260211.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       db:
         condition: service_healthy

--- a/docker/docker-compose-examples/single-node/README.md
+++ b/docker/docker-compose-examples/single-node/README.md
@@ -21,7 +21,7 @@ A single instance of dotcms running on port 8080. Database: postgres
 3. A custom starter can be set through this line (uncomment and change the starter url accordingly):
 
 ```
-#CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20250722/starter-20250722.zip'
+#CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
 ```
 
 #### Run an example:

--- a/docker/docker-compose-examples/single-node/docker-compose.yml
+++ b/docker/docker-compose-examples/single-node/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       GLOWROOT_WEB_UI_ENABLED: 'true' # Enable glowroot web ui on localhost.  do not use in production
       #CMS_SSL_CERTIFICATE_FILE: '/certs/localhost.pem'    # Can create cert with mkcert tool
       #CMS_SSL_CERTIFICATE_KEY_FILE: '/certs/localhost-key.pem'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260211/starter-20260211.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - db
       - opensearch      

--- a/docker/docker-compose-examples/with-opensearch-dashboard/README.md
+++ b/docker/docker-compose-examples/with-opensearch-dashboard/README.md
@@ -21,7 +21,7 @@ A single instance of dotcms running on port 8080. Kibana was included for torubl
 3. A custom starter can be set through this line (uncomment and change the starter url accordingly):
 
 ```
-#CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20250722/starter-20250722.zip'
+#CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
 ```
 
 #### Run an example:

--- a/docker/docker-compose-examples/with-opensearch-dashboard/docker-compose.yml
+++ b/docker/docker-compose-examples/with-opensearch-dashboard/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       DOT_ES_ENDPOINTS: 'https://opensearch:9200'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_DOTCMS_CLUSTER_ID: 'dotcms-production'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - db
       - opensearch

--- a/docker/docker-compose-examples/with-redis-session/README.md
+++ b/docker/docker-compose-examples/with-redis-session/README.md
@@ -25,7 +25,7 @@ The license pack must contain at least two licenses (one for each node in the cl
 3. A custom starter can be set through this line (uncomment and change the starter URL accordingly):
 
 ```
-#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20250722/starter-20250722.zip'
+#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
 ```
 
 4. The most important configuration parameters have already been set in both `docker-compose.yml` files. Please refer to the plugin's official repository above for additional ones.

--- a/docker/docker-compose-examples/with-redis-session/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/with-redis-session/docker-compose-node-1.yml
@@ -51,7 +51,7 @@ services:
         DOT_ES_AUTH_BASIC_PASSWORD: 'admin'
         DOT_ES_ENDPOINTS: 'https://opensearch:9200'
         DOT_INITIAL_ADMIN_PASSWORD: 'admin'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/with-redis/README.md
+++ b/docker/docker-compose-examples/with-redis/README.md
@@ -25,7 +25,7 @@ The license pack must contain at least two licenses (one for each node in the cl
 3. A custom starter can be set through this line (uncomment and change the starter url accordingly):
 
 ```
-#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20250722/starter-20250722.zip'
+#"CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
 ```
 
 #### Deploying nodes:

--- a/docker/docker-compose-examples/with-redis/docker-compose-node-1.yml
+++ b/docker/docker-compose-examples/with-redis/docker-compose-node-1.yml
@@ -48,7 +48,7 @@ services:
         DOT_DOT_PUBSUB_PROVIDER_OVERRIDE: 'com.dotcms.dotpubsub.RedisPubSubImpl'
         DOT_REDIS_LETTUCECLIENT_URLS: 'redis://MY_SECRET_P4SS@redis'
         DOT_CACHE_DEFAULT_CHAIN: 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - opensearch
       - db

--- a/docker/docker-compose-examples/with-redis/docker-compose-node-2.yml
+++ b/docker/docker-compose-examples/with-redis/docker-compose-node-2.yml
@@ -26,7 +26,7 @@ services:
         DOT_DOT_PUBSUB_PROVIDER_OVERRIDE: 'com.dotcms.dotpubsub.RedisPubSubImpl'
         DOT_REDIS_LETTUCECLIENT_URLS: 'redis://MY_SECRET_P4SS@redis'
         DOT_CACHE_DEFAULT_CHAIN: 'com.dotmarketing.business.cache.provider.caffine.CaffineCache,com.dotcms.cache.lettuce.RedisCache'
-        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260409/starter-20260409.zip'
+        #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     volumes:
       #- {local_data_path}:/data/shared
       #- {license_local_path}/license.zip:/data/shared/assets/license.zip

--- a/dotBackendOnboarding.md
+++ b/dotBackendOnboarding.md
@@ -195,7 +195,7 @@ Advanced configurations allow you to customize and optimize your development env
 
 * Another way is to set up the following environment variable:
 	```sh
-	DOT_STARTER_DATA_LOAD =	'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240213/starter-20240213.zip'
+	DOT_STARTER_DATA_LOAD =	'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
 	```
 	Finally, once the change is made (using one of the previous options), remember to **recompile** the code so that the changes will take effect, running the following command:
 	

--- a/dotCMS/src/docker-compose/local-run/docker-compose.yml
+++ b/dotCMS/src/docker-compose/local-run/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
             'CMS_HEAP_SIZE': '1g'
 
-            # "CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20240719/starter-20240719.zip'
+            # "CUSTOM_STARTER_URL": 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
         depends_on:
             db:
                 condition: service_healthy

--- a/dotCMS/src/main/java/com/dotmarketing/util/starter/ImportStarterUtil.java
+++ b/dotCMS/src/main/java/com/dotmarketing/util/starter/ImportStarterUtil.java
@@ -10,7 +10,6 @@ import com.dotcms.experiments.business.ExperimentsFactory;
 import com.dotcms.experiments.model.Experiment;
 import com.dotcms.publishing.BundlerUtil;
 import com.dotcms.rest.api.v1.DotObjectMapperProvider;
-import com.dotcms.variant.VariantAPI;
 import com.dotcms.variant.VariantFactory;
 import com.dotcms.variant.model.Variant;
 import com.dotcms.repackage.net.sf.hibernate.HibernateException;
@@ -603,10 +602,13 @@ public class ImportStarterUtil {
             final VariantFactory variantFactory = FactoryLocator.getVariantFactory();
             for (int j = 0; j < l.size(); j++) {
                 final Variant v = (Variant) l.get(j);
-                // The variant table is not cleared by deleteDotCMS(); the DEFAULT variant always
-                // exists (created at startup), so skip it and any variant already present.
-                if (VariantAPI.DEFAULT_VARIANT.name().equals(v.name())
-                        || variantFactory.get(v.name()).isPresent()) {
+                // Skip variants already present to avoid PK violations (the variant table is not
+                // cleared by deleteDotCMS()). We DO import the DEFAULT variant from the starter:
+                // on a fresh install postgres.sql does not seed it and DefaultVariantInitializer
+                // runs only AFTER the starter import (MainServlet line 129 vs 218), so an experiment
+                // referencing the DEFAULT variant would otherwise fail TrafficProportion validation
+                // when its Experiment model is deserialized below.
+                if (variantFactory.get(v.name()).isPresent()) {
                     continue;
                 }
                 variantFactory.save(v);

--- a/tools/dotcms-cli/api-data-model/src/test/resources/docker-compose.yaml
+++ b/tools/dotcms-cli/api-data-model/src/test/resources/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       DOT_ES_AUTH_BASIC_PASSWORD: 'admin'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_ES_ENDPOINTS: 'http://elasticsearch:9200'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - elasticsearch
       - postgres

--- a/tools/dotcms-cli/cli/src/test/resources/docker-compose.yaml
+++ b/tools/dotcms-cli/cli/src/test/resources/docker-compose.yaml
@@ -49,7 +49,7 @@ services:
       DOT_ES_AUTH_BASIC_PASSWORD: 'admin'
       DOT_INITIAL_ADMIN_PASSWORD: 'admin'
       DOT_ES_ENDPOINTS: 'http://elasticsearch:9200'
-      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20211201/starter-20211201.zip'
+      #CUSTOM_STARTER_URL: 'https://repo.dotcms.com/artifactory/libs-release-local/com/dotcms/starter/20260629/starter-20260629.zip'
     depends_on:
       - elasticsearch
       - postgres


### PR DESCRIPTION
## Proposed Changes

Follow-up to #36339 (export/import of Experiments and Variants in the starter).

Manual round-trip testing surfaced a fatal error when importing a starter that contains experiments — startup aborts with:

```
Cannot construct instance of `com.dotcms.experiments.model.TrafficProportion`,
problem: Invalid Variants provided
```

### Root cause
On a fresh install the starter import runs in `MainServlet.init()` at **line 129** (`executeStartUpTasks()` → `Task00004LoadStarter` → `ImportStarterUtil`), while the `DEFAULT` variant is created later at **line 218** (`DotInitializationService` → `DefaultVariantInitializer`). `postgres.sql` does **not** seed the `DEFAULT` variant row, and the run-once upgrade tasks don't run on this path.

Every experiment's `trafficProportion` references the `DEFAULT` variant. Building the `Experiment` immutable during import triggers `AbstractTrafficProportion`'s `@Value.Check`, which validates that every referenced variant exists via `VariantAPI.get(...)`. Because the import branch was **explicitly skipping** the `DEFAULT` variant, it was absent at deserialize time → validation fails → startup is aborted.

### Fix
Stop skipping `DEFAULT` in the variant import branch — import it from the starter like any other variant. The existing `variantFactory.get(name).isPresent()` guard still prevents PK duplicates and makes it a no-op when the initializer already created the row. With `DEFAULT` (and the experiment variants) present before experiments deserialize, the model builds and `ExperimentsFactory.save()` works as designed.

This keeps the factory-based import (no raw SQL) and changes only `ImportStarterUtil`.

### Also included
- `fix(docker)`: bump `CUSTOM_STARTER_URL` references to the latest starter version (`20260629`) across docker-compose examples and docs, so deployments initialize from a starter that exercises this path.

## How to Test

1. On an instance with at least one A/B Experiment, download a starter (`_downloadStarter` / `_downloadStarterWithAssets`).
2. Point a fresh install at that starter (e.g. `CUSTOM_STARTER_URL`) and boot it.
3. Startup completes (no `Invalid Variants provided`), and the experiment + its variants are present and open correctly in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36337

This PR fixes: #36337