### PR TITLE
fix(opensearch): enforce ES/OS endpoint separation at the OS index-creation chokepoint (#36419)

### DIFF
--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1016,9 +1016,9 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         if (!IndexStartupValidator.endpointsAreSeparate()) {
             Logger.warn(this.getClass(),
                     "Skipping OpenSearch index bootstrap (working=" + workingName
-                    + ", live=" + liveName + "): OS endpoints overlap ES (same cluster)."
-                    + " Migration halted (now ES-only). Set OS_ENDPOINTS to a separate"
-                    + " OpenSearch instance and restart.");
+                    + ", live=" + liveName + "): OS migration configuration rejected"
+                    + " (see the preceding error for the cause — e.g. ES/OS endpoint overlap or"
+                    + " an unresolved OS config). Migration halted (now ES-only).");
             haltMigration();
             return;
         }

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1008,6 +1008,21 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
     private void bootstrapAndPointOS(final String workingName, final String liveName)
             throws DotDataException {
 
+        // Separation gate (issue #36419): OS must be a SEPARATE cluster from ES. Config-only,
+        // no network I/O, so it runs before the connection gate. Placing it at this single
+        // chokepoint closes the window where the empty-DB starter-load path created .os indices
+        // before InitServlet's later validateIndexingConfig() caught the ES==OS overlap. On
+        // overlap we halt the migration (ES-only) and skip OS bootstrap entirely.
+        if (!IndexStartupValidator.endpointsAreSeparate()) {
+            Logger.warn(this.getClass(),
+                    "Skipping OpenSearch index bootstrap (working=" + workingName
+                    + ", live=" + liveName + "): OS endpoints overlap ES (same cluster)."
+                    + " Migration halted (now ES-only). Set OS_ENDPOINTS to a separate"
+                    + " OpenSearch instance and restart.");
+            haltMigration();
+            return;
+        }
+
         // Connection gate (issue #36244): verify OS reachability BEFORE creating OS indices.
         // This is the single chokepoint for all OS index creation (fresh-install bootstrap and
         // migration catchup), so both startup paths — populated-DB (InitServlet) and empty-DB

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1013,18 +1013,10 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         // chokepoint closes the window where the empty-DB starter-load path created .os indices
         // before InitServlet's later validateIndexingConfig() caught the ES==OS overlap. On
         // overlap we halt the migration (ES-only) and skip OS bootstrap entirely.
+        // Phase-aware: in Phase 3 (ES decommissioned, ES_ENDPOINTS not required) the check is
+        // skipped inside endpointsAreSeparate(), so this branch never fires there and the
+        // haltMigration() fallback below only ever runs in dual-write phases where ES is live.
         if (!IndexStartupValidator.endpointsAreSeparate()) {
-            if (isMigrationComplete()) {
-                // Phase 3: ES is decommissioned. Silently halting to ES-only would serve a stale
-                // or absent ES index — the same reason checkAndInitializeIndex and the connection
-                // gate fail loudly in Phase 3. Throw instead of haltMigration(); the outer handler
-                // logs it FATAL. This bites initOSCatchup Case 1 (Phase-3 disaster recovery).
-                throw new DotRuntimeException(
-                        "OpenSearch endpoint-separation check failed in PHASE_3_OPENSEARCH_ONLY"
-                        + " (ES and OS resolve to the same cluster, or the OS config is unresolved)."
-                        + " Cannot auto-rollback to ES (ES may be decommissioned or stale)."
-                        + " Fix OS_ENDPOINTS and restart dotCMS.");
-            }
             Logger.warn(this.getClass(),
                     "Skipping OpenSearch index bootstrap (working=" + workingName
                     + ", live=" + liveName + "): OS migration configuration rejected"

--- a/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
+++ b/dotCMS/src/main/java/com/dotcms/content/elasticsearch/business/ContentletIndexAPIImpl.java
@@ -1014,6 +1014,17 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         // before InitServlet's later validateIndexingConfig() caught the ES==OS overlap. On
         // overlap we halt the migration (ES-only) and skip OS bootstrap entirely.
         if (!IndexStartupValidator.endpointsAreSeparate()) {
+            if (isMigrationComplete()) {
+                // Phase 3: ES is decommissioned. Silently halting to ES-only would serve a stale
+                // or absent ES index — the same reason checkAndInitializeIndex and the connection
+                // gate fail loudly in Phase 3. Throw instead of haltMigration(); the outer handler
+                // logs it FATAL. This bites initOSCatchup Case 1 (Phase-3 disaster recovery).
+                throw new DotRuntimeException(
+                        "OpenSearch endpoint-separation check failed in PHASE_3_OPENSEARCH_ONLY"
+                        + " (ES and OS resolve to the same cluster, or the OS config is unresolved)."
+                        + " Cannot auto-rollback to ES (ES may be decommissioned or stale)."
+                        + " Fix OS_ENDPOINTS and restart dotCMS.");
+            }
             Logger.warn(this.getClass(),
                     "Skipping OpenSearch index bootstrap (working=" + workingName
                     + ", live=" + liveName + "): OS migration configuration rejected"
@@ -1024,10 +1035,12 @@ public class ContentletIndexAPIImpl implements ContentletIndexAPI {
         }
 
         // Connection gate (issue #36244): verify OS reachability BEFORE creating OS indices.
-        // This is the single chokepoint for all OS index creation (fresh-install bootstrap and
+        // This is the single chokepoint for OS working/live index bootstrap (fresh-install and
         // migration catchup), so both startup paths — populated-DB (InitServlet) and empty-DB
         // (Task00004LoadStarter) — pass through the same phase-aware gate instead of failing
         // late and opaquely with a transport exception deep inside createContentIndex.
+        // (Reindex-slot creation via initAndPointReindex does NOT pass through here — see the
+        // runtime phase-flip caveat in PR #36421.)
         //
         // operationsOS.indexAPI() is the OS-specific IndexAPI, so the gate always probes OS
         // regardless of the current read provider (in Phase 1 the read provider is ES). The

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
@@ -87,6 +87,14 @@ public class IndexStartupValidator {
         final OSClientConfig config = resolveConfig();
         logConfigSummary(config);
         validateOSVersion();
+        if (IndexConfigHelper.isMigrationComplete()) {
+            // Phase 3: ES is decommissioned and ES_ENDPOINTS is no longer required, so the
+            // resolved ES side would just be the localhost:9200 default — comparing it against
+            // OS would false-positive on a legitimate config. Skip the separation check.
+            Logger.info(this, "Endpoint separation check skipped: PHASE_3_OPENSEARCH_ONLY"
+                    + " — ES is decommissioned and ES_ENDPOINTS is not required.");
+            return;
+        }
         assertEndpointsSeparate(config);
     }
 
@@ -242,10 +250,21 @@ public class IndexStartupValidator {
      * (empty-DB starter-load or populated-DB InitServlet), closing the window where the
      * starter-load path created {@code .os} indices before the late startup validation ran.
      *
+     * <p><strong>Phase-aware:</strong> in {@code PHASE_3_OPENSEARCH_ONLY} the check is skipped
+     * (returns {@code true}) — ES is decommissioned and {@code ES_ENDPOINTS} is no longer
+     * required, so the resolved ES side would just be the {@code localhost:9200} default and
+     * comparing it against OS would false-positive on a legitimate configuration.</p>
+     *
      * @return {@code true} when ES and OS point to distinct clusters (safe to create OS indices);
      *         {@code false} when they overlap (caller must skip the OS bootstrap and halt the migration)
      */
     public static boolean endpointsAreSeparate() {
+        if (IndexConfigHelper.isMigrationComplete()) {
+            Logger.info(IndexStartupValidator.class,
+                    "Endpoint separation check skipped: PHASE_3_OPENSEARCH_ONLY"
+                    + " — ES is decommissioned and ES_ENDPOINTS is not required.");
+            return true;
+        }
         final OSClientConfig config;
         try {
             config = ConfigurableOpenSearchProvider.configFromProperties();

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
@@ -204,23 +204,13 @@ public class IndexStartupValidator {
     // -------------------------------------------------------------------------
 
     /**
-     * Resolves the effective ES and OS endpoint sets and asserts they do not share
-     * any {@code host:port} pair.
-     *
-     * <p>The OS side comes from the already-resolved {@link OSClientConfig#endpoints()} (the very
-     * endpoints the client is built with), and the ES side is read from config; both are passed
-     * through the same {@link #normalizeEndpoint} path so the comparison is consistent.</p>
-     *
-     * <p><strong>Best-effort:</strong> two configs that refer to the same host via different forms
-     * (e.g. {@code "127.0.0.1"} vs {@code "localhost"}) will not be detected as overlapping.</p>
-     *
-     * @throws DotRuntimeException if at least one endpoint is common to both clients
-     */
-    /**
      * Asserts that the ES and OS clients do not share any {@code host:port}. Shared by the
      * startup validator ({@link #validate()}) and the config-only OS index-creation gate
      * ({@link #endpointsAreSeparate()}) so both enforce separation with identical logic.
      * On success it logs the compared sets so the "passed" line is proof of what was compared.
+     *
+     * <p><strong>Best-effort:</strong> two configs that refer to the same host via different forms
+     * (e.g. {@code "127.0.0.1"} vs {@code "localhost"}) will not be detected as overlapping.</p>
      *
      * @throws DotRuntimeException if at least one endpoint is common to both clients
      */

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
@@ -258,12 +258,23 @@ public class IndexStartupValidator {
      *         {@code false} when they overlap (caller must skip the OS bootstrap and halt the migration)
      */
     public static boolean endpointsAreSeparate() {
+        final OSClientConfig config;
         try {
-            assertEndpointsSeparate(ConfigurableOpenSearchProvider.configFromProperties());
-            return true;
+            config = ConfigurableOpenSearchProvider.configFromProperties();
         } catch (Exception e) {
+            // Config could not be resolved — this is NOT an ES/OS overlap. Log it distinctly so the
+            // operator is not sent chasing a same-endpoint misconfiguration that does not exist.
             Logger.error(IndexStartupValidator.class,
-                    "OpenSearch endpoint-separation check failed: " + e.getMessage());
+                    "Cannot resolve OpenSearch configuration for the endpoint-separation check: "
+                    + e.getMessage());
+            return false;
+        }
+        try {
+            assertEndpointsSeparate(config);
+            return true;
+        } catch (DotRuntimeException e) {
+            // The overlap message (with the actionable "Set OS_ENDPOINTS to a separate instance").
+            Logger.error(IndexStartupValidator.class, e.getMessage());
             return false;
         }
     }

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
@@ -87,7 +87,7 @@ public class IndexStartupValidator {
         final OSClientConfig config = resolveConfig();
         logConfigSummary(config);
         validateOSVersion();
-        validateEndpointSeparation(config);
+        assertEndpointsSeparate(config);
     }
 
     // -------------------------------------------------------------------------
@@ -216,15 +216,11 @@ public class IndexStartupValidator {
      *
      * @throws DotRuntimeException if at least one endpoint is common to both clients
      */
-    private void validateEndpointSeparation(final OSClientConfig config) {
-        assertEndpointsSeparate(config);
-        Logger.info(this, "Endpoint separation check passed.");
-    }
-
     /**
      * Asserts that the ES and OS clients do not share any {@code host:port}. Shared by the
      * startup validator ({@link #validate()}) and the config-only OS index-creation gate
      * ({@link #endpointsAreSeparate()}) so both enforce separation with identical logic.
+     * On success it logs the compared sets so the "passed" line is proof of what was compared.
      *
      * @throws DotRuntimeException if at least one endpoint is common to both clients
      */
@@ -244,6 +240,8 @@ public class IndexStartupValidator {
                     + " — OS endpoints: " + osEndpoints
                     + ". Set OS_ENDPOINTS to a separate OpenSearch instance.");
         }
+        Logger.info(IndexStartupValidator.class, "Endpoint separation check passed."
+                + " ES: " + esEndpoints + " — OS: " + osEndpoints);
     }
 
     /**

--- a/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
+++ b/dotCMS/src/main/java/com/dotcms/content/index/opensearch/IndexStartupValidator.java
@@ -217,6 +217,18 @@ public class IndexStartupValidator {
      * @throws DotRuntimeException if at least one endpoint is common to both clients
      */
     private void validateEndpointSeparation(final OSClientConfig config) {
+        assertEndpointsSeparate(config);
+        Logger.info(this, "Endpoint separation check passed.");
+    }
+
+    /**
+     * Asserts that the ES and OS clients do not share any {@code host:port}. Shared by the
+     * startup validator ({@link #validate()}) and the config-only OS index-creation gate
+     * ({@link #endpointsAreSeparate()}) so both enforce separation with identical logic.
+     *
+     * @throws DotRuntimeException if at least one endpoint is common to both clients
+     */
+    static void assertEndpointsSeparate(final OSClientConfig config) {
         final Set<String> esEndpoints = resolveESEndpoints();
         final Set<String> osEndpoints = config.endpoints().stream()
                 .map(IndexStartupValidator::normalizeEndpoint)
@@ -232,8 +244,28 @@ public class IndexStartupValidator {
                     + " — OS endpoints: " + osEndpoints
                     + ". Set OS_ENDPOINTS to a separate OpenSearch instance.");
         }
-        Logger.info(this, "Endpoint separation check passed."
-                + " ES: " + esEndpoints + " — OS: " + osEndpoints);
+    }
+
+    /**
+     * Config-only endpoint-separation gate for the OS index-creation chokepoint
+     * ({@code ContentletIndexAPIImpl.bootstrapAndPointOS}, issue #36419). Unlike
+     * {@link #validate()} this performs no network I/O — it only compares the resolved ES and OS
+     * endpoints — so it is cheap enough to run before every OS bootstrap on any startup path
+     * (empty-DB starter-load or populated-DB InitServlet), closing the window where the
+     * starter-load path created {@code .os} indices before the late startup validation ran.
+     *
+     * @return {@code true} when ES and OS point to distinct clusters (safe to create OS indices);
+     *         {@code false} when they overlap (caller must skip the OS bootstrap and halt the migration)
+     */
+    public static boolean endpointsAreSeparate() {
+        try {
+            assertEndpointsSeparate(ConfigurableOpenSearchProvider.configFromProperties());
+            return true;
+        } catch (Exception e) {
+            Logger.error(IndexStartupValidator.class,
+                    "OpenSearch endpoint-separation check failed: " + e.getMessage());
+            return false;
+        }
     }
 
     /**

--- a/dotCMS/src/test/java/com/dotcms/content/index/opensearch/IndexStartupValidatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/opensearch/IndexStartupValidatorTest.java
@@ -1,0 +1,81 @@
+package com.dotcms.content.index.opensearch;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.dotmarketing.exception.DotRuntimeException;
+import com.dotmarketing.util.Config;
+import org.junit.After;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link IndexStartupValidator} endpoint-separation logic.
+ *
+ * <p>Covers the config-only separation gate ({@link IndexStartupValidator#endpointsAreSeparate()})
+ * used at the OS index-creation chokepoint (issue #36419): OS must point to a cluster separate
+ * from ES, otherwise the {@code .os} shadow indices must not be created.</p>
+ */
+public class IndexStartupValidatorTest {
+
+    @After
+    public void clearEndpoints() {
+        Config.setProperty("ES_ENDPOINTS", null);
+        Config.setProperty("OS_ENDPOINTS", null);
+    }
+
+    /**
+     * Given Scenario: ES and OS are configured with the same address.
+     * Expected Result: endpointsAreSeparate() returns false — OS bootstrap must be skipped.
+     */
+    @Test
+    public void test_endpointsAreSeparate_sameAddress_returnsFalse() {
+        Config.setProperty("ES_ENDPOINTS", new String[]{"https://localhost:9201"});
+        Config.setProperty("OS_ENDPOINTS", new String[]{"https://localhost:9201"});
+
+        assertFalse(IndexStartupValidator.endpointsAreSeparate());
+    }
+
+    /**
+     * Given Scenario: ES and OS point at different ports on the same host.
+     * Expected Result: endpointsAreSeparate() returns true — safe to create OS indices.
+     */
+    @Test
+    public void test_endpointsAreSeparate_differentAddress_returnsTrue() {
+        Config.setProperty("ES_ENDPOINTS", new String[]{"https://localhost:9200"});
+        Config.setProperty("OS_ENDPOINTS", new String[]{"https://localhost:9201"});
+
+        assertTrue(IndexStartupValidator.endpointsAreSeparate());
+    }
+
+    /**
+     * Given Scenario: same address, but written with different scheme/formatting.
+     * Expected Result: overlap is still detected (normalized to host:port) — returns false.
+     */
+    @Test
+    public void test_endpointsAreSeparate_sameHostPortDifferentScheme_returnsFalse() {
+        Config.setProperty("ES_ENDPOINTS", new String[]{"http://localhost:9201"});
+        Config.setProperty("OS_ENDPOINTS", new String[]{"https://localhost:9201"});
+
+        assertFalse(IndexStartupValidator.endpointsAreSeparate());
+    }
+
+    /**
+     * Given Scenario: ES and OS share the same host:port.
+     * Expected Result: assertEndpointsSeparate throws DotRuntimeException naming the overlap.
+     */
+    @Test
+    public void test_assertEndpointsSeparate_overlap_throws() {
+        Config.setProperty("ES_ENDPOINTS", new String[]{"https://localhost:9201"});
+        Config.setProperty("OS_ENDPOINTS", new String[]{"https://localhost:9201"});
+
+        try {
+            IndexStartupValidator.assertEndpointsSeparate(
+                    ConfigurableOpenSearchProvider.configFromProperties());
+            fail("Expected DotRuntimeException for overlapping ES/OS endpoints");
+        } catch (final DotRuntimeException e) {
+            assertTrue("message should name the overlap",
+                    e.getMessage().contains("point to the same endpoint(s)"));
+        }
+    }
+}

--- a/dotCMS/src/test/java/com/dotcms/content/index/opensearch/IndexStartupValidatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/opensearch/IndexStartupValidatorTest.java
@@ -61,6 +61,33 @@ public class IndexStartupValidatorTest {
     }
 
     /**
+     * Given Scenario: multi-endpoint ES [a,b] and OS [b,c] share one endpoint.
+     * Expected Result: partial overlap is detected — returns false.
+     */
+    @Test
+    public void test_endpointsAreSeparate_multiEndpointPartialOverlap_returnsFalse() {
+        Config.setProperty("ES_ENDPOINTS",
+                new String[]{"https://es-a:9200", "https://shared:9200"});
+        Config.setProperty("OS_ENDPOINTS",
+                new String[]{"https://shared:9200", "https://os-c:9200"});
+
+        assertFalse(IndexStartupValidator.endpointsAreSeparate());
+    }
+
+    /**
+     * Given Scenario: OS config cannot be resolved (blank endpoint trips OSClientConfig validation).
+     * Expected Result: endpointsAreSeparate() fails closed — returns false — rather than throwing
+     *                  out of the OS bootstrap gate.
+     */
+    @Test
+    public void test_endpointsAreSeparate_unresolvableOsConfig_returnsFalse() {
+        Config.setProperty("ES_ENDPOINTS", new String[]{"https://localhost:9200"});
+        Config.setProperty("OS_ENDPOINTS", new String[]{""});
+
+        assertFalse(IndexStartupValidator.endpointsAreSeparate());
+    }
+
+    /**
      * Given Scenario: ES and OS share the same host:port.
      * Expected Result: assertEndpointsSeparate throws DotRuntimeException naming the overlap.
      */

--- a/dotCMS/src/test/java/com/dotcms/content/index/opensearch/IndexStartupValidatorTest.java
+++ b/dotCMS/src/test/java/com/dotcms/content/index/opensearch/IndexStartupValidatorTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.dotcms.content.index.IndexConfigHelper;
 import com.dotmarketing.exception.DotRuntimeException;
 import com.dotmarketing.util.Config;
 import org.junit.After;
@@ -22,6 +23,7 @@ public class IndexStartupValidatorTest {
     public void clearEndpoints() {
         Config.setProperty("ES_ENDPOINTS", null);
         Config.setProperty("OS_ENDPOINTS", null);
+        Config.setProperty(IndexConfigHelper.MigrationPhase.FLAG_KEY, 0);
     }
 
     /**
@@ -85,6 +87,20 @@ public class IndexStartupValidatorTest {
         Config.setProperty("OS_ENDPOINTS", new String[]{""});
 
         assertFalse(IndexStartupValidator.endpointsAreSeparate());
+    }
+
+    /**
+     * Given Scenario: Phase 3 (OPENSEARCH_ONLY) with ES and OS resolving to the same address —
+     *                 legitimate, since ES is decommissioned and ES_ENDPOINTS is not required.
+     * Expected Result: the separation check is skipped — endpointsAreSeparate() returns true.
+     */
+    @Test
+    public void test_endpointsAreSeparate_phase3_checkSkipped_returnsTrue() {
+        Config.setProperty(IndexConfigHelper.MigrationPhase.FLAG_KEY, 3);
+        Config.setProperty("ES_ENDPOINTS", new String[]{"https://localhost:9201"});
+        Config.setProperty("OS_ENDPOINTS", new String[]{"https://localhost:9201"});
+
+        assertTrue(IndexStartupValidator.endpointsAreSeparate());
     }
 
     /**


### PR DESCRIPTION
### Proposed Changes

Fixes the endpoint-separation guard so it actually prevents OpenSearch `.os` shadow indices from being created when the ES and OS clients point at the **same** cluster.

**Root cause:** the separation check only ran in `InitServlet → checkAndInitializeIndex`, which executes *after* the empty-DB starter-load path (`Task00004LoadStarter → bootstrapAndPoint → bootstrapAndPointOS`) has already created the `.os` indices. With `ES==OS` the guard halted the migration but too late — the `.os` indices and their `indicies` rows already existed.

* **`ContentletIndexAPIImpl.bootstrapAndPointOS`** — add a config-only endpoint-separation gate at the single OS index-creation chokepoint, *before* the existing connection gate. On `ES==OS` overlap it logs, calls `haltMigration()` (ES-only fallback), and skips OS bootstrap — so no `.os` artifacts are created on **any** startup path (starter-load or InitServlet).
* **`IndexStartupValidator`** — extract the overlap logic into a shared `assertEndpointsSeparate(config)` and add a network-free `endpointsAreSeparate()` gate reused by both startup validation and the chokepoint (no duplicated comparison logic).
* **`IndexStartupValidatorTest`** — new unit tests for the separation gate (same-address → false, different → true, scheme-normalized overlap → false, assert throws with the overlap message).

Closes #36419

### Verification

Unit: `IndexStartupValidatorTest` 4/4 pass.

E2E (`single-node-os-migration` rig, branch image, `DOT_ES_ENDPOINTS == DOT_OS_ENDPOINTS == https://opensearch3:9200`, Phase 1):

| Check | Before | After |
|---|---|---|
| `.os` rows in `indicies` | 2 | **0** |
| `.os` cluster indices | 2 | **0** |
| `.os` createIndex attempts | created | **0 (prevented)** |
| Migration halted → Phase 0 | ✓ | ✓ |
| dotCMS serving on ES | ✓ | ✓ |

Log confirms the gate fires at the chokepoint before any OS creation:
```
ERROR IndexStartupValidator - OpenSearch endpoint-separation check failed: ES and OS clients point to the same endpoint(s): [opensearch3:9200]...
WARN  ContentletIndexAPIImpl - Skipping OpenSearch index bootstrap (...): OS endpoints overlap ES (same cluster). Migration halted (now ES-only)...
WARN  MigrationPhase - Migration phase reset to PHASE_0_MIGRATION_NOT_STARTED (was PHASE_1_DUAL_WRITE_ES_READS)...
```

### Checklist
- [x] Tests
- [ ] Translations
- [x] Security Implications Contemplated — config-only comparison, no new inputs; strengthens an existing safety guard (prevents dual-write to a shared cluster).

### Additional Info

Found during QA of #36218 (TC-037), part of the OpenSearch migration QA epic #35476. The existing halt behavior (reset to Phase 0, ES-only fallback, "same endpoint(s)" log) is preserved; this only closes the ordering window on the fresh-install/starter-load path.

### Known limitations / follow-ups (from review)

- **Runtime phase-flip (out of scope for #36419):** raising `FEATURE_FLAG_OPEN_SEARCH_PHASE` 0→1+ at runtime without a restart and then running a full reindex creates `.os` reindex slots via `initAndPointReindex → createContentIndex` fan-out, which does not pass through this bootstrap gate. Startup validation remains the primary guard.
- **Pre-existing (not introduced here):** the halt is runtime-only and subject to system-table shadowing (`MigrationPhase.reset()` javadoc). If the phase flag lives in the DB system table, the reset is a no-op from `current()`'s perspective and dual-writes could continue.

This PR fixes: #36419