### PR TITLE
feat(dot-uve-contentlet-tools): implement dynamic positioning for too…

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.html
@@ -23,12 +23,16 @@
         <p-button
             (click)="setPositionFlag('before'); menuHover.toggle($event)"
             class="add-button-top"
+            [style.top.px]="hoverTopClipOffset()"
+            [style.transform]="hoverTopClipOffset() ? 'translate(-50%, 0)' : null"
             data-testId="hover-add-top-button"
             icon="pi pi-plus" />
         @if (!hoverIsEmpty) {
             <p-button
                 (click)="setPositionFlag('after'); menuHover.toggle($event)"
                 class="add-button-bottom"
+                [style.bottom.px]="hoverBottomClipOffset()"
+                [style.transform]="hoverBottomClipOffset() ? 'translate(-50%, 0)' : null"
                 data-testId="hover-add-bottom-button"
                 icon="pi pi-plus" />
         }
@@ -38,7 +42,8 @@
                  outside `.actions` so it's visible at every container
                  size (drag is the one action that has no menu equivalent). -->
             <div
-                class="drag-button absolute flex pointer-events-[all] z-1 bg-white rounded-md border border-solid border-gray-300">
+                class="drag-button pointer-events-[all] absolute z-1 flex rounded-md border border-solid border-gray-300 bg-white"
+                [style.top.px]="hoverDragButtonTopOffset()">
                 <p-button
                     [attr.data-item]="hoverDragItem | json"
                     [attr.data-use-custom-drag-image]="useCustomDragImage"
@@ -54,7 +59,9 @@
             <!-- Full actions row: rendered when the contentlet is wide
                  enough. Hidden by container query below 600px. -->
             <div
