### PR TITLE
test(search): SearchAPI phase-routing, fallback & permission-filtering coverage (#35669)

### DIFF
--- a/dotCMS/src/test/java/com/dotcms/content/index/PhaseRouterTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/PhaseRouterTest.java
@@ -1,11 +1,13 @@
 package com.dotcms.content.index;
 
 import static com.dotcms.content.index.IndexConfigHelper.MigrationPhase.FLAG_KEY;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.dotmarketing.exception.DotDataException;
 import com.dotmarketing.util.Config;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -325,6 +327,127 @@ public class PhaseRouterTest {
     }
 
     // =========================================================================
+    // read() / readChecked() — single-provider read with Phase-2 ES fallback
+    // Used by: SearchAPIImpl.search(), searchRaw(), searchRelated()
+    //
+    // TC-030 (L-5): in Phase 2 OS is the read provider but ES is still active.
+    // If OS throws, the router logs "OS read failed in Phase 2 — falling back to ES"
+    // and retries the read against ES, so a transient OS failure never surfaces.
+    // No fallback exists in phases 0/1 (read from ES) or phase 3 (ES decommissioned).
+    // =========================================================================
+
+    /**
+     * Given Scenario: Phase 2 (OS reads, ES still active). OS.search() throws; ES.search() succeeds.
+     * When : read() delegates the search.
+     * Then : the call does NOT throw and returns the ES fallback result. Both providers are called
+     *        (OS first, then ES). This is the core TC-030 safety mechanism for {@code read()}.
+     */
+    @Test
+    public void test_read_phase2_osFailure_fallsBackToEs() {
+        final AtomicBoolean osCalled = new AtomicBoolean();
+        final AtomicBoolean esCalled = new AtomicBoolean();
+
+        final Supplier<String> osRead = () -> {
+            osCalled.set(true);
+            throw new RuntimeException("OS read failed — index stale or unavailable");
+        };
+        final Supplier<String> esRead = () -> {
+            esCalled.set(true);
+            return "es-result";
+        };
+
+        final PhaseRouter<Supplier<String>> router = new PhaseRouter<>(esRead, osRead);
+        setPhase(2);
+
+        final String result = router.read(Supplier::get);
+
+        assertEquals("Phase-2 read must fall back to the ES result when OS throws",
+                "es-result", result);
+        assertTrue("OS (read provider) must be attempted first", osCalled.get());
+        assertTrue("ES (fallback) must be called after the OS failure", esCalled.get());
+    }
+
+    /**
+     * Given Scenario: Phase 2. OS.search() throws a checked exception; ES.search() succeeds.
+     * When : readChecked() delegates the search (this is the path {@code SearchAPIImpl.search()} uses).
+     * Then : the checked call does NOT throw and returns the ES fallback result.
+     */
+    @Test
+    public void test_readChecked_phase2_osFailure_fallsBackToEs() throws Exception {
+        final AtomicBoolean osCalled = new AtomicBoolean();
+        final AtomicBoolean esCalled = new AtomicBoolean();
+
+        final PhaseRouter<CheckedSupplier<String>> router = new PhaseRouter<>(
+                () -> { esCalled.set(true); return "es-result"; },
+                () -> {
+                    osCalled.set(true);
+                    throw new DotDataException("OS read failed in Phase 2");
+                });
+        setPhase(2);
+
+        final String result = router.readChecked(CheckedSupplier::get);
+
+        assertEquals("Phase-2 checked read must fall back to ES when OS throws",
+                "es-result", result);
+        assertTrue("OS (read provider) must be attempted first", osCalled.get());
+        assertTrue("ES (fallback) must be called after the OS failure", esCalled.get());
+    }
+
+    /**
+     * Given Scenario: Phase 2. Both OS (primary read) and ES (fallback) fail.
+     * When : readChecked() delegates the search.
+     * Then : the fallback is exhausted — the ES exception propagates to the caller.
+     */
+    @Test
+    public void test_readChecked_phase2_bothFail_esExceptionPropagates() {
+        final PhaseRouter<CheckedSupplier<String>> router = new PhaseRouter<>(
+                () -> { throw new DotDataException("ES also unavailable"); },
+                () -> { throw new DotDataException("OS read failed in Phase 2"); });
+        setPhase(2);
+
+        final Exception thrown = assertThrows(Exception.class,
+                () -> router.readChecked(CheckedSupplier::get));
+        assertTrue("the ES (fallback) failure must be the one that surfaces",
+                thrown.getMessage().contains("ES also unavailable"));
+    }
+
+    /**
+     * Given Scenario: Phase 3 (OS only, ES decommissioned). OS.search() throws.
+     * When : read() delegates the search.
+     * Then : there is NO fallback — the OS exception propagates and ES is never contacted.
+     *        Confirms the fallback is strictly Phase-2 scoped.
+     */
+    @Test
+    public void test_read_phase3_osFailure_propagates_esNeverCalled() {
+        final Supplier<String> esRead = () -> { fail("ES must NOT be called in Phase 3"); return null; };
+        final Supplier<String> osRead = () -> { throw new RuntimeException("OS read failed"); };
+
+        final PhaseRouter<Supplier<String>> router = new PhaseRouter<>(esRead, osRead);
+        setPhase(3);
+
+        assertThrows(RuntimeException.class, () -> router.read(Supplier::get));
+    }
+
+    /**
+     * Given Scenario: Phase 1 (dual-write, ES reads). ES is the read provider.
+     * When : read() delegates the search.
+     * Then : the result comes from ES and OS is never contacted — there is no read-path fan-out
+     *        and no spurious fallback in phases 0/1.
+     */
+    @Test
+    public void test_read_phase1_readsFromEs_osNeverCalled() {
+        final AtomicBoolean osCalled = new AtomicBoolean();
+        final Supplier<String> esRead = () -> "es-result";
+        final Supplier<String> osRead = () -> { osCalled.set(true); return "os-result"; };
+
+        final PhaseRouter<Supplier<String>> router = new PhaseRouter<>(esRead, osRead);
+        setPhase(1);
+
+        assertEquals("Phase-1 reads must come from ES", "es-result", router.read(Supplier::get));
+        assertFalse("OS must NOT be contacted on the Phase-1 read path", osCalled.get());
+    }
+
+    // =========================================================================
     // Helpers
     // =========================================================================
 
@@ -332,6 +455,12 @@ public class PhaseRouterTest {
     @FunctionalInterface
     interface ThrowingAction {
         void run() throws Exception;
+    }
+
+    /** Simulates a checked read operation returning a value (e.g. search, searchRaw). */
+    @FunctionalInterface
+    interface CheckedSupplier<R> {
+        R get() throws Exception;
     }
 
     private static void setPhase(final int ordinal) {

--- a/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/OSSearchAPIImplIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/OSSearchAPIImplIntegrationTest.java
@@ -3,6 +3,7 @@ package com.dotcms.content.index.opensearch;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.dotcms.DataProviderWeldRunner;
@@ -18,6 +19,7 @@ import com.dotcms.content.index.domain.IndexBulkRequest;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.common.db.DotConnect;
+import com.dotmarketing.portlets.contentlet.model.Contentlet;
 import com.dotmarketing.util.Logger;
 import com.liferay.portal.model.User;
 import java.util.List;
@@ -360,6 +362,43 @@ public class OSSearchAPIImplIntegrationTest extends IntegrationTestBase {
         assertNotNull("search with respectFrontendRoles=true must return non-null results", results);
         Logger.info(this,
                 "✅ test_search_respectFrontendRoles_nullUser_shouldNotThrow passed");
+    }
+
+    /**
+     * TC-031 (L-6) — {@link ContentSearchResults} exposes the correct index-level total and a
+     * null scroll id for a standard (non-scroll) search.
+     *
+     * <p>Given scenario: One known document is indexed into the working index; a match-all query
+     * is run through {@link OSSearchAPIImpl#search}.</p>
+     *
+     * <p>Expected:</p>
+     * <ul>
+     *   <li>{@code getTotalResults()} reports {@code 1} — the index-level hit count from
+     *       {@code response.hits().getTotalHits().value()}, independent of DB hydration.</li>
+     *   <li>{@code getScrollId()} is {@code null} — the query was not initiated with scroll
+     *       parameters.</li>
+     *   <li>The result type is {@code ContentSearchResults<Contentlet>}, iterated without an
+     *       unchecked cast (compile-time guarantee of the generic {@code List<T>} contract).</li>
+     * </ul>
+     */
+    @Test
+    public void test_search_indexedDocument_totalResultsIsOne_scrollIdIsNull() throws Exception {
+
+        indexTestDocument(physicalWorking);
+
+        final String matchAll = "{\"query\":{\"match_all\":{}}}";
+
+        final ContentSearchResults<Contentlet> results =
+                osSearchAPI.search(matchAll, false, systemUser, false);
+
+        assertNotNull("search must return non-null ContentSearchResults", results);
+        assertEquals("getTotalResults() must report the index-level hit count",
+                1L, results.getTotalResults());
+        assertNull("getScrollId() must be null for a standard non-scroll query",
+                results.getScrollId());
+
+        Logger.info(this,
+                "✅ test_search_indexedDocument_totalResultsIsOne_scrollIdIsNull passed");
     }
 
     // =======================================================================

--- a/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/OSSearchAPIImplIntegrationTest.java
+++ b/dotcms-integration/src/test/java/com/dotcms/content/index/opensearch/OSSearchAPIImplIntegrationTest.java
@@ -16,6 +16,7 @@ import com.dotcms.content.index.domain.AggregationBucket;
 import com.dotcms.content.index.domain.ContentSearchResponse;
 import com.dotcms.content.index.domain.ContentSearchResults;
 import com.dotcms.content.index.domain.IndexBulkRequest;
+import com.dotcms.datagen.UserDataGen;
 import com.dotcms.util.IntegrationTestInitService;
 import com.dotmarketing.business.APILocator;
 import com.dotmarketing.common.db.DotConnect;
@@ -399,6 +400,62 @@ public class OSSearchAPIImplIntegrationTest extends IntegrationTestBase {
 
         Logger.info(this,
                 "✅ test_search_indexedDocument_totalResultsIsOne_scrollIdIsNull passed");
+    }
+
+    // =======================================================================
+    // Tests – permission injection (non-admin filtering)
+    // =======================================================================
+
+    /**
+     * #35669 (point 3) — {@code searchRaw} permission injection filters results for non-admin users.
+     *
+     * <p>Given scenario: One document whose {@code permissions} field carries a token for a role
+     * that no test user holds is indexed into the working index (with {@code live:true}, so the only
+     * possible reason for exclusion is the permission clause). Two searches are then run against the
+     * same index:</p>
+     * <ul>
+     *   <li><b>As the system user (admin)</b> — {@code executeSearch} detects the CMS Admin role and
+     *       injects <i>no</i> permission filter, so the document is visible.</li>
+     *   <li><b>As a freshly-created non-admin user</b> — {@code addPermissionsToQuery} injects a
+     *       required permission clause built from that user's roles. The document matches none of
+     *       them (owner clause fails, permission token belongs to an unrelated role), so it is
+     *       filtered out.</li>
+     * </ul>
+     *
+     * <p>Expected: admin sees {@code 1} hit; the non-admin user sees {@code 0}. This proves the
+     * permission filter is injected for non-admins and skipped for admins on the OS read path.</p>
+     */
+    @Test
+    public void test_searchRaw_nonAdminUser_isFilteredByInjectedPermissions() throws Exception {
+
+        // A role id no test user holds → the injected permission token never matches.
+        final String unheldRoleId = "unheld-role-" + RUN_ID;
+        final String docId = "perm-hidden-" + RUN_ID + "_1_default";
+        final String docJson =
+                "{\"identifier\":\"perm-hidden-" + RUN_ID + "\","
+                + "\"inode\":\"perm-hidden-inode-" + RUN_ID + "\","
+                + "\"live\":true,"
+                + "\"contenttype\":\"testtype\","
+                + "\"permissions\":\"P" + unheldRoleId + ".1P \"}";
+        indexDocument(physicalWorking, docId, docJson);
+
+        final User limitedUser = new UserDataGen().nextPersisted();
+        final String matchAll = "{\"query\":{\"match_all\":{}}}";
+
+        // Admin: no permission filter injected → document is visible.
+        final ContentSearchResponse adminResp =
+                osSearchAPI.searchRaw(matchAll, false, systemUser, false);
+        assertEquals("Admin (no permission filter) must see the document",
+                1L, adminResp.hits().getTotalHits().value());
+
+        // Non-admin: permission filter injected → document is filtered out.
+        final ContentSearchResponse limitedResp =
+                osSearchAPI.searchRaw(matchAll, false, limitedUser, false);
+        assertEquals("Non-admin user must NOT see a document they lack read permission on",
+                0L, limitedResp.hits().getTotalHits().value());
+
+        Logger.info(this,
+                "✅ test_searchRaw_nonAdminUser_isFilteredByInjectedPermissions passed");
     }
 
     // =======================================================================


### PR DESCRIPTION
### Proposed Changes

Adds the deferred integration/unit test coverage for the phase-aware `SearchAPI` layer introduced in #35609, closing the three gaps tracked in #35669. **No production code changes** — the routing, fallback, and permission-injection behaviour were already correct; these tests lock it in and unblock QA sign-off on #35752 (TC-030 / TC-031).

**`PhaseRouterTest` — Phase-2 ES fallback (#35669 point 2 / TC-030, L-5)**
The existing test class covered every write path but had **no** `read`/`readChecked` coverage. Added 5 cases on the existing harness:
- Phase 2 — OS read throws → falls back to ES, does not throw (both `read()` and `readChecked()`)
- Phase 2 — OS and ES both fail → the ES (fallback) exception surfaces
- Phase 3 — OS failure propagates, ES never contacted (fallback is strictly Phase-2 scoped)
- Phase 1 — read comes from ES, OS never contacted (no spurious fallback)

**`OSSearchAPIImplIntegrationTest` — result contract + permission filtering (#35669 points 3 / TC-031, L-6)**
- `ContentSearchResults<Contentlet>` from `search()` reports `getTotalResults() == 1` and a null `getScrollId()` for a standard non-scroll query.
- `searchRaw` permission injection filters results for non-admin users: a document carrying a permission token for a role no test user holds is visible to the system user (admin — no filter injected) but filtered out for a freshly-created non-admin user. Exercises the `executeSearch` / `addPermissionsToQuery` path end-to-end against OpenSearch.

### Why the permission test asserts exclusion rather than a positive match

The indexed `permissions` field uses the `whitespace` (case-sensitive) analyzer while the injected query token is a lowercase wildcard (`permissions:p<roleId>.1p*`). Reproducing a positive wildcard match by hand-crafting a raw document is analyzer-fragile. The security contract in #35669 point 3 is *"filters results for non-admin users"*, so the test asserts the deterministic exclusion contract (admin sees the doc, non-admin does not) through the real `executeSearch` path — no dependence on the wildcard-match internals.

### This PR fixes: #35669

Related to #35752 (QA-G10 — this PR unblocks TC-030 / TC-031; it does not close the QA ticket).

### Checklist
- [x] Tests added (unit + integration)
- [x] No production code changed
- [ ] Integration tests run in CI via `OpenSearchUpgradeSuite` (require the `opensearch-upgrade` container; the `PhaseRouterTest` unit tests run locally and pass 17/17)

### Additional Info

Unblocks QA on #35752 (TC-030 and TC-031 were blocked pending this issue). A separate finding surfaced during QA — `/api/es/raw` bypassing the phase router via the deprecated `esSearchRaw()` — is **out of scope** here and should be tracked on its own before the Phase 3 cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35669