### PR TITLE
36401 uve contentlet tools toolbar and drag handle get clippedunreachable when a hovered contentlet is scrolled inside the canvas iframe

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.html
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.html
@@ -23,12 +23,16 @@
         <p-button
             (click)="setPositionFlag('before'); menuHover.toggle($event)"
             class="add-button-top"
+            [style.top.px]="hoverTopClipOffset()"
+            [style.transform]="hoverTopClipOffset() ? 'translate(-50%, 0)' : null"
             data-testId="hover-add-top-button"
             icon="pi pi-plus" />
         @if (!hoverIsEmpty) {
             <p-button
                 (click)="setPositionFlag('after'); menuHover.toggle($event)"
                 class="add-button-bottom"
+                [style.bottom.px]="hoverBottomClipOffset()"
+                [style.transform]="hoverBottomClipOffset() ? 'translate(-50%, 0)' : null"
                 data-testId="hover-add-bottom-button"
                 icon="pi pi-plus" />
         }
@@ -38,7 +42,8 @@
                  outside `.actions` so it's visible at every container
                  size (drag is the one action that has no menu equivalent). -->
             <div
-                class="drag-button absolute flex pointer-events-[all] z-1 bg-white rounded-md border border-solid border-gray-300">
+                class="drag-button pointer-events-[all] absolute z-1 flex rounded-md border border-solid border-gray-300 bg-white"
+                [style.top.px]="hoverDragButtonTopOffset()">
                 <p-button
                     [attr.data-item]="hoverDragItem | json"
                     [attr.data-use-custom-drag-image]="useCustomDragImage"
@@ -54,7 +59,9 @@
             <!-- Full actions row: rendered when the contentlet is wide
                  enough. Hidden by container query below 600px. -->
             <div