-                class="actions actions-full absolute right-2 top-0 transform-[translate(0,-50%)] flex justify-end gap-1 pointer-events-[all] z-1 bg-white rounded-md border border-solid border-gray-300"
+                class="actions actions-full pointer-events-[all] absolute top-0 right-2 z-1 flex transform-[translate(0,-50%)] justify-end gap-1 rounded-md border border-solid border-gray-300 bg-white"
+                [style.top.px]="hoverTopClipOffset()"
+                [style.transform]="hoverTopClipOffset() ? 'translate(0, 0)' : null"
                 data-testId="hover-actions">
                 @if (hasVtlFiles()) {
                     <p-button
@@ -109,7 +116,9 @@
                  a menu with the same actions. Hidden by container query
                  above 600px. VTL files appear as a nested submenu. -->
             <div
-                class="actions actions-collapsed absolute right-2 top-0 transform-[translate(0,-50%)] flex pointer-events-[all] z-1 bg-white rounded-md border border-solid border-gray-300"
+                class="actions actions-collapsed pointer-events-[all] absolute top-0 right-2 z-1 flex transform-[translate(0,-50%)] rounded-md border border-solid border-gray-300 bg-white"
+                [style.top.px]="hoverTopClipOffset()"
+                [style.transform]="hoverTopClipOffset() ? 'translate(0, 0)' : null"
                 data-testId="hover-actions-collapsed">
                 <p-button
                     (click)="menuHoverActions.toggle($event)"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.spec.ts
@@ -105,6 +105,9 @@ describe('DotUveContentletToolsComponent', () => {
                 useFactory: () => ({
                     editorSelected,
                     $iframeLayoutLocked: () => false,
+                    // Tall enough that none of the fixture areas trigger the
+                    // bottom clip offset unless a test overrides it.
+                    viewIframeHeight: () => 800,
                     // promoteHoverToSelected calls setSelected on the store
                     // before emitting select/quick-edit events. Stub it so
                     // the (click) handler doesn't throw and the output fires.
@@ -627,6 +630,94 @@ describe('DotUveContentletToolsComponent', () => {
                 expect(bounds).toBeTruthy();
                 // The computed uses ?? operator, so undefined x should default to 0
                 expect(parseInt(bounds.style.left, 10)).toBe(0);
+            });
+        });
+
+        describe('hoverTopClipOffset', () => {
+            it('should be null when the top edge is visible', () => {
+                expect(spectator.component.hoverTopClipOffset()).toBeNull();
+            });
+
+            it('should offset the top toolbar row when the top edge is scrolled above the iframe', () => {
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: -50 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                expect(spectator.component.hoverTopClipOffset()).toBe(50);
+
+                const actions = spectator.query(byTestId('hover-actions')) as HTMLElement;
+                expect(actions.style.top).toBe('50px');
+                expect(actions.style.transform).toBe('translate(0, 0)');
+            });
+
+            it('should cap the offset at the contentlet height so it never overshoots the box', () => {
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: -500 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                expect(spectator.component.hoverTopClipOffset()).toBe(scrolledArea.height);
+            });
+        });
+
+        describe('hoverBottomClipOffset', () => {
+            it('should be null when the bottom edge is visible', () => {
+                expect(spectator.component.hoverBottomClipOffset()).toBeNull();
+            });
+
+            it('should offset the bottom add button when the bottom edge overflows the iframe', () => {
+                // Store mock reports an 800px-tall iframe; y(200) + height(400) - 800 = -200 (fits).
+                // Push the area down so it overflows by 100px.
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: 500 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                expect(spectator.component.hoverBottomClipOffset()).toBe(100);
+
+                const addBottomButton = spectator.query(
+                    byTestId('hover-add-bottom-button')
+                ) as HTMLElement;
+                expect(addBottomButton.style.bottom).toBe('100px');
+                expect(addBottomButton.style.transform).toBe('translate(-50%, 0)');
+            });
+        });
+
+        describe('hoverDragButtonTopOffset', () => {
+            it('should be null when the natural vertical center is visible', () => {
+                // center = y(200) + height(400) / 2 = 400, within the 800px mock iframe.
+                expect(spectator.component.hoverDragButtonTopOffset()).toBeNull();
+            });
+
+            it('should clamp the handle to the top of the iframe when the center is scrolled above it', () => {
+                // center = y(-300) + height(400) / 2 = -100, above the iframe top (0).
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: -300 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                // clampedCenter(0) - y(-300) = 300
+                expect(spectator.component.hoverDragButtonTopOffset()).toBe(300);
+
+                const dragButton = spectator.query(byTestId('hover-drag-button'))
+                    ?.parentElement as HTMLElement;
+                expect(dragButton.style.top).toBe('300px');
+            });
+
+            it('should clamp the handle to the bottom of the iframe when the center is scrolled below it', () => {
+                // Store mock reports an 800px-tall iframe.
+                // center = y(700) + height(400) / 2 = 900, below the iframe bottom (800).
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: 700 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                // clampedCenter(800) - y(700) = 100
+                expect(spectator.component.hoverDragButtonTopOffset()).toBe(100);
+            });
+
+            it('should never exceed the contentlet height', () => {
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: -5000 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                expect(spectator.component.hoverDragButtonTopOffset()).toBe(scrolledArea.height);
             });
         });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.ts
@@ -355,6 +355,64 @@ export class DotUveContentletToolsComponent {
     });
 
     /**
+     * How far (in px) the top toolbar row (add-top button + actions) must shift
+     * down from the hovered contentlet's own top edge to stay inside the visible
+     * iframe area. `null` (no override) when the top edge is already visible —
+     * the contentlet's top can scroll above the iframe's internal viewport,
+     * which would otherwise push the toolbar off-screen along with it.
+     */
+    protected readonly hoverTopClipOffset = computed<number | null>(() => {
+        const area = this.contentletArea();
+        if (!area || area.y >= 0) {
+            return null;
+        }
+
+        return Math.min(-area.y, area.height);
+    });
+
+    /**
+     * How far (in px) the add-bottom button must shift up from the hovered
+     * contentlet's own bottom edge to stay inside the visible iframe area.
+     * `null` (no override) when the bottom edge is already visible.
+     */
+    protected readonly hoverBottomClipOffset = computed<number | null>(() => {
+        const area = this.contentletArea();
+        if (!area) {
+            return null;
+        }
+
+        const overflow = area.y + area.height - this.#uveStore.viewIframeHeight();
+
+        return overflow > 0 ? Math.min(overflow, area.height) : null;
+    });
+
+    /**
+     * The drag handle sits at the vertical center of the hovered contentlet
+     * (`top: 50%` in CSS). On a tall contentlet, that center point can itself
+     * be scrolled outside the visible iframe area even while the handle's
+     * default position would otherwise be off-screen. This clamps the
+     * handle's `top` to the closest visible point along the contentlet's own
+     * height, keeping the CSS `translate(-50%, -50%)` centering unchanged.
+     * `null` (no override) when the natural center is already visible.
+     */
+    protected readonly hoverDragButtonTopOffset = computed<number | null>(() => {
+        const area = this.contentletArea();
+        if (!area) {
+            return null;
+        }
+
+        const iframeHeight = this.#uveStore.viewIframeHeight();
+        const center = area.y + area.height / 2;
+        const clampedCenter = Math.min(Math.max(center, 0), iframeHeight);
+
+        if (clampedCenter === center) {
+            return null;
+        }
+
+        return Math.min(Math.max(clampedCenter - area.y, 0), area.height);
+    });
+
+    /**
      * Inline styles that bound the floating toolbar to the visual rectangle of the selected contentlet.
      * The toolbar is absolutely positioned based on `editorSelected.bounds`.
      */


### PR DESCRIPTION
…lbar buttons based on contentlet visibility

## Summary
Enhances the DotUveContentletToolsComponent by adding dynamic positioning for the top and bottom toolbar buttons, ensuring they remain visible within the iframe when the contentlet is scrolled. This is achieved through new computed properties that calculate offsets based on the contentlet's position.

## Changes
- Added , , and  computed properties to manage button positioning.
- Updated the component's HTML to bind the button styles to these computed properties, ensuring proper visibility and alignment.
- Expanded unit tests to cover the new positioning logic, verifying correct behavior under various scrolling scenarios.

## Testing
- Unit tests added for new computed properties to ensure correct offset calculations and button visibility.

https://github.com/user-attachments/assets/95dd8c18-a600-42cf-90b9-06544c22782c




This PR fixes: #36401

This PR fixes: #36401