### PR TITLE
fix(content-drive): hide Upload button when items are selected (#36369)

### DIFF
--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.html
@@ -10,14 +10,16 @@
             <dot-content-drive-search-input data-testid="search-input" class="col-span-2" />
 
             <div class="col-start-3 flex items-center gap-2 justify-self-end">
-                <p-button
-                    [label]="'content-drive.upload' | dm"
-                    icon="pi pi-upload"
-                    [outlined]="true"
-                    data-testid="upload-asset-button"
-                    (click)="$upload.emit()" />
-
                 @if ($displayButton()) {
+                    <p-button
+                        animate.enter="toolbar-enter"
+                        animate.leave="toolbar-leave"
+                        [label]="'content-drive.upload' | dm"
+                        icon="pi pi-upload"
+                        [outlined]="true"
+                        data-testid="upload-asset-button"
+                        (click)="$upload.emit()" />
+
                     <p-button
                         animate.enter="toolbar-enter"
                         animate.leave="toolbar-leave"

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
@@ -16,13 +16,27 @@ import {
     DotHttpErrorManagerService,
     DotLanguagesService
 } from '@dotcms/data-access';
+import { DotContentDriveItem } from '@dotcms/dotcms-models';
 import { DotUVEPaletteListTypes } from '@dotcms/portlets/dot-ema/ui';
 
 import { DotContentDriveToolbarComponent } from './dot-content-drive-toolbar.component';
 
 import { DIALOG_TYPE } from '../../shared/constants';
-import { MOCK_BASE_TYPES, MOCK_CONTENT_TYPES } from '../../shared/mocks';
+import { MOCK_BASE_TYPES, MOCK_CONTENT_TYPES, MOCK_ITEMS } from '../../shared/mocks';
 import { DotContentDriveStore } from '../../store/dot-content-drive.store';
+
+/**
+ * The creation buttons (Upload + "Add New") are driven by an animation state machine that hides
+ * them for {@link ANIMATION_DELAY} ms on init and whenever a selection toggles. Wait past that
+ * window before asserting they are visible. Mirrors the delay used in the component.
+ */
+const settleToolbarAnimation = async (spectator: Spectator<DotContentDriveToolbarComponent>) => {
+    // First detection runs the selection effect so the "show" timer gets scheduled; then we wait
+    // past the delay and render the settled state.
+    spectator.detectChanges();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    spectator.detectChanges();
+};
 
 describe('DotContentDriveToolbarComponent', () => {
     let spectator: Spectator<DotContentDriveToolbarComponent>;
@@ -31,6 +45,7 @@ describe('DotContentDriveToolbarComponent', () => {
     // Real signals so the component's computeds re-run when they change
     const isTreeExpandedSignal = signal(false);
     const filtersSignal = signal<Record<string, unknown>>({});
+    const selectedItemsSignal = signal<DotContentDriveItem[]>([]);
 
     const createComponent = createComponentFactory({
         component: DotContentDriveToolbarComponent,
@@ -44,7 +59,7 @@ describe('DotContentDriveToolbarComponent', () => {
                 clearFilters: jest.fn(),
                 filters: filtersSignal,
                 setDialog: jest.fn(),
-                selectedItems: jest.fn().mockReturnValue([])
+                selectedItems: selectedItemsSignal
             }),
             mockProvider(DotContentTypeService, {
                 getContentTypes: jest.fn().mockReturnValue(of(MOCK_CONTENT_TYPES)),
@@ -79,6 +94,7 @@ describe('DotContentDriveToolbarComponent', () => {
         jest.clearAllMocks();
         isTreeExpandedSignal.set(false);
         filtersSignal.set({});
+        selectedItemsSignal.set([]);
     });
 
     it('should render toolbar container', () => {
@@ -262,11 +278,15 @@ describe('DotContentDriveToolbarComponent', () => {
     });
 
     describe('Upload button', () => {
-        it('should render the upload button', () => {
+        it('should render the upload button when no items are selected', async () => {
+            await settleToolbarAnimation(spectator);
+
             expect(spectator.query(byTestId('upload-asset-button'))).toBeTruthy();
         });
 
-        it('should emit upload when the upload button is clicked', () => {
+        it('should emit upload when the upload button is clicked', async () => {
+            await settleToolbarAnimation(spectator);
+
             const emitSpy = jest.fn();
             spectator.component.$upload.subscribe(emitSpy);
 
@@ -276,6 +296,49 @@ describe('DotContentDriveToolbarComponent', () => {
             spectator.click(uploadButton as HTMLElement);
 
             expect(emitSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('should hide the upload button when a single item is selected', async () => {
+            await settleToolbarAnimation(spectator);
+            expect(spectator.query(byTestId('upload-asset-button'))).toBeTruthy();
+
+            selectedItemsSignal.set([MOCK_ITEMS[0]]);
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('upload-asset-button'))).toBeNull();
+        });
+
+        it('should hide the upload button when multiple items are selected', async () => {
+            await settleToolbarAnimation(spectator);
+            expect(spectator.query(byTestId('upload-asset-button'))).toBeTruthy();
+
+            selectedItemsSignal.set([MOCK_ITEMS[0], MOCK_ITEMS[1]]);
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('upload-asset-button'))).toBeNull();
+        });
+
+        it('should hide the upload button alongside the "Add New" button on selection', async () => {
+            await settleToolbarAnimation(spectator);
+            expect(spectator.query(byTestId('upload-asset-button'))).toBeTruthy();
+            expect(spectator.query(byTestId('add-new-button'))).toBeTruthy();
+
+            selectedItemsSignal.set([MOCK_ITEMS[0]]);
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('upload-asset-button'))).toBeNull();
+            expect(spectator.query(byTestId('add-new-button'))).toBeNull();
+        });
+
+        it('should show the upload button again when the selection is cleared', async () => {
+            selectedItemsSignal.set([MOCK_ITEMS[0]]);
+            spectator.detectChanges();
+            expect(spectator.query(byTestId('upload-asset-button'))).toBeNull();
+
+            selectedItemsSignal.set([]);
+            await settleToolbarAnimation(spectator);
+
+            expect(spectator.query(byTestId('upload-asset-button'))).toBeTruthy();
         });
     });
 });

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.spec.ts
@@ -298,6 +298,10 @@ describe('DotContentDriveToolbarComponent', () => {
             expect(emitSpy).toHaveBeenCalledTimes(1);
         });
 
+        // Hiding is synchronous: the selection effect sets `addNewButton: false` immediately, so
+        // a single detectChanges() removes the button. We deliberately assert before the delayed
+        // workflow-actions transition fires — mounting that child pulls in providers (MessageService)
+        // outside this toolbar unit test's scope.
         it('should hide the upload button when a single item is selected', async () => {
             await settleToolbarAnimation(spectator);
             expect(spectator.query(byTestId('upload-asset-button'))).toBeTruthy();

--- a/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.ts
+++ b/core-web/libs/portlets/dot-content-drive/portlet/src/lib/components/dot-content-drive-toolbar/dot-content-drive-toolbar.component.ts
@@ -195,7 +195,12 @@ export class DotContentDriveToolbarComponent {
     });
 
     /**
-     * Convenience computed signals for template readability
+     * Convenience computed signals for template readability.
+     *
+     * `$displayButton` gates the creation actions (Upload + "Add New"): both are hidden while a
+     * selection is active so they don't compete with the workflow/bulk actions. This keeps the
+     * Upload button from offering an upload in a selection context, where the target folder would
+     * be ambiguous.
      */
     readonly $displayButton = computed(() => this.$animationState().addNewButton);
     readonly $displayActions = computed(() => this.$animationState().workflowActions);

--- a/core-web/libs/sdk/experiments/README.md
+++ b/core-web/libs/sdk/experiments/README.md
@@ -229,7 +229,7 @@ Once you wrap your component with `withExperiments`, the SDK automatically handl
 -   **GitHub Issues**: [open an issue](https://github.com/dotCMS/core/issues/new/choose)
 -   **Community Forum**: [community.dotcms.com](https://community.dotcms.com/)
 -   **Stack Overflow**: tag `dotcms-experiments`
--   **Enterprise Support**: [dotCMS Support Portal](https://helpdesk.dotcms.com/support/)
+-   **Enterprise Support**: [dotCMS Support](https://www.dotcms.com/support)
 
 When reporting issues, include SDK version, framework version, minimal reproduction steps, and expected vs. actual behavior.
 


### PR DESCRIPTION
## Proposed Changes

Fixes #36369

While doing QA on Content Drive, the **Upload** button stayed visible even when items were selected in the grid. Uploading in that state stored the asset in the **root/current folder** rather than the selection — confusing, since the selection implies an action context.

The toolbar already establishes the right pattern: when `selectedItems().length > 0` (`$showWorkflowActions`), the **"Add New"** button is hidden and the workflow/bulk actions are swapped in via the `$displayButton()` animation state. The **Upload** button was simply hardcoded outside that gate and left always-visible.

This PR moves the Upload button **inside** the same `@if ($displayButton())` block (with matching enter/leave animations), so both creation actions hide/show together on selection.

### Behavior

| Selection | Upload button |
|---|---|
| None | Visible — uploads to the current/navigated folder (unchanged) |
| One or more items | Hidden (consistent with "Add New") |
| Cleared | Reappears |

**Per team decision** (Slack thread), we hide the button rather than redirecting the upload target to the selected folder — this avoids coupling a spatial drag-and-drop gesture to a checkbox selection and the ambiguity that comes with it. **No changes to upload-target logic or drag-and-drop.**

## Checklist

- [x] Tests added/updated (visible with empty selection, hidden on single/multiple selection, hides alongside "Add New", reappears when cleared)
- [x] `pnpm nx test portlets-content-drive` — 672/672 pass
- [x] `pnpm nx lint portlets-content-drive` — clean

## Screenshots

_Manual QA: select one or more items in the grid → Upload button hides alongside "Add New"; clear the selection → both reappear._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #36369