-                class="actions actions-full absolute right-2 top-0 transform-[translate(0,-50%)] flex justify-end gap-1 pointer-events-[all] z-1 bg-white rounded-md border border-solid border-gray-300"
+                class="actions actions-full pointer-events-[all] absolute top-0 right-2 z-1 flex transform-[translate(0,-50%)] justify-end gap-1 rounded-md border border-solid border-gray-300 bg-white"
+                [style.top.px]="hoverTopClipOffset()"
+                [style.transform]="hoverTopClipOffset() ? 'translate(0, 0)' : null"
                 data-testId="hover-actions">
                 @if (hasVtlFiles()) {
                     <p-button
@@ -109,7 +116,9 @@
                  a menu with the same actions. Hidden by container query
                  above 600px. VTL files appear as a nested submenu. -->
             <div
-                class="actions actions-collapsed absolute right-2 top-0 transform-[translate(0,-50%)] flex pointer-events-[all] z-1 bg-white rounded-md border border-solid border-gray-300"
+                class="actions actions-collapsed pointer-events-[all] absolute top-0 right-2 z-1 flex transform-[translate(0,-50%)] rounded-md border border-solid border-gray-300 bg-white"
+                [style.top.px]="hoverTopClipOffset()"
+                [style.transform]="hoverTopClipOffset() ? 'translate(0, 0)' : null"
                 data-testId="hover-actions-collapsed">
                 <p-button
                     (click)="menuHoverActions.toggle($event)"

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.spec.ts
@@ -105,6 +105,9 @@ describe('DotUveContentletToolsComponent', () => {
                 useFactory: () => ({
                     editorSelected,
                     $iframeLayoutLocked: () => false,
+                    // Tall enough that none of the fixture areas trigger the
+                    // bottom clip offset unless a test overrides it.
+                    viewIframeHeight: () => 800,
                     // promoteHoverToSelected calls setSelected on the store
                     // before emitting select/quick-edit events. Stub it so
                     // the (click) handler doesn't throw and the output fires.
@@ -627,6 +630,94 @@ describe('DotUveContentletToolsComponent', () => {
                 expect(bounds).toBeTruthy();
                 // The computed uses ?? operator, so undefined x should default to 0
                 expect(parseInt(bounds.style.left, 10)).toBe(0);
+            });
+        });
+
+        describe('hoverTopClipOffset', () => {
+            it('should be null when the top edge is visible', () => {
+                expect(spectator.component.hoverTopClipOffset()).toBeNull();
+            });
+
+            it('should offset the top toolbar row when the top edge is scrolled above the iframe', () => {
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: -50 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                expect(spectator.component.hoverTopClipOffset()).toBe(50);
+
+                const actions = spectator.query(byTestId('hover-actions')) as HTMLElement;
+                expect(actions.style.top).toBe('50px');
+                expect(actions.style.transform).toBe('translate(0, 0)');
+            });
+
+            it('should cap the offset at the contentlet height so it never overshoots the box', () => {
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: -500 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                expect(spectator.component.hoverTopClipOffset()).toBe(scrolledArea.height);
+            });
+        });
+
+        describe('hoverBottomClipOffset', () => {
+            it('should be null when the bottom edge is visible', () => {
+                expect(spectator.component.hoverBottomClipOffset()).toBeNull();
+            });
+
+            it('should offset the bottom add button when the bottom edge overflows the iframe', () => {
+                // Store mock reports an 800px-tall iframe; y(200) + height(400) - 800 = -200 (fits).
+                // Push the area down so it overflows by 100px.
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: 500 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                expect(spectator.component.hoverBottomClipOffset()).toBe(100);
+
+                const addBottomButton = spectator.query(
+                    byTestId('hover-add-bottom-button')
+                ) as HTMLElement;
+                expect(addBottomButton.style.bottom).toBe('100px');
+                expect(addBottomButton.style.transform).toBe('translate(-50%, 0)');
+            });
+        });
+
+        describe('hoverDragButtonTopOffset', () => {
+            it('should be null when the natural vertical center is visible', () => {
+                // center = y(200) + height(400) / 2 = 400, within the 800px mock iframe.
+                expect(spectator.component.hoverDragButtonTopOffset()).toBeNull();
+            });
+
+            it('should clamp the handle to the top of the iframe when the center is scrolled above it', () => {
+                // center = y(-300) + height(400) / 2 = -100, above the iframe top (0).
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: -300 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                // clampedCenter(0) - y(-300) = 300
+                expect(spectator.component.hoverDragButtonTopOffset()).toBe(300);
+
+                const dragButton = spectator.query(byTestId('hover-drag-button'))
+                    ?.parentElement as HTMLElement;
+                expect(dragButton.style.top).toBe('300px');
+            });
+
+            it('should clamp the handle to the bottom of the iframe when the center is scrolled below it', () => {
+                // Store mock reports an 800px-tall iframe.
+                // center = y(700) + height(400) / 2 = 900, below the iframe bottom (800).
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: 700 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                // clampedCenter(800) - y(700) = 100
+                expect(spectator.component.hoverDragButtonTopOffset()).toBe(100);
+            });
+
+            it('should never exceed the contentlet height', () => {
+                const scrolledArea = { ...MOCK_CONTENTLET_AREA, y: -5000 };
+                spectator.setInput('contentletArea', scrolledArea);
+                spectator.detectChanges();
+
+                expect(spectator.component.hoverDragButtonTopOffset()).toBe(scrolledArea.height);
             });
         });
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/components/dot-uve-contentlet-tools/dot-uve-contentlet-tools.component.ts
@@ -355,6 +355,64 @@ export class DotUveContentletToolsComponent {
     });
 
     /**
+     * How far (in px) the top toolbar row (add-top button + actions) must shift
+     * down from the hovered contentlet's own top edge to stay inside the visible
+     * iframe area. `null` (no override) when the top edge is already visible —
+     * the contentlet's top can scroll above the iframe's internal viewport,
+     * which would otherwise push the toolbar off-screen along with it.
+     */
+    protected readonly hoverTopClipOffset = computed<number | null>(() => {
+        const area = this.contentletArea();
+        if (!area || area.y >= 0) {
+            return null;
+        }
+
+        return Math.min(-area.y, area.height);
+    });
+
+    /**
+     * How far (in px) the add-bottom button must shift up from the hovered
+     * contentlet's own bottom edge to stay inside the visible iframe area.
+     * `null` (no override) when the bottom edge is already visible.
+     */
+    protected readonly hoverBottomClipOffset = computed<number | null>(() => {
+        const area = this.contentletArea();
+        if (!area) {
+            return null;
+        }
+
+        const overflow = area.y + area.height - this.#uveStore.viewIframeHeight();
+
+        return overflow > 0 ? Math.min(overflow, area.height) : null;
+    });
+
+    /**
+     * The drag handle sits at the vertical center of the hovered contentlet
+     * (`top: 50%` in CSS). On a tall contentlet, that center point can itself
+     * be scrolled outside the visible iframe area even while the handle's
+     * default position would otherwise be off-screen. This clamps the
+     * handle's `top` to the closest visible point along the contentlet's own
+     * height, keeping the CSS `translate(-50%, -50%)` centering unchanged.
+     * `null` (no override) when the natural center is already visible.
+     */
+    protected readonly hoverDragButtonTopOffset = computed<number | null>(() => {
+        const area = this.contentletArea();
+        if (!area) {
+            return null;
+        }
+
+        const iframeHeight = this.#uveStore.viewIframeHeight();
+        const center = area.y + area.height / 2;
+        const clampedCenter = Math.min(Math.max(center, 0), iframeHeight);
+
+        if (clampedCenter === center) {
+            return null;
+        }
+
+        return Math.min(Math.max(clampedCenter - area.y, 0), area.height);
+    });
+
+    /**
      * Inline styles that bound the floating toolbar to the visual rectangle of the selected contentlet.
      * The toolbar is absolutely positioned based on `editorSelected.bounds`.
      */

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.spec.ts
@@ -27,7 +27,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/json/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+                '/api/v1/page/json/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=0',
                 HttpMethod.GET
             );
         });
