### PR TITLE
feat(dot-page-api): add depth parameter handling in DotPageApiService

### DIFF
--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/edit-ema-editor/edit-ema-editor.component.ts
@@ -432,6 +432,7 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
          */
         const { pageType } = this.uveStore.$reloadEditorContent();
         const isClientReady = untracked(() => this.uveStore.isClientReady());
+        const hasClientQuery = untracked(() => !!this.uveStore.requestMetadata());
 
         untracked(() => {
             this.uveStore.resetEditorProperties();
@@ -439,6 +440,16 @@ export class EditEmaEditorComponent implements OnDestroy, AfterViewInit {
         });
 
         if (pageType === PageType.TRADITIONAL || !isClientReady) {
+            return;
+        }
+
+        // Headless pages are driven entirely by the client's own GraphQL
+        // query. Never push a REST-sourced pageAsset into the iframe — it
+        // never carries the relationships that query defines, and the
+        // client already has its own correct render. Skip until a
+        // GraphQL-backed update (requestMetadata set from CLIENT_READY)
+        // is available; this effect re-fires once that happens.
+        if (pageType === PageType.HEADLESS && !hasClientQuery) {
             return;
         }
 

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.spec.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.spec.ts
@@ -27,7 +27,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/json/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+                '/api/v1/page/json/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=0',
                 HttpMethod.GET
             );
         });
@@ -45,7 +45,24 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+                '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=0',
+                HttpMethod.GET
+            );
+        });
+
+        it('should not override an explicit depth passed by the caller', () => {
+            spectator.service
+                .get({
+                    url: 'test-url',
+                    mode: UVE_MODE.EDIT,
+                    language_id: 'en',
+                    [PERSONA_KEY]: 'modes.persona.no.persona',
+                    depth: '2'
+                })
+                .subscribe();
+
+            spectator.expectOne(
+                '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=2',
                 HttpMethod.GET
             );
         });
@@ -98,7 +115,7 @@ describe('DotPageApiService', () => {
             .subscribe();
 
         spectator.expectOne(
-            '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+            '/api/v1/page/render/test-url?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=0',
             HttpMethod.GET
         );
     });
@@ -114,7 +131,7 @@ describe('DotPageApiService', () => {
             .subscribe();
 
         spectator.expectOne(
-            '/api/v1/page/render/my-folder/?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona',
+            '/api/v1/page/render/my-folder/?mode=EDIT_MODE&language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&depth=0',
             HttpMethod.GET
         );
     });
@@ -131,13 +148,13 @@ describe('DotPageApiService', () => {
 
         it('should request the page in the right `UVE_MODE` based on the `mode`', () => {
             spectator.service.get({ ...BASE_PARAMS, mode: UVE_MODE.EDIT }).subscribe();
-            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.EDIT}`, HttpMethod.GET);
+            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.EDIT}&depth=0`, HttpMethod.GET);
 
             spectator.service.get({ ...BASE_PARAMS, mode: UVE_MODE.PREVIEW }).subscribe();
-            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.PREVIEW}`, HttpMethod.GET);
+            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.PREVIEW}&depth=0`, HttpMethod.GET);
 
             spectator.service.get({ ...BASE_PARAMS, mode: UVE_MODE.LIVE }).subscribe();
