### PR TITLE
fix(edit-content): category field button styles, clear-all & chip alignment

### DIFF
--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.html
@@ -1,4 +1,4 @@
-<div class="flex gap-2 items-center flex-wrap justify-start" data-testId="category-list">
+<div class="flex flex-wrap items-center justify-start gap-2" data-testId="category-list">
     @for (category of $categoriesToShow(); track category.key) {
         <p-chip
             [pTooltip]="category.path || category.value"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.html
@@ -1,4 +1,4 @@
-<div class="flex gap-2 items-center flex-wrap justify-center" data-testId="category-list">
+<div class="flex gap-2 items-center flex-wrap justify-start" data-testId="category-list">
     @for (category of $categoriesToShow(); track category.key) {
         <p-chip
             [pTooltip]="category.path || category.value"

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-chips/dot-category-field-chips.component.spec.ts
@@ -36,6 +36,13 @@ describe('DotCategoryFieldChipsComponent', () => {
         expect(spectator.component).toBeTruthy();
     });
 
+    it('should left-align the chips list container', () => {
+        spectator.detectChanges();
+        const container = spectator.query(byTestId('category-list'));
+        expect(container.classList).toContain('justify-start');
+        expect(container.classList).not.toContain('justify-center');
+    });
+
     it('should the max input be equal to constant by default', () => {
         spectator.detectChanges();
         expect(spectator.component.$max()).toBe(MAX_CHIPS);

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.html
@@ -72,7 +72,8 @@
         <p-button
             (click)="closedDialog.emit()"
             [label]="'Cancel' | dm"
-            class="p-button-outlined"
+            [text]="true"
+            severity="secondary"
             data-testId="dialog-cancel" />
         <p-button (click)="confirmCategories()" [label]="'Apply' | dm" data-testId="dialog-apply" />
     </ng-template>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field-dialog/dot-category-field-dialog.component.spec.ts
@@ -2,6 +2,9 @@ import { expect, it } from '@jest/globals';
 import { byTestId, createComponentFactory, mockProvider, Spectator } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
 
+import { By } from '@angular/platform-browser';
+
+import { Button } from 'primeng/button';
 import { Dialog } from 'primeng/dialog';
 
 import { DotHttpErrorManagerService, DotMessageService } from '@dotcms/data-access';
@@ -92,6 +95,21 @@ describe('DotCategoryFieldDialogComponent', () => {
 
         expect(closedDialogSpy).toHaveBeenCalled();
         expect(addConfirmedCategoriesSky).toHaveBeenCalled();
+    });
+
+    it('should render `Cancel` as tertiary (text + secondary) and `Apply` as primary', () => {
+        const cancelButton = spectator.fixture.debugElement
+            .query(By.css('[data-testId="dialog-cancel"]'))
+            .injector.get(Button);
+        const applyButton = spectator.fixture.debugElement
+            .query(By.css('[data-testId="dialog-apply"]'))
+            .injector.get(Button);
+
+        expect(cancelButton.text).toBe(true);
+        expect(cancelButton.severity).toBe('secondary');
+
+        expect(applyButton.text).toBeFalsy();
+        expect(applyButton.severity).toBeFalsy();
     });
 
     it('should render the CategoryFieldCategoryList component', () => {

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.html
@@ -8,13 +8,23 @@
     </div>
 }
 
-<div class="dot-category-field__actions flex flex-wrap items-center px-0 justify-end">
+<div class="dot-category-field__actions flex flex-wrap items-center justify-end px-0">
+    @if ($hasSelectedCategories()) {
+        <button
+            type="button"
+            (click)="clearAllSelected()"
+            [disabled]="$isDisabled()"
+            [label]="'edit.content.category-field.clear-all' | dm"
+            class="p-button-sm p-button-text p-button-secondary"
+            data-testId="clear-all-btn"
+            pButton></button>
+    }
     <button
         type="button"
         (click)="openCategoriesDialog()"
         [disabled]="store.isDialogOpen() || $isDisabled()"
         [label]="'edit.content.category-field.show-categories-dialog' | dm"
-        class="p-button-sm p-button-text p-button-secondary"
+        class="p-button-sm m-1"
         data-testId="show-dialog-btn"
         pButton></button>
 </div>

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.spec.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.spec.ts
@@ -9,7 +9,7 @@ import { MockComponent } from 'ng-mocks';
 import { of } from 'rxjs';
 
 import { Component } from '@angular/core';
-import { fakeAsync } from '@angular/core/testing';
+import { fakeAsync, tick } from '@angular/core/testing';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
 import { DotHttpErrorManagerService, DotMessageService } from '@dotcms/data-access';
@@ -96,6 +96,67 @@ describe('DotCategoryFieldComponent', () => {
                 expect(selectBtn.type).toBe('button');
             });
 
+            it('should render the `Select` button as primary', () => {
+                spectator.detectChanges();
+                const selectBtn = spectator.query<HTMLButtonElement>(byTestId('show-dialog-btn'));
+                expect(selectBtn.classList).not.toContain('p-button-secondary');
+                expect(selectBtn.classList).not.toContain('p-button-text');
+            });
+
+            it('should render a `Clear all` button when there are selected categories', () => {
+                spectator.detectChanges();
+                expect(spectator.query(byTestId('clear-all-btn'))).not.toBeNull();
+            });
+
+            it('should invoke `clearAllSelected` method when the `Clear all` button is clicked', () => {
+                spectator.detectChanges();
+                const clearAllBtn = spectator.query(byTestId('clear-all-btn'));
+                const clearAllSelectedSpy = jest.spyOn(spectator.component, 'clearAllSelected');
+                expect(clearAllBtn).not.toBeNull();
+
+                spectator.click(clearAllBtn);
+
+                expect(clearAllSelectedSpy).toHaveBeenCalled();
+            });
+
+            it('should clear the store selection and emit an empty value when `Clear all` is clicked', fakeAsync(() => {
+                spectator.detectChanges();
+                spectator.component.ngOnInit();
+                spectator.detectChanges();
+                expect(spectator.component.store.selected().length).toBe(2);
+
+                // `onChange` is the ControlValueAccessor callback the effect() in
+                // ngOnInit calls whenever `store.selected()` changes; spying on it
+                // directly is more reliable in this test harness than reading the
+                // value back off the shared host FormGroup (see the disabled tests
+                // at the bottom of this file for the same limitation).
+                const onChangeSpy = jest.spyOn(
+                    spectator.component as unknown as { onChange: (value: unknown) => void },
+                    'onChange'
+                );
+
+                const clearAllBtn = spectator.query(byTestId('clear-all-btn'));
+                spectator.click(clearAllBtn);
+                spectator.detectChanges();
+                spectator.flushEffects();
+                tick();
+
+                expect(spectator.component.store.selected().length).toBe(0);
+                expect(onChangeSpy).toHaveBeenCalledWith([]);
+            }));
+
+            it('should not render the `Clear all` button after clearing all selected categories', fakeAsync(() => {
+                spectator.detectChanges();
+                spectator.component.ngOnInit();
+                spectator.detectChanges();
+                const clearAllBtn = spectator.query(byTestId('clear-all-btn'));
+                spectator.click(clearAllBtn);
+                spectator.detectChanges();
+                tick();
+
+                expect(spectator.query(byTestId('clear-all-btn'))).toBeNull();
+            }));
+
             it('should display the category list with chips when there are categories', async () => {
                 spectator.detectChanges();
                 spectator.component.ngOnInit();
@@ -144,6 +205,32 @@ describe('DotCategoryFieldComponent', () => {
             spectator.detectChanges();
 
             expect(spectator.query(byTestId('category-chip-list'))).toBeNull();
+        });
+
+        it('should not render the `Clear all` button when there are no categories', () => {
+            spectator = createHost(
+                `<form [formGroup]="formGroup">
+                    <dot-category-field [field]="field" [contentlet]="contentlet" formControlName="categorias" [hasError]="hasError" />
+                </form>`,
+                {
+                    hostProps: {
+                        formGroup: FAKE_FORM_GROUP,
+                        field: CATEGORY_FIELD_MOCK,
+                        contentlet: {
+                            ...CATEGORY_FIELD_CONTENTLET_MOCK,
+                            [CATEGORY_FIELD_MOCK.variable]: []
+                        },
+                        hasError: false
+                    }
+                }
+            );
+
+            service = spectator.inject(CategoriesService, true);
+            service.getSelectedHierarchy.mockReturnValue(of([]));
+
+            spectator.detectChanges();
+
+            expect(spectator.query(byTestId('clear-all-btn'))).toBeNull();
         });
     });
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.ts
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-category-field/components/dot-category-field/dot-category-field.component.ts
@@ -136,6 +136,20 @@ export class DotCategoryFieldComponent
         this.onTouched();
     }
 
+    /**
+     * Clear all selected categories from the field without opening the dialog.
+     *
+     * @memberof DotEditContentCategoryFieldComponent
+     */
+    clearAllSelected(): void {
+        if (this.$isDisabled()) {
+            return;
+        }
+
+        this.store.removeRootSelected(this.store.selected().map((category) => category.key));
+        this.onTouched();
+    }
+
     override writeValue(value: string[]): void {
         super.writeValue(value);
 

--- a/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/components/tag-field/tag-field.component.html
+++ b/core-web/libs/edit-content/src/lib/fields/dot-edit-content-tag-field/components/tag-field/tag-field.component.html
@@ -24,6 +24,8 @@
     (completeMethod)="onSearch($event)"
     (keydown.enter)="onEnterKey($event)">
     <ng-template pTemplate="removetokenicon">
-        <i class="pi pi-times"></i>
+        <span class="flex items-center leading-none">
+            <i class="pi pi-times text-xs"></i>
+        </span>
     </ng-template>
 </p-autoComplete>

--- a/core-web/libs/ui/src/lib/theme/theme.config.ts
+++ b/core-web/libs/ui/src/lib/theme/theme.config.ts
@@ -88,11 +88,21 @@ export const CustomLaraPreset = definePreset(Lara, {
             // without per-template classes. PrimeNG has no chip size token, so this
             // is expressed as CSS — same mechanism as card/confirmpopup. Content
             // status badges use `p-tag` (see the `tag` block below), not chips.
+            //
+            // The remove icon is flipped to the left of the label app-wide via flexbox
+            // `order` (`.p-chip` is `display:flex`): PrimeNG's Chip template always
+            // renders the remove icon after the label with no input to reorder it, so
+            // this is the only way to achieve it without forking the component. DOM
+            // order (and keyboard focus order) is unaffected — only the visual order
+            // changes.
             css: `
                 .p-chip {
                     height: calc(var(--spacing) * 7); /* 1.75rem */
                     padding: 0 calc(var(--spacing) * 2); /* 0.5rem */
                     font-size: var(--text-xs); /* 0.75rem */
+                }
+                .p-chip .p-chip-remove-icon {
+                    order: -1;
                 }
             `
         },

--- a/dotCMS/src/main/resources/dotmarketing-config.properties
+++ b/dotCMS/src/main/resources/dotmarketing-config.properties
@@ -870,9 +870,6 @@ FEATURE_FLAG_UVE_LEGACY_SCRIPT_INJECTION=false
 ## Enhanced locale selector v2 in the edit-content sidebar
 FEATURE_FLAG_LOCALE_SELECTOR_V2=true
 
-## Enhanced locale selector v2 in the edit-content sidebar
-FEATURE_FLAG_LOCALE_SELECTOR_V2=true
-
 ## libvips image engine toggle. Off by default (legacy Java2D engine). The new image
 ## editor reads this (via the configuration endpoint) to gate the libvips-only AVIF
 ## output format. Declared here so the endpoint returns an explicit boolean instead

--- a/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
+++ b/dotCMS/src/main/webapp/WEB-INF/messages/Language.properties
@@ -6314,6 +6314,7 @@ edit.content.unsaved.changes.discard=Discard changes
 edit.content.unsaved.changes.keep=Keep editing
 
 edit.content.category-field.show-categories-dialog=Select
+edit.content.category-field.clear-all=Clear all
 edit.content.category-field.dialog.header.select-categories=Select categories
 edit.content.category-field.dialog.button.clear-all=Clear all
 


### PR DESCRIPTION
## Summary
Closes #36379

- **Selector dialog**: Apply is now primary (default), Cancel is tertiary (`[text]="true" severity="secondary"`), matching the convention used in other recent dialogs (e.g. image-editor-footer, ai-content-dialog). The dialog's existing "Clear all" is untouched.
- **Category field component**: Select button is now primary. Added a new field-level "Clear all" button (`data-testId="clear-all-btn"`) so users can clear all selected categories without opening the dialog — the field value auto-empties via the existing `store.selected()` effect, no extra wiring needed.
- **Chip layout**: fixed centered rows on wrap (`justify-center` → `justify-start`).
- **Chip X position**: investigated moving the remove icon to the left of the label. PrimeNG's `Chip` template has no input to reorder it, so it's applied as a flexbox `order: -1` rule on `.p-chip-remove-icon` at the theme level (`theme.config.ts`), app-wide. DOM/tab order is unaffected, only the visual order changes.
- **Tags field propagation**: per the issue comment, checked whether the X-to-left change needs to propagate to Tags. PrimeNG's `p-autoComplete` multi-value tokens render as real `p-chip` instances internally, so the theme-level fix already applies there with no extra code.
- **Bonus**: while comparing both chip implementations, noticed the Tags field's remove icon wasn't vertically centered (missing the flex wrapper that Category's chip template has) — fixed for visual consistency.
- Unrelated one-line cleanup: removed a duplicated `FEATURE_FLAG_LOCALE_SELECTOR_V2` line in `dotmarketing-config.properties`.

## Images
<img width="796" height="450" alt="Screenshot 2026-07-06 at 2 06 33 PM" src="https://github.com/user-attachments/assets/4bff7565-ed4e-4caa-8769-854d9c5347b3" />

<img width="959" height="847" alt="Screenshot 2026-07-06 at 2 06 43 PM" src="https://github.com/user-attachments/assets/c76faaab-e92b-4b56-b626-8b1a806e2c4f" />
<img width="786" height="312" alt="Screenshot 2026-07-06 at 2 06 59 PM" src="https://github.com/user-attachments/assets/b563eb4d-2df1-4c0b-a124-65d4bf468e58" />
<img width="888" height="525" alt="Screenshot 2026-07-06 at 2 44 55 PM" src="https://github.com/user-attachments/assets/ea72524a-94b8-4569-8893-4c0cbafe1dfa" />


## Unit tests added
- `dot-category-field.component.spec.ts`: `Clear all` button renders only with selections, invokes `clearAllSelected()` on click, clears the store and emits an empty value via the CVA `onChange` callback, `Select` button no longer carries secondary/text classes.
- `dot-category-field-dialog.component.spec.ts`: Cancel/Apply render as tertiary (`text` + `secondary`) / primary respectively (asserted on the `Button` component instance, not CSS strings).
- `dot-category-field-chips.component.spec.ts`: chip container uses `justify-start` instead of `justify-center`.
- Not unit-tested: the chip remove-icon `order: -1` rule — it's a global `theme.config.ts` CSS rule that jsdom doesn't apply, so a unit test would be a false positive. Verify visually.

## Test plan
- [ ] Add unit test coverage for the new "Clear all" button and severities
- [ ] Open a content with a Category field, select several categories so chips wrap to 2+ rows → confirm left alignment on every row
- [ ] Confirm the chip "X" renders to the left of the label on both Category and Tags fields
- [ ] Confirm Tags field "X" is vertically centered
- [ ] Open the category selector dialog → Apply renders primary, Cancel renders tertiary (text/secondary)
- [ ] On the field (dialog closed), click "Clear all" → all chips disappear and the field value is empty
- [ ] Existing dialog "Clear all" still works as before

This PR fixes: #36379