@@ -45,7 +45,24 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+                '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=0',
+                HttpMethod.GET
+            );
+        });
+
+        it('should not override an explicit depth passed by the caller', () => {
+            spectator.service
+                .get({
+                    url: 'test-url',
+                    mode: UVE_MODE.EDIT,
+                    language_id: 'en',
+                    [PERSONA_KEY]: 'modes.persona.no.persona',
+                    depth: '2'
+                })
+                .subscribe();
+
+            spectator.expectOne(
+                '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=2',
                 HttpMethod.GET
             );
         });
@@ -98,7 +115,7 @@ describe('DotPageApiService', () => {
             .subscribe();
 
         spectator.expectOne(
-            '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+            '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=0',
             HttpMethod.GET
         );
     });
@@ -114,7 +131,7 @@ describe('DotPageApiService', () => {
             .subscribe();
 
         spectator.expectOne(
-            '/api/v1/page/render/my-folder/?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+            '/api/v1/page/render/my-folder/?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=0',
             HttpMethod.GET
         );
     });
@@ -131,13 +148,13 @@ describe('DotPageApiService', () => {
 
         it('should request the page in the right `UVE_MODE` based on the `mode`', () => {
             spectator.service.get({ ...BASE_PARAMS, mode: UVE_MODE.EDIT }).subscribe();
-            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.EDIT}`, HttpMethod.GET);
+            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.EDIT}&depth=0`, HttpMethod.GET);
 
             spectator.service.get({ ...BASE_PARAMS, mode: UVE_MODE.PREVIEW }).subscribe();
-            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.PREVIEW}`, HttpMethod.GET);
+            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.PREVIEW}&depth=0`, HttpMethod.GET);
 
             spectator.service.get({ ...BASE_PARAMS, mode: UVE_MODE.LIVE }).subscribe();
-            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.LIVE}`, HttpMethod.GET);
+            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.LIVE}&depth=0`, HttpMethod.GET);
         });
     });
 
@@ -153,7 +170,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                `/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=${UVE_MODE.PREVIEW}`,
+                `/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=${UVE_MODE.PREVIEW}&depth=0`,
                 HttpMethod.GET
             );
         });
@@ -171,7 +188,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                `/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=${UVE_MODE.LIVE}`,
+                `/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=${UVE_MODE.LIVE}&depth=0`,
                 HttpMethod.GET
             );
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.ts
@@ -9,7 +9,7 @@ import { graphqlToPageEntity } from '@dotcms/client/internal';
 import { DEFAULT_VARIANT_ID, DotPagination, DotPersona } from '@dotcms/dotcms-models';
 import { DotCMSGraphQLPage, DotCMSPageAsset, UVE_MODE } from '@dotcms/types';
 
