### PR TITLE
fix(ui): decode $ entity in legacy Story Block editor on reopen (#35782)

### DIFF
--- a/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
+++ b/dotCMS/src/main/webapp/html/portlet/ext/contentlet/field/edit_field.jsp
@@ -265,16 +265,21 @@
                         const proseMirror = blockEditor.querySelector('.ProseMirror');
                         blockEditor.id = "block-editor-<%=field.getVelocityVarName()%>";
 
-                        const editorValue = <%=safeTextValue%> || null;
+                        // Decode the template-literal-safety encoding applied server-side above
+                        // (`$` -> &#36;, backtick -> &#96;) so the runtime value is restored on BOTH
+                        // the JSON (Block Editor) and markdown-fallback paths. Without this, valid
+                        // Block Editor JSON parses successfully, the catch never runs, and &#36; leaks
+                        // into ProseMirror (and can be re-persisted via JSON.stringify below).
+                        const editorValue = (<%=safeTextValue%> || '')
+                            .replace(/&#96;/g, '`').replace(/&#36;/g, '$') || null;
                         let content;
 
                         try {
                             content = JSON.parse(editorValue);
                         } catch (e) {
                             // If it can't be parsed as a JSON, then it means that the value is a string
-                              const text = editorValue.replace(/&#96;/g, '`').replace(/&#36;/g, '$');
                             const converter = new showdown.Converter({ tables: true });
-                            content = converter.makeHtml(text || '');
+                            content = converter.makeHtml(editorValue || '');
                         }
 
 


### PR DESCRIPTION
## Proposed Changes

Follow-up to #36346. That PR fixed the backend read boundary so both editors now receive a clean literal `$`. This PR fixes the remaining failure in the **legacy** content editor.

### Problem
When a Story Block field contains a `$`, reopening the content in the **legacy** content editor showed `&#36;50` instead of `$50` (and could re-persist `&#36;` on save). The **new** editor was already correct after #36346.

### Root cause
`edit_field.jsp` re-encodes `$` → `&#36;` and backtick → `&#96;` server-side (line ~220) so the value can be embedded safely inside a JS **template literal** (`$` guards against `${...}` interpolation, backtick against early string termination — `StringEscapeUtils.escapeJavaScript` does not cover either).

The only code that reversed that encoding lived **inside the `JSON.parse` `catch`** (the markdown fallback). A real Block Editor value is valid JSON, so `JSON.parse` succeeds, the `catch` never runs, and `&#36;` flowed straight into ProseMirror — and could be re-persisted via the `JSON.stringify(content)` assignment below.

### Fix
Decode the template-literal-safety encoding **once, before the `try`**, so both the JSON (Block Editor) and markdown-fallback paths receive a clean value. The now-redundant `.replace(...)` inside the `catch` is removed.

This does **not** weaken the server-side escaping: the `.replace()` runs on the already-parsed runtime string, changing data content only — never code structure — so template-literal injection remains neutralized.

## Checklist
- [x] Tested manually in the legacy editor: `$50` now displays correctly on reopen
- [x] New editor unaffected (still correct)
- [ ] `#` / `&#35;` sister-case remains out of scope (intentional, per #36346)

## How to test
1. Content Type with a Story Block field, rendered via the legacy content editor
2. Enter `The application fee is $50.`, save + publish
3. Reopen in the legacy editor → shows `$50`, not `&#36;50`

Refs: #35782

🤖 Generated with [Claude Code](https://claude.com/claude-code)

This PR fixes: #35782