### PR TITLE
fix(build): select Node.js arch in build_dotcms.sh so the arm64 image build works

### DIFF
--- a/docker/images/dotcms/build-src/build_dotcms.sh
+++ b/docker/images/dotcms/build-src/build_dotcms.sh
@@ -11,8 +11,12 @@ build_target_dir=/build/cms
 mkdir -p "${build_target_dir}"
 
 mkdir -p /tmp/nodetmp
-curl --output /tmp/nodetmp/testing.tar.gz https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-x64.tar.gz && tar -zxvf /tmp/nodetmp/testing.tar.gz -C /tmp/nodetmp/
-export PATH=$PATH:/tmp/nodetmp/node-v7.9.0-linux-x64:/tmp/nodetmp/node-v7.9.0-linux-x64/bin
+# Pick the Node.js build matching the target architecture so the multi-arch
+# (linux/amd64,linux/arm64) docker build works. Hardcoding linux-x64 breaks the
+# arm64 leg (npm exits 127 - cannot exec an x64 binary).
+NODE_ARCH=x64; [ "$(uname -m)" = "aarch64" ] && NODE_ARCH=arm64
+curl --output /tmp/nodetmp/testing.tar.gz https://nodejs.org/dist/v7.9.0/node-v7.9.0-linux-${NODE_ARCH}.tar.gz && tar -zxvf /tmp/nodetmp/testing.tar.gz -C /tmp/nodetmp/
+export PATH=$PATH:/tmp/nodetmp/node-v7.9.0-linux-${NODE_ARCH}:/tmp/nodetmp/node-v7.9.0-linux-${NODE_ARCH}/bin
 
 get_by_url() {
     build_download_dir=/build/download


### PR DESCRIPTION
## Problem
The `build-docker-image-5x` workflow (multi-arch `linux/amd64,linux/arm64`) has been **failing on the arm64 leg since ~Oct 2025** (last green build: 2025-08-29). Most recently it failed on the merge of #36210 — [run 28550262803](https://github.com/dotCMS/core/actions/runs/28550262803):

```
Execution failed for task ':installDotcmsUI'.
> Process 'command 'npm'' finished with non-zero exit value 127
```

## Root cause
`docker/images/dotcms/build-src/build_dotcms.sh` hard-codes the **amd64** Node.js binary:
```bash
curl ... node-v7.9.0-linux-x64.tar.gz
export PATH=$PATH:/tmp/nodetmp/node-v7.9.0-linux-x64/bin
```
On the `linux/arm64` build leg that x64 `node`/`npm` can't execute (exit 127 = cannot exec), so `installDotcmsUI` fails and sinks the whole multi-arch build. (The amd64 leg builds fine — it historically worked on arm64 too because the amd64 runner could exec x64 binaries inside the emulated container, until a runner/buildx change stopped that.)

## Fix
Detect the target arch via `uname -m` and download the matching Node.js tarball. The `node-v7.9.0-linux-arm64` build is published upstream.

```bash
NODE_ARCH=x64; [ "$(uname -m)" = "aarch64" ] && NODE_ARCH=arm64
curl ... node-v7.9.0-linux-${NODE_ARCH}.tar.gz
export PATH=$PATH:/tmp/nodetmp/node-v7.9.0-linux-${NODE_ARCH}/bin
```

## Verification
Pushed to the `fix-arm64-node-build-5.1.6.k` branch, which triggered the workflow — **[run 28552812911](https://github.com/dotCMS/core/actions/runs/28552812911) succeeded** (30m59s, both legs green) and published multi-arch (amd64 + arm64) images:
- `dotcms/dotcms:5.1.6.k_0bd3d58_SNAPSHOT`
- `dotcms/dotcms:5.1.6.k_latest_SNAPSHOT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)