### PR TITLE
fix(ui): reload legacy portlet iframe on site switch regardless of WebSocket state

### DIFF
--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.ts
@@ -2,9 +2,10 @@ import { BehaviorSubject, Subject } from 'rxjs';
 
 import { AsyncPipe } from '@angular/common';
 import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterModule, UrlSegment } from '@angular/router';
 
-import { map, mergeMap, takeUntil, withLatestFrom } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, mergeMap, skip, takeUntil, withLatestFrom } from 'rxjs/operators';
 
 import {
     DotContentTypeService,
@@ -37,6 +38,7 @@ export class IframePortletLegacyComponent implements OnInit, OnDestroy {
     private dotCustomEventHandlerService = inject(DotCustomEventHandlerService);
     loggerService = inject(LoggerService);
     readonly #globalStore = inject(GlobalStore);
+    readonly #siteChange$ = toObservable(this.#globalStore.siteDetails);
     private dotEventsSocket = inject(DotEventsSocket);
     private dotIframeService = inject(DotIframeService);
 
@@ -52,9 +54,13 @@ export class IframePortletLegacyComponent implements OnInit, OnDestroy {
                 this.reloadIframePortlet(portletId);
             }
         });
-        this.#globalStore
-            .switchSiteEvent$()
-            .pipe(takeUntil(this.destroy$))
+        this.#siteChange$
+            .pipe(
+                skip(1),
+                filter(Boolean),
+                distinctUntilChanged((a, b) => a.identifier === b.identifier),
+                takeUntil(this.destroy$)
+            )
             .subscribe(() => {
                 if (this.url.getValue() !== '') {
                     this.reloadIframePortlet();

--- a/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.ts
+++ b/core-web/apps/dotcms-ui/src/app/view/components/_common/iframe/iframe-porlet-legacy/iframe-porlet-legacy.component.ts
@@ -5,7 +5,15 @@ import { Component, OnDestroy, OnInit, inject, signal } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, RouterModule, UrlSegment } from '@angular/router';
 
-import { distinctUntilChanged, filter, map, mergeMap, skip, takeUntil, withLatestFrom } from 'rxjs/operators';
+import {
+    distinctUntilChanged,
+    filter,
+    map,
+    mergeMap,
+    skip,
+    takeUntil,
+    withLatestFrom
+} from 'rxjs/operators';
 
 import {
     DotContentTypeService,


### PR DESCRIPTION
## Summary

- `IframePortletLegacyComponent` was subscribed to `switchSiteEvent$()`, a WebSocket-only stream, to trigger legacy portlet reloads on site switch
- When the WebSocket is reconnecting or down, the `SWITCH_SITE` event never arrives at the client, so `reloadIframePortlet()` was never called and the iframe kept showing the old site's content
- Replaced the WebSocket subscription with `toObservable(siteDetails)` — the store signal is always updated via the HTTP-backed `switchCurrentSite()` call regardless of WebSocket state
- `distinctUntilChanged` by site identifier prevents a double reload in the healthy case where both the HTTP response and the WebSocket event update `siteDetails` with the same identifier

## Root cause

`switchCurrentSite()` in `with-site.feature.ts` makes an HTTP `PUT` to switch the site and then fetches the current site — it always updates the `siteDetails` signal. But `IframePortletLegacyComponent` never listened to that signal; it only reacted to the WebSocket `SWITCH_SITE` event. When the WebSocket dropped, the reload was silently skipped with no error shown.

## Test plan

- [ ] Navigate to any legacy portlet (Content Search, Site Browser, etc.)
- [ ] Switch sites using the site selector — portlet content should update immediately
- [ ] Verify no double reload occurs when switching sites with WebSocket connected
- [ ] Verify modern Angular-based portlets are unaffected (this component is only used for legacy JSP portlets)

Closes #35909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35909