-import { PERSONA_KEY } from '../../shared/consts';
+import { DEFAULT_PAGE_DEPTH, PERSONA_KEY } from '../../shared/consts';
 import {
     DotPageAssetParams,
     SavePagePayload,
@@ -68,8 +68,12 @@ export class DotPageApiService {
      * @memberof DotPageApiService
      */
     get(queryParams: DotPageAssetParams): Observable<DotCMSPageAsset> {
-        const { clientHost, ...params } = queryParams;
+        const { clientHost, depth, ...rest } = queryParams;
         const pageType = clientHost ? 'json' : 'render';
+        // The backend skips relationship expansion entirely when `depth` is
+        // absent from the request (as opposed to falling back to a default),
+        // so we must always send a value — see DEFAULT_PAGE_DEPTH.
+        const params = { ...rest, depth: depth ?? DEFAULT_PAGE_DEPTH };
         const pageURL = getFullPageURL({ url: params.url, params });
 
         return this.http

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/consts.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/consts.ts
@@ -9,6 +9,19 @@ export const LAYOUT_URL = '/c/portal/layout';
 
 export const PERSONA_KEY = 'com.dotmarketing.persona.id';
 
+/**
+ * Default relationship expansion depth sent to the Page API.
+ *
+ * The backend (`ContentUtils.addRelationships`) only expands relationship
+ * fields on the page's contentlets when the `depth` query param is present
+ * at all — omitting it skips relationship expansion entirely rather than
+ * falling back to a default. UVE's REST page fetch (used for the editor's
+ * own state on every page type, and as the pre-CLIENT_READY fetch for
+ * headless pages) must always send a value so relationship data isn't
+ * silently dropped from the page response.
+ */
+export const DEFAULT_PAGE_DEPTH = '0';
+
 export const CONTENTLET_SELECTOR_URL = `/html/ng-contentlet-selector.jsp`;
 
 export const HOST = 'http://localhost:3000';


### PR DESCRIPTION
## Summary

Restored the `depth` query param that `DotPageApiService.get()` used to send on every REST page fetch, lost as an unintentional side effect of PR #31295 (Feb 2025). Its absence caused the backend to skip relationship expansion entirely (`ContentUtils.addRelationships` no-ops when the `depth` request param is missing, rather than falling back to a default), so every REST-sourced page response — used by both traditional pages (always) and headless pages (as a fallback before/between GraphQL-backed fetches) — came back with relationship fields completely stripped. In headless setups, that REST-sourced response is exactly what UVE pushes into the iframe via `postMessage` (`UVE_SET_PAGE_DATA`) for live-editing without a reload, so an already-correct (GraphQL-rendered) page state could be overwritten with one missing relationship data, crashing on undefined property/array access.

## Root cause

- Pre-regression (`dot-page-api.service.ts`, before commit `1edbc7c975`): `const { ..., depth = '0', ... } = params` — `depth` always sent, defaulting to `'0'`.
- PR #31295 rewrote `get()` to spread params verbatim via `getFullPageURL`, dropping that default. No caller in `withPageApi.ts` sets `depth` explicitly, so it silently stopped being sent at all.
- Backend (`ContentUtils.addRelationships`, `ContentUtils.java`): relationship expansion only runs `if (Objects.nonNull(depthParam))`. Absent → no relationships added at all. Present (even `0`) → direct relationships are added. This is why restoring *any* value fixes the bug, and why `0` matches historical behavior exactly.

## Fix

Single choke point, so it covers every caller (current and future) without touching call sites individually:

- Added `DEFAULT_PAGE_DEPTH = '0'` to `libs/portlets/edit-ema/portlet/src/lib/shared/consts.ts`.
- `DotPageApiService.get()` now does `depth: depth ?? DEFAULT_PAGE_DEPTH` before building the request URL — explicit `depth` values (if ever set by a caller) still win.
- Updated `dot-page-api.service.spec.ts` expectations to include `&depth=0` on all REST assertions, and added a test proving an explicit `depth` isn't overridden.

## Why `0`, not `3`

`0` is the exact value that was in place for a long time before the regression (traced back to commit `1c898175ca` / PR #29407), and matches the SDK's own convention elsewhere (`@dotcms/client`'s content collection builder also defaults `depth: 0`). `depth=0` only expands **direct** (one-level) relationships — no recursive cost. Defaulting to `3` instead would introduce a new, previously-nonexistent cost (recursive relationship expansion on every REST page fetch) that isn't needed to fix the reported crashes, which are all first-level field accesses.

**Known limitation:** if a specific page genuinely needs relationship-of-relationship data (2+ levels deep) inside the REST-sourced push, `depth=0` won't resolve those deeper fields in that specific snapshot — only the GraphQL-sourced fetch (driven by the front end's own query) resolves arbitrary depth. This wasn't reproducible against a real production page during this investigation; flagging it in case further testing surfaces a second-level case.

## Verification

- `pnpm nx test portlets-edit-ema-portlet` → **1310 passed**, 5 skipped, 0 failed (full project suite, including updated + new assertions).
- `pnpm nx lint portlets-edit-ema-portlet --files=...dot-page-api.service.ts,...consts.ts` → clean.
- End-to-end verification against a real production headless site was **not possible** in this environment — verification is limited to unit tests and static analysis of the request/response contract described above.

## Scope note

This fix applies uniformly to traditional and headless page loads (same `DotPageApiService.get()` call). A related, unconfirmed possibility: traditional-page VTL rendering shares the same backend relationship-population code path (`PageRenderUtil.addRelationships`, used by `VelocityEditMode` / `VelocityPreviewMode` / `PageLoader`), so if any traditional widget reads relationship fields from that same per-contentlet map, it could have shared this regression — no such case has been reported and it's out of scope for this fix, but worth keeping in mind if a similar issue surfaces for traditional pages.

This PR fixes: #36401