-            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.LIVE}`, HttpMethod.GET);
+            spectator.expectOne(`${BASE_URL}&mode=${UVE_MODE.LIVE}&depth=0`, HttpMethod.GET);
         });
     });
 
@@ -153,7 +170,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                `/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=${UVE_MODE.PREVIEW}`,
+                `/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=${UVE_MODE.PREVIEW}&depth=0`,
                 HttpMethod.GET
             );
         });
@@ -171,7 +188,7 @@ describe('DotPageApiService', () => {
                 .subscribe();
 
             spectator.expectOne(
-                `/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=${UVE_MODE.LIVE}`,
+                `/api/v1/page/render/test-url?language_id=en&com.dotmarketing.persona.id=modes.persona.no.persona&mode=${UVE_MODE.LIVE}&depth=0`,
                 HttpMethod.GET
             );
         });

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/services/dot-page-api/dot-page-api.service.ts
@@ -9,7 +9,7 @@ import { graphqlToPageEntity } from '@dotcms/client/internal';
 import { DEFAULT_VARIANT_ID, DotPagination, DotPersona } from '@dotcms/dotcms-models';
 import { DotCMSGraphQLPage, DotCMSPageAsset, UVE_MODE } from '@dotcms/types';
 
-import { PERSONA_KEY } from '../../shared/consts';
+import { DEFAULT_PAGE_DEPTH, PERSONA_KEY } from '../../shared/consts';
 import {
     DotPageAssetParams,
     SavePagePayload,
@@ -68,8 +68,12 @@ export class DotPageApiService {
      * @memberof DotPageApiService
      */
     get(queryParams: DotPageAssetParams): Observable<DotCMSPageAsset> {
-        const { clientHost, ...params } = queryParams;
+        const { clientHost, depth, ...rest } = queryParams;
         const pageType = clientHost ? 'json' : 'render';
+        // The backend skips relationship expansion entirely when `depth` is
+        // absent from the request (as opposed to falling back to a default),
+        // so we must always send a value — see DEFAULT_PAGE_DEPTH.
+        const params = { ...rest, depth: depth ?? DEFAULT_PAGE_DEPTH };
         const pageURL = getFullPageURL({ url: params.url, params });
 
         return this.http

--- a/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/consts.ts
+++ b/core-web/libs/portlets/edit-ema/portlet/src/lib/shared/consts.ts
@@ -9,6 +9,19 @@ export const LAYOUT_URL = '/c/portal/layout';
 
 export const PERSONA_KEY = 'com.dotmarketing.persona.id';
 
+/**
+ * Default relationship expansion depth sent to the Page API.
+ *
+ * The backend (`ContentUtils.addRelationships`) only expands relationship
+ * fields on the page's contentlets when the `depth` query param is present
+ * at all — omitting it skips relationship expansion entirely rather than
+ * falling back to a default. UVE's REST page fetch (used for the editor's
+ * own state on every page type, and as the pre-CLIENT_READY fetch for
+ * headless pages) must always send a value so relationship data isn't
+ * silently dropped from the page response.
+ */
+export const DEFAULT_PAGE_DEPTH = '0';
+
 export const CONTENTLET_SELECTOR_URL = `/html/ng-contentlet-selector.jsp`;
 
 export const HOST = 'http://localhost:3000';


### PR DESCRIPTION
## Problem

UVE's REST page fetch stopped sending `depth`. Backend skips relationship expansion entirely without it. Headless clients got that incomplete data pushed into their iframe, crashing on `undefined` relationship fields.

## Fix 1 — Restore `depth` on REST

**Files:** `dot-page-api.service.ts`, `consts.ts`

- `DotPageApiService.get()` now always sends `depth`, defaulting to `'0'` — the exact value used before the Feb 2025 regression.
- Explicit `depth` values still win.
- Applies to traditional and headless (same method, one fix point).

## Fix 2 — Don't push REST data to a headless iframe

**File:** `edit-ema-editor.component.ts`

- The `postMessage` push to headless clients now waits for `requestMetadata` (the client's GraphQL query) to exist.
- Traditional pages: untouched, they already exit before this check.
- Self-healing: once `CLIENT_READY` arrives, the same effect re-fires and pushes correct GraphQL data.

## Why both

| Fix | Protects |
|---|---|
| 1 — `depth` default | Traditional pages (always REST) + UVE's own editor UI |
| 2 — gate the push | Headless client, so it never sees REST data at all |

Fix 2 doesn't replace Fix 1 — traditional never goes through Fix 2's check.

## Tests

- `pnpm nx test portlets-edit-ema-portlet` → **1310 passed**, 0 failed.
- Lint clean.
- No dedicated test yet for Fix 2's gating — existing suite unaffected, follow-up if needed.

## Known gaps

- `depth=0` resolves one relationship level only (matches historical behavior).
- Not verified against a real production headless site (not available in this environment).

This PR fixes: #36410

This PR fixes: #36410